### PR TITLE
Bound the full Codex web fetch deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 - Menu bar: show provider status markers only for the provider rendered in each icon. Thanks @Zihao-Qi!
 - Codex CLI: make automatic usage reads prefer OAuth and CLI sources instead of blocking on the optional web dashboard.
+- Codex web: apply `--web-timeout` to the full cookie import, account verification, retry, and dashboard fetch path.
 - Provider probes: cap captured subprocess output at 1 MiB per stream without dropping valid text at a truncated UTF-8 boundary. Thanks @ProspectOre!
 - Provider switcher: keep Codex quota rows visible when switching away and back during a manual refresh, including menus with usage-history sections. Thanks @Yuxin-Qiao!
 - Bedrock: ignore invalid billing dates when selecting the latest usage values. Thanks @ProspectOre!

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -299,6 +299,29 @@ public enum CookieHeaderCache {
         }
     }
 
+    static func loadSerialized(provider: UsageProvider, scope: Scope? = nil) -> Entry? {
+        do {
+            return try self.withLegacyMutationLock {
+                let key = self.key(for: provider, scope: scope)
+                switch KeychainCacheStore.load(key: key, as: Entry.self) {
+                case let .found(entry):
+                    return entry
+                case .temporarilyUnavailable:
+                    return nil
+                case .invalid:
+                    KeychainCacheStore.clear(key: key)
+                case .missing:
+                    break
+                }
+                guard scope == nil else { return nil }
+                return self.migrateLegacyEntryIfNeededLocked(provider: provider)
+            }
+        } catch {
+            self.log.error("Cookie cache serialized load failed: \(error)")
+            return nil
+        }
+    }
+
     private static func loadOutcome(
         provider: UsageProvider,
         scope: Scope?,
@@ -337,31 +360,35 @@ public enum CookieHeaderCache {
     private static func migrateLegacyEntryIfNeeded(provider: UsageProvider) -> Entry? {
         do {
             return try self.withLegacyMutationLock {
-                let key = self.key(for: provider, scope: nil)
-                switch KeychainCacheStore.load(key: key, as: Entry.self) {
-                case let .found(entry):
-                    _ = self.removeLegacyEntry(for: provider)
-                    return entry
-                case .temporarilyUnavailable:
-                    return nil
-                case .invalid:
-                    KeychainCacheStore.clear(key: key)
-                case .missing:
-                    break
-                }
-
-                guard let legacy = self.loadLegacyEntry(for: provider) else { return nil }
-                if KeychainCacheStore.storeResult(key: key, entry: legacy),
-                   self.removeLegacyEntry(for: provider) == .removed
-                {
-                    self.log.debug("Cookie cache migrated from legacy store", metadata: ["provider": provider.rawValue])
-                }
-                return legacy
+                self.migrateLegacyEntryIfNeededLocked(provider: provider)
             }
         } catch {
             self.log.error("Cookie cache migration lock failed: \(error)")
             return nil
         }
+    }
+
+    private static func migrateLegacyEntryIfNeededLocked(provider: UsageProvider) -> Entry? {
+        let key = self.key(for: provider, scope: nil)
+        switch KeychainCacheStore.load(key: key, as: Entry.self) {
+        case let .found(entry):
+            _ = self.removeLegacyEntry(for: provider)
+            return entry
+        case .temporarilyUnavailable:
+            return nil
+        case .invalid:
+            KeychainCacheStore.clear(key: key)
+        case .missing:
+            break
+        }
+
+        guard let legacy = self.loadLegacyEntry(for: provider) else { return nil }
+        if KeychainCacheStore.storeResult(key: key, entry: legacy),
+           self.removeLegacyEntry(for: provider) == .removed
+        {
+            self.log.debug("Cookie cache migrated from legacy store", metadata: ["provider": provider.rawValue])
+        }
+        return legacy
     }
 
     public static func store(
@@ -377,16 +404,12 @@ public enum CookieHeaderCache {
             return
         }
         let entry = Entry(cookieHeader: normalized, storedAt: now, sourceLabel: sourceLabel)
-        if scope == nil {
-            do {
-                try self.withLegacyMutationLock {
-                    self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
-                }
-            } catch {
-                self.log.error("Cookie cache store lock failed: \(error)")
+        do {
+            try self.withLegacyMutationLock {
+                self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
             }
-        } else {
-            self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+        } catch {
+            self.log.error("Cookie cache store lock failed: \(error)")
         }
     }
 
@@ -411,17 +434,14 @@ public enum CookieHeaderCache {
     }
 
     public static func clearDetailed(provider: UsageProvider, scope: Scope? = nil) -> ClearSummary {
-        if scope == nil {
-            do {
-                return try self.withLegacyMutationLock {
-                    self.clearDetailedLocked(provider: provider, scope: scope)
-                }
-            } catch {
-                self.log.error("Cookie cache clear lock failed: \(error)")
-                return ClearSummary(clearedCount: 0, failedCount: 1)
+        do {
+            return try self.withLegacyMutationLock {
+                self.clearDetailedLocked(provider: provider, scope: scope)
             }
+        } catch {
+            self.log.error("Cookie cache clear lock failed: \(error)")
+            return ClearSummary(clearedCount: 0, failedCount: 1)
         }
-        return self.clearDetailedLocked(provider: provider, scope: scope)
     }
 
     private static func clearDetailedLocked(provider: UsageProvider, scope: Scope?) -> ClearSummary {

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
@@ -7,7 +7,7 @@ extension OpenAIDashboardBrowserCookieImporter {
         let task: Task<Void, Never>
     }
 
-    private static var pendingCookieStoreMutations: [ObjectIdentifier: PendingCookieStoreMutation] = [:]
+    @MainActor private static var pendingCookieStoreMutations: [ObjectIdentifier: PendingCookieStoreMutation] = [:]
 
     private final class CookieLoadCompletion: @unchecked Sendable {
         private let lock = NSLock()

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
@@ -8,6 +8,8 @@ extension OpenAIDashboardBrowserCookieImporter {
     }
 
     @MainActor private static var pendingCookieStoreMutations: [ObjectIdentifier: PendingCookieStoreMutation] = [:]
+    private nonisolated static let cookieCacheQueue = DispatchQueue(
+        label: "com.steipete.codexbar.openai-cookie-cache")
 
     private final class CookieLoadCompletion: @unchecked Sendable {
         private let lock = NSLock()
@@ -54,6 +56,15 @@ extension OpenAIDashboardBrowserCookieImporter {
             DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
                 completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
             }
+        }
+    }
+
+    nonisolated static func runBoundedCookieCacheOperation<T: Sendable>(
+        deadline: Date?,
+        operation: @escaping @Sendable () throws -> T) async throws -> T
+    {
+        try await self.runBoundedCookieLoad(deadline: deadline) {
+            try self.cookieCacheQueue.sync(execute: operation)
         }
     }
 

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
@@ -1,0 +1,122 @@
+#if os(macOS)
+import Foundation
+
+extension OpenAIDashboardBrowserCookieImporter {
+    private struct PendingCookieStoreMutation {
+        let token: UUID
+        let task: Task<Void, Never>
+    }
+
+    private static var pendingCookieStoreMutations: [ObjectIdentifier: PendingCookieStoreMutation] = [:]
+
+    private final class CookieLoadCompletion: @unchecked Sendable {
+        private let lock = NSLock()
+        private var didFinish = false
+
+        func finish(_ action: () -> Void) {
+            let shouldFinish = self.lock.withLock {
+                guard !self.didFinish else { return false }
+                self.didFinish = true
+                return true
+            }
+            if shouldFinish { action() }
+        }
+    }
+
+    nonisolated static func remainingTimeout(
+        until deadline: Date?,
+        cappedAt localLimit: TimeInterval? = nil,
+        now: Date = Date()) throws -> TimeInterval
+    {
+        guard let deadline else {
+            return localLimit.map(OpenAIDashboardFetcher.sanitizedTimeout) ?? .greatestFiniteMagnitude
+        }
+        let remaining = deadline.timeIntervalSince(now)
+        guard remaining > 0 else { throw URLError(.timedOut) }
+        guard let localLimit else { return remaining }
+        return min(OpenAIDashboardFetcher.sanitizedTimeout(localLimit), remaining)
+    }
+
+    nonisolated static func runBoundedCookieLoad<T: Sendable>(
+        deadline: Date?,
+        operation: @escaping @Sendable () throws -> T) async throws -> T
+    {
+        guard let deadline else {
+            return try await Task.detached(priority: .userInitiated, operation: operation).value
+        }
+        let timeout = try self.remainingTimeout(until: deadline)
+        let completion = CookieLoadCompletion()
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let result = Result(catching: operation)
+                completion.finish { continuation.resume(with: result) }
+            }
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+                completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
+            }
+        }
+    }
+
+    static func runBoundedCallback(
+        deadline: Date?,
+        start: (@escaping @Sendable () -> Void) -> Void) async throws
+    {
+        let completion = CookieLoadCompletion()
+        guard let deadline else {
+            await withCheckedContinuation { continuation in
+                start {
+                    completion.finish { continuation.resume() }
+                }
+            }
+            return
+        }
+
+        let timeout = try self.remainingTimeout(until: deadline)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            start {
+                completion.finish { continuation.resume() }
+            }
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+                completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
+            }
+        }
+    }
+
+    static func runSerializedCallback(
+        key: ObjectIdentifier,
+        deadline: Date?,
+        start: @escaping (@escaping @Sendable () -> Void) -> Void) async throws
+    {
+        while let pending = self.pendingCookieStoreMutations[key] {
+            try await self.waitForMutation(pending.task, deadline: deadline)
+            if self.pendingCookieStoreMutations[key]?.token == pending.token {
+                self.pendingCookieStoreMutations[key] = nil
+            }
+        }
+
+        let token = UUID()
+        let task = Task { @MainActor in
+            await withCheckedContinuation { continuation in
+                start { continuation.resume() }
+            }
+        }
+        self.pendingCookieStoreMutations[key] = PendingCookieStoreMutation(token: token, task: task)
+        Task { @MainActor in
+            await task.value
+            if self.pendingCookieStoreMutations[key]?.token == token {
+                self.pendingCookieStoreMutations[key] = nil
+            }
+        }
+        try await self.waitForMutation(task, deadline: deadline)
+    }
+
+    private static func waitForMutation(_ task: Task<Void, Never>, deadline: Date?) async throws {
+        try await self.runBoundedCallback(deadline: deadline) { completion in
+            Task { @MainActor in
+                await task.value
+                completion()
+            }
+        }
+    }
+}
+#endif

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
@@ -93,6 +93,30 @@ extension OpenAIDashboardBrowserCookieImporter {
         }
     }
 
+    static func runBoundedValueCallback<T: Sendable>(
+        deadline: Date?,
+        start: (@escaping @Sendable (T) -> Void) -> Void) async throws -> T
+    {
+        let completion = CookieLoadCompletion()
+        guard let deadline else {
+            return await withCheckedContinuation { continuation in
+                start { value in
+                    completion.finish { continuation.resume(returning: value) }
+                }
+            }
+        }
+
+        let timeout = try self.remainingTimeout(until: deadline)
+        return try await withCheckedThrowingContinuation { continuation in
+            start { value in
+                completion.finish { continuation.resume(returning: value) }
+            }
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+                completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
+            }
+        }
+    }
+
     static func runSerializedCallback(
         key: ObjectIdentifier,
         deadline: Date?,

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -90,9 +90,23 @@ public struct OpenAIDashboardBrowserCookieImporter {
     }
 
     private static let cookieDomains = ["chatgpt.com", "openai.com"]
-    private static let cookieClient = BrowserCookieClient()
+    private nonisolated static let cookieClient = BrowserCookieClient()
     private static let cookieImportOrder: BrowserCookieImportOrder =
         ProviderDefaults.metadata[.codex]?.browserCookieOrder ?? Browser.defaultImportOrder
+
+    private final class CookieLoadCompletion: @unchecked Sendable {
+        private let lock = NSLock()
+        private var didFinish = false
+
+        func finish(_ action: () -> Void) {
+            let shouldFinish = self.lock.withLock {
+                guard !self.didFinish else { return false }
+                self.didFinish = true
+                return true
+            }
+            if shouldFinish { action() }
+        }
+    }
 
     nonisolated static func remainingTimeout(
         until deadline: Date?,
@@ -106,6 +120,26 @@ public struct OpenAIDashboardBrowserCookieImporter {
         guard remaining > 0 else { throw URLError(.timedOut) }
         guard let localLimit else { return remaining }
         return min(OpenAIDashboardFetcher.sanitizedTimeout(localLimit), remaining)
+    }
+
+    nonisolated static func runBoundedCookieLoad<T: Sendable>(
+        deadline: Date?,
+        operation: @escaping @Sendable () throws -> T) async throws -> T
+    {
+        guard let deadline else {
+            return try await Task.detached(priority: .userInitiated, operation: operation).value
+        }
+        let timeout = try self.remainingTimeout(until: deadline)
+        let completion = CookieLoadCompletion()
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let result = Result(catching: operation)
+                completion.finish { continuation.resume(with: result) }
+            }
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+                completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
+            }
+        }
     }
 
     private enum CandidateEvaluation {
@@ -281,10 +315,9 @@ public struct OpenAIDashboardBrowserCookieImporter {
         // Safari first: avoids touching Keychain ("Chrome Safe Storage") when Safari already matches.
         do {
             let query = BrowserCookieQuery(domains: Self.cookieDomains)
-            let sources = try Self.cookieClient.codexBarRecords(
-                matching: query,
-                in: .safari,
-                logger: log)
+            let sources = try await Self.runBoundedCookieLoad(deadline: deadline) {
+                try Self.cookieClient.codexBarRecords(matching: query, in: .safari)
+            }
             _ = try Self.remainingTimeout(until: deadline)
             guard !sources.isEmpty else {
                 log("Safari contained 0 matching records.")
@@ -338,9 +371,9 @@ public struct OpenAIDashboardBrowserCookieImporter {
     {
         do {
             let query = BrowserCookieQuery(domains: Self.cookieDomains)
-            let sources = try Self.cookieClient.codexBarRecords(
-                matching: query,
-                in: browser)
+            let sources = try await Self.runBoundedCookieLoad(deadline: deadline) {
+                try Self.cookieClient.codexBarRecords(matching: query, in: browser)
+            }
             _ = try Self.remainingTimeout(until: deadline)
             guard !sources.isEmpty else {
                 log("\(browser.displayName) contained 0 matching records.")

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -140,7 +140,10 @@ public struct OpenAIDashboardBrowserCookieImporter {
         var diagnostics = ImportDiagnostics()
 
         if preferCachedCookieHeader {
-            if let cached = CookieHeaderCache.load(provider: .codex, scope: cacheScope),
+            let cached = try await Self.runBoundedCookieCacheOperation(deadline: deadline) {
+                CookieHeaderCache.loadSerialized(provider: .codex, scope: cacheScope)
+            }
+            if let cached,
                !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             {
                 log("Using cached cookie header from \(cached.sourceLabel)")
@@ -155,7 +158,13 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 } catch let error as ImportError {
                     switch error {
                     case .manualCookieHeaderInvalid, .noMatchingAccount, .dashboardStillRequiresLogin:
-                        CookieHeaderCache.clear(provider: .codex, scope: cacheScope)
+                        do {
+                            _ = try await Self.runBoundedCookieCacheOperation(deadline: deadline) {
+                                CookieHeaderCache.clear(provider: .codex, scope: cacheScope)
+                            }
+                        } catch {
+                            log("Stale cookie cache cleanup did not finish before the web deadline.")
+                        }
                     default:
                         throw error
                     }
@@ -424,7 +433,11 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 deadline: deadline,
                 logger: log)
             {
-                self.cacheCookies(candidate: candidate, scope: context.cacheScope)
+                await self.cacheCookies(
+                    candidate: candidate,
+                    scope: context.cacheScope,
+                    deadline: deadline,
+                    logger: log)
                 return result
             }
             _ = try Self.remainingTimeout(until: deadline)
@@ -447,7 +460,11 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 deadline: deadline,
                 logger: log)
             {
-                self.cacheCookies(candidate: candidate, scope: context.cacheScope)
+                await self.cacheCookies(
+                    candidate: candidate,
+                    scope: context.cacheScope,
+                    deadline: deadline,
+                    logger: log)
                 return result
             }
             _ = try Self.remainingTimeout(until: deadline)
@@ -460,7 +477,11 @@ public struct OpenAIDashboardBrowserCookieImporter {
                     deadline: deadline,
                     logger: log)
                 {
-                    self.cacheCookies(candidate: candidate, scope: context.cacheScope)
+                    await self.cacheCookies(
+                        candidate: candidate,
+                        scope: context.cacheScope,
+                        deadline: deadline,
+                        logger: log)
                     return result
                 }
                 _ = try Self.remainingTimeout(until: deadline)
@@ -763,10 +784,26 @@ public struct OpenAIDashboardBrowserCookieImporter {
         return cookies
     }
 
-    private func cacheCookies(candidate: Candidate, scope: CookieHeaderCache.Scope?) {
+    private func cacheCookies(
+        candidate: Candidate,
+        scope: CookieHeaderCache.Scope?,
+        deadline: Date?,
+        logger: @escaping (String) -> Void) async
+    {
         let header = self.cookieHeader(from: candidate.cookies)
         guard !header.isEmpty else { return }
-        CookieHeaderCache.store(provider: .codex, scope: scope, cookieHeader: header, sourceLabel: candidate.label)
+        do {
+            _ = try await Self.runBoundedCookieCacheOperation(deadline: deadline) {
+                CookieHeaderCache.store(
+                    provider: .codex,
+                    scope: scope,
+                    cookieHeader: header,
+                    sourceLabel: candidate.label)
+                return true
+            }
+        } catch {
+            logger("Cookie cache write did not finish before the web deadline.")
+        }
     }
 
     private func cookieHeader(from cookies: [HTTPCookie]) -> String {

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -94,6 +94,20 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private static let cookieImportOrder: BrowserCookieImportOrder =
         ProviderDefaults.metadata[.codex]?.browserCookieOrder ?? Browser.defaultImportOrder
 
+    nonisolated static func remainingTimeout(
+        until deadline: Date?,
+        cappedAt localLimit: TimeInterval? = nil,
+        now: Date = Date()) throws -> TimeInterval
+    {
+        guard let deadline else {
+            return localLimit.map(OpenAIDashboardFetcher.sanitizedTimeout) ?? .greatestFiniteMagnitude
+        }
+        let remaining = deadline.timeIntervalSince(now)
+        guard remaining > 0 else { throw URLError(.timedOut) }
+        guard let localLimit else { return remaining }
+        return min(OpenAIDashboardFetcher.sanitizedTimeout(localLimit), remaining)
+    }
+
     private enum CandidateEvaluation {
         case match(candidate: Candidate, signedInEmail: String)
         case mismatch(candidate: Candidate, signedInEmail: String)
@@ -107,6 +121,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
         allowAnyAccount: Bool = false,
         preferCachedCookieHeader: Bool = true,
         cacheScope: CookieHeaderCache.Scope? = nil,
+        deadline: Date? = nil,
         logger: ((String) -> Void)? = nil) async throws -> ImportResult
     {
         let log: (String) -> Void = { message in
@@ -142,6 +157,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
                         intoAccountEmail: context.targetEmail,
                         allowAnyAccount: context.allowAnyAccount,
                         cacheScope: cacheScope,
+                        deadline: deadline,
                         logger: log)
                 } catch let error as ImportError {
                     switch error {
@@ -161,15 +177,18 @@ public struct OpenAIDashboardBrowserCookieImporter {
         // Filter to cookie-eligible browsers to avoid unnecessary keychain prompts
         let installedBrowsers = Self.cookieImportOrder.cookieImportCandidates(using: self.browserDetection)
         for browserSource in installedBrowsers {
-            if let match = await self.trySource(
+            _ = try Self.remainingTimeout(until: deadline)
+            if let match = try await self.trySource(
                 browserSource,
                 context: context,
+                deadline: deadline,
                 log: log,
                 diagnostics: &diagnostics)
             {
                 return match
             }
         }
+        _ = try Self.remainingTimeout(until: deadline)
 
         if !diagnostics.mismatches.isEmpty {
             let found = Array(Set(diagnostics.mismatches)).sorted { lhs, rhs in
@@ -199,6 +218,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
         intoAccountEmail targetEmail: String?,
         allowAnyAccount: Bool = false,
         cacheScope _: CookieHeaderCache.Scope? = nil,
+        deadline: Date? = nil,
         logger: ((String) -> Void)? = nil) async throws -> ImportResult
     {
         let log: (String) -> Void = { message in
@@ -216,10 +236,11 @@ public struct OpenAIDashboardBrowserCookieImporter {
         guard !cookies.isEmpty else { throw ImportError.manualCookieHeaderInvalid }
 
         let candidate = Candidate(label: "Manual", cookies: cookies)
-        switch await self.evaluateCandidate(
+        switch try await self.evaluateCandidate(
             candidate,
             targetEmail: normalizedTarget,
             allowAnyAccount: allowAnyAccount,
+            deadline: deadline,
             log: log)
         {
         case let .match(_, signedInEmail):
@@ -227,18 +248,23 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 candidate: candidate,
                 targetEmail: signedInEmail,
                 verifiedSignedInEmail: signedInEmail,
+                deadline: deadline,
                 logger: log)
         case let .loggedIn(_, signedInEmail):
             return try await self.persistVerifiedCandidate(
                 candidate: candidate,
                 targetEmail: signedInEmail,
                 verifiedSignedInEmail: signedInEmail,
+                deadline: deadline,
                 logger: log)
         case let .mismatch(_, signedInEmail):
             throw ImportError.noMatchingAccount(found: [FoundAccount(sourceLabel: "Manual", email: signedInEmail)])
         case .unknown:
             if allowAnyAccount {
-                return try await self.persistToDefaultStore(candidate: candidate, logger: log)
+                return try await self.persistToDefaultStore(
+                    candidate: candidate,
+                    deadline: deadline,
+                    logger: log)
             }
             throw ImportError.noMatchingAccount(found: [])
         case .loginRequired:
@@ -248,8 +274,9 @@ public struct OpenAIDashboardBrowserCookieImporter {
 
     private func trySafari(
         context: ImportContext,
+        deadline: Date?,
         log: @escaping (String) -> Void,
-        diagnostics: inout ImportDiagnostics) async -> ImportResult?
+        diagnostics: inout ImportDiagnostics) async throws -> ImportResult?
     {
         // Safari first: avoids touching Keychain ("Chrome Safe Storage") when Safari already matches.
         do {
@@ -258,11 +285,13 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 matching: query,
                 in: .safari,
                 logger: log)
+            _ = try Self.remainingTimeout(until: deadline)
             guard !sources.isEmpty else {
                 log("Safari contained 0 matching records.")
                 return nil
             }
             for source in sources {
+                _ = try Self.remainingTimeout(until: deadline)
                 let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
                 guard !cookies.isEmpty else {
                     log("\(source.label) produced 0 HTTPCookies.")
@@ -272,9 +301,10 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 diagnostics.foundAnyCookies = true
                 log("Loaded \(cookies.count) cookies from \(source.label) (\(self.cookieSummary(cookies)))")
                 let candidate = Candidate(label: source.label, cookies: cookies)
-                if let match = await self.applyCandidate(
+                if let match = try await self.applyCandidate(
                     candidate,
                     context: context,
+                    deadline: deadline,
                     log: log,
                     diagnostics: &diagnostics)
                 {
@@ -282,6 +312,8 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 }
             }
             return nil
+        } catch let error as URLError where error.code == .timedOut {
+            throw error
         } catch let error as BrowserCookieError {
             BrowserCookieAccessGate.recordIfNeeded(error)
             if let hint = error.accessDeniedHint {
@@ -300,19 +332,22 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private func tryBrowser(
         _ browser: Browser,
         context: ImportContext,
+        deadline: Date?,
         log: @escaping (String) -> Void,
-        diagnostics: inout ImportDiagnostics) async -> ImportResult?
+        diagnostics: inout ImportDiagnostics) async throws -> ImportResult?
     {
         do {
             let query = BrowserCookieQuery(domains: Self.cookieDomains)
             let sources = try Self.cookieClient.codexBarRecords(
                 matching: query,
                 in: browser)
+            _ = try Self.remainingTimeout(until: deadline)
             guard !sources.isEmpty else {
                 log("\(browser.displayName) contained 0 matching records.")
                 return nil
             }
             for source in sources {
+                _ = try Self.remainingTimeout(until: deadline)
                 let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
                 guard !cookies.isEmpty else {
                     log("\(source.label) produced 0 HTTPCookies.")
@@ -321,9 +356,10 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 diagnostics.foundAnyCookies = true
                 log("Loaded \(cookies.count) cookies from \(source.label) (\(self.cookieSummary(cookies)))")
                 let candidate = Candidate(label: source.label, cookies: cookies)
-                if let match = await self.applyCandidate(
+                if let match = try await self.applyCandidate(
                     candidate,
                     context: context,
+                    deadline: deadline,
                     log: log,
                     diagnostics: &diagnostics)
                 {
@@ -331,6 +367,8 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 }
             }
             return nil
+        } catch let error as URLError where error.code == .timedOut {
+            throw error
         } catch let error as BrowserCookieError {
             BrowserCookieAccessGate.recordIfNeeded(error)
             if let hint = error.accessDeniedHint {
@@ -347,21 +385,24 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private func trySource(
         _ source: Browser,
         context: ImportContext,
+        deadline: Date?,
         log: @escaping (String) -> Void,
-        diagnostics: inout ImportDiagnostics) async -> ImportResult?
+        diagnostics: inout ImportDiagnostics) async throws -> ImportResult?
     {
         switch source {
         case .safari:
-            await self.trySafari(
+            try await self.trySafari(
                 context: context,
+                deadline: deadline,
                 log: log,
                 diagnostics: &diagnostics)
         default:
             // All non-Safari browsers (Chrome, Edge, Firefox, Brave, Arc, etc.)
             // share the same cookie loading path via SweetCookieKit.
-            await self.tryBrowser(
+            try await self.tryBrowser(
                 source,
                 context: context,
+                deadline: deadline,
                 log: log,
                 diagnostics: &diagnostics)
         }
@@ -370,13 +411,15 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private func applyCandidate(
         _ candidate: Candidate,
         context: ImportContext,
+        deadline: Date?,
         log: @escaping (String) -> Void,
-        diagnostics: inout ImportDiagnostics) async -> ImportResult?
+        diagnostics: inout ImportDiagnostics) async throws -> ImportResult?
     {
-        switch await self.evaluateCandidate(
+        switch try await self.evaluateCandidate(
             candidate,
             targetEmail: context.targetEmail,
             allowAnyAccount: context.allowAnyAccount,
+            deadline: deadline,
             log: log)
         {
         case let .match(candidate, signedInEmail):
@@ -386,11 +429,13 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 candidate: candidate,
                 targetEmail: targetEmail,
                 verifiedSignedInEmail: signedInEmail,
+                deadline: deadline,
                 logger: log)
             {
                 self.cacheCookies(candidate: candidate, scope: context.cacheScope)
                 return result
             }
+            _ = try Self.remainingTimeout(until: deadline)
             return nil
         case let .mismatch(candidate, signedInEmail):
             await self.handleMismatch(
@@ -398,6 +443,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 signedInEmail: signedInEmail,
                 log: log,
                 diagnostics: &diagnostics)
+            _ = try Self.remainingTimeout(until: deadline)
             return nil
         case let .loggedIn(candidate, signedInEmail):
             log("Selected \(candidate.label) (signed in: \(signedInEmail))")
@@ -405,19 +451,26 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 candidate: candidate,
                 targetEmail: signedInEmail,
                 verifiedSignedInEmail: signedInEmail,
+                deadline: deadline,
                 logger: log)
             {
                 self.cacheCookies(candidate: candidate, scope: context.cacheScope)
                 return result
             }
+            _ = try Self.remainingTimeout(until: deadline)
             return nil
         case .unknown:
             if context.allowAnyAccount {
                 log("Selected \(candidate.label) (signed in: unknown)")
-                if let result = try? await self.persistToDefaultStore(candidate: candidate, logger: log) {
+                if let result = try? await self.persistToDefaultStore(
+                    candidate: candidate,
+                    deadline: deadline,
+                    logger: log)
+                {
                     self.cacheCookies(candidate: candidate, scope: context.cacheScope)
                     return result
                 }
+                _ = try Self.remainingTimeout(until: deadline)
                 return nil
             }
             diagnostics.foundUnknownEmail = true
@@ -431,11 +484,15 @@ public struct OpenAIDashboardBrowserCookieImporter {
         _ candidate: Candidate,
         targetEmail: String?,
         allowAnyAccount: Bool,
-        log: @escaping (String) -> Void) async -> CandidateEvaluation
+        deadline: Date?,
+        log: @escaping (String) -> Void) async throws -> CandidateEvaluation
     {
         log("Trying candidate \(candidate.label) (\(candidate.cookies.count) cookies)")
 
-        let apiEmail = await self.fetchSignedInEmailFromAPI(cookies: candidate.cookies, logger: log)
+        let apiEmail = try await self.fetchSignedInEmailFromAPI(
+            cookies: candidate.cookies,
+            deadline: deadline,
+            logger: log)
         if let apiEmail {
             log("Candidate \(candidate.label) API email: \(apiEmail)")
         }
@@ -458,12 +515,13 @@ public struct OpenAIDashboardBrowserCookieImporter {
 
         let scratch = WKWebsiteDataStore.nonPersistent()
         await self.setCookies(candidate.cookies, into: scratch)
+        _ = try Self.remainingTimeout(until: deadline)
 
         do {
             let probe = try await OpenAIDashboardFetcher().probeUsagePage(
                 websiteDataStore: scratch,
                 logger: log,
-                timeout: 25)
+                timeout: Self.remainingTimeout(until: deadline, cappedAt: 25))
             let signedInEmail = probe.signedInEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
             log("Candidate \(candidate.label) DOM email: \(signedInEmail ?? "unknown")")
 
@@ -483,6 +541,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
             log("Candidate \(candidate.label) requires login.")
             return .loginRequired(candidate: candidate)
         } catch {
+            _ = try Self.remainingTimeout(until: deadline)
             log("Candidate \(candidate.label) probe error: \(error.localizedDescription)")
             return .unknown(candidate: candidate)
         }
@@ -515,7 +574,8 @@ public struct OpenAIDashboardBrowserCookieImporter {
 
     private func fetchSignedInEmailFromAPI(
         cookies: [HTTPCookie],
-        logger: (String) -> Void) async -> String?
+        deadline: Date?,
+        logger: (String) -> Void) async throws -> String?
     {
         let chatgptCookies = cookies.filter { $0.domain.lowercased().contains("chatgpt.com") }
         guard !chatgptCookies.isEmpty else { return nil }
@@ -530,10 +590,11 @@ public struct OpenAIDashboardBrowserCookieImporter {
         ]
 
         for urlString in endpoints {
+            let requestTimeout = try Self.remainingTimeout(until: deadline, cappedAt: 10)
             guard let url = URL(string: urlString) else { continue }
             var request = URLRequest(url: url)
             request.httpMethod = "GET"
-            request.timeoutInterval = 10
+            request.timeoutInterval = requestTimeout
             request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
             request.setValue("application/json", forHTTPHeaderField: "Accept")
 
@@ -546,6 +607,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
                     return email.trimmingCharacters(in: .whitespacesAndNewlines)
                 }
             } catch {
+                _ = try Self.remainingTimeout(until: deadline)
                 logger("API request failed: \(error.localizedDescription)")
             }
         }
@@ -579,10 +641,15 @@ public struct OpenAIDashboardBrowserCookieImporter {
         candidate: Candidate,
         targetEmail: String,
         verifiedSignedInEmail: String,
+        deadline: Date?,
         logger: @escaping (String) -> Void) async throws -> ImportResult
     {
         do {
-            return try await self.persist(candidate: candidate, targetEmail: targetEmail, logger: logger)
+            return try await self.persist(
+                candidate: candidate,
+                targetEmail: targetEmail,
+                deadline: deadline,
+                logger: logger)
         } catch {
             guard Self.shouldTrustVerifiedSession(afterPersistFailure: error) else {
                 throw error
@@ -603,18 +670,20 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private func persist(
         candidate: Candidate,
         targetEmail: String,
+        deadline: Date?,
         logger: @escaping (String) -> Void) async throws -> ImportResult
     {
         let persistent = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: targetEmail)
         await self.clearChatGPTCookies(in: persistent)
         await self.setCookies(candidate.cookies, into: persistent)
+        _ = try Self.remainingTimeout(until: deadline)
 
         // Validate against the persistent store (login + email sync).
         do {
             let probe = try await OpenAIDashboardFetcher().probeUsagePage(
                 websiteDataStore: persistent,
                 logger: logger,
-                timeout: 20,
+                timeout: Self.remainingTimeout(until: deadline, cappedAt: 20),
                 preserveLoadedPageForReuse: true)
             let signed = probe.signedInEmail?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
             let matches = signed?.lowercased() == targetEmail.lowercased()
@@ -642,17 +711,19 @@ public struct OpenAIDashboardBrowserCookieImporter {
 
     private func persistToDefaultStore(
         candidate: Candidate,
+        deadline: Date?,
         logger: @escaping (String) -> Void) async throws -> ImportResult
     {
         let persistent = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: nil)
         await self.clearChatGPTCookies(in: persistent)
         await self.setCookies(candidate.cookies, into: persistent)
+        _ = try Self.remainingTimeout(until: deadline)
 
         do {
             let probe = try await OpenAIDashboardFetcher().probeUsagePage(
                 websiteDataStore: persistent,
                 logger: logger,
-                timeout: 20,
+                timeout: Self.remainingTimeout(until: deadline, cappedAt: 20),
                 preserveLoadedPageForReuse: true)
             let signed = probe.signedInEmail?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
             logger("Persistent session signed in as: \(signed ?? "unknown")")
@@ -823,6 +894,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
         allowAnyAccount _: Bool = false,
         preferCachedCookieHeader _: Bool = true,
         cacheScope _: CookieHeaderCache.Scope? = nil,
+        deadline _: Date? = nil,
         logger _: ((String) -> Void)? = nil) async throws -> ImportResult
     {
         throw ImportError.browserAccessDenied(details: "OpenAI web cookie import is only supported on macOS.")
@@ -833,6 +905,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
         intoAccountEmail _: String?,
         allowAnyAccount _: Bool = false,
         cacheScope _: CookieHeaderCache.Scope? = nil,
+        deadline _: Date? = nil,
         logger _: ((String) -> Void)? = nil) async throws -> ImportResult
     {
         throw ImportError.browserAccessDenied(details: "OpenAI web cookie import is only supported on macOS.")

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -71,9 +71,16 @@ public struct OpenAIDashboardBrowserCookieImporter {
 
     private let browserDetection: BrowserDetection
 
+    struct PersistentValidationTimeout: Error {}
+
     nonisolated static func shouldTrustVerifiedSession(afterPersistFailure error: Error) -> Bool {
+        error is PersistentValidationTimeout
+    }
+
+    nonisolated static func persistentValidationFailure(_ error: Error) -> Error {
         let nsError = error as NSError
-        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut
+        guard nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorTimedOut else { return error }
+        return PersistentValidationTimeout()
     }
 
     private struct ImportDiagnostics {
@@ -93,54 +100,6 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private nonisolated static let cookieClient = BrowserCookieClient()
     private static let cookieImportOrder: BrowserCookieImportOrder =
         ProviderDefaults.metadata[.codex]?.browserCookieOrder ?? Browser.defaultImportOrder
-
-    private final class CookieLoadCompletion: @unchecked Sendable {
-        private let lock = NSLock()
-        private var didFinish = false
-
-        func finish(_ action: () -> Void) {
-            let shouldFinish = self.lock.withLock {
-                guard !self.didFinish else { return false }
-                self.didFinish = true
-                return true
-            }
-            if shouldFinish { action() }
-        }
-    }
-
-    nonisolated static func remainingTimeout(
-        until deadline: Date?,
-        cappedAt localLimit: TimeInterval? = nil,
-        now: Date = Date()) throws -> TimeInterval
-    {
-        guard let deadline else {
-            return localLimit.map(OpenAIDashboardFetcher.sanitizedTimeout) ?? .greatestFiniteMagnitude
-        }
-        let remaining = deadline.timeIntervalSince(now)
-        guard remaining > 0 else { throw URLError(.timedOut) }
-        guard let localLimit else { return remaining }
-        return min(OpenAIDashboardFetcher.sanitizedTimeout(localLimit), remaining)
-    }
-
-    nonisolated static func runBoundedCookieLoad<T: Sendable>(
-        deadline: Date?,
-        operation: @escaping @Sendable () throws -> T) async throws -> T
-    {
-        guard let deadline else {
-            return try await Task.detached(priority: .userInitiated, operation: operation).value
-        }
-        let timeout = try self.remainingTimeout(until: deadline)
-        let completion = CookieLoadCompletion()
-        return try await withCheckedThrowingContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let result = Result(catching: operation)
-                completion.finish { continuation.resume(with: result) }
-            }
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
-                completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
-            }
-        }
-    }
 
     private enum CandidateEvaluation {
         case match(candidate: Candidate, signedInEmail: String)
@@ -471,9 +430,10 @@ public struct OpenAIDashboardBrowserCookieImporter {
             _ = try Self.remainingTimeout(until: deadline)
             return nil
         case let .mismatch(candidate, signedInEmail):
-            await self.handleMismatch(
+            try await self.handleMismatch(
                 candidate: candidate,
                 signedInEmail: signedInEmail,
+                deadline: deadline,
                 log: log,
                 diagnostics: &diagnostics)
             _ = try Self.remainingTimeout(until: deadline)
@@ -547,8 +507,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
         }
 
         let scratch = WKWebsiteDataStore.nonPersistent()
-        await self.setCookies(candidate.cookies, into: scratch)
-        _ = try Self.remainingTimeout(until: deadline)
+        try await self.setCookies(candidate.cookies, into: scratch, deadline: deadline)
 
         do {
             let probe = try await OpenAIDashboardFetcher().probeUsagePage(
@@ -594,15 +553,25 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private func handleMismatch(
         candidate: Candidate,
         signedInEmail: String,
+        deadline: Date?,
         log: @escaping (String) -> Void,
-        diagnostics: inout ImportDiagnostics) async
+        diagnostics: inout ImportDiagnostics) async throws
     {
         log("Candidate \(candidate.label) mismatch (\(signedInEmail)); continuing browser search")
         diagnostics.mismatches.append(FoundAccount(sourceLabel: candidate.label, email: signedInEmail))
         // Mismatch still means we found a valid signed-in session. Persist it keyed by its email so if
         // the user switches Codex accounts later, we can reuse this session immediately without another
         // Keychain prompt.
-        await self.persistCookies(candidate: candidate, accountEmail: signedInEmail, logger: log)
+        do {
+            try await self.persistCookies(
+                candidate: candidate,
+                accountEmail: signedInEmail,
+                deadline: deadline,
+                logger: log)
+        } catch {
+            log("Could not cache mismatched session: \(error.localizedDescription)")
+            _ = try Self.remainingTimeout(until: deadline)
+        }
     }
 
     private func fetchSignedInEmailFromAPI(
@@ -707,9 +676,8 @@ public struct OpenAIDashboardBrowserCookieImporter {
         logger: @escaping (String) -> Void) async throws -> ImportResult
     {
         let persistent = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: targetEmail)
-        await self.clearChatGPTCookies(in: persistent)
-        await self.setCookies(candidate.cookies, into: persistent)
-        _ = try Self.remainingTimeout(until: deadline)
+        try await self.clearChatGPTCookies(in: persistent, deadline: deadline)
+        try await self.setCookies(candidate.cookies, into: persistent, deadline: deadline)
 
         // Validate against the persistent store (login + email sync).
         do {
@@ -738,7 +706,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
             throw ImportError.dashboardStillRequiresLogin
         } catch {
             OpenAIDashboardWebViewCache.shared.evict(websiteDataStore: persistent)
-            throw error
+            throw Self.persistentValidationFailure(error)
         }
     }
 
@@ -748,9 +716,8 @@ public struct OpenAIDashboardBrowserCookieImporter {
         logger: @escaping (String) -> Void) async throws -> ImportResult
     {
         let persistent = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: nil)
-        await self.clearChatGPTCookies(in: persistent)
-        await self.setCookies(candidate.cookies, into: persistent)
-        _ = try Self.remainingTimeout(until: deadline)
+        try await self.clearChatGPTCookies(in: persistent, deadline: deadline)
+        try await self.setCookies(candidate.cookies, into: persistent, deadline: deadline)
 
         do {
             let probe = try await OpenAIDashboardFetcher().probeUsagePage(
@@ -813,31 +780,46 @@ public struct OpenAIDashboardBrowserCookieImporter {
 
     // MARK: - WebKit cookie store
 
-    private func persistCookies(candidate: Candidate, accountEmail: String, logger: (String) -> Void) async {
+    private func persistCookies(
+        candidate: Candidate,
+        accountEmail: String,
+        deadline: Date?,
+        logger: (String) -> Void) async throws
+    {
         let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: accountEmail)
-        await self.clearChatGPTCookies(in: store)
-        await self.setCookies(candidate.cookies, into: store)
+        try await self.clearChatGPTCookies(in: store, deadline: deadline)
+        try await self.setCookies(candidate.cookies, into: store, deadline: deadline)
         logger("Persisted cookies for \(accountEmail) (source=\(candidate.label))")
     }
 
-    private func clearChatGPTCookies(in store: WKWebsiteDataStore) async {
-        await withCheckedContinuation { cont in
+    private func clearChatGPTCookies(in store: WKWebsiteDataStore, deadline: Date?) async throws {
+        try await Self.runSerializedCallback(
+            key: ObjectIdentifier(store),
+            deadline: deadline)
+        { completion in
             store.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
                 let filtered = records.filter { record in
                     let name = record.displayName.lowercased()
                     return name.contains("chatgpt.com") || name.contains("openai.com")
                 }
                 store.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), for: filtered) {
-                    cont.resume()
+                    completion()
                 }
             }
         }
     }
 
-    private func setCookies(_ cookies: [HTTPCookie], into store: WKWebsiteDataStore) async {
+    private func setCookies(
+        _ cookies: [HTTPCookie],
+        into store: WKWebsiteDataStore,
+        deadline: Date?) async throws
+    {
         for cookie in cookies {
-            await withCheckedContinuation { cont in
-                store.httpCookieStore.setCookie(cookie) { cont.resume() }
+            try await Self.runSerializedCallback(
+                key: ObjectIdentifier(store),
+                deadline: deadline)
+            { completion in
+                store.httpCookieStore.setCookie(cookie, completionHandler: completion)
             }
         }
     }

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -227,7 +227,7 @@ public struct OpenAIDashboardFetcher {
         timeout: TimeInterval = 60) async throws -> OpenAIDashboardSnapshot
     {
         let deadline = Self.deadline(startingAt: Date(), timeout: timeout)
-        let preflight = await Self.fetchDashboardAPIPreflight(
+        let preflight = try await Self.fetchDashboardAPIPreflight(
             websiteDataStore: websiteDataStore,
             deadline: deadline,
             logger: { logger?($0) })
@@ -713,9 +713,9 @@ public struct OpenAIDashboardFetcher {
         websiteDataStore: WKWebsiteDataStore,
         deadline: Date,
         logger: @escaping (String) -> Void)
-        async -> (apiData: DashboardAPIData?, verifiedSignedInEmail: String?)
+        async throws -> (apiData: DashboardAPIData?, verifiedSignedInEmail: String?)
     {
-        let cookieHeader = await self.chatGPTCookieHeader(in: websiteDataStore)
+        let cookieHeader = try await self.chatGPTCookieHeader(in: websiteDataStore, deadline: deadline)
         let apiData = await self.fetchDashboardUsageAPI(
             cookieHeader: cookieHeader,
             deadline: deadline,
@@ -739,7 +739,9 @@ public struct OpenAIDashboardFetcher {
         websiteDataStore: WKWebsiteDataStore,
         logger: @escaping (String) -> Void) async -> DashboardAPIData?
     {
-        let cookieHeader = await self.chatGPTCookieHeader(in: websiteDataStore)
+        guard let cookieHeader = try? await self.chatGPTCookieHeader(in: websiteDataStore, deadline: nil) else {
+            return nil
+        }
         return await self.fetchDashboardUsageAPI(cookieHeader: cookieHeader, deadline: nil, logger: logger)
     }
 
@@ -805,11 +807,11 @@ public struct OpenAIDashboardFetcher {
         return nil
     }
 
-    private static func chatGPTCookieHeader(in store: WKWebsiteDataStore) async -> String {
-        let cookies = await withCheckedContinuation { continuation in
-            store.httpCookieStore.getAllCookies { cookies in
-                continuation.resume(returning: cookies)
-            }
+    private static func chatGPTCookieHeader(in store: WKWebsiteDataStore, deadline: Date?) async throws -> String {
+        let cookies = try await OpenAIDashboardBrowserCookieImporter.runBoundedValueCallback(
+            deadline: deadline)
+        { completion in
+            store.httpCookieStore.getAllCookies(completion)
         }
 
         return cookies

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -229,14 +229,16 @@ public struct OpenAIDashboardFetcher {
         let deadline = Self.deadline(startingAt: Date(), timeout: timeout)
         let preflight = await Self.fetchDashboardAPIPreflight(
             websiteDataStore: websiteDataStore,
+            deadline: deadline,
             logger: { logger?($0) })
         try Task.checkCancellation()
         let (apiData, verifiedSignedInEmail) = (preflight.apiData, preflight.verifiedSignedInEmail)
+        let remainingTimeout = try Self.requiredRemainingTimeout(until: deadline)
 
         let lease = try await self.makeWebView(
             websiteDataStore: websiteDataStore,
             logger: logger,
-            timeout: Self.remainingTimeout(until: deadline),
+            timeout: remainingTimeout,
             allowNavigationTimeoutRetry: allowNavigationTimeoutRetry)
         defer { lease.release() }
         let webView = lease.webView
@@ -697,28 +699,6 @@ public struct OpenAIDashboardFetcher {
         return request
     }
 
-    nonisolated static func dashboardUsageAPIRequest(cookieHeader: String) -> URLRequest {
-        var request = URLRequest(url: Self.dashboardUsageAPIURL)
-        request.httpMethod = "GET"
-        request.timeoutInterval = 4
-        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
-        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
-        return request
-    }
-
-    nonisolated static func dashboardIdentityAPIRequest(url: URL, cookieHeader: String) -> URLRequest {
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.timeoutInterval = 2
-        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
-        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
-        return request
-    }
-
     nonisolated static func dashboardAPIData(from response: CodexUsageResponse) -> DashboardAPIData {
         DashboardAPIData(
             primaryLimit: self.rateWindow(from: response.rateLimit?.primaryWindow),
@@ -731,13 +711,20 @@ public struct OpenAIDashboardFetcher {
 
     private static func fetchDashboardAPIPreflight(
         websiteDataStore: WKWebsiteDataStore,
+        deadline: Date,
         logger: @escaping (String) -> Void)
         async -> (apiData: DashboardAPIData?, verifiedSignedInEmail: String?)
     {
         let cookieHeader = await self.chatGPTCookieHeader(in: websiteDataStore)
-        let apiData = await self.fetchDashboardUsageAPI(cookieHeader: cookieHeader, logger: logger)
+        let apiData = await self.fetchDashboardUsageAPI(
+            cookieHeader: cookieHeader,
+            deadline: deadline,
+            logger: logger)
         let verifiedEmail: String? = if apiData?.hasUsageData == true {
-            await self.fetchSignedInEmailFromAPI(cookieHeader: cookieHeader, logger: logger)
+            await self.fetchSignedInEmailFromAPI(
+                cookieHeader: cookieHeader,
+                deadline: deadline,
+                logger: logger)
         } else {
             nil
         }
@@ -753,18 +740,21 @@ public struct OpenAIDashboardFetcher {
         logger: @escaping (String) -> Void) async -> DashboardAPIData?
     {
         let cookieHeader = await self.chatGPTCookieHeader(in: websiteDataStore)
-        return await self.fetchDashboardUsageAPI(cookieHeader: cookieHeader, logger: logger)
+        return await self.fetchDashboardUsageAPI(cookieHeader: cookieHeader, deadline: nil, logger: logger)
     }
 
     private static func fetchDashboardUsageAPI(
         cookieHeader: String,
+        deadline: Date?,
         logger: @escaping (String) -> Void) async -> DashboardAPIData?
     {
         guard !cookieHeader.isEmpty else { return nil }
+        let remaining = deadline.map { self.remainingTimeout(until: $0) } ?? 4
+        guard remaining > 0 else { return nil }
 
         do {
             let (data, response) = try await ProviderHTTPClient.shared.data(
-                for: self.dashboardUsageAPIRequest(cookieHeader: cookieHeader))
+                for: self.dashboardUsageAPIRequest(cookieHeader: cookieHeader, timeout: min(4, remaining)))
             let status = (response as? HTTPURLResponse)?.statusCode ?? -1
             logger("usage api status=\(status)")
             guard status >= 200, status < 300 else { return nil }
@@ -782,6 +772,7 @@ public struct OpenAIDashboardFetcher {
 
     private static func fetchSignedInEmailFromAPI(
         cookieHeader: String,
+        deadline: Date?,
         logger: @escaping (String) -> Void) async -> String?
     {
         guard !cookieHeader.isEmpty else { return nil }
@@ -792,9 +783,14 @@ public struct OpenAIDashboardFetcher {
         ].compactMap(\.self)
 
         for url in endpoints {
+            let remaining = deadline.map { self.remainingTimeout(until: $0) } ?? 2
+            guard remaining > 0 else { return nil }
             do {
                 let (data, response) = try await ProviderHTTPClient.shared.data(
-                    for: self.dashboardIdentityAPIRequest(url: url, cookieHeader: cookieHeader))
+                    for: self.dashboardIdentityAPIRequest(
+                        url: url,
+                        cookieHeader: cookieHeader,
+                        timeout: min(2, remaining)))
                 let status = (response as? HTTPURLResponse)?.statusCode ?? -1
                 logger("identity api \(url.path) status=\(status)")
                 guard status >= 200, status < 300 else { continue }
@@ -978,6 +974,44 @@ extension OpenAIDashboardFetcher {
 }
 
 extension OpenAIDashboardFetcher {
+    nonisolated static func requiredRemainingTimeout(
+        until deadline: Date,
+        now: Date = Date()) throws -> TimeInterval
+    {
+        let remaining = self.remainingTimeout(until: deadline, now: now)
+        guard remaining > 0 else { throw URLError(.timedOut) }
+        return remaining
+    }
+
+    nonisolated static func dashboardUsageAPIRequest(
+        cookieHeader: String,
+        timeout: TimeInterval = 4) -> URLRequest
+    {
+        var request = URLRequest(url: Self.dashboardUsageAPIURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
+        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
+    nonisolated static func dashboardIdentityAPIRequest(
+        url: URL,
+        cookieHeader: String,
+        timeout: TimeInterval = 2) -> URLRequest
+    {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
+        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
     private static func logBlockingStateIfNeeded(_ scrape: ScrapeResult, logger: (String) -> Void) {
         guard scrape.loginRequired || scrape.cloudflareInterstitial else { return }
         let route = self.isUsageRoute(scrape.href) ? "usage" : "other"

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -162,6 +162,15 @@ final class OpenAIDashboardWebViewCache {
         self.idleTimeout = idleTimeout
     }
 
+    nonisolated static func remainingNavigationTimeout(
+        until deadline: Date,
+        now: Date = Date()) throws -> TimeInterval
+    {
+        let remaining = deadline.timeIntervalSince(now)
+        guard remaining > 0 else { throw URLError(.timedOut) }
+        return remaining
+    }
+
     private func releaseCachedEntry(_ entry: Entry, preserveLoadedPage: Bool) {
         entry.isBusy = false
         let now = Date()
@@ -282,7 +291,7 @@ final class OpenAIDashboardWebViewCache {
         allowTimeoutRetry: Bool = true,
         preserveLoadedPageOnRelease: Bool = false) async throws -> OpenAIDashboardWebViewLease
     {
-        let deadline = Date().addingTimeInterval(max(navigationTimeout, 1))
+        let deadline = Date().addingTimeInterval(max(navigationTimeout, 0.01))
         return try await self.acquire(
             websiteDataStore: websiteDataStore,
             usageURL: usageURL,
@@ -307,7 +316,7 @@ final class OpenAIDashboardWebViewCache {
             logger?("[webview] \(message)")
         }
         let key = ObjectIdentifier(websiteDataStore)
-        let remainingTimeout = max(0.5, deadline.timeIntervalSince(now))
+        let remainingTimeout = try Self.remainingNavigationTimeout(until: deadline, now: now)
 
         if let entry = self.entries[key] {
             if entry.isBusy {
@@ -611,7 +620,7 @@ final class OpenAIDashboardWebViewCache {
         log: @escaping (String) -> Void,
         deadline: Date) async throws -> OpenAIDashboardWebViewLease
     {
-        let remainingTimeout = max(0.5, deadline.timeIntervalSinceNow)
+        let remainingTimeout = try Self.remainingNavigationTimeout(until: deadline)
         let (webView, host) = self.makeWebView(websiteDataStore: websiteDataStore)
         host.show()
         do {

--- a/Sources/CodexBarCore/Providers/Codex/CodexWebDashboardStrategy.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexWebDashboardStrategy.swift
@@ -26,15 +26,16 @@ public struct CodexWebDashboardStrategy: ProviderFetchStrategy {
             throw OpenAIDashboardFetcher.FetchError.loginRequired
         }
 
+        let options = OpenAIWebOptions(
+            deadline: OpenAIDashboardFetcher.deadline(startingAt: Date(), timeout: context.webTimeout),
+            debugDumpHTML: context.webDebugDumpHTML,
+            verbose: context.verbose)
+
         // Ensure AppKit is initialized before using WebKit in a CLI.
         await MainActor.run {
             _ = NSApplication.shared
         }
 
-        let options = OpenAIWebOptions(
-            timeout: context.webTimeout,
-            debugDumpHTML: context.webDebugDumpHTML,
-            verbose: context.verbose)
         let result = try await Self.fetchOpenAIWebCodex(
             context: context,
             options: options,
@@ -107,7 +108,7 @@ enum OpenAIWebCodexError: LocalizedError, Equatable {
 }
 
 private struct OpenAIWebOptions {
-    let timeout: TimeInterval
+    let deadline: Date
     let debugDumpHTML: Bool
     let verbose: Bool
 }
@@ -165,6 +166,7 @@ extension CodexWebDashboardStrategy {
             guard Self.shouldRetryWithFreshBrowserImport(after: error) else {
                 throw error
             }
+            _ = try OpenAIDashboardBrowserCookieImporter.remainingTimeout(until: options.deadline)
             log("Retrying OpenAI web dashboard with a fresh browser cookie import.")
             let result = try await Self.fetchOpenAIWebDashboard(
                 context: context,
@@ -285,6 +287,7 @@ extension CodexWebDashboardStrategy {
                 intoAccountEmail: routingTargetEmail,
                 allowAnyAccount: allowAnyAccount,
                 preferCachedCookieHeader: preferCachedCookieHeader,
+                deadline: options.deadline,
                 logger: logger)
         let effectiveEmail = routingTargetEmail ?? importResult.signedInEmail?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -293,7 +296,7 @@ extension CodexWebDashboardStrategy {
             accountEmail: effectiveEmail,
             logger: logger,
             debugDumpHTML: options.debugDumpHTML,
-            timeout: options.timeout)
+            timeout: OpenAIDashboardBrowserCookieImporter.remainingTimeout(until: options.deadline))
         return OpenAIWebDashboardFetchResult(
             dashboard: dashboard,
             routingTargetEmail: routingTargetEmail)

--- a/Sources/CodexBarCore/Providers/Codex/CodexWebDashboardStrategy.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexWebDashboardStrategy.swift
@@ -36,10 +36,15 @@ public struct CodexWebDashboardStrategy: ProviderFetchStrategy {
             _ = NSApplication.shared
         }
 
-        let result = try await Self.fetchOpenAIWebCodex(
-            context: context,
-            options: options,
-            browserDetection: context.browserDetection)
+        let result: OpenAIWebCodexResult
+        do {
+            result = try await Self.fetchOpenAIWebCodex(
+                context: context,
+                options: options,
+                browserDetection: context.browserDetection)
+        } catch let error as URLError where error.code == .timedOut {
+            throw OpenAIWebCodexError.timedOut(seconds: context.webTimeout)
+        }
         return self.makeResult(
             usage: result.usage,
             credits: result.credits,
@@ -70,11 +75,14 @@ struct OpenAIWebCodexResult {
 enum OpenAIWebCodexError: LocalizedError, Equatable {
     case missingUsage
     case policyRejected(CodexDashboardAuthorityDecision)
+    case timedOut(seconds: TimeInterval)
 
     var errorDescription: String? {
         switch self {
         case .missingUsage:
             return "OpenAI web dashboard did not include usage limits."
+        case let .timedOut(seconds):
+            return "OpenAI web dashboard fetch timed out after \(seconds.formatted()) seconds."
         case let .policyRejected(decision):
             switch decision.reason {
             case let .wrongEmail(expected, actual):

--- a/Tests/CodexBarTests/CLIWebFallbackTests.swift
+++ b/Tests/CodexBarTests/CLIWebFallbackTests.swift
@@ -70,6 +70,14 @@ struct CLIWebFallbackTests {
             after: OpenAIDashboardFetcher.FetchError.noDashboardData(body: "missing")))
         #expect(!CodexWebDashboardStrategy.shouldRetryWithFreshBrowserImport(
             after: OpenAIDashboardFetcher.FetchError.loginRequired))
+        #expect(!CodexWebDashboardStrategy.shouldRetryWithFreshBrowserImport(
+            after: OpenAIWebCodexError.timedOut(seconds: 30)))
+    }
+
+    @Test
+    func `codex shared deadline timeout has useful error`() {
+        let error = OpenAIWebCodexError.timedOut(seconds: 30)
+        #expect(error.localizedDescription == "OpenAI web dashboard fetch timed out after 30 seconds.")
     }
 
     @Test

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -223,6 +223,33 @@ struct CookieHeaderCacheTests {
         #expect(loadedAgain?.cookieHeader == "auth=legacy")
     }
 
+    @Test
+    func `serialized load migrates legacy file to keychain`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+        let legacyBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
+        defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
+
+        let provider: UsageProvider = .codex
+        let legacyURL = legacyBase.appendingPathComponent("\(provider.rawValue)-cookie.json")
+        CookieHeaderCache.store(
+            CookieHeaderCache.Entry(
+                cookieHeader: "auth=legacy",
+                storedAt: Date(timeIntervalSince1970: 0),
+                sourceLabel: "Legacy"),
+            to: legacyURL)
+
+        let loaded = CookieHeaderCache.loadSerialized(provider: provider)
+        defer { CookieHeaderCache.clear(provider: provider) }
+
+        #expect(loaded?.cookieHeader == "auth=legacy")
+        #expect(FileManager.default.fileExists(atPath: legacyURL.path) == false)
+        #expect(CookieHeaderCache.load(provider: provider)?.cookieHeader == "auth=legacy")
+    }
+
     #if os(macOS)
     @Test
     func `temporary keychain unavailability returns nil without migrating legacy file`() {

--- a/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
@@ -2,6 +2,37 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+private final class CookieCallbackHarness: @unchecked Sendable {
+    private let lock = NSLock()
+    private var callback: (@Sendable () -> Void)?
+
+    func capture(_ callback: @escaping @Sendable () -> Void) {
+        self.lock.withLock { self.callback = callback }
+    }
+
+    func finish() {
+        let callback = self.lock.withLock {
+            let callback = self.callback
+            self.callback = nil
+            return callback
+        }
+        callback?()
+    }
+}
+
+private final class CookieCallbackFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue = false
+
+    var value: Bool {
+        self.lock.withLock { self.storedValue }
+    }
+
+    func set() {
+        self.lock.withLock { self.storedValue = true }
+    }
+}
+
 struct OpenAIDashboardBrowserCookieImporterTests {
     @Test
     func `shared deadline clamps each local timeout to remaining budget`() throws {
@@ -65,6 +96,57 @@ struct OpenAIDashboardBrowserCookieImporterTests {
         }
     }
 
+    @Test @MainActor
+    func `stalled callback cannot exceed shared deadline`() async {
+        let start = Date()
+
+        do {
+            try await OpenAIDashboardBrowserCookieImporter.runBoundedCallback(
+                deadline: start.addingTimeInterval(0.05))
+            { _ in }
+            Issue.record("Expected callback timeout")
+        } catch let error as URLError {
+            #expect(error.code == .timedOut)
+            #expect(Date().timeIntervalSince(start) < 0.3)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test @MainActor
+    func `retry waits for timed out cookie store mutation`() async throws {
+        let keyOwner = NSObject()
+        let key = ObjectIdentifier(keyOwner)
+        let first = CookieCallbackHarness()
+
+        do {
+            try await OpenAIDashboardBrowserCookieImporter.runSerializedCallback(
+                key: key,
+                deadline: Date().addingTimeInterval(0.05),
+                start: first.capture)
+            Issue.record("Expected first mutation timeout")
+        } catch let error as URLError {
+            #expect(error.code == .timedOut)
+        }
+
+        let secondStarted = CookieCallbackFlag()
+        let second = Task { @MainActor in
+            try await OpenAIDashboardBrowserCookieImporter.runSerializedCallback(
+                key: key,
+                deadline: Date().addingTimeInterval(1))
+            { completion in
+                secondStarted.set()
+                completion()
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(!secondStarted.value)
+        first.finish()
+        try await second.value
+        #expect(secondStarted.value)
+    }
+
     @Test
     func `mismatch error mentions source label`() {
         let err = OpenAIDashboardBrowserCookieImporter.ImportError.noMatchingAccount(
@@ -79,7 +161,14 @@ struct OpenAIDashboardBrowserCookieImporterTests {
 
     @Test
     func `timed out persistent validation keeps verified session`() {
+        let failure = OpenAIDashboardBrowserCookieImporter.persistentValidationFailure(URLError(.timedOut))
         #expect(OpenAIDashboardBrowserCookieImporter.shouldTrustVerifiedSession(
+            afterPersistFailure: failure))
+    }
+
+    @Test
+    func `raw cookie mutation timeout is not trusted`() {
+        #expect(!OpenAIDashboardBrowserCookieImporter.shouldTrustVerifiedSession(
             afterPersistFailure: URLError(.timedOut)))
     }
 

--- a/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
@@ -33,6 +33,19 @@ private final class CookieCallbackFlag: @unchecked Sendable {
     }
 }
 
+private final class CookieOperationLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [String] = []
+
+    var snapshot: [String] {
+        self.lock.withLock { self.entries }
+    }
+
+    func append(_ entry: String) {
+        self.lock.withLock { self.entries.append(entry) }
+    }
+}
+
 struct OpenAIDashboardBrowserCookieImporterTests {
     @Test
     func `shared deadline clamps each local timeout to remaining budget`() throws {
@@ -94,6 +107,33 @@ struct OpenAIDashboardBrowserCookieImporterTests {
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+    }
+
+    @Test
+    func `timed out cookie cache work stays ordered before retry`() async throws {
+        let log = CookieOperationLog()
+
+        do {
+            _ = try await OpenAIDashboardBrowserCookieImporter.runBoundedCookieCacheOperation(
+                deadline: Date().addingTimeInterval(0.05))
+            {
+                log.append("first-start")
+                Thread.sleep(forTimeInterval: 0.15)
+                log.append("first-end")
+                return true
+            }
+            Issue.record("Expected first cache operation timeout")
+        } catch let error as URLError {
+            #expect(error.code == .timedOut)
+        }
+
+        _ = try await OpenAIDashboardBrowserCookieImporter.runBoundedCookieCacheOperation(
+            deadline: Date().addingTimeInterval(1))
+        {
+            log.append("second")
+            return true
+        }
+        #expect(log.snapshot == ["first-start", "first-end", "second"])
     }
 
     @Test @MainActor

--- a/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
@@ -46,6 +46,26 @@ struct OpenAIDashboardBrowserCookieImporterTests {
     }
 
     @Test
+    func `blocking browser cookie load cannot exceed shared deadline`() async {
+        let start = Date()
+
+        do {
+            _ = try await OpenAIDashboardBrowserCookieImporter.runBoundedCookieLoad(
+                deadline: start.addingTimeInterval(0.05))
+            {
+                Thread.sleep(forTimeInterval: 0.5)
+                return true
+            }
+            Issue.record("Expected cookie load timeout")
+        } catch let error as URLError {
+            #expect(error.code == .timedOut)
+            #expect(Date().timeIntervalSince(start) < 0.3)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
     func `mismatch error mentions source label`() {
         let err = OpenAIDashboardBrowserCookieImporter.ImportError.noMatchingAccount(
             found: [

--- a/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
@@ -4,6 +4,48 @@ import Testing
 
 struct OpenAIDashboardBrowserCookieImporterTests {
     @Test
+    func `shared deadline clamps each local timeout to remaining budget`() throws {
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+        let deadline = start.addingTimeInterval(30)
+
+        let remaining = try OpenAIDashboardBrowserCookieImporter.remainingTimeout(
+            until: deadline,
+            cappedAt: 10,
+            now: start.addingTimeInterval(27))
+
+        #expect(remaining == 3)
+    }
+
+    @Test
+    func `shared deadline preserves smaller local timeout`() throws {
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+        let deadline = start.addingTimeInterval(30)
+
+        let remaining = try OpenAIDashboardBrowserCookieImporter.remainingTimeout(
+            until: deadline,
+            cappedAt: 10,
+            now: start.addingTimeInterval(5))
+
+        #expect(remaining == 10)
+    }
+
+    @Test
+    func `expired shared deadline throws structured timeout`() {
+        let deadline = Date(timeIntervalSinceReferenceDate: 1000)
+
+        do {
+            _ = try OpenAIDashboardBrowserCookieImporter.remainingTimeout(
+                until: deadline,
+                now: deadline)
+            Issue.record("Expected deadline timeout")
+        } catch let error as URLError {
+            #expect(error.code == .timedOut)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
     func `mismatch error mentions source label`() {
         let err = OpenAIDashboardBrowserCookieImporter.ImportError.noMatchingAccount(
             found: [

--- a/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
@@ -154,6 +154,23 @@ struct OpenAIDashboardBrowserCookieImporterTests {
     }
 
     @Test @MainActor
+    func `stalled value callback cannot exceed shared deadline`() async {
+        let start = Date()
+
+        do {
+            let _: [String] = try await OpenAIDashboardBrowserCookieImporter.runBoundedValueCallback(
+                deadline: start.addingTimeInterval(0.05))
+            { _ in }
+            Issue.record("Expected value callback timeout")
+        } catch let error as URLError {
+            #expect(error.code == .timedOut)
+            #expect(Date().timeIntervalSince(start) < 0.3)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test @MainActor
     func `retry waits for timed out cookie store mutation`() async throws {
         let keyOwner = NSObject()
         let key = ObjectIdentifier(keyOwner)

--- a/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
@@ -282,6 +282,21 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
     }
 
     @Test
+    func `dashboard api requests accept shared deadline timeout clamps`() throws {
+        let url = try #require(URL(string: "https://chatgpt.com/backend-api/me"))
+        let usageRequest = OpenAIDashboardFetcher.dashboardUsageAPIRequest(
+            cookieHeader: "a=b",
+            timeout: 1.25)
+        let identityRequest = OpenAIDashboardFetcher.dashboardIdentityAPIRequest(
+            url: url,
+            cookieHeader: "a=b",
+            timeout: 0.75)
+
+        #expect(usageRequest.timeoutInterval == 1.25)
+        #expect(identityRequest.timeoutInterval == 0.75)
+    }
+
+    @Test
     func `usage api data maps language independent rate limits and credits`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -20,6 +20,34 @@ struct OpenAIDashboardWebViewCacheTests {
     // MARK: - Data Store Identity Tests
 
     @Test
+    func `navigation retry uses only remaining shared deadline`() throws {
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+        let deadline = start.addingTimeInterval(10)
+
+        let remaining = try OpenAIDashboardWebViewCache.remainingNavigationTimeout(
+            until: deadline,
+            now: start.addingTimeInterval(9.75))
+
+        #expect(remaining == 0.25)
+    }
+
+    @Test
+    func `navigation retry refuses expired shared deadline`() {
+        let deadline = Date(timeIntervalSinceReferenceDate: 1000)
+
+        do {
+            _ = try OpenAIDashboardWebViewCache.remainingNavigationTimeout(
+                until: deadline,
+                now: deadline)
+            Issue.record("Expected deadline timeout")
+        } catch let error as URLError {
+            #expect(error.code == .timedOut)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
     func `WKWebsiteDataStore should return same instance for same email`() {
         if self.shouldSkipOnCI() { return }
         OpenAIDashboardWebsiteDataStore.clearCacheForTesting()


### PR DESCRIPTION
## Summary

- Start one absolute deadline at the Codex web strategy boundary.
- Clamp browser cookie extraction, cookie-cache Keychain access, WebKit cookie reads/writes, account API requests, scratch and persistent probes, dashboard preflight, navigation retries, final dashboard load, and fresh-import retry to the remaining budget.
- Run synchronous browser and Keychain reads off the caller path so macOS consent/security services cannot block past the deadline.
- Serialize late cookie-store and cache mutations so retries and direct cache clears cannot be overtaken by stale work.
- Trust timeout fallback only after cookies were persisted and post-write validation timed out.
- Preserve legacy cookie-cache migration and make mismatched-account caching and stale-cache cleanup best-effort.
- Return a clear Codex web timeout error instead of opaque `NSURLError -1001` text.

Closes #1607.

## Proof

Exact reviewed head: `3de913ac6a20e73ec9d5979cda28c56d13af4f30`

- 72 focused cookie-import, cache, dashboard-fetcher, WebView-cache, and CLI fallback tests passed.
- Additional cookie-cache suite verifies scoped serialization and legacy credential migration.
- `make check` passes with zero format or lint findings.
- Full exact-head branch autoreview: no actionable findings, confidence 0.82.
- Source CLI live proof with blocked macOS security access: `--source web --web-timeout 3` returned in 3 seconds with `OpenAI web dashboard fetch timed out after 3 seconds.`
- `CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh` packaged exact head; deep strict codesign passed; bundle reports `CodexGitCommit=3de913ac`.
- Packaged CLI repeated the same blocked-access proof in 3 seconds with the structured timeout message.

No App Data or Keychain permission was granted during testing.

