### PR TITLE
fix(ci): surface test discovery failures

### DIFF
--- a/Scripts/ci_swift_test_by_suite.py
+++ b/Scripts/ci_swift_test_by_suite.py
@@ -50,7 +50,16 @@ def run_command(command: list[str], timeout: int | None = None) -> int:
 
 
 def swift_test_list(swift_command: list[str]) -> list[TestSelection]:
-    result = subprocess.run([*swift_command, "test", "list"], check=True, capture_output=True, text=True)
+    command = [*swift_command, "test", "list"]
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as error:
+        print(f"+ {swift_command[0]} test list", flush=True)
+        if error.stdout:
+            print(error.stdout, end="" if error.stdout.endswith("\n") else "\n", flush=True)
+        if error.stderr:
+            print(error.stderr, end="" if error.stderr.endswith("\n") else "\n", file=sys.stderr, flush=True)
+        raise
     selections: set[TestSelection] = set()
     unknown: list[str] = []
     for line in result.stdout.splitlines():

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 
 printf '%s\n' "$*" >> "${FAKE_SWIFT_LOG}"
 if [[ "$*" == "test list" ]]; then
+  if [[ "${FAKE_SWIFT_LIST_FAIL:-0}" == "1" ]]; then
+    printf 'test-list stdout marker\n'
+    printf 'test-list stderr marker\n' >&2
+    exit 42
+  fi
   printf '%s\n' \
     "CodexBarTests.Alpha/test_one()" \
     "CodexBarTests.Alpha/test_two(argument:)" \
@@ -95,5 +100,21 @@ if FAKE_SWIFT_GROUP_ALWAYS_FAIL=1 \
   echo "ERROR: Repeated shard failure was masked." >&2
   exit 1
 fi
+
+if FAKE_SWIFT_LIST_FAIL=1 \
+  python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
+    --group-size 1 \
+    --timeout 10 \
+    --list-only \
+    --swift-command /bin/bash \
+    --swift-command-arg=-c \
+    --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
+    --swift-command-arg=fake-swift \
+    >"${TEMP_DIR}/list-failure.log" 2>&1; then
+  echo "ERROR: Failed test discovery was masked." >&2
+  exit 1
+fi
+grep -Fq "test-list stdout marker" "${TEMP_DIR}/list-failure.log"
+grep -Fq "test-list stderr marker" "${TEMP_DIR}/list-failure.log"
 
 echo "Swift test sharding tests passed."


### PR DESCRIPTION
## Summary

- print captured stdout and stderr when `swift test list` fails in the macOS sharding wrapper
- preserve the original discovery failure and exit status
- cover both captured streams with a failing fake Swift command

## Proof

- `bash Scripts/test_swift_test_sharding.sh`
- `make check`
- autoreview clean (0.90)

No changelog entry: internal CI diagnostics only.
