### PR TITLE
ci: shard macOS Swift tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
   swift-test-macos:
     runs-on: macos-15-intel
-    timeout-minutes: 25
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -70,7 +70,7 @@ jobs:
           swift package --version
 
       - name: Swift Test
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           CODEXBAR_TEST_GROUP_SIZE=1 \
             CODEXBAR_TEST_SUITE_TIMEOUT=120 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-build-test:
+  lint:
     runs-on: macos-15-intel
-    timeout-minutes: 70
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -40,10 +40,64 @@ jobs:
       - name: Lint
         run: ./Scripts/lint.sh lint
 
-      - name: Swift Test
-        timeout-minutes: 60
+  swift-test-macos:
+    runs-on: macos-15-intel
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard-index: [0, 1, 2, 3]
+        shard-count: [4]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Select Xcode 26.1.1 (if present) or fallback to default
         run: |
-          CODEXBAR_TEST_GROUP_SIZE=1 CODEXBAR_TEST_SUITE_TIMEOUT=120 ./Scripts/test.sh
+          set -euo pipefail
+          for candidate in /Applications/Xcode_26.1.1.app /Applications/Xcode_26.1.app /Applications/Xcode.app; do
+            if [[ -d "$candidate" ]]; then
+              sudo xcode-select -s "${candidate}/Contents/Developer"
+              echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
+              break
+            fi
+          done
+          /usr/bin/xcodebuild -version
+
+      - name: Swift toolchain version
+        run: |
+          set -euo pipefail
+          swift --version
+          swift package --version
+
+      - name: Swift Test
+        timeout-minutes: 20
+        run: |
+          CODEXBAR_TEST_GROUP_SIZE=1 \
+            CODEXBAR_TEST_SUITE_TIMEOUT=120 \
+            CODEXBAR_TEST_SHARD_INDEX=${{ matrix.shard-index }} \
+            CODEXBAR_TEST_SHARD_COUNT=${{ matrix.shard-count }} \
+            ./Scripts/test.sh
+
+  lint-build-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - lint
+      - swift-test-macos
+    if: ${{ always() }}
+    steps:
+      - name: Verify macOS lint and test jobs
+        run: |
+          set -euo pipefail
+          if [[ "${{ needs.lint.result }}" != "success" ]]; then
+            echo "lint job finished with ${{ needs.lint.result }}" >&2
+            exit 1
+          fi
+          if [[ "${{ needs.swift-test-macos.result }}" != "success" ]]; then
+            echo "swift-test-macos job finished with ${{ needs.swift-test-macos.result }}" >&2
+            exit 1
+          fi
+          echo "macOS lint and Swift test shards passed."
 
   build-linux-cli:
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   lint:
     runs-on: macos-15-intel
     timeout-minutes: 10
+    needs:
+      - swift-test-macos
     steps:
       - uses: actions/checkout@v6
 
@@ -42,7 +44,7 @@ jobs:
 
   swift-test-macos:
     runs-on: macos-15-intel
-    timeout-minutes: 35
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -70,7 +72,7 @@ jobs:
           swift package --version
 
       - name: Swift Test
-        timeout-minutes: 30
+        timeout-minutes: 35
         run: |
           CODEXBAR_TEST_GROUP_SIZE=1 \
             CODEXBAR_TEST_SUITE_TIMEOUT=120 \

--- a/Scripts/ci_swift_test_by_suite.py
+++ b/Scripts/ci_swift_test_by_suite.py
@@ -25,6 +25,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--group-size", type=int, default=12)
     parser.add_argument("--timeout", type=int, default=180)
     parser.add_argument("--limit-groups", type=int)
+    parser.add_argument("--shard-index", type=int)
+    parser.add_argument("--shard-count", type=int)
     parser.add_argument("--list-only", action="store_true")
     parser.add_argument("--swift-command", default="swift")
     parser.add_argument("--swift-command-arg", action="append", default=[])
@@ -91,6 +93,18 @@ def chunks(items: list[TestSelection], size: int) -> Iterable[list[TestSelection
         yield items[index : index + size]
 
 
+def shard_groups(groups: list[list[TestSelection]], shard_index: int | None, shard_count: int | None) -> list[list[TestSelection]]:
+    if shard_index is None and shard_count is None:
+        return groups
+    if shard_index is None or shard_count is None:
+        raise ValueError("--shard-index and --shard-count must be passed together")
+    if shard_count < 1:
+        raise ValueError("--shard-count must be positive")
+    if shard_index < 0 or shard_index >= shard_count:
+        raise ValueError("--shard-index must be in the range [0, --shard-count)")
+    return [group for index, group in enumerate(groups) if index % shard_count == shard_index]
+
+
 def prioritized_suites(suites: list[TestSelection]) -> list[TestSelection]:
     priority = ["CodexBarTests.CLIEntryTests"]
     ordered = [suite for name in priority for suite in suites if suite.suite_name == name]
@@ -130,15 +144,28 @@ def main() -> int:
 
     swift_command = [args.swift_command, *args.swift_command_arg]
     suites = prioritized_suites(filtered_suites_for_environment(swift_test_list(swift_command)))
-    print(f"Discovered {len(suites)} test selections", flush=True)
-    if args.list_only:
-        for suite in suites:
-            print(suite.name)
-        return 0
-
     suite_groups = list(chunks(suites, args.group_size))
+    try:
+        suite_groups = shard_groups(suite_groups, args.shard_index, args.shard_count)
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 2
     if args.limit_groups is not None:
         suite_groups = suite_groups[: args.limit_groups]
+
+    shard_suffix = ""
+    if args.shard_index is not None and args.shard_count is not None:
+        shard_suffix = f" in shard {args.shard_index + 1}/{args.shard_count}"
+    print(f"Discovered {len(suites)} test selections; running {len(suite_groups)} groups{shard_suffix}", flush=True)
+    if args.list_only:
+        for group in suite_groups:
+            for suite in group:
+                print(suite.name)
+        return 0
+
+    if not suite_groups:
+        print("No test groups selected.", flush=True)
+        return 0
 
     for group_index, group in enumerate(suite_groups, start=1):
         print(

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -7,7 +7,16 @@ GROUP_SIZE="${CODEXBAR_TEST_GROUP_SIZE:-12}"
 SUITE_TIMEOUT="${CODEXBAR_TEST_SUITE_TIMEOUT:-180}"
 
 cd "${ROOT_DIR}"
-exec python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
-  --group-size "${GROUP_SIZE}" \
-  --timeout "${SUITE_TIMEOUT}" \
-  "$@"
+ARGS=(
+  --group-size "${GROUP_SIZE}"
+  --timeout "${SUITE_TIMEOUT}"
+)
+
+if [[ -n "${CODEXBAR_TEST_SHARD_INDEX:-}" || -n "${CODEXBAR_TEST_SHARD_COUNT:-}" ]]; then
+  ARGS+=(
+    --shard-index "${CODEXBAR_TEST_SHARD_INDEX:?CODEXBAR_TEST_SHARD_COUNT requires CODEXBAR_TEST_SHARD_INDEX}"
+    --shard-count "${CODEXBAR_TEST_SHARD_COUNT:?CODEXBAR_TEST_SHARD_INDEX requires CODEXBAR_TEST_SHARD_COUNT}"
+  )
+fi
+
+exec python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" "${ARGS[@]}" "$@"

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -44,6 +44,45 @@ grep -Fq "CodexBarTests\\..*top\\ level\\ works" "${FAKE_SWIFT_LOG}"
 grep -Fq "CodexBarTests\\..*top/level\\ slash\\ works" "${FAKE_SWIFT_LOG}"
 [[ "$(wc -l < "${FAKE_SWIFT_LOG}")" -eq 3 ]]
 
+python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
+  --group-size 1 \
+  --timeout 10 \
+  --shard-index 0 \
+  --shard-count 2 \
+  --list-only \
+  --swift-command /bin/bash \
+  --swift-command-arg=-c \
+  --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
+  --swift-command-arg=fake-swift \
+  >"${TEMP_DIR}/shard-0.log"
+
+python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
+  --group-size 1 \
+  --timeout 10 \
+  --shard-index 1 \
+  --shard-count 2 \
+  --list-only \
+  --swift-command /bin/bash \
+  --swift-command-arg=-c \
+  --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
+  --swift-command-arg=fake-swift \
+  >"${TEMP_DIR}/shard-1.log"
+
+cat "${TEMP_DIR}/shard-0.log" "${TEMP_DIR}/shard-1.log" \
+  | grep -v '^Discovered ' \
+  | sort >"${TEMP_DIR}/shards-combined.log"
+python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
+  --group-size 1 \
+  --timeout 10 \
+  --list-only \
+  --swift-command /bin/bash \
+  --swift-command-arg=-c \
+  --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
+  --swift-command-arg=fake-swift \
+  | grep -v '^Discovered ' \
+  | sort >"${TEMP_DIR}/shards-expected.log"
+diff -u "${TEMP_DIR}/shards-expected.log" "${TEMP_DIR}/shards-combined.log"
+
 if FAKE_SWIFT_GROUP_ALWAYS_FAIL=1 \
   python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
     --group-size 4 \


### PR DESCRIPTION
## Summary
- split macOS lint and Swift tests into separate CI jobs
- run macOS Swift test suite groups across 4 matrix shards
- keep the existing `lint-build-test` check as an aggregate gate for branch protection compatibility
- extend the sharding self-test to prove shard union equals the full test list

## Local validation
- `python3 -m py_compile Scripts/ci_swift_test_by_suite.py`
- `bash -n Scripts/test.sh`
- `bash -n Scripts/test_swift_test_sharding.sh`
- `bash Scripts/test_swift_test_sharding.sh`
- `git diff --check`

This is a draft PR to validate whether CI wall-clock time improves before requesting review.