### PR TITLE
Show Codex banked reset availability

### DIFF
--- a/Sources/CodexBar/MenuSessionCoordinator.swift
+++ b/Sources/CodexBar/MenuSessionCoordinator.swift
@@ -51,7 +51,12 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
 
     func hasRequiredClosedPreparation(for menuIDs: some Sequence<MenuID>) -> Bool {
         guard self.latestRequiredRebuildVersion > 0 else { return false }
-        return menuIDs.contains { self.isRenderedVersion($0, olderThan: self.latestRequiredRebuildVersion) }
+        return menuIDs.contains { menuID in
+            guard let renderedVersion = self.renderedVersions[menuID] else {
+                return self.latestRequiredRebuildVersion == self.contentVersion
+            }
+            return renderedVersion < self.latestRequiredRebuildVersion
+        }
     }
 
     func closedPreparationPlan(for menuIDs: some Sequence<MenuID>) -> ClosedPreparationPlan {

--- a/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
@@ -172,6 +172,22 @@ struct CodexConsumerProjection {
         }
     }
 
+    struct BankedResetsProjection {
+        let snapshot: CodexBankedResetsSnapshot?
+        let userFacingError: String?
+
+        var availableCount: Int {
+            self.snapshot?.availableCount ?? 0
+        }
+
+        var expiryDates: [Date] {
+            guard let snapshot = self.snapshot else { return [] }
+            return snapshot.availableResets
+                .prefix(snapshot.availableCount)
+                .compactMap(\.expiresAt)
+        }
+    }
+
     struct UserFacingErrors {
         let usage: String?
         let credits: String?
@@ -183,11 +199,39 @@ struct CodexConsumerProjection {
         let rawUsageError: String?
         let liveCredits: CreditsSnapshot?
         let rawCreditsError: String?
+        let liveBankedResets: CodexBankedResetsSnapshot?
+        let rawBankedResetsError: String?
         let liveDashboard: OpenAIDashboardSnapshot?
         let rawDashboardError: String?
         let dashboardAttachmentAuthorized: Bool
         let dashboardRequiresLogin: Bool
         let now: Date
+
+        init(
+            snapshot: UsageSnapshot?,
+            rawUsageError: String?,
+            liveCredits: CreditsSnapshot?,
+            rawCreditsError: String?,
+            liveBankedResets: CodexBankedResetsSnapshot? = nil,
+            rawBankedResetsError: String? = nil,
+            liveDashboard: OpenAIDashboardSnapshot?,
+            rawDashboardError: String?,
+            dashboardAttachmentAuthorized: Bool,
+            dashboardRequiresLogin: Bool,
+            now: Date)
+        {
+            self.snapshot = snapshot
+            self.rawUsageError = rawUsageError
+            self.liveCredits = liveCredits
+            self.rawCreditsError = rawCreditsError
+            self.liveBankedResets = liveBankedResets
+            self.rawBankedResetsError = rawBankedResetsError
+            self.liveDashboard = liveDashboard
+            self.rawDashboardError = rawDashboardError
+            self.dashboardAttachmentAuthorized = dashboardAttachmentAuthorized
+            self.dashboardRequiresLogin = dashboardRequiresLogin
+            self.now = now
+        }
     }
 
     enum MenuBarFallback {
@@ -200,6 +244,7 @@ struct CodexConsumerProjection {
     let planUtilizationLanes: [PlanUtilizationLane]
     let dashboardVisibility: DashboardVisibility
     let credits: CreditsProjection?
+    let bankedResets: BankedResetsProjection?
     let menuBarFallback: MenuBarFallback
     let userFacingErrors: UserFacingErrors
     let canShowBuyCredits: Bool
@@ -225,6 +270,17 @@ struct CodexConsumerProjection {
             CreditsProjection(
                 snapshot: context.liveCredits,
                 userFacingError: CodexUIErrorMapper.userFacingMessage(context.rawCreditsError))
+        } else {
+            nil
+        }
+
+        let bankedResetsProjection: BankedResetsProjection? = if allowsLiveAdjuncts,
+                                                                 context.liveBankedResets != nil
+                                                                 || context.rawBankedResetsError != nil
+        {
+            BankedResetsProjection(
+                snapshot: context.liveBankedResets,
+                userFacingError: CodexUIErrorMapper.userFacingMessage(context.rawBankedResetsError))
         } else {
             nil
         }
@@ -259,6 +315,7 @@ struct CodexConsumerProjection {
             planUtilizationLanes: planUtilizationLanes,
             dashboardVisibility: dashboardVisibility,
             credits: creditsProjection,
+            bankedResets: bankedResetsProjection,
             menuBarFallback: self.menuBarFallback(
                 creditsRemaining: creditsProjection?.remaining,
                 rateWindowsByLane: rateWindowsByLane),
@@ -414,6 +471,8 @@ extension UsageStore {
             rawUsageError: rawUsageError,
             liveCredits: self.credits,
             rawCreditsError: self.lastCreditsError,
+            liveBankedResets: self.bankedResets,
+            rawBankedResetsError: self.lastBankedResetsError,
             liveDashboard: self.openAIDashboard,
             rawDashboardError: self.lastOpenAIDashboardError,
             dashboardAttachmentAuthorized: self.openAIDashboardAttachmentAuthorized,

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -45,6 +45,7 @@ extension UsageStore {
         phaseDidChange?(.usage)
         await self.refreshCreditsIfNeeded(minimumSnapshotUpdatedAt: refreshStartedAt)
         phaseDidChange?(.credits)
+        await self.refreshBankedResetsIfNeeded(minimumSnapshotUpdatedAt: refreshStartedAt)
 
         if self.settings.codexCookieSource.isEnabled {
             let expectedGuard = self.freshCodexOpenAIWebRefreshGuard()
@@ -60,6 +61,7 @@ extension UsageStore {
             phaseDidChange?(.usage)
             await self.refreshCreditsIfNeeded(minimumSnapshotUpdatedAt: refreshStartedAt)
             phaseDidChange?(.credits)
+            await self.refreshBankedResetsIfNeeded(minimumSnapshotUpdatedAt: refreshStartedAt)
         }
 
         self.persistWidgetSnapshot(reason: "codex-account-refresh")
@@ -95,6 +97,11 @@ extension UsageStore {
         self.lastCreditsSnapshotAccountKey = nil
         self.lastCreditsSource = .none
         self.creditsFailureStreak = 0
+        self.bankedResets = nil
+        self.lastBankedResetsError = nil
+        self.lastBankedResetsSnapshot = nil
+        self.lastBankedResetsSnapshotAccountKey = nil
+        self.bankedResetsFailureStreak = 0
 
         self.clearCodexOpenAIWebStateForAccountTransition(targetEmail: self.codexAccountEmailForOpenAIDashboard())
 
@@ -240,7 +247,9 @@ extension UsageStore {
         guard currentGuard.source == expectedGuard.source else { return nil }
         guard Self.codexGuardAuthFingerprintAllowsUsageApply(currentGuard, expectedGuard) else { return nil }
         guard expectedGuard.identity != .unresolved else { return nil }
-        guard currentGuard.identity == expectedGuard.identity else { return nil }
+        guard currentGuard.identity == expectedGuard.identity ||
+            Self.codexScopedRefreshGuardsShareEmailBackedIdentityBridge(expectedGuard, currentGuard)
+        else { return nil }
         return currentGuard
     }
 
@@ -253,7 +262,8 @@ extension UsageStore {
         guard currentGuard.source == expectedGuard.source else { return false }
         guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
         guard expectedGuard.identity != .unresolved else { return false }
-        return currentGuard.identity == expectedGuard.identity
+        return currentGuard.identity == expectedGuard.identity ||
+            Self.codexScopedRefreshGuardsShareEmailBackedIdentityBridge(expectedGuard, currentGuard)
     }
 
     func shouldApplyOpenAIDashboardRefreshGuard(
@@ -431,13 +441,34 @@ extension UsageStore {
     {
         guard lhs.source == rhs.source else { return false }
         if lhs == rhs { return true }
-        guard lhs.identity != .unresolved,
-              lhs.identity == rhs.identity,
-              lhs.accountKey == rhs.accountKey
-        else {
+        guard lhs.identity != .unresolved, rhs.identity != .unresolved else {
             return false
         }
+        if lhs.identity != rhs.identity,
+           !self.codexScopedRefreshGuardsShareEmailBackedIdentityBridge(lhs, rhs)
+        {
+            return false
+        }
+        guard lhs.accountKey == rhs.accountKey else { return false }
         return self.codexGuardAuthFingerprintAllowsUsageApply(lhs, rhs)
+    }
+
+    private nonisolated static func codexScopedRefreshGuardsShareEmailBackedIdentityBridge(
+        _ lhs: CodexAccountScopedRefreshGuard,
+        _ rhs: CodexAccountScopedRefreshGuard) -> Bool
+    {
+        guard lhs.source == rhs.source,
+              let lhsAccountKey = lhs.accountKey,
+              !lhsAccountKey.isEmpty,
+              lhsAccountKey == rhs.accountKey
+        else { return false }
+
+        return switch (lhs.identity, rhs.identity) {
+        case (.emailOnly, .providerAccount), (.providerAccount, .emailOnly):
+            true
+        default:
+            false
+        }
     }
 
     private nonisolated static func codexUsageResultAccountKeyMatchesCurrentGuard(

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
@@ -45,6 +45,41 @@ extension UsageStore {
         self.creditsRefreshTaskKey = nil
     }
 
+    func scheduleBankedResetsRefreshIfNeeded(minimumSnapshotUpdatedAt: Date? = nil) {
+        let refreshKey = self.codexBankedResetsRefreshKey(
+            expectedGuard: self.freshCodexAccountScopedRefreshGuard())
+        if let existing = self.bankedResetsRefreshTask,
+           !existing.isCancelled,
+           self.bankedResetsRefreshTaskKey == refreshKey
+        {
+            return
+        }
+
+        self.bankedResetsRefreshTask?.cancel()
+        self.bankedResetsRefreshTaskKey = refreshKey
+        self.bankedResetsRefreshTask = Task(priority: .utility) { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                if self.bankedResetsRefreshTaskKey == refreshKey {
+                    self.bankedResetsRefreshTask = nil
+                    self.bankedResetsRefreshTaskKey = nil
+                }
+            }
+            await self.refreshBankedResetsIfNeeded(minimumSnapshotUpdatedAt: minimumSnapshotUpdatedAt)
+        }
+    }
+
+    func cancelScheduledBankedResetsRefresh() {
+        self.bankedResetsRefreshTask?.cancel()
+        self.bankedResetsRefreshTask = nil
+        self.bankedResetsRefreshTaskKey = nil
+    }
+
+    func refreshBankedResetsNow(minimumSnapshotUpdatedAt: Date? = nil) async {
+        self.cancelScheduledBankedResetsRefresh()
+        await self.refreshBankedResetsIfNeeded(minimumSnapshotUpdatedAt: minimumSnapshotUpdatedAt)
+    }
+
     func refreshCreditsNow(minimumSnapshotUpdatedAt: Date? = nil) async {
         self.cancelScheduledCreditsRefresh()
         await self.refreshCreditsIfNeeded(minimumSnapshotUpdatedAt: minimumSnapshotUpdatedAt)
@@ -73,6 +108,10 @@ extension UsageStore {
             expectedGuard.accountKey ?? "account:nil",
             "auth:\(expectedGuard.authFingerprint ?? "nil")",
         ].joined(separator: "|")
+    }
+
+    func codexBankedResetsRefreshKey(expectedGuard: CodexAccountScopedRefreshGuard) -> String {
+        self.codexCreditsRefreshKey(expectedGuard: expectedGuard)
     }
 
     func refreshCreditsIfNeeded(minimumSnapshotUpdatedAt: Date? = nil) async {
@@ -160,6 +199,88 @@ extension UsageStore {
                 }
             }
         }
+    }
+
+    func refreshBankedResetsIfNeeded(minimumSnapshotUpdatedAt: Date? = nil) async {
+        guard self.isEnabled(.codex) else { return }
+        var expectedGuard = self.freshCodexAccountScopedRefreshGuard()
+        if expectedGuard.identity == .unresolved,
+           let minimumSnapshotUpdatedAt,
+           case .liveSystem = expectedGuard.source
+        {
+            _ = await self.waitForCodexSnapshotOrRefreshCompletion(minimumUpdatedAt: minimumSnapshotUpdatedAt)
+            expectedGuard = self.freshCodexAccountScopedRefreshGuard()
+        }
+        guard expectedGuard.identity != .unresolved,
+              expectedGuard.accountKey != nil
+        else {
+            return
+        }
+        do {
+            let snapshot = try await self.loadLatestCodexBankedResets()
+            guard !Task.isCancelled else { return }
+            guard let applyGuard = self.codexScopedNonUsageSuccessApplyGuard(
+                expectedGuard: expectedGuard)
+            else {
+                return
+            }
+            await MainActor.run {
+                self.bankedResets = snapshot
+                self.lastBankedResetsError = nil
+                self.lastBankedResetsSnapshot = snapshot
+                self.lastBankedResetsSnapshotAccountKey = applyGuard.accountKey
+                self.bankedResetsFailureStreak = 0
+                self.lastCodexAccountScopedRefreshGuard = applyGuard
+            }
+        } catch {
+            guard !Task.isCancelled else { return }
+            let message = error.localizedDescription
+            if message.localizedCaseInsensitiveContains("data not available yet") {
+                guard self.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard) else { return }
+                await MainActor.run {
+                    if let cached = self.lastBankedResetsSnapshot,
+                       self.lastBankedResetsSnapshotAccountKey == expectedGuard.accountKey
+                    {
+                        self.bankedResets = cached
+                        self.lastBankedResetsError = nil
+                        self.lastCodexAccountScopedRefreshGuard = expectedGuard
+                    } else {
+                        self.bankedResets = nil
+                        self.lastBankedResetsError = "Codex banked resets are still loading; will retry shortly."
+                    }
+                }
+                return
+            }
+
+            guard self.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard) else { return }
+            await MainActor.run {
+                self.bankedResetsFailureStreak += 1
+                if let cached = self.lastBankedResetsSnapshot,
+                   self.lastBankedResetsSnapshotAccountKey == expectedGuard.accountKey
+                {
+                    self.bankedResets = cached
+                    let stamp = cached.updatedAt.formatted(date: .abbreviated, time: .shortened)
+                    self.lastBankedResetsError =
+                        "Last Codex banked resets refresh failed: \(message). Cached values from \(stamp)."
+                    self.lastCodexAccountScopedRefreshGuard = expectedGuard
+                } else {
+                    self.lastBankedResetsError = message
+                    self.bankedResets = nil
+                }
+            }
+        }
+    }
+
+    private func loadLatestCodexBankedResets() async throws -> CodexBankedResetsSnapshot {
+        if let override = self._test_codexBankedResetsLoaderOverride {
+            return try await override()
+        }
+        let context = self.makeFetchContext(provider: .codex, override: nil)
+        let credentials = try await CodexOAuthCredentialsStore.loadRefreshed(env: context.env)
+        return try await CodexBankedResetsFetcher.fetchBankedResets(
+            accessToken: credentials.accessToken,
+            accountId: credentials.accountId,
+            env: context.env)
     }
 
     private func loadLatestCodexCredits() async throws -> CreditsSnapshot {

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -790,6 +790,9 @@
 "Using CLI fallback" = "استخدام CLI الخطة الاحتياطية";
 "Balance updates in near-real time (up to 5 min lag)" = "تحديثات التوازن في الوقت شبه الحقيقي (حتى تأخير 5 دقائق)";
 "Daily billing data finalizes at 07:00 UTC" = "يتم الانتهاء من بيانات الفوترة اليومية في الساعة 07:00 UTC";
+"Banked reset: %d available" = "إعادة تعيين محفوظة: %d متاحة";
+"Banked resets: %d available" = "إعادات تعيين محفوظة: %d متاحة";
+"Expires: %@" = "تنتهي: %@";
 "%@ of %@ credits left" = "%@ من %@ اعتمادات متبقية";
 "%@ of %@ bonus credits left" = "%@ من %@ رصيد إضافي متبقي";
 "%@ / %@ (%@ remaining)" = "%@ / %@ (%@ متبقية)";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -790,6 +790,9 @@
 "Using CLI fallback" = "Using CLI fallback";
 "Balance updates in near-real time (up to 5 min lag)" = "Balance updates in near-real time (up to 5 min lag)";
 "Daily billing data finalizes at 07:00 UTC" = "Daily billing data finalizes at 07:00 UTC";
+"Banked reset: %d available" = "Banked reset: %d available";
+"Banked resets: %d available" = "Banked resets: %d available";
+"Expires: %@" = "Expires: %@";
 "%@ of %@ credits left" = "%@ of %@ credits left";
 "%@ of %@ bonus credits left" = "%@ of %@ bonus credits left";
 "%@ / %@ (%@ remaining)" = "%@ / %@ (%@ remaining)";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -790,6 +790,9 @@
 "Using CLI fallback" = "استفاده از CLI پشتیبان";
 "Balance updates in near-real time (up to 5 min lag)" = "به روزرسانی تعادل تقریبا در زمان واقعی (تا ۵ دقیقه تأخیر)";
 "Daily billing data finalizes at 07:00 UTC" = "داده های صورتحساب روزانه در ساعت ۰۷:۰۰ نهایی می شود UTC";
+"Banked reset: %d available" = "بازنشانی ذخیره‌شده: %d موجود";
+"Banked resets: %d available" = "بازنشانی‌های ذخیره‌شده: %d موجود";
+"Expires: %@" = "انقضا: %@";
 "%@ of %@ credits left" = "%@ از %@ اعتبار باقی مانده";
 "%@ of %@ bonus credits left" = "%@ از %@ اعتبار اضافی باقی مانده";
 "%@ / %@ (%@ remaining)" = "%@ / %@ (%@ باقی مانده)";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -790,6 +790,9 @@
 "Using CLI fallback" = "การใช้ CLI สํารอง";
 "Balance updates in near-real time (up to 5 min lag)" = "อัปเดตเครื่องชั่งแบบเกือบเรียลไทม์ (หน่วงสูงสุด 5 นาที)";
 "Daily billing data finalizes at 07:00 UTC" = "ข้อมูลการเรียกเก็บเงินรายวันจะสรุปเวลา 07:00 น. UTC";
+"Banked reset: %d available" = "รีเซ็ตที่เก็บไว้: พร้อมใช้ %d รายการ";
+"Banked resets: %d available" = "รีเซ็ตที่เก็บไว้: พร้อมใช้ %d รายการ";
+"Expires: %@" = "หมดอายุ: %@";
 "%@ of %@ credits left" = "เหลือ %@ จาก %@ หน่วยกิต";
 "%@ of %@ bonus credits left" = "%@ จาก %@ เครดิตโบนัสที่เหลืออยู่";
 "%@ / %@ (%@ remaining)" = "%@ / %@ (เหลือ %@)";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -768,6 +768,9 @@
 "Using CLI fallback" = "使用 CLI 回退";
 "Balance updates in near-real time (up to 5 min lag)" = "余额接近实时更新（最多延迟 5 分钟）";
 "Daily billing data finalizes at 07:00 UTC" = "每日账单数据会在 UTC 07:00 完成结算";
+"Banked reset: %d available" = "已存重置：%d 个可用";
+"Banked resets: %d available" = "已存重置：%d 个可用";
+"Expires: %@" = "过期：%@";
 "%@ of %@ credits left" = "剩余 %@ / %@ 点额度";
 "%@ of %@ bonus credits left" = "剩余 %@ / %@ 点奖励额度";
 "%@ / %@ (%@ remaining)" = "%@ / %@（剩余 %@）";

--- a/Sources/CodexBar/StatusItemController+BankedResetsMenu.swift
+++ b/Sources/CodexBar/StatusItemController+BankedResetsMenu.swift
@@ -1,0 +1,35 @@
+import AppKit
+import CodexBarCore
+
+extension StatusItemController {
+    func makeBankedResetsMenuItem(for provider: UsageProvider) -> NSMenuItem? {
+        guard provider == .codex else { return nil }
+        guard let bankedResets = self.store.codexConsumerProjectionIfNeeded(
+            for: .codex,
+            surface: .liveCard)?.bankedResets
+        else { return nil }
+        let count = bankedResets.availableCount
+        guard count > 0 else { return nil }
+
+        let titleKey = count == 1 ? "Banked reset: %d available" : "Banked resets: %d available"
+        let title = String(format: L(titleKey), count)
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = true
+        if let image = NSImage(systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: nil) {
+            image.isTemplate = true
+            image.size = NSSize(width: 16, height: 16)
+            item.image = image
+        }
+
+        let expiryDates = bankedResets.expiryDates
+        if !expiryDates.isEmpty {
+            let formatter = DateFormatter()
+            formatter.locale = .current
+            formatter.timeZone = .current
+            formatter.setLocalizedDateFormatFromTemplate("MMM d")
+            let expiryText = expiryDates.map { formatter.string(from: $0) }.joined(separator: " · ")
+            self.applySubtitle(String(format: L("Expires: %@"), expiryText), to: item, title: title)
+        }
+        return item
+    }
+}

--- a/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
+++ b/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
@@ -56,6 +56,10 @@ extension StatusItemController {
                 heightCacheFingerprint: model.heightFingerprint(section: "card"),
                 containsInteractiveControls: true))
         }
+        if let bankedResetsItem = self.makeBankedResetsMenuItem(for: context.currentProvider) {
+            menu.addItem(.separator())
+            menu.addItem(bankedResetsItem)
+        }
         menu.addItem(.separator())
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
             menu.addItem(.separator())

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -115,9 +115,11 @@ extension StatusItemController {
             }
         }
 
-        if self.isMenuRefreshEnabled, (provider ?? self.lastMenuProvider) == .codex {
+        let resolvedOpenMenuProvider = provider ?? self.lastMenuProvider
+        if self.isMenuRefreshEnabled, resolvedOpenMenuProvider == .codex {
             self.deferOpenAIDashboardRefreshUntilMenuCloses(reason: "parent menu open")
         }
+        self.scheduleBankedResetsRefreshForOpenCodexMenuIfNeeded(provider: resolvedOpenMenuProvider)
         if self.settings.providerStorageFootprintsEnabled {
             self.store.refreshStorageFootprintsForOverview()
         }
@@ -645,6 +647,10 @@ extension StatusItemController {
             heightCacheScope: context.currentProvider.rawValue,
             heightCacheFingerprint: renderedModel.heightFingerprint(section: "card"),
             containsInteractiveControls: true))
+        if let bankedResetsItem = self.makeBankedResetsMenuItem(for: context.currentProvider) {
+            menu.addItem(.separator())
+            menu.addItem(bankedResetsItem)
+        }
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
             menu.addItem(.separator())
         }
@@ -1289,6 +1295,11 @@ extension StatusItemController {
                 heightCacheScope: provider.rawValue,
                 heightCacheFingerprint: layoutModel.heightFingerprint(section: "header"),
                 containsInteractiveControls: true))
+        }
+
+        if let bankedResetsItem = self.makeBankedResetsMenuItem(for: provider) {
+            menu.addItem(.separator())
+            menu.addItem(bankedResetsItem)
         }
 
         if hasStorage || hasCredits || hasExtraUsage || hasCost {

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -119,6 +119,12 @@ extension StatusItemController {
             "credits=\(self.store.credits == nil ? "0" : "1")",
             "planHistoryRevision=\(self.store.planUtilizationHistoryRevision)",
         ]
+        if self.openMenus.values.contains(where: { self.menuProvider(for: $0) == .codex }),
+           let bankedResets = self.store.bankedResets,
+           bankedResets.availableCount > 0
+        {
+            parts.append("bankedResets=\(bankedResets.availableCount)")
+        }
 
         for provider in self.store.enabledProvidersForDisplay() {
             let tokenSignature = self.tokenSnapshotReadinessSignature(for: provider)
@@ -134,6 +140,23 @@ extension StatusItemController {
         }
 
         return parts.joined(separator: "|")
+    }
+
+    func scheduleBankedResetsRefreshForOpenCodexMenuIfNeeded(provider: UsageProvider?) {
+        guard self.isMenuRefreshEnabled else { return }
+        guard provider == .codex else { return }
+        guard self.store.bankedResets == nil else { return }
+
+        let expectedGuard = self.store.freshCodexAccountScopedRefreshGuard()
+        guard expectedGuard.identity != .unresolved,
+              expectedGuard.accountKey != nil,
+              expectedGuard.authFingerprint != nil
+        else {
+            return
+        }
+
+        self.store.scheduleBankedResetsRefreshIfNeeded(
+            minimumSnapshotUpdatedAt: self.store.snapshot(for: .codex)?.updatedAt)
     }
 
     static func dashboardBreakdownReadinessSignature(

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -408,6 +408,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastKnownScreenCount = NSScreen.screens.count
         // Status items for individual providers are now created lazily in updateVisibility()
         super.init()
+        self.lastMenuLocalizationSignature = self.menuLocalizationSignature()
         if !repairedStatusItemVisibilityKeys.isEmpty {
             self.menuLogger.info(
                 "Repaired hidden macOS status-item visibility defaults",

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -255,6 +255,7 @@ extension UsageStore {
             }
             if provider == .codex {
                 self.recordCodexHistoricalSampleIfNeeded(snapshot: backfilled)
+                self.scheduleBankedResetsRefreshIfNeeded(minimumSnapshotUpdatedAt: backfilled.updatedAt)
             }
         case let .failure(error):
             if provider == .codex,

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -143,6 +143,8 @@ final class UsageStore {
     var tokenRefreshInFlight: Set<UsageProvider> = []
     var credits: CreditsSnapshot?
     var lastCreditsError: String?
+    var bankedResets: CodexBankedResetsSnapshot?
+    var lastBankedResetsError: String?
     var openAIDashboard: OpenAIDashboardSnapshot?
     var lastOpenAIDashboardError: String?
     var openAIDashboardRequiresLogin: Bool = false
@@ -162,6 +164,9 @@ final class UsageStore {
     @ObservationIgnored var lastCreditsSnapshotAccountKey: String?
     @ObservationIgnored var lastCreditsSource: CodexCreditsSource = .none
     @ObservationIgnored var creditsFailureStreak: Int = 0
+    @ObservationIgnored var lastBankedResetsSnapshot: CodexBankedResetsSnapshot?
+    @ObservationIgnored var lastBankedResetsSnapshotAccountKey: String?
+    @ObservationIgnored var bankedResetsFailureStreak: Int = 0
     @ObservationIgnored var openAIDashboardAttachmentAuthorized: Bool = false {
         didSet {
             guard self.openAIDashboardAttachmentAuthorized != oldValue else { return }
@@ -181,6 +186,8 @@ final class UsageStore {
     @ObservationIgnored var openAIWebAccountDidChange: Bool = false
     @ObservationIgnored var creditsRefreshTask: Task<Void, Never>?
     @ObservationIgnored var creditsRefreshTaskKey: String?
+    @ObservationIgnored var bankedResetsRefreshTask: Task<Void, Never>?
+    @ObservationIgnored var bankedResetsRefreshTaskKey: String?
     @ObservationIgnored var openAIDashboardBackgroundRefreshTask: Task<Void, Never>?
     @ObservationIgnored var openAIDashboardBackgroundRefreshTaskKey: String?
     @ObservationIgnored var openAIDashboardRefreshTask: Task<Void, Never>?
@@ -198,6 +205,8 @@ final class UsageStore {
         Bool,
         TimeInterval) async throws -> OpenAIDashboardSnapshot)?
     @ObservationIgnored var _test_codexCreditsLoaderOverride: (@MainActor () async throws -> CreditsSnapshot)?
+    @ObservationIgnored var _test_codexBankedResetsLoaderOverride: (@MainActor () async throws
+        -> CodexBankedResetsSnapshot)?
     @ObservationIgnored var _test_widgetSnapshotSaveOverride: (@MainActor (WidgetSnapshot) async -> Void)?
     @ObservationIgnored var _test_providerRefreshOverride: (@MainActor (UsageProvider) async -> Void)?
     @ObservationIgnored var _test_tokenUsageRefreshOverride: (@MainActor (UsageProvider, Bool) async -> Void)?
@@ -596,11 +605,13 @@ final class UsageStore {
                 }
                 if forceTokenUsage {
                     group.addTask { await self.refreshCreditsNow(minimumSnapshotUpdatedAt: refreshStartedAt) }
+                    group.addTask { await self.refreshBankedResetsNow(minimumSnapshotUpdatedAt: refreshStartedAt) }
                 }
             }
 
             if !forceTokenUsage {
                 self.scheduleCreditsRefreshIfNeeded(minimumSnapshotUpdatedAt: refreshStartedAt)
+                self.scheduleBankedResetsRefreshIfNeeded(minimumSnapshotUpdatedAt: refreshStartedAt)
             }
 
             if forceTokenUsage {
@@ -645,6 +656,7 @@ final class UsageStore {
             if forceTokenUsage, self.openAIDashboardRequiresLogin {
                 await self.refreshProvider(.codex)
                 await self.refreshCreditsNow(minimumSnapshotUpdatedAt: refreshStartedAt)
+                await self.refreshBankedResetsNow(minimumSnapshotUpdatedAt: refreshStartedAt)
             }
 
             self.persistWidgetSnapshot(reason: "refresh")

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexBankedResetsFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexBankedResetsFetcher.swift
@@ -1,0 +1,70 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum CodexBankedResetsFetcher {
+    private static let bankedResetsPath = "/wham/rate-limit-reset-credits"
+
+    public static func fetchBankedResets(
+        accessToken: String,
+        accountId: String?,
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        now: Date = Date(),
+        configContents: String? = nil,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> CodexBankedResetsSnapshot
+    {
+        var request = URLRequest(url: Self.resolveBankedResetsURL(env: env, configContents: configContents))
+        request.httpMethod = "GET"
+        request.timeoutInterval = 30
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let accountId, !accountId.isEmpty {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+
+        do {
+            let response = try await transport.response(for: request)
+            let data = response.data
+
+            switch response.statusCode {
+            case 200...299:
+                do {
+                    let endpointResponse = try CodexBankedResetsResponse.decodeEndpointPayload(data)
+                    return endpointResponse.snapshot(updatedAt: now)
+                } catch {
+                    throw CodexOAuthFetchError.invalidResponse
+                }
+            case 401, 403:
+                throw CodexOAuthFetchError.unauthorized
+            default:
+                let body = String(data: data, encoding: .utf8)
+                throw CodexOAuthFetchError.serverError(response.statusCode, body)
+            }
+        } catch let error as CodexOAuthFetchError {
+            throw error
+        } catch {
+            throw CodexOAuthFetchError.networkError(error)
+        }
+    }
+
+    private static func resolveBankedResetsURL(env: [String: String], configContents: String?) -> URL {
+        let normalized = CodexChatGPTBaseURLResolver.resolveNormalizedBaseURL(
+            env: env,
+            configContents: configContents,
+            backendAPIResolution: .always)
+        let full = normalized + Self.bankedResetsPath
+        return URL(string: full) ?? URL(
+            string: CodexChatGPTBaseURLResolver.defaultBackendAPIBaseURL + Self.bankedResetsPath)!
+    }
+}
+
+#if DEBUG
+extension CodexBankedResetsFetcher {
+    static func _resolveBankedResetsURLForTesting(env: [String: String] = [:], configContents: String? = nil) -> URL {
+        self.resolveBankedResetsURL(env: env, configContents: configContents)
+    }
+}
+#endif

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexBankedResetsModels.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexBankedResetsModels.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+public struct CodexBankedResetsResponse: Decodable, Equatable, Sendable {
+    public let resets: [CodexBankedReset]
+    public let availableCount: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case resets = "credits"
+        case availableCount = "available_count"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.availableCount = try container.decodeIfPresent(Int.self, forKey: .availableCount)
+        let decodedResets = try container.decodeIfPresent([LossyBankedReset].self, forKey: .resets) ?? []
+        self.resets = decodedResets.compactMap(\.value)
+    }
+
+    public static func decodeEndpointPayload(_ data: Data) throws -> CodexBankedResetsResponse {
+        try JSONDecoder().decode(CodexBankedResetsResponse.self, from: data)
+    }
+
+    public func snapshot(updatedAt: Date) -> CodexBankedResetsSnapshot {
+        CodexBankedResetsSnapshot(
+            resets: self.resets,
+            availableCount: self.availableCount,
+            updatedAt: updatedAt)
+    }
+
+    private struct LossyBankedReset: Decodable {
+        let value: CodexBankedReset?
+
+        init(from decoder: Decoder) throws {
+            self.value = try? CodexBankedReset(from: decoder)
+        }
+    }
+}
+
+public struct CodexBankedResetsSnapshot: Equatable, Sendable {
+    public let resets: [CodexBankedReset]
+    private let endpointAvailableCount: Int?
+    public let updatedAt: Date
+
+    public init(resets: [CodexBankedReset], availableCount: Int?, updatedAt: Date) {
+        self.resets = resets
+        self.endpointAvailableCount = availableCount
+        self.updatedAt = updatedAt
+    }
+
+    public var availableCount: Int {
+        self.endpointAvailableCount ?? self.availableResets.count
+    }
+
+    public var availableResets: [CodexBankedReset] {
+        self.resets
+            .filter { $0.isAvailable(referenceDate: self.updatedAt) }
+            .sorted { lhs, rhs in
+                switch (lhs.expiresAt, rhs.expiresAt) {
+                case let (lhs?, rhs?):
+                    lhs < rhs
+                case (_?, nil):
+                    true
+                case (nil, _?):
+                    false
+                case (nil, nil):
+                    lhs.id < rhs.id
+                }
+            }
+    }
+
+    public var nextExpiry: Date? {
+        self.availableResets.compactMap(\.expiresAt).min()
+    }
+}
+
+public struct CodexBankedReset: Decodable, Equatable, Sendable {
+    public let id: String
+    public let resetType: String?
+    public let status: CodexBankedResetStatus
+    public let grantedAt: Date?
+    public let expiresAt: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case resetType = "reset_type"
+        case status
+        case grantedAt = "granted_at"
+        case expiresAt = "expires_at"
+    }
+
+    public init(id: String, resetType: String?, status: CodexBankedResetStatus, grantedAt: Date?, expiresAt: Date?) {
+        self.id = id
+        self.resetType = resetType
+        self.status = status
+        self.grantedAt = grantedAt
+        self.expiresAt = expiresAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.resetType = try? container.decodeIfPresent(String.self, forKey: .resetType)
+        self.status = (try? container.decode(CodexBankedResetStatus.self, forKey: .status)) ?? .unknown("")
+        self.grantedAt = Self.decodeDate(container, forKey: .grantedAt)
+        self.expiresAt = Self.decodeDate(container, forKey: .expiresAt)
+    }
+
+    func isAvailable(referenceDate: Date) -> Bool {
+        guard !self.status.isUnavailable else { return false }
+        if let expiresAt {
+            return expiresAt > referenceDate
+        }
+        return true
+    }
+
+    private static func decodeDate(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) -> Date? {
+        guard let value = try? container.decodeIfPresent(String.self, forKey: key), !value.isEmpty else { return nil }
+        return Self.parseDate(value)
+    }
+
+    private static func parseDate(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: value) {
+            return date
+        }
+        return ISO8601DateFormatter().date(from: value)
+    }
+}
+
+public enum CodexBankedResetStatus: Equatable, Sendable {
+    case available
+    case redeemed
+    case expired
+    case unknown(String)
+
+    fileprivate var isUnavailable: Bool {
+        switch self {
+        case .redeemed, .expired, .unknown:
+            true
+        case .available:
+            false
+        }
+    }
+}
+
+extension CodexBankedResetStatus: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        switch value {
+        case "available":
+            self = .available
+        case "redeemed":
+            self = .redeemed
+        case "expired":
+            self = .expired
+        default:
+            self = .unknown(value)
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexChatGPTBaseURLResolver.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexChatGPTBaseURLResolver.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+enum CodexChatGPTBaseURLResolver {
+    static let defaultBackendAPIBaseURL = "https://chatgpt.com/backend-api"
+
+    enum BackendAPIResolution {
+        case chatGPTHostsOnly
+        case always
+    }
+
+    static func resolveNormalizedBaseURL(
+        env: [String: String],
+        configContents: String? = nil,
+        backendAPIResolution: BackendAPIResolution) -> String
+    {
+        let baseURL = self.resolveBaseURL(env: env, configContents: configContents)
+        return self.normalizeBaseURL(baseURL, backendAPIResolution: backendAPIResolution)
+    }
+
+    private static func resolveBaseURL(env: [String: String], configContents: String?) -> String {
+        if let configContents, let parsed = self.parseChatGPTBaseURL(from: configContents) {
+            return parsed
+        }
+        if let contents = self.loadConfigContents(env: env),
+           let parsed = self.parseChatGPTBaseURL(from: contents)
+        {
+            return parsed
+        }
+        return Self.defaultBackendAPIBaseURL
+    }
+
+    private static func normalizeBaseURL(_ value: String, backendAPIResolution: BackendAPIResolution) -> String {
+        var trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { trimmed = Self.defaultBackendAPIBaseURL }
+        while trimmed.hasSuffix("/") {
+            trimmed.removeLast()
+        }
+
+        switch backendAPIResolution {
+        case .chatGPTHostsOnly:
+            if self.isChatGPTHost(trimmed), !trimmed.contains("/backend-api") {
+                trimmed += "/backend-api"
+            }
+        case .always:
+            if !trimmed.contains("/backend-api") {
+                trimmed += "/backend-api"
+            }
+        }
+
+        return trimmed
+    }
+
+    private static func isChatGPTHost(_ value: String) -> Bool {
+        value.hasPrefix("https://chatgpt.com") || value.hasPrefix("https://chat.openai.com")
+    }
+
+    private static func parseChatGPTBaseURL(from contents: String) -> String? {
+        for rawLine in contents.split(whereSeparator: \.isNewline) {
+            let line = rawLine.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: true).first
+            let trimmed = line?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !trimmed.isEmpty else { continue }
+            let parts = trimmed.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: true)
+            guard parts.count == 2 else { continue }
+            let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard key == "chatgpt_base_url" else { continue }
+            var value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            if value.hasPrefix("\""), value.hasSuffix("\"") {
+                value = String(value.dropFirst().dropLast())
+            } else if value.hasPrefix("'"), value.hasSuffix("'") {
+                value = String(value.dropFirst().dropLast())
+            }
+            return value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return nil
+    }
+
+    private static func loadConfigContents(env: [String: String]) -> String? {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let codexHome = env["CODEX_HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let root = (codexHome?.isEmpty == false) ? URL(fileURLWithPath: codexHome!) : home
+            .appendingPathComponent(".codex")
+        let url = root.appendingPathComponent("config.toml")
+        return try? String(contentsOf: url, encoding: .utf8)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
@@ -67,6 +67,17 @@ public enum CodexOAuthCredentialsStore {
         return try self.parse(data: data)
     }
 
+    public static func loadRefreshed(
+        env: [String: String] = ProcessInfo.processInfo.environment) async throws -> CodexOAuthCredentials
+    {
+        var credentials = try self.load(env: env)
+        if credentials.needsRefresh, !credentials.refreshToken.isEmpty {
+            credentials = try await CodexTokenRefresher.refresh(credentials)
+            try self.save(credentials, env: env)
+        }
+        return credentials
+    }
+
     public static func parse(data: Data) throws -> CodexOAuthCredentials {
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw CodexOAuthCredentialsError.decodeFailed("Invalid JSON")

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -230,7 +230,6 @@ public enum CodexOAuthFetchError: LocalizedError, Sendable {
 }
 
 public enum CodexOAuthUsageFetcher {
-    private static let defaultChatGPTBaseURL = "https://chatgpt.com/backend-api/"
     private static let chatGPTUsagePath = "/wham/usage"
     private static let codexUsagePath = "/api/codex/usage"
 
@@ -279,66 +278,14 @@ public enum CodexOAuthUsageFetcher {
     }
 
     private static func resolveUsageURL(env: [String: String], configContents: String?) -> URL {
-        let baseURL = self.resolveChatGPTBaseURL(env: env, configContents: configContents)
-        let normalized = self.normalizeChatGPTBaseURL(baseURL)
+        let normalized = CodexChatGPTBaseURLResolver.resolveNormalizedBaseURL(
+            env: env,
+            configContents: configContents,
+            backendAPIResolution: .chatGPTHostsOnly)
         let path = normalized.contains("/backend-api") ? Self.chatGPTUsagePath : Self.codexUsagePath
         let full = normalized + path
-        return URL(string: full) ?? URL(string: Self.defaultChatGPTBaseURL + Self.chatGPTUsagePath)!
-    }
-
-    private static func resolveChatGPTBaseURL(env: [String: String], configContents: String?) -> String {
-        if let configContents, let parsed = self.parseChatGPTBaseURL(from: configContents) {
-            return parsed
-        }
-        if let contents = self.loadConfigContents(env: env),
-           let parsed = self.parseChatGPTBaseURL(from: contents)
-        {
-            return parsed
-        }
-        return Self.defaultChatGPTBaseURL
-    }
-
-    private static func normalizeChatGPTBaseURL(_ value: String) -> String {
-        var trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { trimmed = Self.defaultChatGPTBaseURL }
-        while trimmed.hasSuffix("/") {
-            trimmed.removeLast()
-        }
-        if trimmed.hasPrefix("https://chatgpt.com") || trimmed.hasPrefix("https://chat.openai.com"),
-           !trimmed.contains("/backend-api")
-        {
-            trimmed += "/backend-api"
-        }
-        return trimmed
-    }
-
-    private static func parseChatGPTBaseURL(from contents: String) -> String? {
-        for rawLine in contents.split(whereSeparator: \.isNewline) {
-            let line = rawLine.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: true).first
-            let trimmed = line?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            guard !trimmed.isEmpty else { continue }
-            let parts = trimmed.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: true)
-            guard parts.count == 2 else { continue }
-            let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
-            guard key == "chatgpt_base_url" else { continue }
-            var value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-            if value.hasPrefix("\""), value.hasSuffix("\"") {
-                value = String(value.dropFirst().dropLast())
-            } else if value.hasPrefix("'"), value.hasSuffix("'") {
-                value = String(value.dropFirst().dropLast())
-            }
-            return value.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        return nil
-    }
-
-    private static func loadConfigContents(env: [String: String]) -> String? {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let codexHome = env["CODEX_HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let root = (codexHome?.isEmpty == false) ? URL(fileURLWithPath: codexHome!) : home
-            .appendingPathComponent(".codex")
-        let url = root.appendingPathComponent("config.toml")
-        return try? String(contentsOf: url, encoding: .utf8)
+        return URL(string: full) ?? URL(
+            string: CodexChatGPTBaseURLResolver.defaultBackendAPIBaseURL + Self.chatGPTUsagePath)!
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -167,13 +167,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        var credentials = try CodexOAuthCredentialsStore.load(env: context.env)
-
-        if credentials.needsRefresh, !credentials.refreshToken.isEmpty {
-            credentials = try await CodexTokenRefresher.refresh(credentials)
-            try CodexOAuthCredentialsStore.save(credentials, env: context.env)
-        }
-
+        let credentials = try await CodexOAuthCredentialsStore.loadRefreshed(env: context.env)
         let usage = try await CodexOAuthUsageFetcher.fetchUsage(
             accessToken: credentials.accessToken,
             accountId: credentials.accountId,

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshBankedResetsTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshBankedResetsTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `banked resets fallback only reuses cache for the same codex account`() async {
+        let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-banked-resets")
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = self.liveAccount(email: "alpha@example.com")
+
+        let store = self.makeUsageStore(settings: settings)
+        let cachedResets = self.bankedResets(count: 2)
+        store._setSnapshotForTesting(self.codexSnapshot(email: "alpha@example.com", usedPercent: 10), provider: .codex)
+        store.lastBankedResetsSnapshot = cachedResets
+        store.lastBankedResetsSnapshotAccountKey = "alpha@example.com"
+        store._test_codexBankedResetsLoaderOverride = {
+            throw TestRefreshError(message: "Codex banked resets data not available yet")
+        }
+        defer { store._test_codexBankedResetsLoaderOverride = nil }
+
+        await store.refreshBankedResetsIfNeeded()
+        #expect(store.bankedResets == cachedResets)
+        #expect(store.lastBankedResetsError == nil)
+
+        settings._test_liveSystemCodexAccount = self.liveAccount(email: "beta@example.com")
+        store._setSnapshotForTesting(self.codexSnapshot(email: "beta@example.com", usedPercent: 10), provider: .codex)
+
+        await store.refreshBankedResetsIfNeeded()
+        #expect(store.bankedResets == nil)
+        #expect(store.lastBankedResetsError == "Codex banked resets are still loading; will retry shortly.")
+    }
+
+    @Test
+    func `refresh loads banked resets when codex email is discovered by usage in the same cycle`() async {
+        let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-refresh-banked-resets")
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "alpha@example.com",
+            identity: .providerAccount(id: "acct-alpha"))
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+        store._test_codexBankedResetsLoaderOverride = { self.bankedResets(count: 2) }
+        defer { store._test_codexBankedResetsLoaderOverride = nil }
+
+        let refreshTask = Task { await store.refresh() }
+        await blocker.waitUntilStarted()
+        await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 12)))
+        await refreshTask.value
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "alpha@example.com")
+
+        await store.bankedResetsRefreshTask?.value
+
+        #expect(store.bankedResets?.availableCount == 2)
+        #expect(store.lastBankedResetsError == nil)
+    }
+
+    @Test
+    func `codex provider refresh schedules banked resets refresh`() async {
+        let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-provider-refresh-banked-resets")
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "alpha@example.com",
+            identity: .providerAccount(id: "acct-alpha"))
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+        store._test_codexBankedResetsLoaderOverride = { self.bankedResets(count: 2) }
+        defer { store._test_codexBankedResetsLoaderOverride = nil }
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 12)))
+        await refreshTask.value
+
+        await store.bankedResetsRefreshTask?.value
+
+        #expect(store.bankedResets?.availableCount == 2)
+        #expect(store.lastBankedResetsError == nil)
+    }
+
+    @Test
+    func `banked resets survive live identity enrichment from email to provider account`() {
+        let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-banked-resets-identity-bridge")
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "alpha@example.com",
+            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+
+        let store = self.makeUsageStore(settings: settings)
+        let cachedResets = self.bankedResets(count: 2)
+        store.bankedResets = cachedResets
+        store.lastBankedResetsSnapshot = cachedResets
+        store.lastBankedResetsSnapshotAccountKey = "alpha@example.com"
+        let emailOnlyGuard = store.currentCodexAccountScopedRefreshGuard()
+        store.lastCodexAccountScopedRefreshGuard = emailOnlyGuard
+        #expect(emailOnlyGuard.identity == .emailOnly(normalizedEmail: "alpha@example.com"))
+
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "alpha@example.com",
+            identity: .providerAccount(id: "acct-alpha"))
+
+        let applyGuard = store.codexScopedNonUsageSuccessApplyGuard(expectedGuard: emailOnlyGuard)
+        #expect(applyGuard?.identity == .providerAccount(id: "acct-alpha"))
+
+        let didInvalidate = store.prepareCodexAccountScopedRefreshIfNeeded()
+
+        #expect(!didInvalidate)
+        #expect(store.bankedResets == cachedResets)
+        #expect(store.lastBankedResetsSnapshot == cachedResets)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.identity == .providerAccount(id: "acct-alpha"))
+    }
+}

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
@@ -100,6 +100,25 @@ extension CodexAccountScopedRefreshTests {
         CreditsSnapshot(remaining: remaining, events: [], updatedAt: Date())
     }
 
+    func bankedResets(
+        count: Int,
+        accountOffset: TimeInterval = 0,
+        updatedAt: Date = Date()) -> CodexBankedResetsSnapshot
+    {
+        let resets = (0..<count).map { index in
+            CodexBankedReset(
+                id: "RateLimitResetCredit_\(Int(accountOffset))_\(index)",
+                resetType: "codex_rate_limits",
+                status: .available,
+                grantedAt: updatedAt,
+                expiresAt: updatedAt.addingTimeInterval(86400 * Double(index + 1)))
+        }
+        return CodexBankedResetsSnapshot(
+            resets: resets,
+            availableCount: count,
+            updatedAt: updatedAt)
+    }
+
     func dashboard(email: String, creditsRemaining: Double, usedPercent: Double) -> OpenAIDashboardSnapshot {
         OpenAIDashboardSnapshot(
             signedInEmail: email,

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
@@ -16,6 +16,7 @@ struct CodexAccountScopedRefreshTests {
         let store = self.makeUsageStore(settings: settings)
         let staleSnapshot = self.codexSnapshot(email: "alpha@example.com", usedPercent: 10)
         let staleCredits = self.credits(remaining: 42)
+        let staleBankedResets = self.bankedResets(count: 2)
         let staleDashboard = self.dashboard(email: "alpha@example.com", creditsRemaining: 42, usedPercent: 20)
         let tokenSnapshot = CostUsageTokenSnapshot(
             sessionTokens: 120,
@@ -31,6 +32,9 @@ struct CodexAccountScopedRefreshTests {
         store.lastCreditsSnapshot = staleCredits
         store.lastCreditsSnapshotAccountKey = "alpha@example.com"
         store.lastCreditsSource = .api
+        store.bankedResets = staleBankedResets
+        store.lastBankedResetsSnapshot = staleBankedResets
+        store.lastBankedResetsSnapshotAccountKey = "alpha@example.com"
         store.openAIDashboard = staleDashboard
         store.lastOpenAIDashboardSnapshot = staleDashboard
         store.lastOpenAIDashboardTargetEmail = "alpha@example.com"
@@ -51,6 +55,9 @@ struct CodexAccountScopedRefreshTests {
         #expect(store.lastCreditsSnapshot == nil)
         #expect(store.lastCreditsSnapshotAccountKey == nil)
         #expect(store.lastCreditsSource == .none)
+        #expect(store.bankedResets == nil)
+        #expect(store.lastBankedResetsSnapshot == nil)
+        #expect(store.lastBankedResetsSnapshotAccountKey == nil)
         #expect(store.openAIDashboard == nil)
         #expect(store.lastOpenAIDashboardSnapshot == nil)
         #expect(store.tokenSnapshots[.codex] == tokenSnapshot)

--- a/Tests/CodexBarTests/CodexBankedResetsFetcherTests.swift
+++ b/Tests/CodexBarTests/CodexBankedResetsFetcherTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct CodexBankedResetsFetcherTests {
+    @Test
+    func `fetcher sends read only request with CodexBar OAuth headers`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            #expect(request.httpMethod == "GET")
+            #expect(request.url?.absoluteString == "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer access-token")
+            #expect(request.value(forHTTPHeaderField: "User-Agent") == "CodexBar")
+            #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+            #expect(request.value(forHTTPHeaderField: "ChatGPT-Account-Id") == "account-123")
+            #expect(request.value(forHTTPHeaderField: "OpenAI-Beta") == nil)
+            #expect(request.value(forHTTPHeaderField: "originator") == nil)
+
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            return (Data(#"{"credits":[],"available_count":0}"#.utf8), response)
+        }
+
+        let snapshot = try await CodexBankedResetsFetcher.fetchBankedResets(
+            accessToken: "access-token",
+            accountId: "account-123",
+            env: [:],
+            now: Date(timeIntervalSince1970: 1_700_000_000),
+            transport: transport)
+
+        #expect(snapshot.availableCount == 0)
+        #expect(snapshot.updatedAt == Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    @Test
+    func `fetcher uses configured ChatGPT backend base URL`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            #expect(request.url?.absoluteString == "https://example.test/backend-api/wham/rate-limit-reset-credits")
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil)!
+            return (Data(#"{"credits":[],"available_count":0}"#.utf8), response)
+        }
+        let config = #"chatgpt_base_url = "https://example.test/backend-api""#
+
+        _ = try await CodexBankedResetsFetcher.fetchBankedResets(
+            accessToken: "access-token",
+            accountId: nil,
+            env: [:],
+            configContents: config,
+            transport: transport)
+    }
+
+    @Test
+    func `fetcher maps unauthorized response to OAuth unauthorized error`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 401,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil)!
+            return (Data(#"{"error":{"message":"bad token"}}"#.utf8), response)
+        }
+
+        do {
+            _ = try await CodexBankedResetsFetcher.fetchBankedResets(
+                accessToken: "access-token",
+                accountId: nil,
+                env: [:],
+                transport: transport)
+            Issue.record("Expected unauthorized error")
+        } catch let error as CodexOAuthFetchError {
+            #expect(error.errorDescription == CodexOAuthFetchError.unauthorized.errorDescription)
+        } catch {
+            Issue.record("Expected CodexOAuthFetchError, got \(error)")
+        }
+    }
+}

--- a/Tests/CodexBarTests/CodexBankedResetsModelsTests.swift
+++ b/Tests/CodexBarTests/CodexBankedResetsModelsTests.swift
@@ -1,0 +1,162 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CodexBankedResetsModelsTests {
+    @Test
+    func `decodes endpoint payload into banked resets snapshot`() throws {
+        let json = """
+        {
+          "credits": [
+            {
+              "id": "RateLimitResetCredit_available",
+              "reset_type": "codex_rate_limits",
+              "status": "available",
+              "granted_at": "2026-06-12T01:29:41.346025Z",
+              "expires_at": "2026-07-12T01:29:41.346025Z",
+              "title": "One free rate limit reset",
+              "description": "Thanks for using Codex!"
+            },
+            {
+              "id": "RateLimitResetCredit_redeemed",
+              "reset_type": "codex_rate_limits",
+              "status": "redeemed",
+              "granted_at": "2026-06-01T00:00:00Z",
+              "expires_at": "2026-07-01T00:00:00Z"
+            }
+          ],
+          "available_count": 1
+        }
+        """
+        let updatedAt = try #require(Self.date("2026-06-18T10:00:00Z"))
+
+        let response = try CodexBankedResetsResponse.decodeEndpointPayload(Data(json.utf8))
+        let snapshot = response.snapshot(updatedAt: updatedAt)
+
+        #expect(snapshot.availableCount == 1)
+        #expect(snapshot.resets.map(\.id) == [
+            "RateLimitResetCredit_available",
+            "RateLimitResetCredit_redeemed",
+        ])
+        #expect(snapshot.resets[0].status == .available)
+        #expect(snapshot.resets[1].status == .redeemed)
+        #expect(snapshot.availableResets.map(\.id) == ["RateLimitResetCredit_available"])
+        #expect(snapshot.nextExpiry == Self.date("2026-07-12T01:29:41.346025Z"))
+        #expect(snapshot.updatedAt == updatedAt)
+    }
+
+    @Test
+    func `falls back to local available reset count when endpoint omits available count`() throws {
+        let json = """
+        {
+          "credits": [
+            {
+              "id": "RateLimitResetCredit_available",
+              "status": "available",
+              "granted_at": "2026-06-12T01:29:41Z",
+              "expires_at": "2026-07-12T01:29:41Z"
+            },
+            {
+              "id": "RateLimitResetCredit_expired_by_status",
+              "status": "expired",
+              "granted_at": "2026-06-12T01:29:41Z",
+              "expires_at": "2026-07-12T01:29:41Z"
+            },
+            {
+              "id": "RateLimitResetCredit_expired_by_date",
+              "status": "available",
+              "granted_at": "2026-05-12T01:29:41Z",
+              "expires_at": "2026-06-12T01:29:41Z"
+            },
+            {
+              "id": "RateLimitResetCredit_unknown",
+              "status": "future_server_status",
+              "granted_at": "2026-06-12T01:29:41Z",
+              "expires_at": "2026-07-13T01:29:41Z"
+            },
+            {
+              "id": "RateLimitResetCredit_redeemed",
+              "status": "redeemed",
+              "granted_at": "2026-06-12T01:29:41Z",
+              "expires_at": "2026-07-14T01:29:41Z"
+            }
+          ]
+        }
+        """
+        let updatedAt = try #require(Self.date("2026-06-18T10:00:00Z"))
+
+        let response = try CodexBankedResetsResponse.decodeEndpointPayload(Data(json.utf8))
+        let snapshot = response.snapshot(updatedAt: updatedAt)
+
+        #expect(snapshot.availableCount == 1)
+        #expect(snapshot.availableResets.map(\.id) == [
+            "RateLimitResetCredit_available",
+        ])
+    }
+
+    @Test
+    func `keeps unknown reset status without counting it as available`() throws {
+        let json = """
+        {
+          "credits": [
+            {
+              "id": "RateLimitResetCredit_pending",
+              "status": "pending_review",
+              "granted_at": "2026-06-12T01:29:41Z",
+              "expires_at": "2026-07-12T01:29:41Z"
+            }
+          ],
+          "available_count": 0
+        }
+        """
+
+        let response = try CodexBankedResetsResponse.decodeEndpointPayload(Data(json.utf8))
+        let updatedAt = try #require(Self.date("2026-06-18T10:00:00Z"))
+        let snapshot = response.snapshot(updatedAt: updatedAt)
+
+        #expect(response.resets.first?.status == .unknown("pending_review"))
+        #expect(snapshot.availableCount == 0)
+        #expect(snapshot.availableResets.isEmpty)
+    }
+
+    @Test
+    func `skips malformed reset entries without dropping the whole response`() throws {
+        let json = """
+        {
+          "credits": [
+            {
+              "id": "RateLimitResetCredit_available",
+              "status": "available",
+              "expires_at": "2026-07-12T01:29:41Z"
+            },
+            {
+              "status": "available",
+              "expires_at": "2026-07-13T01:29:41Z"
+            },
+            {
+              "id": "RateLimitResetCredit_redeemed",
+              "status": "redeemed",
+              "expires_at": "2026-07-14T01:29:41Z"
+            }
+          ],
+          "available_count": 1
+        }
+        """
+        let updatedAt = try #require(Self.date("2026-06-18T10:00:00Z"))
+
+        let response = try CodexBankedResetsResponse.decodeEndpointPayload(Data(json.utf8))
+        let snapshot = response.snapshot(updatedAt: updatedAt)
+
+        #expect(snapshot.resets.map(\.id) == [
+            "RateLimitResetCredit_available",
+            "RateLimitResetCredit_redeemed",
+        ])
+        #expect(snapshot.availableResets.map(\.id) == ["RateLimitResetCredit_available"])
+    }
+
+    private static func date(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+    }
+}

--- a/Tests/CodexBarTests/CodexConsumerProjectionTests.swift
+++ b/Tests/CodexBarTests/CodexConsumerProjectionTests.swift
@@ -106,6 +106,18 @@ struct CodexConsumerProjectionTests {
             provider: .codex)
         store.credits = CreditsSnapshot(remaining: 42, events: [], updatedAt: now)
         store.lastCreditsError = "Frame load interrupted"
+        store.bankedResets = CodexBankedResetsSnapshot(
+            resets: [
+                CodexBankedReset(
+                    id: "RateLimitResetCredit_live",
+                    resetType: "codex_rate_limits",
+                    status: .available,
+                    grantedAt: now,
+                    expiresAt: now.addingTimeInterval(86400)),
+            ],
+            availableCount: 1,
+            updatedAt: now)
+        store.lastBankedResetsError = "Live banked resets error"
         store.openAIDashboard = OpenAIDashboardSnapshot(
             signedInEmail: "codex@example.com",
             codeReviewRemainingPercent: 88,
@@ -136,6 +148,7 @@ struct CodexConsumerProjectionTests {
         #expect(projection.visibleRateLanes == [.session])
         #expect(projection.dashboardVisibility == .hidden)
         #expect(projection.credits == nil)
+        #expect(projection.bankedResets == nil)
         #expect(projection.supplementalMetrics.isEmpty)
         #expect(!projection.canShowBuyCredits)
         #expect(!projection.hasUsageBreakdown)
@@ -143,6 +156,53 @@ struct CodexConsumerProjectionTests {
         #expect(projection.userFacingErrors.usage == "Override error")
         #expect(projection.userFacingErrors.credits == nil)
         #expect(projection.userFacingErrors.dashboard == nil)
+    }
+
+    @Test
+    func `live card projection exposes banked resets adjunct`() {
+        let store = self.makeStore(suite: "CodexConsumerProjectionTests-banked-resets")
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let firstExpiry = now.addingTimeInterval(86400)
+        let secondExpiry = now.addingTimeInterval(2 * 86400)
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 20,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(1800),
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now),
+            provider: .codex)
+        store.bankedResets = CodexBankedResetsSnapshot(
+            resets: [
+                CodexBankedReset(
+                    id: "RateLimitResetCredit_1",
+                    resetType: "codex_rate_limits",
+                    status: .available,
+                    grantedAt: now,
+                    expiresAt: secondExpiry),
+                CodexBankedReset(
+                    id: "RateLimitResetCredit_2",
+                    resetType: "codex_rate_limits",
+                    status: .available,
+                    grantedAt: now,
+                    expiresAt: firstExpiry),
+                CodexBankedReset(
+                    id: "RateLimitResetCredit_3",
+                    resetType: "codex_rate_limits",
+                    status: .redeemed,
+                    grantedAt: now,
+                    expiresAt: now.addingTimeInterval(3 * 86400)),
+            ],
+            availableCount: nil,
+            updatedAt: now)
+
+        let projection = store.codexConsumerProjection(surface: .liveCard, now: now)
+
+        #expect(projection.bankedResets?.availableCount == 2)
+        #expect(projection.bankedResets?.expiryDates == [firstExpiry, secondExpiry])
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -78,6 +78,37 @@ struct CodexOAuthTests {
     }
 
     @Test
+    func `load refreshed returns fresh credentials without rewriting auth file`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-codex-oauth-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let authURL = root.appendingPathComponent("auth.json")
+        let json = """
+        {
+          "tokens": {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "account_id": "account-123"
+          },
+          "last_refresh": "\(ISO8601DateFormatter().string(from: Date()))"
+        }
+        """
+        try Data(json.utf8).write(to: authURL)
+        let before = try Data(contentsOf: authURL)
+
+        let creds = try await CodexOAuthCredentialsStore.loadRefreshed(env: ["CODEX_HOME": root.path])
+        let after = try Data(contentsOf: authURL)
+
+        #expect(creds.accessToken == "access-token")
+        #expect(creds.refreshToken == "refresh-token")
+        #expect(creds.accountId == "account-123")
+        #expect(after == before)
+    }
+
+    @Test
     func `decodes credits balance string`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/MenuSessionCoordinatorTests.swift
+++ b/Tests/CodexBarTests/MenuSessionCoordinatorTests.swift
@@ -42,6 +42,21 @@ struct MenuSessionCoordinatorTests {
     }
 
     @Test
+    func `data invalidation suppresses required preparation for menus first attached afterward`() {
+        var coordinator = MenuSessionCoordinator<String>()
+        let renderedMenu = "rendered"
+        let freshMenu = "fresh"
+
+        coordinator.invalidate(allowsStaleContent: false, requiresRebuild: true)
+        coordinator.markFresh(renderedMenu)
+        coordinator.invalidate(allowsStaleContent: false, requiresRebuild: true)
+        coordinator.invalidate(allowsStaleContent: true, requiresRebuild: false)
+
+        #expect(coordinator.closedPreparationPlan(for: [freshMenu]) == .none)
+        #expect(coordinator.closedPreparationPlan(for: [renderedMenu]) == .required(version: 2))
+    }
+
+    @Test
     func `stale content survives only a data generation after latest structural render`() {
         var coordinator = MenuSessionCoordinator<String>()
         let menu = "menu"

--- a/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
+++ b/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
@@ -58,6 +58,69 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `opening codex menu schedules missing banked resets refresh`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        self.enableOnlyCodexForInstantOpenTesting(settings)
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "codex@example.com",
+            authFingerprint: "fingerprint-alpha",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let now = Date()
+        var loaderCalls = 0
+        store._test_codexBankedResetsLoaderOverride = {
+            loaderCalls += 1
+            return CodexBankedResetsSnapshot(
+                resets: [
+                    CodexBankedReset(
+                        id: "reset-1",
+                        resetType: "codex_rate_limits",
+                        status: .available,
+                        grantedAt: now,
+                        expiresAt: now.addingTimeInterval(86400)),
+                    CodexBankedReset(
+                        id: "reset-2",
+                        resetType: "codex_rate_limits",
+                        status: .available,
+                        grantedAt: now,
+                        expiresAt: now.addingTimeInterval(172_800)),
+                ],
+                availableCount: 2,
+                updatedAt: now)
+        }
+        defer { store._test_codexBankedResetsLoaderOverride = nil }
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        for _ in 0..<50 where store.bankedResets == nil {
+            await Task.yield()
+        }
+
+        #expect(loaderCalls == 1)
+        #expect(store.bankedResets?.availableCount == 2)
+    }
+
+    @Test
     func `delayed open refresh does not rebuild fresh menu after unrelated data invalidation`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -66,6 +66,51 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `open codex menu tracks banked resets readiness signature`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        self.enableOnlyCodexForReadinessBaseline(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        store.bankedResets = CodexBankedResetsSnapshot(
+            resets: [],
+            availableCount: 0,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuProviders[ObjectIdentifier(menu)] = .codex
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+        let before = controller.menuAdjunctReadinessSignature()
+        store.bankedResets = CodexBankedResetsSnapshot(
+            resets: [
+                CodexBankedReset(
+                    id: "reset-1",
+                    resetType: "codex_rate_limits",
+                    status: .available,
+                    grantedAt: nil,
+                    expiresAt: Date(timeIntervalSince1970: 200)),
+            ],
+            availableCount: 1,
+            updatedAt: Date(timeIntervalSince1970: 100))
+
+        #expect(controller.menuAdjunctReadinessSignature() != before)
+        #expect(controller.didMenuAdjunctReadinessChange())
+    }
+
+    @Test
     func `root open during in flight refresh preserves stale content and does not resync baseline`() {
         // When `refreshMenuForOpenIfNeeded` keeps existing menu content during an in-flight provider
         // refresh, the readiness baseline must not be re-anchored to live store data. Otherwise the

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -1214,6 +1214,17 @@ extension StatusMenuTests {
             ],
             updatedAt: now)
         store._setSnapshotForTesting(usage.toUsageSnapshot(), provider: .openai)
+        store.bankedResets = CodexBankedResetsSnapshot(
+            resets: [
+                CodexBankedReset(
+                    id: "reset-1",
+                    resetType: "codex_rate_limits",
+                    status: .available,
+                    grantedAt: now,
+                    expiresAt: now.addingTimeInterval(86400)),
+            ],
+            availableCount: 1,
+            updatedAt: now)
 
         let controller = StatusItemController(
             store: store,
@@ -1232,6 +1243,7 @@ extension StatusMenuTests {
             .contains { ($0.representedObject as? String) == StatusItemController.costHistoryChartID } == true)
         #expect(menu.items.contains { ($0.representedObject as? String) == "menuCardHeader" } == false)
         #expect(menu.items.contains { ($0.representedObject as? String) == "menuCardExtraUsage" } == false)
+        #expect(menu.items.contains { $0.title.hasPrefix("Banked reset") } == false)
     }
 
     @Test
@@ -1257,7 +1269,25 @@ extension StatusMenuTests {
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let now = Date()
         store.credits = CreditsSnapshot(remaining: 100, events: [], updatedAt: Date())
+        store.bankedResets = CodexBankedResetsSnapshot(
+            resets: [
+                CodexBankedReset(
+                    id: "reset-1",
+                    resetType: "codex_rate_limits",
+                    status: .available,
+                    grantedAt: now,
+                    expiresAt: now.addingTimeInterval(86400)),
+                CodexBankedReset(
+                    id: "reset-2",
+                    resetType: "codex_rate_limits",
+                    status: .available,
+                    grantedAt: now,
+                    expiresAt: now.addingTimeInterval(172_800)),
+            ],
+            availableCount: 2,
+            updatedAt: now)
         store.openAIDashboard = OpenAIDashboardSnapshot(
             signedInEmail: "user@example.com",
             codeReviewRemainingPercent: 100,
@@ -1299,9 +1329,11 @@ extension StatusMenuTests {
         let ids = menu.items.compactMap { $0.representedObject as? String }
         let creditsIndex = ids.firstIndex(of: "menuCardCredits")
         let costIndex = ids.firstIndex(of: "menuCardCost")
+        let bankedResetsItem = menu.items.first { $0.title == "Banked resets: 2 available" }
         #expect(creditsIndex != nil)
         #expect(costIndex != nil)
         #expect(try #require(creditsIndex) < costIndex!)
+        #expect(bankedResetsItem?.isEnabled == true)
     }
 
     @Test

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,7 +1,8 @@
 ---
-summary: "Codex provider data sources: OpenAI web dashboard, Codex CLI RPC, credits, and local cost usage."
+summary: "Codex provider data sources: OpenAI web dashboard, Codex CLI RPC, credits, banked resets, and local cost usage."
 read_when:
   - Debugging Codex usage/credits parsing
+  - Updating Codex banked reset display
   - Updating OpenAI dashboard scraping or cookie import
   - Changing Codex CLI RPC or diagnostic PTY behavior
   - Reviewing local cost usage scanning
@@ -35,6 +36,7 @@ Usage source picker:
 - `additional_rate_limits[]` (model-specific limits such as GPT-5.3-Codex-Spark) map to named
   `UsageSnapshot.extraRateWindows` entries (Spark uses a stable `codex-spark` id / `Codex Spark` title).
   When the field is absent, the snapshot is unchanged.
+- Banked resets are a separate read-only OAuth adjunct, fetched outside the usage hot path.
 
 ### OpenAI web dashboard (optional, off by default)
 - Enable it in Preferences -> Providers -> Codex -> OpenAI web extras.
@@ -111,6 +113,23 @@ Usage source picker:
 - CLI RPC: `account/rateLimits/read` → credits balance.
 - CLI PTY diagnostics can still parse `Credits:` from saved/manual `/status` output.
 
+## Banked resets
+- Read-only first: CodexBar does not redeem or consume reset credits.
+- Source: refreshed Codex OAuth credentials from `~/.codex/auth.json` (or `$CODEX_HOME/auth.json`).
+- Endpoint: `GET https://chatgpt.com/backend-api/wham/rate-limit-reset-credits`.
+- Headers match CodexBar's OAuth usage requests: `Authorization`, `User-Agent: CodexBar`, `Accept: application/json`,
+  and `ChatGPT-Account-Id` when an account id is available. Do not add `OpenAI-Beta` or `originator`.
+- Response fields used:
+  - `available_count`
+  - `credits[].id`
+  - `credits[].status`
+  - `credits[].granted_at`
+  - `credits[].expires_at`
+- Refresh is an independent best-effort utility task. It uses the same Codex account-scoped guard as credits so cached
+  values do not leak across selected Codex accounts.
+- UI: the Codex menu card shows `Banked resets: N available` and an `Expires:` line in the usage notes area when
+  at least one reset is available.
+
 ## Cost usage (local log scan)
 - Source files:
   - Native Codex logs:
@@ -134,6 +153,9 @@ Usage source picker:
 - Web: `Sources/CodexBarCore/OpenAIWeb/*`
 - CLI RPC + diagnostic PTY parser: `Sources/CodexBarCore/UsageFetcher.swift`,
   `Sources/CodexBarCore/Providers/Codex/CodexStatusProbe.swift`
+- Banked resets: `Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexBankedResets*.swift`,
+  `Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift`,
+  `Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift`
 - Cost usage: `Sources/CodexBarCore/CostUsageFetcher.swift`,
   `Sources/CodexBarCore/PiSessionCostScanner.swift`,
   `Sources/CodexBarCore/PiSessionCostCache.swift`,


### PR DESCRIPTION
## Summary

Adds read-only visibility for Codex banked rate-limit resets in the Codex menu.

This surfaces the number of available banked resets and their expiry dates using the Codex OAuth credentials already available to CodexBar. The feature is intentionally informational only; it does not redeem or consume resets.

Refs #1633.
Refs #1502.

## What changed

- Add Codex banked reset models and a read-only fetcher for `wham/rate-limit-reset-credits`.
- Extract a shared `loadRefreshed` credential path and route both Codex usage and banked resets through it.
- Add a shared ChatGPT backend base URL resolver used by Codex OAuth usage and banked resets.
- Store banked resets as independent Codex state with its own refresh task, error state, cache fallback, and account-scoped apply guard.
- Add banked resets to the Codex consumer projection.
- Show banked resets in the Codex menu section, including available count and expiry dates.
- Schedule a banked reset refresh when opening the Codex menu if the data has not been loaded yet.
- Include banked resets in the open-menu readiness signature so an open Codex menu refreshes when the data arrives.
- Fix closed-menu preparation so a newly attached menu is not forced to rebuild by a superseded required-rebuild version.
- Preserve Codex state when the same account is enriched from email-only identity to provider-account identity.
- Seed the initial menu localization signature to avoid a spurious localization-change refresh on the first settings evaluation.
- Document the banked resets endpoint and refresh strategy in `docs/codex.md`.

## Notes

This is read-only by design. Redeeming a reset is a separate write operation, consumes a scarce account resource, and is harder to test safely.

The decoder is conservative: malformed reset entries are skipped instead of failing the whole response, and unknown reset statuses are not counted as available.

## Testing

- `swift test --filter CodexBankedResetsModelsTests`
- `swift test --filter CodexBankedResetsFetcherTests`
- `swift test --filter CodexAccountScopedRefreshBankedResetsTests`
- `swift test --filter MenuSessionCoordinatorTests`
- `swift test --filter StatusMenuInstantOpenTests`
- `swift test --filter StatusMenuReadinessBaselineTests`
- `make format`
- `make check`
- `git diff --check`
- `git diff --cached --check`