### PR TITLE
feat(mistral): add Monthly Plan menu bar metric (subscription usage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Codex: show available manual rate-limit reset credits and their next expiry for signed-in OAuth accounts. Thanks @rogdex24!
+- Mistral: add Vibe monthly-plan usage and menu bar metric selection. Thanks @lfmundim!
 - Linux CLI: publish static musl release tarballs for x86_64 and aarch64. Thanks @Yuxin-Qiao!
 - Documentation: add safe troubleshooting for browser Keychain prompts that persist after uninstall. Thanks @Yuxin-Qiao!
 - Codex agents: add a read-only `codexbar` skill for bounded, redacted provider usage JSON. Thanks @coygeek!

--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -17,6 +17,8 @@ enum MenuBarMetricWindowResolver {
     {
         guard let snapshot else { return nil }
         switch preference {
+        case .monthlyPlan:
+            return snapshot.extraRateWindows?.first { $0.id == "mistral-monthly-plan" }?.window
         case .extraUsage:
             return Self.extraUsageWindow(snapshot: snapshot)
         case .tertiary:

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -543,6 +543,11 @@ struct ProvidersPane: View {
                     id: MenuBarMetricPreference.primary.rawValue,
                     title: L("primary_api_key_limit")),
             ]
+        } else if provider == .mistral {
+            options = [
+                ProviderSettingsPickerOption(id: MenuBarMetricPreference.automatic.rawValue, title: L("metric_mistral_payg")),
+                ProviderSettingsPickerOption(id: MenuBarMetricPreference.monthlyPlan.rawValue, title: L("metric_mistral_monthly_plan")),
+            ]
         } else if SettingsStore.isBalanceOnlyProvider(provider) {
             options = [
                 ProviderSettingsPickerOption(id: MenuBarMetricPreference.automatic.rawValue, title: L("Automatic")),

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -545,8 +545,12 @@ struct ProvidersPane: View {
             ]
         } else if provider == .mistral {
             options = [
-                ProviderSettingsPickerOption(id: MenuBarMetricPreference.automatic.rawValue, title: L("metric_mistral_payg")),
-                ProviderSettingsPickerOption(id: MenuBarMetricPreference.monthlyPlan.rawValue, title: L("metric_mistral_monthly_plan")),
+                ProviderSettingsPickerOption(
+                    id: MenuBarMetricPreference.automatic.rawValue,
+                    title: L("metric_mistral_payg")),
+                ProviderSettingsPickerOption(
+                    id: MenuBarMetricPreference.monthlyPlan.rawValue,
+                    title: L("metric_mistral_monthly_plan")),
             ]
         } else if SettingsStore.isBalanceOnlyProvider(provider) {
             options = [

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -628,6 +628,8 @@
 "metric_pref_tertiary" = "الدرجة الثالثة";
 "metric_pref_extra_usage" = "الاستخدام الإضافي";
 "metric_pref_average" = "المتوسط";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "النسبة المئوية";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -617,6 +617,8 @@
 "metric_pref_tertiary" = "Terciari";
 "metric_pref_extra_usage" = "Ús addicional";
 "metric_pref_average" = "Mitjana";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Percentatge";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -628,6 +628,8 @@
 "metric_pref_tertiary" = "Tertiär";
 "metric_pref_extra_usage" = "Zusätzliche Nutzung";
 "metric_pref_average" = "Durchschnitt";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Prozent";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -628,6 +628,8 @@
 "metric_pref_tertiary" = "Tertiary";
 "metric_pref_extra_usage" = "Extra usage";
 "metric_pref_average" = "Average";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Percent";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -617,6 +617,8 @@
 "metric_pref_tertiary" = "Terciario";
 "metric_pref_extra_usage" = "Uso adicional";
 "metric_pref_average" = "Promedio";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Porcentaje";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -628,6 +628,8 @@
 "metric_pref_tertiary" = "دوره سوم";
 "metric_pref_extra_usage" = "استفاده اضافی";
 "metric_pref_average" = "میانگین";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "درصد";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -628,6 +628,8 @@
 "metric_pref_tertiary" = "Tertiaire";
 "metric_pref_extra_usage" = "Utilisation supplémentaire";
 "metric_pref_average" = "Moyenne";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Pourcentage";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -630,6 +630,8 @@
 "metric_pref_tertiary" = "Tersier";
 "metric_pref_extra_usage" = "Penggunaan ekstra";
 "metric_pref_average" = "Rata-rata";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Persen";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -630,8 +630,8 @@
 "metric_pref_tertiary" = "Terziario";
 "metric_pref_extra_usage" = "Uso extra";
 "metric_pref_average" = "Media";
-"metric_mistral_payg" = "Pay-as-you-go";
-"metric_mistral_monthly_plan" = "Monthly Plan";
+"metric_mistral_payg" = "A consumo";
+"metric_mistral_monthly_plan" = "Piano mensile";
 
 /* Display modes */
 "display_mode_percent" = "Percentuale";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -630,6 +630,8 @@
 "metric_pref_tertiary" = "Terziario";
 "metric_pref_extra_usage" = "Uso extra";
 "metric_pref_average" = "Media";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Percentuale";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -625,6 +625,8 @@
 "metric_pref_tertiary" = "第3";
 "metric_pref_extra_usage" = "追加使用量";
 "metric_pref_average" = "平均";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "パーセント";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -611,6 +611,8 @@
 "metric_pref_tertiary" = "3차";
 "metric_pref_extra_usage" = "추가 사용량";
 "metric_pref_average" = "평균";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 "display_mode_percent" = "백분율";
 "display_mode_pace" = "사용 속도";
 "display_mode_both" = "둘 다";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -628,6 +628,8 @@
 "metric_pref_tertiary" = "Tertiair";
 "metric_pref_extra_usage" = "Extra gebruik";
 "metric_pref_average" = "Gemiddeld";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Procent";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -630,6 +630,8 @@
 "metric_pref_tertiary" = "Trzeciorzędny";
 "metric_pref_extra_usage" = "Dodatkowe użycie";
 "metric_pref_average" = "Średnia";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Procent";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -625,6 +625,8 @@
 "metric_pref_tertiary" = "Terciário";
 "metric_pref_extra_usage" = "Uso extra";
 "metric_pref_average" = "Média";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Porcentagem";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -627,6 +627,8 @@
 "metric_pref_tertiary" = "Tertiär";
 "metric_pref_extra_usage" = "Extra användning";
 "metric_pref_average" = "Genomsnitt";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Procent";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -628,6 +628,8 @@
 "metric_pref_tertiary" = "ระดับอุดมศึกษา";
 "metric_pref_extra_usage" = "การใช้งานเพิ่มเติม";
 "metric_pref_average" = "ค่าเฉลี่ย";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "เปอร์เซ็นต์";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -628,6 +628,8 @@
 "metric_pref_tertiary" = "Üçüncül";
 "metric_pref_extra_usage" = "Ekstra kullanım";
 "metric_pref_average" = "Ortalama";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Yüzde";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -628,6 +628,8 @@
 "metric_pref_tertiary" = "Третинний";
 "metric_pref_extra_usage" = "Додаткове використання";
 "metric_pref_average" = "Середній";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Відсоток";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -624,6 +624,8 @@
 "metric_pref_tertiary" = "Đại học";
 "metric_pref_extra_usage" = "Bổ sung Mức sử dụng";
 "metric_pref_average" = "Trung bình";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 
 /* Display modes */
 "display_mode_percent" = "Phần trăm";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -606,6 +606,8 @@
 "metric_pref_tertiary" = "第三";
 "metric_pref_extra_usage" = "额外用量";
 "metric_pref_average" = "平均";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 "display_mode_percent" = "百分比";
 "display_mode_pace" = "进度";
 "display_mode_both" = "两者";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -617,6 +617,8 @@
 "metric_pref_tertiary" = "第三";
 "metric_pref_extra_usage" = "額外使用量";
 "metric_pref_average" = "平均";
+"metric_mistral_payg" = "Pay-as-you-go";
+"metric_mistral_monthly_plan" = "Monthly Plan";
 "display_mode_percent" = "百分比";
 "display_mode_pace" = "進度";
 "display_mode_both" = "兩者";

--- a/Sources/CodexBar/SettingsStore+MenuPreferences.swift
+++ b/Sources/CodexBar/SettingsStore+MenuPreferences.swift
@@ -6,6 +6,16 @@ extension SettingsStore {
         if Self.isBalanceOnlyProvider(provider), provider != .mistral {
             return .automatic
         }
+        if provider == .mistral {
+            let raw = self.menuBarMetricPreferencesRaw[provider.rawValue] ?? ""
+            let preference = MenuBarMetricPreference(rawValue: raw) ?? .automatic
+            switch preference {
+            case .automatic, .monthlyPlan:
+                return preference
+            case .primary, .secondary, .tertiary, .extraUsage, .average:
+                return .automatic
+            }
+        }
         if provider == .openrouter {
             let raw = self.menuBarMetricPreferencesRaw[provider.rawValue] ?? ""
             let preference = MenuBarMetricPreference(rawValue: raw) ?? .automatic
@@ -33,6 +43,15 @@ extension SettingsStore {
     func setMenuBarMetricPreference(_ preference: MenuBarMetricPreference, for provider: UsageProvider) {
         if Self.isBalanceOnlyProvider(provider), provider != .mistral {
             self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
+            return
+        }
+        if provider == .mistral {
+            switch preference {
+            case .automatic, .monthlyPlan:
+                self.menuBarMetricPreferencesRaw[provider.rawValue] = preference.rawValue
+            case .primary, .secondary, .tertiary, .extraUsage, .average:
+                self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
+            }
             return
         }
         if provider == .openrouter {

--- a/Sources/CodexBar/SettingsStore+MenuPreferences.swift
+++ b/Sources/CodexBar/SettingsStore+MenuPreferences.swift
@@ -37,6 +37,9 @@ extension SettingsStore {
         if preference == .extraUsage, !self.menuBarMetricSupportsExtraUsage(for: provider) {
             return .automatic
         }
+        if preference == .monthlyPlan {
+            return .automatic
+        }
         return preference
     }
 
@@ -68,6 +71,10 @@ extension SettingsStore {
             return
         }
         if preference == .extraUsage, !self.menuBarMetricSupportsExtraUsage(for: provider) {
+            self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
+            return
+        }
+        if preference == .monthlyPlan {
             self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
             return
         }

--- a/Sources/CodexBar/SettingsStore+MenuPreferences.swift
+++ b/Sources/CodexBar/SettingsStore+MenuPreferences.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension SettingsStore {
     func menuBarMetricPreference(for provider: UsageProvider) -> MenuBarMetricPreference {
-        if Self.isBalanceOnlyProvider(provider) {
+        if Self.isBalanceOnlyProvider(provider), provider != .mistral {
             return .automatic
         }
         if provider == .openrouter {
@@ -12,7 +12,7 @@ extension SettingsStore {
             switch preference {
             case .automatic, .primary:
                 return preference
-            case .secondary, .average, .tertiary, .extraUsage:
+            case .secondary, .average, .tertiary, .extraUsage, .monthlyPlan:
                 return .automatic
             }
         }
@@ -31,7 +31,7 @@ extension SettingsStore {
     }
 
     func setMenuBarMetricPreference(_ preference: MenuBarMetricPreference, for provider: UsageProvider) {
-        if Self.isBalanceOnlyProvider(provider) {
+        if Self.isBalanceOnlyProvider(provider), provider != .mistral {
             self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
             return
         }
@@ -39,7 +39,7 @@ extension SettingsStore {
             switch preference {
             case .automatic, .primary:
                 self.menuBarMetricPreferencesRaw[provider.rawValue] = preference.rawValue
-            case .secondary, .average, .tertiary, .extraUsage:
+            case .secondary, .average, .tertiary, .extraUsage, .monthlyPlan:
                 self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
             }
             return

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -45,6 +45,7 @@ enum MenuBarMetricPreference: String, CaseIterable, Identifiable {
     case tertiary
     case extraUsage
     case average
+    case monthlyPlan
 
     var id: String {
         self.rawValue
@@ -58,6 +59,7 @@ enum MenuBarMetricPreference: String, CaseIterable, Identifiable {
         case .tertiary: L("metric_pref_tertiary")
         case .extraUsage: L("metric_pref_extra_usage")
         case .average: L("metric_pref_average")
+        case .monthlyPlan: "Monthly Plan"
         }
     }
 }
@@ -493,7 +495,7 @@ extension SettingsStore {
             migrated[UsageProvider.antigravity.rawValue] = MenuBarMetricPreference.primary.rawValue
         case .tertiary:
             migrated[UsageProvider.antigravity.rawValue] = MenuBarMetricPreference.primary.rawValue
-        case .automatic, .extraUsage, .average, .none:
+        case .automatic, .extraUsage, .average, .monthlyPlan, .none:
             break
         }
         userDefaults.set(migrated, forKey: "menuBarMetricPreferences")

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -59,7 +59,7 @@ enum MenuBarMetricPreference: String, CaseIterable, Identifiable {
         case .tertiary: L("metric_pref_tertiary")
         case .extraUsage: L("metric_pref_extra_usage")
         case .average: L("metric_pref_average")
-        case .monthlyPlan: "Monthly Plan"
+        case .monthlyPlan: L("metric_mistral_monthly_plan")
         }
     }
 }

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -700,11 +700,14 @@ extension StatusItemController {
         {
             return balance
         }
-        if provider == .mistral,
-           self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) != .monthlyPlan,
-           let spend = Self.mistralSpendDisplayText(snapshot: snapshot)
-        {
-            return spend
+        if provider == .mistral {
+            let preference = self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot)
+            let hasMonthlyWindow = snapshot?.extraRateWindows?.contains { $0.id == "mistral-monthly-plan" } == true
+            if preference != .monthlyPlan || !hasMonthlyWindow,
+               let spend = Self.mistralSpendDisplayText(snapshot: snapshot)
+            {
+                return spend
+            }
         }
         if provider == .kimik2,
            let credits = Self.kimiK2CreditsDisplayText(snapshot: snapshot)

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -701,6 +701,7 @@ extension StatusItemController {
             return balance
         }
         if provider == .mistral,
+           self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) != .monthlyPlan,
            let spend = Self.mistralSpendDisplayText(snapshot: snapshot)
         {
             return spend

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -367,7 +367,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             let usedPercent = (primary.usedPercent + secondary.usedPercent) / 2
             return RateWindow(
                 usedPercent: usedPercent, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
-        case .automatic, .primary:
+        case .automatic, .primary, .monthlyPlan:
             return first
         }
     }

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -54,31 +54,23 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
         let cookieSource = context.settings?.mistral?.cookieSource ?? .auto
         do {
             let (cookieHeader, csrfToken) = try Self.resolveCookieHeader(context: context, allowCached: true)
-            let snapshot = try await MistralUsageFetcher.fetchUsage(
+            let usage = try await Self.fetchUsageWithVibe(
                 cookieHeader: cookieHeader,
                 csrfToken: csrfToken,
                 timeout: context.webTimeout)
-            let vibeResult = try? await MistralUsageFetcher.fetchVibeUsage(
-                cookieHeader: cookieHeader,
-                csrfToken: csrfToken,
-                timeout: min(context.webTimeout, 10))
             return self.makeResult(
-                usage: Self.attachVibeWindow(to: snapshot.toUsageSnapshot(), vibeResult: vibeResult),
+                usage: usage,
                 sourceLabel: "web")
         } catch MistralUsageError.invalidCredentials where cookieSource != .manual {
             #if os(macOS)
             CookieHeaderCache.clear(provider: .mistral)
             let (cookieHeader, csrfToken) = try Self.resolveCookieHeader(context: context, allowCached: false)
-            let snapshot = try await MistralUsageFetcher.fetchUsage(
+            let usage = try await Self.fetchUsageWithVibe(
                 cookieHeader: cookieHeader,
                 csrfToken: csrfToken,
                 timeout: context.webTimeout)
-            let vibeResult = try? await MistralUsageFetcher.fetchVibeUsage(
-                cookieHeader: cookieHeader,
-                csrfToken: csrfToken,
-                timeout: min(context.webTimeout, 10))
             return self.makeResult(
-                usage: Self.attachVibeWindow(to: snapshot.toUsageSnapshot(), vibeResult: vibeResult),
+                usage: usage,
                 sourceLabel: "web")
             #else
             throw MistralUsageError.invalidCredentials
@@ -86,7 +78,28 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
         }
     }
 
-    private static func attachVibeWindow(
+    private static func fetchUsageWithVibe(
+        cookieHeader: String,
+        csrfToken: String?,
+        timeout: TimeInterval) async throws -> UsageSnapshot
+    {
+        let deadline = Date().addingTimeInterval(timeout)
+        let snapshot = try await MistralUsageFetcher.fetchUsage(
+            cookieHeader: cookieHeader,
+            csrfToken: csrfToken,
+            timeout: timeout)
+        let remaining = deadline.timeIntervalSinceNow
+        let vibeResult: MistralUsageFetcher.MistralVibeUsageResult? = if let csrfToken, remaining > 0 {
+            try? await MistralUsageFetcher.fetchVibeUsage(
+                csrfToken: csrfToken,
+                timeout: min(remaining, 4))
+        } else {
+            nil
+        }
+        return Self.attachVibeWindow(to: snapshot.toUsageSnapshot(), vibeResult: vibeResult)
+    }
+
+    static func attachVibeWindow(
         to usageSnapshot: UsageSnapshot,
         vibeResult: MistralUsageFetcher.MistralVibeUsageResult?) -> UsageSnapshot
     {
@@ -97,7 +110,8 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
             resetsAt: vibeResult.resetAt,
             resetDescription: nil)
         let named = NamedRateWindow(id: "mistral-monthly-plan", title: "Monthly Plan", window: window)
-        return usageSnapshot.with(extraRateWindows: [named])
+        let existing = usageSnapshot.extraRateWindows?.filter { $0.id != named.id } ?? []
+        return usageSnapshot.with(extraRateWindows: existing + [named])
     }
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -90,13 +90,32 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
             timeout: timeout)
         let remaining = deadline.timeIntervalSinceNow
         let vibeResult: MistralUsageFetcher.MistralVibeUsageResult? = if let csrfToken, remaining > 0 {
-            try? await MistralUsageFetcher.fetchVibeUsage(
+            try await Self.fetchOptionalVibeUsage(
                 csrfToken: csrfToken,
                 timeout: min(remaining, 4))
         } else {
             nil
         }
         return Self.attachVibeWindow(to: snapshot.toUsageSnapshot(), vibeResult: vibeResult)
+    }
+
+    static func fetchOptionalVibeUsage(
+        csrfToken: String,
+        timeout: TimeInterval,
+        transport: ProviderHTTPTransport = ProviderHTTPClient.shared) async throws
+        -> MistralUsageFetcher.MistralVibeUsageResult?
+    {
+        do {
+            return try await MistralUsageFetcher.fetchVibeUsage(
+                csrfToken: csrfToken,
+                timeout: timeout,
+                transport: transport)
+        } catch {
+            if error is CancellationError || (error as? URLError)?.code == .cancelled || Task.isCancelled {
+                throw CancellationError()
+            }
+            return nil
+        }
     }
 
     static func attachVibeWindow(

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -58,8 +58,12 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
                 cookieHeader: cookieHeader,
                 csrfToken: csrfToken,
                 timeout: context.webTimeout)
+            let vibeResult = try? await MistralUsageFetcher.fetchVibeUsage(
+                cookieHeader: cookieHeader,
+                csrfToken: csrfToken,
+                timeout: context.webTimeout)
             return self.makeResult(
-                usage: snapshot.toUsageSnapshot(),
+                usage: Self.attachVibeWindow(to: snapshot.toUsageSnapshot(), vibeResult: vibeResult),
                 sourceLabel: "web")
         } catch MistralUsageError.invalidCredentials where cookieSource != .manual {
             #if os(macOS)
@@ -69,13 +73,31 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
                 cookieHeader: cookieHeader,
                 csrfToken: csrfToken,
                 timeout: context.webTimeout)
+            let vibeResult = try? await MistralUsageFetcher.fetchVibeUsage(
+                cookieHeader: cookieHeader,
+                csrfToken: csrfToken,
+                timeout: context.webTimeout)
             return self.makeResult(
-                usage: snapshot.toUsageSnapshot(),
+                usage: Self.attachVibeWindow(to: snapshot.toUsageSnapshot(), vibeResult: vibeResult),
                 sourceLabel: "web")
             #else
             throw MistralUsageError.invalidCredentials
             #endif
         }
+    }
+
+    private static func attachVibeWindow(
+        to usageSnapshot: UsageSnapshot,
+        vibeResult: MistralUsageFetcher.MistralVibeUsageResult?) -> UsageSnapshot
+    {
+        guard let vibeResult else { return usageSnapshot }
+        let window = RateWindow(
+            usedPercent: vibeResult.usagePercentage,
+            windowMinutes: nil,
+            resetsAt: vibeResult.resetAt,
+            resetDescription: nil)
+        let named = NamedRateWindow(id: "mistral-monthly-plan", title: "Monthly Plan", window: window)
+        return usageSnapshot.with(extraRateWindows: [named])
     }
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -61,7 +61,7 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
             let vibeResult = try? await MistralUsageFetcher.fetchVibeUsage(
                 cookieHeader: cookieHeader,
                 csrfToken: csrfToken,
-                timeout: context.webTimeout)
+                timeout: min(context.webTimeout, 10))
             return self.makeResult(
                 usage: Self.attachVibeWindow(to: snapshot.toUsageSnapshot(), vibeResult: vibeResult),
                 sourceLabel: "web")
@@ -76,7 +76,7 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
             let vibeResult = try? await MistralUsageFetcher.fetchVibeUsage(
                 cookieHeader: cookieHeader,
                 csrfToken: csrfToken,
-                timeout: context.webTimeout)
+                timeout: min(context.webTimeout, 10))
             return self.makeResult(
                 usage: Self.attachVibeWindow(to: snapshot.toUsageSnapshot(), vibeResult: vibeResult),
                 sourceLabel: "web")

--- a/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
@@ -6,7 +6,7 @@ import FoundationNetworking
 public enum MistralUsageFetcher {
     private static let baseURL = URL(string: "https://admin.mistral.ai")!
 
-    public struct MistralVibeUsageResult: Sendable {
+    public struct MistralVibeUsageResult: Equatable, Sendable {
         public let usagePercentage: Double
         public let resetAt: Date?
     }
@@ -58,9 +58,9 @@ public enum MistralUsageFetcher {
     }
 
     public static func fetchVibeUsage(
-        cookieHeader: String,
-        csrfToken: String?,
-        timeout: TimeInterval = 15) async throws -> MistralVibeUsageResult
+        csrfToken: String,
+        timeout: TimeInterval = 4,
+        transport: ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> MistralVibeUsageResult
     {
         let urlString = "https://console.mistral.ai/api-ui/trpc/billing.vibeUsage?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%2C%22v%22%3A1%7D%7D%7D"
         guard let url = URL(string: urlString) else {
@@ -68,13 +68,13 @@ public enum MistralUsageFetcher {
         }
 
         var request = URLRequest(url: url, timeoutInterval: timeout)
+        // The observed console request sends only csrftoken; keep admin Ory cookies origin-bound.
+        let cookieHeader = try Self.vibeCookieHeader(csrfToken: csrfToken)
         request.setValue("*/*", forHTTPHeaderField: "Accept")
         request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
-        if let csrfToken {
-            request.setValue(csrfToken, forHTTPHeaderField: "X-CSRFToken")
-        }
+        request.setValue(csrfToken, forHTTPHeaderField: "X-CSRFToken")
 
-        let response = try await ProviderHTTPClient.shared.response(for: request)
+        let response = try await transport.response(for: request)
         let data = response.data
 
         switch response.statusCode {
@@ -87,32 +87,42 @@ public enum MistralUsageFetcher {
             throw MistralUsageError.apiError("HTTP \(response.statusCode): \(body)")
         }
 
+        return try Self.parseVibeUsage(data: data)
+    }
+
+    static func parseVibeUsage(data: Data) throws -> MistralVibeUsageResult {
+        let responses: [VibeUsageResponse]
         do {
-            let responses = try JSONDecoder().decode([VibeUsageResponse].self, from: data)
-            guard let first = responses.first else {
-                throw MistralUsageError.parseFailed("Empty response array")
-            }
-            let usagePercentage = first.result.data.json.usagePercentage
-            let resetAtString = first.result.data.json.resetAt
-            
-            let resetAt: Date?
-            if let resetAtString {
-                let formatter = ISO8601DateFormatter()
-                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-                if let date = formatter.date(from: resetAtString) {
-                    resetAt = date
-                } else {
-                    formatter.formatOptions = [.withInternetDateTime]
-                    resetAt = formatter.date(from: resetAtString)
-                }
-            } else {
-                resetAt = nil
-            }
-            
-            return MistralVibeUsageResult(usagePercentage: usagePercentage, resetAt: resetAt)
+            responses = try JSONDecoder().decode([VibeUsageResponse].self, from: data)
         } catch {
             throw MistralUsageError.parseFailed(error.localizedDescription)
         }
+        guard let json = responses.first?.result.data.json else {
+            throw MistralUsageError.parseFailed("Empty response array")
+        }
+        guard json.usagePercentage.isFinite, (0...100).contains(json.usagePercentage) else {
+            throw MistralUsageError.parseFailed("Invalid usage percentage")
+        }
+        return MistralVibeUsageResult(
+            usagePercentage: json.usagePercentage,
+            resetAt: json.resetAt.flatMap(Self.parseISO8601Date))
+    }
+
+    static func vibeCookieHeader(csrfToken: String) throws -> String {
+        let token = csrfToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        let forbidden = CharacterSet(charactersIn: ";,\r\n")
+        guard !token.isEmpty, token.rangeOfCharacter(from: forbidden) == nil else {
+            throw MistralUsageError.invalidCredentials
+        }
+        return "csrftoken=\(token)"
+    }
+
+    private static func parseISO8601Date(_ value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: value) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
     }
 
     static func parseResponse(data: Data, updatedAt: Date) throws -> MistralUsageSnapshot {

--- a/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
@@ -6,6 +6,11 @@ import FoundationNetworking
 public enum MistralUsageFetcher {
     private static let baseURL = URL(string: "https://admin.mistral.ai")!
 
+    public struct MistralVibeUsageResult: Sendable {
+        public let usagePercentage: Double
+        public let resetAt: Date?
+    }
+
     public static func fetchUsage(
         cookieHeader: String,
         csrfToken: String?,
@@ -50,6 +55,64 @@ public enum MistralUsageFetcher {
         }
 
         return try Self.parseResponse(data: data, updatedAt: now)
+    }
+
+    public static func fetchVibeUsage(
+        cookieHeader: String,
+        csrfToken: String?,
+        timeout: TimeInterval = 15) async throws -> MistralVibeUsageResult
+    {
+        let urlString = "https://console.mistral.ai/api-ui/trpc/billing.vibeUsage?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%2C%22v%22%3A1%7D%7D%7D"
+        guard let url = URL(string: urlString) else {
+            throw MistralUsageError.apiError("Failed to construct URL")
+        }
+
+        var request = URLRequest(url: url, timeoutInterval: timeout)
+        request.setValue("*/*", forHTTPHeaderField: "Accept")
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        if let csrfToken {
+            request.setValue(csrfToken, forHTTPHeaderField: "X-CSRFToken")
+        }
+
+        let response = try await ProviderHTTPClient.shared.response(for: request)
+        let data = response.data
+
+        switch response.statusCode {
+        case 200:
+            break
+        case 401, 403:
+            throw MistralUsageError.invalidCredentials
+        default:
+            let body = String(data: data.prefix(200), encoding: .utf8) ?? ""
+            throw MistralUsageError.apiError("HTTP \(response.statusCode): \(body)")
+        }
+
+        do {
+            let responses = try JSONDecoder().decode([VibeUsageResponse].self, from: data)
+            guard let first = responses.first else {
+                throw MistralUsageError.parseFailed("Empty response array")
+            }
+            let usagePercentage = first.result.data.json.usagePercentage
+            let resetAtString = first.result.data.json.resetAt
+            
+            let resetAt: Date?
+            if let resetAtString {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                if let date = formatter.date(from: resetAtString) {
+                    resetAt = date
+                } else {
+                    formatter.formatOptions = [.withInternetDateTime]
+                    resetAt = formatter.date(from: resetAtString)
+                }
+            } else {
+                resetAt = nil
+            }
+            
+            return MistralVibeUsageResult(usagePercentage: usagePercentage, resetAt: resetAt)
+        } catch {
+            throw MistralUsageError.parseFailed(error.localizedDescription)
+        }
     }
 
     static func parseResponse(data: Data, updatedAt: Date) throws -> MistralUsageSnapshot {
@@ -385,5 +448,23 @@ private struct ModelAccumulator {
             inputTokens: self.inputTokens,
             cachedTokens: self.cachedTokens,
             outputTokens: self.outputTokens)
+    }
+}
+
+private struct VibeUsageResponse: Decodable {
+    let result: VibeResult
+    struct VibeResult: Decodable {
+        let data: VibeData
+        struct VibeData: Decodable {
+            let json: VibeJson
+            struct VibeJson: Decodable {
+                let usagePercentage: Double
+                let resetAt: String?
+                enum CodingKeys: String, CodingKey {
+                    case usagePercentage = "usage_percentage"
+                    case resetAt = "reset_at"
+                }
+            }
+        }
     }
 }

--- a/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
@@ -69,10 +69,11 @@ public enum MistralUsageFetcher {
 
         var request = URLRequest(url: url, timeoutInterval: timeout)
         // The observed console request sends only csrftoken; keep admin Ory cookies origin-bound.
-        let cookieHeader = try Self.vibeCookieHeader(csrfToken: csrfToken)
+        request.httpShouldHandleCookies = false
+        let validatedCSRFToken = try Self.validatedVibeCSRFToken(csrfToken)
         request.setValue("*/*", forHTTPHeaderField: "Accept")
-        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
-        request.setValue(csrfToken, forHTTPHeaderField: "X-CSRFToken")
+        request.setValue("csrftoken=\(validatedCSRFToken)", forHTTPHeaderField: "Cookie")
+        request.setValue(validatedCSRFToken, forHTTPHeaderField: "X-CSRFToken")
 
         let response = try await transport.response(for: request)
         let data = response.data
@@ -109,12 +110,16 @@ public enum MistralUsageFetcher {
     }
 
     static func vibeCookieHeader(csrfToken: String) throws -> String {
+        try "csrftoken=\(self.validatedVibeCSRFToken(csrfToken))"
+    }
+
+    private static func validatedVibeCSRFToken(_ csrfToken: String) throws -> String {
         let token = csrfToken.trimmingCharacters(in: .whitespacesAndNewlines)
         let forbidden = CharacterSet(charactersIn: ";,\r\n")
         guard !token.isEmpty, token.rangeOfCharacter(from: forbidden) == nil else {
             throw MistralUsageError.invalidCredentials
         }
-        return "csrftoken=\(token)"
+        return token
     }
 
     private static func parseISO8601Date(_ value: String) -> Date? {

--- a/Tests/CodexBarTests/LocalizationLanguageCatalogTests.swift
+++ b/Tests/CodexBarTests/LocalizationLanguageCatalogTests.swift
@@ -254,6 +254,8 @@ struct LocalizationLanguageCatalogTests {
         #expect(italian["display_mode_reset_time_desc"]?.contains("↻ 15:56") == true)
         #expect(italian["ory_session_…=…; csrftoken=…"] == "ory_session_…=…; csrftoken=…")
         #expect(italian["quota_warning_notifications_subtitle"]?.contains("scende sotto") == true)
+        #expect(italian["metric_mistral_payg"] == "A consumo")
+        #expect(italian["metric_mistral_monthly_plan"] == "Piano mensile")
 
         let intentionallyUnchanged: Set = [
             "Account",

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -208,6 +208,28 @@ struct MenuBarMetricWindowResolverTests {
     }
 
     @Test
+    func `monthly plan metric selects Mistral subscription window`() {
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "mistral-monthly-plan",
+                    title: "Monthly Plan",
+                    window: RateWindow(usedPercent: 42, windowMinutes: nil, resetsAt: nil, resetDescription: nil)),
+            ],
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .monthlyPlan,
+            provider: .mistral,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.usedPercent == 42)
+    }
+
+    @Test
     func `extra usage metric maps provider cost into a menu bar window`() {
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 12, windowMinutes: nil, resetsAt: nil, resetDescription: nil),

--- a/Tests/CodexBarTests/MistralVibeUsageTests.swift
+++ b/Tests/CodexBarTests/MistralVibeUsageTests.swift
@@ -82,6 +82,45 @@ struct MistralVibeUsageTests {
     }
 
     @Test
+    func `optional subscription request propagates in flight cancellation`() async throws {
+        let started = AsyncStream<Void>.makeStream(of: Void.self)
+        let transport = ProviderHTTPTransportHandler { _ in
+            started.continuation.yield(())
+            try await Task.sleep(for: .seconds(30))
+            throw URLError(.timedOut)
+        }
+        let task = Task {
+            try await MistralWebFetchStrategy.fetchOptionalVibeUsage(
+                csrfToken: "csrf-value",
+                timeout: 30,
+                transport: transport)
+        }
+
+        var iterator = started.stream.makeAsyncIterator()
+        _ = await iterator.next()
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        started.continuation.finish()
+    }
+
+    @Test
+    func `optional subscription request ignores ordinary endpoint failures`() async throws {
+        let transport = ProviderHTTPTransportHandler { _ in
+            throw URLError(.cannotConnectToHost)
+        }
+
+        let result = try await MistralWebFetchStrategy.fetchOptionalVibeUsage(
+            csrfToken: "csrf-value",
+            timeout: 2,
+            transport: transport)
+
+        #expect(result == nil)
+    }
+
+    @Test
     func `monthly plan window preserves existing extras`() {
         let existing = NamedRateWindow(
             id: "existing",

--- a/Tests/CodexBarTests/MistralVibeUsageTests.swift
+++ b/Tests/CodexBarTests/MistralVibeUsageTests.swift
@@ -57,7 +57,7 @@ struct MistralVibeUsageTests {
         }
 
         let result = try await MistralUsageFetcher.fetchVibeUsage(
-            csrfToken: "csrf-value",
+            csrfToken: " csrf-value ",
             timeout: 2,
             transport: transport)
         let request = try #require(capture.request)
@@ -65,6 +65,7 @@ struct MistralVibeUsageTests {
         #expect(result.usagePercentage == 12.5)
         #expect(request.url?.host == "console.mistral.ai")
         #expect(request.timeoutInterval == 2)
+        #expect(request.httpShouldHandleCookies == false)
         #expect(request.value(forHTTPHeaderField: "Cookie") == "csrftoken=csrf-value")
         #expect(request.value(forHTTPHeaderField: "X-CSRFToken") == "csrf-value")
         #expect(request.allHTTPHeaderFields?.values.contains { $0.contains("ory_session") } != true)

--- a/Tests/CodexBarTests/MistralVibeUsageTests.swift
+++ b/Tests/CodexBarTests/MistralVibeUsageTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+@testable import CodexBarCore
+
+private final class MistralRequestCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedRequest: URLRequest?
+
+    var request: URLRequest? {
+        self.lock.withLock { self.storedRequest }
+    }
+
+    func record(_ request: URLRequest) {
+        self.lock.withLock { self.storedRequest = request }
+    }
+}
+
+struct MistralVibeUsageTests {
+    @Test
+    func `parses subscription percentage and reset`() throws {
+        let data = Data(Self.responseJSON(usagePercentage: 2.8141356666666666).utf8)
+
+        let result = try MistralUsageFetcher.parseVibeUsage(data: data)
+
+        #expect(result.usagePercentage == 2.8141356666666666)
+        #expect(result.resetAt == ISO8601DateFormatter().date(from: "2026-07-01T00:00:00Z"))
+    }
+
+    @Test
+    func `rejects subscription percentages outside rate window range`() {
+        let data = Data(Self.responseJSON(usagePercentage: 101).utf8)
+
+        #expect(throws: MistralUsageError.self) {
+            try MistralUsageFetcher.parseVibeUsage(data: data)
+        }
+    }
+
+    @Test
+    func `subscription request sends only csrf cookie`() async throws {
+        let capture = MistralRequestCapture()
+        let data = Data(Self.responseJSON(usagePercentage: 12.5).utf8)
+        let transport = ProviderHTTPTransportHandler { request in
+            capture.record(request)
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 200,
+                      httpVersion: nil,
+                      headerFields: nil)
+            else {
+                throw URLError(.badURL)
+            }
+            return (data, response)
+        }
+
+        let result = try await MistralUsageFetcher.fetchVibeUsage(
+            csrfToken: "csrf-value",
+            timeout: 2,
+            transport: transport)
+        let request = try #require(capture.request)
+
+        #expect(result.usagePercentage == 12.5)
+        #expect(request.url?.host == "console.mistral.ai")
+        #expect(request.timeoutInterval == 2)
+        #expect(request.value(forHTTPHeaderField: "Cookie") == "csrftoken=csrf-value")
+        #expect(request.value(forHTTPHeaderField: "X-CSRFToken") == "csrf-value")
+        #expect(request.allHTTPHeaderFields?.values.contains { $0.contains("ory_session") } != true)
+    }
+
+    @Test
+    func `rejects csrf values that could add cookies or headers`() {
+        #expect(throws: MistralUsageError.self) {
+            try MistralUsageFetcher.vibeCookieHeader(csrfToken: "csrf; ory_session_secret=leak")
+        }
+        #expect(throws: MistralUsageError.self) {
+            try MistralUsageFetcher.vibeCookieHeader(csrfToken: "csrf\r\nX-Leak: value")
+        }
+    }
+
+    @Test
+    func `monthly plan window preserves existing extras`() {
+        let existing = NamedRateWindow(
+            id: "existing",
+            title: "Existing",
+            window: RateWindow(usedPercent: 5, windowMinutes: nil, resetsAt: nil, resetDescription: nil))
+        let usage = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: [existing],
+            updatedAt: Date())
+
+        let updated = MistralWebFetchStrategy.attachVibeWindow(
+            to: usage,
+            vibeResult: .init(usagePercentage: 25, resetAt: nil))
+
+        #expect(updated.extraRateWindows?.map(\.id) == ["existing", "mistral-monthly-plan"])
+        #expect(updated.extraRateWindows?.last?.window.usedPercent == 25)
+    }
+
+    private static func responseJSON(usagePercentage: Double) -> String {
+        """
+        [{"result":{"data":{"json":{
+          "usage_percentage":\(usagePercentage),
+          "quota_changed_this_month":false,
+          "payg_enabled":false,
+          "reset_at":"2026-07-01T00:00:00Z"
+        }}}}]
+        """
+    }
+}

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -149,7 +149,7 @@ struct ProvidersPaneCoverageTests {
     }
 
     @Test
-    func `mistral menu bar metric picker shows spend only copy`() {
+    func `mistral menu bar metric picker shows payg and monthly plan options`() {
         Self.withEnglishLocalization {
             let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-mistral-picker")
             let store = Self.makeUsageStore(settings: settings)
@@ -158,7 +158,10 @@ struct ProvidersPaneCoverageTests {
             let picker = pane._test_menuBarMetricPicker(for: .mistral)
             #expect(picker?.options.map(\.id) == [
                 MenuBarMetricPreference.automatic.rawValue,
+                MenuBarMetricPreference.monthlyPlan.rawValue,
             ])
+            #expect(picker?.options.first?.title == "Pay-as-you-go")
+            #expect(picker?.options.last?.title == "Monthly Plan")
             #expect(picker?.subtitle == "Shows current-month Mistral API spend in the menu bar.")
         }
     }

--- a/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
@@ -125,10 +125,21 @@ struct SettingsStoreAdditionalTests {
     }
 
     @Test
+    func `menu bar metric preference restricts mistral to payg or monthly plan`() {
+        let settings = Self.makeSettingsStore(suite: "SettingsStoreAdditionalTests-mistral-metric")
+
+        settings.setMenuBarMetricPreference(.monthlyPlan, for: .mistral)
+        #expect(settings.menuBarMetricPreference(for: .mistral) == .monthlyPlan)
+
+        settings.setMenuBarMetricPreference(.secondary, for: .mistral)
+        #expect(settings.menuBarMetricPreference(for: .mistral) == .automatic)
+    }
+
+    @Test
     func `menu bar metric preference restricts text only balance providers to automatic`() {
         let settings = Self.makeSettingsStore(suite: "SettingsStoreAdditionalTests-text-only-metric")
 
-        for provider in [UsageProvider.deepseek, .mistral, .kimik2, .poe] {
+        for provider in [UsageProvider.deepseek, .kimik2, .poe] {
             settings.setMenuBarMetricPreference(.primary, for: provider)
             #expect(settings.menuBarMetricPreference(for: provider) == .automatic)
 

--- a/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
@@ -74,6 +74,13 @@ struct SettingsStoreAdditionalTests {
         settings.setMenuBarMetricPreference(.average, for: .codex)
         #expect(settings.menuBarMetricPreference(for: .codex) == .automatic)
 
+        settings.setMenuBarMetricPreference(.monthlyPlan, for: .codex)
+        #expect(settings.menuBarMetricPreference(for: .codex) == .automatic)
+
+        settings.menuBarMetricPreferencesRaw[UsageProvider.codex.rawValue] = MenuBarMetricPreference.monthlyPlan
+            .rawValue
+        #expect(settings.menuBarMetricPreference(for: .codex) == .automatic)
+
         settings.setMenuBarMetricPreference(.average, for: .gemini)
         #expect(settings.menuBarMetricPreference(for: .gemini) == .average)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -57,7 +57,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Xiaomi MiMo | Browser cookies → balance/token plan endpoints (`web`). |
 | Doubao | API key from config/env → Volcengine Ark chat-completions probe (`api`). |
 | Abacus AI | Browser cookies → compute points + billing API (`web`). |
-| Mistral | Console billing API via Ory Kratos session cookies (`web`). |
+| Mistral | Console billing and Vibe subscription usage via browser cookies (`web`). |
 | DeepSeek | API key from env or token accounts → balance endpoint (`api`). |
 | Moonshot | API key from config/env → balance endpoint (`api`). |
 | Codebuff | API token from config/env or `codebuff login` credentials → usage API (`api`). |
@@ -319,10 +319,12 @@ headers, source selection, provider ordering, and token accounts are stored in `
 
 ## Mistral
 - Session cookie (`ory_session_*`) from browser auto-import or manual `Cookie:` header.
-- CSRF token (`csrftoken` cookie) sent as `X-CSRFTOKEN` header.
-- Domain: `admin.mistral.ai`.
+- CSRF token (`csrftoken` cookie) sent as `X-CSRFTOKEN` for billing and Vibe usage requests.
+- Domains: `admin.mistral.ai` for API billing and `console.mistral.ai` for optional Vibe subscription usage. Admin Ory cookies are never forwarded to the console origin.
 - Reads monthly usage and pricing from the Mistral billing API.
 - Cost is computed client-side from token counts and response pricing.
+- Reads Vibe monthly-plan usage percentage and reset time when the console endpoint is available.
+- The menu bar metric can show either pay-as-you-go API spend or monthly-plan usage.
 - Resets at end of calendar month.
 - Status: `https://status.mistral.ai` (link only, no auto-polling).
 


### PR DESCRIPTION
## Summary

Closes #1363.

- Add a Mistral Monthly Plan menu bar metric backed by the console Vibe usage endpoint.
- Keep Pay-as-you-go API spend available and preserve existing extra usage windows.
- Send only one trimmed, validated CSRF token to `console.mistral.ai`; disable automatic URLSession cookies so admin Ory sessions remain origin-bound.
- Bound optional console enrichment to the existing billing deadline with a 4-second cap.
- Validate percentage bounds, scope/clamp the stored metric preference, localize all 21 app catalogs, and document provider behavior.

## Live proof

- Issue #1363 contains the contributor's redacted successful request/response for the endpoint, returning `usage_percentage` and `reset_at` with csrf-only authentication.
- Contributor verified the settings picker, persistence, Monthly Plan percentage/reset display, Pay-as-you-go fallback, and no-plan fallback against a real account.
- Screenshots below show the provider setting and rendered result.
- Maintainer 1Password access was retried in the retained tmux session but desktop authorization timed out; no credential was exposed or silently substituted.

## Verification

Exact candidate: `920ca4d105c4b172f6d72d21e720b0ecdac9f8db`

- 73 focused Mistral/settings/menu tests passed on the final exact head; the source-equivalent pre-rebase stack passed 96 focused tests.
- All 18 strict localization catalog tests pass after translating the new Italian metric titles caught by hosted shard 0.
- The focused set includes all 7 Vibe tests, covering in-flight cancellation propagation and ordinary optional-endpoint fallback.
- `make check` passed; localization parity, SwiftFormat, and SwiftLint clean.
- Focused cookie privacy review clean (0.90).
- Final whole-branch autoreview clean (0.86); focused localization and cancellation repair reviews clean (0.93/0.86).

<img width="384" height="449" alt="Mistral Monthly Plan metric setting" src="https://github.com/user-attachments/assets/f371509a-6942-4a7c-b34d-9f0bc3c2df3b" />
<img width="904" height="862" alt="Mistral Monthly Plan usage result" src="https://github.com/user-attachments/assets/c4c6c2bf-3d93-489d-addd-d79ba0dce536" />
