### PR TITLE
Fix menu bar quota for exhausted sublimits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 - Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!
+- Cursor: ignore an exhausted Auto or API subquota only when another independent quota remains usable, while preserving the overall cap. Thanks @Yuxin-Qiao!
 - Memory: release idle OpenAI WebViews under system pressure without blocking the main thread. Thanks @ProspectOre!
 - Memory: trim rebuildable menu and OpenAI debug caches under system pressure. Thanks @ProspectOre!
 - Provider plans: keep Claude and Kiro plan matching on one rendered line to avoid bogus labels from adjacent usage hints. Thanks @elijahfriedman!

--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -132,7 +132,7 @@ enum MenuBarMetricWindowResolver {
                 api: snapshot.tertiary)
         }
         if provider == .minimax {
-            return Self.mostConstrainedUsableWindow(
+            return Self.mostConstrainedWindow(
                 primary: snapshot.primary,
                 secondary: snapshot.secondary,
                 tertiary: snapshot.tertiary)
@@ -217,19 +217,6 @@ enum MenuBarMetricWindowResolver {
         let windows = [primary, secondary, tertiary].compactMap(\.self)
         guard !windows.isEmpty else { return nil }
         return windows.max(by: { $0.usedPercent < $1.usedPercent })
-    }
-
-    private static func mostConstrainedUsableWindow(
-        primary: RateWindow?,
-        secondary: RateWindow?,
-        tertiary: RateWindow?)
-        -> RateWindow?
-    {
-        let windows = [primary, secondary, tertiary].compactMap(\.self)
-        guard !windows.isEmpty else { return nil }
-        let usableWindows = windows.filter { $0.usedPercent < 100 }
-        return (usableWindows.isEmpty ? windows : usableWindows)
-            .max(by: { $0.usedPercent < $1.usedPercent })
     }
 
     private static func mostConstrainedCursorWindow(

--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -126,7 +126,7 @@ enum MenuBarMetricWindowResolver {
             return primary.usedPercent >= secondary.usedPercent ? primary : secondary
         }
         if provider == .cursor || provider == .minimax {
-            return Self.mostConstrainedWindow(
+            return Self.mostConstrainedUsableWindow(
                 primary: snapshot.primary,
                 secondary: snapshot.secondary,
                 tertiary: snapshot.tertiary)
@@ -211,6 +211,19 @@ enum MenuBarMetricWindowResolver {
         let windows = [primary, secondary, tertiary].compactMap(\.self)
         guard !windows.isEmpty else { return nil }
         return windows.max(by: { $0.usedPercent < $1.usedPercent })
+    }
+
+    private static func mostConstrainedUsableWindow(
+        primary: RateWindow?,
+        secondary: RateWindow?,
+        tertiary: RateWindow?)
+        -> RateWindow?
+    {
+        let windows = [primary, secondary, tertiary].compactMap(\.self)
+        guard !windows.isEmpty else { return nil }
+        let usableWindows = windows.filter { $0.usedPercent < 100 }
+        return (usableWindows.isEmpty ? windows : usableWindows)
+            .max(by: { $0.usedPercent < $1.usedPercent })
     }
 
     private static func shouldUseClaudeSpendLimit(

--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -125,7 +125,13 @@ enum MenuBarMetricWindowResolver {
         {
             return primary.usedPercent >= secondary.usedPercent ? primary : secondary
         }
-        if provider == .cursor || provider == .minimax {
+        if provider == .cursor {
+            return Self.mostConstrainedCursorWindow(
+                total: snapshot.primary,
+                auto: snapshot.secondary,
+                api: snapshot.tertiary)
+        }
+        if provider == .minimax {
             return Self.mostConstrainedUsableWindow(
                 primary: snapshot.primary,
                 secondary: snapshot.secondary,
@@ -223,6 +229,26 @@ enum MenuBarMetricWindowResolver {
         guard !windows.isEmpty else { return nil }
         let usableWindows = windows.filter { $0.usedPercent < 100 }
         return (usableWindows.isEmpty ? windows : usableWindows)
+            .max(by: { $0.usedPercent < $1.usedPercent })
+    }
+
+    private static func mostConstrainedCursorWindow(
+        total: RateWindow?,
+        auto: RateWindow?,
+        api: RateWindow?)
+        -> RateWindow?
+    {
+        if let total, total.usedPercent >= 100 {
+            return total
+        }
+
+        let subquotaWindows = [auto, api].compactMap(\.self)
+        let usableSubquotaWindows = subquotaWindows.filter { $0.usedPercent < 100 }
+        if !subquotaWindows.isEmpty, usableSubquotaWindows.isEmpty {
+            return subquotaWindows.max(by: { $0.usedPercent < $1.usedPercent })
+        }
+
+        return ([total].compactMap(\.self) + usableSubquotaWindows)
             .max(by: { $0.usedPercent < $1.usedPercent })
     }
 

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -39,6 +39,58 @@ struct MenuBarMetricWindowResolverTests {
     }
 
     @Test
+    func `automatic metric skips exhausted cursor subquota when total remains usable`() {
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 67, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Total"),
+            secondary: RateWindow(usedPercent: 34, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Auto"),
+            tertiary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "API"),
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .cursor,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.remainingPercent == 33)
+        #expect(window?.resetDescription == "Total")
+    }
+
+    @Test
+    func `automatic metric still reports cursor exhausted when every subquota is exhausted`() {
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Total"),
+            secondary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Auto"),
+            tertiary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "API"),
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .cursor,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.remainingPercent == 0)
+    }
+
+    @Test
+    func `automatic metric skips exhausted minimax lane when another lane remains usable`() {
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 100, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 97, windowMinutes: 7 * 24 * 60, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .minimax,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.usedPercent == 97)
+        #expect(window?.windowMinutes == 7 * 24 * 60)
+    }
+
+    @Test
     func `automatic metric uses team budget for team-bound LiteLLM keys`() {
         let snapshot = UsageSnapshot(
             primary: RateWindow(

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -42,7 +42,11 @@ struct MenuBarMetricWindowResolverTests {
     func `automatic metric skips exhausted cursor subquota when total remains usable`() {
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 67, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Total"),
-            secondary: RateWindow(usedPercent: 34, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Auto"),
+            secondary: RateWindow(
+                usedPercent: 34,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "Auto"),
             tertiary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "API"),
             updatedAt: Date())
 
@@ -59,8 +63,63 @@ struct MenuBarMetricWindowResolverTests {
     @Test
     func `automatic metric still reports cursor exhausted when every subquota is exhausted`() {
         let snapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Total"),
-            secondary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Auto"),
+            primary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "Total"),
+            secondary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "Auto"),
+            tertiary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "API"),
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .cursor,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.remainingPercent == 0)
+    }
+
+    @Test
+    func `automatic metric keeps exhausted cursor total when a subquota remains usable`() {
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "Total"),
+            secondary: RateWindow(
+                usedPercent: 60,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "Auto"),
+            tertiary: nil,
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .cursor,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.remainingPercent == 0)
+        #expect(window?.resetDescription == "Total")
+    }
+
+    @Test
+    func `automatic metric reports cursor exhausted when all present subquotas are exhausted`() {
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 67, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Total"),
+            secondary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "Auto"),
             tertiary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "API"),
             updatedAt: Date())
 

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -133,7 +133,7 @@ struct MenuBarMetricWindowResolverTests {
     }
 
     @Test
-    func `automatic metric skips exhausted minimax lane when another lane remains usable`() {
+    func `automatic metric preserves exhausted minimax session lane`() {
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 100, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
             secondary: RateWindow(usedPercent: 97, windowMinutes: 7 * 24 * 60, resetsAt: nil, resetDescription: nil),
@@ -145,8 +145,8 @@ struct MenuBarMetricWindowResolverTests {
             snapshot: snapshot,
             supportsAverage: false)
 
-        #expect(window?.usedPercent == 97)
-        #expect(window?.windowMinutes == 7 * 24 * 60)
+        #expect(window?.usedPercent == 100)
+        #expect(window?.windowMinutes == 300)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
@@ -166,6 +166,29 @@ struct StatusItemBalanceDisplayTests {
     }
 
     @Test
+    func `menu bar display text skips exhausted cursor api subquota when total remains usable`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-cursor-exhausted-api",
+            provider: .cursor)
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.automatic, for: .cursor)
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 67, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Total"),
+            secondary: RateWindow(usedPercent: 34, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Auto"),
+            tertiary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "API"),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .cursor)
+        store._setErrorForTesting(nil, provider: .cursor)
+
+        let displayText = controller.menuBarDisplayText(for: .cursor, snapshot: snapshot)
+
+        #expect(displayText == "33%")
+    }
+
+    @Test
     func `menu bar display text uses deepseek balance`() {
         let settings = self.makeSettings(
             suiteName: "StatusItemBalanceDisplayTests-deepseek-balance",

--- a/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
@@ -176,7 +176,11 @@ struct StatusItemBalanceDisplayTests {
         defer { controller.releaseStatusItemsForTesting() }
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 67, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Total"),
-            secondary: RateWindow(usedPercent: 34, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Auto"),
+            secondary: RateWindow(
+                usedPercent: 34,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "Auto"),
             tertiary: RateWindow(usedPercent: 100, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "API"),
             updatedAt: Date())
 


### PR DESCRIPTION
## Summary

- Skip an exhausted Cursor Auto/API subquota when another child quota remains usable.
- Keep Cursor's overall Total cap authoritative.
- Retain 0% when every present Cursor child subquota is exhausted.
- Preserve MiniMax's existing session-exhaustion behavior.
- Add resolver, menu-bar display, and highest-usage regression coverage.

## Review and proof

- Hosted CI exposed a real highest-usage regression in the initial head; the repaired resolver now treats Cursor Total separately from child subquotas.
- `swift test --filter 'MenuBarMetricWindowResolverTests|StatusItemBalanceDisplayTests|UsageStoreHighestUsageTests'`: 65 tests passed on the exact head.
- `make check`: format and strict lint clean.
- Exact-head Codex autoreview: clean, confidence 0.86.

Exact candidate: `7052fb4060da3ef29a5ec072606fb586b415e882`.
