### PR TITLE
Fix Antigravity highest-usage icon ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Memory: release idle OpenAI WebViews under system pressure without blocking the main thread. Thanks @ProspectOre!
 - Memory: trim rebuildable menu and OpenAI debug caches under system pressure. Thanks @ProspectOre!
 - Provider plans: keep Claude and Kiro plan matching on one rendered line to avoid bogus labels from adjacent usage hints. Thanks @elijahfriedman!
-- Antigravity: use current Gemini 5-hour and weekly quota-summary lanes for the compact menu bar icon. Thanks @Zihao-Qi!
+- Antigravity: use current Gemini 5-hour and weekly quota-summary lanes for the compact menu bar icon and merged highest-usage selection. Thanks @Zihao-Qi!
 - Usage bars: render values rounded to 0% or 100% as fully empty or full. Thanks @Zihao-Qi!
 - Codex web: keep cookie-import deadlines responsive when browser cookie work blocks the shared worker pool.
 - Codex pace: extrapolate historically exhausted weeks for run-out forecasts and avoid contradictory reset headlines. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -28,7 +28,13 @@ extension UsageStore {
     }
 
     private func menuBarMetricWindowForHighestUsage(provider: UsageProvider, snapshot: UsageSnapshot) -> RateWindow? {
-        MenuBarMetricWindowResolver.rateWindow(
+        if provider == .antigravity {
+            let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
+            return [windows.primary, windows.secondary]
+                .compactMap(\.self)
+                .max(by: { $0.usedPercent < $1.usedPercent })
+        }
+        return MenuBarMetricWindowResolver.rateWindow(
             preference: self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot),
             provider: provider,
             snapshot: snapshot,
@@ -43,6 +49,11 @@ extension UsageStore {
     {
         let effectivePreference = self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot)
         guard metricPercent >= 100 else { return false }
+        if provider == .antigravity {
+            let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
+            let percents = [windows.primary?.usedPercent, windows.secondary?.usedPercent].compactMap(\.self)
+            return percents.allSatisfy { $0 >= 100 }
+        }
         if provider == .copilot,
            effectivePreference == .automatic,
            let primary = snapshot.primary,
@@ -51,40 +62,18 @@ extension UsageStore {
             // In automatic mode Copilot can have one depleted lane while another still has quota.
             return primary.usedPercent >= 100 && secondary.usedPercent >= 100
         }
-        if provider == .cursor || provider == .antigravity,
+        if provider == .cursor,
            effectivePreference == .automatic
         {
-            if provider == .antigravity,
-               let percents = Self.antigravityQuotaSummaryUsedPercents(snapshot: snapshot),
-               !percents.isEmpty
-            {
-                return percents.allSatisfy { $0 >= 100 }
-            }
             let percents = [
                 snapshot.primary?.usedPercent,
                 snapshot.secondary?.usedPercent,
                 snapshot.tertiary?.usedPercent,
-            ].compactMap(\.self) + (provider == .antigravity
-                ? Self.antigravityLegacyExtraUsedPercents(snapshot: snapshot)
-                : [])
+            ].compactMap(\.self)
             guard !percents.isEmpty else { return true }
             return percents.allSatisfy { $0 >= 100 }
         }
 
         return true
-    }
-
-    private nonisolated static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
-
-    private nonisolated static func antigravityQuotaSummaryUsedPercents(snapshot: UsageSnapshot) -> [Double]? {
-        snapshot.extraRateWindows?
-            .filter { $0.usageKnown && $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix) }
-            .map(\.window.usedPercent)
-    }
-
-    private nonisolated static func antigravityLegacyExtraUsedPercents(snapshot: UsageSnapshot) -> [Double] {
-        snapshot.extraRateWindows?
-            .filter { $0.usageKnown && !$0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix) }
-            .map(\.window.usedPercent) ?? []
     }
 }

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -28,14 +28,15 @@ extension UsageStore {
     }
 
     private func menuBarMetricWindowForHighestUsage(provider: UsageProvider, snapshot: UsageSnapshot) -> RateWindow? {
-        if provider == .antigravity {
+        let effectivePreference = self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot)
+        if provider == .antigravity, effectivePreference == .automatic {
             let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
             return [windows.primary, windows.secondary]
                 .compactMap(\.self)
                 .max(by: { $0.usedPercent < $1.usedPercent })
         }
         return MenuBarMetricWindowResolver.rateWindow(
-            preference: self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot),
+            preference: effectivePreference,
             provider: provider,
             snapshot: snapshot,
             supportsAverage: self.settings.menuBarMetricSupportsAverage(for: provider))
@@ -49,7 +50,7 @@ extension UsageStore {
     {
         let effectivePreference = self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot)
         guard metricPercent >= 100 else { return false }
-        if provider == .antigravity {
+        if provider == .antigravity, effectivePreference == .automatic {
             let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
             let percents = [windows.primary?.usedPercent, windows.secondary?.usedPercent].compactMap(\.self)
             return percents.allSatisfy { $0 >= 100 }

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -118,7 +118,7 @@ struct UsageStoreHighestUsageTests {
     }
 
     @Test
-    func `automatic metric uses antigravity tertiary when leading lanes are missing`() {
+    func `automatic metric ignores antigravity tertiary when compact icon has no quota summary`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-tertiary"),
             zaiTokenStore: NoopZaiTokenStore(),
@@ -152,12 +152,12 @@ struct UsageStoreHighestUsageTests {
         store._setSnapshotForTesting(antigravitySnapshot, provider: .antigravity)
 
         let highest = store.providerWithHighestUsage()
-        #expect(highest?.provider == .antigravity)
-        #expect(highest?.usedPercent == 85)
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 70)
     }
 
     @Test
-    func `automatic metric ranks unclassified antigravity compact fallback`() throws {
+    func `automatic metric ignores unclassified antigravity compact fallback`() throws {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-unclassified"),
             zaiTokenStore: NoopZaiTokenStore(),
@@ -200,12 +200,12 @@ struct UsageStoreHighestUsageTests {
         store._setSnapshotForTesting(antigravitySnapshot, provider: .antigravity)
 
         let highest = store.providerWithHighestUsage()
-        #expect(highest?.provider == .antigravity)
-        #expect(highest?.usedPercent == 64)
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 50)
     }
 
     @Test
-    func `automatic metric ranks antigravity by constrained gemini family lane`() {
+    func `automatic metric ignores legacy antigravity family lanes without quota summary`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-constrained-gemini"),
             zaiTokenStore: NoopZaiTokenStore(),
@@ -239,12 +239,74 @@ struct UsageStoreHighestUsageTests {
         store._setSnapshotForTesting(antigravitySnapshot, provider: .antigravity)
 
         let highest = store.providerWithHighestUsage()
-        #expect(highest?.provider == .antigravity)
-        #expect(highest?.usedPercent == 100)
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 70)
     }
 
     @Test
-    func `automatic metric excludes antigravity only when every lane is exhausted`() {
+    func `automatic metric ranks antigravity by rendered gemini quota summary lanes`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-rendered-gemini"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.setMenuBarMetricPreference(.automatic, for: .antigravity)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let antigravityMeta = registry.metadata[.antigravity] {
+            settings.setProviderEnabled(provider: .antigravity, metadata: antigravityMeta, enabled: true)
+        }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .codex)
+        store._setSnapshotForTesting(
+            self.antigravityQuotaSummarySnapshot(
+                geminiSessionUsed: 10,
+                geminiWeeklyUsed: 20,
+                otherSessionUsed: 95,
+                otherWeeklyUsed: 90),
+            provider: .antigravity)
+
+        var highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 80)
+
+        store._setSnapshotForTesting(
+            self.antigravityQuotaSummarySnapshot(
+                geminiSessionUsed: 95,
+                geminiWeeklyUsed: 20,
+                otherSessionUsed: 10,
+                otherWeeklyUsed: 10),
+            provider: .antigravity)
+        highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .antigravity)
+        #expect(highest?.usedPercent == 95)
+
+        store._setSnapshotForTesting(
+            self.antigravityQuotaSummarySnapshot(
+                geminiSessionUsed: 100,
+                geminiWeeklyUsed: 100,
+                otherSessionUsed: 50,
+                otherWeeklyUsed: 50),
+            provider: .antigravity)
+        highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+    }
+
+    @Test
+    func `automatic metric keeps antigravity when one rendered lane has quota`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-all-100"),
             zaiTokenStore: NoopZaiTokenStore(),
@@ -268,22 +330,22 @@ struct UsageStoreHighestUsageTests {
             primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
             secondary: nil,
             updatedAt: Date())
-        let antigravitySnapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 100, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
-            secondary: RateWindow(usedPercent: 100, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
-            tertiary: RateWindow(usedPercent: 100, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
-            updatedAt: Date())
+        let antigravitySnapshot = self.antigravityQuotaSummarySnapshot(
+            geminiSessionUsed: 100,
+            geminiWeeklyUsed: 40,
+            otherSessionUsed: 100,
+            otherWeeklyUsed: 100)
 
         store._setSnapshotForTesting(codexSnapshot, provider: .codex)
         store._setSnapshotForTesting(antigravitySnapshot, provider: .antigravity)
 
         let highest = store.providerWithHighestUsage()
-        #expect(highest?.provider == .codex)
-        #expect(highest?.usedPercent == 80)
+        #expect(highest?.provider == .antigravity)
+        #expect(highest?.usedPercent == 100)
     }
 
     @Test
-    func `automatic metric keeps antigravity when a legacy detail row has quota`() {
+    func `automatic metric ignores antigravity legacy detail rows`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-fallback-detail"),
             zaiTokenStore: NoopZaiTokenStore(),
@@ -337,8 +399,8 @@ struct UsageStoreHighestUsageTests {
             provider: .antigravity)
 
         let highest = store.providerWithHighestUsage()
-        #expect(highest?.provider == .antigravity)
-        #expect(highest?.usedPercent == 100)
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 80)
     }
 
     @Test
@@ -810,5 +872,52 @@ struct UsageStoreHighestUsageTests {
         let highest = store.providerWithHighestUsage()
         #expect(highest?.provider == .cursor)
         #expect(highest?.usedPercent == 100)
+    }
+
+    private func antigravityQuotaSummarySnapshot(
+        geminiSessionUsed: Double,
+        geminiWeeklyUsed: Double,
+        otherSessionUsed: Double,
+        otherWeeklyUsed: Double) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-5h",
+                    title: "Gemini Session",
+                    window: RateWindow(
+                        usedPercent: geminiSessionUsed,
+                        windowMinutes: 5 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-weekly",
+                    title: "Gemini Weekly",
+                    window: RateWindow(
+                        usedPercent: geminiWeeklyUsed,
+                        windowMinutes: 7 * 24 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-3p-5h",
+                    title: "Claude + GPT Session",
+                    window: RateWindow(
+                        usedPercent: otherSessionUsed,
+                        windowMinutes: 5 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-3p-weekly",
+                    title: "Claude + GPT Weekly",
+                    window: RateWindow(
+                        usedPercent: otherWeeklyUsed,
+                        windowMinutes: 7 * 24 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+            ],
+            updatedAt: Date())
     }
 }

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -921,3 +921,56 @@ struct UsageStoreHighestUsageTests {
             updatedAt: Date())
     }
 }
+
+extension UsageStoreHighestUsageTests {
+    @Test
+    func `explicit antigravity metric remains authoritative for highest usage`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-explicit"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.setMenuBarMetricPreference(.secondary, for: .antigravity)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let antigravityMeta = registry.metadata[.antigravity] {
+            settings.setProviderEnabled(provider: .antigravity, metadata: antigravityMeta, enabled: true)
+        }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .codex)
+        let antigravity = self.antigravityQuotaSummarySnapshot(
+            geminiSessionUsed: 10,
+            geminiWeeklyUsed: 20,
+            otherSessionUsed: 95,
+            otherWeeklyUsed: 90)
+            .with(
+                primary: RateWindow(usedPercent: 10, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(usedPercent: 95, windowMinutes: nil, resetsAt: nil, resetDescription: nil))
+        store._setSnapshotForTesting(antigravity, provider: .antigravity)
+
+        var highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .antigravity)
+        #expect(highest?.usedPercent == 95)
+
+        store._setSnapshotForTesting(
+            antigravity.with(
+                primary: antigravity.primary,
+                secondary: RateWindow(usedPercent: 100, windowMinutes: nil, resetsAt: nil, resetDescription: nil)),
+            provider: .antigravity)
+        highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+    }
+}


### PR DESCRIPTION
## Summary

- Rank Antigravity in merged highest-usage automatic mode from the Gemini quota-summary lanes rendered by the compact icon.
- Exclude Antigravity only when every rendered Gemini lane is exhausted.
- Preserve explicit Antigravity metric preferences for highest-usage ranking and exhaustion.
- Cover legacy, mixed-family, partial-exhaustion, full-exhaustion, and explicit-preference cases.

Follow-up to #1631.

## Proof

- `swift test --filter 'UsageStoreHighestUsageTests|StatusItemAnimationSignatureTests|CodexbarTests'`: 62 tests passed on the final current-main head.
- `make check`: format and strict lint clean.
- Initial whole-branch review found explicit preferences were overridden; fixed with automatic-only gating and regression coverage.
- Focused fix review and final whole-branch Codex autoreview clean, confidence 0.82.

Exact candidate: `095fbf51ab915d1216a5a114b1f8f008711003af`.
