### PR TITLE
Make cookie deadline timing tests saturation-safe

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
@@ -44,6 +44,7 @@ extension OpenAIDashboardBrowserCookieImporter {
 
     nonisolated static func runBoundedCookieLoad<T: Sendable>(
         deadline: Date?,
+        timeoutObserver: (@Sendable () -> Void)? = nil,
         operation: @escaping @Sendable () throws -> T) async throws -> T
     {
         guard let deadline else {
@@ -57,7 +58,10 @@ extension OpenAIDashboardBrowserCookieImporter {
                 completion.finish { continuation.resume(with: result) }
             }
             self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
-                completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
+                completion.finish {
+                    timeoutObserver?()
+                    continuation.resume(throwing: URLError(.timedOut))
+                }
             }
         }
     }
@@ -73,6 +77,7 @@ extension OpenAIDashboardBrowserCookieImporter {
 
     static func runBoundedCallback(
         deadline: Date?,
+        timeoutObserver: (@Sendable () -> Void)? = nil,
         start: (@escaping @Sendable () -> Void) -> Void) async throws
     {
         let completion = CookieLoadCompletion()
@@ -91,13 +96,17 @@ extension OpenAIDashboardBrowserCookieImporter {
                 completion.finish { continuation.resume() }
             }
             self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
-                completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
+                completion.finish {
+                    timeoutObserver?()
+                    continuation.resume(throwing: URLError(.timedOut))
+                }
             }
         }
     }
 
     static func runBoundedValueCallback<T: Sendable>(
         deadline: Date?,
+        timeoutObserver: (@Sendable () -> Void)? = nil,
         start: (@escaping @Sendable (T) -> Void) -> Void) async throws -> T
     {
         let completion = CookieLoadCompletion()
@@ -115,7 +124,10 @@ extension OpenAIDashboardBrowserCookieImporter {
                 completion.finish { continuation.resume(returning: value) }
             }
             self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
-                completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
+                completion.finish {
+                    timeoutObserver?()
+                    continuation.resume(throwing: URLError(.timedOut))
+                }
             }
         }
     }

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
@@ -2,60 +2,6 @@
 import Foundation
 
 extension OpenAIDashboardBrowserCookieImporter {
-    /// GCD timer blocks can be delayed with the work they are supposed to bound when its pool is saturated.
-    private final class DeadlineScheduler: @unchecked Sendable {
-        private struct Entry {
-            let deadline: Date
-            let action: @Sendable () -> Void
-        }
-
-        private let condition = NSCondition()
-        private var entries: [Entry] = []
-
-        init() {
-            let thread = Thread { [weak self] in
-                self?.run()
-            }
-            thread.name = "com.steipete.codexbar.openai-cookie-deadline"
-            thread.qualityOfService = .userInitiated
-            thread.start()
-        }
-
-        func schedule(after timeout: TimeInterval, action: @escaping @Sendable () -> Void) {
-            let entry = Entry(deadline: Date().addingTimeInterval(timeout), action: action)
-            self.condition.lock()
-            let insertionIndex = self.entries.firstIndex { entry.deadline < $0.deadline } ?? self.entries.endIndex
-            self.entries.insert(entry, at: insertionIndex)
-            self.condition.signal()
-            self.condition.unlock()
-        }
-
-        private func run() {
-            while true {
-                self.condition.lock()
-                while self.entries.isEmpty {
-                    self.condition.wait()
-                }
-
-                guard let entry = self.entries.first else {
-                    self.condition.unlock()
-                    continue
-                }
-                if entry.deadline.timeIntervalSinceNow > 0 {
-                    self.condition.wait(until: entry.deadline)
-                    self.condition.unlock()
-                    continue
-                }
-
-                self.entries.removeFirst()
-                self.condition.unlock()
-                autoreleasepool {
-                    entry.action()
-                }
-            }
-        }
-    }
-
     private struct PendingCookieStoreMutation {
         let token: UUID
         let task: Task<Void, Never>
@@ -64,7 +10,9 @@ extension OpenAIDashboardBrowserCookieImporter {
     @MainActor private static var pendingCookieStoreMutations: [ObjectIdentifier: PendingCookieStoreMutation] = [:]
     private nonisolated static let cookieCacheQueue = DispatchQueue(
         label: "com.steipete.codexbar.openai-cookie-cache")
-    private nonisolated static let deadlineScheduler = DeadlineScheduler()
+    private nonisolated static let deadlineQueue = DispatchQueue(
+        label: "com.steipete.codexbar.openai-cookie-deadline",
+        qos: .userInitiated)
 
     private final class CookieLoadCompletion: @unchecked Sendable {
         private let lock = NSLock()
@@ -108,7 +56,7 @@ extension OpenAIDashboardBrowserCookieImporter {
                 let result = Result(catching: operation)
                 completion.finish { continuation.resume(with: result) }
             }
-            self.deadlineScheduler.schedule(after: timeout) {
+            self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
                 completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
             }
         }
@@ -142,7 +90,7 @@ extension OpenAIDashboardBrowserCookieImporter {
             start {
                 completion.finish { continuation.resume() }
             }
-            self.deadlineScheduler.schedule(after: timeout) {
+            self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
                 completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
             }
         }
@@ -166,7 +114,7 @@ extension OpenAIDashboardBrowserCookieImporter {
             start { value in
                 completion.finish { continuation.resume(returning: value) }
             }
-            self.deadlineScheduler.schedule(after: timeout) {
+            self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
                 completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
             }
         }

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
@@ -2,6 +2,60 @@
 import Foundation
 
 extension OpenAIDashboardBrowserCookieImporter {
+    /// GCD timer blocks can be delayed with the work they are supposed to bound when its pool is saturated.
+    private final class DeadlineScheduler: @unchecked Sendable {
+        private struct Entry {
+            let deadline: Date
+            let action: @Sendable () -> Void
+        }
+
+        private let condition = NSCondition()
+        private var entries: [Entry] = []
+
+        init() {
+            let thread = Thread { [weak self] in
+                self?.run()
+            }
+            thread.name = "com.steipete.codexbar.openai-cookie-deadline"
+            thread.qualityOfService = .userInitiated
+            thread.start()
+        }
+
+        func schedule(after timeout: TimeInterval, action: @escaping @Sendable () -> Void) {
+            let entry = Entry(deadline: Date().addingTimeInterval(timeout), action: action)
+            self.condition.lock()
+            let insertionIndex = self.entries.firstIndex { entry.deadline < $0.deadline } ?? self.entries.endIndex
+            self.entries.insert(entry, at: insertionIndex)
+            self.condition.signal()
+            self.condition.unlock()
+        }
+
+        private func run() {
+            while true {
+                self.condition.lock()
+                while self.entries.isEmpty {
+                    self.condition.wait()
+                }
+
+                guard let entry = self.entries.first else {
+                    self.condition.unlock()
+                    continue
+                }
+                if entry.deadline.timeIntervalSinceNow > 0 {
+                    self.condition.wait(until: entry.deadline)
+                    self.condition.unlock()
+                    continue
+                }
+
+                self.entries.removeFirst()
+                self.condition.unlock()
+                autoreleasepool {
+                    entry.action()
+                }
+            }
+        }
+    }
+
     private struct PendingCookieStoreMutation {
         let token: UUID
         let task: Task<Void, Never>
@@ -10,9 +64,7 @@ extension OpenAIDashboardBrowserCookieImporter {
     @MainActor private static var pendingCookieStoreMutations: [ObjectIdentifier: PendingCookieStoreMutation] = [:]
     private nonisolated static let cookieCacheQueue = DispatchQueue(
         label: "com.steipete.codexbar.openai-cookie-cache")
-    private nonisolated static let deadlineQueue = DispatchQueue(
-        label: "com.steipete.codexbar.openai-cookie-deadline",
-        qos: .userInitiated)
+    private nonisolated static let deadlineScheduler = DeadlineScheduler()
 
     private final class CookieLoadCompletion: @unchecked Sendable {
         private let lock = NSLock()
@@ -56,7 +108,7 @@ extension OpenAIDashboardBrowserCookieImporter {
                 let result = Result(catching: operation)
                 completion.finish { continuation.resume(with: result) }
             }
-            self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
+            self.deadlineScheduler.schedule(after: timeout) {
                 completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
             }
         }
@@ -90,7 +142,7 @@ extension OpenAIDashboardBrowserCookieImporter {
             start {
                 completion.finish { continuation.resume() }
             }
-            self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
+            self.deadlineScheduler.schedule(after: timeout) {
                 completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
             }
         }
@@ -114,7 +166,7 @@ extension OpenAIDashboardBrowserCookieImporter {
             start { value in
                 completion.finish { continuation.resume(returning: value) }
             }
-            self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
+            self.deadlineScheduler.schedule(after: timeout) {
                 completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
             }
         }

--- a/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
@@ -46,6 +46,23 @@ private final class CookieOperationLog: @unchecked Sendable {
     }
 }
 
+private final class CookieTimeoutProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedFiredAt: Date?
+
+    var firedAt: Date? {
+        self.lock.withLock { self.storedFiredAt }
+    }
+
+    func record() {
+        self.lock.withLock {
+            if self.storedFiredAt == nil {
+                self.storedFiredAt = Date()
+            }
+        }
+    }
+}
+
 struct OpenAIDashboardBrowserCookieImporterTests {
     @Test
     func `shared deadline clamps each local timeout to remaining budget`() throws {
@@ -90,12 +107,14 @@ struct OpenAIDashboardBrowserCookieImporterTests {
     }
 
     @Test
-    func `blocking browser cookie load cannot exceed shared deadline`() async {
+    func `blocking browser cookie load cannot exceed shared deadline`() async throws {
         let start = Date()
+        let timeoutProbe = CookieTimeoutProbe()
 
         do {
             _ = try await OpenAIDashboardBrowserCookieImporter.runBoundedCookieLoad(
-                deadline: start.addingTimeInterval(0.05))
+                deadline: start.addingTimeInterval(0.05),
+                timeoutObserver: timeoutProbe.record)
             {
                 Thread.sleep(forTimeInterval: 0.5)
                 return true
@@ -103,10 +122,27 @@ struct OpenAIDashboardBrowserCookieImporterTests {
             Issue.record("Expected cookie load timeout")
         } catch let error as URLError {
             #expect(error.code == .timedOut)
-            #expect(Date().timeIntervalSince(start) < 0.3)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+        let firedAt = try #require(timeoutProbe.firedAt)
+        #expect(firedAt.timeIntervalSince(start) < 0.3)
+    }
+
+    @Test
+    func `timeout observer stays silent when operation wins`() async throws {
+        let timeoutProbe = CookieTimeoutProbe()
+
+        let value = try await OpenAIDashboardBrowserCookieImporter.runBoundedCookieLoad(
+            deadline: Date().addingTimeInterval(0.05),
+            timeoutObserver: timeoutProbe.record)
+        {
+            true
+        }
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(value)
+        #expect(timeoutProbe.firedAt == nil)
     }
 
     @Test
@@ -137,37 +173,51 @@ struct OpenAIDashboardBrowserCookieImporterTests {
     }
 
     @Test @MainActor
-    func `stalled callback cannot exceed shared deadline`() async {
+    func `slow callback times out before completion`() async throws {
         let start = Date()
+        let timeoutProbe = CookieTimeoutProbe()
 
         do {
             try await OpenAIDashboardBrowserCookieImporter.runBoundedCallback(
-                deadline: start.addingTimeInterval(0.05))
-            { _ in }
+                deadline: start.addingTimeInterval(0.05),
+                timeoutObserver: timeoutProbe.record)
+            { completion in
+                DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.5) {
+                    completion()
+                }
+            }
             Issue.record("Expected callback timeout")
         } catch let error as URLError {
             #expect(error.code == .timedOut)
-            #expect(Date().timeIntervalSince(start) < 0.3)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+        let firedAt = try #require(timeoutProbe.firedAt)
+        #expect(firedAt.timeIntervalSince(start) < 0.3)
     }
 
     @Test @MainActor
-    func `stalled value callback cannot exceed shared deadline`() async {
+    func `slow value callback times out before completion`() async throws {
         let start = Date()
+        let timeoutProbe = CookieTimeoutProbe()
 
         do {
             let _: [String] = try await OpenAIDashboardBrowserCookieImporter.runBoundedValueCallback(
-                deadline: start.addingTimeInterval(0.05))
-            { _ in }
+                deadline: start.addingTimeInterval(0.05),
+                timeoutObserver: timeoutProbe.record)
+            { completion in
+                DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.5) {
+                    completion([])
+                }
+            }
             Issue.record("Expected value callback timeout")
         } catch let error as URLError {
             #expect(error.code == .timedOut)
-            #expect(Date().timeIntervalSince(start) < 0.3)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+        let firedAt = try #require(timeoutProbe.firedAt)
+        #expect(firedAt.timeIntervalSince(start) < 0.3)
     }
 
     @Test @MainActor


### PR DESCRIPTION
## Summary

- measure when cookie-import timeout callbacks win instead of when a starved async test task resumes
- race callback deadlines against delayed completions so timeout enforcement remains covered
- verify timeout observers stay silent when the operation wins

## Proof

- `swift test --filter OpenAIDashboardBrowserCookieImporterTests`: 13 passed
- combined with #1573: 32 parser/cookie tests passed under the 32-worker parser stress
- `make check`
- final `autoreview --mode local`: clean, 0.87

## Context

#1573 exposed a test-only assumption: Swift's cooperative executor can delay the awaiting test task for roughly 1.9 seconds under CPU saturation even though the 50 ms timeout callback already won. The old wall-clock assertions measured caller resumption, not deadline delivery. The observer is nil by default and runs only inside the winning timeout completion guard; existing production callers are unchanged.
