### PR TITLE
fix: prevent date axis labels from being clipped in cost history chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 
 ### Fixed
+- Cost history: keep the first and last date labels aligned and visible without clipping. Thanks @elijahfriedman!
 - Xiaomi MiMo: retry another imported browser session when a stale session redirects API requests to login. Thanks @Yuxin-Qiao!
 - Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!
 - Cursor: ignore an exhausted Auto or API subquota only when another independent quota remains usable, while preserving the overall cap. Thanks @Yuxin-Qiao!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 
 ### Fixed
-- Cost history: keep the first and last date labels aligned and visible without clipping. Thanks @elijahfriedman!
+- Cost history: keep chart date labels aligned with their bars and visible without clipping. Thanks @elijahfriedman!
 - Xiaomi MiMo: retry another imported browser session when a stale session redirects API requests to login. Thanks @Yuxin-Qiao!
 - Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!
 - Cursor: ignore an exhausted Auto or API subquota only when another independent quota remains usable, while preserving the overall cap. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -92,15 +92,7 @@ struct CostHistoryChartMenuView: View {
                     }
                 }
                 .chartYAxis(.hidden)
-                .chartXAxis {
-                    AxisMarks(values: model.axisDates) { _ in
-                        AxisGridLine().foregroundStyle(Color.clear)
-                        AxisTick().foregroundStyle(Color.clear)
-                        AxisValueLabel(format: .dateTime.month(.abbreviated).day())
-                            .font(.caption2)
-                            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                    }
-                }
+                .chartXAxis(.hidden)
                 .chartLegend(.hidden)
                 .frame(height: Self.chartHeight)
                 .accessibilityLabel(L("Cost history chart"))
@@ -125,6 +117,22 @@ struct CostHistoryChartMenuView: View {
                             .contentShape(Rectangle())
                         }
                     }
+                }
+
+                if !model.axisDates.isEmpty {
+                    HStack {
+                        Text(model.axisDates[0], format: .dateTime.month(.abbreviated).day())
+                            .font(.caption2)
+                            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                        if model.axisDates.count > 1 {
+                            Spacer()
+                            Text(model.axisDates[model.axisDates.count - 1], format: .dateTime.month(.abbreviated).day())
+                                .font(.caption2)
+                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                        }
+                    }
+                    .frame(height: Self.axisLabelAreaHeight)
+                    .padding(.top, -Self.outerSpacing)
                 }
 
                 let detail = self.detailContent(selectedDateKey: selectedDateKey, model: model)
@@ -229,7 +237,8 @@ struct CostHistoryChartMenuView: View {
     private static let compactDetailRowHeight: CGFloat = 36
     private static let expandedDetailRowHeight: CGFloat = 44
     private static let detailSpacing: CGFloat = 6
-    private static let chartHeight: CGFloat = 130
+    private static let chartHeight: CGFloat = 114
+    private static let axisLabelAreaHeight: CGFloat = 16
     private static let outerSpacing: CGFloat = 10
     static let verticalPadding: CGFloat = 10
 
@@ -240,6 +249,7 @@ struct CostHistoryChartMenuView: View {
     private static func totalCardHeight(rows: [DetailRow], hasTotal: Bool) -> CGFloat {
         var height = self.verticalPadding * 2
         height += self.chartHeight
+        height += self.axisLabelAreaHeight
         height += self.outerSpacing
         height += self.detailBlockHeight(rows: rows)
         if hasTotal {

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -6,6 +6,12 @@ import SwiftUI
 struct CostHistoryChartMenuView: View {
     typealias DailyEntry = CostUsageDailyReport.Entry
 
+    enum AxisLabelPlacement: Equatable {
+        case hidden
+        case centered
+        case edges
+    }
+
     private struct Point: Identifiable {
         let id: String
         let date: Date
@@ -119,13 +125,17 @@ struct CostHistoryChartMenuView: View {
                     }
                 }
 
-                if !model.axisDates.isEmpty {
+                let axisLabelPlacement = Self.axisLabelPlacement(for: model.axisDates)
+                if axisLabelPlacement != .hidden {
                     HStack {
+                        if axisLabelPlacement == .centered {
+                            Spacer()
+                        }
                         Text(model.axisDates[0], format: .dateTime.month(.abbreviated).day())
                             .font(.caption2)
                             .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                        if model.axisDates.count > 1 {
-                            Spacer()
+                        Spacer()
+                        if axisLabelPlacement == .edges {
                             Text(
                                 model.axisDates[model.axisDates.count - 1],
                                 format: .dateTime.month(.abbreviated).day())
@@ -336,6 +346,14 @@ struct CostHistoryChartMenuView: View {
             barColor: barColor,
             peakKey: maxCostUSD > 0 ? peak?.key : nil,
             maxCostUSD: maxCostUSD)
+    }
+
+    private static func axisLabelPlacement(for dates: [Date]) -> AxisLabelPlacement {
+        switch dates.count {
+        case 0: .hidden
+        case 1: .centered
+        default: .edges
+        }
     }
 
     private static func barColor(for provider: UsageProvider) -> Color {
@@ -579,6 +597,13 @@ extension CostHistoryChartMenuView {
 
     static func _axisDatesForTesting(provider: UsageProvider, daily: [DailyEntry]) -> [Date] {
         self.makeModel(provider: provider, daily: daily).axisDates
+    }
+
+    static func _axisLabelPlacementForTesting(
+        provider: UsageProvider,
+        daily: [DailyEntry]) -> AxisLabelPlacement
+    {
+        self.axisLabelPlacement(for: self.makeModel(provider: provider, daily: daily).axisDates)
     }
 
     static func _detailViewportHeightForTesting(modeSubtitlePresence: [Bool]) -> CGFloat {

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -575,6 +575,10 @@ extension CostHistoryChartMenuView {
         self.defaultSelectedDateKey(model: self.makeModel(provider: provider, daily: daily))
     }
 
+    static func _axisDatesForTesting(provider: UsageProvider, daily: [DailyEntry]) -> [Date] {
+        self.makeModel(provider: provider, daily: daily).axisDates
+    }
+
     static func _detailViewportHeightForTesting(modeSubtitlePresence: [Bool]) -> CGFloat {
         let rows = modeSubtitlePresence.enumerated().map { index, hasModeSubtitle in
             DetailRow(

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -126,7 +126,9 @@ struct CostHistoryChartMenuView: View {
                             .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                         if model.axisDates.count > 1 {
                             Spacer()
-                            Text(model.axisDates[model.axisDates.count - 1], format: .dateTime.month(.abbreviated).day())
+                            Text(
+                                model.axisDates[model.axisDates.count - 1],
+                                format: .dateTime.month(.abbreviated).day())
                                 .font(.caption2)
                                 .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                         }

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -89,6 +89,54 @@ struct CostHistoryChartMenuViewTests {
 
     @Test
     @MainActor
+    func `axis dates span first to last for multi-day data`() {
+        let daily = [
+            CostUsageDailyReport.Entry(
+                date: "2026-05-21",
+                inputTokens: nil, outputTokens: nil, totalTokens: nil,
+                costUSD: 1.0, modelsUsed: nil, modelBreakdowns: nil),
+            CostUsageDailyReport.Entry(
+                date: "2026-06-17",
+                inputTokens: nil, outputTokens: nil, totalTokens: nil,
+                costUSD: 2.0, modelsUsed: nil, modelBreakdowns: nil),
+        ]
+        let dates = CostHistoryChartMenuView._axisDatesForTesting(provider: .codex, daily: daily)
+        let cal = Calendar.current
+        #expect(dates.count == 2)
+        #expect(cal.component(.month, from: dates[0]) == 5)
+        #expect(cal.component(.day, from: dates[0]) == 21)
+        #expect(cal.component(.month, from: dates[1]) == 6)
+        #expect(cal.component(.day, from: dates[1]) == 17)
+    }
+
+    @Test
+    @MainActor
+    func `axis dates collapse to one for single-day data`() {
+        let daily = [
+            CostUsageDailyReport.Entry(
+                date: "2026-06-17",
+                inputTokens: nil, outputTokens: nil, totalTokens: nil,
+                costUSD: 1.0, modelsUsed: nil, modelBreakdowns: nil),
+        ]
+        let dates = CostHistoryChartMenuView._axisDatesForTesting(provider: .codex, daily: daily)
+        #expect(dates.count == 1)
+    }
+
+    @Test
+    @MainActor
+    func `axis dates are empty when there is no cost data`() {
+        let daily = [
+            CostUsageDailyReport.Entry(
+                date: "2026-06-17",
+                inputTokens: nil, outputTokens: nil, totalTokens: nil,
+                costUSD: nil, modelsUsed: nil, modelBreakdowns: nil),
+        ]
+        let dates = CostHistoryChartMenuView._axisDatesForTesting(provider: .codex, daily: daily)
+        #expect(dates.isEmpty)
+    }
+
+    @Test
+    @MainActor
     func `cost history total card height grows with rows and the total line`() {
         let oneRow = CostHistoryChartMenuView._totalCardHeightForTesting(
             modeSubtitlePresence: [false],

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -93,12 +93,20 @@ struct CostHistoryChartMenuViewTests {
         let daily = [
             CostUsageDailyReport.Entry(
                 date: "2026-05-21",
-                inputTokens: nil, outputTokens: nil, totalTokens: nil,
-                costUSD: 1.0, modelsUsed: nil, modelBreakdowns: nil),
+                inputTokens: nil,
+                outputTokens: nil,
+                totalTokens: nil,
+                costUSD: 1.0,
+                modelsUsed: nil,
+                modelBreakdowns: nil),
             CostUsageDailyReport.Entry(
                 date: "2026-06-17",
-                inputTokens: nil, outputTokens: nil, totalTokens: nil,
-                costUSD: 2.0, modelsUsed: nil, modelBreakdowns: nil),
+                inputTokens: nil,
+                outputTokens: nil,
+                totalTokens: nil,
+                costUSD: 2.0,
+                modelsUsed: nil,
+                modelBreakdowns: nil),
         ]
         let dates = CostHistoryChartMenuView._axisDatesForTesting(provider: .codex, daily: daily)
         let cal = Calendar.current
@@ -115,8 +123,12 @@ struct CostHistoryChartMenuViewTests {
         let daily = [
             CostUsageDailyReport.Entry(
                 date: "2026-06-17",
-                inputTokens: nil, outputTokens: nil, totalTokens: nil,
-                costUSD: 1.0, modelsUsed: nil, modelBreakdowns: nil),
+                inputTokens: nil,
+                outputTokens: nil,
+                totalTokens: nil,
+                costUSD: 1.0,
+                modelsUsed: nil,
+                modelBreakdowns: nil),
         ]
         let dates = CostHistoryChartMenuView._axisDatesForTesting(provider: .codex, daily: daily)
         #expect(dates.count == 1)
@@ -128,8 +140,12 @@ struct CostHistoryChartMenuViewTests {
         let daily = [
             CostUsageDailyReport.Entry(
                 date: "2026-06-17",
-                inputTokens: nil, outputTokens: nil, totalTokens: nil,
-                costUSD: nil, modelsUsed: nil, modelBreakdowns: nil),
+                inputTokens: nil,
+                outputTokens: nil,
+                totalTokens: nil,
+                costUSD: nil,
+                modelsUsed: nil,
+                modelBreakdowns: nil),
         ]
         let dates = CostHistoryChartMenuView._axisDatesForTesting(provider: .codex, daily: daily)
         #expect(dates.isEmpty)

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -115,6 +115,10 @@ struct CostHistoryChartMenuViewTests {
         #expect(cal.component(.day, from: dates[0]) == 21)
         #expect(cal.component(.month, from: dates[1]) == 6)
         #expect(cal.component(.day, from: dates[1]) == 17)
+        #expect(
+            CostHistoryChartMenuView._axisLabelPlacementForTesting(
+                provider: .codex,
+                daily: daily) == .edges)
     }
 
     @Test
@@ -132,6 +136,10 @@ struct CostHistoryChartMenuViewTests {
         ]
         let dates = CostHistoryChartMenuView._axisDatesForTesting(provider: .codex, daily: daily)
         #expect(dates.count == 1)
+        #expect(
+            CostHistoryChartMenuView._axisLabelPlacementForTesting(
+                provider: .codex,
+                daily: daily) == .centered)
     }
 
     @Test
@@ -149,6 +157,10 @@ struct CostHistoryChartMenuViewTests {
         ]
         let dates = CostHistoryChartMenuView._axisDatesForTesting(provider: .codex, daily: daily)
         #expect(dates.isEmpty)
+        #expect(
+            CostHistoryChartMenuView._axisLabelPlacementForTesting(
+                provider: .codex,
+                daily: daily) == .hidden)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace SwiftCharts axis label rendering with plain SwiftUI `Text` views: centered for one day, edge-aligned for multiple days
- fixes first date label being shifted right by Charts' internal anti-clipping logic, and last date label being truncated against the chart frame bounds
- keep `totalCardHeight` accurate by splitting the old `chartHeight` constant into `chartHeight` (bars only) + `axisLabelAreaHeight`, preserving the same total

## Tests

- add test seams for axis dates and explicit hidden/centered/edges placement, with cases for multi-day, single-day, and no-cost data
- full suite: 488 tests passed

## Verification

- exact head: `d5aab52aa0f4da0c1db35d584eeb07a1c57feb9e`
- `swift test --filter CostHistoryChartMenuViewTests`: 8 tests passed
- `make check`: green
- `make test`: all 41 test shards passed
- context-aware local and final whole-branch autoreviews: clean (`0.86` / `0.86`)
- rebased onto current `main`; maintainer changelog credit added
- contributor full suite: 488 tests passed

## Screenshots

Before:

<img width="307" height="295" alt="Screenshot 2026-06-19 at 8 37 15 AM" src="https://github.com/user-attachments/assets/d41d1e21-d2d9-45f8-9f01-ada5151a1fd5" />


After:

<img width="311" height="297" alt="Screenshot 2026-06-19 at 9 08 30 AM" src="https://github.com/user-attachments/assets/72622b13-a903-497d-89e8-c7c55dbfe6d1" />
