### PR TITLE
Fix Kiro usage when account probe times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@
 - Codex pace: extrapolate historically exhausted weeks for run-out forecasts and avoid contradictory reset headlines. Thanks @Yuxin-Qiao!
 - Localization: correct the German in-progress refresh label. Thanks @ChrisLauinger77!
 - Localization: correct misleading literal German UI translations. Thanks @madebyjulz!
-- Kiro: return usage when the optional account probe times out, while preserving cancellation. Thanks @Yuxin-Qiao!
 - Settings: switch tabs immediately before animated window resizing and reduce Providers sidebar work. Thanks @elijahfriedman!
 - Windsurf: import complete Devin sessions from the current app origin before legacy browser storage. Thanks @kiranmagic7!
 - Antigravity: humanize raw model identifiers while preserving server-provided quota labels. Thanks @bcharleson!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Codex pace: extrapolate historically exhausted weeks for run-out forecasts and avoid contradictory reset headlines. Thanks @Yuxin-Qiao!
 - Localization: correct the German in-progress refresh label. Thanks @ChrisLauinger77!
 - Localization: correct misleading literal German UI translations. Thanks @madebyjulz!
+- Kiro: return usage when the optional account probe times out, while preserving cancellation. Thanks @Yuxin-Qiao!
 - Settings: switch tabs immediately before animated window resizing and reduce Providers sidebar work. Thanks @elijahfriedman!
 - Windsurf: import complete Devin sessions from the current app origin before legacy browser storage. Thanks @kiranmagic7!
 - Antigravity: humanize raw model identifiers while preserving server-provided quota labels. Thanks @bcharleson!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 
 ### Fixed
+- Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!
 - Memory: release idle OpenAI WebViews under system pressure without blocking the main thread. Thanks @ProspectOre!
 - Memory: trim rebuildable menu and OpenAI debug caches under system pressure. Thanks @ProspectOre!
 - Provider plans: keep Claude and Kiro plan matching on one rendered line to avoid bogus labels from adjacent usage hints. Thanks @elijahfriedman!

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -259,28 +259,39 @@ public struct KiroStatusProbe: Sendable {
     }
 
     public func fetch() async throws -> KiroUsageSnapshot {
-        let accountTask = Task { await self.fetchAccountIfAvailable() }
+        let accountTask = Task { await self.fetchAccountStatus() }
+
+        let output: String
         do {
-            let output = try await self.runUsageCommand()
-            var contextUsage: KiroContextUsageSnapshot?
-            do {
-                contextUsage = try await self.fetchContextUsage()
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch {
-                Self.logger.debug("Kiro context usage probe failed: \(error.localizedDescription)")
-            }
-            let accountInfo = await accountTask.value
-            return try self.parse(
-                output: output,
-                accountEmail: accountInfo?.email,
-                authMethod: accountInfo?.authMethod,
-                contextUsage: contextUsage)
-        } catch {
+            output = try await self.runUsageCommand()
+        } catch is CancellationError {
             accountTask.cancel()
             _ = await accountTask.value
+            throw CancellationError()
+        } catch {
+            if await accountTask.value == .notLoggedIn {
+                throw KiroStatusProbeError.notLoggedIn
+            }
             throw error
         }
+
+        var contextUsage: KiroContextUsageSnapshot?
+        do {
+            contextUsage = try await self.fetchContextUsage()
+        } catch is CancellationError {
+            accountTask.cancel()
+            _ = await accountTask.value
+            throw CancellationError()
+        } catch {
+            Self.logger.debug("Kiro context usage probe failed: \(error.localizedDescription)")
+        }
+
+        let accountInfo = await accountTask.value.account
+        return try self.parse(
+            output: output,
+            accountEmail: accountInfo?.email,
+            authMethod: accountInfo?.authMethod,
+            contextUsage: contextUsage)
     }
 
     struct KiroCLIResult {
@@ -295,12 +306,25 @@ public struct KiroStatusProbe: Sendable {
         let email: String?
     }
 
-    private func fetchAccountIfAvailable() async -> KiroAccountInfo? {
+    private enum KiroAccountProbeStatus: Equatable {
+        case account(KiroAccountInfo)
+        case notLoggedIn
+        case unavailable
+
+        var account: KiroAccountInfo? {
+            guard case let .account(info) = self else { return nil }
+            return info
+        }
+    }
+
+    private func fetchAccountStatus() async -> KiroAccountProbeStatus {
         do {
-            return try await self.ensureLoggedIn()
+            return try await .account(self.ensureLoggedIn())
+        } catch KiroStatusProbeError.notLoggedIn {
+            return .notLoggedIn
         } catch {
             Self.logger.debug("Kiro account probe failed: \(error.localizedDescription)")
-            return nil
+            return .unavailable
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -288,11 +288,15 @@ public struct KiroStatusProbe: Sendable {
 
         let accountStatus = try await self.awaitAccountStatus(accountTask)
         let accountInfo = accountStatus.account
-        return try self.parse(
-            output: output,
-            accountEmail: accountInfo?.email,
-            authMethod: accountInfo?.authMethod,
-            contextUsage: contextUsage)
+        do {
+            return try self.parse(
+                output: output,
+                accountEmail: accountInfo?.email,
+                authMethod: accountInfo?.authMethod,
+                contextUsage: contextUsage)
+        } catch KiroStatusProbeError.parseError where accountStatus == .notLoggedIn {
+            throw KiroStatusProbeError.notLoggedIn
+        }
     }
 
     struct KiroCLIResult {

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -227,13 +227,16 @@ public enum KiroStatusProbeError: LocalizedError, Sendable {
 
 public struct KiroStatusProbe: Sendable {
     private let cliBinaryResolver: @Sendable () -> String?
+    private let accountProbeTimeout: TimeInterval
 
     public init() {
         self.cliBinaryResolver = { TTYCommandRunner.which("kiro-cli") }
+        self.accountProbeTimeout = 3.0
     }
 
-    init(cliBinaryResolver: @escaping @Sendable () -> String?) {
+    init(cliBinaryResolver: @escaping @Sendable () -> String?, accountProbeTimeout: TimeInterval = 3.0) {
         self.cliBinaryResolver = cliBinaryResolver
+        self.accountProbeTimeout = accountProbeTimeout
     }
 
     private static let logger = CodexBarLog.logger(LogCategories.kiro)
@@ -256,19 +259,26 @@ public struct KiroStatusProbe: Sendable {
     }
 
     public func fetch() async throws -> KiroUsageSnapshot {
-        let account = try await self.ensureLoggedIn()
-        let output = try await self.runUsageCommand()
-        var contextUsage: KiroContextUsageSnapshot?
+        let accountTask = Task { await self.fetchAccountIfAvailable() }
         do {
-            contextUsage = try await self.fetchContextUsage()
+            let output = try await self.runUsageCommand()
+            var contextUsage: KiroContextUsageSnapshot?
+            do {
+                contextUsage = try await self.fetchContextUsage()
+            } catch {
+                Self.logger.debug("Kiro context usage probe failed: \(error.localizedDescription)")
+            }
+            let accountInfo = await accountTask.value
+            return try self.parse(
+                output: output,
+                accountEmail: accountInfo?.email,
+                authMethod: accountInfo?.authMethod,
+                contextUsage: contextUsage)
         } catch {
-            Self.logger.debug("Kiro context usage probe failed: \(error.localizedDescription)")
+            accountTask.cancel()
+            _ = await accountTask.value
+            throw error
         }
-        return try self.parse(
-            output: output,
-            accountEmail: account.email,
-            authMethod: account.authMethod,
-            contextUsage: contextUsage)
     }
 
     struct KiroCLIResult {
@@ -283,8 +293,17 @@ public struct KiroStatusProbe: Sendable {
         let email: String?
     }
 
+    private func fetchAccountIfAvailable() async -> KiroAccountInfo? {
+        do {
+            return try await self.ensureLoggedIn()
+        } catch {
+            Self.logger.debug("Kiro account probe failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
     private func ensureLoggedIn() async throws -> KiroAccountInfo {
-        let result = try await self.runCommand(arguments: ["whoami"], timeout: 5.0)
+        let result = try await self.runCommand(arguments: ["whoami"], timeout: self.accountProbeTimeout)
         return try self.validateWhoAmIOutput(
             stdout: result.stdout,
             stderr: result.stderr,

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -269,7 +269,7 @@ public struct KiroStatusProbe: Sendable {
             _ = await accountTask.value
             throw CancellationError()
         } catch {
-            if await accountTask.value == .notLoggedIn {
+            if try await self.awaitAccountStatus(accountTask) == .notLoggedIn {
                 throw KiroStatusProbeError.notLoggedIn
             }
             throw error
@@ -286,13 +286,7 @@ public struct KiroStatusProbe: Sendable {
             Self.logger.debug("Kiro context usage probe failed: \(error.localizedDescription)")
         }
 
-        let accountStatus = await withTaskCancellationHandler {
-            await accountTask.value
-        } onCancel: {
-            accountTask.cancel()
-        }
-        try Task.checkCancellation()
-
+        let accountStatus = try await self.awaitAccountStatus(accountTask)
         let accountInfo = accountStatus.account
         return try self.parse(
             output: output,
@@ -333,6 +327,18 @@ public struct KiroStatusProbe: Sendable {
             Self.logger.debug("Kiro account probe failed: \(error.localizedDescription)")
             return .unavailable
         }
+    }
+
+    private func awaitAccountStatus(
+        _ task: Task<KiroAccountProbeStatus, Never>) async throws -> KiroAccountProbeStatus
+    {
+        let status = await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        try Task.checkCancellation()
+        return status
     }
 
     private func ensureLoggedIn() async throws -> KiroAccountInfo {

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -265,6 +265,8 @@ public struct KiroStatusProbe: Sendable {
             var contextUsage: KiroContextUsageSnapshot?
             do {
                 contextUsage = try await self.fetchContextUsage()
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 Self.logger.debug("Kiro context usage probe failed: \(error.localizedDescription)")
             }

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -286,7 +286,14 @@ public struct KiroStatusProbe: Sendable {
             Self.logger.debug("Kiro context usage probe failed: \(error.localizedDescription)")
         }
 
-        let accountInfo = await accountTask.value.account
+        let accountStatus = await withTaskCancellationHandler {
+            await accountTask.value
+        } onCancel: {
+            accountTask.cancel()
+        }
+        try Task.checkCancellation()
+
+        let accountInfo = accountStatus.account
         return try self.parse(
             output: output,
             accountEmail: accountInfo?.email,

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -7,6 +7,13 @@ import Darwin
 import Glibc
 #endif
 
+private func waitForFile(_ url: URL) async throws {
+    for _ in 0..<100 where !FileManager.default.fileExists(atPath: url.path) {
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    #expect(FileManager.default.fileExists(atPath: url.path))
+}
+
 @Suite(.serialized)
 struct KiroStatusProbeTests {
     @Test
@@ -143,10 +150,50 @@ struct KiroStatusProbeTests {
         let task = Task { try await probe.fetch() }
         defer { task.cancel() }
 
-        for _ in 0..<100 where !FileManager.default.fileExists(atPath: contextStarted.path) {
-            try await Task.sleep(for: .milliseconds(20))
+        try await waitForFile(contextStarted)
+
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
         }
-        #expect(FileManager.default.fileExists(atPath: contextStarted.path))
+    }
+
+    @Test
+    func `fetch cancellation while waiting for account probe is preserved`() async throws {
+        let accountStarted = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-account-\(UUID().uuidString).started")
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              : > '\(accountStarted.path)'
+              trap '' TERM
+              while true; do sleep 1; done
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\\n'
+              printf 'Credits (12.50 of 50 covered in plan)\\n'
+              printf '████████████████████ 25%%\\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+
+            exit 1
+            """)
+        defer {
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: accountStarted)
+        }
+
+        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        let task = Task { try await probe.fetch() }
+        defer { task.cancel() }
+
+        try await waitForFile(accountStarted)
 
         task.cancel()
         await #expect(throws: CancellationError.self) {

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -489,7 +489,9 @@ struct KiroStatusProbeTests {
         }
         #expect(kill(processID, 0) == -1)
     }
+}
 
+extension KiroStatusProbeTests {
     // MARK: - Happy Path Parsing
 
     @Test

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -943,3 +943,42 @@ struct KiroStatusProbeTests {
         #expect(account.email == "user@example.com")
     }
 }
+
+extension KiroStatusProbeTests {
+    @Test
+    func `fetch cancellation while joining account after usage failure is preserved`() async throws {
+        let accountStarted = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-failed-usage-account-\(UUID().uuidString).started")
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              : > '\(accountStarted.path)'
+              trap '' TERM
+              while true; do sleep 1; done
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              exit 1
+            fi
+
+            exit 1
+            """)
+        defer {
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: accountStarted)
+        }
+
+        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path }, accountProbeTimeout: 2.0)
+        let task = Task { try await probe.fetch() }
+        defer { task.cancel() }
+
+        try await waitForFile(accountStarted)
+        try await Task.sleep(for: .milliseconds(300))
+
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+}

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -115,6 +115,37 @@ struct KiroStatusProbeTests {
     }
 
     @Test
+    func `fetch preserves not logged in when usage output cannot be parsed`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              printf 'Not logged in\\n'
+              exit 1
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        await #expect {
+            _ = try await probe.fetch()
+        } throws: { error in
+            guard case KiroStatusProbeError.notLoggedIn = error else { return false }
+            return true
+        }
+    }
+
+    @Test
     func `fetch cancellation during context probe is preserved`() async throws {
         let contextStarted = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-kiro-context-\(UUID().uuidString).started")

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -77,6 +77,53 @@ struct KiroStatusProbeTests {
     }
 
     @Test
+    func `fetch cancellation during context probe is preserved`() async throws {
+        let contextStarted = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-context-\(UUID().uuidString).started")
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              : > '\(contextStarted.path)'
+              trap '' TERM
+              while true; do sleep 1; done
+            fi
+
+            exit 1
+            """)
+        defer {
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: contextStarted)
+        }
+
+        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        let task = Task { try await probe.fetch() }
+        defer { task.cancel() }
+
+        for _ in 0..<100 where !FileManager.default.fileExists(atPath: contextStarted.path) {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(FileManager.default.fileExists(atPath: contextStarted.path))
+
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @Test
     func `fetch returns when usage helper leaves inherited pipes open`() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-kiro-pipe-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -77,6 +77,37 @@ struct KiroStatusProbeTests {
     }
 
     @Test
+    func `fetch preserves not logged in when usage fails without auth detail`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              printf 'Not logged in\\n'
+              exit 1
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              exit 1
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        await #expect {
+            _ = try await probe.fetch()
+        } throws: { error in
+            guard case KiroStatusProbeError.notLoggedIn = error else { return false }
+            return true
+        }
+    }
+
+    @Test
     func `fetch cancellation during context probe is preserved`() async throws {
         let contextStarted = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-kiro-context-\(UUID().uuidString).started")

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -7,7 +7,75 @@ import Darwin
 import Glibc
 #endif
 
+@Suite(.serialized)
 struct KiroStatusProbeTests {
+    @Test
+    func `fetch returns usage when account probe times out`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              sleep 5
+              printf 'Logged in with Google\\nEmail: person@example.com\\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\\n'
+              printf 'Credits (12.50 of 50 covered in plan)\\n'
+              printf '████████████████████ 25%%\\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path }, accountProbeTimeout: 0.2)
+        let snapshot = try await probe.fetch()
+
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(snapshot.creditsUsed == 12.50)
+        #expect(snapshot.accountEmail == nil)
+        #expect(snapshot.authMethod == nil)
+    }
+
+    @Test
+    func `fetch preserves account info when account probe succeeds`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\\nEmail: person@example.com\\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\\n'
+              printf 'Credits (12.50 of 50 covered in plan)\\n'
+              printf '████████████████████ 25%%\\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        let snapshot = try await probe.fetch()
+
+        #expect(snapshot.accountEmail == "person@example.com")
+        #expect(snapshot.authMethod == "Google")
+    }
+
     @Test
     func `fetch returns when usage helper leaves inherited pipes open`() async throws {
         let root = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Summary

- return parsed Kiro usage when the optional account probe times out or fails
- preserve account details when the probe succeeds
- preserve cancellation and not-logged-in signals across usage/account probe races
- preserve definitive `whoami` not-logged-in results when `/usage` exits 0 but returns empty or unparseable output
- cover timeout, cancellation, auth, parse-fallback, process cleanup, and usage-failure paths
- split the probe tests across same-file extensions so strict lint remains under the type-body limit
- add maintainer changelog credit for the user-facing fix

## Proof

- `swift test --filter KiroStatusProbeTests` - all 40 tests passed on exact head `4c1eda04`
- `make check` - passed with zero SwiftFormat or SwiftLint violations
- final whole-branch maintainer autoreview - clean, confidence 0.82; lint-only repair review clean, confidence 0.83
- previous exact production head passed all four macOS shards, Linux x64/arm64, and security; its sole failure was the repaired deterministic test type-body lint violation
- fresh exact-head hosted CI is queued

Exact candidate: `4c1eda0427125096450121b9d8245546eac786fa`.

Live proof status: no live-account Kiro result is claimed from this machine because an authenticated Kiro account was unavailable. The behavior is covered with real helper processes, timeout/cancellation paths, and process-cleanup assertions.
