### PR TITLE
test: stabilize cookie cache timeout ordering

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
@@ -70,8 +70,24 @@ extension OpenAIDashboardBrowserCookieImporter {
         deadline: Date?,
         operation: @escaping @Sendable () throws -> T) async throws -> T
     {
-        try await self.runBoundedCookieLoad(deadline: deadline) {
-            try self.cookieCacheQueue.sync(execute: operation)
+        guard let deadline else {
+            return try await withCheckedThrowingContinuation { continuation in
+                self.cookieCacheQueue.async {
+                    continuation.resume(with: Result(catching: operation))
+                }
+            }
+        }
+
+        let timeout = try self.remainingTimeout(until: deadline)
+        let completion = CookieLoadCompletion()
+        return try await withCheckedThrowingContinuation { continuation in
+            self.cookieCacheQueue.async {
+                let result = Result(catching: operation)
+                completion.finish { continuation.resume(with: result) }
+            }
+            self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {
+                completion.finish { continuation.resume(throwing: URLError(.timedOut)) }
+            }
         }
     }
 

--- a/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
@@ -148,20 +148,24 @@ struct OpenAIDashboardBrowserCookieImporterTests {
     @Test
     func `timed out cookie cache work stays ordered before retry`() async throws {
         let log = CookieOperationLog()
+        let allowFirstOperationToFinish = DispatchSemaphore(value: 0)
 
         do {
             _ = try await OpenAIDashboardBrowserCookieImporter.runBoundedCookieCacheOperation(
                 deadline: Date().addingTimeInterval(0.05))
             {
                 log.append("first-start")
-                Thread.sleep(forTimeInterval: 0.15)
+                _ = allowFirstOperationToFinish.wait(timeout: .now() + 5)
                 log.append("first-end")
                 return true
             }
             Issue.record("Expected first cache operation timeout")
         } catch let error as URLError {
             #expect(error.code == .timedOut)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
+        allowFirstOperationToFinish.signal()
 
         _ = try await OpenAIDashboardBrowserCookieImporter.runBoundedCookieCacheOperation(
             deadline: Date().addingTimeInterval(1))

--- a/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
@@ -148,6 +148,7 @@ struct OpenAIDashboardBrowserCookieImporterTests {
     @Test
     func `timed out cookie cache work stays ordered before retry`() async throws {
         let log = CookieOperationLog()
+        let firstOperationStarted = DispatchSemaphore(value: 0)
         let allowFirstOperationToFinish = DispatchSemaphore(value: 0)
 
         do {
@@ -155,6 +156,7 @@ struct OpenAIDashboardBrowserCookieImporterTests {
                 deadline: Date().addingTimeInterval(0.05))
             {
                 log.append("first-start")
+                firstOperationStarted.signal()
                 _ = allowFirstOperationToFinish.wait(timeout: .now() + 5)
                 log.append("first-end")
                 return true
@@ -165,14 +167,29 @@ struct OpenAIDashboardBrowserCookieImporterTests {
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+        let firstOperationStartResult = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: firstOperationStarted.wait(timeout: .now() + 5))
+            }
+        }
+        #expect(firstOperationStartResult == .success)
+        do {
+            _ = try await OpenAIDashboardBrowserCookieImporter.runBoundedCookieCacheOperation(
+                deadline: Date().addingTimeInterval(0.05))
+            {
+                log.append("second")
+                return true
+            }
+            Issue.record("Expected retry to wait behind first cache operation")
+        } catch let error as URLError {
+            #expect(error.code == .timedOut)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
         allowFirstOperationToFinish.signal()
 
         _ = try await OpenAIDashboardBrowserCookieImporter.runBoundedCookieCacheOperation(
-            deadline: Date().addingTimeInterval(1))
-        {
-            log.append("second")
-            return true
-        }
+            deadline: Date().addingTimeInterval(1)) { true }
         #expect(log.snapshot == ["first-start", "first-end", "second"])
     }
 


### PR DESCRIPTION
## Summary

- Make the cookie-cache timeout ordering regression deterministic under saturated CI runners.
- Bound the operation gate so timeout regressions fail cleanly instead of hanging the test process.

## Validation

- `swift test --filter OpenAIDashboardBrowserCookieImporterTests`
- Exact regression repeated 20 times
- `make check`
- Autoreview clean (0.86)
- `make test`: the unrelated existing Codex RPC Python-startup stall recurred on shard 12 after its retry; the affected suite is independently green.
