### PR TITLE
feat: add alphabetical sort toggle to providers pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Codex: show available manual rate-limit reset credits and their next expiry for signed-in OAuth accounts. Thanks @rogdex24!
 - Mistral: add Vibe monthly-plan usage and menu bar metric selection. Thanks @lfmundim!
 - Storage: show a compact segmented provider breakdown with an expandable Other group. Thanks @elijahfriedman!
+- Settings: add an optional enabled-first alphabetical sort for the Providers sidebar without changing custom order. Thanks @elijahfriedman!
 - Linux CLI: publish static musl release tarballs for x86_64 and aarch64. Thanks @Yuxin-Qiao!
 - Documentation: add safe troubleshooting for browser Keychain prompts that persist after uninstall. Thanks @Yuxin-Qiao!
 - Diagnostics: report provider-neutral usage confidence and mark fully decoded Codex OAuth windows exact. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/PreferencesProviderSidebarView.swift
+++ b/Sources/CodexBar/PreferencesProviderSidebarView.swift
@@ -167,6 +167,9 @@ private struct ProviderSidebarRowView: View {
                         self.draggingProvider = self.provider
                         return NSItemProvider(object: self.provider.rawValue as NSString)
                     }
+            } else {
+                // Inset the icon a touch so rows don't hug the left edge once the drag handle is gone.
+                Color.clear.frame(width: 8, height: 1)
             }
 
             ProviderSidebarBrandIcon(provider: self.provider, color: palette.secondary)

--- a/Sources/CodexBar/PreferencesProviderSidebarView.swift
+++ b/Sources/CodexBar/PreferencesProviderSidebarView.swift
@@ -12,14 +12,18 @@ struct ProviderSidebarListView: View {
     let subtitle: (UsageProvider) -> String
     @Binding var searchText: String
     @Binding var selection: UsageProvider?
+    @Binding var sortAlphabetically: Bool
     let moveProviders: (IndexSet, Int) -> Void
     @State private var draggingProvider: UsageProvider?
 
     var body: some View {
         VStack(spacing: 8) {
-            ProviderSidebarSearchField(searchText: self.$searchText)
-                .padding(.horizontal, 8)
-                .padding(.top, 8)
+            HStack(spacing: 6) {
+                ProviderSidebarSearchField(searchText: self.$searchText)
+                ProviderSidebarSortToggle(isOn: self.$sortAlphabetically)
+            }
+            .padding(.horizontal, 8)
+            .padding(.top, 8)
 
             ScrollView {
                 VStack(spacing: 0) {
@@ -37,6 +41,7 @@ struct ProviderSidebarListView: View {
                             isEnabled: self.isEnabled(provider),
                             subtitle: self.subtitle(provider),
                             isSelected: self.selection == provider,
+                            showsReorderHandle: !self.sortAlphabetically,
                             draggingProvider: self.$draggingProvider)
                             .padding(.horizontal, 8)
                             .background(
@@ -106,6 +111,35 @@ private struct ProviderSidebarSearchField: View {
     }
 }
 
+private struct ProviderSidebarSortToggle: View {
+    @Binding var isOn: Bool
+
+    var body: some View {
+        Button {
+            self.isOn.toggle()
+        } label: {
+            Image(systemName: "arrow.up.arrow.down")
+                .font(.callout)
+                .foregroundStyle(self.isOn ? Color.accentColor : Color.secondary)
+                .frame(width: 28, height: 28)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(self.isOn
+                            ? Color.accentColor.opacity(0.15)
+                            : Color(nsColor: .textBackgroundColor)))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(Color(nsColor: .separatorColor).opacity(0.7), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .help(self.isOn
+            ? L("Sorted alphabetically (enabled first) — click to use your custom order")
+            : L("Sort providers alphabetically (enabled first)"))
+        .accessibilityLabel(L("Sort providers alphabetically"))
+        .accessibilityAddTraits(self.isOn ? .isSelected : [])
+    }
+}
+
 @MainActor
 private struct ProviderSidebarRowView: View {
     let provider: UsageProvider
@@ -113,6 +147,7 @@ private struct ProviderSidebarRowView: View {
     @Binding var isEnabled: Bool
     let subtitle: String
     let isSelected: Bool
+    let showsReorderHandle: Bool
     @Binding var draggingProvider: UsageProvider?
 
     var body: some View {
@@ -122,15 +157,17 @@ private struct ProviderSidebarRowView: View {
         let palette = ProviderSidebarRowPalette(isSelected: self.isSelected)
 
         HStack(alignment: .center, spacing: 10) {
-            ProviderSidebarReorderHandle(color: palette.tertiary)
-                .contentShape(Rectangle())
-                .padding(.vertical, 4)
-                .padding(.horizontal, 2)
-                .help(L("Drag to reorder"))
-                .onDrag {
-                    self.draggingProvider = self.provider
-                    return NSItemProvider(object: self.provider.rawValue as NSString)
-                }
+            if self.showsReorderHandle {
+                ProviderSidebarReorderHandle(color: palette.tertiary)
+                    .contentShape(Rectangle())
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 2)
+                    .help(L("Drag to reorder"))
+                    .onDrag {
+                        self.draggingProvider = self.provider
+                        return NSItemProvider(object: self.provider.rawValue as NSString)
+                    }
+            }
 
             ProviderSidebarBrandIcon(provider: self.provider, color: palette.secondary)
 

--- a/Sources/CodexBar/PreferencesProvidersPane+Testing.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane+Testing.swift
@@ -11,6 +11,10 @@ extension ProvidersPane {
         self.providerSubtitle(provider)
     }
 
+    func _test_moveProviders(fromOffsets: IndexSet, toOffset: Int) {
+        self.moveProviders(fromOffsets: fromOffsets, toOffset: toOffset)
+    }
+
     func _test_menuBarMetricPicker(for provider: UsageProvider) -> ProviderSettingsPickerDescriptor? {
         self.menuBarMetricPicker(for: provider)
     }

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -20,7 +20,12 @@ struct ProvidersPane: View {
     @State private var selectedProvider: UsageProvider?
 
     private var providers: [UsageProvider] {
-        self.settings.orderedProviders()
+        guard self.settings.providersSortedAlphabetically else {
+            return self.settings.orderedProviders()
+        }
+        return CodexBarConfig.alphabeticalProviderOrder(enablement: { provider in
+            self.settings.isProviderEnabled(provider: provider, metadata: self.store.metadata(for: provider))
+        })
     }
 
     private var filteredProviders: [UsageProvider] {
@@ -60,6 +65,9 @@ struct ProvidersPane: View {
                 subtitle: { provider in self.providerSidebarSubtitle(provider) },
                 searchText: self.$providerSearchText,
                 selection: self.$selectedProvider,
+                sortAlphabetically: Binding(
+                    get: { self.settings.providersSortedAlphabetically },
+                    set: { self.settings.providersSortedAlphabetically = $0 }),
                 moveProviders: { fromOffsets, toOffset in
                     self.settings.moveProvider(fromOffsets: fromOffsets, toOffset: toOffset)
                 })

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -69,7 +69,7 @@ struct ProvidersPane: View {
                     get: { self.settings.providersSortedAlphabetically },
                     set: { self.settings.providersSortedAlphabetically = $0 }),
                 moveProviders: { fromOffsets, toOffset in
-                    self.settings.moveProvider(fromOffsets: fromOffsets, toOffset: toOffset)
+                    self.moveProviders(fromOffsets: fromOffsets, toOffset: toOffset)
                 })
 
             if let provider = self.selectedVisibleProvider {
@@ -183,6 +183,11 @@ struct ProvidersPane: View {
             displayName(provider).localizedCaseInsensitiveContains(trimmedQuery)
                 || provider.rawValue.localizedCaseInsensitiveContains(trimmedQuery)
         }
+    }
+
+    func moveProviders(fromOffsets: IndexSet, toOffset: Int) {
+        guard !self.settings.providersSortedAlphabetically else { return }
+        self.settings.moveProvider(fromOffsets: fromOffsets, toOffset: toOffset)
     }
 
     private func ensureSelection() {

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -977,6 +977,9 @@
 "Day" = "اليوم";
 "Deployment" = "النشر";
 "Drag to reorder" = "سحب لإعادة ترتيب";
+"Sort providers alphabetically" = "فرز المزوّدين أبجديًا";
+"Sort providers alphabetically (enabled first)" = "فرز المزوّدين أبجديًا (المفعّلون أولاً)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "مرتّبة أبجديًا (المفعّلون أولاً) — انقر لاستخدام ترتيبك المخصّص";
 "Endpoint" = "نقطة النهاية";
 "Enterprise host" = "مضيف مؤسسي";
 "Extra usage balance: %@" = "توازن الاستخدام الإضافي: %@";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -830,6 +830,9 @@
 "Day" = "Dia";
 "Deployment" = "Desplegament";
 "Drag to reorder" = "Arrossega per reordenar";
+"Sort providers alphabetically" = "Ordena els proveïdors alfabèticament";
+"Sort providers alphabetically (enabled first)" = "Ordena els proveïdors alfabèticament (els activats primer)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Ordenats alfabèticament (els activats primer) — fes clic per utilitzar l’ordre personalitzat";
 "Endpoint" = "Endpoint";
 "Enterprise host" = "Host Enterprise";
 "Extra usage balance: %@" = "Saldo d'ús extra: %@";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -974,6 +974,9 @@
 "Day" = "Tag";
 "Deployment" = "Einsatz";
 "Drag to reorder" = "Zum Neuanordnen ziehen";
+"Sort providers alphabetically" = "Anbieter alphabetisch sortieren";
+"Sort providers alphabetically (enabled first)" = "Anbieter alphabetisch sortieren (aktivierte zuerst)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Alphabetisch sortiert (aktivierte zuerst) — klicken, um die eigene Reihenfolge zu verwenden";
 "Endpoint" = "Endpunkt";
 "Enterprise host" = "Unternehmenshost";
 "Extra usage balance: %@" = "Zusätzlicher Nutzungssaldo: %@";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -977,6 +977,9 @@
 "Day" = "Day";
 "Deployment" = "Deployment";
 "Drag to reorder" = "Drag to reorder";
+"Sort providers alphabetically" = "Sort providers alphabetically";
+"Sort providers alphabetically (enabled first)" = "Sort providers alphabetically (enabled first)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Sorted alphabetically (enabled first) — click to use your custom order";
 "Endpoint" = "Endpoint";
 "Enterprise host" = "Enterprise host";
 "Extra usage balance: %@" = "Extra usage balance: %@";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -830,6 +830,9 @@
 "Day" = "Día";
 "Deployment" = "Despliegue";
 "Drag to reorder" = "Arrastra para reordenar";
+"Sort providers alphabetically" = "Ordenar proveedores alfabéticamente";
+"Sort providers alphabetically (enabled first)" = "Ordenar proveedores alfabéticamente (activados primero)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Ordenados alfabéticamente (activados primero) — haz clic para usar tu orden personalizado";
 "Endpoint" = "Endpoint";
 "Enterprise host" = "Host Enterprise";
 "Extra usage balance: %@" = "Saldo de uso extra: %@";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -977,6 +977,9 @@
 "Day" = "روز";
 "Deployment" = "استقرار";
 "Drag to reorder" = "درگ برای بازآرایی";
+"Sort providers alphabetically" = "مرتب‌سازی ارائه‌دهندگان بر اساس حروف الفبا";
+"Sort providers alphabetically (enabled first)" = "مرتب‌سازی الفبایی ارائه‌دهندگان (فعال‌ها ابتدا)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "مرتب‌شده بر اساس حروف الفبا (فعال‌ها ابتدا) — برای استفاده از ترتیب سفارشی کلیک کنید";
 "Endpoint" = "نقطه پایان";
 "Enterprise host" = "میزبان سازمانی";
 "Extra usage balance: %@" = "تعادل استفاده اضافی: %@";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -974,6 +974,9 @@
 "Day" = "Jour";
 "Deployment" = "Déploiement";
 "Drag to reorder" = "Faites glisser pour réorganiser";
+"Sort providers alphabetically" = "Trier les fournisseurs par ordre alphabétique";
+"Sort providers alphabetically (enabled first)" = "Trier les fournisseurs par ordre alphabétique (activés en premier)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Triés par ordre alphabétique (activés en premier) — cliquez pour utiliser votre ordre personnalisé";
 "Endpoint" = "Point de terminaison";
 "Enterprise host" = "Hôte d'entreprise";
 "Extra usage balance: %@" = "Solde d'utilisation supplémentaire : %@";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -979,6 +979,9 @@
 "Day" = "Hari";
 "Deployment" = "Deployment";
 "Drag to reorder" = "Seret untuk mengatur ulang";
+"Sort providers alphabetically" = "Urutkan penyedia menurut abjad";
+"Sort providers alphabetically (enabled first)" = "Urutkan penyedia menurut abjad (yang aktif lebih dulu)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Diurutkan menurut abjad (yang aktif lebih dulu) — klik untuk memakai urutan khusus";
 "Endpoint" = "Endpoint";
 "Enterprise host" = "Host enterprise";
 "Extra usage balance: %@" = "Saldo penggunaan ekstra: %@";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -979,6 +979,9 @@
 "Day" = "Giorno";
 "Deployment" = "Deployment";
 "Drag to reorder" = "Trascina per riordinare";
+"Sort providers alphabetically" = "Ordina i provider alfabeticamente";
+"Sort providers alphabetically (enabled first)" = "Ordina i provider alfabeticamente (prima quelli attivi)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Ordinati alfabeticamente (prima quelli attivi) — fai clic per usare l’ordine personalizzato";
 "Endpoint" = "Endpoint";
 "Enterprise host" = "Host Enterprise";
 "Extra usage balance: %@" = "Saldo uso extra: %@";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -971,6 +971,9 @@
 "Day" = "日";
 "Deployment" = "デプロイメント";
 "Drag to reorder" = "ドラッグして並べ替え";
+"Sort providers alphabetically" = "プロバイダーをアルファベット順に並べ替え";
+"Sort providers alphabetically (enabled first)" = "プロバイダーをアルファベット順に並べ替え（有効なものを先頭）";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "アルファベット順（有効なものを先頭）— クリックしてカスタム順に戻す";
 "Endpoint" = "エンドポイント";
 "Enterprise host" = "Enterprise ホスト";
 "Extra usage balance: %@" = "追加使用量の残高: %@";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -941,6 +941,9 @@
 "Day" = "일간";
 "Deployment" = "배포";
 "Drag to reorder" = "드래그하여 순서 변경";
+"Sort providers alphabetically" = "공급자를 알파벳순으로 정렬";
+"Sort providers alphabetically (enabled first)" = "공급자를 알파벳순으로 정렬(활성화 항목 우선)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "알파벳순으로 정렬됨(활성화 항목 우선) — 사용자 지정 순서를 사용하려면 클릭";
 "Endpoint" = "엔드포인트";
 "Enterprise host" = "엔터프라이즈 호스트";
 "Extra usage balance: %@" = "추가 사용량 잔액: %@";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -974,6 +974,9 @@
 "Day" = "Dag";
 "Deployment" = "Inzet";
 "Drag to reorder" = "Sleep om de volgorde te wijzigen";
+"Sort providers alphabetically" = "Providers alfabetisch sorteren";
+"Sort providers alphabetically (enabled first)" = "Providers alfabetisch sorteren (ingeschakelde eerst)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Alfabetisch gesorteerd (ingeschakelde eerst) — klik om je aangepaste volgorde te gebruiken";
 "Endpoint" = "Eindpunt";
 "Enterprise host" = "Enterprise-host";
 "Extra usage balance: %@" = "Extra gebruikssaldo: %@";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -979,6 +979,9 @@
 "Day" = "Dzień";
 "Deployment" = "Wdrożenie";
 "Drag to reorder" = "Przeciągnij, aby zmienić kolejność";
+"Sort providers alphabetically" = "Sortuj dostawców alfabetycznie";
+"Sort providers alphabetically (enabled first)" = "Sortuj dostawców alfabetycznie (włączeni najpierw)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Posortowano alfabetycznie (włączeni najpierw) — kliknij, aby użyć własnej kolejności";
 "Endpoint" = "Punkt końcowy";
 "Enterprise host" = "Host Enterprise";
 "Extra usage balance: %@" = "Saldo dodatkowego użycia: %@";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -971,6 +971,9 @@
 "Day" = "Dia";
 "Deployment" = "Deployment";
 "Drag to reorder" = "Arraste para reordenar";
+"Sort providers alphabetically" = "Ordenar provedores alfabeticamente";
+"Sort providers alphabetically (enabled first)" = "Ordenar provedores alfabeticamente (ativados primeiro)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Ordenados alfabeticamente (ativados primeiro) — clique para usar sua ordem personalizada";
 "Endpoint" = "Endpoint";
 "Enterprise host" = "Host Enterprise";
 "Extra usage balance: %@" = "Saldo de uso extra: %@";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -936,6 +936,9 @@
 "Windsurf session JSON bundle" = "Windsurf-sessionspaket i JSON";
 "CodexBar will ask macOS Keychain for your Cursor cookie header so it can fetch usage. Click OK to continue." = "CodexBar kommer att be macOS Nyckelring om din Cursor-cookie-header så att användning kan hämtas. Klicka på OK för att fortsätta.";
 "Drag to reorder" = "Dra för att ändra ordning";
+"Sort providers alphabetically" = "Sortera leverantörer alfabetiskt";
+"Sort providers alphabetically (enabled first)" = "Sortera leverantörer alfabetiskt (aktiverade först)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Alfabetiskt sorterade (aktiverade först) — klicka för att använda din anpassade ordning";
 "cache-hit input" = "cacheträff-indata";
 "Automatically imports browser cookies." = "Importerar webbläsarcookies automatiskt.";
 "Open Volcengine Ark Console" = "Öppna Volcengine Ark-konsol";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -977,6 +977,9 @@
 "Day" = "วัน";
 "Deployment" = "การปรับใช้";
 "Drag to reorder" = "ลากเพื่อจัดลําดับใหม่";
+"Sort providers alphabetically" = "เรียงผู้ให้บริการตามตัวอักษร";
+"Sort providers alphabetically (enabled first)" = "เรียงผู้ให้บริการตามตัวอักษร (ที่เปิดใช้ก่อน)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "เรียงตามตัวอักษรแล้ว (ที่เปิดใช้ก่อน) — คลิกเพื่อใช้ลำดับที่กำหนดเอง";
 "Endpoint" = "ปลายทาง";
 "Enterprise host" = "โฮสต์องค์กร";
 "Extra usage balance: %@" = "ยอดการใช้งานเพิ่มเติม: %@";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -974,6 +974,9 @@
 "Day" = "Gün";
 "Deployment" = "Dağıtım";
 "Drag to reorder" = "Yeniden sıralamak için sürükleyin";
+"Sort providers alphabetically" = "Sağlayıcıları alfabetik sırala";
+"Sort providers alphabetically (enabled first)" = "Sağlayıcıları alfabetik sırala (etkin olanlar önce)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Alfabetik sıralandı (etkin olanlar önce) — özel sıranızı kullanmak için tıklayın";
 "Endpoint" = "Uç nokta";
 "Enterprise host" = "Kurumsal sunucu";
 "Extra usage balance: %@" = "Ekstra kullanım bakiyesi: %@";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -974,6 +974,9 @@
 "Day" = "День";
 "Deployment" = "Розгортання";
 "Drag to reorder" = "Перетягніть, щоб змінити порядок";
+"Sort providers alphabetically" = "Сортувати постачальників за алфавітом";
+"Sort providers alphabetically (enabled first)" = "Сортувати постачальників за алфавітом (увімкнені спочатку)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Відсортовано за алфавітом (увімкнені спочатку) — натисніть, щоб використати власний порядок";
 "Endpoint" = "Кінцева точка";
 "Enterprise host" = "Корпоративний хост";
 "Extra usage balance: %@" = "Баланс додаткового використання: %@";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -970,6 +970,9 @@
 "Day" = "Ngày";
 "Deployment" = "Triển khai";
 "Drag to reorder" = "Kéo để sắp xếp lại";
+"Sort providers alphabetically" = "Sắp xếp nhà cung cấp theo bảng chữ cái";
+"Sort providers alphabetically (enabled first)" = "Sắp xếp nhà cung cấp theo bảng chữ cái (đã bật trước)";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "Đã sắp xếp theo bảng chữ cái (đã bật trước) — nhấp để dùng thứ tự tùy chỉnh";
 "Endpoint" = "Điểm cuối";
 "Enterprise host" = "Máy chủ doanh nghiệp";
 "Extra usage balance: %@" = "Extra usage balance: %@";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -945,6 +945,9 @@
 "Day" = "日期";
 "Deployment" = "部署";
 "Drag to reorder" = "拖动以重新排序";
+"Sort providers alphabetically" = "按字母顺序排列提供商";
+"Sort providers alphabetically (enabled first)" = "按字母顺序排列提供商（已启用的优先）";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "已按字母顺序排列（已启用的优先）— 点击使用自定义顺序";
 "Endpoint" = "端点";
 "Enterprise host" = "Enterprise 主机";
 "Extra usage balance: %@" = "额外使用量余额：%@";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -840,6 +840,9 @@
 "Day" = "日期";
 "Deployment" = "部署";
 "Drag to reorder" = "拖曳以重新排序";
+"Sort providers alphabetically" = "依字母順序排列供應商";
+"Sort providers alphabetically (enabled first)" = "依字母順序排列供應商（已啟用的優先）";
+"Sorted alphabetically (enabled first) — click to use your custom order" = "已依字母順序排列（已啟用的優先）— 按一下使用自訂順序";
 "Endpoint" = "端點";
 "Enterprise host" = "Enterprise 主機";
 "Extra usage balance: %@" = "額外使用量餘額：%@";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -665,8 +665,8 @@ extension SettingsStore {
     }
 
     /// Whether the Providers settings pane displays providers sorted alphabetically (enabled on
-    /// top). Defaults to `true`. Purely a display preference — it never rewrites the stored manual
-    /// order, so turning it off restores the user's hand-arranged sequence.
+    /// top). Defaults to `false`. Purely a display preference — it never rewrites the stored manual
+    /// order, so turning it on sorts the display without losing the user's hand-arranged sequence.
     var providersSortedAlphabetically: Bool {
         get { self.defaultsState.providersSortedAlphabetically }
         set {

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -664,6 +664,17 @@ extension SettingsStore {
         }
     }
 
+    /// Whether the Providers settings pane displays providers sorted alphabetically (enabled on
+    /// top). Defaults to `true`. Purely a display preference — it never rewrites the stored manual
+    /// order, so turning it off restores the user's hand-arranged sequence.
+    var providersSortedAlphabetically: Bool {
+        get { self.defaultsState.providersSortedAlphabetically }
+        set {
+            self.defaultsState.providersSortedAlphabetically = newValue
+            self.userDefaults.set(newValue, forKey: "providersSortedAlphabetically")
+        }
+    }
+
     var appLanguage: String {
         get { self.defaultsState.appLanguageRaw ?? "" }
         set {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -412,6 +412,8 @@ extension SettingsStore {
             forKey: "mergedOverviewSelectedProviders") as? [String] ?? []
         let selectedMenuProviderRaw = userDefaults.string(forKey: "selectedMenuProvider")
         let providerDetectionCompleted = userDefaults.object(forKey: "providerDetectionCompleted") as? Bool ?? false
+        let providersSortedAlphabetically = userDefaults.object(
+            forKey: "providersSortedAlphabetically") as? Bool ?? true
         let appLanguageRaw = userDefaults.string(forKey: "appLanguage")
         return SettingsDefaultsState(
             refreshFrequency: refreshFrequency,
@@ -465,6 +467,7 @@ extension SettingsStore {
             mergedOverviewSelectedProvidersRaw: mergedOverviewSelectedProvidersRaw,
             selectedMenuProviderRaw: selectedMenuProviderRaw,
             providerDetectionCompleted: providerDetectionCompleted,
+            providersSortedAlphabetically: providersSortedAlphabetically,
             appLanguageRaw: appLanguageRaw,
             terminalAppRaw: userDefaults.string(forKey: "terminalApp"))
     }

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -413,7 +413,7 @@ extension SettingsStore {
         let selectedMenuProviderRaw = userDefaults.string(forKey: "selectedMenuProvider")
         let providerDetectionCompleted = userDefaults.object(forKey: "providerDetectionCompleted") as? Bool ?? false
         let providersSortedAlphabetically = userDefaults.object(
-            forKey: "providersSortedAlphabetically") as? Bool ?? true
+            forKey: "providersSortedAlphabetically") as? Bool ?? false
         let appLanguageRaw = userDefaults.string(forKey: "appLanguage")
         return SettingsDefaultsState(
             refreshFrequency: refreshFrequency,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -52,6 +52,7 @@ struct SettingsDefaultsState {
     var mergedOverviewSelectedProvidersRaw: [String]
     var selectedMenuProviderRaw: String?
     var providerDetectionCompleted: Bool
+    var providersSortedAlphabetically: Bool
     var appLanguageRaw: String?
     var terminalAppRaw: String?
 }

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -22,6 +22,27 @@ public struct CodexBarConfig: Codable, Sendable {
         return CodexBarConfig(version: Self.currentVersion, providers: providers)
     }
 
+    /// Alphabetical provider ordering with enabled providers on top: enabled first, then disabled,
+    /// each group sorted case-insensitively by display name. Used by the Providers settings pane's
+    /// alphabetical sort toggle; it never mutates the user's stored manual order.
+    public static func alphabeticalProviderOrder(
+        metadata: [UsageProvider: ProviderMetadata] = ProviderDescriptorRegistry.metadata,
+        enablement: (UsageProvider) -> Bool) -> [UsageProvider]
+    {
+        UsageProvider.allCases.sorted { lhs, rhs in
+            let lhsEnabled = enablement(lhs)
+            let rhsEnabled = enablement(rhs)
+            if lhsEnabled != rhsEnabled { return lhsEnabled }
+            let lhsName = metadata[lhs]?.displayName ?? lhs.rawValue
+            let rhsName = metadata[rhs]?.displayName ?? rhs.rawValue
+            switch lhsName.localizedCaseInsensitiveCompare(rhsName) {
+            case .orderedAscending: return true
+            case .orderedDescending: return false
+            case .orderedSame: return lhs.rawValue < rhs.rawValue
+            }
+        }
+    }
+
     public func normalized(
         metadata: [UsageProvider: ProviderMetadata] = ProviderDescriptorRegistry.metadata) -> CodexBarConfig
     {

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -53,6 +53,22 @@ struct ProvidersPaneCoverageTests {
     }
 
     @Test
+    func `provider reordering is inert while alphabetical sorting is enabled`() {
+        let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-sorted-reorder")
+        let store = Self.makeUsageStore(settings: settings)
+        let pane = ProvidersPane(settings: settings, store: store)
+        let original = settings.orderedProviders()
+
+        settings.providersSortedAlphabetically = true
+        pane._test_moveProviders(fromOffsets: IndexSet(integer: 0), toOffset: original.count)
+        #expect(settings.orderedProviders() == original)
+
+        settings.providersSortedAlphabetically = false
+        pane._test_moveProviders(fromOffsets: IndexSet(integer: 0), toOffset: original.count)
+        #expect(settings.orderedProviders().last == original.first)
+    }
+
+    @Test
     func `selected provider sidebar palette uses contrasting selected text colors`() {
         let palette = ProviderSidebarRowPalette(isSelected: true)
 

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -138,7 +138,7 @@ struct SettingsStoreTests {
     }
 
     @Test
-    func `providers sorted alphabetically defaults on and persists`() throws {
+    func `providers sorted alphabetically defaults off and persists`() throws {
         let suite = "SettingsStoreTests-providers-sorted-alpha"
         let defaultsA = try #require(UserDefaults(suiteName: suite))
         defaultsA.removePersistentDomain(forName: suite)

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -138,6 +138,55 @@ struct SettingsStoreTests {
     }
 
     @Test
+    func `providers sorted alphabetically defaults on and persists`() throws {
+        let suite = "SettingsStoreTests-providers-sorted-alpha"
+        let defaultsA = try #require(UserDefaults(suiteName: suite))
+        defaultsA.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let storeA = SettingsStore(
+            userDefaults: defaultsA,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(storeA.providersSortedAlphabetically == true)
+        storeA.providersSortedAlphabetically = false
+
+        let defaultsB = try #require(UserDefaults(suiteName: suite))
+        let storeB = SettingsStore(
+            userDefaults: defaultsB,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(storeB.providersSortedAlphabetically == false)
+    }
+
+    @Test
+    func `alphabetical provider order puts enabled first then sorts by name`() {
+        let metadata = ProviderDescriptorRegistry.metadata
+        let enabled: Set<UsageProvider> = [.cursor, .claude, .codex]
+        let ordered = CodexBarConfig.alphabeticalProviderOrder(
+            enablement: { enabled.contains($0) })
+
+        #expect(Set(ordered) == Set(UsageProvider.allCases))
+
+        let displayName: (UsageProvider) -> String = { metadata[$0]?.displayName ?? $0.rawValue }
+        let enabledPart = ordered.filter { enabled.contains($0) }
+        let disabledPart = ordered.filter { !enabled.contains($0) }
+        // Enabled providers occupy the top of the list, ahead of every disabled provider.
+        #expect(Array(ordered.prefix(enabled.count)) == enabledPart)
+        #expect(ordered == enabledPart + disabledPart)
+        let isSortedByName: ([UsageProvider]) -> Bool = { group in
+            group == group.sorted {
+                displayName($0).localizedCaseInsensitiveCompare(displayName($1)) == .orderedAscending
+            }
+        }
+        #expect(isSortedByName(enabledPart))
+        #expect(isSortedByName(disabledPart))
+    }
+
+    @Test
     func `provider changelog links setting defaults off and persists`() throws {
         let suite = "SettingsStoreTests-provider-changelog-links"
         let defaultsA = try #require(UserDefaults(suiteName: suite))

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -149,8 +149,8 @@ struct SettingsStoreTests {
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
 
-        #expect(storeA.providersSortedAlphabetically == true)
-        storeA.providersSortedAlphabetically = false
+        #expect(storeA.providersSortedAlphabetically == false)
+        storeA.providersSortedAlphabetically = true
 
         let defaultsB = try #require(UserDefaults(suiteName: suite))
         let storeB = SettingsStore(
@@ -159,7 +159,7 @@ struct SettingsStoreTests {
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
 
-        #expect(storeB.providersSortedAlphabetically == false)
+        #expect(storeB.providersSortedAlphabetically == true)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add a persisted sort toggle beside Providers search; default remains custom order.
- When enabled, show enabled providers first and sort each group alphabetically.
- Keep stored custom order unchanged and make drag/drop reorder requests inert while sorted.
- Hide drag handles in sorted mode while preserving row alignment.
- Localize the control label/help across every app catalog and add contributor changelog credit.

## Proof

- `swift test --filter 'SettingsStoreTests|ProvidersPaneCoverageTests|UserFacingLocalizationCoverageTests'`: 90 tests passed on the exact head.
- `make check`: localization parity, SwiftFormat, and strict SwiftLint clean.
- Exact-head Codex autoreview clean, confidence 0.82.
- Exact UI package launched successfully; production-size Providers screenshots show sort off/on without clipping.

Exact candidate: `60c8c4b677011e8f3a3a36ab84fbb7cc14b25bca`.

## Screenshots

With sorting off:

<img width="790" height="749" alt="Providers custom order" src="https://github.com/user-attachments/assets/068d4851-7c78-450c-b023-70e8355f8671" />

With sorting on:

<img width="779" height="747" alt="Providers alphabetical order" src="https://github.com/user-attachments/assets/8ba3c989-41d9-421c-91ac-14a061705fa7" />
