### PR TITLE
ci: keep lint independent of macOS test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
   lint:
     runs-on: macos-15-intel
     timeout-minutes: 10
-    needs:
-      - swift-test-macos
     steps:
       - uses: actions/checkout@v6
 
@@ -86,7 +84,7 @@ jobs:
     needs:
       - lint
       - swift-test-macos
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}
     steps:
       - name: Verify macOS lint and test jobs
         run: |


### PR DESCRIPTION
## Summary

- run the macOS lint job independently from the Swift test shard matrix
- keep the existing `lint-build-test` aggregate gate depending on both lint and the macOS shards
- avoid turning superseded/cancelled workflow runs into misleading aggregate failures

## Rationale

The shard split from #1629 reduced macOS test wall-clock time, but `lint` still had `needs: swift-test-macos`. That serialized lint behind the slowest shard and skipped lint feedback whenever the matrix failed or was cancelled. The aggregate gate is the right place to depend on both producers; lint itself should remain a fast, independent signal.

The aggregate job still runs on real dependency failures through `always()`, but now skips when the workflow itself is cancelled, which avoids the noisy `1 failed, 5 cancelled` pattern on runs superseded by a newer push.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"`
- `bash Scripts/test_swift_test_sharding.sh`
- `git diff --check`
- Completed exact-head CI run: https://github.com/steipete/CodexBar/actions/runs/27802962340
  - `lint`: passed in 1m31s
  - `swift-test-macos (0, 4)`: passed in 16m56s
  - `swift-test-macos (1, 4)`: passed in 24m45s
  - `swift-test-macos (2, 4)`: passed in 21m29s
  - `swift-test-macos (3, 4)`: passed in 19m37s
  - `lint-build-test`: passed in 3s after lint and macOS shards completed
  - `build-linux-cli` x64/arm64 and GitGuardian also passed
