### PR TITLE
Stabilize process cleanup timing tests

### DIFF
--- a/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
+++ b/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
@@ -129,14 +129,18 @@ struct SpawnedProcessGroupTests {
             stderrPipe: stderrPipe)
 
         var childPID: pid_t?
-        for _ in 0..<100 {
+        for _ in 0..<500 {
             if let text = try? String(contentsOf: childPIDFile, encoding: .utf8) {
                 childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
                 break
             }
             try await Task.sleep(for: .milliseconds(20))
         }
-        let escapedPID = try #require(childPID)
+        guard let escapedPID = childPID else {
+            await process.terminate(grace: 0)
+            Issue.record("Timed out waiting for escaped child PID")
+            return
+        }
         defer { _ = kill(escapedPID, SIGKILL) }
 
         let start = Date()

--- a/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
+++ b/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
@@ -130,8 +130,10 @@ struct SpawnedProcessGroupTests {
 
         var childPID: pid_t?
         for _ in 0..<500 {
-            if let text = try? String(contentsOf: childPIDFile, encoding: .utf8) {
-                childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            if let text = try? String(contentsOf: childPIDFile, encoding: .utf8),
+               let parsedPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            {
+                childPID = parsedPID
                 break
             }
             try await Task.sleep(for: .milliseconds(20))

--- a/Tests/CodexBarTests/SubprocessRunnerTests.swift
+++ b/Tests/CodexBarTests/SubprocessRunnerTests.swift
@@ -15,7 +15,7 @@ struct SubprocessRunnerTests {
             binary: "/usr/bin/python3",
             arguments: ["-c", "print('x' * 1_000_000)"],
             environment: ProcessInfo.processInfo.environment,
-            timeout: 5,
+            timeout: 15,
             label: "python large stdout")
 
         #expect(result.stdout.count >= 1_000_000)


### PR DESCRIPTION
## Summary

- allow the large-output subprocess test enough time on saturated x86 macOS runners
- allow escaped-child startup enough time and wait for a parseable PID before asserting readiness
- terminate the spawned process if readiness still times out

## Proof

- exact head `6b8fa7fd1235aaf7f74e22fdd3a62fac78c91236`
- `swift test --filter 'SubprocessRunnerTests|SpawnedProcessGroupTests'` (24 tests)
- same exact focused suites repeated 10 times with `--skip-build`
- `make check`
- exact branch autoreview clean, confidence 0.86

## CI provenance

Observed on unrelated provider PRs:

- `SubprocessRunnerTests`: one-million-byte Python stdout exceeded the test-only 5-second deadline
- `SpawnedProcessGroupTests`: escaped-child PID file was not ready within the test-only 2-second polling window

No production timeout or process-cleanup behavior changes.
