### PR TITLE
ci: install lint tools selectively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install lint tools
-        run: ./Scripts/install_lint_tools.sh
+        run: ./Scripts/install_lint_tools.sh swiftlint
 
       - name: Lint
         run: ./Scripts/lint.sh lint-linux

--- a/Scripts/install_lint_tools.sh
+++ b/Scripts/install_lint_tools.sh
@@ -17,6 +17,32 @@ SWIFTLINT_SHA256_LINUX_X86_64="dd1017cfd20a1457f264590bcb5875a6ee06cd75b9a9d4f77
 log() { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
+INSTALL_SWIFTFORMAT=false
+INSTALL_SWIFTLINT=false
+
+if [[ "$#" -eq 0 ]]; then
+  INSTALL_SWIFTFORMAT=true
+  INSTALL_SWIFTLINT=true
+else
+  for tool in "$@"; do
+    case "$tool" in
+      all)
+        INSTALL_SWIFTFORMAT=true
+        INSTALL_SWIFTLINT=true
+        ;;
+      swiftformat)
+        INSTALL_SWIFTFORMAT=true
+        ;;
+      swiftlint)
+        INSTALL_SWIFTLINT=true
+        ;;
+      *)
+        fail "Unknown lint tool '${tool}'. Usage: $(basename "$0") [all|swiftformat|swiftlint]..."
+        ;;
+    esac
+  done
+fi
+
 sha256_value() {
   local path="$1"
   if command -v shasum >/dev/null 2>&1; then
@@ -82,13 +108,21 @@ install_zip_binary() {
 
 mkdir -p "$BIN_DIR"
 
-if [[ -x "${BIN_DIR}/swiftformat" && -x "${BIN_DIR}/swiftlint" ]]; then
-  if [[ "$("${BIN_DIR}/swiftformat" --version 2>/dev/null || true)" == "${SWIFTFORMAT_VERSION}" ]] \
+swiftformat_installed() {
+  [[ -x "${BIN_DIR}/swiftformat" ]] \
+    && [[ "$("${BIN_DIR}/swiftformat" --version 2>/dev/null || true)" == "${SWIFTFORMAT_VERSION}" ]]
+}
+
+swiftlint_installed() {
+  [[ -x "${BIN_DIR}/swiftlint" ]] \
     && [[ "$("${BIN_DIR}/swiftlint" version 2>/dev/null || true)" == "${SWIFTLINT_VERSION}" ]]
-  then
-    log "==> Lint tools already installed (${SWIFTFORMAT_VERSION}, ${SWIFTLINT_VERSION})"
-    exit 0
-  fi
+}
+
+if { [[ "$INSTALL_SWIFTFORMAT" != true ]] || swiftformat_installed; } \
+  && { [[ "$INSTALL_SWIFTLINT" != true ]] || swiftlint_installed; }
+then
+  log "==> Requested lint tools already installed"
+  exit 0
 fi
 
 OS="$(uname -s)"
@@ -99,8 +133,12 @@ case "$OS" in
     SWIFTFORMAT_URL="https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip"
     SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/portable_swiftlint.zip"
 
-    install_zip_binary "SwiftFormat ${SWIFTFORMAT_VERSION}" "$SWIFTFORMAT_URL" "$SWIFTFORMAT_SHA256_DARWIN" "swiftformat"
-    install_zip_binary "SwiftLint ${SWIFTLINT_VERSION}" "$SWIFTLINT_URL" "$SWIFTLINT_SHA256_DARWIN" "swiftlint"
+    if [[ "$INSTALL_SWIFTFORMAT" == true ]] && ! swiftformat_installed; then
+      install_zip_binary "SwiftFormat ${SWIFTFORMAT_VERSION}" "$SWIFTFORMAT_URL" "$SWIFTFORMAT_SHA256_DARWIN" "swiftformat"
+    fi
+    if [[ "$INSTALL_SWIFTLINT" == true ]] && ! swiftlint_installed; then
+      install_zip_binary "SwiftLint ${SWIFTLINT_VERSION}" "$SWIFTLINT_URL" "$SWIFTLINT_SHA256_DARWIN" "swiftlint"
+    fi
     ;;
   Linux)
     case "$ARCH" in
@@ -121,11 +159,17 @@ case "$OS" in
         ;;
     esac
 
-    if [[ -z "$SWIFTFORMAT_SHA256" || -z "$SWIFTLINT_SHA256" ]]; then
+    if { [[ "$INSTALL_SWIFTFORMAT" == true ]] && [[ -z "$SWIFTFORMAT_SHA256" ]]; } \
+      || { [[ "$INSTALL_SWIFTLINT" == true ]] && [[ -z "$SWIFTLINT_SHA256" ]]; }
+    then
       log "WARN: Linux SHA256 verification not configured for ${ARCH}; installing anyway."
     fi
-    install_zip_binary "SwiftFormat ${SWIFTFORMAT_VERSION}" "$SWIFTFORMAT_URL" "$SWIFTFORMAT_SHA256" "swiftformat_linux" "swiftformat"
-    install_zip_binary "SwiftLint ${SWIFTLINT_VERSION}" "$SWIFTLINT_URL" "$SWIFTLINT_SHA256" "swiftlint"
+    if [[ "$INSTALL_SWIFTFORMAT" == true ]] && ! swiftformat_installed; then
+      install_zip_binary "SwiftFormat ${SWIFTFORMAT_VERSION}" "$SWIFTFORMAT_URL" "$SWIFTFORMAT_SHA256" "swiftformat_linux" "swiftformat"
+    fi
+    if [[ "$INSTALL_SWIFTLINT" == true ]] && ! swiftlint_installed; then
+      install_zip_binary "SwiftLint ${SWIFTLINT_VERSION}" "$SWIFTLINT_URL" "$SWIFTLINT_SHA256" "swiftlint"
+    fi
     ;;
   *)
     fail "Unsupported OS: ${OS}"
@@ -133,5 +177,9 @@ case "$OS" in
 esac
 
 log "==> Installed lint tools to ${BIN_DIR}"
-"${BIN_DIR}/swiftformat" --version
-"${BIN_DIR}/swiftlint" version
+if [[ "$INSTALL_SWIFTFORMAT" == true ]]; then
+  "${BIN_DIR}/swiftformat" --version
+fi
+if [[ "$INSTALL_SWIFTLINT" == true ]]; then
+  "${BIN_DIR}/swiftlint" version
+fi

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -5,10 +5,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN_DIR="${ROOT_DIR}/.build/lint-tools/bin"
 
-ensure_tools() {
-  # Always delegate to the installer so pinned versions are enforced.
-  # The installer is idempotent and exits early when the expected versions are already present.
-  "${ROOT_DIR}/Scripts/install_lint_tools.sh"
+ensure_swiftformat() {
+  "${ROOT_DIR}/Scripts/install_lint_tools.sh" swiftformat
+}
+
+ensure_swiftlint() {
+  "${ROOT_DIR}/Scripts/install_lint_tools.sh" swiftlint
 }
 
 check_codex_parser_hash() {
@@ -48,14 +50,15 @@ run_portable_checks() {
   check_sparkle_signing_paths
   check_swift_test_sharding
   check_site_locales
-  ensure_tools
 }
 
 run_swiftformat_lint() {
+  ensure_swiftformat
   "${BIN_DIR}/swiftformat" Sources Tests --lint
 }
 
 run_swiftlint() {
+  ensure_swiftlint
   "${BIN_DIR}/swiftlint" --strict
 }
 
@@ -74,11 +77,10 @@ case "$cmd" in
     ;;
   lint-macos)
     check_app_locales
-    ensure_tools
     run_swiftformat_lint
     ;;
   format)
-    ensure_tools
+    ensure_swiftformat
     "${BIN_DIR}/swiftformat" Sources Tests
     ;;
   *)


### PR DESCRIPTION
## Summary
- teach `Scripts/install_lint_tools.sh` to install only requested pinned lint tools
- make Linux lint preinstall only SwiftLint, since `lint-linux` does not run SwiftFormat
- keep default installer behavior compatible by installing both tools when no tool is specified

## Why
After moving lint to Ubuntu, the Linux lint lane still downloaded SwiftFormat even though it only runs portable checks and SwiftLint. This keeps the same validation coverage while removing an unnecessary download and one extra external dependency from the fast lint path.

## Validation
- workflow YAML parsed with `yaml.safe_load`
- `bash -n Scripts/lint.sh`
- `bash -n Scripts/install_lint_tools.sh`
- `./Scripts/install_lint_tools.sh swiftlint` downloaded only SwiftLint 0.63.2
- `./Scripts/install_lint_tools.sh swiftformat` downloaded only SwiftFormat 0.59.1
- `./Scripts/install_lint_tools.sh` exited with requested tools already installed
- `./Scripts/lint.sh lint-linux` passed: portable checks + SwiftLint across 1153 files, 0 violations
- `./Scripts/lint.sh lint-macos` passed: app locale checks + SwiftFormat, 0 files require formatting

## Exact-head proof

- exact head: `07feb1cd66b82c88da9bd59cde8629613104e40e`
- shell syntax and `make check`: green
- isolated branch autoreview: clean (0.86)
