### PR TITLE
fix: retry MiniMax China region for invalid token responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Fixed
 - Xiaomi MiMo: retry another imported browser session when a stale session redirects API requests to login. Thanks @Yuxin-Qiao!
+- MiniMax: retry the China API region when the global token endpoint reports a structured invalid-key response.
 - Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!
 - Cursor: ignore an exhausted Auto or API subquota only when another independent quota remains usable, while preserving the overall cap. Thanks @Yuxin-Qiao!
 - Memory: release idle OpenAI WebViews under system pressure without blocking the main thread. Thanks @ProspectOre!

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -102,8 +102,7 @@ public struct MiniMaxUsageFetcher: Sendable {
                 apiToken: cleaned,
                 region: .global,
                 now: now,
-                transport: transport,
-                preserveTokenPlanCredentialFailure: true)
+                transport: transport)
         } catch let error as MiniMaxUsageError {
             guard case .invalidCredentials = error else { throw error }
             Self.log.debug("MiniMax API token rejected for global host, retrying China mainland host")
@@ -125,8 +124,7 @@ public struct MiniMaxUsageFetcher: Sendable {
         apiToken: String,
         region: MiniMaxAPIRegion,
         now: Date,
-        transport: any ProviderHTTPTransport,
-        preserveTokenPlanCredentialFailure: Bool = false) async throws -> MiniMaxUsageSnapshot
+        transport: any ProviderHTTPTransport) async throws -> MiniMaxUsageSnapshot
     {
         var lastError: Error?
         var tokenPlanCredentialFailure = false
@@ -147,9 +145,7 @@ public struct MiniMaxUsageFetcher: Sendable {
                     }
                     throw error
                 }
-                if preserveTokenPlanCredentialFailure,
-                   case .invalidCredentials = error
-                {
+                if case .invalidCredentials = error {
                     tokenPlanCredentialFailure = true
                 }
                 Self.log.debug("MiniMax token-plan API failed, trying legacy coding-plan endpoint")

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -98,7 +98,12 @@ public struct MiniMaxUsageFetcher: Sendable {
         }
 
         do {
-            return try await self.fetchUsageOnce(apiToken: cleaned, region: .global, now: now, transport: transport)
+            return try await self.fetchUsageOnce(
+                apiToken: cleaned,
+                region: .global,
+                now: now,
+                transport: transport,
+                preserveTokenPlanCredentialFailure: true)
         } catch let error as MiniMaxUsageError {
             guard case .invalidCredentials = error else { throw error }
             Self.log.debug("MiniMax API token rejected for global host, retrying China mainland host")
@@ -120,9 +125,11 @@ public struct MiniMaxUsageFetcher: Sendable {
         apiToken: String,
         region: MiniMaxAPIRegion,
         now: Date,
-        transport: any ProviderHTTPTransport) async throws -> MiniMaxUsageSnapshot
+        transport: any ProviderHTTPTransport,
+        preserveTokenPlanCredentialFailure: Bool = false) async throws -> MiniMaxUsageSnapshot
     {
         var lastError: Error?
+        var tokenPlanCredentialFailure = false
         for remainsURL in [region.tokenPlanRemainsURL, region.apiRemainsURL] {
             do {
                 return try await self.fetchAPIUsageOnce(
@@ -135,7 +142,15 @@ public struct MiniMaxUsageFetcher: Sendable {
                 guard remainsURL == region.tokenPlanRemainsURL,
                       self.shouldTryLegacyAPIEndpoint(after: error)
                 else {
+                    if tokenPlanCredentialFailure {
+                        throw MiniMaxUsageError.invalidCredentials
+                    }
                     throw error
+                }
+                if preserveTokenPlanCredentialFailure,
+                   case .invalidCredentials = error
+                {
+                    tokenPlanCredentialFailure = true
                 }
                 Self.log.debug("MiniMax token-plan API failed, trying legacy coding-plan endpoint")
             }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -177,7 +177,7 @@ public struct MiniMaxUsageFetcher: Sendable {
         do {
             snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: response.data, now: now)
         } catch let error as MiniMaxUsageError {
-            throw error
+            throw self.normalizedAPITokenError(error)
         } catch {
             throw MiniMaxUsageError.parseFailed(error.localizedDescription)
         }
@@ -185,6 +185,12 @@ public struct MiniMaxUsageFetcher: Sendable {
             Self.log.debug("MiniMax multi-service response detected: \(services.count) services")
         }
         return snapshot
+    }
+
+    private static func normalizedAPITokenError(_ error: MiniMaxUsageError) -> MiniMaxUsageError {
+        guard case let .apiError(message) = error else { return error }
+        let normalizedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalizedMessage == "invalid api key" ? .invalidCredentials : error
     }
 
     private static func shouldTryLegacyAPIEndpoint(after error: MiniMaxUsageError) -> Bool {

--- a/Tests/CodexBarTests/MiniMaxAPITokenFetchTests.swift
+++ b/Tests/CodexBarTests/MiniMaxAPITokenFetchTests.swift
@@ -105,6 +105,37 @@ struct MiniMaxAPITokenFetchTests {
     }
 
     @Test
+    func `explicit china region preserves structured invalid credentials across legacy fallback`() async throws {
+        defer {
+            MiniMaxAPITokenStubURLProtocol.handler = nil
+            MiniMaxAPITokenStubURLProtocol.requests = []
+        }
+        MiniMaxAPITokenStubURLProtocol.requests = []
+
+        MiniMaxAPITokenStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            if url.path == "/v1/token_plan/remains" {
+                return Self.makeResponse(
+                    url: url,
+                    body: #"{"base_resp":{"status_code":1004,"status_msg":"invalid api key"}}"#)
+            }
+            return Self.makeResponse(url: url, body: "{}", statusCode: 404)
+        }
+
+        await #expect(throws: MiniMaxUsageError.invalidCredentials) {
+            _ = try await MiniMaxUsageFetcher.fetchUsage(
+                apiToken: "sk-cp-test",
+                region: .chinaMainland,
+                session: Self.makeSession())
+        }
+
+        #expect(MiniMaxAPITokenStubURLProtocol.requests.map { $0.url?.path } == [
+            "/v1/token_plan/remains",
+            "/v1/api/openplatform/coding_plan/remains",
+        ])
+    }
+
+    @Test
     func `does not retry when region is china mainland`() async throws {
         defer {
             MiniMaxAPITokenStubURLProtocol.handler = nil

--- a/Tests/CodexBarTests/MiniMaxTokenPlanChangeTests.swift
+++ b/Tests/CodexBarTests/MiniMaxTokenPlanChangeTests.swift
@@ -418,7 +418,7 @@ struct MiniMaxTokenPlanChangeTests {
     }
 
     @Test
-    func `global api token fetch retries China after structured credential failures`() async throws {
+    func `global api token fetch preserves structured credential failure across legacy error`() async throws {
         let now = Date(timeIntervalSince1970: 1_780_282_340)
         let transport = ProviderHTTPTransportStub { request in
             let url = try #require(request.url)
@@ -433,7 +433,8 @@ struct MiniMaxTokenPlanChangeTests {
             case ("api.minimax.io", "/v1/api/openplatform/coding_plan/remains"):
                 return Self.httpResponse(
                     url: url,
-                    body: #"{"base_resp":{"status_code":1004,"status_msg":"cookie is missing, log in again"}}"#,
+                    body: #"{"error":"legacy endpoint unavailable"}"#,
+                    statusCode: 404,
                     contentType: "application/json")
             case ("api.minimaxi.com", "/v1/token_plan/remains"):
                 return Self.httpResponse(

--- a/Tests/CodexBarTests/MiniMaxTokenPlanChangeTests.swift
+++ b/Tests/CodexBarTests/MiniMaxTokenPlanChangeTests.swift
@@ -418,6 +418,55 @@ struct MiniMaxTokenPlanChangeTests {
     }
 
     @Test
+    func `global api token fetch retries China after structured credential failures`() async throws {
+        let now = Date(timeIntervalSince1970: 1_780_282_340)
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-cp-test")
+
+            switch (url.host, url.path) {
+            case ("api.minimax.io", "/v1/token_plan/remains"):
+                return Self.httpResponse(
+                    url: url,
+                    body: #"{"base_resp":{"status_code":1001,"status_msg":"invalid api key"}}"#,
+                    contentType: "application/json")
+            case ("api.minimax.io", "/v1/api/openplatform/coding_plan/remains"):
+                return Self.httpResponse(
+                    url: url,
+                    body: #"{"base_resp":{"status_code":1004,"status_msg":"cookie is missing, log in again"}}"#,
+                    contentType: "application/json")
+            case ("api.minimaxi.com", "/v1/token_plan/remains"):
+                return Self.httpResponse(
+                    url: url,
+                    body: Self.percentBasedRemainsJSON,
+                    contentType: "application/json")
+            default:
+                Issue.record("Unexpected MiniMax API request: \(url.absoluteString)")
+                return Self.httpResponse(url: url, body: "{}", statusCode: 500, contentType: "application/json")
+            }
+        }
+
+        let snapshot = try await MiniMaxUsageFetcher.fetchUsage(
+            apiToken: "sk-cp-test",
+            region: .global,
+            now: now,
+            session: transport)
+        let requests = await transport.requests()
+
+        #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 4)
+        #expect(requests.map { $0.url?.host } == [
+            "api.minimax.io",
+            "api.minimax.io",
+            "api.minimaxi.com",
+        ])
+        #expect(requests.map { $0.url?.path } == [
+            "/v1/token_plan/remains",
+            "/v1/api/openplatform/coding_plan/remains",
+            "/v1/token_plan/remains",
+        ])
+    }
+
+    @Test
     func `api token fetch falls back to legacy coding plan endpoint after official parse failure`() async throws {
         let now = Date(timeIntervalSince1970: 1_780_282_340)
         let transport = ProviderHTTPTransportStub { request in


### PR DESCRIPTION
## Summary

- normalize MiniMax's structured `invalid api key` API-token response as an authentication failure
- preserve the existing legacy-endpoint fallback before automatically retrying the China API region
- cover the exact global official → global legacy → China official request sequence
- preserve the original invalid-credential result when a later legacy or regional fallback ends differently

Fixes #1615.

## Verification

- exact head: `e5deea270ef11844f2d43efb32ebc441618ed75f`
- focused API-token and token-plan suites: 26 passed on the exact head
- prior full MiniMax suite and `make check`: green
- exact hosted lint: green
- exact whole-branch and final follow-up autoreviews: clean (`0.86` / `0.86`)
