### PR TITLE
feat: show Bedrock Claude activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Widgets: add single-window and combined burn-down charts for Codex and Claude session/weekly limits. Thanks @jamesjlopez!
+- AWS Bedrock: show optional rolling 14-day Claude token and request totals from CloudWatch. Thanks @zyaiire!
 - Cursor: show personal on-demand spend alongside the shared team pool. Thanks @yashiels!
 - Documentation: link the community KDE Plasma panel integration. Thanks @tylxr59!
 - Codex: expose explicitly configured profile homes as switchable accounts without copying their credentials. Thanks @kiranmagic7!

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See [CLI configuration](docs/cli-configuration.md) for the full flow.
 - [Crof](docs/crof.md) — API key for dollar credit balance and request quota tracking.
 - [Command Code](docs/command-code.md) — Browser cookies for monthly USD credits from Command Code billing.
 - [StepFun](docs/stepfun.md) — Username + password login for Step Plan rate limits (5‑hour + weekly windows) and subscription plan name.
-- [AWS Bedrock](docs/bedrock.md) — AWS access keys or a named AWS profile (SSO/assume-role via the AWS CLI) for Cost Explorer usage and monthly budget tracking.
+- [AWS Bedrock](docs/bedrock.md) — AWS access keys or a named AWS profile (SSO/assume-role via the AWS CLI) for Cost Explorer spend, monthly budgets, and optional CloudWatch Claude activity.
 - [Grok](docs/grok.md) — Grok CLI billing RPC plus grok.com browser-session fallback.
 - [GroqCloud](docs/groqcloud.md) — API key for Enterprise Prometheus request/token/cache-hit metrics.
 - [LLM Proxy](docs/llm-proxy.md) — API key + base URL for aggregate proxy quota stats and provider breakdowns.

--- a/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
+++ b/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
@@ -49,6 +49,20 @@ struct ProviderEndpointOverrideValidator {
         return url
     }
 
+    func validatedURLAllowingLoopbackHTTP(_ raw: String?) -> URL? {
+        guard let raw,
+              Self.hasExplicitURLScheme(raw),
+              let url = URL(string: raw),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "http",
+              url.user == nil,
+              url.password == nil,
+              let host = self.validatedDecodedHost(for: url, policy: .allowAnyHTTPSHost),
+              scheme == "https" || Self.isLoopbackHost(host)
+        else { return nil }
+        return url
+    }
+
     static func normalizedHTTPSURL(from raw: String) -> URL? {
         let url = if Self.hasExplicitURLScheme(raw) {
             URL(string: raw)
@@ -94,6 +108,16 @@ struct ProviderEndpointOverrideValidator {
         let scheme = raw[..<colonIndex]
         guard let first = scheme.first, first.isLetter else { return false }
         return scheme.dropFirst().allSatisfy { $0.isLetter || $0.isNumber || ["+", "-", "."].contains($0) }
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
+        if host == "localhost" || host == "::1" { return true }
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4,
+              let first = UInt8(octets[0]),
+              octets.dropFirst().allSatisfy({ UInt8($0) != nil })
+        else { return false }
+        return first == 127
     }
 
     private func hostAuthority(host: String, port: Int?) -> String {

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockCloudWatchUsage.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockCloudWatchUsage.swift
@@ -157,11 +157,8 @@ enum BedrockCloudWatchUsageFetcher {
     private static func endpoint(region: String, override: String?) throws -> URL {
         if override != nil {
             guard let override = BedrockSettingsReader.cleaned(override),
-                  let components = URLComponents(string: override),
-                  let scheme = components.scheme?.lowercased(),
-                  scheme == "http" || scheme == "https",
-                  components.host?.isEmpty == false,
-                  let url = components.url
+                  let url = ProviderEndpointOverrideValidator()
+                      .validatedURLAllowingLoopbackHTTP(override)
             else {
                 throw BedrockUsageError.cloudWatchParseFailed("invalid endpoint override")
             }

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockCloudWatchUsage.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockCloudWatchUsage.swift
@@ -155,10 +155,42 @@ enum BedrockCloudWatchUsageFetcher {
     }
 
     private static func endpoint(region: String, override: String?) throws -> URL {
-        if let override = BedrockSettingsReader.cleaned(override), let url = URL(string: override) {
+        if override != nil {
+            guard let override = BedrockSettingsReader.cleaned(override),
+                  let components = URLComponents(string: override),
+                  let scheme = components.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https",
+                  components.host?.isEmpty == false,
+                  let url = components.url
+            else {
+                throw BedrockUsageError.cloudWatchParseFailed("invalid endpoint override")
+            }
             return url
         }
-        guard let url = URL(string: "https://monitoring.\(region).amazonaws.com") else {
+        guard region.range(
+            of: #"^[a-z0-9]+(?:-[a-z0-9]+)+-[0-9]+$"#,
+            options: .regularExpression) != nil
+        else {
+            throw BedrockUsageError.cloudWatchParseFailed("invalid region endpoint")
+        }
+        // Match the CloudWatch partition suffixes published by the AWS SDK endpoint resolver.
+        let suffix = switch region {
+        case let region where region.hasPrefix("cn-"):
+            "amazonaws.com.cn"
+        case let region where region.hasPrefix("eusc-"):
+            "amazonaws.eu"
+        case let region where region.hasPrefix("us-iso-"):
+            "c2s.ic.gov"
+        case let region where region.hasPrefix("us-isob-"):
+            "sc2s.sgov.gov"
+        case let region where region.hasPrefix("eu-isoe-"):
+            "cloud.adc-e.uk"
+        case let region where region.hasPrefix("us-isof-"):
+            "csp.hci.ic.gov"
+        default:
+            "amazonaws.com"
+        }
+        guard let url = URL(string: "https://monitoring.\(region).\(suffix)") else {
             throw BedrockUsageError.cloudWatchParseFailed("invalid region endpoint")
         }
         return url

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockCloudWatchUsage.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockCloudWatchUsage.swift
@@ -1,0 +1,202 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct BedrockClaudeActivity: Equatable {
+    let inputTokens: Int
+    let outputTokens: Int
+    let requestCount: Int
+}
+
+enum BedrockCloudWatchUsageFetcher {
+    static let lookbackDays = 14
+
+    private static let maxResponseBytes = 4 * 1024 * 1024
+    private static let maxPages = 20
+    private static let requestTimeoutSeconds: TimeInterval = 15
+
+    private enum Metric: String, CaseIterable {
+        case inputTokens
+        case outputTokens
+        case requests
+
+        var cloudWatchName: String {
+            switch self {
+            case .inputTokens: "InputTokenCount"
+            case .outputTokens: "OutputTokenCount"
+            case .requests: "Invocations"
+            }
+        }
+    }
+
+    private struct RequestContext {
+        let credentials: BedrockAWSSigner.Credentials
+        let region: String
+        let now: Date
+        let endpoint: URL
+        let transport: any ProviderHTTPTransport
+    }
+
+    static func fetch(
+        credentials: BedrockAWSSigner.Credentials,
+        region: String,
+        now: Date,
+        endpointOverride: String?,
+        transport: any ProviderHTTPTransport) async throws -> BedrockClaudeActivity
+    {
+        let totals = try await self.fetchTotals(
+            credentials: credentials,
+            region: region,
+            now: now,
+            endpointOverride: endpointOverride,
+            transport: transport)
+
+        return BedrockClaudeActivity(
+            inputTokens: totals[.inputTokens] ?? 0,
+            outputTokens: totals[.outputTokens] ?? 0,
+            requestCount: totals[.requests] ?? 0)
+    }
+
+    private static func fetchTotals(
+        credentials: BedrockAWSSigner.Credentials,
+        region: String,
+        now: Date,
+        endpointOverride: String?,
+        transport: any ProviderHTTPTransport) async throws -> [Metric: Int]
+    {
+        let context = try RequestContext(
+            credentials: credentials,
+            region: region,
+            now: now,
+            endpoint: self.endpoint(region: region, override: endpointOverride),
+            transport: transport)
+        var totals: [Metric: Double] = [:]
+        var nextToken: String?
+        var seenTokens: Set<String> = []
+        var pageCount = 0
+
+        repeat {
+            pageCount += 1
+            guard pageCount <= self.maxPages else {
+                throw BedrockUsageError.cloudWatchParseFailed("too many response pages")
+            }
+
+            let response = try await self.callPage(
+                context: context,
+                nextToken: nextToken)
+            for (metric, value) in response.totals {
+                totals[metric, default: 0] += value
+            }
+            nextToken = response.nextToken
+            if let nextToken, !seenTokens.insert(nextToken).inserted {
+                throw BedrockUsageError.cloudWatchParseFailed("repeated NextToken")
+            }
+        } while nextToken != nil
+
+        var converted: [Metric: Int] = [:]
+        for metric in Metric.allCases {
+            let total = totals[metric] ?? 0
+            guard total.isFinite, total >= 0, total <= Double(Int.max) else {
+                throw BedrockUsageError.cloudWatchParseFailed("invalid metric total")
+            }
+            converted[metric] = Int(total.rounded())
+        }
+        return converted
+    }
+
+    private static func callPage(
+        context: RequestContext,
+        nextToken: String?) async throws
+        -> (totals: [Metric: Double], nextToken: String?)
+    {
+        let start = context.now.addingTimeInterval(-Double(self.lookbackDays) * 24 * 60 * 60)
+        let queries: [[String: Any]] = Metric.allCases.map { metric in
+            let search = "SEARCH('{AWS/Bedrock,ModelId} "
+                + "MetricName=\"\(metric.cloudWatchName)\" claude', 'Sum', 86400)"
+            return [
+                "Id": metric.rawValue,
+                "Expression": "SUM(\(search))",
+                "ReturnData": true,
+            ]
+        }
+        var payload: [String: Any] = [
+            "StartTime": start.timeIntervalSince1970,
+            "EndTime": context.now.timeIntervalSince1970,
+            "ScanBy": "TimestampAscending",
+            "MetricDataQueries": queries,
+        ]
+        if let nextToken {
+            payload["NextToken"] = nextToken
+        }
+
+        var request = URLRequest(url: context.endpoint)
+        request.httpMethod = "POST"
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        request.timeoutInterval = self.requestTimeoutSeconds
+        request.setValue("application/x-amz-json-1.0", forHTTPHeaderField: "Content-Type")
+        request.setValue(
+            "GraniteServiceVersion20100801.GetMetricData",
+            forHTTPHeaderField: "X-Amz-Target")
+        BedrockAWSSigner.sign(
+            request: &request,
+            credentials: context.credentials,
+            region: context.region,
+            service: "monitoring")
+
+        let response = try await context.transport.response(for: request)
+        guard response.statusCode == 200 else {
+            throw BedrockUsageError.cloudWatchAPIError("HTTP \(response.statusCode)")
+        }
+        guard response.data.count <= self.maxResponseBytes else {
+            throw BedrockUsageError.cloudWatchParseFailed("response exceeds 4 MiB")
+        }
+        return try self.parsePage(response.data)
+    }
+
+    private static func endpoint(region: String, override: String?) throws -> URL {
+        if let override = BedrockSettingsReader.cleaned(override), let url = URL(string: override) {
+            return url
+        }
+        guard let url = URL(string: "https://monitoring.\(region).amazonaws.com") else {
+            throw BedrockUsageError.cloudWatchParseFailed("invalid region endpoint")
+        }
+        return url
+    }
+
+    private static func parsePage(_ data: Data) throws
+        -> (totals: [Metric: Double], nextToken: String?)
+    {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw BedrockUsageError.cloudWatchParseFailed("invalid JSON response")
+        }
+
+        if let messages = json["Messages"] as? [[String: Any]], !messages.isEmpty {
+            throw BedrockUsageError.cloudWatchParseFailed("CloudWatch reported incomplete results")
+        }
+
+        let results = json["MetricDataResults"] as? [[String: Any]] ?? []
+        var totals: [Metric: Double] = [:]
+        for result in results {
+            guard let id = result["Id"] as? String, let metric = Metric(rawValue: id) else {
+                throw BedrockUsageError.cloudWatchParseFailed("metric result had an unknown ID")
+            }
+            guard result["StatusCode"] as? String == "Complete" else {
+                throw BedrockUsageError.cloudWatchParseFailed("metric result was incomplete")
+            }
+            guard let values = result["Values"] as? [Any] else { continue }
+            for value in values {
+                guard let number = value as? NSNumber else {
+                    throw BedrockUsageError.cloudWatchParseFailed("metric value was not numeric")
+                }
+                let double = number.doubleValue
+                guard double.isFinite, double >= 0 else {
+                    throw BedrockUsageError.cloudWatchParseFailed("metric value was invalid")
+                }
+                totals[metric, default: 0] += double
+            }
+        }
+
+        return (totals, BedrockSettingsReader.cleaned(json["NextToken"] as? String))
+    }
+}

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockSettingsReader.swift
@@ -12,6 +12,7 @@ public enum BedrockSettingsReader {
     public static let regionKeys = ["AWS_REGION", "AWS_DEFAULT_REGION"]
     public static let budgetKey = "CODEXBAR_BEDROCK_BUDGET"
     public static let apiURLKey = "CODEXBAR_BEDROCK_API_URL"
+    public static let cloudWatchAPIURLKey = "CODEXBAR_BEDROCK_CLOUDWATCH_API_URL"
     public static let profileKey = "AWS_PROFILE"
     public static let authModeKey = "CODEXBAR_BEDROCK_AUTH_MODE"
     public static let defaultRegion = "us-east-1"

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockUsageStats.swift
@@ -8,6 +8,7 @@ public struct BedrockUsageSnapshot: Codable, Sendable {
     public let monthlyBudget: Double?
     public let inputTokens: Int?
     public let outputTokens: Int?
+    public let requestCount: Int?
     public let region: String
     public let updatedAt: Date
 
@@ -16,6 +17,7 @@ public struct BedrockUsageSnapshot: Codable, Sendable {
         monthlyBudget: Double?,
         inputTokens: Int? = nil,
         outputTokens: Int? = nil,
+        requestCount: Int? = nil,
         region: String,
         updatedAt: Date)
     {
@@ -23,6 +25,7 @@ public struct BedrockUsageSnapshot: Codable, Sendable {
         self.monthlyBudget = monthlyBudget
         self.inputTokens = inputTokens
         self.outputTokens = outputTokens
+        self.requestCount = requestCount
         self.region = region
         self.updatedAt = updatedAt
     }
@@ -64,7 +67,10 @@ extension BedrockUsageSnapshot {
             loginParts.append(String(format: "Budget: $%.2f", budget))
         }
         if let total = self.totalTokens {
-            loginParts.append("Tokens: \(Self.formattedTokenCount(total))")
+            loginParts.append("Claude 14d: \(Self.formattedTokenCount(total)) tokens")
+        }
+        if let requestCount = self.requestCount {
+            loginParts.append("Requests: \(Self.formattedTokenCount(requestCount))")
         }
 
         let identity = ProviderIdentitySnapshot(
@@ -115,20 +121,40 @@ enum BedrockUsageFetcher {
         credentials: BedrockAWSSigner.Credentials,
         region: String,
         budget: Double?,
-        environment: [String: String] = ProcessInfo.processInfo.environment) async throws
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        now: Date = Date(),
+        cloudWatchTransport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws
         -> BedrockUsageSnapshot
     {
         let spend = try await Self.fetchMonthlyCost(
             credentials: credentials,
             environment: environment)
 
+        var activity: BedrockClaudeActivity?
+        let cloudWatchOverride = environment[BedrockSettingsReader.cloudWatchAPIURLKey]
+        let shouldFetchCloudWatch = environment[BedrockSettingsReader.apiURLKey] == nil || cloudWatchOverride != nil
+        if shouldFetchCloudWatch {
+            do {
+                activity = try await BedrockCloudWatchUsageFetcher.fetch(
+                    credentials: credentials,
+                    region: region,
+                    now: now,
+                    endpointOverride: cloudWatchOverride,
+                    transport: cloudWatchTransport)
+            } catch {
+                if Task.isCancelled { throw error }
+                Self.log.debug("AWS CloudWatch Claude activity unavailable; keeping Cost Explorer usage.")
+            }
+        }
+
         return BedrockUsageSnapshot(
             monthlySpend: spend,
             monthlyBudget: budget,
-            inputTokens: nil,
-            outputTokens: nil,
+            inputTokens: activity?.inputTokens,
+            outputTokens: activity?.outputTokens,
+            requestCount: activity?.requestCount,
             region: region,
-            updatedAt: Date())
+            updatedAt: now)
     }
 
     static func fetchDailyReport(
@@ -446,6 +472,8 @@ public enum BedrockUsageError: LocalizedError, Sendable, Equatable {
     case networkError(String)
     case apiError(String)
     case parseFailed(String)
+    case cloudWatchAPIError(String)
+    case cloudWatchParseFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -462,6 +490,10 @@ public enum BedrockUsageError: LocalizedError, Sendable, Equatable {
             "AWS Cost Explorer API error: \(message)"
         case let .parseFailed(message):
             "Failed to parse AWS Cost Explorer response: \(message)"
+        case let .cloudWatchAPIError(message):
+            "AWS CloudWatch API error: \(message)"
+        case let .cloudWatchParseFailed(message):
+            "Failed to parse AWS CloudWatch response: \(message)"
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockUsageStats.swift
@@ -232,10 +232,14 @@ enum BedrockUsageFetcher {
         environment: [String: String]) async throws -> Data
     {
         let ceRegion = "us-east-1"
-        let baseURL: URL = if let override = environment[BedrockSettingsReader.apiURLKey],
-                              let url = URL(string: BedrockSettingsReader.cleaned(override) ?? "")
-        {
-            url
+        let baseURL: URL = if environment[BedrockSettingsReader.apiURLKey] != nil {
+            if let override = BedrockSettingsReader.cleaned(environment[BedrockSettingsReader.apiURLKey]),
+               let url = ProviderEndpointOverrideValidator().validatedURLAllowingLoopbackHTTP(override)
+            {
+                url
+            } else {
+                throw BedrockUsageError.parseFailed("invalid endpoint override")
+            }
         } else {
             URL(string: "https://ce.\(ceRegion).amazonaws.com")!
         }

--- a/Tests/CodexBarTests/BedrockUsageStatsTests.swift
+++ b/Tests/CodexBarTests/BedrockUsageStatsTests.swift
@@ -505,6 +505,63 @@ struct BedrockUsageStatsTests {
         #expect(usage.updatedAt == now)
     }
 
+    @Test
+    func `cloudwatch invalid override fails closed without transport`() async throws {
+        let capture = BedrockRequestCapture()
+        let transport = ProviderHTTPTransportHandler { request in
+            capture.append(request)
+            throw URLError(.badURL)
+        }
+
+        for override in ["   ", "not-an-absolute-url"] {
+            await #expect(throws: BedrockUsageError.cloudWatchParseFailed("invalid endpoint override")) {
+                try await BedrockCloudWatchUsageFetcher.fetch(
+                    credentials: Self.testCredentials,
+                    region: "us-east-1",
+                    now: Date(timeIntervalSince1970: 1_750_000_000),
+                    endpointOverride: override,
+                    transport: transport)
+            }
+        }
+        #expect(capture.requests.isEmpty)
+    }
+
+    @Test
+    func `cloudwatch resolves AWS partition endpoints`() async throws {
+        let capture = BedrockRequestCapture()
+        let transport = ProviderHTTPTransportHandler { request in
+            capture.append(request)
+            let requestURL = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: requestURL,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil))
+            return (Data(#"{"MetricDataResults":[]}"#.utf8), response)
+        }
+        let cases = [
+            ("us-east-1", "monitoring.us-east-1.amazonaws.com"),
+            ("us-gov-west-1", "monitoring.us-gov-west-1.amazonaws.com"),
+            ("cn-north-1", "monitoring.cn-north-1.amazonaws.com.cn"),
+            ("eusc-de-east-1", "monitoring.eusc-de-east-1.amazonaws.eu"),
+            ("us-iso-east-1", "monitoring.us-iso-east-1.c2s.ic.gov"),
+            ("us-isob-east-1", "monitoring.us-isob-east-1.sc2s.sgov.gov"),
+            ("eu-isoe-west-1", "monitoring.eu-isoe-west-1.cloud.adc-e.uk"),
+            ("us-isof-south-1", "monitoring.us-isof-south-1.csp.hci.ic.gov"),
+        ]
+
+        for (region, _) in cases {
+            _ = try await BedrockCloudWatchUsageFetcher.fetch(
+                credentials: Self.testCredentials,
+                region: region,
+                now: Date(timeIntervalSince1970: 1_750_000_000),
+                endpointOverride: nil,
+                transport: transport)
+        }
+
+        #expect(capture.requests.compactMap(\.url?.host) == cases.map(\.1))
+    }
+
     private static let testCredentials = BedrockAWSSigner.Credentials(
         accessKeyID: "AKIATEST",
         secretAccessKey: "testSecret",

--- a/Tests/CodexBarTests/BedrockUsageStatsTests.swift
+++ b/Tests/CodexBarTests/BedrockUsageStatsTests.swift
@@ -11,6 +11,7 @@ struct BedrockUsageStatsTests {
             monthlyBudget: 200,
             inputTokens: 1_500_000,
             outputTokens: 500_000,
+            requestCount: 42,
             region: "us-east-1",
             updatedAt: Date(timeIntervalSince1970: 1_739_841_600))
 
@@ -25,6 +26,8 @@ struct BedrockUsageStatsTests {
         #expect(usage.providerCost?.period == "Monthly")
         #expect(usage.identity?.providerID == .bedrock)
         #expect(usage.identity?.loginMethod?.contains("Spend: $50.00") == true)
+        #expect(usage.identity?.loginMethod?.contains("Claude 14d: 2.0M tokens") == true)
+        #expect(usage.identity?.loginMethod?.contains("Requests: 42") == true)
     }
 
     @Test
@@ -333,6 +336,180 @@ struct BedrockUsageStatsTests {
         #expect(range.end == "2026-05-11")
     }
 
+    @Test
+    func `cloudwatch fetch aggregates Claude activity with bounded signed query`() async throws {
+        let now = try #require(ISO8601DateFormatter().date(from: "2026-06-19T12:00:00Z"))
+        let capture = BedrockRequestCapture()
+        let transport = ProviderHTTPTransportHandler { request in
+            capture.append(request)
+            let requestURL = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: requestURL,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]))
+            let body = """
+            {
+                "MetricDataResults": [
+                    {"Id":"inputTokens","StatusCode":"Complete","Values":[1000,2500]},
+                    {"Id":"outputTokens","StatusCode":"Complete","Values":[400,600]},
+                    {"Id":"requests","StatusCode":"Complete","Values":[7,8]}
+                ]
+            }
+            """
+            return (Data(body.utf8), response)
+        }
+
+        let activity = try await BedrockCloudWatchUsageFetcher.fetch(
+            credentials: Self.testCredentials,
+            region: "us-west-2",
+            now: now,
+            endpointOverride: "https://cloudwatch.test",
+            transport: transport)
+
+        #expect(activity == BedrockClaudeActivity(inputTokens: 3500, outputTokens: 1000, requestCount: 15))
+        let request = try #require(capture.requests.first)
+        #expect(capture.requests.count == 1)
+        #expect(request.value(forHTTPHeaderField: "X-Amz-Target") ==
+            "GraniteServiceVersion20100801.GetMetricData")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-amz-json-1.0")
+        #expect(request.value(forHTTPHeaderField: "Authorization")?.contains(
+            "/us-west-2/monitoring/aws4_request") == true)
+
+        let requestBody = try #require(request.httpBody)
+        let payload = try #require(try JSONSerialization.jsonObject(with: requestBody) as? [String: Any])
+        #expect(payload["StartTime"] as? Double == now.timeIntervalSince1970 - 14 * 24 * 60 * 60)
+        #expect(payload["EndTime"] as? Double == now.timeIntervalSince1970)
+        let queries = try #require(payload["MetricDataQueries"] as? [[String: Any]])
+        #expect(queries.count == 3)
+        #expect(queries.allSatisfy { query in
+            guard let expression = query["Expression"] as? String else { return false }
+            return expression.hasPrefix("SUM(SEARCH(") && expression.contains("claude") &&
+                expression.contains("86400")
+        })
+    }
+
+    @Test
+    func `cloudwatch pagination aggregates pages`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            let requestBody = try #require(request.httpBody)
+            let payload = try #require(JSONSerialization.jsonObject(with: requestBody) as? [String: Any])
+            let isSecondPage = payload["NextToken"] as? String == "page-2"
+            let body = if isSecondPage {
+                """
+                {"MetricDataResults":[{"Id":"inputTokens","StatusCode":"Complete","Values":[3]}]}
+                """
+            } else {
+                """
+                {
+                    "NextToken":"page-2",
+                    "MetricDataResults":[{"Id":"inputTokens","StatusCode":"Complete","Values":[2]}]
+                }
+                """
+            }
+            let requestURL = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: requestURL,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil))
+            return (Data(body.utf8), response)
+        }
+
+        let activity = try await BedrockCloudWatchUsageFetcher.fetch(
+            credentials: Self.testCredentials,
+            region: "us-east-1",
+            now: Date(timeIntervalSince1970: 1_750_000_000),
+            endpointOverride: "https://cloudwatch.test",
+            transport: transport)
+
+        #expect(activity.inputTokens == 5)
+        #expect(activity.outputTokens == 0)
+        #expect(activity.requestCount == 0)
+    }
+
+    @Test
+    func `cloudwatch rejects incomplete search results`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            let requestURL = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: requestURL,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil))
+            let body = #"{"Messages":[{"Code":"MaxQueryLimit","Value":"Maximum number exceeded"}]}"#
+            return (Data(body.utf8), response)
+        }
+
+        await #expect(throws: BedrockUsageError.cloudWatchParseFailed(
+            "CloudWatch reported incomplete results"))
+        {
+            try await BedrockCloudWatchUsageFetcher.fetch(
+                credentials: Self.testCredentials,
+                region: "us-east-1",
+                now: Date(timeIntervalSince1970: 1_750_000_000),
+                endpointOverride: "https://cloudwatch.test",
+                transport: transport)
+        }
+    }
+
+    @Test
+    func `cloudwatch permission failure preserves cost explorer usage`() async throws {
+        let registered = URLProtocol.registerClass(BedrockStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(BedrockStubURLProtocol.self)
+            }
+            BedrockStubURLProtocol.handler = nil
+        }
+        BedrockStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            let body = """
+            {
+                "ResultsByTime": [{
+                    "Groups": [{
+                        "Keys": ["Amazon Bedrock"],
+                        "Metrics": {"UnblendedCost": {"Amount": "12.50"}}
+                    }]
+                }]
+            }
+            """
+            return Self.makeResponse(url: url, body: body)
+        }
+        let cloudWatchTransport = ProviderHTTPTransportHandler { request in
+            let requestURL = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: requestURL,
+                statusCode: 403,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil))
+            return (Data(), response)
+        }
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+        let usage = try await BedrockUsageFetcher.fetchUsage(
+            credentials: Self.testCredentials,
+            region: "us-east-1",
+            budget: nil,
+            environment: [
+                BedrockSettingsReader.apiURLKey: "https://bedrock.test",
+                BedrockSettingsReader.cloudWatchAPIURLKey: "https://cloudwatch.test",
+            ],
+            now: now,
+            cloudWatchTransport: cloudWatchTransport)
+
+        #expect(usage.monthlySpend == 12.5)
+        #expect(usage.inputTokens == nil)
+        #expect(usage.outputTokens == nil)
+        #expect(usage.requestCount == nil)
+        #expect(usage.updatedAt == now)
+    }
+
+    private static let testCredentials = BedrockAWSSigner.Credentials(
+        accessKeyID: "AKIATEST",
+        secretAccessKey: "testSecret",
+        sessionToken: nil)
+
     private final class BedrockStubResponseQueue {
         private let lock = NSLock()
         private var bodies: [String]
@@ -372,6 +549,23 @@ struct BedrockUsageStatsTests {
             httpVersion: "HTTP/1.1",
             headerFields: ["Content-Type": "application/json"])!
         return (response, Data(body.utf8))
+    }
+}
+
+private final class BedrockRequestCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [URLRequest] = []
+
+    var requests: [URLRequest] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.storage
+    }
+
+    func append(_ request: URLRequest) {
+        self.lock.lock()
+        self.storage.append(request)
+        self.lock.unlock()
     }
 }
 

--- a/Tests/CodexBarTests/BedrockUsageStatsTests.swift
+++ b/Tests/CodexBarTests/BedrockUsageStatsTests.swift
@@ -192,6 +192,31 @@ struct BedrockUsageStatsTests {
     }
 
     @Test
+    func `cost explorer rejects remote HTTP override before transport`() async throws {
+        let registered = URLProtocol.registerClass(BedrockStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(BedrockStubURLProtocol.self)
+            }
+            BedrockStubURLProtocol.handler = nil
+        }
+        let capture = BedrockRequestCapture()
+        BedrockStubURLProtocol.handler = { request in
+            capture.append(request)
+            throw URLError(.badURL)
+        }
+
+        await #expect(throws: BedrockUsageError.parseFailed("invalid endpoint override")) {
+            try await BedrockUsageFetcher.fetchUsage(
+                credentials: Self.testCredentials,
+                region: "us-east-1",
+                budget: nil,
+                environment: [BedrockSettingsReader.apiURLKey: "http://bedrock.test"])
+        }
+        #expect(capture.requests.isEmpty)
+    }
+
+    @Test
     func `cost explorer pagination aggregates monthly total`() async throws {
         let registered = URLProtocol.registerClass(BedrockStubURLProtocol.self)
         defer {
@@ -513,7 +538,7 @@ struct BedrockUsageStatsTests {
             throw URLError(.badURL)
         }
 
-        for override in ["   ", "not-an-absolute-url"] {
+        for override in ["   ", "not-an-absolute-url", "http://cloudwatch.test"] {
             await #expect(throws: BedrockUsageError.cloudWatchParseFailed("invalid endpoint override")) {
                 try await BedrockCloudWatchUsageFetcher.fetch(
                     credentials: Self.testCredentials,
@@ -524,6 +549,37 @@ struct BedrockUsageStatsTests {
             }
         }
         #expect(capture.requests.isEmpty)
+    }
+
+    @Test
+    func `cloudwatch allows HTTP only for loopback overrides`() async throws {
+        let capture = BedrockRequestCapture()
+        let transport = ProviderHTTPTransportHandler { request in
+            capture.append(request)
+            let requestURL = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: requestURL,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil))
+            return (Data(#"{"MetricDataResults":[]}"#.utf8), response)
+        }
+        let overrides = [
+            "http://localhost:8080",
+            "http://127.42.0.1:8080",
+            "http://[::1]:8080",
+        ]
+
+        for endpointOverride in overrides {
+            _ = try await BedrockCloudWatchUsageFetcher.fetch(
+                credentials: Self.testCredentials,
+                region: "us-east-1",
+                now: Date(timeIntervalSince1970: 1_750_000_000),
+                endpointOverride: endpointOverride,
+                transport: transport)
+        }
+
+        #expect(capture.requests.compactMap(\.url?.absoluteString) == overrides)
     }
 
     @Test

--- a/docs/bedrock.md
+++ b/docs/bedrock.md
@@ -69,8 +69,8 @@ tracking continue unchanged.
 - Claude activity: rolling 14-day input tokens, output tokens, and requests from the configured region's `AWS/Bedrock`
   CloudWatch metrics. Other model families are excluded.
 - Budget: `CODEXBAR_BEDROCK_BUDGET`, when set to a positive dollar amount.
-- Test override: `CODEXBAR_BEDROCK_API_URL` replaces the Cost Explorer endpoint.
-- Test override: `CODEXBAR_BEDROCK_CLOUDWATCH_API_URL` replaces the CloudWatch endpoint.
+- Test override: `CODEXBAR_BEDROCK_API_URL` replaces the Cost Explorer endpoint; use HTTPS or loopback HTTP.
+- Test override: `CODEXBAR_BEDROCK_CLOUDWATCH_API_URL` replaces the CloudWatch endpoint; use HTTPS or loopback HTTP.
 
 ## Display
 

--- a/docs/bedrock.md
+++ b/docs/bedrock.md
@@ -8,7 +8,8 @@ read_when:
 
 # AWS Bedrock provider
 
-CodexBar reads AWS Cost Explorer for Bedrock spend and can compare the current month against an optional budget.
+CodexBar reads AWS Cost Explorer for Bedrock spend and can compare the current month against an optional budget. When
+permitted, it also reads CloudWatch for rolling 14-day Claude token and request totals in the configured region.
 
 ## Authentication
 
@@ -57,19 +58,25 @@ export AWS_CLI_PATH="/opt/homebrew/bin/aws"   # optional override
 ```
 
 The AWS identity (from either mode) must have permission to call Cost Explorer APIs, including `ce:GetCostAndUsage`.
+Grant `cloudwatch:GetMetricData` to add the optional Claude activity totals. Without that permission, cost and budget
+tracking continue unchanged.
 
 ## Data source
 
 - Service: AWS Cost Explorer.
 - Region: `AWS_REGION` or `AWS_DEFAULT_REGION`, defaulting to `us-east-1`.
 - Usage: current-month Bedrock spend and historical daily cost buckets.
+- Claude activity: rolling 14-day input tokens, output tokens, and requests from the configured region's `AWS/Bedrock`
+  CloudWatch metrics. Other model families are excluded.
 - Budget: `CODEXBAR_BEDROCK_BUDGET`, when set to a positive dollar amount.
 - Test override: `CODEXBAR_BEDROCK_API_URL` replaces the Cost Explorer endpoint.
+- Test override: `CODEXBAR_BEDROCK_CLOUDWATCH_API_URL` replaces the CloudWatch endpoint.
 
 ## Display
 
 - Shows month-to-date Bedrock spend.
 - Shows budget progress when a budget is configured.
+- Shows rolling 14-day Claude tokens and requests when CloudWatch access is available.
 - Reuses the shared inline dashboard for daily cost history when enough buckets are available.
 
 ## CLI
@@ -86,6 +93,8 @@ codexbar --provider bedrock --format json --pretty
 - Confirm the credentials are visible to CodexBar.
 - Confirm the AWS account has Cost Explorer enabled.
 - Confirm the IAM principal can call `ce:GetCostAndUsage`.
+- To include Claude token/request totals, confirm the principal can call `cloudwatch:GetMetricData` in the configured
+  region.
 - If using temporary credentials, include `AWS_SESSION_TOKEN`.
 - In profile mode, confirm the AWS CLI is installed (or set `AWS_CLI_PATH`) and that the profile name is correct.
 

--- a/docs/bedrock.md
+++ b/docs/bedrock.md
@@ -1,9 +1,9 @@
 ---
-summary: "AWS Bedrock provider: Cost Explorer credentials, budget tracking, and usage display."
+summary: "AWS Bedrock provider: Cost Explorer spend, CloudWatch Claude activity, credentials, and budgets."
 read_when:
   - Setting up AWS Bedrock usage tracking
-  - Debugging Bedrock Cost Explorer fetches
-  - Updating Bedrock credentials, region, or budget handling
+  - Debugging Bedrock Cost Explorer or CloudWatch fetches
+  - Updating Bedrock credentials, region, budget, or activity handling
 ---
 
 # AWS Bedrock provider

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -65,7 +65,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Venice | API key from config/env → DIEM/USD balance API (`api`). |
 | Command Code | Web billing API via Command Code session cookies (`web`). |
 | StepFun | Username/password login or manual Oasis token (`web`). |
-| AWS Bedrock | AWS credentials → Cost Explorer usage and budget tracking (`api`). |
+| AWS Bedrock | AWS credentials → Cost Explorer spend/budgets and optional CloudWatch Claude activity (`api`). |
 | Grok | `grok agent stdio` JSON-RPC `x.ai/billing` (`cli`) → grok.com billing gRPC-web via Chrome session cookies (`web`); local `~/.grok/sessions` signals as fallback. |
 | GroqCloud | API key → Prometheus metrics API for request/token/cache-hit rates (`api`). |
 | LLM Proxy | API key + base URL → `/v1/quota-stats` aggregate proxy usage (`api`). |
@@ -384,6 +384,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - AWS credentials from `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN`.
 - Region from `AWS_REGION` / `AWS_DEFAULT_REGION`, defaulting to `us-east-1`.
 - Reads AWS Cost Explorer for Bedrock spend and can compare usage against `CODEXBAR_BEDROCK_BUDGET`.
+- Optionally reads rolling 14-day Claude token and request totals from CloudWatch with `cloudwatch:GetMetricData`.
 - Override Cost Explorer base URL with `CODEXBAR_BEDROCK_API_URL` for tests.
 - Details: `docs/bedrock.md`.
 


### PR DESCRIPTION
## Summary

- add optional rolling 14-day Claude input-token, output-token, and request totals to the existing AWS Bedrock provider
- query the configured region's `AWS/Bedrock` CloudWatch metrics with one bounded, paginated, SigV4-signed `GetMetricData` request
- preserve Cost Explorer spend and budget data when CloudWatch permission, data, or transport is unavailable
- document the optional `cloudwatch:GetMetricData` permission and add changelog credit for #1415

## Contract

- AWS documents `InputTokenCount`, `OutputTokenCount`, and `Invocations` under `AWS/Bedrock` with a `ModelId` dimension: https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring-runtime-metrics.html
- CloudWatch documents partial-match search, the two-week discovery window, and `SUM(SEARCH(...))`: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/search-expression-syntax.html
- AWS's canonical service model declares the `monitoring` SigV4 name and JSON 1.0 protocol used here: https://github.com/aws/api-models-aws/blob/f990bd54c8b7b81c624d828ecb97335fd4a0596d/models/cloudwatch/service/2010-08-01/cloudwatch-2010-08-01.json
- endpoint suffixes follow the official AWS SDK partition rules for commercial, China, EU sovereign, and isolated regions

## Safety

- CloudWatch is best-effort and sequential after the required Cost Explorer fetch; cancellation still propagates
- CloudWatch and Cost Explorer endpoint overrides require HTTPS, except exact loopback hosts may use HTTP for isolated tests; invalid overrides fail before signing or transport
- search results are server-summed per metric, capped to 20 pages and 4 MiB per page, and reject repeated page tokens, unknown IDs, invalid values, partial results, and global truncation messages
- only model IDs matching the `claude` search token contribute; other Bedrock model families remain excluded
- Cost Explorer endpoint overrides do not accidentally make a real CloudWatch request unless a valid CloudWatch override is also supplied

## Verification

Exact head: `c5515b9f2fdda2890b69bd0424202294e14d6fe3`, rebased onto current main `1066194c`.

- `swift test --filter BedrockUsageStatsTests`: 18 tests passed
- `make check`: passed; SwiftFormat clean and SwiftLint reported zero violations
- `make test`: all 41 groups passed on the prior repaired head; the current-main rebase changed only base/changelog integration, with fresh hosted CI authoritative
- `make docs-list`: passed; Bedrock routing metadata, README, provider catalog, and dedicated guide updated
- request-shape regression covers JSON 1.0 content type, target, `monitoring` signing scope, configured region, 14-day bounds, and all three server-summed searches
- endpoint regressions cover invalid and remote-HTTP zero-transport behavior, loopback HTTP, and every supported AWS partition suffix
- pagination, incomplete-result rejection, display projection, and permission-failure fallback regressions passed
- autoreview: local security repair and prior full-branch reviews clean (0.83 and 0.84); final current-main context-aware review clean (0.83)
- protocol review: AWS's primary service model supports JSON 1.0, Query, and Query-compatible requests; botocore likewise lists JSON among supported CloudWatch protocols with the `GraniteServiceVersion20100801` target prefix
- live boundary: this Mac has no AWS CLI or configured AWS profile, so no live-account CloudWatch success is claimed

Closes #1415.
