### PR TITLE
feat: read-only imported (cliproxyapi) codex accounts + multi-account menu-bar gauge

### DIFF
--- a/Sources/CodexBar/CodexAccountMenuPresentation.swift
+++ b/Sources/CodexBar/CodexAccountMenuPresentation.swift
@@ -3,6 +3,7 @@ import Foundation
 
 enum CodexAccountHealth: Equatable {
     case ok
+    case importedCredentialExpired
     case needsReauth
     case workspaceDeactivated
     case missingAuth
@@ -12,6 +13,8 @@ enum CodexAccountHealth: Equatable {
         switch self {
         case .ok:
             nil
+        case .importedCredentialExpired:
+            "Imported Codex credential expired. Refresh it in the source tool."
         case .needsReauth:
             "Needs re-auth"
         case .workspaceDeactivated:
@@ -35,6 +38,9 @@ enum CodexAccountHealth: Equatable {
 
     static func status(forError error: String) -> CodexAccountHealth {
         let normalized = error.lowercased()
+        if normalized.contains("imported"), normalized.contains("credential"), normalized.contains("expired") {
+            return .importedCredentialExpired
+        }
         if normalized.contains("deactivated") {
             return .workspaceDeactivated
         }

--- a/Sources/CodexBar/IconRenderer.swift
+++ b/Sources/CodexBar/IconRenderer.swift
@@ -129,8 +129,12 @@ enum IconRenderer {
                 let trackStrokeAlpha: CGFloat = stale ? 0.28 : 0.44
                 let fillColor = baseFill.withAlphaComponent(stale ? 0.55 : 1.0)
 
-                let barWidthPx = 30 // 15 pt at 2×, uses the slot better without touching edges.
-                let barXPx = (Self.canvasPx - barWidthPx) / 2
+                let baseBarWidthPx = 30 // 15 pt at 2×, uses the slot better without touching edges.
+                // When a status badge is present, reserve a right-edge gutter so the badge does not
+                // merge visually with the bottom usage bar fill.
+                let statusBadgeGutterPx = statusIndicator.hasIssue ? 4 : 0
+                let barWidthPx = baseBarWidthPx - statusBadgeGutterPx
+                let barXPx = (Self.canvasPx - baseBarWidthPx) / 2
 
                 func drawBar(
                     rectPx: RectPx,
@@ -938,30 +942,34 @@ enum IconRenderer {
 
         switch indicator {
         case .minor, .maintenance:
-            let size: CGFloat = 4
-            let rect = Self.snapRect(
-                x: Self.baseSize.width - size - 2,
-                y: 2,
-                width: size,
-                height: size)
+            // Pixel-space badge in the reserved right gutter (bars stop at x=29px when a badge shows).
+            let rect = Self.grid.rect(
+                x: Self.canvasPx - 5,
+                y: 3,
+                w: 4,
+                h: 4)
             let path = NSBezierPath(ovalIn: rect)
             color.setFill()
             path.fill()
         case .major, .critical, .unknown:
-            let lineRect = Self.snapRect(
-                x: Self.baseSize.width - 6,
-                y: 4,
-                width: 2.0,
-                height: 6)
-            let linePath = NSBezierPath(roundedRect: lineRect, xRadius: 1, yRadius: 1)
+            // Keep the exclamation mark in the same right gutter, outside both bars.
+            let lineRect = Self.grid.rect(
+                x: Self.canvasPx - 5,
+                y: 7,
+                w: 2,
+                h: 6)
+            let linePath = NSBezierPath(
+                roundedRect: lineRect,
+                xRadius: Self.grid.pt(1),
+                yRadius: Self.grid.pt(1))
             color.setFill()
             linePath.fill()
 
-            let dotRect = Self.snapRect(
-                x: Self.baseSize.width - 6,
-                y: 2,
-                width: 2.0,
-                height: 2.0)
+            let dotRect = Self.grid.rect(
+                x: Self.canvasPx - 5,
+                y: 3,
+                w: 2,
+                h: 2)
             NSBezierPath(ovalIn: dotRect).fill()
         case .none:
             break

--- a/Sources/CodexBar/ImportedCodexAccountsMenuView.swift
+++ b/Sources/CodexBar/ImportedCodexAccountsMenuView.swift
@@ -1,0 +1,200 @@
+import CodexBarCore
+import SwiftUI
+
+struct ImportedCodexAccountsMenuView: View {
+    struct Model {
+        struct Row: Identifiable {
+            let id: String
+            let email: String
+            let sourceLabel: String
+            let metrics: [Metric]
+            let statusText: String?
+        }
+
+        struct Metric: Identifiable {
+            let id: String
+            let title: String
+            let percent: Double
+            let percentText: String
+        }
+
+        let rows: [Row]
+        let averageUsedPercent: Double?
+
+        static func make(
+            snapshots: [ImportedCodexAccountUsageSnapshot],
+            showUsed: Bool)
+            -> Model
+        {
+            let metadata = ProviderDescriptorRegistry.descriptor(for: .codex).metadata
+            let rows = snapshots.map { imported in
+                let metrics = imported.snapshot.map {
+                    Self.metrics(snapshot: $0, metadata: metadata, showUsed: showUsed)
+                } ?? []
+                let health = imported.error.map(CodexAccountHealth.status(forError:))
+                return Row(
+                    id: imported.id,
+                    email: imported.account.email,
+                    sourceLabel: imported.sourceLabel ?? L("Imported"),
+                    metrics: metrics,
+                    statusText: health?.label ?? imported.error)
+            }
+            let averageWindows = snapshots.compactMap { imported in
+                Self.firstVisibleWindow(snapshot: imported.snapshot)
+            }
+            let average = averageWindows.isEmpty
+                ? nil
+                : averageWindows.map(\.usedPercent).reduce(0, +) / Double(averageWindows.count)
+            return Model(rows: rows, averageUsedPercent: average)
+        }
+
+        private static func metrics(
+            snapshot: UsageSnapshot,
+            metadata: ProviderMetadata,
+            showUsed: Bool)
+            -> [Metric]
+        {
+            let projection = Self.projection(snapshot: snapshot)
+            return projection.visibleRateLanes.compactMap { lane in
+                guard let window = projection.rateWindow(for: lane) else { return nil }
+                let title = switch lane {
+                case .session:
+                    L(metadata.sessionLabel)
+                case .weekly:
+                    L(metadata.weeklyLabel)
+                }
+                let percent = showUsed ? window.usedPercent : window.remainingPercent
+                return Metric(
+                    id: lane.rawValue,
+                    title: title,
+                    percent: min(100, max(0, percent)),
+                    percentText: String(format: "%.0f%%", min(100, max(0, percent))))
+            }
+        }
+
+        private static func firstVisibleWindow(snapshot: UsageSnapshot?) -> RateWindow? {
+            guard let snapshot else { return nil }
+            let projection = Self.projection(snapshot: snapshot)
+            return projection.visibleRateLanes
+                .lazy
+                .compactMap { projection.rateWindow(for: $0) }
+                .first
+        }
+
+        private static func projection(snapshot: UsageSnapshot) -> CodexConsumerProjection {
+            CodexConsumerProjection.make(
+                surface: .menuBar,
+                context: CodexConsumerProjection.Context(
+                    snapshot: snapshot,
+                    rawUsageError: nil,
+                    liveCredits: nil,
+                    rawCreditsError: nil,
+                    liveDashboard: nil,
+                    rawDashboardError: nil,
+                    dashboardAttachmentAuthorized: false,
+                    dashboardRequiresLogin: false,
+                    now: snapshot.updatedAt))
+        }
+    }
+
+    let model: Model
+    let width: CGFloat
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Imported (\(self.model.rows.count))")
+                    .font(.body.weight(.semibold))
+                Spacer(minLength: 8)
+                if let average = self.model.averageUsedPercent {
+                    Text(String(format: "avg %.0f%%", average))
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(self.model.rows) { row in
+                    ImportedCodexAccountMiniRow(row: row)
+                }
+            }
+        }
+        .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
+        .padding(.top, UsageMenuCardLayout.sectionTopPadding)
+        .padding(.bottom, UsageMenuCardLayout.sectionBottomPadding)
+        .frame(width: self.width, alignment: .leading)
+    }
+}
+
+private struct ImportedCodexAccountMiniRow: View {
+    let row: ImportedCodexAccountsMenuView.Model.Row
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(alignment: .firstTextBaseline, spacing: 5) {
+                Text(self.row.email)
+                    .font(.caption.weight(.medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(self.row.sourceLabel)
+                    .font(.caption)
+                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            if let statusText = self.row.statusText {
+                Text(statusText)
+                    .font(.caption2)
+                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    .lineLimit(2)
+            } else {
+                HStack(alignment: .center, spacing: 8) {
+                    ForEach(self.row.metrics.prefix(2)) { metric in
+                        ImportedCodexAccountMiniMetric(metric: metric)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct ImportedCodexAccountMiniMetric: View {
+    let metric: ImportedCodexAccountsMenuView.Model.Metric
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 4) {
+            Text(self.metric.title)
+                .font(.caption2)
+                .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                .lineLimit(1)
+                .frame(minWidth: 34, alignment: .leading)
+            ImportedCodexMiniGauge(percent: self.metric.percent)
+                .frame(width: 38, height: 4)
+            Text(self.metric.percentText)
+                .font(.caption2.monospacedDigit())
+                .lineLimit(1)
+                .frame(width: 32, alignment: .trailing)
+        }
+    }
+}
+
+private struct ImportedCodexMiniGauge: View {
+    let percent: Double
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.secondary.opacity(0.22))
+                Capsule()
+                    .fill(UsageMenuCardView.Model.progressColor(for: .codex))
+                    .frame(width: proxy.size.width * CGFloat(min(100, max(0, self.percent)) / 100))
+            }
+        }
+    }
+}

--- a/Sources/CodexBar/MenuContent.swift
+++ b/Sources/CodexBar/MenuContent.swift
@@ -182,23 +182,26 @@ struct StatusIconView: View {
 
     private var accessibilityValue: String {
         let snapshot = self.store.snapshot(for: self.provider)
-        guard let snap = snapshot else {
-            return L("No data")
+        let percents = self.store.menuBarIconPercents(
+            for: self.provider,
+            snapshot: snapshot,
+            style: self.store.style(for: self.provider),
+            showUsed: false)
+        guard let primary = percents.primary else {
+            return snapshot == nil ? L("No data") : L("Unknown")
         }
-        let remaining = IconRemainingResolver.resolvedRemaining(
-            snapshot: snap,
-            style: self.store.style(for: self.provider))
-        let primary = remaining.primary
-        let percent = primary.map { String(format: L("%d percent remaining"), Int($0 * 100)) } ?? L("Unknown")
+        let percent = String(format: L("%d percent remaining"), Int(primary))
         let stale = self.store.isStale(provider: self.provider)
         return stale ? "\(percent), \(L("stale data"))" : percent
     }
 
     private var icon: NSImage {
         let snapshot = self.store.snapshot(for: self.provider)
-        let remaining = snapshot.map {
-            IconRemainingResolver.resolvedRemaining(snapshot: $0, style: self.store.style(for: self.provider))
-        }
+        let remaining = self.store.menuBarIconPercents(
+            for: self.provider,
+            snapshot: snapshot,
+            style: self.store.style(for: self.provider),
+            showUsed: false)
         let creditsProjection = self.store.codexConsumerProjectionIfNeeded(
             for: self.provider,
             surface: .menuBar,
@@ -210,8 +213,8 @@ struct StatusIconView: View {
                 now: snapshot?.updatedAt ?? Date())
             : nil
         return IconRenderer.makeIcon(
-            primaryRemaining: remaining?.primary,
-            weeklyRemaining: remaining?.secondary,
+            primaryRemaining: remaining.primary,
+            weeklyRemaining: remaining.secondary,
             creditsRemaining: creditsRemaining,
             stale: self.store.isStale(provider: self.provider),
             style: self.store.style(for: self.provider),

--- a/Sources/CodexBar/PreferencesImportedCredentialsSection.swift
+++ b/Sources/CodexBar/PreferencesImportedCredentialsSection.swift
@@ -1,0 +1,196 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+
+@MainActor
+struct ImportedCredentialsSectionView: View {
+    @Bindable var settings: SettingsStore
+    @Bindable var store: UsageStore
+    @State private var selectedPlatform = UsageProvider.codex.rawValue
+    @State private var selectedFormat = CLIProxyCodexAdapter.format
+
+    var body: some View {
+        ProviderSettingsSection(title: L("Imported Credentials")) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline, spacing: 10) {
+                    Text(L("Platform"))
+                        .font(.subheadline.weight(.semibold))
+                        .frame(width: ProviderSettingsMetrics.pickerLabelWidth, alignment: .leading)
+
+                    Picker("", selection: self.$selectedPlatform) {
+                        Text("Codex").tag(UsageProvider.codex.rawValue)
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .controlSize(.small)
+
+                    Spacer(minLength: 0)
+                }
+
+                HStack(alignment: .firstTextBaseline, spacing: 10) {
+                    Text(L("Format"))
+                        .font(.subheadline.weight(.semibold))
+                        .frame(width: ProviderSettingsMetrics.pickerLabelWidth, alignment: .leading)
+
+                    Picker("", selection: self.$selectedFormat) {
+                        Text(CLIProxyCodexAdapter.format).tag(CLIProxyCodexAdapter.format)
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .controlSize(.small)
+
+                    Spacer(minLength: 0)
+                }
+
+                Button(L("Add Source…")) {
+                    self.addSource()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            let sources = self.settings.importedCodexCredentialSources
+            if sources.isEmpty {
+                Text(L("No imported credential sources added."))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(sources) { source in
+                        ImportedCredentialSourceRowView(
+                            source: source,
+                            remove: {
+                                self.settings.removeImportedCredentialSource(id: source.id)
+                                Task { @MainActor in
+                                    await self.store.refreshImportedCodexAccounts()
+                                }
+                            })
+                    }
+                }
+            }
+        }
+    }
+
+    private func addSource() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = true
+        panel.canCreateDirectories = false
+        panel.title = L("Add Imported Credential Source")
+        panel.prompt = L("Add")
+
+        guard panel.runModal() == .OK else { return }
+        var knownPaths = Set(self.settings.importedCodexCredentialSources.map {
+            URL(fileURLWithPath: $0.path).standardizedFileURL.path
+        })
+        var didAddSource = false
+        for url in panel.urls {
+            let path = url.standardizedFileURL.path
+            guard knownPaths.insert(path).inserted else { continue }
+            self.settings.addImportedCredentialSource(ImportedCredentialSource(
+                platform: self.selectedPlatform,
+                path: path,
+                format: self.selectedFormat))
+            didAddSource = true
+        }
+
+        guard didAddSource else { return }
+        Task { @MainActor in
+            await self.store.refreshImportedCodexAccounts()
+        }
+    }
+}
+
+@MainActor
+private struct ImportedCredentialSourceRowView: View {
+    let source: ImportedCredentialSource
+    let remove: () -> Void
+    @State private var previews: [CLIProxyCodexAccountPreview] = []
+    @State private var didLoad = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(self.title)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(self.source.path)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                Spacer(minLength: 8)
+
+                Button(L("Remove")) {
+                    self.remove()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            if self.didLoad {
+                if self.previews.isEmpty {
+                    Text(L("No Codex accounts detected."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    VStack(alignment: .leading, spacing: 3) {
+                        ForEach(self.previews) { preview in
+                            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                                Text(preview.email)
+                                    .font(.caption)
+                                Text(self.statusText(for: preview))
+                                    .font(.caption)
+                                    .foregroundStyle(self.statusColor(for: preview))
+                            }
+                        }
+                    }
+                }
+            } else {
+                Text(L("Checking accounts…"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .task(id: self.source.path) {
+            await self.reloadPreview()
+        }
+    }
+
+    private var title: String {
+        if let label = self.source.label?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !label.isEmpty
+        {
+            return label
+        }
+        let lastPath = URL(fileURLWithPath: self.source.path).lastPathComponent
+        return lastPath.isEmpty ? self.source.path : lastPath
+    }
+
+    private func reloadPreview() async {
+        let path = self.source.path
+        let now = Date()
+        let previews = await Task.detached(priority: .utility) {
+            CLIProxyCodexAdapter.previewAccounts(from: path, now: now)
+        }.value
+        self.previews = previews
+        self.didLoad = true
+    }
+
+    private func statusText(for preview: CLIProxyCodexAccountPreview) -> String {
+        if preview.isDisabled { return L("Disabled") }
+        if preview.isExpired { return L("Expired") }
+        return L("Ready")
+    }
+
+    private func statusColor(for preview: CLIProxyCodexAccountPreview) -> Color {
+        if preview.isDisabled { return .secondary }
+        if preview.isExpired { return .orange }
+        return .secondary
+    }
+}

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -111,6 +111,7 @@ struct ProvidersPane: View {
                                         await self.addManagedCodexAccount()
                                     }
                                 })
+                            ImportedCredentialsSectionView(settings: self.settings, store: self.store)
                         }
                     })
             } else {

--- a/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
+++ b/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
@@ -34,7 +34,7 @@ private struct ConfigChangeContext {
 }
 
 extension SettingsStore {
-    private func updateConfig(reason: String, mutate: (inout CodexBarConfig) -> Void) {
+    func updateConfig(reason: String, mutate: (inout CodexBarConfig) -> Void) {
         guard !self.configLoading else { return }
         var config = self.config
         mutate(&config)

--- a/Sources/CodexBar/SettingsStore+ImportedCredentials.swift
+++ b/Sources/CodexBar/SettingsStore+ImportedCredentials.swift
@@ -1,0 +1,23 @@
+import CodexBarCore
+import Foundation
+
+extension SettingsStore {
+    var importedCodexCredentialSources: [ImportedCredentialSource] {
+        self.configSnapshot.importedCredentialSources.filter { source in
+            source.platform == UsageProvider.codex.rawValue &&
+                source.format == CLIProxyCodexAdapter.format
+        }
+    }
+
+    func addImportedCredentialSource(_ source: ImportedCredentialSource) {
+        self.updateConfig(reason: "imported-credential-source-add") { config in
+            config.importedCredentialSources.append(source)
+        }
+    }
+
+    func removeImportedCredentialSource(id: UUID) {
+        self.updateConfig(reason: "imported-credential-source-remove") { config in
+            config.importedCredentialSources.removeAll { $0.id == id }
+        }
+    }
+}

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -244,14 +244,13 @@ extension StatusItemController {
 
         // IconRenderer treats these values as a left-to-right "progress fill" percentage; depending on the
         // user setting we pass either "percent left" or "percent used".
-        let resolved = snapshot.map {
-            IconRemainingResolver.resolvedPercents(
-                snapshot: $0,
-                style: style,
-                showUsed: showUsed)
-        }
-        var primary = resolved?.primary
-        var weekly = resolved?.secondary
+        let resolved = self.store.menuBarIconPercents(
+            for: primaryProvider,
+            snapshot: snapshot,
+            style: style,
+            showUsed: showUsed)
+        var primary = resolved.primary
+        var weekly = resolved.secondary
         if showUsed,
            primaryProvider == .warp,
            let remaining = snapshot?.secondary?.remainingPercent,
@@ -451,14 +450,13 @@ extension StatusItemController {
         self.setButtonTitle(nil, for: button)
 
         // OpenRouter always gets a meter here — the brand-logo fallback was removed on purpose.
-        let resolved = snapshot.map {
-            IconRemainingResolver.resolvedPercents(
-                snapshot: $0,
-                style: style,
-                showUsed: showUsed)
-        }
-        var primary = resolved?.primary
-        var weekly = resolved?.secondary
+        let resolved = self.store.menuBarIconPercents(
+            for: provider,
+            snapshot: snapshot,
+            style: style,
+            showUsed: showUsed)
+        var primary = resolved.primary
+        var weekly = resolved.secondary
         if showUsed,
            provider == .warp,
            let remaining = snapshot?.secondary?.remainingPercent,
@@ -702,6 +700,7 @@ extension StatusItemController {
 
         if mode == .percent,
            !self.settings.usageBarsShowUsed,
+           self.store.importedCodexMenuBarMetricWindows().isEmpty,
            codexProjection?.menuBarFallback == .creditsBalance,
            let creditsRemaining = codexProjection?.credits?.remaining,
            creditsRemaining > 0

--- a/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
+++ b/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CodexBarCore
 
 extension StatusItemController {
     func addStackedCodexMenuCards(
@@ -46,6 +47,7 @@ extension StatusItemController {
             }
         }
 
+        var didAddCards = cardIndex > 0
         if cardIndex == 0, let model = self.menuCardModel(for: context.selectedProvider) {
             menu.addItem(self.makeMenuCardItem(
                 UsageMenuCardView(model: model, width: context.menuWidth),
@@ -53,11 +55,61 @@ extension StatusItemController {
                 width: context.menuWidth,
                 heightCacheScope: context.currentProvider.rawValue,
                 heightCacheFingerprint: model.heightFingerprint(section: "card")))
+            didAddCards = true
         }
-        menu.addItem(.separator())
+        if didAddCards {
+            menu.addItem(.separator())
+        }
+        if self.addImportedCodexMenuCards(to: menu, context: context) {
+            menu.addItem(.separator())
+        }
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
             menu.addItem(.separator())
         }
+    }
+
+    func addImportedCodexMenuCards(to menu: NSMenu, context: MenuCardContext) -> Bool {
+        guard context.currentProvider == .codex else { return false }
+        let snapshots = self.store.importedCodexAccountSnapshots
+        guard !snapshots.isEmpty else { return false }
+
+        let model = ImportedCodexAccountsMenuView.Model.make(
+            snapshots: snapshots,
+            showUsed: self.settings.usageBarsShowUsed)
+        menu.addItem(self.makeMenuCardItem(
+            ImportedCodexAccountsMenuView(model: model, width: context.menuWidth),
+            id: "importedCodexAccountsMenuCard",
+            width: context.menuWidth,
+            heightCacheScope: "imported-codex-accounts",
+            heightCacheFingerprint: self.importedCodexAccountsHeightFingerprint(model: model)))
+        return true
+    }
+
+    private func importedCodexAccountsHeightFingerprint(model: ImportedCodexAccountsMenuView.Model) -> String {
+        let rowFingerprints = model.rows.map { row in
+            let metricFingerprint = row.metrics.map { metric in
+                [
+                    metric.id,
+                    UsageMenuCardView.Model.heightFingerprintField("title", metric.title),
+                    "percent=\(Int(metric.percent.rounded()))",
+                    UsageMenuCardView.Model.heightFingerprintField("percentText", metric.percentText),
+                ].joined(separator: "|")
+            }.joined(separator: ";")
+            return [
+                row.id,
+                UsageMenuCardView.Model.heightFingerprintField("email", row.email),
+                UsageMenuCardView.Model.heightFingerprintField("source", row.sourceLabel),
+                UsageMenuCardView.Model.heightFingerprintField("status", row.statusText),
+                "metrics=\(metricFingerprint)",
+            ].joined(separator: "|")
+        }.joined(separator: "||")
+        return [
+            "section=imported-codex-accounts",
+            "localization=\(codexBarLocalizationSignature())",
+            "rows=\(model.rows.count)",
+            "avg=\(model.averageUsedPercent.map { Int($0.rounded()) } ?? -1)",
+            rowFingerprints,
+        ].joined(separator: "|")
     }
 
     private func addCodexWorkspaceHeader(_ title: String, index: Int, to menu: NSMenu) {

--- a/Sources/CodexBar/StatusItemController+IconObservation.swift
+++ b/Sources/CodexBar/StatusItemController+IconObservation.swift
@@ -37,20 +37,19 @@ extension StatusItemController {
     private func providerStoreIconObservationSignature(for provider: UsageProvider, showBrandPercent: Bool) -> String {
         let snapshot = self.store.snapshot(for: provider)
         let style = self.store.style(for: provider)
-        let resolved = snapshot.map {
-            IconRemainingResolver.resolvedPercents(
-                snapshot: $0,
-                style: style,
-                showUsed: self.settings.usageBarsShowUsed)
-        }
+        let resolved = self.store.menuBarIconPercents(
+            for: provider,
+            snapshot: snapshot,
+            style: style,
+            showUsed: self.settings.usageBarsShowUsed)
         let creditsRemaining = self.menuBarCreditsRemainingForIcon(provider: provider, snapshot: snapshot)
         let displayText = showBrandPercent ? self.menuBarDisplayText(for: provider, snapshot: snapshot) : nil
 
         return [
             provider.rawValue,
             "style=\(style.rawValue)",
-            "primary=\(Self.iconSignatureValue(resolved?.primary))",
-            "weekly=\(Self.iconSignatureValue(resolved?.secondary))",
+            "primary=\(Self.iconSignatureValue(resolved.primary))",
+            "weekly=\(Self.iconSignatureValue(resolved.secondary))",
             "credits=\(Self.iconSignatureValue(creditsRemaining))",
             "stale=\(self.store.isStale(provider: provider) ? "1" : "0")",
             "status=\(self.store.statusIndicator(for: provider).rawValue)",

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -689,6 +689,12 @@ extension StatusItemController {
                 provider: context.currentProvider,
                 width: context.menuWidth,
                 webItems: webItems)
+            if context.currentProvider == .codex, !self.store.importedCodexAccountSnapshots.isEmpty {
+                menu.addItem(.separator())
+            }
+            if self.addImportedCodexMenuCards(to: menu, context: context) {
+                menu.addItem(.separator())
+            }
             return true
         }
 
@@ -698,13 +704,16 @@ extension StatusItemController {
             width: context.menuWidth,
             heightCacheScope: context.currentProvider.rawValue,
             heightCacheFingerprint: model.heightFingerprint(section: "card")))
+        menu.addItem(.separator())
+        if self.addImportedCodexMenuCards(to: menu, context: context) {
+            menu.addItem(.separator())
+        }
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
             menu.addItem(.separator())
         }
         if context.openAIContext.canShowBuyCredits {
             menu.addItem(self.makeBuyCreditsItem())
         }
-        menu.addItem(.separator())
         return false
     }
 
@@ -1368,14 +1377,13 @@ extension StatusItemController {
         let snapshot = self.store.snapshot(for: provider)
         let showUsed = self.settings.usageBarsShowUsed
         let style = self.store.style(for: provider)
-        let resolved = snapshot.map {
-            IconRemainingResolver.resolvedPercents(
-                snapshot: $0,
-                style: style,
-                showUsed: showUsed)
-        }
-        let primary = resolved?.primary
-        var weekly = resolved?.secondary
+        let resolved = self.store.menuBarIconPercents(
+            for: provider,
+            snapshot: snapshot,
+            style: style,
+            showUsed: showUsed)
+        let primary = resolved.primary
+        var weekly = resolved.secondary
         if showUsed,
            provider == .warp,
            let remaining = snapshot?.secondary?.remainingPercent,

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -300,52 +300,13 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
     func menuBarMetricWindow(for provider: UsageProvider, snapshot: UsageSnapshot?) -> RateWindow? {
         if provider == .codex {
-            return self.codexMenuBarMetricWindow(snapshot: snapshot)
+            return self.store.codexMenuBarMetricWindowIncludingImported(activeSnapshot: snapshot)
         }
         return MenuBarMetricWindowResolver.rateWindow(
             preference: self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot),
             provider: provider,
             snapshot: snapshot,
             supportsAverage: self.settings.menuBarMetricSupportsAverage(for: provider))
-    }
-
-    private func codexMenuBarMetricWindow(snapshot: UsageSnapshot?) -> RateWindow? {
-        guard let snapshot else { return nil }
-        let projection = CodexConsumerProjection.make(
-            surface: .menuBar,
-            context: CodexConsumerProjection.Context(
-                snapshot: snapshot,
-                rawUsageError: nil,
-                liveCredits: self.store.credits,
-                rawCreditsError: self.store.lastCreditsError,
-                liveDashboard: self.store.openAIDashboard,
-                rawDashboardError: self.store.lastOpenAIDashboardError,
-                dashboardAttachmentAuthorized: self.store.openAIDashboardAttachmentAuthorized,
-                dashboardRequiresLogin: self.store.openAIDashboardRequiresLogin,
-                now: snapshot.updatedAt))
-        let lanes = projection.visibleRateLanes
-        let first = lanes.first.flatMap { projection.rateWindow(for: $0) }
-        let second = lanes.dropFirst().first.flatMap { projection.rateWindow(for: $0) }
-        let preference = self.settings.menuBarMetricPreference(for: .codex, snapshot: snapshot)
-
-        switch preference {
-        case .secondary, .tertiary:
-            return second ?? first
-        case .extraUsage:
-            return first
-        case .average:
-            guard self.settings.menuBarMetricSupportsAverage(for: .codex),
-                  let primary = first,
-                  let secondary = second
-            else {
-                return first
-            }
-            let usedPercent = (primary.usedPercent + secondary.usedPercent) / 2
-            return RateWindow(
-                usedPercent: usedPercent, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
-        case .automatic, .primary:
-            return first
-        }
     }
 
     init(

--- a/Sources/CodexBar/UsageStore+CodexMenuBarMetric.swift
+++ b/Sources/CodexBar/UsageStore+CodexMenuBarMetric.swift
@@ -1,0 +1,132 @@
+import CodexBarCore
+import Foundation
+
+enum CodexMenuBarMetricAverage {
+    static func averageWindow(active: RateWindow?, imported: [RateWindow]) -> RateWindow? {
+        let windows = [active].compactMap(\.self) + imported
+        guard !windows.isEmpty else { return nil }
+        guard windows.count > 1 else { return windows[0] }
+
+        let usedPercent = windows.map(\.usedPercent).reduce(0, +) / Double(windows.count)
+        return RateWindow(usedPercent: usedPercent, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
+    }
+}
+
+@MainActor
+extension UsageStore {
+    func codexMenuBarMetricWindowIncludingImported(activeSnapshot: UsageSnapshot?) -> RateWindow? {
+        let importedWindows = self.importedCodexMenuBarMetricWindows()
+        guard !importedWindows.isEmpty else {
+            return MenuBarMetricWindowResolver.rateWindow(
+                preference: self.settings.menuBarMetricPreference(for: .codex, snapshot: activeSnapshot),
+                provider: .codex,
+                snapshot: activeSnapshot,
+                supportsAverage: self.settings.menuBarMetricSupportsAverage(for: .codex))
+        }
+
+        let activeWindow = self.codexMenuBarMetricWindow(snapshot: activeSnapshot, includeLiveAdjuncts: true)
+        return CodexMenuBarMetricAverage.averageWindow(active: activeWindow, imported: importedWindows)
+    }
+
+    func menuBarIconPercents(
+        for provider: UsageProvider,
+        snapshot: UsageSnapshot?,
+        style: IconStyle,
+        showUsed: Bool)
+        -> (primary: Double?, secondary: Double?)
+    {
+        if provider == .codex {
+            let importedWindows = self.importedCodexMenuBarMetricWindows()
+            if !importedWindows.isEmpty,
+               let window = CodexMenuBarMetricAverage.averageWindow(
+                   active: self.codexMenuBarMetricWindow(snapshot: snapshot, includeLiveAdjuncts: true),
+                   imported: importedWindows)
+            {
+                return (
+                    primary: showUsed ? window.usedPercent : window.remainingPercent,
+                    secondary: nil)
+            }
+        }
+
+        guard let snapshot else { return (primary: nil, secondary: nil) }
+        return IconRemainingResolver.resolvedPercents(
+            snapshot: snapshot,
+            style: style,
+            showUsed: showUsed)
+    }
+
+    func importedCodexMenuBarMetricWindows() -> [RateWindow] {
+        self.importedCodexAccountSnapshots.compactMap { imported in
+            self.codexMenuBarMetricWindow(snapshot: imported.snapshot, includeLiveAdjuncts: false)
+        }
+    }
+
+    func codexMenuBarMetricWindow(
+        snapshot: UsageSnapshot?,
+        includeLiveAdjuncts: Bool)
+        -> RateWindow?
+    {
+        guard let snapshot else { return nil }
+        let projection = self.codexMenuBarProjection(snapshot: snapshot, includeLiveAdjuncts: includeLiveAdjuncts)
+        return Self.codexMenuBarMetricWindow(
+            projection: projection,
+            preference: self.settings.menuBarMetricPreference(for: .codex, snapshot: snapshot),
+            supportsAverage: self.settings.menuBarMetricSupportsAverage(for: .codex))
+    }
+
+    private func codexMenuBarProjection(
+        snapshot: UsageSnapshot,
+        includeLiveAdjuncts: Bool)
+        -> CodexConsumerProjection
+    {
+        CodexConsumerProjection.make(
+            surface: .menuBar,
+            context: CodexConsumerProjection.Context(
+                snapshot: snapshot,
+                rawUsageError: nil,
+                liveCredits: includeLiveAdjuncts ? self.credits : nil,
+                rawCreditsError: includeLiveAdjuncts ? self.lastCreditsError : nil,
+                liveDashboard: includeLiveAdjuncts ? self.openAIDashboard : nil,
+                rawDashboardError: includeLiveAdjuncts ? self.lastOpenAIDashboardError : nil,
+                dashboardAttachmentAuthorized: includeLiveAdjuncts
+                    ? self.openAIDashboardAttachmentAuthorized
+                    : false,
+                dashboardRequiresLogin: includeLiveAdjuncts
+                    ? self.openAIDashboardRequiresLogin
+                    : false,
+                now: snapshot.updatedAt))
+    }
+
+    private static func codexMenuBarMetricWindow(
+        projection: CodexConsumerProjection,
+        preference: MenuBarMetricPreference,
+        supportsAverage: Bool)
+        -> RateWindow?
+    {
+        let lanes = projection.visibleRateLanes
+        let first = lanes.first.flatMap { projection.rateWindow(for: $0) }
+        let second = lanes.dropFirst().first.flatMap { projection.rateWindow(for: $0) }
+
+        switch preference {
+        case .secondary, .tertiary:
+            return second ?? first
+        case .extraUsage:
+            return first
+        case .average:
+            guard supportsAverage,
+                  let primary = first,
+                  let secondary = second
+            else {
+                return first
+            }
+            let usedPercent = (primary.usedPercent + secondary.usedPercent) / 2
+            return RateWindow(
+                usedPercent: usedPercent,
+                windowMinutes: nil,
+                resetsAt: nil,
+                resetDescription: nil)
+        case .automatic, .primary:
+            return first
+        }
+    }
+}

--- a/Sources/CodexBar/UsageStore+CodexMenuBarMetric.swift
+++ b/Sources/CodexBar/UsageStore+CodexMenuBarMetric.swift
@@ -36,15 +36,12 @@ extension UsageStore {
         -> (primary: Double?, secondary: Double?)
     {
         if provider == .codex {
-            let importedWindows = self.importedCodexMenuBarMetricWindows()
-            if !importedWindows.isEmpty,
-               let window = CodexMenuBarMetricAverage.averageWindow(
-                   active: self.codexMenuBarMetricWindow(snapshot: snapshot, includeLiveAdjuncts: true),
-                   imported: importedWindows)
-            {
-                return (
-                    primary: showUsed ? window.usedPercent : window.remainingPercent,
-                    secondary: nil)
+            let importedSnapshots = self.importedCodexAccountSnapshots.compactMap(\.snapshot)
+            if !importedSnapshots.isEmpty {
+                return Self.codexMenuBarIconPercentsIncludingImported(
+                    activeSnapshot: snapshot,
+                    importedSnapshots: importedSnapshots,
+                    showUsed: showUsed)
             }
         }
 
@@ -128,5 +125,28 @@ extension UsageStore {
         case .automatic, .primary:
             return first
         }
+    }
+
+    private static func codexMenuBarIconPercentsIncludingImported(
+        activeSnapshot: UsageSnapshot?,
+        importedSnapshots: [UsageSnapshot],
+        showUsed: Bool)
+        -> (primary: Double?, secondary: Double?)
+    {
+        let windows = ([activeSnapshot].compactMap(\.self) + importedSnapshots).map {
+            IconRemainingResolver.resolvedWindows(snapshot: $0, style: .codex)
+        }
+        return (
+            primary: self.averagePercent(windows.compactMap {
+                showUsed ? $0.primary?.usedPercent : $0.primary?.remainingPercent
+            }),
+            secondary: self.averagePercent(windows.compactMap {
+                showUsed ? $0.secondary?.usedPercent : $0.secondary?.remainingPercent
+            }))
+    }
+
+    private static func averagePercent(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / Double(values.count)
     }
 }

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -8,9 +8,12 @@ extension UsageStore {
     func providerWithHighestUsage() -> (provider: UsageProvider, usedPercent: Double)? {
         var highest: (provider: UsageProvider, usedPercent: Double)?
         for provider in self.enabledProviders() {
-            guard let snapshot = self.snapshots[provider] else { continue }
+            let snapshot = self.snapshots[provider]
+            if provider != .codex, snapshot == nil { continue }
             let window = self.menuBarMetricWindowForHighestUsage(provider: provider, snapshot: snapshot)
+            if provider == .codex, snapshot == nil, window == nil { continue }
             let percent = window?.usedPercent ?? 0
+            if provider == .codex, !percent.isFinite { continue }
             guard !self.shouldExcludeFromHighestUsage(
                 provider: provider,
                 snapshot: snapshot,
@@ -25,8 +28,12 @@ extension UsageStore {
         return highest
     }
 
-    private func menuBarMetricWindowForHighestUsage(provider: UsageProvider, snapshot: UsageSnapshot) -> RateWindow? {
-        MenuBarMetricWindowResolver.rateWindow(
+    private func menuBarMetricWindowForHighestUsage(provider: UsageProvider, snapshot: UsageSnapshot?) -> RateWindow? {
+        if provider == .codex {
+            return self.codexMenuBarMetricWindowIncludingImported(activeSnapshot: snapshot)
+        }
+        guard let snapshot else { return nil }
+        return MenuBarMetricWindowResolver.rateWindow(
             preference: self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot),
             provider: provider,
             snapshot: snapshot,
@@ -35,7 +42,7 @@ extension UsageStore {
 
     private func shouldExcludeFromHighestUsage(
         provider: UsageProvider,
-        snapshot: UsageSnapshot,
+        snapshot: UsageSnapshot?,
         metricPercent: Double)
         -> Bool
     {
@@ -43,8 +50,8 @@ extension UsageStore {
         guard metricPercent >= 100 else { return false }
         if provider == .copilot,
            effectivePreference == .automatic,
-           let primary = snapshot.primary,
-           let secondary = snapshot.secondary
+           let primary = snapshot?.primary,
+           let secondary = snapshot?.secondary
         {
             // In automatic mode Copilot can have one depleted lane while another still has quota.
             return primary.usedPercent >= 100 && secondary.usedPercent >= 100
@@ -53,9 +60,9 @@ extension UsageStore {
            effectivePreference == .automatic
         {
             let percents = [
-                snapshot.primary?.usedPercent,
-                snapshot.secondary?.usedPercent,
-                snapshot.tertiary?.usedPercent,
+                snapshot?.primary?.usedPercent,
+                snapshot?.secondary?.usedPercent,
+                snapshot?.tertiary?.usedPercent,
             ].compactMap(\.self)
             guard !percents.isEmpty else { return true }
             return percents.allSatisfy { $0 >= 100 }
@@ -64,9 +71,9 @@ extension UsageStore {
            effectivePreference == .automatic
         {
             let percents = [
-                snapshot.primary?.usedPercent,
-                snapshot.secondary?.usedPercent,
-                snapshot.tertiary?.usedPercent,
+                snapshot?.primary?.usedPercent,
+                snapshot?.secondary?.usedPercent,
+                snapshot?.tertiary?.usedPercent,
             ].compactMap(\.self)
             guard !percents.isEmpty else { return true }
             return percents.allSatisfy { $0 >= 100 }

--- a/Sources/CodexBar/UsageStore+ImportedCodexAccounts.swift
+++ b/Sources/CodexBar/UsageStore+ImportedCodexAccounts.swift
@@ -1,0 +1,139 @@
+import CodexBarCore
+import Foundation
+
+struct ImportedCodexAccountUsageSnapshot: Identifiable {
+    let id: String
+    let account: BorrowedCodexAccount
+    let snapshot: UsageSnapshot?
+    let error: String?
+    let sourceLabel: String?
+
+    init(account: BorrowedCodexAccount, snapshot: UsageSnapshot?, error: String?, sourceLabel: String?) {
+        self.id = account.id
+        self.account = account
+        self.snapshot = snapshot
+        self.error = error
+        self.sourceLabel = sourceLabel
+    }
+}
+
+private struct ImportedCodexAccountFetchResult {
+    let index: Int
+    let account: BorrowedCodexAccount
+    let sourceLabel: String?
+    let result: Result<ProviderFetchResult, Error>
+}
+
+private struct ImportedCodexLoadedAccount: Sendable {
+    let account: BorrowedCodexAccount
+    let sourceLabel: String?
+}
+
+extension UsageStore {
+    typealias ImportedCodexUsageFetchOverride = @Sendable (BorrowedCodexAccount) async throws -> ProviderFetchResult
+
+    func refreshImportedCodexAccounts(now: Date = Date()) async {
+        let sources = self.settings.importedCodexCredentialSources
+        guard !sources.isEmpty else {
+            self.importedCodexAccountSnapshots = []
+            return
+        }
+
+        let loadedAccounts = await self.loadImportedCodexAccounts(sources: sources, now: now)
+        guard !loadedAccounts.isEmpty else {
+            self.importedCodexAccountSnapshots = []
+            return
+        }
+
+        let results = await self.fetchImportedCodexAccountResults(accounts: loadedAccounts, updatedAt: now)
+        self.importedCodexAccountSnapshots = results.map { result in
+            switch result.result {
+            case let .success(fetchResult):
+                ImportedCodexAccountUsageSnapshot(
+                    account: result.account,
+                    snapshot: fetchResult.usage.scoped(to: .codex),
+                    error: nil,
+                    sourceLabel: result.sourceLabel ?? fetchResult.sourceLabel)
+            case let .failure(error):
+                ImportedCodexAccountUsageSnapshot(
+                    account: result.account,
+                    snapshot: nil,
+                    error: self.tokenAccountSnapshotErrorMessage(error),
+                    sourceLabel: result.sourceLabel)
+            }
+        }
+    }
+
+    private nonisolated func loadImportedCodexAccounts(
+        sources: [ImportedCredentialSource],
+        now: Date) async -> [ImportedCodexLoadedAccount]
+    {
+        await withTaskGroup(
+            of: [ImportedCodexLoadedAccount].self,
+            returning: [ImportedCodexLoadedAccount].self)
+        { group in
+            for source in sources {
+                group.addTask {
+                    let label = source.label?.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let sourceLabel = label?.isEmpty == false ? label : nil
+                    return CLIProxyCodexAdapter.loadAccounts(from: source.path, now: now).map { account in
+                        ImportedCodexLoadedAccount(account: account, sourceLabel: sourceLabel)
+                    }
+                }
+            }
+
+            var accounts: [ImportedCodexLoadedAccount] = []
+            for await result in group {
+                accounts.append(contentsOf: result)
+            }
+            let sortedAccounts = accounts.sorted { lhs, rhs in
+                if lhs.account.email != rhs.account.email { return lhs.account.email < rhs.account.email }
+                return lhs.account.id < rhs.account.id
+            }
+            var seenIDs = Set<String>()
+            return sortedAccounts.filter { seenIDs.insert($0.account.id).inserted }
+        }
+    }
+
+    private func fetchImportedCodexAccountResults(
+        accounts: [ImportedCodexLoadedAccount],
+        updatedAt: Date) async -> [ImportedCodexAccountFetchResult]
+    {
+        let override = self._test_importedCodexUsageFetchOverride
+        return await withTaskGroup(
+            of: ImportedCodexAccountFetchResult.self,
+            returning: [ImportedCodexAccountFetchResult].self)
+        { group in
+            for (index, loadedAccount) in accounts.enumerated() {
+                group.addTask {
+                    let account = loadedAccount.account
+                    do {
+                        let result = if let override {
+                            try await override(account)
+                        } else {
+                            try await BorrowedCodexUsageFetcher.fetchUsage(account: account, updatedAt: updatedAt)
+                        }
+                        return ImportedCodexAccountFetchResult(
+                            index: index,
+                            account: account,
+                            sourceLabel: loadedAccount.sourceLabel,
+                            result: .success(result))
+                    } catch {
+                        return ImportedCodexAccountFetchResult(
+                            index: index,
+                            account: account,
+                            sourceLabel: loadedAccount.sourceLabel,
+                            result: .failure(error))
+                    }
+                }
+            }
+
+            var results: [ImportedCodexAccountFetchResult] = []
+            results.reserveCapacity(accounts.count)
+            for await result in group {
+                results.append(result)
+            }
+            return results.sorted { $0.index < $1.index }
+        }
+    }
+}

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -33,6 +33,10 @@ extension UsageStore {
         self.refreshingProviders.insert(provider)
         defer { self.refreshingProviders.remove(provider) }
 
+        if provider == .codex {
+            await self.refreshImportedCodexAccounts()
+        }
+
         if provider == .codex, self.shouldFetchAllCodexVisibleAccounts() {
             await self.refreshCodexVisibleAccountsForMenu()
             return
@@ -173,6 +177,7 @@ extension UsageStore {
             self.accountSnapshots.removeValue(forKey: provider)
             if provider == .codex {
                 self.codexAccountSnapshots = []
+                self.importedCodexAccountSnapshots = []
             }
             if provider == .kilo {
                 self.kiloScopeSnapshots = []

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -15,6 +15,7 @@ extension UsageStore {
         _ = self.lastFetchAttempts
         _ = self.accountSnapshots
         _ = self.codexAccountSnapshots
+        _ = self.importedCodexAccountSnapshots
         _ = self.kiloScopeSnapshots
         _ = self.tokenSnapshots
         _ = self.tokenErrors
@@ -39,6 +40,7 @@ extension UsageStore {
 
     var iconObservationToken: Int {
         _ = self.snapshots
+        _ = self.importedCodexAccountSnapshots
         _ = self.errors
         _ = self.credits
         _ = self.lastCreditsError
@@ -137,6 +139,7 @@ final class UsageStore {
     var lastFetchAttempts: [UsageProvider: [ProviderFetchAttempt]] = [:]
     var accountSnapshots: [UsageProvider: [TokenAccountUsageSnapshot]] = [:]
     var codexAccountSnapshots: [CodexAccountUsageSnapshot] = []
+    var importedCodexAccountSnapshots: [ImportedCodexAccountUsageSnapshot] = []
     var kiloScopeSnapshots: [KiloScopeSnapshot] = []
     var tokenSnapshots: [UsageProvider: CostUsageTokenSnapshot] = [:]
     var tokenErrors: [UsageProvider: String] = [:]
@@ -201,6 +204,7 @@ final class UsageStore {
     @ObservationIgnored var _test_widgetSnapshotSaveOverride: (@MainActor (WidgetSnapshot) async -> Void)?
     @ObservationIgnored var _test_providerRefreshOverride: (@MainActor (UsageProvider) async -> Void)?
     @ObservationIgnored var _test_tokenUsageRefreshOverride: (@MainActor (UsageProvider, Bool) async -> Void)?
+    @ObservationIgnored var _test_importedCodexUsageFetchOverride: ImportedCodexUsageFetchOverride?
     @ObservationIgnored var _test_providerStatusFetchOverride: (@MainActor (
         UsageProvider) async throws -> ProviderStatus)?
     @ObservationIgnored var _test_startupConnectivityRetryScheduled: (@MainActor (Int, TimeInterval) -> Void)?

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -5,10 +5,31 @@ public struct CodexBarConfig: Codable, Sendable {
 
     public var version: Int
     public var providers: [ProviderConfig]
+    public var importedCredentialSources: [ImportedCredentialSource]
 
-    public init(version: Int = Self.currentVersion, providers: [ProviderConfig]) {
+    public init(
+        version: Int = Self.currentVersion,
+        providers: [ProviderConfig],
+        importedCredentialSources: [ImportedCredentialSource] = [])
+    {
         self.version = version
         self.providers = providers
+        self.importedCredentialSources = importedCredentialSources
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case providers
+        case importedCredentialSources
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.version = try container.decode(Int.self, forKey: .version)
+        self.providers = try container.decode([ProviderConfig].self, forKey: .providers)
+        self.importedCredentialSources = try container.decodeIfPresent(
+            [ImportedCredentialSource].self,
+            forKey: .importedCredentialSources) ?? []
     }
 
     public static func makeDefault(
@@ -43,7 +64,8 @@ public struct CodexBarConfig: Codable, Sendable {
 
         return CodexBarConfig(
             version: Self.currentVersion,
-            providers: normalized)
+            providers: normalized,
+            importedCredentialSources: self.importedCredentialSources)
     }
 
     public func orderedProviders() -> [UsageProvider] {

--- a/Sources/CodexBarCore/ImportedCredentials/BorrowedCodexUsageFetcher.swift
+++ b/Sources/CodexBarCore/ImportedCredentials/BorrowedCodexUsageFetcher.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+public enum BorrowedCredentialError: LocalizedError, Equatable, Sendable {
+    case expired(accountID: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .expired(accountID):
+            "Imported Codex credential expired for \(accountID). Refresh it in the source tool."
+        }
+    }
+}
+
+public enum BorrowedCodexUsageFetcher {
+    private static let fetchEnvironment = [
+        "CODEX_HOME": "/var/empty/codexbar-borrowed-codex",
+    ]
+
+    public static func fetchUsage(
+        account: BorrowedCodexAccount,
+        updatedAt: Date) async throws -> ProviderFetchResult
+    {
+        guard !account.isExpired else {
+            throw BorrowedCredentialError.expired(accountID: account.id)
+        }
+
+        let usageResponse = try await CodexOAuthUsageFetcher.fetchUsage(
+            accessToken: account.credentials.accessToken,
+            accountId: account.accountId,
+            env: self.fetchEnvironment)
+        return try self.makeResult(
+            usageResponse: usageResponse,
+            credentials: account.credentials,
+            updatedAt: updatedAt)
+    }
+
+    private static func makeResult(
+        usageResponse: CodexUsageResponse,
+        credentials: CodexOAuthCredentials,
+        updatedAt: Date) throws -> ProviderFetchResult
+    {
+        let credits = self.mapCredits(usageResponse.credits, updatedAt: updatedAt)
+        let reconciled = CodexReconciledState.fromOAuth(
+            response: usageResponse,
+            credentials: credentials,
+            updatedAt: updatedAt)
+
+        if let reconciled {
+            return ProviderFetchResult(
+                usage: reconciled.toUsageSnapshot(),
+                credits: credits,
+                dashboard: nil,
+                sourceLabel: "borrowed",
+                strategyID: "codex.borrowed",
+                strategyKind: .oauth)
+        }
+
+        guard let credits else {
+            throw UsageError.noRateLimitsFound
+        }
+
+        return ProviderFetchResult(
+            usage: UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                tertiary: nil,
+                updatedAt: updatedAt,
+                identity: CodexReconciledState.oauthIdentity(
+                    response: usageResponse,
+                    credentials: credentials)),
+            credits: credits,
+            dashboard: nil,
+            sourceLabel: "borrowed",
+            strategyID: "codex.borrowed",
+            strategyKind: .oauth)
+    }
+
+    private static func mapCredits(
+        _ credits: CodexUsageResponse.CreditDetails?,
+        updatedAt: Date) -> CreditsSnapshot?
+    {
+        guard let credits, let balance = credits.balance else { return nil }
+        return CreditsSnapshot(remaining: balance, events: [], updatedAt: updatedAt)
+    }
+}

--- a/Sources/CodexBarCore/ImportedCredentials/CLIProxyCodexAdapter.swift
+++ b/Sources/CodexBarCore/ImportedCredentials/CLIProxyCodexAdapter.swift
@@ -65,7 +65,7 @@ public enum CLIProxyCodexAdapter {
     private static func credentialFiles(from url: URL, fileManager: FileManager) -> [URL] {
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else { return [] }
-        guard isDirectory.boolValue else { return [url] }
+        guard isDirectory.boolValue else { return self.isCredentialFile(url) ? [url] : [] }
 
         guard let contents = try? fileManager.contentsOfDirectory(
             at: url,
@@ -76,10 +76,12 @@ public enum CLIProxyCodexAdapter {
         }
 
         return contents
-            .filter { candidate in
-                candidate.lastPathComponent.hasPrefix("codex-") && candidate.pathExtension == "json"
-            }
+            .filter(self.isCredentialFile)
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    private static func isCredentialFile(_ url: URL) -> Bool {
+        url.lastPathComponent.hasPrefix("codex-") && url.pathExtension == "json"
     }
 
     private static func loadAccount(from url: URL, now: Date) -> BorrowedCodexAccount? {

--- a/Sources/CodexBarCore/ImportedCredentials/CLIProxyCodexAdapter.swift
+++ b/Sources/CodexBarCore/ImportedCredentials/CLIProxyCodexAdapter.swift
@@ -1,0 +1,178 @@
+import Crypto
+import Foundation
+
+public struct BorrowedCodexAccount: Sendable, Identifiable {
+    public let id: String
+    public let email: String
+    public let accountId: String
+    public let credentials: CodexOAuthCredentials
+    public let expired: Date?
+    public let isExpired: Bool
+    public let sourcePath: String
+
+    public init(
+        id: String,
+        email: String,
+        accountId: String,
+        credentials: CodexOAuthCredentials,
+        expired: Date?,
+        isExpired: Bool,
+        sourcePath: String)
+    {
+        self.id = id
+        self.email = email
+        self.accountId = accountId
+        self.credentials = credentials
+        self.expired = expired
+        self.isExpired = isExpired
+        self.sourcePath = sourcePath
+    }
+}
+
+public struct CLIProxyCodexAccountPreview: Sendable, Identifiable {
+    public let id: String
+    public let email: String
+    public let accountId: String
+    public let expired: Date?
+    public let isExpired: Bool
+    public let isDisabled: Bool
+    public let sourcePath: String
+}
+
+public enum CLIProxyCodexAdapter {
+    public static let format = "cliproxyapi-codex"
+
+    public static func loadAccounts(
+        from path: String,
+        now: Date,
+        fileManager: FileManager = .default) -> [BorrowedCodexAccount]
+    {
+        let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+        let files = self.credentialFiles(from: url, fileManager: fileManager)
+        return files.compactMap { self.loadAccount(from: $0, now: now) }
+    }
+
+    public static func previewAccounts(
+        from path: String,
+        now: Date,
+        fileManager: FileManager = .default) -> [CLIProxyCodexAccountPreview]
+    {
+        let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+        let files = self.credentialFiles(from: url, fileManager: fileManager)
+        return files.compactMap { self.previewAccount(from: $0, now: now) }
+    }
+
+    private static func credentialFiles(from url: URL, fileManager: FileManager) -> [URL] {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else { return [] }
+        guard isDirectory.boolValue else { return [url] }
+
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles])
+        else {
+            return []
+        }
+
+        return contents
+            .filter { candidate in
+                candidate.lastPathComponent.hasPrefix("codex-") && candidate.pathExtension == "json"
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    private static func loadAccount(from url: URL, now: Date) -> BorrowedCodexAccount? {
+        guard let data = try? Data(contentsOf: url),
+              let file = try? JSONDecoder().decode(CLIProxyCodexFile.self, from: data),
+              file.type == "codex",
+              file.disabled != true
+        else {
+            return nil
+        }
+
+        let lastRefresh = self.parseISO8601(file.lastRefresh)
+        let expired = self.parseISO8601(file.expired)
+        let sourcePath = self.standardizedPath(for: url)
+        let credentials = CodexOAuthCredentials(
+            accessToken: file.accessToken,
+            refreshToken: file.refreshToken,
+            idToken: file.idToken,
+            accountId: file.accountId,
+            lastRefresh: lastRefresh)
+
+        return BorrowedCodexAccount(
+            id: self.accountID(accountId: file.accountId, sourcePath: sourcePath),
+            email: file.email,
+            accountId: file.accountId,
+            credentials: credentials,
+            expired: expired,
+            isExpired: expired.map { $0 <= now } ?? false,
+            sourcePath: sourcePath)
+    }
+
+    private static func previewAccount(from url: URL, now: Date) -> CLIProxyCodexAccountPreview? {
+        guard let data = try? Data(contentsOf: url),
+              let file = try? JSONDecoder().decode(CLIProxyCodexFile.self, from: data),
+              file.type == "codex"
+        else {
+            return nil
+        }
+
+        let expired = self.parseISO8601(file.expired)
+        let sourcePath = self.standardizedPath(for: url)
+        return CLIProxyCodexAccountPreview(
+            id: self.accountID(accountId: file.accountId, sourcePath: sourcePath),
+            email: file.email,
+            accountId: file.accountId,
+            expired: expired,
+            isExpired: expired.map { $0 <= now } ?? false,
+            isDisabled: file.disabled == true,
+            sourcePath: sourcePath)
+    }
+
+    private static func parseISO8601(_ value: String?) -> Date? {
+        guard let value, !value.isEmpty else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: value) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
+    }
+
+    private static func accountID(accountId: String, sourcePath: String) -> String {
+        "borrowed:\(accountId):\(self.sourcePathHash(sourcePath))"
+    }
+
+    private static func sourcePathHash(_ path: String) -> String {
+        SHA256.hash(data: Data(path.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func standardizedPath(for url: URL) -> String {
+        url.standardizedFileURL.path
+    }
+}
+
+private struct CLIProxyCodexFile: Decodable {
+    let type: String
+    let email: String
+    let accountId: String
+    let accessToken: String
+    let idToken: String
+    let refreshToken: String
+    let lastRefresh: String?
+    let expired: String?
+    let disabled: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case email
+        case accountId = "account_id"
+        case accessToken = "access_token"
+        case idToken = "id_token"
+        case refreshToken = "refresh_token"
+        case lastRefresh = "last_refresh"
+        case expired
+        case disabled
+    }
+}

--- a/Sources/CodexBarCore/ImportedCredentials/ImportedCredentialSource.swift
+++ b/Sources/CodexBarCore/ImportedCredentials/ImportedCredentialSource.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public struct ImportedCredentialSource: Codable, Sendable, Identifiable {
+    public let id: UUID
+    public var platform: String
+    public var path: String
+    public var format: String
+    public var label: String?
+
+    public init(
+        id: UUID = UUID(),
+        platform: String,
+        path: String,
+        format: String,
+        label: String? = nil)
+    {
+        self.id = id
+        self.platform = platform
+        self.path = path
+        self.format = format
+        self.label = label
+    }
+}

--- a/Tests/CodexBarTests/CodexMenuBarMetricAverageTests.swift
+++ b/Tests/CodexBarTests/CodexMenuBarMetricAverageTests.swift
@@ -45,7 +45,99 @@ struct CodexMenuBarMetricAverageTests {
         #expect(window.usedPercent == 40)
     }
 
+    @MainActor
+    @Test
+    func `menu bar icon averages primary and secondary lanes for active and imported codex snapshots`() {
+        let store = Self.makeStore(suite: "CodexMenuBarMetricAverageTests-icon-mixed")
+        let active = Self.snapshot(primary: 20, secondary: 40)
+        store.importedCodexAccountSnapshots = [
+            Self.importedCodexSnapshot(id: "borrowed:one:path", primary: 80, secondary: 60),
+            Self.importedCodexSnapshot(id: "borrowed:two:path", primary: 50, secondary: 100),
+        ]
+
+        let percents = store.menuBarIconPercents(for: .codex, snapshot: active, style: .codex, showUsed: true)
+
+        #expect(abs((percents.primary ?? -1) - 50) < 0.0001)
+        #expect(abs((percents.secondary ?? -1) - 66.66666666666667) < 0.0001)
+    }
+
+    @MainActor
+    @Test
+    func `menu bar icon averages primary and secondary lanes for imported only codex snapshots`() {
+        let store = Self.makeStore(suite: "CodexMenuBarMetricAverageTests-icon-imported-only")
+        store.importedCodexAccountSnapshots = [
+            Self.importedCodexSnapshot(id: "borrowed:one:path", primary: 30, secondary: 40),
+            Self.importedCodexSnapshot(id: "borrowed:two:path", primary: 90, secondary: 80),
+        ]
+
+        let percents = store.menuBarIconPercents(for: .codex, snapshot: nil, style: .codex, showUsed: true)
+
+        #expect(percents.primary == 60)
+        #expect(percents.secondary == 60)
+    }
+
+    @MainActor
+    @Test
+    func `menu bar icon secondary average ignores codex snapshots without weekly lane`() {
+        let store = Self.makeStore(suite: "CodexMenuBarMetricAverageTests-icon-missing-weekly")
+        let active = Self.snapshot(primary: 30, secondary: 60)
+        store.importedCodexAccountSnapshots = [
+            Self.importedCodexSnapshot(id: "borrowed:one:path", primary: 90, secondary: nil),
+            Self.importedCodexSnapshot(id: "borrowed:two:path", primary: 60, secondary: 30),
+        ]
+
+        let percents = store.menuBarIconPercents(for: .codex, snapshot: active, style: .codex, showUsed: true)
+
+        #expect(percents.primary == 60)
+        #expect(percents.secondary == 45)
+    }
+
     private static func window(usedPercent: Double) -> RateWindow {
         RateWindow(usedPercent: usedPercent, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+    }
+
+    @MainActor
+    private static func makeStore(suite: String) -> UsageStore {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        return UsageStore(fetcher: UsageFetcher(), browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+    }
+
+    private static func snapshot(primary: Double, secondary: Double?) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(usedPercent: primary, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: secondary.map {
+                RateWindow(usedPercent: $0, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)
+            },
+            updatedAt: Date())
+    }
+
+    private static func importedCodexSnapshot(
+        id: String,
+        primary: Double,
+        secondary: Double?)
+        -> ImportedCodexAccountUsageSnapshot
+    {
+        ImportedCodexAccountUsageSnapshot(
+            account: BorrowedCodexAccount(
+                id: id,
+                email: "\(id)@example.com",
+                accountId: id,
+                credentials: CodexOAuthCredentials(
+                    accessToken: "access-token",
+                    refreshToken: "refresh-token",
+                    idToken: nil,
+                    accountId: id,
+                    lastRefresh: nil),
+                expired: nil,
+                isExpired: false,
+                sourcePath: "/tmp/\(id).json"),
+            snapshot: Self.snapshot(primary: primary, secondary: secondary),
+            error: nil,
+            sourceLabel: "borrowed")
     }
 }

--- a/Tests/CodexBarTests/CodexMenuBarMetricAverageTests.swift
+++ b/Tests/CodexBarTests/CodexMenuBarMetricAverageTests.swift
@@ -1,0 +1,51 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CodexMenuBarMetricAverageTests {
+    @Test
+    func `average window is nil for empty inputs`() {
+        let window = CodexMenuBarMetricAverage.averageWindow(active: nil, imported: [])
+
+        #expect(window == nil)
+    }
+
+    @Test
+    func `average window keeps active only value`() throws {
+        let active = Self.window(usedPercent: 37)
+
+        let window = try #require(CodexMenuBarMetricAverage.averageWindow(active: active, imported: []))
+
+        #expect(window.usedPercent == 37)
+        #expect(window.windowMinutes == 300)
+    }
+
+    @Test
+    func `average window averages imported only values`() throws {
+        let window = try #require(CodexMenuBarMetricAverage.averageWindow(
+            active: nil,
+            imported: [
+                Self.window(usedPercent: 20),
+                Self.window(usedPercent: 80),
+            ]))
+
+        #expect(window.usedPercent == 50)
+    }
+
+    @Test
+    func `average window averages active and imported values`() throws {
+        let window = try #require(CodexMenuBarMetricAverage.averageWindow(
+            active: Self.window(usedPercent: 10),
+            imported: [
+                Self.window(usedPercent: 40),
+                Self.window(usedPercent: 70),
+            ]))
+
+        #expect(window.usedPercent == 40)
+    }
+
+    private static func window(usedPercent: Double) -> RateWindow {
+        RateWindow(usedPercent: usedPercent, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+    }
+}

--- a/Tests/CodexBarTests/ImportedCodexUsageStoreTests.swift
+++ b/Tests/CodexBarTests/ImportedCodexUsageStoreTests.swift
@@ -1,0 +1,254 @@
+@testable import CodexBar
+@testable import CodexBarCore
+import Foundation
+import Testing
+
+@MainActor
+struct ImportedCodexUsageStoreTests {
+    @Test
+    func `settings store persists imported credential source additions and removals`() throws {
+        let suite = "ImportedCodexUsageStoreTests-settings-persist-\(UUID().uuidString)"
+        let configStore = testConfigStore(suiteName: suite)
+        try configStore.save(CodexBarConfig(providers: [ProviderConfig(id: .codex, enabled: true)]))
+        let settings = SettingsStore(configStore: configStore)
+        let sourceID = UUID()
+
+        settings.addImportedCredentialSource(ImportedCredentialSource(
+            id: sourceID,
+            platform: "codex",
+            path: "/tmp/imported-codex",
+            format: CLIProxyCodexAdapter.format,
+            label: "Imported"))
+
+        var loadedConfig = try configStore.load()
+        var reloaded = try #require(loadedConfig)
+        #expect(reloaded.importedCredentialSources.map(\.id) == [sourceID])
+        #expect(settings.importedCodexCredentialSources.map(\.id) == [sourceID])
+
+        settings.removeImportedCredentialSource(id: sourceID)
+
+        loadedConfig = try configStore.load()
+        reloaded = try #require(loadedConfig)
+        #expect(reloaded.importedCredentialSources.isEmpty)
+        #expect(settings.importedCodexCredentialSources.isEmpty)
+    }
+
+    @Test
+    func `imported codex expired error maps to imported credential health label`() {
+        let health = CodexAccountHealth.status(forError: "Imported Codex credential expired. Refresh it in the source tool.")
+
+        #expect(health == .importedCredentialExpired)
+        #expect(health.label == "Imported Codex credential expired. Refresh it in the source tool.")
+    }
+
+    @Test
+    func `settings exposes only cliproxyapi codex imported credential sources`() throws {
+        let suite = "ImportedCodexUsageStoreTests-source-filter-\(UUID().uuidString)"
+        let configStore = testConfigStore(suiteName: suite)
+        try configStore.save(CodexBarConfig(
+            providers: [ProviderConfig(id: .codex, enabled: true)],
+            importedCredentialSources: [
+                ImportedCredentialSource(
+                    platform: "codex",
+                    path: "/tmp/codex",
+                    format: CLIProxyCodexAdapter.format),
+                ImportedCredentialSource(
+                    platform: "claude",
+                    path: "/tmp/claude",
+                    format: CLIProxyCodexAdapter.format),
+                ImportedCredentialSource(
+                    platform: "codex",
+                    path: "/tmp/other",
+                    format: "other-format"),
+            ]))
+        let settings = SettingsStore(configStore: configStore)
+
+        #expect(settings.importedCodexCredentialSources.map(\.path) == ["/tmp/codex"])
+    }
+
+    @Test
+    func `refresh imported codex accounts live reads fixtures without modifying files`() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let validFile = directory.appendingPathComponent("codex-valid.json")
+        let disabledFile = directory.appendingPathComponent("codex-disabled.json")
+        let expiredFile = directory.appendingPathComponent("codex-expired.json")
+        try Self.writeCLIProxyCodexFile(
+            to: validFile,
+            email: "valid@example.com",
+            accountID: "account-valid",
+            expired: "2026-06-22T14:11:59+09:00")
+        try Self.writeCLIProxyCodexFile(
+            to: disabledFile,
+            email: "disabled@example.com",
+            accountID: "account-disabled",
+            expired: "2026-06-22T14:11:59+09:00",
+            disabled: true)
+        try Self.writeCLIProxyCodexFile(
+            to: expiredFile,
+            email: "expired@example.com",
+            accountID: "account-expired",
+            expired: "2026-06-13T00:00:00Z")
+        let before = try Self.contents(of: [validFile, disabledFile, expiredFile])
+
+        let suite = "ImportedCodexUsageStoreTests-refresh-\(UUID().uuidString)"
+        let configStore = testConfigStore(suiteName: suite)
+        try configStore.save(CodexBarConfig(
+            providers: [ProviderConfig(id: .codex, enabled: true)],
+            importedCredentialSources: [
+                ImportedCredentialSource(
+                    platform: "codex",
+                    path: directory.path,
+                    format: CLIProxyCodexAdapter.format),
+            ]))
+        let settings = SettingsStore(configStore: configStore)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: ["CODEX_HOME": "/tmp/ambient-codex-home"])
+        let usageUpdatedAt = try Self.date("2026-06-14T00:00:00Z")
+        store._test_importedCodexUsageFetchOverride = { account in
+            if account.isExpired {
+                throw BorrowedCredentialError.expired(accountID: account.id)
+            }
+            return ProviderFetchResult(
+                usage: UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: 25,
+                        windowMinutes: 300,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    secondary: nil,
+                    updatedAt: usageUpdatedAt),
+                credits: nil,
+                dashboard: nil,
+                sourceLabel: "borrowed",
+                strategyID: "codex.borrowed",
+                strategyKind: .oauth)
+        }
+
+        await store.refreshImportedCodexAccounts(now: try Self.date("2026-06-14T00:00:00Z"))
+
+        let snapshots = store.importedCodexAccountSnapshots
+        #expect(snapshots.count == 2)
+        #expect(snapshots.map(\.account.email).sorted() == ["expired@example.com", "valid@example.com"])
+        #expect(snapshots.first { $0.account.email == "valid@example.com" }?.snapshot?.primary?.usedPercent == 25)
+        #expect(snapshots.first { $0.account.email == "valid@example.com" }?.sourceLabel == "borrowed")
+        #expect(snapshots.first { $0.account.email == "expired@example.com" }?.snapshot == nil)
+        #expect(snapshots.first { $0.account.email == "expired@example.com" }?.error?.contains("expired") == true)
+        #expect(try Self.contents(of: [validFile, disabledFile, expiredFile]) == before)
+    }
+
+    @Test
+    func `refresh imported codex accounts is cheap no-op without sources`() async throws {
+        let suite = "ImportedCodexUsageStoreTests-empty-\(UUID().uuidString)"
+        let configStore = testConfigStore(suiteName: suite)
+        try configStore.save(CodexBarConfig(providers: [ProviderConfig(id: .codex, enabled: true)]))
+        let settings = SettingsStore(configStore: configStore)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+
+        await store.refreshImportedCodexAccounts()
+
+        #expect(store.importedCodexAccountSnapshots.isEmpty)
+    }
+
+    @Test
+    func `refresh imported codex accounts deduplicates loaded accounts by id`() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("codex-valid.json")
+        try Self.writeCLIProxyCodexFile(
+            to: file,
+            email: "valid@example.com",
+            accountID: "account-valid",
+            expired: "2026-06-22T14:11:59+09:00")
+
+        let suite = "ImportedCodexUsageStoreTests-dedup-\(UUID().uuidString)"
+        let configStore = testConfigStore(suiteName: suite)
+        try configStore.save(CodexBarConfig(
+            providers: [ProviderConfig(id: .codex, enabled: true)],
+            importedCredentialSources: [
+                ImportedCredentialSource(
+                    platform: "codex",
+                    path: directory.path,
+                    format: CLIProxyCodexAdapter.format),
+                ImportedCredentialSource(
+                    platform: "codex",
+                    path: directory.standardizedFileURL.path,
+                    format: CLIProxyCodexAdapter.format),
+            ]))
+        let settings = SettingsStore(configStore: configStore)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+        store._test_importedCodexUsageFetchOverride = { _ in
+            ProviderFetchResult(
+                usage: UsageSnapshot(
+                    primary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                    secondary: nil,
+                    updatedAt: Date()),
+                credits: nil,
+                dashboard: nil,
+                sourceLabel: "borrowed",
+                strategyID: "codex.borrowed",
+                strategyKind: .oauth)
+        }
+
+        await store.refreshImportedCodexAccounts(now: try Self.date("2026-06-14T00:00:00Z"))
+
+        #expect(store.importedCodexAccountSnapshots.count == 1)
+        #expect(store.importedCodexAccountSnapshots.first?.account.email == "valid@example.com")
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ImportedCodexUsageStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func writeCLIProxyCodexFile(
+        to url: URL,
+        type: String = "codex",
+        email: String,
+        accountID: String,
+        accessToken: String = "access-token",
+        idToken: String = "id-token",
+        refreshToken: String = "refresh-token",
+        lastRefresh: String = "2026-06-10T14:11:59+09:00",
+        expired: String,
+        disabled: Bool = false) throws
+    {
+        let object: [String: Any] = [
+            "type": type,
+            "email": email,
+            "account_id": accountID,
+            "access_token": accessToken,
+            "id_token": idToken,
+            "refresh_token": refreshToken,
+            "last_refresh": lastRefresh,
+            "expired": expired,
+            "disabled": disabled,
+        ]
+        let data = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url)
+    }
+
+    private static func contents(of urls: [URL]) throws -> [URL: Data] {
+        try Dictionary(uniqueKeysWithValues: urls.map { ($0, try Data(contentsOf: $0)) })
+    }
+
+    private static func date(_ text: String) throws -> Date {
+        try #require(ISO8601DateFormatter().date(from: text))
+    }
+}

--- a/Tests/CodexBarTests/ImportedCredentialsTests.swift
+++ b/Tests/CodexBarTests/ImportedCredentialsTests.swift
@@ -146,6 +146,36 @@ struct ImportedCredentialsTests {
     }
 
     @Test
+    func `cliproxyapi direct file import applies codex json filename filter`() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let valid = directory.appendingPathComponent("codex-valid.json")
+        let sidecar = directory.appendingPathComponent("codex-valid.json.dead-rt123")
+        let nonCodexJSON = directory.appendingPathComponent("manual.json")
+        try Self.writeCLIProxyCodexFile(
+            to: valid,
+            email: "valid@example.com",
+            accountID: "account-valid")
+        try Self.writeCLIProxyCodexFile(
+            to: sidecar,
+            email: "sidecar@example.com",
+            accountID: "account-sidecar")
+        try Self.writeCLIProxyCodexFile(
+            to: nonCodexJSON,
+            email: "manual@example.com",
+            accountID: "account-manual")
+
+        let now = try Self.date("2026-06-14T00:00:00Z")
+
+        #expect(CLIProxyCodexAdapter.loadAccounts(from: sidecar.path, now: now).isEmpty)
+        #expect(CLIProxyCodexAdapter.previewAccounts(from: sidecar.path, now: now).isEmpty)
+        #expect(CLIProxyCodexAdapter.loadAccounts(from: nonCodexJSON.path, now: now).isEmpty)
+        #expect(CLIProxyCodexAdapter.previewAccounts(from: nonCodexJSON.path, now: now).isEmpty)
+        #expect(CLIProxyCodexAdapter.loadAccounts(from: valid.path, now: now).map(\.email) == ["valid@example.com"])
+        #expect(CLIProxyCodexAdapter.previewAccounts(from: valid.path, now: now).map(\.email) == ["valid@example.com"])
+    }
+
+    @Test
     func `cliproxyapi preview includes disabled and expired account statuses`() throws {
         let directory = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/CodexBarTests/ImportedCredentialsTests.swift
+++ b/Tests/CodexBarTests/ImportedCredentialsTests.swift
@@ -1,0 +1,276 @@
+@testable import CodexBarCore
+import Foundation
+import Testing
+
+struct ImportedCredentialsTests {
+    @Test
+    func `legacy config without imported credential sources decodes to empty list`() throws {
+        let legacyJSON = """
+        {
+            "version": 1,
+            "providers": [
+                {
+                    "id": "codex"
+                }
+            ]
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(CodexBarConfig.self, from: Data(legacyJSON.utf8))
+
+        #expect(decoded.importedCredentialSources.isEmpty)
+    }
+
+    @Test
+    func `config store round trips imported credential sources`() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = CodexBarConfigStore(fileURL: directory.appendingPathComponent("config.json"))
+        let sourceID = UUID()
+
+        try store.save(CodexBarConfig(
+            providers: [ProviderConfig(id: .codex)],
+            importedCredentialSources: [
+                ImportedCredentialSource(
+                    id: sourceID,
+                    platform: "codex",
+                    path: "/tmp/imported-codex",
+                    format: CLIProxyCodexAdapter.format,
+                    label: "Work"),
+            ]))
+
+        let loadedConfig = try store.load()
+        let reloaded = try #require(loadedConfig)
+        let source = try #require(reloaded.importedCredentialSources.first)
+        #expect(reloaded.importedCredentialSources.count == 1)
+        #expect(source.id == sourceID)
+        #expect(source.platform == "codex")
+        #expect(source.path == "/tmp/imported-codex")
+        #expect(source.format == CLIProxyCodexAdapter.format)
+        #expect(source.label == "Work")
+    }
+
+    @Test
+    func `cliproxyapi codex file converts flat credentials to codex oauth credentials`() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("codex-primary.json")
+        try Self.writeCLIProxyCodexFile(
+            to: file,
+            email: "user@example.com",
+            accountID: "account-123",
+            accessToken: "access-token",
+            idToken: "id-token",
+            refreshToken: "refresh-token",
+            lastRefresh: "2026-06-10T14:11:59+09:00",
+            expired: "2026-06-22T14:11:59+09:00")
+
+        let accounts = CLIProxyCodexAdapter.loadAccounts(
+            from: file.path,
+            now: try Self.date("2026-06-14T00:00:00Z"))
+        let account = try #require(accounts.first)
+
+        #expect(accounts.count == 1)
+        #expect(account.email == "user@example.com")
+        #expect(account.accountId == "account-123")
+        #expect(account.id.hasPrefix("borrowed:account-123:"))
+        #expect(account.id.count == "borrowed:account-123:".count + 64)
+        #expect(account.credentials.accessToken == "access-token")
+        #expect(account.credentials.accountId == "account-123")
+        #expect(account.credentials.idToken == "id-token")
+        #expect(account.credentials.refreshToken == "refresh-token")
+    }
+
+    @Test
+    func `cliproxyapi account id includes source path hash`() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let first = directory.appendingPathComponent("codex-plus.json")
+        let second = directory.appendingPathComponent("codex-team.json")
+        try Self.writeCLIProxyCodexFile(
+            to: first,
+            email: "plus@example.com",
+            accountID: "shared-account")
+        try Self.writeCLIProxyCodexFile(
+            to: second,
+            email: "team@example.com",
+            accountID: "shared-account")
+
+        let accounts = CLIProxyCodexAdapter.loadAccounts(
+            from: directory.path,
+            now: try Self.date("2026-06-14T00:00:00Z"))
+
+        #expect(accounts.count == 2)
+        #expect(Set(accounts.map(\.accountId)) == ["shared-account"])
+        #expect(Set(accounts.map(\.id)).count == 2)
+        #expect(accounts.allSatisfy { $0.id.hasPrefix("borrowed:shared-account:") })
+    }
+
+    @Test
+    func `cliproxyapi directory scan keeps codex json files and skips sidecars disabled and malformed entries`() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-active.json"),
+            email: "active@example.com",
+            accountID: "account-active")
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-disabled.json"),
+            email: "disabled@example.com",
+            accountID: "account-disabled",
+            disabled: true)
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-not-codex.json"),
+            type: "claude",
+            email: "other@example.com",
+            accountID: "account-other")
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-sidecar.json.bak"),
+            email: "bak@example.com",
+            accountID: "account-bak")
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-sidecar.json.dead-rt123"),
+            email: "dead@example.com",
+            accountID: "account-dead")
+        try "not json".write(
+            to: directory.appendingPathComponent("codex-bad.json"),
+            atomically: true,
+            encoding: .utf8)
+
+        let accounts = CLIProxyCodexAdapter.loadAccounts(
+            from: directory.path,
+            now: try Self.date("2026-06-14T00:00:00Z"))
+
+        #expect(accounts.map(\.email) == ["active@example.com"])
+        #expect(accounts.map(\.accountId) == ["account-active"])
+    }
+
+    @Test
+    func `cliproxyapi preview includes disabled and expired account statuses`() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-active.json"),
+            email: "active@example.com",
+            accountID: "account-active",
+            expired: "2026-06-22T14:11:59+09:00")
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-disabled.json"),
+            email: "disabled@example.com",
+            accountID: "account-disabled",
+            expired: "2026-06-22T14:11:59+09:00",
+            disabled: true)
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-expired.json"),
+            email: "expired@example.com",
+            accountID: "account-expired",
+            expired: "2026-06-13T00:00:00Z")
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-not-codex.json"),
+            type: "claude",
+            email: "other@example.com",
+            accountID: "account-other")
+
+        let previews = CLIProxyCodexAdapter.previewAccounts(
+            from: directory.path,
+            now: try Self.date("2026-06-14T00:00:00Z"))
+        let byEmail = Dictionary(uniqueKeysWithValues: previews.map { ($0.email, $0) })
+
+        #expect(previews.map(\.email).sorted() == [
+            "active@example.com",
+            "disabled@example.com",
+            "expired@example.com",
+        ])
+        #expect(byEmail["active@example.com"]?.isDisabled == false)
+        #expect(byEmail["active@example.com"]?.isExpired == false)
+        #expect(byEmail["disabled@example.com"]?.isDisabled == true)
+        #expect(byEmail["expired@example.com"]?.isExpired == true)
+    }
+
+    @Test
+    func `cliproxyapi expiration is computed against injected date`() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-past.json"),
+            email: "past@example.com",
+            accountID: "account-past",
+            expired: "2026-06-13T23:59:59Z")
+        try Self.writeCLIProxyCodexFile(
+            to: directory.appendingPathComponent("codex-future.json"),
+            email: "future@example.com",
+            accountID: "account-future",
+            expired: "2026-06-15T00:00:00Z")
+
+        let accounts = CLIProxyCodexAdapter.loadAccounts(
+            from: directory.path,
+            now: try Self.date("2026-06-14T00:00:00Z"))
+        let states = Dictionary(uniqueKeysWithValues: accounts.map { ($0.email, $0.isExpired) })
+
+        #expect(states["past@example.com"] == true)
+        #expect(states["future@example.com"] == false)
+    }
+
+    @Test
+    func `borrowed codex usage fetcher rejects expired accounts before network`() async throws {
+        let account = BorrowedCodexAccount(
+            id: "borrowed:account-expired:path",
+            email: "expired@example.com",
+            accountId: "account-expired",
+            credentials: CodexOAuthCredentials(
+                accessToken: "access-token",
+                refreshToken: "refresh-token",
+                idToken: nil,
+                accountId: "account-expired",
+                lastRefresh: nil),
+            expired: try Self.date("2026-06-13T00:00:00Z"),
+            isExpired: true,
+            sourcePath: "/tmp/codex-expired.json")
+
+        await #expect(throws: BorrowedCredentialError.expired(accountID: account.id)) {
+            _ = try await BorrowedCodexUsageFetcher.fetchUsage(
+                account: account,
+                updatedAt: try Self.date("2026-06-14T00:00:00Z"))
+        }
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ImportedCredentialsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func writeCLIProxyCodexFile(
+        to url: URL,
+        type: String = "codex",
+        email: String,
+        accountID: String,
+        accessToken: String = "access-token",
+        idToken: String = "id-token",
+        refreshToken: String = "refresh-token",
+        lastRefresh: String = "2026-06-10T14:11:59+09:00",
+        expired: String = "2026-06-22T14:11:59+09:00",
+        disabled: Bool = false) throws
+    {
+        let object: [String: Any] = [
+            "type": type,
+            "email": email,
+            "account_id": accountID,
+            "access_token": accessToken,
+            "id_token": idToken,
+            "refresh_token": refreshToken,
+            "last_refresh": lastRefresh,
+            "expired": expired,
+            "disabled": disabled,
+        ]
+        let data = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url)
+    }
+
+    private static func date(_ text: String) throws -> Date {
+        try #require(ISO8601DateFormatter().date(from: text))
+    }
+}

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -118,6 +118,137 @@ struct UsageStoreHighestUsageTests {
     }
 
     @Test
+    func `codex imported account average participates in highest usage selection`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-codex-imported-average"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+
+        let codexSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        let claudeSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 60, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store._setSnapshotForTesting(codexSnapshot, provider: .codex)
+        store._setSnapshotForTesting(claudeSnapshot, provider: .claude)
+        store.importedCodexAccountSnapshots = [
+            Self.importedCodexSnapshot(id: "borrowed:one:path", usedPercent: 95),
+            Self.importedCodexSnapshot(id: "borrowed:two:path", usedPercent: 70),
+        ]
+
+        let highest = store.providerWithHighestUsage()
+
+        #expect(highest?.provider == .codex)
+        #expect(abs((highest?.usedPercent ?? 0) - 61.666666666666664) < 0.0001)
+    }
+
+    @Test
+    func `codex imported account average participates without native snapshot`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-codex-imported-only-average"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+
+        let claudeSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store._setSnapshotForTesting(claudeSnapshot, provider: .claude)
+        store.importedCodexAccountSnapshots = [
+            Self.importedCodexSnapshot(id: "borrowed:one:path", usedPercent: 80),
+            Self.importedCodexSnapshot(id: "borrowed:two:path", usedPercent: 60),
+        ]
+
+        let highest = store.providerWithHighestUsage()
+        let iconPercents = store.menuBarIconPercents(
+            for: .codex,
+            snapshot: nil,
+            style: store.style(for: .codex),
+            showUsed: true)
+
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 70)
+        #expect(iconPercents.primary == 70)
+        #expect(iconPercents.secondary == nil)
+    }
+
+    @Test
+    func `codex without native snapshot or imported accounts is excluded from highest usage`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-codex-empty-excluded"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+
+        if let codexMeta = ProviderRegistry.shared.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+
+        let highest = store.providerWithHighestUsage()
+
+        #expect(highest == nil)
+    }
+
+    @Test
+    func `codex selection metric matches legacy resolver when no imported accounts exist`() throws {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-codex-no-imported-legacy"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 80, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        let expected = try #require(MenuBarMetricWindowResolver.rateWindow(
+            preference: settings.menuBarMetricPreference(for: .codex, snapshot: snapshot),
+            provider: .codex,
+            snapshot: snapshot,
+            supportsAverage: settings.menuBarMetricSupportsAverage(for: .codex)))
+        let actual = try #require(store.codexMenuBarMetricWindowIncludingImported(activeSnapshot: snapshot))
+
+        #expect(actual == expected)
+    }
+
+    @Test
     func `automatic metric uses antigravity tertiary when leading lanes are missing`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-tertiary"),
@@ -620,5 +751,28 @@ struct UsageStoreHighestUsageTests {
         let highest = store.providerWithHighestUsage()
         #expect(highest?.provider == .cursor)
         #expect(highest?.usedPercent == 100)
+    }
+
+    private static func importedCodexSnapshot(id: String, usedPercent: Double) -> ImportedCodexAccountUsageSnapshot {
+        ImportedCodexAccountUsageSnapshot(
+            account: BorrowedCodexAccount(
+                id: id,
+                email: "\(id)@example.com",
+                accountId: id,
+                credentials: CodexOAuthCredentials(
+                    accessToken: "access-token",
+                    refreshToken: "refresh-token",
+                    idToken: nil,
+                    accountId: id,
+                    lastRefresh: nil),
+                expired: nil,
+                isExpired: false,
+                sourcePath: "/tmp/\(id).json"),
+            snapshot: UsageSnapshot(
+                primary: RateWindow(usedPercent: usedPercent, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            error: nil,
+            sourceLabel: "borrowed")
     }
 }

--- a/docs/pr-feat-imported-credentials.md
+++ b/docs/pr-feat-imported-credentials.md
@@ -1,0 +1,102 @@
+# PR: feat/manual-credential-json
+
+## Problem
+
+Users need to use manually imported `cliproxyapi` Codex credentials without completing the full CodexBar OAuth flow. The external files use a flat JSON shape, so CodexBar needs a read-only import path that can display usage for those accounts without owning or mutating their tokens.
+
+## Changes
+
+Commits and changed files from `git log -p a4f278d9..feat/manual-credential-json`:
+
+- `7e11eb81` `feat: read-only imported credential (cliproxyapi codex) accounts`
+  - `Sources/CodexBar/CodexAccountMenuPresentation.swift`
+  - `Sources/CodexBar/ImportedCodexAccountsMenuView.swift`
+  - `Sources/CodexBar/MenuContent.swift`
+  - `Sources/CodexBar/PreferencesImportedCredentialsSection.swift`
+  - `Sources/CodexBar/PreferencesProvidersPane.swift`
+  - `Sources/CodexBar/SettingsStore+ConfigPersistence.swift`
+  - `Sources/CodexBar/SettingsStore+ImportedCredentials.swift`
+  - `Sources/CodexBar/StatusItemController+Animation.swift`
+  - `Sources/CodexBar/StatusItemController+CodexStackedMenu.swift`
+  - `Sources/CodexBar/StatusItemController+IconObservation.swift`
+  - `Sources/CodexBar/StatusItemController+Menu.swift`
+  - `Sources/CodexBar/StatusItemController.swift`
+  - `Sources/CodexBar/UsageStore+CodexMenuBarMetric.swift`
+  - `Sources/CodexBar/UsageStore+HighestUsage.swift`
+  - `Sources/CodexBar/UsageStore+ImportedCodexAccounts.swift`
+  - `Sources/CodexBar/UsageStore+Refresh.swift`
+  - `Sources/CodexBar/UsageStore.swift`
+  - `Sources/CodexBarCore/Config/CodexBarConfig.swift`
+  - `Sources/CodexBarCore/ImportedCredentials/BorrowedCodexUsageFetcher.swift`
+  - `Sources/CodexBarCore/ImportedCredentials/CLIProxyCodexAdapter.swift`
+  - `Sources/CodexBarCore/ImportedCredentials/ImportedCredentialSource.swift`
+  - `Tests/CodexBarTests/CodexMenuBarMetricAverageTests.swift`
+  - `Tests/CodexBarTests/ImportedCodexUsageStoreTests.swift`
+  - `Tests/CodexBarTests/ImportedCredentialsTests.swift`
+  - `Tests/CodexBarTests/UsageStoreHighestUsageTests.swift`
+  - Added imported credential source config, preferences UI, compact imported-account menu rows, flat -> nested `cliproxyapi` Codex credential adaptation, read-only borrowed usage fetch, and imported Codex snapshots in highest-usage/menu-bar metric selection.
+
+- `cfb673be` `fix(menu-bar): restore weekly gauge on codex icon with imported accounts`
+  - `Sources/CodexBar/UsageStore+CodexMenuBarMetric.swift`
+  - `Tests/CodexBarTests/CodexMenuBarMetricAverageTests.swift`
+  - Restored multi-account menu-bar gauge averaging for both primary and secondary Codex lanes, including import-only Codex accounts.
+
+- `471d00e0` `fix(menu-bar): keep the status badge out of the weekly bar (no more "full + extra chunk")`
+  - `Sources/CodexBar/IconRenderer.swift`
+  - Added a status-badge gutter so the provider service-status badge no longer visually merges with the weekly usage bar.
+
+- `d897d545` `fix(imported-creds): apply the codex-*.json filter to directly-picked file sources too`
+  - `Sources/CodexBarCore/ImportedCredentials/CLIProxyCodexAdapter.swift`
+  - `Tests/CodexBarTests/ImportedCredentialsTests.swift`
+  - Applied the `codex-*.json` filename filter to both directory imports and directly selected file imports.
+
+Feature summary:
+
+- Flat `cliproxyapi` Codex JSON is adapted into in-memory Codex OAuth credential structs.
+- Imported credentials are configured through `ImportedCredentialSource` and persisted in CodexBar config.
+- Directory imports and direct-file imports both accept only `codex-*.json` files.
+- Imported accounts appear as read-only Codex menu rows with source labels, status handling, and usage metrics.
+- Active Codex and imported Codex accounts participate together in highest-usage selection.
+- The menu-bar icon averages primary and secondary Codex gauge lanes across active + imported accounts.
+- `IconRenderer` reserves a status-badge gutter so the status badge cannot look like an extra chunk of weekly usage fill.
+
+## Read-only safety guarantee
+
+Borrowed tokens are NEVER refreshed or written back.
+
+The read-only path calls `CodexOAuthUsageFetcher` directly through `BorrowedCodexUsageFetcher`, bypassing the normal refresh/save strategy used by owned Codex OAuth credentials. That means imported access tokens can be used for usage fetches, but CodexBar does not attempt to rotate, refresh, persist, or repair those credentials.
+
+The borrowed fetch environment is isolated with:
+
+```text
+CODEX_HOME=/var/empty
+```
+
+That isolation prevents accidental writes into a real Codex home directory while imported credentials are being used. Expired imported credentials are rejected before network fetch.
+
+## Testing
+
+- `swift test`
+  - 3427 tests passed.
+  - 1 pre-existing MiniMax locale failure was observed and treated as expected for this branch.
+
+Manual verification:
+
+- Add a folder containing valid `codex-*.json` `cliproxyapi` Codex credentials.
+- Confirm disabled, expired, malformed, sidecar, and non-Codex files are skipped or shown with the expected status.
+- Add a directly selected file and confirm only `codex-*.json` is accepted.
+- Confirm imported Codex accounts render as read-only menu rows.
+- Confirm usage refreshes fetch current usage without modifying the source JSON files.
+- Confirm imported-only Codex accounts can drive the menu-bar icon.
+- Confirm active + imported Codex accounts average both primary and weekly gauge lanes.
+- Confirm status badges render in the reserved gutter and do not merge into the weekly bar.
+
+## Safety notes
+
+- The `codex-*.json` filter is enforced for both directory and direct-file sources.
+- Imported accounts are marked and handled as read-only borrowed credentials.
+- Refresh/save logic for owned OAuth credentials is bypassed for imported credentials.
+- `CODEX_HOME=/var/empty` is used for borrowed fetches to avoid accidental local Codex state writes.
+- Imported account errors are surfaced in menu presentation instead of triggering token repair or write-back.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
# PR: feat/manual-credential-json

## Problem

Users need to use manually imported `cliproxyapi` Codex credentials without completing the full CodexBar OAuth flow. The external files use a flat JSON shape, so CodexBar needs a read-only import path that can display usage for those accounts without owning or mutating their tokens.

## Changes

Commits and changed files from `git log -p a4f278d9..feat/manual-credential-json`:

- `7e11eb81` `feat: read-only imported credential (cliproxyapi codex) accounts`
  - `Sources/CodexBar/CodexAccountMenuPresentation.swift`
  - `Sources/CodexBar/ImportedCodexAccountsMenuView.swift`
  - `Sources/CodexBar/MenuContent.swift`
  - `Sources/CodexBar/PreferencesImportedCredentialsSection.swift`
  - `Sources/CodexBar/PreferencesProvidersPane.swift`
  - `Sources/CodexBar/SettingsStore+ConfigPersistence.swift`
  - `Sources/CodexBar/SettingsStore+ImportedCredentials.swift`
  - `Sources/CodexBar/StatusItemController+Animation.swift`
  - `Sources/CodexBar/StatusItemController+CodexStackedMenu.swift`
  - `Sources/CodexBar/StatusItemController+IconObservation.swift`
  - `Sources/CodexBar/StatusItemController+Menu.swift`
  - `Sources/CodexBar/StatusItemController.swift`
  - `Sources/CodexBar/UsageStore+CodexMenuBarMetric.swift`
  - `Sources/CodexBar/UsageStore+HighestUsage.swift`
  - `Sources/CodexBar/UsageStore+ImportedCodexAccounts.swift`
  - `Sources/CodexBar/UsageStore+Refresh.swift`
  - `Sources/CodexBar/UsageStore.swift`
  - `Sources/CodexBarCore/Config/CodexBarConfig.swift`
  - `Sources/CodexBarCore/ImportedCredentials/BorrowedCodexUsageFetcher.swift`
  - `Sources/CodexBarCore/ImportedCredentials/CLIProxyCodexAdapter.swift`
  - `Sources/CodexBarCore/ImportedCredentials/ImportedCredentialSource.swift`
  - `Tests/CodexBarTests/CodexMenuBarMetricAverageTests.swift`
  - `Tests/CodexBarTests/ImportedCodexUsageStoreTests.swift`
  - `Tests/CodexBarTests/ImportedCredentialsTests.swift`
  - `Tests/CodexBarTests/UsageStoreHighestUsageTests.swift`
  - Added imported credential source config, preferences UI, compact imported-account menu rows, flat -> nested `cliproxyapi` Codex credential adaptation, read-only borrowed usage fetch, and imported Codex snapshots in highest-usage/menu-bar metric selection.

- `cfb673be` `fix(menu-bar): restore weekly gauge on codex icon with imported accounts`
  - `Sources/CodexBar/UsageStore+CodexMenuBarMetric.swift`
  - `Tests/CodexBarTests/CodexMenuBarMetricAverageTests.swift`
  - Restored multi-account menu-bar gauge averaging for both primary and secondary Codex lanes, including import-only Codex accounts.

- `471d00e0` `fix(menu-bar): keep the status badge out of the weekly bar (no more "full + extra chunk")`
  - `Sources/CodexBar/IconRenderer.swift`
  - Added a status-badge gutter so the provider service-status badge no longer visually merges with the weekly usage bar.

- `d897d545` `fix(imported-creds): apply the codex-*.json filter to directly-picked file sources too`
  - `Sources/CodexBarCore/ImportedCredentials/CLIProxyCodexAdapter.swift`
  - `Tests/CodexBarTests/ImportedCredentialsTests.swift`
  - Applied the `codex-*.json` filename filter to both directory imports and directly selected file imports.

Feature summary:

- Flat `cliproxyapi` Codex JSON is adapted into in-memory Codex OAuth credential structs.
- Imported credentials are configured through `ImportedCredentialSource` and persisted in CodexBar config.
- Directory imports and direct-file imports both accept only `codex-*.json` files.
- Imported accounts appear as read-only Codex menu rows with source labels, status handling, and usage metrics.
- Active Codex and imported Codex accounts participate together in highest-usage selection.
- The menu-bar icon averages primary and secondary Codex gauge lanes across active + imported accounts.
- `IconRenderer` reserves a status-badge gutter so the status badge cannot look like an extra chunk of weekly usage fill.

## Read-only safety guarantee

Borrowed tokens are NEVER refreshed or written back.

The read-only path calls `CodexOAuthUsageFetcher` directly through `BorrowedCodexUsageFetcher`, bypassing the normal refresh/save strategy used by owned Codex OAuth credentials. That means imported access tokens can be used for usage fetches, but CodexBar does not attempt to rotate, refresh, persist, or repair those credentials.

The borrowed fetch environment is isolated with:

```text
CODEX_HOME=/var/empty
```

That isolation prevents accidental writes into a real Codex home directory while imported credentials are being used. Expired imported credentials are rejected before network fetch.

## Testing

- `swift test`
  - 3427 tests passed.
  - 1 pre-existing MiniMax locale failure was observed and treated as expected for this branch.

Manual verification:

- Add a folder containing valid `codex-*.json` `cliproxyapi` Codex credentials.
- Confirm disabled, expired, malformed, sidecar, and non-Codex files are skipped or shown with the expected status.
- Add a directly selected file and confirm only `codex-*.json` is accepted.
- Confirm imported Codex accounts render as read-only menu rows.
- Confirm usage refreshes fetch current usage without modifying the source JSON files.
- Confirm imported-only Codex accounts can drive the menu-bar icon.
- Confirm active + imported Codex accounts average both primary and weekly gauge lanes.
- Confirm status badges render in the reserved gutter and do not merge into the weekly bar.

## Safety notes

- The `codex-*.json` filter is enforced for both directory and direct-file sources.
- Imported accounts are marked and handled as read-only borrowed credentials.
- Refresh/save logic for owned OAuth credentials is bypassed for imported credentials.
- `CODEX_HOME=/var/empty` is used for borrowed fetches to avoid accidental local Codex state writes.
- Imported account errors are surfaced in menu presentation instead of triggering token repair or write-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
