### PR TITLE
fix: expose MiniMax quota diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Cost history: keep chart date labels aligned with their bars and visible without clipping. Thanks @elijahfriedman!
 - Claude settings: dim and disable Avoid Keychain prompts while global Keychain access is disabled. Thanks @Zihao-Qi!
 - Linux CLI: read OpenCode Go local SQLite usage in automatic mode and allow Command Code billing with a configured manual cookie.
+- MiniMax diagnostics: include safe per-service usage and boosted quota limits for mismatch reports. Thanks @sagelga!
 - Xiaomi MiMo: retry another imported browser session when a stale session redirects API requests to login. Thanks @Yuxin-Qiao!
 - MiniMax: retry the China API region when the global token endpoint reports a structured invalid-key response.
 - Menu refresh: scope manual refreshes to the visible provider, keep Command-R consistent with mouse refresh, and avoid animated refresh-row compositing. Thanks @jangisaac-dev!

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -399,6 +399,18 @@ public struct MiniMaxDiagnosticServiceUsage: Codable, Sendable {
     public let resetsAt: Date?
     public let hasResetDescription: Bool
 
+    private enum CodingKeys: String, CodingKey {
+        case displayName
+        case percent
+        case usage
+        case limit
+        case remaining
+        case isUnlimited
+        case windowType
+        case resetsAt
+        case hasResetDescription
+    }
+
     public init(from service: MiniMaxServiceUsage) {
         self.displayName = service.displayName
         self.percent = service.percent
@@ -409,6 +421,19 @@ public struct MiniMaxDiagnosticServiceUsage: Codable, Sendable {
         self.windowType = service.windowType
         self.resetsAt = service.resetsAt
         self.hasResetDescription = !service.resetDescription.isEmpty
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.displayName = try container.decode(String.self, forKey: .displayName)
+        self.percent = try container.decode(Double.self, forKey: .percent)
+        self.usage = try container.decodeIfPresent(Int.self, forKey: .usage) ?? 0
+        self.limit = try container.decodeIfPresent(Int.self, forKey: .limit) ?? 0
+        self.remaining = try container.decodeIfPresent(Int.self, forKey: .remaining)
+        self.isUnlimited = try container.decodeIfPresent(Bool.self, forKey: .isUnlimited) ?? false
+        self.windowType = try container.decode(String.self, forKey: .windowType)
+        self.resetsAt = try container.decodeIfPresent(Date.self, forKey: .resetsAt)
+        self.hasResetDescription = try container.decode(Bool.self, forKey: .hasResetDescription)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -391,6 +391,10 @@ public struct MiniMaxDiagnosticDetails: Codable, Sendable {
 public struct MiniMaxDiagnosticServiceUsage: Codable, Sendable {
     public let displayName: String
     public let percent: Double
+    public let usage: Int
+    public let limit: Int
+    public let remaining: Int?
+    public let isUnlimited: Bool
     public let windowType: String
     public let resetsAt: Date?
     public let hasResetDescription: Bool
@@ -398,6 +402,10 @@ public struct MiniMaxDiagnosticServiceUsage: Codable, Sendable {
     public init(from service: MiniMaxServiceUsage) {
         self.displayName = service.displayName
         self.percent = service.percent
+        self.usage = service.usage
+        self.limit = service.limit
+        self.remaining = service.isUnlimited ? nil : max(0, service.limit - service.usage)
+        self.isUnlimited = service.isUnlimited
         self.windowType = service.windowType
         self.resetsAt = service.resetsAt
         self.hasResetDescription = !service.resetDescription.isEmpty

--- a/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
+++ b/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
@@ -437,6 +437,30 @@ struct ProviderDiagnosticExportTests {
     }
 
     @Test
+    func `legacy MiniMax service diagnostic decodes without quota values`() throws {
+        let data = Data(#"""
+        {
+          "displayName": "General",
+          "percent": 4,
+          "windowType": "Weekly",
+          "resetsAt": null,
+          "hasResetDescription": true
+        }
+        """#.utf8)
+
+        let diagnostic = try JSONDecoder().decode(MiniMaxDiagnosticServiceUsage.self, from: data)
+
+        #expect(diagnostic.displayName == "General")
+        #expect(diagnostic.percent == 4)
+        #expect(diagnostic.usage == 0)
+        #expect(diagnostic.limit == 0)
+        #expect(diagnostic.remaining == nil)
+        #expect(!diagnostic.isUnlimited)
+        #expect(diagnostic.windowType == "Weekly")
+        #expect(diagnostic.hasResetDescription)
+    }
+
+    @Test
     func `builder creates generic safe diagnostic with error on failure`() {
         let outcome = ProviderFetchOutcome(
             result: .failure(MiniMaxUsageError.networkError("timeout")),

--- a/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
+++ b/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
@@ -388,24 +388,52 @@ struct ProviderDiagnosticExportTests {
     func `service usage maps from MiniMaxServiceUsage correctly`() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let service = MiniMaxServiceUsage(
-            serviceType: "Text Generation",
-            windowType: "5 hours",
-            timeRange: "10:00-15:00(UTC+8)",
-            usage: 750,
-            limit: 1000,
-            percent: 75,
+            serviceType: "General",
+            windowType: "Weekly",
+            timeRange: "Jun 15-Jun 22",
+            usage: 6,
+            limit: 150,
+            percent: 4,
             resetsAt: now.addingTimeInterval(18000),
-            resetDescription: "5 hours")
+            resetDescription: "Weekly")
 
         let diagService = MiniMaxDiagnosticServiceUsage(from: service)
-        #expect(diagService.displayName == "Text Generation")
-        #expect(diagService.percent == 75)
-        #expect(diagService.windowType == "5 hours")
+        #expect(diagService.displayName == "General")
+        #expect(diagService.percent == 4)
+        #expect(diagService.usage == 6)
+        #expect(diagService.limit == 150)
+        #expect(diagService.remaining == 144)
+        #expect(diagService.isUnlimited == false)
+        #expect(diagService.windowType == "Weekly")
         #expect(diagService.hasResetDescription == true)
 
         let json = try self.json(diagService)
         #expect(json.contains("hasResetDescription"))
+        #expect(json.contains(#""usage" : 6"#))
+        #expect(json.contains(#""limit" : 150"#))
+        #expect(json.contains(#""remaining" : 144"#))
         #expect(!json.contains("resetDescription"))
+    }
+
+    @Test
+    func `unlimited MiniMax diagnostic omits remaining quota`() throws {
+        let service = MiniMaxServiceUsage(
+            serviceType: "General",
+            windowType: "Weekly",
+            timeRange: "",
+            usage: 0,
+            limit: 0,
+            percent: 0,
+            isUnlimited: true,
+            resetsAt: nil,
+            resetDescription: "Unlimited")
+
+        let diagnostic = MiniMaxDiagnosticServiceUsage(from: service)
+        #expect(diagnostic.isUnlimited)
+        #expect(diagnostic.remaining == nil)
+
+        let json = try self.json(diagnostic)
+        #expect(!json.contains("remaining"))
     }
 
     @Test

--- a/docs/minimax.md
+++ b/docs/minimax.md
@@ -75,6 +75,8 @@ codexbar diagnose --provider minimax --format json --pretty
 
 ### Output
 - Structural diagnostic JSON with provider, source/source mode, auth summary, usage summary, fetch attempts, and error categories.
+- Per-service quota percentages, used values, limits, remaining values, reset metadata, and unlimited state. These are
+  the same non-secret values shown in the menu and help diagnose boosted quota denominators.
 - All sensitive fields (API tokens, cookies, emails, auth headers) are redacted via `LogRedactor`.
 - Errors are mapped to safe categories (`network`, `auth`, `api`, `parse`) with user-friendly descriptions.
 - No raw API responses, raw error messages, tokens, cookies, emails, account IDs, org IDs, or billing history.


### PR DESCRIPTION
## Summary

- include per-service `usage`, `limit`, computed `remaining`, and `isUnlimited` values in redacted MiniMax diagnostics
- make boosted quota evidence explicit, so a normalized `4%` can be distinguished as `6/150` rather than `4/100`
- omit `remaining` for unlimited lanes and retain the existing redaction boundary
- preserve decoding of legacy schema-1.0 diagnostics that predate the new quota fields
- document the safe fields and credit the #1362 reporter

## Why

The current #1362 diagnostic reports only normalized percentage and reset metadata. It cannot show whether CodexBar decoded MiniMax's 150% boosted denominator, so the requested diagnostic does not contain enough evidence to distinguish a parser defect from mathematically normalized capacity usage.

This is a diagnostic prerequisite, not a claim that the underlying quota mismatch is fixed. After release, the reporter can rerun the same command and provide the safe `usage`, `limit`, `remaining`, and `percent` values.

## Safety

- values come from the existing `MiniMaxServiceUsage` already rendered in the menu
- no raw response, token, cookie, header, email, account ID, org ID, or billing-history detail is added
- remaining quota is clamped to zero and omitted for unlimited lanes
- legacy diagnostics decode missing quota fields as safe zero/false/nil values; current exports always populate them

## Verification

Exact head: `0258ee4c24b26fed43fe72f04aac4f11299cb8ec`

- rebased onto current main after #1663; changelog conflict resolved by preserving the landed Linux CLI entry and MiniMax contributor credit
- `swift test --filter ProviderDiagnosticExportTests`: 23 tests passed
- `make check`: passed; SwiftFormat clean and SwiftLint reported zero violations
- `make test`: all 42 groups / 493 selections passed on the final source-identical tree
- boosted regression exports `percent: 4`, `usage: 6`, `limit: 150`, and `remaining: 144`
- unlimited regression omits `remaining`
- legacy schema-1.0 regression decodes without the new fields
- whole-branch autoreview: clean (0.86); final exact-tree review clean (0.88)

Refs #1362.
