### PR TITLE
Fix cookie import timeout scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 
 ### Fixed
+- Codex web: keep cookie-import deadlines responsive when browser cookie work blocks the shared worker pool.
 - Codex pace: extrapolate historically exhausted weeks for run-out forecasts and avoid contradictory reset headlines. Thanks @Yuxin-Qiao!
 - Localization: correct the German in-progress refresh label. Thanks @ChrisLauinger77!
 - Localization: correct misleading literal German UI translations. Thanks @madebyjulz!

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
@@ -10,6 +10,9 @@ extension OpenAIDashboardBrowserCookieImporter {
     @MainActor private static var pendingCookieStoreMutations: [ObjectIdentifier: PendingCookieStoreMutation] = [:]
     private nonisolated static let cookieCacheQueue = DispatchQueue(
         label: "com.steipete.codexbar.openai-cookie-cache")
+    private nonisolated static let deadlineQueue = DispatchQueue(
+        label: "com.steipete.codexbar.openai-cookie-deadline",
+        qos: .userInitiated)
 
     private final class CookieLoadCompletion: @unchecked Sendable {
         private let lock = NSLock()
@@ -53,7 +56,7 @@ extension OpenAIDashboardBrowserCookieImporter {
                 let result = Result(catching: operation)
                 completion.finish { continuation.resume(with: result) }
             }
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+            self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
                 completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
             }
         }
@@ -87,7 +90,7 @@ extension OpenAIDashboardBrowserCookieImporter {
             start {
                 completion.finish { continuation.resume() }
             }
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+            self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
                 completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
             }
         }
@@ -111,7 +114,7 @@ extension OpenAIDashboardBrowserCookieImporter {
             start { value in
                 completion.finish { continuation.resume(returning: value) }
             }
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+            self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
                 completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
             }
         }


### PR DESCRIPTION
## Summary

- schedule OpenAI dashboard cookie-import deadlines on a dedicated queue
- keep timeout delivery responsive when browser cookie work blocks the shared worker pool
- document the reliability fix

## Proof

- `swift test --filter OpenAIDashboardBrowserCookieImporterTests`
- 20 repeated `OpenAIDashboardBrowserCookieImporterTests` suite runs
- exact local CI shard 0/4: all 121 groups passed
- `make check`
- `autoreview --mode local --parallel-tests ...`: clean, 0.86

## Context

The macOS Intel CI lane for #1573 exposed this shared-main race: blocking cache work completed before a delayed timeout callback that shared the global worker pool. Other #1573 lanes passed; this fix is intentionally separate from that contributor PR.
