### PR TITLE
perf(menu): fix open-menu beachball/stutter on multi-provider setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Cost history: keep chart date labels aligned with their bars and visible without clipping. Thanks @elijahfriedman!
 - Xiaomi MiMo: retry another imported browser session when a stale session redirects API requests to login. Thanks @Yuxin-Qiao!
 - MiniMax: retry the China API region when the global token endpoint reports a structured invalid-key response.
+- Menu refresh: scope manual refreshes to the visible provider, keep Command-R consistent with mouse refresh, and avoid animated refresh-row compositing. Thanks @jangisaac-dev!
 - Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!
 - Cursor: ignore an exhausted Auto or API subquota only when another independent quota remains usable, while preserving the overall cap. Thanks @Yuxin-Qiao!
 - Memory: release idle OpenAI WebViews under system pressure without blocking the main thread. Thanks @ProspectOre!

--- a/Sources/CodexBar/MenuCardRefreshMonitor.swift
+++ b/Sources/CodexBar/MenuCardRefreshMonitor.swift
@@ -14,27 +14,37 @@ final class MenuCardRefreshMonitor {
 
     private let resolveModel: ModelResolver
     var isManualRefreshInFlight = false
+    private var manualRefreshProvider: UsageProvider?
     private var frozenManualRefreshModels: [UsageProvider: UsageMenuCardView.Model] = [:]
 
     init(resolveModel: @escaping ModelResolver) {
         self.resolveModel = resolveModel
     }
 
-    func beginManualRefresh(frozenModels: [UsageProvider: UsageMenuCardView.Model]) {
+    func beginManualRefresh(
+        frozenModels: [UsageProvider: UsageMenuCardView.Model],
+        provider: UsageProvider? = nil)
+    {
         self.frozenManualRefreshModels = frozenModels
+        self.manualRefreshProvider = provider
         self.isManualRefreshInFlight = true
     }
 
     func endManualRefresh() {
         self.isManualRefreshInFlight = false
+        self.manualRefreshProvider = nil
         self.frozenManualRefreshModels.removeAll(keepingCapacity: true)
+    }
+
+    func isManualRefreshInFlight(for provider: UsageProvider) -> Bool {
+        self.isManualRefreshInFlight && (self.manualRefreshProvider == nil || self.manualRefreshProvider == provider)
     }
 
     func model(
         for provider: UsageProvider,
         fallback: UsageMenuCardView.Model) -> UsageMenuCardView.Model
     {
-        guard !self.isManualRefreshInFlight else {
+        guard !self.isManualRefreshInFlight(for: provider) else {
             guard let frozen = self.frozenManualRefreshModels[provider] else {
                 return fallback
             }
@@ -61,7 +71,7 @@ final class MenuCardRefreshMonitor {
         for provider: UsageProvider,
         fallback: MenuCardLiveSubtitle) -> MenuCardLiveSubtitle
     {
-        if self.isManualRefreshInFlight {
+        if self.isManualRefreshInFlight(for: provider) {
             return MenuCardLiveSubtitle(text: "\(L("Refreshing"))…", style: .loading)
         }
         guard let model = self.resolveModel(provider) else { return fallback }

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -51,6 +51,8 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             let refreshStartedAt = Date()
             await self.store.refreshProvider(provider)
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+            await self.store.refreshProviderStatus(provider)
+            guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
             await self.store.refreshTokenUsageNow(for: provider, force: true)
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
             if provider == .codex {
@@ -62,6 +64,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
                 guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
             }
             self.store.scheduleStorageFootprintRefresh(for: [provider], force: true)
+            self.store.persistWidgetSnapshot(reason: "provider-refresh")
             if refreshOpenMenusWhenComplete {
                 self.refreshOpenMenusAfterExplicitStoreAction()
             } else {

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -42,6 +42,34 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         }
     }
 
+    func performStoreRefresh(
+        for provider: UsageProvider,
+        refreshOpenMenusWhenComplete: Bool,
+        interaction: ProviderInteraction) async
+    {
+        await ProviderInteractionContext.$current.withValue(interaction) {
+            let refreshStartedAt = Date()
+            await self.store.refreshProvider(provider)
+            guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+            await self.store.refreshTokenUsageNow(for: provider, force: true)
+            guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+            if provider == .codex {
+                await self.store.refreshCreditsNow(minimumSnapshotUpdatedAt: refreshStartedAt)
+                guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+                await self.store.refreshOpenAIDashboardIfNeeded(
+                    force: true,
+                    expectedGuard: self.store.freshCodexOpenAIWebRefreshGuard())
+                guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+            }
+            self.store.scheduleStorageFootprintRefresh(for: [provider], force: true)
+            if refreshOpenMenusWhenComplete {
+                self.refreshOpenMenusAfterExplicitStoreAction()
+            } else {
+                self.invalidateMenus()
+            }
+        }
+    }
+
     func refreshOpenMenusAfterExplicitStoreAction() {
         self.invalidateMenus(
             refreshOpenMenus: true,
@@ -49,6 +77,30 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     @objc func refreshNow() {
+        self.startManualRefresh(for: nil)
+    }
+
+    func refreshMenuProviderNow(in menu: NSMenu?) {
+        guard let provider = self.manualRefreshProvider(for: menu) else {
+            self.startManualRefresh(for: nil)
+            return
+        }
+        self.startManualRefresh(for: provider)
+    }
+
+    private func refreshMenuProviderNow(menuID: ObjectIdentifier) {
+        if let menu = self.openMenus[menuID] {
+            self.refreshMenuProviderNow(in: menu)
+        } else if let mergedMenu = self.mergedMenu, ObjectIdentifier(mergedMenu) == menuID {
+            self.refreshMenuProviderNow(in: mergedMenu)
+        } else if let provider = self.menuProviders[menuID] {
+            self.startManualRefresh(for: provider)
+        } else {
+            self.startManualRefresh(for: nil)
+        }
+    }
+
+    private func startManualRefresh(for provider: UsageProvider?) {
         guard !self.hasPreparedForAppShutdown,
               self.manualRefreshTask == nil,
               !self.store.isRefreshing
@@ -59,6 +111,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             guard let self else { return }
             defer {
                 self.manualRefreshTask = nil
+                self.manualRefreshProvider = nil
                 self.menuCardRefreshMonitor.endManualRefresh()
                 self.updatePersistentRefreshRowsInProgress()
             }
@@ -70,14 +123,32 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
                 return
             }
             #endif
-            await self.performStoreRefresh(
-                forceTokenUsage: true,
-                refreshOpenMenusWhenComplete: true,
-                interaction: .userInitiated)
+            if let provider {
+                await self.performStoreRefresh(
+                    for: provider,
+                    refreshOpenMenusWhenComplete: true,
+                    interaction: .userInitiated)
+            } else {
+                await self.performStoreRefresh(
+                    forceTokenUsage: true,
+                    refreshOpenMenusWhenComplete: true,
+                    interaction: .userInitiated)
+            }
         }
+        self.manualRefreshProvider = provider
         self.manualRefreshTask = task
-        self.menuCardRefreshMonitor.beginManualRefresh(frozenModels: frozenModels)
+        self.menuCardRefreshMonitor.beginManualRefresh(frozenModels: frozenModels, provider: provider)
         self.updatePersistentRefreshRowsInProgress()
+    }
+
+    private func manualRefreshProvider(for menu: NSMenu?) -> UsageProvider? {
+        guard let menu else { return nil }
+        if self.shouldMergeIcons {
+            guard self.mergedMenu == nil || menu === self.mergedMenu else { return nil }
+            guard !self.isMergedOverviewSelected(in: menu) else { return nil }
+            return self.resolvedMenuProvider()
+        }
+        return self.menuProviders[ObjectIdentifier(menu)]
     }
 
     private func frozenManualRefreshMenuCardModels() -> [UsageProvider: UsageMenuCardView.Model] {
@@ -100,9 +171,10 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         return models
     }
 
-    nonisolated func performPersistentRefreshAction() {
+    nonisolated func performPersistentRefreshAction(in menuID: ObjectIdentifier) {
         Task { @MainActor [weak self] in
-            self?.refreshNow()
+            guard let self else { return }
+            self.refreshMenuProviderNow(menuID: menuID)
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -104,9 +104,12 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     private func startManualRefresh(for provider: UsageProvider?) {
+        let scopedRefreshInFlight = provider.map { self.store.refreshingProviders.contains($0) }
+            ?? !self.store.refreshingProviders.isEmpty
         guard !self.hasPreparedForAppShutdown,
               self.manualRefreshTask == nil,
-              !self.store.isRefreshing
+              !self.store.isRefreshing,
+              !scopedRefreshInFlight
         else { return }
 
         let frozenModels = self.frozenManualRefreshMenuCardModels()

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -120,6 +120,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
                 self.manualRefreshProvider = nil
                 self.menuCardRefreshMonitor.endManualRefresh()
                 self.updatePersistentRefreshRowsInProgress()
+                self.prepareAttachedClosedMenusIfNeeded()
             }
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
             #if DEBUG

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -62,6 +62,12 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
                     force: true,
                     expectedGuard: self.store.freshCodexOpenAIWebRefreshGuard())
                 guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+                if self.store.openAIDashboardRequiresLogin {
+                    await self.store.refreshProvider(.codex)
+                    guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+                    await self.store.refreshCreditsNow(minimumSnapshotUpdatedAt: refreshStartedAt)
+                    guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+                }
             }
             self.store.scheduleStorageFootprintRefresh(for: [provider], force: true)
             self.store.persistWidgetSnapshot(reason: "provider-refresh")

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -162,7 +162,8 @@ extension StatusItemController {
         }
 
         self.clearMergedSwitcherContentCache(for: menu)
-        self.openMenus.removeValue(forKey: key)
+        let wasTracked = self.openMenus.removeValue(forKey: key) != nil
+        let menuTrackingEnded = wasTracked && self.openMenus.isEmpty
         if self.openMenus.isEmpty {
             self.parentMenuRebuildPendingAfterHostedSubviewClose = false
         }
@@ -181,6 +182,9 @@ extension StatusItemController {
         self.scheduleDeferredMenuInteractionRefreshIfNeeded()
         if wasMergedMenu {
             self.applyDeferredMergedIconRenderAfterTrackingIfNeeded()
+        }
+        if menuTrackingEnded {
+            self.prepareAttachedClosedMenusIfNeeded()
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -880,7 +880,7 @@ extension StatusItemController {
             })
 
         if action == .refresh {
-            row.setInProgress(self.manualRefreshTask != nil || self.store.isRefreshing)
+            row.setInProgress(self.isRefreshActionInFlight(for: menu))
             self.persistentRefreshRows.add(row)
         }
 

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -240,6 +240,7 @@ final class PersistentMenuActionItemView: NSView, MenuCardHighlighting {
     private let titleField: NSTextField
     private let shortcutField: NSTextField
     private let onClick: () -> Void
+    private var highlighted = false
     private var isInProgress = false
 
     override var intrinsicContentSize: NSSize {
@@ -280,39 +281,45 @@ final class PersistentMenuActionItemView: NSView, MenuCardHighlighting {
 
     override func mouseUp(with event: NSEvent) {
         guard event.type == .leftMouseUp else { return }
+        guard !self.isInProgress else { return }
         self.onClick()
     }
 
     func setHighlighted(_ highlighted: Bool) {
-        let primaryColor = highlighted ? NSColor.selectedMenuItemTextColor : NSColor.controlTextColor
-        let secondaryColor = highlighted ? NSColor.selectedMenuItemTextColor : NSColor.secondaryLabelColor
-        self.backgroundView.isHidden = !highlighted
-        self.titleField.textColor = primaryColor
-        self.shortcutField.textColor = secondaryColor
-        self.imageView.contentTintColor = primaryColor
-        self.progressIndicator.appearance = highlighted ? NSAppearance(named: .darkAqua) : nil
+        self.highlighted = highlighted
+        self.updateVisualState()
     }
 
-    /// Gives the persistent Refresh row immediate, in-place feedback while a manual refresh
-    /// is in flight: the leading `arrow.clockwise` icon is swapped for a spinner occupying the
-    /// same fixed 18×18 slot, so the row height and layout never change (no menu rebuild).
+    /// Gives the persistent Refresh row static, in-place feedback without an animated view inside
+    /// the vibrant menu, which would continuously trigger WindowServer recompositing.
     func setInProgress(_ inProgress: Bool) {
         guard self.isInProgress != inProgress else { return }
         self.isInProgress = inProgress
-        // Fade the icon rather than `isHidden`: a hidden NSStackView arranged subview collapses
-        // its slot and shifts the title, whereas `alphaValue` keeps the fixed 18pt slot in place.
-        self.imageView.alphaValue = inProgress ? 0 : 1
-        self.progressIndicator.isHidden = !inProgress
-        if inProgress {
-            self.progressIndicator.startAnimation(nil)
-        } else {
-            self.progressIndicator.stopAnimation(nil)
-        }
+        self.progressIndicator.stopAnimation(nil)
+        self.progressIndicator.isHidden = true
+        self.updateVisualState()
+    }
+
+    private func updateVisualState() {
+        let primaryColor = self.highlighted ? NSColor.selectedMenuItemTextColor : NSColor.controlTextColor
+        let secondaryColor = self.highlighted ? NSColor.selectedMenuItemTextColor : NSColor.secondaryLabelColor
+        let alpha: CGFloat = self.isInProgress ? 0.62 : 1
+        self.backgroundView.isHidden = !self.highlighted
+        self.titleField.textColor = primaryColor
+        self.shortcutField.textColor = secondaryColor
+        self.imageView.contentTintColor = primaryColor
+        self.titleField.alphaValue = alpha
+        self.shortcutField.alphaValue = alpha
+        self.imageView.alphaValue = alpha
     }
 
     #if DEBUG
     var isInProgressForTesting: Bool {
         self.isInProgress
+    }
+
+    var isProgressIndicatorHiddenForTesting: Bool {
+        self.progressIndicator.isHidden
     }
     #endif
 

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -111,6 +111,8 @@ extension StatusItemController {
 
     var isMenuDataRefreshInFlight: Bool {
         self.store.isRefreshing ||
+            self.manualRefreshTask != nil ||
+            !self.store.refreshingProviders.isEmpty ||
             UsageProvider.allCases.contains { self.store.isTokenRefreshInFlight(for: $0) }
     }
 
@@ -260,7 +262,8 @@ extension StatusItemController {
             guard self.closedMenuRebuildRequests.isCurrent(rebuildToken, for: key) else { return }
             guard !self.hasPreparedForAppShutdown else { return }
             guard !self.isMenuDataRefreshInFlight else { return }
-            guard self.openMenus[ObjectIdentifier(menu)] == nil else { return }
+            // A delayed prewarm for one menu must never populate while another menu is tracking.
+            guard self.openMenus.isEmpty else { return }
             guard self.menuNeedsRefresh(menu) else { return }
             self.populateMenu(menu, provider: provider)
             self.markMenuFresh(menu)

--- a/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
@@ -63,9 +63,7 @@ extension StatusItemController {
 
     func isRefreshActionInFlight(for menu: NSMenu) -> Bool {
         if self.manualRefreshTask != nil {
-            guard let manualRefreshProvider else { return true }
-            if self.isMergedOverviewSelected(in: menu) { return false }
-            return self.menuProvider(for: menu) == manualRefreshProvider
+            return true
         }
 
         if self.isMergedOverviewSelected(in: menu) {

--- a/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
@@ -67,10 +67,8 @@ extension StatusItemController {
         }
 
         if self.isMergedOverviewSelected(in: menu) {
-            let providers = self.settings.resolvedMergedOverviewProviders(
-                activeProviders: self.store.enabledProvidersForDisplay(),
-                maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
-            return self.store.isRefreshing || providers.contains { self.store.refreshingProviders.contains($0) }
+            // Overview refresh is global, so its busy state must mirror the global manual-refresh gate.
+            return self.store.isRefreshing || !self.store.refreshingProviders.isEmpty
         }
         if let provider = self.menuProvider(for: menu) {
             return self.store.isRefreshing || self.store.refreshingProviders.contains(provider)

--- a/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
@@ -30,7 +30,7 @@ extension StatusItemController {
     func performPersistentMenuAction(_ action: MenuDescriptor.MenuAction, in menu: NSMenu?) {
         switch action {
         case .refresh:
-            self.refreshNow()
+            self.refreshMenuProviderNow(in: menu)
         case .installUpdate:
             self.closeMenuForPersistentAction(menu)
             self.installUpdate()
@@ -48,14 +48,45 @@ extension StatusItemController {
         }
     }
 
-    /// Syncs every live persistent Refresh row's spinner to the refresh lifecycle. This is
+    /// Syncs every live persistent Refresh row's static progress state to the refresh lifecycle. This is
     /// an in-place AppKit mutation on the existing row views — it never rebuilds the menu, so it
     /// is safe to call during NSMenu tracking.
     func updatePersistentRefreshRowsInProgress() {
-        let inProgress = self.manualRefreshTask != nil || self.store.isRefreshing
         for row in self.persistentRefreshRows.allObjects {
-            row.setInProgress(inProgress)
+            guard let menu = row.enclosingMenuItem?.menu else {
+                row.setInProgress(self.manualRefreshTask != nil || self.store.isRefreshing)
+                continue
+            }
+            row.setInProgress(self.isRefreshActionInFlight(for: menu))
         }
+    }
+
+    func isRefreshActionInFlight(for menu: NSMenu) -> Bool {
+        if self.manualRefreshTask != nil {
+            guard let manualRefreshProvider else { return true }
+            if self.isMergedOverviewSelected(in: menu) { return false }
+            return self.menuProvider(for: menu) == manualRefreshProvider
+        }
+
+        if self.isMergedOverviewSelected(in: menu) {
+            let providers = self.settings.resolvedMergedOverviewProviders(
+                activeProviders: self.store.enabledProvidersForDisplay(),
+                maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
+            return self.store.isRefreshing || providers.contains { self.store.refreshingProviders.contains($0) }
+        }
+        if let provider = self.menuProvider(for: menu) {
+            return self.store.isRefreshing || self.store.refreshingProviders.contains(provider)
+        }
+        return self.store.isRefreshing || !self.store.refreshingProviders.isEmpty
+    }
+
+    func isMergedOverviewSelected(in menu: NSMenu) -> Bool {
+        guard self.shouldMergeIcons else { return false }
+        if let mergedMenu = self.mergedMenu, menu !== mergedMenu { return false }
+        let providers = self.settings.resolvedMergedOverviewProviders(
+            activeProviders: self.store.enabledProvidersForDisplay(),
+            maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
+        return !providers.isEmpty && self.settings.mergedMenuLastSelectedWasOverview
     }
 
     private func closeMenuForPersistentAction(_ menu: NSMenu?) {

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -30,6 +30,7 @@ extension StatusItemController {
         self.loginTask = nil
         self.manualRefreshTask?.cancel()
         self.manualRefreshTask = nil
+        self.manualRefreshProvider = nil
         self.menuCardRefreshMonitor.endManualRefresh()
         self.screenChangeVisibilityTask?.cancel()
         self.screenChangeVisibilityTask = nil

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -140,6 +140,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var openMenus: [ObjectIdentifier: NSMenu] = [:]
     var menuRefreshTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
     var manualRefreshTask: Task<Void, Never>?
+    var manualRefreshProvider: UsageProvider?
     var closedMenuRebuildTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
     var closedMenuRebuildRequests = MenuRebuildRequestRegistry<ObjectIdentifier>()
     var openMenuRebuildTasks: [ObjectIdentifier: Task<Void, Never>] = [:]

--- a/Sources/CodexBar/StatusItemMenu.swift
+++ b/Sources/CodexBar/StatusItemMenu.swift
@@ -6,7 +6,7 @@ enum StatusItemMenuProviderNavigationDirection {
 }
 
 protocol StatusItemMenuPersistentActionDelegate: AnyObject {
-    func performPersistentRefreshAction()
+    func performPersistentRefreshAction(in menuID: ObjectIdentifier)
     func performPersistentSettingsAction()
     func performPersistentQuitAction()
     func performProviderNavigation(_ direction: StatusItemMenuProviderNavigationDirection)
@@ -19,7 +19,7 @@ final class StatusItemMenu: NSMenu {
         if let action = Self.persistentAction(for: event) {
             switch action {
             case .refresh:
-                self.persistentActionDelegate?.performPersistentRefreshAction()
+                self.persistentActionDelegate?.performPersistentRefreshAction(in: ObjectIdentifier(self))
             case .settings:
                 self.persistentActionDelegate?.performPersistentSettingsAction()
             case .quit:

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -723,18 +723,21 @@ final class UsageStore {
     }
 
     private func refreshTokenUsageSequenceNow(force: Bool) async {
-        if force, let existing = self.tokenRefreshSequenceTask {
-            existing.cancel()
-            await existing.value
-            self.tokenRefreshSequenceTask = nil
-        }
-
+        await self.drainScheduledTokenRefreshIfNeeded(force: force)
         await self.refreshTokenUsageSequence(force: force)
     }
 
     func refreshTokenUsageNow(for provider: UsageProvider, force: Bool) async {
+        await self.drainScheduledTokenRefreshIfNeeded(force: force)
         await self.refreshTokenUsage(provider, force: force)
         self.scheduleMemoryPressureRelief()
+    }
+
+    private func drainScheduledTokenRefreshIfNeeded(force: Bool) async {
+        guard force, let existing = self.tokenRefreshSequenceTask else { return }
+        existing.cancel()
+        await existing.value
+        self.tokenRefreshSequenceTask = nil
     }
 
     private func refreshTokenUsageSequence(force: Bool) async {

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -732,6 +732,11 @@ final class UsageStore {
         await self.refreshTokenUsageSequence(force: force)
     }
 
+    func refreshTokenUsageNow(for provider: UsageProvider, force: Bool) async {
+        await self.refreshTokenUsage(provider, force: force)
+        self.scheduleMemoryPressureRelief()
+    }
+
     private func refreshTokenUsageSequence(force: Bool) async {
         for provider in self.enabledProvidersForBackgroundWork() {
             if Task.isCancelled { break }

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -234,6 +234,7 @@ final class UsageStore {
     @ObservationIgnored private var timerTask: Task<Void, Never>?
     @ObservationIgnored private var tokenTimerTask: Task<Void, Never>?
     @ObservationIgnored private var tokenRefreshSequenceTask: Task<Void, Never>?
+    @ObservationIgnored private var tokenRefreshSequenceProvider: UsageProvider?
     @ObservationIgnored var memoryPressureReliefTask: Task<Void, Never>?
     @ObservationIgnored var startupConnectivityRetryTask: Task<Void, Never>?
     @ObservationIgnored var startupConnectivityRetryNeeded = false
@@ -723,27 +724,31 @@ final class UsageStore {
     }
 
     private func refreshTokenUsageSequenceNow(force: Bool) async {
-        await self.drainScheduledTokenRefreshIfNeeded(force: force)
+        await self.drainScheduledTokenRefreshIfNeeded(force: force, scopedTo: nil)
         await self.refreshTokenUsageSequence(force: force)
     }
 
     func refreshTokenUsageNow(for provider: UsageProvider, force: Bool) async {
-        await self.drainScheduledTokenRefreshIfNeeded(force: force)
+        await self.drainScheduledTokenRefreshIfNeeded(force: force, scopedTo: provider)
         await self.refreshTokenUsage(provider, force: force)
         self.scheduleMemoryPressureRelief()
     }
 
-    private func drainScheduledTokenRefreshIfNeeded(force: Bool) async {
+    private func drainScheduledTokenRefreshIfNeeded(force: Bool, scopedTo provider: UsageProvider?) async {
         guard force, let existing = self.tokenRefreshSequenceTask else { return }
+        if let provider, self.tokenRefreshSequenceProvider != provider { return }
         existing.cancel()
         await existing.value
         self.tokenRefreshSequenceTask = nil
     }
 
     private func refreshTokenUsageSequence(force: Bool) async {
+        defer { self.tokenRefreshSequenceProvider = nil }
         for provider in self.enabledProvidersForBackgroundWork() {
             if Task.isCancelled { break }
+            self.tokenRefreshSequenceProvider = provider
             await self.refreshTokenUsage(provider, force: force)
+            self.tokenRefreshSequenceProvider = nil
         }
         self.scheduleMemoryPressureRelief()
     }
@@ -1452,11 +1457,6 @@ extension UsageStore {
             return
         }
 
-        if let override = self._test_tokenUsageRefreshOverride {
-            await override(provider, force)
-            return
-        }
-
         if Self.tokenCostRequiresProviderSnapshot(provider) {
             if let snapshot = self.tokenSnapshot(fromProviderSnapshot: self.snapshots[provider], provider: provider) {
                 self.tokenSnapshots[provider] = snapshot
@@ -1507,6 +1507,15 @@ extension UsageStore {
         self.tokenRefreshInFlight.insert(provider)
         defer { self.tokenRefreshInFlight.remove(provider) }
 
+        if let override = self._test_tokenUsageRefreshOverride {
+            await override(provider, force)
+            if Task.isCancelled {
+                self.lastTokenFetchAt.removeValue(forKey: provider)
+                self.lastTokenFetchScope.removeValue(forKey: provider)
+            }
+            return
+        }
+
         let startedAt = Date()
         let providerText = provider.rawValue
         self.tokenCostLogger
@@ -1546,6 +1555,7 @@ extension UsageStore {
                 guard let snapshot = try await group.next() else { throw CancellationError() }
                 return snapshot
             }
+            try Task.checkCancellation()
 
             guard !snapshot.daily.isEmpty else {
                 self.tokenSnapshots.removeValue(forKey: provider)
@@ -1570,7 +1580,11 @@ extension UsageStore {
             self.tokenFailureGates[provider]?.recordSuccess()
             self.persistWidgetSnapshot(reason: "token-usage")
         } catch {
-            if error is CancellationError { return }
+            if error is CancellationError {
+                self.lastTokenFetchAt.removeValue(forKey: provider)
+                self.lastTokenFetchScope.removeValue(forKey: provider)
+                return
+            }
             let duration = Date().timeIntervalSince(startedAt)
             let msg = error.localizedDescription
             let durationText = String(format: "%.2f", duration)

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -592,7 +592,7 @@ final class UsageStore {
                                 (ProviderInteractionContext.current == .background))
                     }
                     if availableRefreshProviders.contains(provider) {
-                        group.addTask { await self.refreshStatus(provider) }
+                        group.addTask { await self.refreshProviderStatus(provider) }
                     }
                 }
                 if forceTokenUsage {
@@ -866,7 +866,7 @@ final class UsageStore {
         self.sessionQuotaNotifier.post(transition: transition, provider: provider, badge: nil)
     }
 
-    private func refreshStatus(_ provider: UsageProvider) async {
+    func refreshProviderStatus(_ provider: UsageProvider) async {
         guard self.settings.statusChecksEnabled else { return }
         guard let meta = self.providerMetadata[provider] else { return }
 

--- a/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
@@ -4,6 +4,31 @@ import Foundation
 import Testing
 @testable import CodexBar
 
+@MainActor
+private final class ClosedMenuManualRefreshGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func wait() async {
+        if self.isOpen {
+            self.isOpen = false
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func resume() {
+        if let continuation = self.continuation {
+            continuation.resume()
+            self.continuation = nil
+        } else {
+            self.isOpen = true
+        }
+    }
+}
+
 extension StatusMenuTests {
     @Test
     func `stale data refresh suppresses icon attached closed menu preparation`() async {
@@ -111,6 +136,67 @@ extension StatusMenuTests {
         controller.statusItem.menu = menu
         controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
         for _ in 0..<40 where controller.menuVersions[key] == openedVersion {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus.isEmpty)
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+
+    @Test
+    func `manual refresh completion requeues required closed menu preparation`() async throws {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            if let metadata = registry.metadata[provider] {
+                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+            }
+        }
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.fallbackMenu = menu
+        controller.statusItem.menu = menu
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let initialVersion = controller.menuVersions[key]
+
+        let gate = ClosedMenuManualRefreshGate()
+        controller._test_manualRefreshOperation = { await gate.wait() }
+        defer {
+            gate.resume()
+            controller._test_manualRefreshOperation = nil
+        }
+        controller.refreshNow()
+        let task = try #require(controller.manualRefreshTask)
+
+        controller.invalidateMenus()
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+
+        #expect(controller.menuVersions[key] == initialVersion)
+
+        gate.resume()
+        await task.value
+        for _ in 0..<40 where controller.menuVersions[key] == initialVersion {
             await Task.yield()
         }
 

--- a/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
@@ -205,6 +205,58 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `closed menu prewarm waits for other menu tracking to end`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.milliseconds(50))
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let closedMenu = controller.makeMenu(for: .claude)
+        controller.providerMenus[.claude] = closedMenu
+        controller.populateMenu(closedMenu, provider: .claude)
+        controller.markMenuFresh(closedMenu)
+        let closedKey = ObjectIdentifier(closedMenu)
+        let closedVersion = controller.menuVersions[closedKey]
+
+        controller.invalidateMenus()
+        controller.rebuildClosedMenuIfNeeded(closedMenu)
+        #expect(controller.closedMenuRebuildTasks[closedKey] != nil)
+
+        let visibleMenu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(visibleMenu)
+        try? await Task.sleep(for: .milliseconds(80))
+        for _ in 0..<20 where controller.closedMenuRebuildTasks[closedKey] != nil {
+            await Task.yield()
+        }
+
+        #expect(controller.menuVersions[closedKey] == closedVersion)
+        #expect(controller.openMenus[ObjectIdentifier(visibleMenu)] != nil)
+
+        controller.menuDidClose(visibleMenu)
+        try? await Task.sleep(for: .milliseconds(80))
+        for _ in 0..<20 where controller.menuVersions[closedKey] == closedVersion {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus.isEmpty)
+        #expect(controller.menuVersions[closedKey] == controller.menuContentVersion)
+    }
+
+    @Test
     func `data refresh while persistent menu is open rebuilds on close`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuMergedOverviewRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuMergedOverviewRefreshTests.swift
@@ -1,0 +1,92 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuMergedOverviewRefreshTests {
+    @Test
+    func `overview stays busy for an omitted provider refresh`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        let activeProviders: Set<UsageProvider> = [.claude, .codex, .cursor, .opencode]
+        self.enableOnly(activeProviders, settings: settings)
+        settings.mergedOverviewSelectedProviders = [.claude, .codex, .cursor]
+        settings.mergedMenuLastSelectedWasOverview = true
+
+        let controller = self.makeController(settings: settings)
+        let menu = try #require(controller.makeMenu() as? StatusItemMenu)
+        controller.mergedMenu = menu
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        let visibleProviders = settings.resolvedMergedOverviewProviders(
+            activeProviders: controller.store.enabledProvidersForDisplay())
+        #expect(!visibleProviders.contains(.opencode))
+
+        controller.store.refreshingProviders.insert(.opencode)
+        controller.updatePersistentRefreshRowsInProgress()
+        #expect(controller.isRefreshActionInFlight(for: menu))
+        let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
+        let row = try #require(refreshItem.view as? PersistentMenuActionItemView)
+        #expect(row.isInProgressForTesting)
+
+        var requestCount = 0
+        controller._test_manualRefreshOperation = { requestCount += 1 }
+        controller.performPersistentMenuAction(.refresh, in: menu)
+        #expect(try menu.performKeyEquivalent(with: self.keyEvent("r", keyCode: 15)))
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+
+        #expect(requestCount == 0)
+        #expect(controller.manualRefreshTask == nil)
+        #expect(controller.manualRefreshProvider == nil)
+    }
+
+    private func makeSettings() -> SettingsStore {
+        let suite = "StatusMenuMergedOverviewRefreshTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    private func makeController(settings: SettingsStore) -> StatusItemController {
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        return StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+    }
+
+    private func enableOnly(_ providers: Set<UsageProvider>, settings: SettingsStore) {
+        for provider in UsageProvider.allCases {
+            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: providers.contains(provider))
+        }
+    }
+
+    private func keyEvent(_ characters: String, keyCode: UInt16) throws -> NSEvent {
+        try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode))
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -130,49 +130,6 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `closed menu prewarm does not populate while another menu is tracking`() async {
-        self.disableMenuCardsForTesting()
-        let settings = self.makeSettings()
-        settings.statusChecksEnabled = false
-        settings.refreshFrequency = .manual
-        settings.mergeIcons = false
-
-        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
-        let controller = StatusItemController(
-            store: store,
-            settings: settings,
-            account: UsageFetcher().loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: self.makeStatusBarForTesting())
-        defer { controller.releaseStatusItemsForTesting() }
-        StatusItemController.setClosedMenuPreparationDelayForTesting(.milliseconds(50))
-        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
-
-        controller.menuRefreshEnabledOverrideForTesting = true
-        let closedMenu = controller.makeMenu(for: .claude)
-        controller.populateMenu(closedMenu, provider: .claude)
-        controller.markMenuFresh(closedMenu)
-        let closedKey = ObjectIdentifier(closedMenu)
-        let closedVersion = controller.menuVersions[closedKey]
-
-        controller.invalidateMenus()
-        controller.rebuildClosedMenuIfNeeded(closedMenu)
-        #expect(controller.closedMenuRebuildTasks[closedKey] != nil)
-
-        let visibleMenu = controller.makeMenu(for: .codex)
-        controller.menuWillOpen(visibleMenu)
-        defer { controller.menuDidClose(visibleMenu) }
-        try? await Task.sleep(for: .milliseconds(80))
-        for _ in 0..<20 where controller.closedMenuRebuildTasks[closedKey] != nil {
-            await Task.yield()
-        }
-
-        #expect(controller.menuVersions[closedKey] == closedVersion)
-        #expect(controller.openMenus[ObjectIdentifier(visibleMenu)] != nil)
-    }
-
-    @Test
     func `data refresh invalidation does not rebuild closed non merged attached menu`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -130,6 +130,49 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `closed menu prewarm does not populate while another menu is tracking`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.milliseconds(50))
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let closedMenu = controller.makeMenu(for: .claude)
+        controller.populateMenu(closedMenu, provider: .claude)
+        controller.markMenuFresh(closedMenu)
+        let closedKey = ObjectIdentifier(closedMenu)
+        let closedVersion = controller.menuVersions[closedKey]
+
+        controller.invalidateMenus()
+        controller.rebuildClosedMenuIfNeeded(closedMenu)
+        #expect(controller.closedMenuRebuildTasks[closedKey] != nil)
+
+        let visibleMenu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(visibleMenu)
+        defer { controller.menuDidClose(visibleMenu) }
+        try? await Task.sleep(for: .milliseconds(80))
+        for _ in 0..<20 where controller.closedMenuRebuildTasks[closedKey] != nil {
+            await Task.yield()
+        }
+
+        #expect(controller.menuVersions[closedKey] == closedVersion)
+        #expect(controller.openMenus[ObjectIdentifier(visibleMenu)] != nil)
+    }
+
+    @Test
     func `data refresh invalidation does not rebuild closed non merged attached menu`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -257,11 +257,14 @@ struct StatusMenuPersistentRefreshTests {
         #expect(row != nil)
         #expect(controller.persistentRefreshRows.allObjects.contains { $0 === row })
 
+        controller.manualRefreshProvider = .claude
         controller.manualRefreshTask = Task {}
         controller.updatePersistentRefreshRowsInProgress()
         #expect(row?.isInProgressForTesting == true)
+        #expect(controller.isRefreshActionInFlight(for: menu))
 
         controller.manualRefreshTask = nil
+        controller.manualRefreshProvider = nil
         controller.store.isRefreshing = false
         controller.updatePersistentRefreshRowsInProgress()
         #expect(row?.isInProgressForTesting == false)
@@ -798,14 +801,24 @@ struct StatusMenuPersistentRefreshTests {
 
         let controller = self.makeController(settings: settings)
         let menu = try #require(controller.makeMenu(for: .claude) as? StatusItemMenu)
+        let codexMenu = try #require(controller.makeMenu(for: .codex) as? StatusItemMenu)
         controller.menuWillOpen(menu)
         defer { controller.menuDidClose(menu) }
 
         let mouseGate = ManualRefreshGate()
-        controller._test_manualRefreshOperation = { await mouseGate.wait() }
+        var requestCount = 0
+        controller._test_manualRefreshOperation = {
+            requestCount += 1
+            await mouseGate.wait()
+        }
         controller.performPersistentMenuAction(.refresh, in: menu)
         let mouseTask = try #require(controller.manualRefreshTask)
         #expect(controller.manualRefreshProvider == .claude)
+        #expect(controller.isRefreshActionInFlight(for: codexMenu))
+        #expect(controller.isRefreshActionInFlight(for: NSMenu()))
+        controller.performPersistentMenuAction(.refresh, in: codexMenu)
+        await Task.yield()
+        #expect(requestCount == 1)
         mouseGate.resume()
         await mouseTask.value
 

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -822,6 +822,33 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
+    func `provider menu does not replace matching scoped refresh`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        self.enableOnly([.claude, .codex], settings: settings)
+
+        let controller = self.makeController(settings: settings)
+        let menu = try #require(controller.makeMenu(for: .claude) as? StatusItemMenu)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        controller.store.refreshingProviders.insert(.claude)
+        var requestCount = 0
+        controller._test_manualRefreshOperation = { requestCount += 1 }
+
+        controller.performPersistentMenuAction(.refresh, in: menu)
+        #expect(try menu.performKeyEquivalent(with: self.keyEvent("r", keyCode: 15)))
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+
+        #expect(requestCount == 0)
+        #expect(controller.manualRefreshTask == nil)
+        #expect(controller.manualRefreshProvider == nil)
+    }
+
+    @Test
     func `merged overview refreshes globally while selected provider stays scoped`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -858,6 +858,34 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
+    func `provider scoped refresh updates status and widget snapshot`() async {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = true
+        self.enableOnly([.synthetic], settings: settings)
+
+        let controller = self.makeController(settings: settings)
+        controller.store._test_providerRefreshOverride = { _ in }
+        controller.store._test_providerStatusFetchOverride = { provider in
+            #expect(provider == .synthetic)
+            return ProviderStatus(indicator: .none, description: "Operational", updatedAt: Date())
+        }
+        var savedSnapshots = 0
+        controller.store._test_widgetSnapshotSaveOverride = { _ in
+            savedSnapshots += 1
+        }
+
+        await controller.performStoreRefresh(
+            for: .synthetic,
+            refreshOpenMenusWhenComplete: false,
+            interaction: .userInitiated)
+        _ = await controller.store.widgetSnapshotPersistTask?.result
+
+        #expect(controller.store.statuses[.synthetic]?.description == "Operational")
+        #expect(savedSnapshots == 1)
+    }
+
+    @Test
     func `failed manual refresh returns row to idle and surfaces error`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -6,12 +6,14 @@ import Testing
 
 private final class RefreshShortcutRecorder: StatusItemMenuPersistentActionDelegate {
     var refreshCount = 0
+    var refreshMenuIDs: [ObjectIdentifier] = []
     var settingsCount = 0
     var quitCount = 0
     var navigationDirections: [StatusItemMenuProviderNavigationDirection] = []
 
-    func performPersistentRefreshAction() {
+    func performPersistentRefreshAction(in menuID: ObjectIdentifier) {
         self.refreshCount += 1
+        self.refreshMenuIDs.append(menuID)
     }
 
     func performPersistentSettingsAction() {
@@ -99,6 +101,13 @@ struct StatusMenuPersistentRefreshTests {
             updater: updater,
             preferencesSelection: PreferencesSelection(),
             statusBar: .system)
+    }
+
+    private func enableOnly(_ providers: Set<UsageProvider>, settings: SettingsStore) {
+        for provider in UsageProvider.allCases {
+            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: providers.contains(provider))
+        }
     }
 
     private static func makeTokenSnapshot() -> CostUsageTokenSnapshot {
@@ -209,7 +218,7 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
-    func `refresh row in-progress spinner keeps fixed metrics`() {
+    func `refresh row static in-progress state keeps fixed metrics`() {
         let view = PersistentMenuActionItemView(
             title: "Refresh",
             systemImageName: "arrow.clockwise",
@@ -218,6 +227,7 @@ struct StatusMenuPersistentRefreshTests {
             onClick: {})
 
         view.setInProgress(true)
+        #expect(view.isProgressIndicatorHiddenForTesting)
         #expect(view.frame.height == PersistentMenuActionItemView.rowHeight)
         #expect(view.intrinsicContentSize.height == PersistentMenuActionItemView.rowHeight)
         #expect(view.fittingSize.height == PersistentMenuActionItemView.rowHeight)
@@ -226,6 +236,7 @@ struct StatusMenuPersistentRefreshTests {
         #expect(view.frame.height == PersistentMenuActionItemView.rowHeight)
 
         view.setInProgress(false)
+        #expect(view.isProgressIndicatorHiddenForTesting)
         #expect(view.frame.height == PersistentMenuActionItemView.rowHeight)
         #expect(view.intrinsicContentSize.height == PersistentMenuActionItemView.rowHeight)
         #expect(view.fittingSize.height == PersistentMenuActionItemView.rowHeight)
@@ -255,8 +266,12 @@ struct StatusMenuPersistentRefreshTests {
         controller.updatePersistentRefreshRowsInProgress()
         #expect(row?.isInProgressForTesting == false)
 
-        // And a live refresh flag is mirrored onto the row.
-        controller.store.isRefreshing = true
+        // An unrelated scoped refresh does not affect this provider's row.
+        controller.store.refreshingProviders.insert(.claude)
+        controller.updatePersistentRefreshRowsInProgress()
+        #expect(row?.isInProgressForTesting == false)
+
+        controller.store.refreshingProviders.insert(.codex)
         controller.updatePersistentRefreshRowsInProgress()
         #expect(row?.isInProgressForTesting == true)
     }
@@ -299,6 +314,26 @@ struct StatusMenuPersistentRefreshTests {
 
         monitor.isManualRefreshInFlight = true
         #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .loading)
+    }
+
+    @Test
+    func `scoped refresh monitor leaves unrelated providers unchanged`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        let monitor = controller.menuCardRefreshMonitor
+        let codexModel = try #require(controller.menuCardModel(for: .codex))
+        let fallback = MenuCardLiveSubtitle(text: "Claude idle", style: .info)
+        let expectedClaude = monitor.subtitle(for: .claude, fallback: fallback)
+
+        monitor.beginManualRefresh(frozenModels: [.codex: codexModel], provider: .codex)
+        defer { monitor.endManualRefresh() }
+
+        #expect(monitor.isManualRefreshInFlight(for: .codex))
+        #expect(!monitor.isManualRefreshInFlight(for: .claude))
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .loading)
+        let actualClaude = monitor.subtitle(for: .claude, fallback: fallback)
+        #expect(actualClaude.text == expectedClaude.text)
+        #expect(actualClaude.style == expectedClaude.style)
     }
 
     @Test
@@ -755,6 +790,74 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
+    func `provider menu mouse and command R refresh only that provider`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        self.enableOnly([.claude, .codex], settings: settings)
+
+        let controller = self.makeController(settings: settings)
+        let menu = try #require(controller.makeMenu(for: .claude) as? StatusItemMenu)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        let mouseGate = ManualRefreshGate()
+        controller._test_manualRefreshOperation = { await mouseGate.wait() }
+        controller.performPersistentMenuAction(.refresh, in: menu)
+        let mouseTask = try #require(controller.manualRefreshTask)
+        #expect(controller.manualRefreshProvider == .claude)
+        mouseGate.resume()
+        await mouseTask.value
+
+        let keyboardGate = ManualRefreshGate()
+        controller._test_manualRefreshOperation = { await keyboardGate.wait() }
+        #expect(try menu.performKeyEquivalent(with: self.keyEvent("r", keyCode: 15)))
+        for _ in 0..<20 where controller.manualRefreshTask == nil {
+            await Task.yield()
+        }
+        let keyboardTask = try #require(controller.manualRefreshTask)
+        #expect(controller.manualRefreshProvider == .claude)
+        keyboardGate.resume()
+        await keyboardTask.value
+    }
+
+    @Test
+    func `merged overview refreshes globally while selected provider stays scoped`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnly([.claude, .codex], settings: settings)
+        settings.mergedMenuLastSelectedWasOverview = true
+
+        let controller = self.makeController(settings: settings)
+        let menu = try #require(controller.makeMenu() as? StatusItemMenu)
+        controller.mergedMenu = menu
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        let overviewGate = ManualRefreshGate()
+        controller._test_manualRefreshOperation = { await overviewGate.wait() }
+        controller.performPersistentMenuAction(.refresh, in: menu)
+        let overviewTask = try #require(controller.manualRefreshTask)
+        #expect(controller.manualRefreshProvider == nil)
+        overviewGate.resume()
+        await overviewTask.value
+
+        settings.mergedMenuLastSelectedWasOverview = false
+        controller.selectedMenuProvider = .claude
+        let providerGate = ManualRefreshGate()
+        controller._test_manualRefreshOperation = { await providerGate.wait() }
+        #expect(try menu.performKeyEquivalent(with: self.keyEvent("r", keyCode: 15)))
+        for _ in 0..<20 where controller.manualRefreshTask == nil {
+            await Task.yield()
+        }
+        let providerTask = try #require(controller.manualRefreshTask)
+        #expect(controller.manualRefreshProvider == .claude)
+        providerGate.resume()
+        await providerTask.value
+    }
+
+    @Test
     func `failed manual refresh returns row to idle and surfaces error`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
@@ -796,6 +899,7 @@ struct StatusMenuPersistentRefreshTests {
         #expect(try menu.performKeyEquivalent(with: self.keyEvent("q", keyCode: 12)) == true)
 
         #expect(recorder.refreshCount == 1)
+        #expect(recorder.refreshMenuIDs == [ObjectIdentifier(menu)])
         #expect(recorder.settingsCount == 1)
         #expect(recorder.quitCount == 1)
     }

--- a/Tests/CodexBarTests/StatusMenuScopedCodexRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuScopedCodexRefreshTests.swift
@@ -1,0 +1,79 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuScopedCodexRefreshTests {
+    @Test
+    func `scoped refresh reconciles usage after dashboard login expires`() async {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.openAIWebAccessEnabled = true
+        settings.codexCookieSource = .auto
+        self.enableOnlyCodex(settings)
+
+        let account = AccountInfo(email: "test@example.com", plan: "pro")
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store.accountInfoCache[.codex] = UsageStore.AccountInfoCacheEntry(
+            account: account,
+            configRevision: settings.configRevision,
+            expiresAt: .distantFuture)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: account,
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+
+        var providerRefreshes = 0
+        store._test_providerRefreshOverride = { provider in
+            #expect(provider == .codex)
+            providerRefreshes += 1
+        }
+        store._test_tokenUsageRefreshOverride = { _, _ in }
+        store._test_codexCreditsLoaderOverride = {
+            CreditsSnapshot(remaining: 25, events: [], updatedAt: Date())
+        }
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
+            throw OpenAIDashboardFetcher.FetchError.loginRequired
+        }
+        store._test_openAIDashboardCookieImportOverride = { targetEmail, _, _, _, _ in
+            OpenAIDashboardBrowserCookieImporter.ImportResult(
+                sourceLabel: "Chrome",
+                cookieCount: 2,
+                signedInEmail: targetEmail,
+                matchesCodexEmail: true)
+        }
+
+        await controller.performStoreRefresh(
+            for: .codex,
+            refreshOpenMenusWhenComplete: false,
+            interaction: .userInitiated)
+
+        #expect(store.openAIDashboardRequiresLogin)
+        #expect(providerRefreshes == 2)
+    }
+
+    private func makeSettings() -> SettingsStore {
+        let suite = "StatusMenuScopedCodexRefreshTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    private func enableOnlyCodex(_ settings: SettingsStore) {
+        for provider in UsageProvider.allCases {
+            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+        }
+    }
+}

--- a/Tests/CodexBarTests/UsageStoreManualTokenRefreshTests.swift
+++ b/Tests/CodexBarTests/UsageStoreManualTokenRefreshTests.swift
@@ -149,6 +149,52 @@ struct UsageStoreManualTokenRefreshTests {
     }
 
     @Test
+    func `scoped manual refresh drains scheduled token-cost refresh before forced pass`() async {
+        let store = Self.makeStore()
+        let scheduledGate = TokenRefreshGate()
+        let forcedGate = TokenRefreshGate()
+        let recorder = TokenRefreshRecorder()
+        let completion = CompletionFlag()
+        store._test_providerRefreshOverride = { _ in }
+        store._test_tokenUsageRefreshOverride = { provider, force in
+            await recorder.record(provider: provider, force: force)
+            if force {
+                await forcedGate.start(provider: provider, force: force)
+                await forcedGate.waitForRelease()
+                await forcedGate.finish()
+            } else {
+                await scheduledGate.start(provider: provider, force: force)
+                await scheduledGate.waitForRelease()
+                await scheduledGate.finish()
+            }
+        }
+
+        await store.refresh(forceTokenUsage: false)
+        await scheduledGate.waitForStart()
+
+        let task = Task { @MainActor in
+            await store.refreshTokenUsageNow(for: .codex, force: true)
+            await completion.markCompleted()
+        }
+
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(await completion.isCompleted() == false)
+
+        await scheduledGate.release()
+        await forcedGate.waitForStart()
+        #expect(await completion.isCompleted() == false)
+
+        await forcedGate.release()
+        await task.value
+
+        #expect(await completion.isCompleted())
+        #expect(await scheduledGate.hasFinished())
+        #expect(await forcedGate.hasFinished())
+        #expect(await recorder.calls.map(\.provider) == [.codex, .codex])
+        #expect(await recorder.calls.map(\.force) == [false, true])
+    }
+
+    @Test
     func `regular refresh schedules token-cost refresh without waiting`() async {
         let store = Self.makeStore()
         let gate = TokenRefreshGate()

--- a/Tests/CodexBarTests/UsageStoreManualTokenRefreshTests.swift
+++ b/Tests/CodexBarTests/UsageStoreManualTokenRefreshTests.swift
@@ -9,6 +9,7 @@ private actor TokenRefreshGate {
     private var released = false
     private var startWaiters: [CheckedContinuation<Void, Never>] = []
     private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private var finishWaiters: [CheckedContinuation<Void, Never>] = []
     private(set) var calls: [(provider: UsageProvider, force: Bool)] = []
 
     func start(provider: UsageProvider, force: Bool) {
@@ -42,10 +43,20 @@ private actor TokenRefreshGate {
 
     func finish() {
         self.didFinish = true
+        let waiters = self.finishWaiters
+        self.finishWaiters.removeAll()
+        waiters.forEach { $0.resume() }
     }
 
     func hasFinished() -> Bool {
         self.didFinish
+    }
+
+    func waitForFinish() async {
+        if self.didFinish { return }
+        await withCheckedContinuation { continuation in
+            self.finishWaiters.append(continuation)
+        }
     }
 }
 
@@ -195,6 +206,50 @@ struct UsageStoreManualTokenRefreshTests {
     }
 
     @Test
+    func `scoped manual refresh leaves unrelated scheduled token-cost refresh running`() async {
+        let store = Self.makeStore(enabledProviders: [.claude, .codex])
+        let scheduledGate = TokenRefreshGate()
+        let forcedGate = TokenRefreshGate()
+        let recorder = TokenRefreshRecorder()
+        let completion = CompletionFlag()
+        store._test_providerRefreshOverride = { _ in }
+        store._test_tokenUsageRefreshOverride = { provider, force in
+            await recorder.record(provider: provider, force: force)
+            if force {
+                await forcedGate.start(provider: provider, force: force)
+                await forcedGate.waitForRelease()
+                await forcedGate.finish()
+            } else {
+                await scheduledGate.start(provider: provider, force: force)
+                await scheduledGate.waitForRelease()
+                await scheduledGate.finish()
+            }
+        }
+
+        await store.refresh(forceTokenUsage: false)
+        await scheduledGate.waitForStart()
+
+        let task = Task { @MainActor in
+            await store.refreshTokenUsageNow(for: .claude, force: true)
+            await completion.markCompleted()
+        }
+
+        await forcedGate.waitForStart()
+        #expect(await scheduledGate.hasFinished() == false)
+        #expect(await completion.isCompleted() == false)
+        #expect(await recorder.calls.map(\.provider) == [.codex, .claude])
+        #expect(await recorder.calls.map(\.force) == [false, true])
+
+        await forcedGate.release()
+        await task.value
+        #expect(await completion.isCompleted())
+        #expect(await scheduledGate.hasFinished() == false)
+
+        await scheduledGate.release()
+        await scheduledGate.waitForFinish()
+    }
+
+    @Test
     func `regular refresh schedules token-cost refresh without waiting`() async {
         let store = Self.makeStore()
         let gate = TokenRefreshGate()
@@ -218,7 +273,7 @@ struct UsageStoreManualTokenRefreshTests {
         }
     }
 
-    private static func makeStore() -> UsageStore {
+    private static func makeStore(enabledProviders: Set<UsageProvider> = [.codex]) -> UsageStore {
         let suite = "UsageStoreManualTokenRefreshTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
@@ -237,7 +292,10 @@ struct UsageStoreManualTokenRefreshTests {
         let registry = ProviderRegistry.shared
         for provider in UsageProvider.allCases {
             guard let metadata = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+            settings.setProviderEnabled(
+                provider: provider,
+                metadata: metadata,
+                enabled: enabledProviders.contains(provider))
         }
 
         return UsageStore(


### PR DESCRIPTION
## Summary

- Scope manual Refresh actions to the visible provider; merged Overview remains an all-provider refresh.
- Route Command-R through the same menu scope as mouse activation.
- Keep the Refresh row static and dimmed while work is in flight, avoiding an animated spinner inside the vibrant menu.
- Mark Refresh busy across every menu scope while the singleton manual task is in flight, suppressing duplicate actions.
- Prevent delayed closed-menu prewarming while any other menu is tracking.
- Retry deferred closed-menu prewarming when menu tracking or manual refresh ends.
- Treat scoped provider and token work as active menu data refreshes.
- Drain scheduled token-cost work before a forced scoped pass only when that same provider is in flight; cancellation clears its throttle state.
- Reconcile scoped Codex usage and credits after dashboard login is required.
- Keep merged Overview busy whenever any provider refresh is in flight, including providers omitted by the three-provider display limit or a custom selection.

This replaces the stale diagnostic/WIP branch with a narrow current-main implementation. The old instrumentation, custom settle queue, card-reuse architecture, and test harnesses are intentionally excluded because current main already owns those concerns through menu-session invalidation, recyclable hosting views, and live card monitoring.

## Exact-head verification

- Exact head `0fb58bae3826db0be0df88e50155e4bddd189409`, rebased onto current main `669d1e9b`.
- Current-main rebase proof: all 261 `StatusMenu` tests and all 5 `UsageStoreManualTokenRefreshTests` passed.
- Prior exact-head proof before the clean current-main rebase: `make test` all 41 groups / 492 selections green.
- `make check`: green; 0 formatting changes and 0 lint violations.
- Final current-main whole-branch autoreview: clean (0.82).
- Ad-hoc package and CLI config validation: green.

Regression coverage includes separate-provider mouse and Command-R refresh scope, merged Overview/global behavior, omitted-provider Overview busy/suppression behavior, merged selected-provider scope, global singleton-task busy state, unrelated-provider refresh isolation, same-provider forced token-work draining and throttle cleanup, cross-menu/manual-refresh delayed-prewarm retries, and Codex reconciliation after dashboard login expires.

Co-authored with @jangisaac-dev.
