### PR TITLE
Fix Xiaomi MiMo fallback after auth redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 
 ### Fixed
+- Xiaomi MiMo: retry another imported browser session when a stale session redirects API requests to login. Thanks @Yuxin-Qiao!
 - Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!
 - Memory: release idle OpenAI WebViews under system pressure without blocking the main thread. Thanks @ProspectOre!
 - Memory: trim rebuildable menu and OpenAI debug caches under system pressure. Thanks @ProspectOre!

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift
@@ -168,6 +168,9 @@ public enum MiMoUsageFetcher {
         switch response.statusCode {
         case 200:
             break
+        // Expired browser sessions can redirect API requests to the login flow.
+        case 300..<400:
+            throw MiMoUsageError.loginRequired
         case 401:
             throw MiMoUsageError.loginRequired
         case 403:

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -561,6 +561,25 @@ struct MiMoProviderTests {
 
         #expect(elapsed < .seconds(1), "Required failure was delayed by optional requests: \(elapsed)")
     }
+
+    @Test
+    func `fetch usage treats auth redirect as login required`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            let (response, data) = Self.makeResponse(url: url, body: "", statusCode: 302)
+            return (data, response)
+        }
+
+        do {
+            _ = try await MiMoUsageFetcher.fetchUsage(
+                cookieHeader: "userId=123; api-platform_serviceToken=expired-token",
+                environment: ["MIMO_API_URL": "https://mimo.test/api/v1"],
+                session: transport)
+            Issue.record("Expected MiMo auth redirect to require login")
+        } catch MiMoUsageError.loginRequired {
+            // Expected.
+        }
+    }
 }
 
 private actor MiMoOptionalRequestGate {
@@ -940,6 +959,73 @@ extension MiMoProviderTests {
         #expect(requestedCookies.contains(where: { $0.contains("valid-token") }))
         #expect(result.usage.mimoUsage?.balanceDetail == "$25.51")
         #expect(CookieHeaderCache.load(provider: .mimo)?.sourceLabel == "Active Chrome")
+    }
+
+    @Test
+    func `mimo web strategy retries safari after stale chrome auth redirect`() async throws {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        let registered = URLProtocol.registerClass(MiMoStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(MiMoStubURLProtocol.self)
+            }
+            MiMoStubURLProtocol.handler = nil
+            MiMoCookieImporter.importSessionsOverrideForTesting = nil
+            CookieHeaderCache.clear(provider: .mimo)
+        }
+
+        CookieHeaderCache.clear(provider: .mimo)
+        CookieHeaderCache.store(
+            provider: .mimo,
+            cookieHeader: "api-platform_serviceToken=stale-chrome-token; userId=111",
+            sourceLabel: "Chrome")
+
+        MiMoCookieImporter.importSessionsOverrideForTesting = { _, _ in
+            [
+                .init(
+                    cookieHeader: "api-platform_serviceToken=stale-chrome-token; userId=111",
+                    sourceLabel: "Chrome"),
+                .init(
+                    cookieHeader: "api-platform_serviceToken=valid-safari-token; userId=222",
+                    sourceLabel: "Safari"),
+            ]
+        }
+
+        let lock = NSLock()
+        var requestedCookies: [String] = []
+        MiMoStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            let cookie = request.value(forHTTPHeaderField: "Cookie") ?? ""
+            lock.withLock {
+                requestedCookies.append(cookie)
+            }
+
+            if cookie.contains("stale-chrome-token") {
+                return Self.makeResponse(url: url, body: "", statusCode: 302)
+            }
+
+            let body = """
+            {
+              "code": 0,
+              "message": "",
+              "data": {
+                "balance": "25.51",
+                "currency": "USD"
+              }
+            }
+            """
+            return Self.makeResponse(url: url, body: body)
+        }
+
+        let strategy = MiMoWebFetchStrategy()
+        let result = try await strategy
+            .fetch(self.makeContext(environment: ["MIMO_API_URL": "https://mimo.test/api/v1"]))
+
+        #expect(requestedCookies.contains(where: { $0.contains("stale-chrome-token") }))
+        #expect(requestedCookies.contains(where: { $0.contains("valid-safari-token") }))
+        #expect(result.usage.mimoUsage?.balanceDetail == "$25.51")
+        #expect(CookieHeaderCache.load(provider: .mimo)?.sourceLabel == "Safari")
     }
 
     #if os(macOS)


### PR DESCRIPTION
## Summary

- Treat Xiaomi MiMo API auth redirects as `loginRequired` instead of a terminal network error.
- Preserve browser import order while allowing a stale cached/Chrome session to fall through to a later valid imported session.
- Add focused regression coverage for redirects and stale-Chrome-to-Safari fallback.

## Root Cause

A stale session can make the MiMo API return a login redirect. Classifying that redirect as a terminal network error prevents the web strategy from clearing stale state and trying later browser sessions. Mapping it to login-required uses the existing bounded retry path.

## Proof

- `swift test --filter MiMoProviderTests`: 35 tests passed on the exact head.
- `make check`: format and strict lint clean on the exact head.
- Exact-head Codex autoreview clean, confidence 0.82.
- Exact CLI browser-cookie routing reached the real Chrome Safe Storage Keychain prompt; the read stopped there because unattended login-keychain entry was unavailable. No live account-success claim is made.

Exact candidate: `215584c29306bb016f35662a235fe48cf703ca7f`.

Fixes #1548.
