### PR TITLE
ci: run lint on Linux runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: ./Scripts/install_lint_tools.sh
 
       - name: Lint
-        run: ./Scripts/lint.sh lint-portable
+        run: ./Scripts/lint.sh lint-linux
 
   swift-test-macos:
     runs-on: macos-15-intel
@@ -51,9 +51,9 @@ jobs:
           swift --version
           swift package --version
 
-      - name: Check app locales
+      - name: Check app locales and Swift formatting
         if: ${{ matrix.shard-index == 0 }}
-        run: ./Scripts/lint.sh app-locales
+        run: ./Scripts/lint.sh lint-macos
 
       - name: Swift Test
         timeout-minutes: 35

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,28 +11,10 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: macos-15-intel
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-
-      - name: Select Xcode 26.1.1 (if present) or fallback to default
-        run: |
-          set -euo pipefail
-          for candidate in /Applications/Xcode_26.1.1.app /Applications/Xcode_26.1.app /Applications/Xcode.app; do
-            if [[ -d "$candidate" ]]; then
-              sudo xcode-select -s "${candidate}/Contents/Developer"
-              echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
-              break
-            fi
-          done
-          /usr/bin/xcodebuild -version
-
-      - name: Swift toolchain version
-        run: |
-          set -euo pipefail
-          swift --version
-          swift package --version
 
       - name: Install lint tools
         run: ./Scripts/install_lint_tools.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: ./Scripts/install_lint_tools.sh
 
       - name: Lint
-        run: ./Scripts/lint.sh lint
+        run: ./Scripts/lint.sh lint-portable
 
   swift-test-macos:
     runs-on: macos-15-intel
@@ -51,6 +51,10 @@ jobs:
           swift --version
           swift package --version
 
+      - name: Check app locales
+        if: ${{ matrix.shard-index == 0 }}
+        run: ./Scripts/lint.sh app-locales
+
       - name: Swift Test
         timeout-minutes: 35
         run: |
@@ -68,7 +72,7 @@ jobs:
       - swift-test-macos
     if: ${{ always() && !cancelled() }}
     steps:
-      - name: Verify macOS lint and test jobs
+      - name: Verify lint and macOS test jobs
         run: |
           set -euo pipefail
           if [[ "${{ needs.lint.result }}" != "success" ]]; then
@@ -79,7 +83,7 @@ jobs:
             echo "swift-test-macos job finished with ${{ needs.swift-test-macos.result }}" >&2
             exit 1
           fi
-          echo "macOS lint and Swift test shards passed."
+          echo "Lint and macOS Swift test shards passed."
 
   build-linux-cli:
     timeout-minutes: 20

--- a/Scripts/install_lint_tools.sh
+++ b/Scripts/install_lint_tools.sh
@@ -11,6 +11,8 @@ SWIFTLINT_VERSION="0.63.2"
 
 SWIFTFORMAT_SHA256_DARWIN="8b6289b608a44e73cd3851c3589dbd7c553f32cc805aa54b3a496ce2b90febe7"
 SWIFTLINT_SHA256_DARWIN="c59a405c85f95b92ced677a500804e081596a4cae4a6a485af76065557d6ed29"
+SWIFTFORMAT_SHA256_LINUX_X86_64="150d9693570cf234ec91d8a03ba7165bd36a78335c5e40ed91e4c013a492eb54"
+SWIFTLINT_SHA256_LINUX_X86_64="dd1017cfd20a1457f264590bcb5875a6ee06cd75b9a9d4f77cd43a552499143b"
 
 log() { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -39,6 +41,7 @@ install_zip_binary() {
   local url="$2"
   local expected_sha="$3"
   local binary_name="$4"
+  local installed_name="${5:-$binary_name}"
 
   local tmp_zip
   tmp_zip="$(mktemp -t "${label}.XXXX")"
@@ -71,7 +74,7 @@ install_zip_binary() {
     fail "${label} binary '${binary_name}' not found in archive"
   fi
 
-  install -m 0755 "$extracted_path" "${BIN_DIR}/${binary_name}"
+  install -m 0755 "$extracted_path" "${BIN_DIR}/${installed_name}"
 
   rm -f "$tmp_zip"
   rm -rf "$tmp_dir"
@@ -104,21 +107,25 @@ case "$OS" in
       x86_64)
         SWIFTFORMAT_URL="https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat_linux.zip"
         SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/swiftlint_linux_amd64.zip"
+        SWIFTFORMAT_SHA256="$SWIFTFORMAT_SHA256_LINUX_X86_64"
+        SWIFTLINT_SHA256="$SWIFTLINT_SHA256_LINUX_X86_64"
         ;;
       aarch64|arm64)
         SWIFTFORMAT_URL="https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat_linux_aarch64.zip"
         SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/swiftlint_linux_arm64.zip"
+        SWIFTFORMAT_SHA256=""
+        SWIFTLINT_SHA256=""
         ;;
       *)
         fail "Unsupported Linux arch: ${ARCH}"
         ;;
     esac
 
-    # SHA256 is intentionally only enforced for the macOS CI path.
-    # If we later run lint on Linux CI, add pinned SHAs here as well.
-    log "WARN: Linux SHA256 verification not configured for ${ARCH}; installing anyway."
-    install_zip_binary "SwiftFormat ${SWIFTFORMAT_VERSION}" "$SWIFTFORMAT_URL" "" "swiftformat"
-    install_zip_binary "SwiftLint ${SWIFTLINT_VERSION}" "$SWIFTLINT_URL" "" "swiftlint"
+    if [[ -z "$SWIFTFORMAT_SHA256" || -z "$SWIFTLINT_SHA256" ]]; then
+      log "WARN: Linux SHA256 verification not configured for ${ARCH}; installing anyway."
+    fi
+    install_zip_binary "SwiftFormat ${SWIFTFORMAT_VERSION}" "$SWIFTFORMAT_URL" "$SWIFTFORMAT_SHA256" "swiftformat_linux" "swiftformat"
+    install_zip_binary "SwiftLint ${SWIFTLINT_VERSION}" "$SWIFTLINT_URL" "$SWIFTLINT_SHA256" "swiftlint"
     ;;
   *)
     fail "Unsupported OS: ${OS}"

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -31,33 +31,47 @@ check_swift_test_sharding() {
   "${ROOT_DIR}/Scripts/test_swift_test_sharding.sh"
 }
 
-check_site_locales() {
+check_app_locales() {
   node "${ROOT_DIR}/Scripts/check-app-locales.mjs" --test
   node "${ROOT_DIR}/Scripts/check-app-locales.mjs"
+}
+
+check_site_locales() {
   node "${ROOT_DIR}/Scripts/check-site-locales.mjs"
   node --check "${ROOT_DIR}/docs/site.js"
+}
+
+run_portable_lint() {
+  check_codex_parser_hash
+  check_package_product_paths
+  check_release_dsym_paths
+  check_sparkle_signing_paths
+  check_swift_test_sharding
+  check_site_locales
+  ensure_tools
+  "${BIN_DIR}/swiftformat" Sources Tests --lint
+  "${BIN_DIR}/swiftlint" --strict
 }
 
 cmd="${1:-lint}"
 
 case "$cmd" in
   lint)
-    check_codex_parser_hash
-    check_package_product_paths
-    check_release_dsym_paths
-    check_sparkle_signing_paths
-    check_swift_test_sharding
-    check_site_locales
-    ensure_tools
-    "${BIN_DIR}/swiftformat" Sources Tests --lint
-    "${BIN_DIR}/swiftlint" --strict
+    check_app_locales
+    run_portable_lint
+    ;;
+  lint-portable)
+    run_portable_lint
+    ;;
+  app-locales)
+    check_app_locales
     ;;
   format)
     ensure_tools
     "${BIN_DIR}/swiftformat" Sources Tests
     ;;
   *)
-    printf 'Usage: %s [lint|format]\n' "$(basename "$0")" >&2
+    printf 'Usage: %s [lint|lint-portable|app-locales|format]\n' "$(basename "$0")" >&2
     exit 2
     ;;
 esac

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -41,7 +41,7 @@ check_site_locales() {
   node --check "${ROOT_DIR}/docs/site.js"
 }
 
-run_portable_lint() {
+run_portable_checks() {
   check_codex_parser_hash
   check_package_product_paths
   check_release_dsym_paths
@@ -49,7 +49,13 @@ run_portable_lint() {
   check_swift_test_sharding
   check_site_locales
   ensure_tools
+}
+
+run_swiftformat_lint() {
   "${BIN_DIR}/swiftformat" Sources Tests --lint
+}
+
+run_swiftlint() {
   "${BIN_DIR}/swiftlint" --strict
 }
 
@@ -58,20 +64,25 @@ cmd="${1:-lint}"
 case "$cmd" in
   lint)
     check_app_locales
-    run_portable_lint
+    run_portable_checks
+    run_swiftformat_lint
+    run_swiftlint
     ;;
-  lint-portable)
-    run_portable_lint
+  lint-linux)
+    run_portable_checks
+    run_swiftlint
     ;;
-  app-locales)
+  lint-macos)
     check_app_locales
+    ensure_tools
+    run_swiftformat_lint
     ;;
   format)
     ensure_tools
     "${BIN_DIR}/swiftformat" Sources Tests
     ;;
   *)
-    printf 'Usage: %s [lint|lint-portable|app-locales|format]\n' "$(basename "$0")" >&2
+    printf 'Usage: %s [lint|lint-linux|lint-macos|format]\n' "$(basename "$0")" >&2
     exit 2
     ;;
 esac

--- a/Sources/CodexBar/Providers/Copilot/CopilotProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Copilot/CopilotProviderImplementation.swift
@@ -182,7 +182,8 @@ struct CopilotProviderImplementation: ProviderImplementation {
             ProviderSettingsFieldDescriptor(
                 id: "copilot-enterprise-host",
                 title: "Enterprise host",
-                subtitle: "Optional. Enter your GitHub Enterprise host, for example octocorp.ghe.com. Leave blank for github.com.",
+                subtitle: "Optional. Enter your GitHub Enterprise host, for example octocorp.ghe.com. " +
+                    "Leave blank for github.com.",
                 kind: .plain,
                 placeholder: "github.com",
                 binding: context.stringBinding(\.copilotEnterpriseHost),

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift
@@ -109,7 +109,8 @@ public enum MiniMaxSettingsError: LocalizedError, Sendable {
     public var errorDescription: String? {
         switch self {
         case .missingCookie:
-            "MiniMax session not found. Sign in to platform.minimax.io or platform.minimaxi.com in your browser and try again."
+            "MiniMax session not found. Sign in to platform.minimax.io or platform.minimaxi.com " +
+                "in your browser and try again."
         }
     }
 }


### PR DESCRIPTION
## Summary

- Run portable lint on `ubuntu-latest` instead of requesting a fifth macOS runner.
- Keep app locales and SwiftFormat on macOS test shard 0, preserving both existing gates without another runner.
- Pin SHA256 checksums for the Linux x86_64 SwiftFormat and SwiftLint archives.

## Rationale

Each PR now asks for four macOS test runners. Moving portable lint to Ubuntu removes the additional macOS slot request while the aggregate `lint-build-test` job still requires both lint and every macOS shard.

The first Linux attempt exposed the app locale check's macOS `plutil` dependency. The second exposed Linux SwiftFormat per-rule timeouts on two large files. This head keeps those checks on macOS shard 0 and runs shell, site-localization, and SwiftLint checks in the independent Linux lint job.

## Validation

- `./Scripts/lint.sh lint-linux`: portable checks and strict SwiftLint passed across 1,152 files.
- `./Scripts/lint.sh lint-macos`: app locales and SwiftFormat passed across 20 catalogs / 1,059 English keys and 1,153 files.
- Linux SwiftLint exposed two pre-existing 120-column violations missed by the macOS binary; both literals are now wrapped without changing values.
- Workflow YAML parse, shell syntax, and `git diff --check`: passed.
- Platform-split reviews clean; final literal-wrap review confidence 0.96.
- The prior failed run confirmed both pinned Linux binaries install and report the expected versions before reaching the macOS-only locale command.

Exact candidate: `ca0787c8f330e94e64a23d96ca31c82d3413bd83`

Pinned Linux x86_64 archives:

- SwiftFormat 0.59.1: `150d9693570cf234ec91d8a03ba7165bd36a78335c5e40ed91e4c013a492eb54`
- SwiftLint 0.63.2: `dd1017cfd20a1457f264590bcb5875a6ee06cd75b9a9d4f77cd43a552499143b`
