### PR TITLE
Fix Codex CLI automatic source order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 - Menu bar: show provider status markers only for the provider rendered in each icon. Thanks @Zihao-Qi!
+- Codex CLI: make automatic usage reads prefer OAuth and CLI sources instead of blocking on the optional web dashboard.
 - Provider probes: cap captured subprocess output at 1 MiB per stream without dropping valid text at a truncated UTF-8 boundary. Thanks @ProspectOre!
 - Provider switcher: keep Codex quota rows visible when switching away and back during a manual refresh, including menus with usage-history sections. Thanks @Yuxin-Qiao!
 - Bedrock: ignore invalid billing dates when selecting the latest usage values. Thanks @ProspectOre!

--- a/Sources/CodexBarCLI/CLIOptions.swift
+++ b/Sources/CodexBarCLI/CLIOptions.swift
@@ -63,7 +63,7 @@ struct UsageOptions: CommanderParsable {
     @Option(name: .long("source"), help: Self.sourceHelp)
     var source: String?
 
-    @Option(name: .long("web-timeout"), help: "Web fetch timeout (seconds) (Codex only; source=auto|web)")
+    @Option(name: .long("web-timeout"), help: "Web fetch timeout (seconds) (Codex only; source=web)")
     var webTimeout: Double?
 
     @Flag(name: .long("web-debug-dump-html"), help: "Dump HTML snapshots to /tmp when Codex dashboard data is missing")

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -548,6 +548,9 @@ extension CodexBarCLI {
         guard provider != .grok, provider != .amp else {
             return false
         }
+        if provider == .codex, sourceMode == .auto {
+            return false
+        }
         if provider == .ollama,
            sourceMode == .auto
         {

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -57,7 +57,7 @@ public enum CodexProviderDescriptor {
             case .api:
                 return []
             case .auto:
-                return [web, oauth, cli]
+                return [oauth, cli]
             }
         case .app:
             switch context.sourceMode {

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -318,7 +318,7 @@ final class CLIEntryTests: XCTestCase {
         try Data("{}".utf8).write(to: invalidMiMoCache)
 
         XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .kilo))
-        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .codex))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .codex))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .kilo))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .grok))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .grok))
@@ -328,7 +328,7 @@ final class CLIEntryTests: XCTestCase {
             .auto,
             provider: .ollama,
             environment: ["OLLAMA_API_KEY": "ollama-test"]))
-        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
             .auto,
             provider: .codex,
             environment: ["OLLAMA_API_KEY": "ollama-test"]))

--- a/Tests/CodexBarTests/CodexBaselineCharacterizationTests.swift
+++ b/Tests/CodexBarTests/CodexBaselineCharacterizationTests.swift
@@ -143,9 +143,9 @@ struct CodexBaselineCharacterizationTests {
     }
 
     @Test
-    func `CLI auto pipeline order is web then OAuth then CLI`() async {
+    func `CLI auto pipeline order is OAuth then CLI without web`() async {
         let strategyIDs = await self.strategyIDs(runtime: .cli, sourceMode: .auto)
-        #expect(strategyIDs == ["codex.web.dashboard", "codex.oauth", "codex.cli"])
+        #expect(strategyIDs == ["codex.oauth", "codex.cli"])
     }
 
     @Test
@@ -292,7 +292,7 @@ struct CodexBaselineCharacterizationTests {
     }
 
     @Test
-    func `CLI auto records unavailable web and OAuth before successful CLI`() async throws {
+    func `CLI auto records unavailable OAuth before successful CLI`() async throws {
         let stubCLI = self.makeStubCodexCLI()
         let codexHome = try self.makeEmptyCodexHome()
         defer { try? FileManager.default.removeItem(at: codexHome) }
@@ -313,8 +313,8 @@ struct CodexBaselineCharacterizationTests {
             settings: settings,
             codexArguments: stubCLI.arguments)
 
-        #expect(outcome.attempts.map(\.strategyID) == ["codex.web.dashboard", "codex.oauth", "codex.cli"])
-        #expect(outcome.attempts.map(\.wasAvailable) == [false, false, true])
+        #expect(outcome.attempts.map(\.strategyID) == ["codex.oauth", "codex.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [false, true])
 
         switch outcome.result {
         case let .success(result):
@@ -345,8 +345,8 @@ struct CodexBaselineCharacterizationTests {
             ],
             settings: settings)
 
-        #expect(outcome.attempts.map(\.strategyID) == ["codex.web.dashboard", "codex.oauth"])
-        #expect(outcome.attempts.map(\.wasAvailable) == [false, true])
+        #expect(outcome.attempts.map(\.strategyID) == ["codex.oauth"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [true])
 
         switch outcome.result {
         case .success:


### PR DESCRIPTION
## Summary

- Make Codex CLI automatic mode use OAuth, then the local Codex CLI, matching app behavior.
- Keep the web dashboard available only through explicit `--source web`.
- Let Codex automatic mode run on non-macOS platforms without the obsolete web-support rejection.
- Update strategy, fallback-attempt, platform-gate, and CLI-help coverage.

Closes #1608.

## Proof

Exact reviewed head: `4f0ed26f7203defe40cefc92704cf1e7187308c0`

- `swift test --filter CodexBaselineCharacterizationTests` - 9 tests passed.
- `swift test --filter CLIEntryTests/test_sourceModeRequiresWebSupportIsProviderAware` - passed.
- `swift test --filter CLIProviderSelectionTests` - 9 tests passed.
- `make check` - clean.
- Exact rebased-head autoreview - clean, confidence 0.82.
- Default source-build command against the local signed-in account returned in 0.75s without entering WebKit.
- Explicit OAuth returned in 0.32s; explicit CLI succeeded in 1.91s.
- `CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh` packaged exact head; deep strict codesign passed; bundle reports `CodexGitCommit=4f0ed26f`.
- Packaged default helper returned through the non-web automatic path in 0.87s.

The current account's OAuth response contains no usable rate-limit windows, so automatic mode surfaces the existing fast provider error instead of falling through on a non-auth OAuth failure. That fallback policy matches the app and is unchanged here.
