### PR TITLE
Disable inactive Claude keychain toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 - Cost history: keep chart date labels aligned with their bars and visible without clipping. Thanks @elijahfriedman!
+- Claude settings: dim and disable Avoid Keychain prompts while global Keychain access is disabled. Thanks @Zihao-Qi!
 - Xiaomi MiMo: retry another imported browser session when a stale session redirects API requests to login. Thanks @Yuxin-Qiao!
 - Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!
 - Cursor: ignore an exhausted Auto or API subquota only when another independent quota remains usable, while preserving the overall cap. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/PreferencesProviderSettingsRows.swift
+++ b/Sources/CodexBar/PreferencesProviderSettingsRows.swift
@@ -38,14 +38,16 @@ struct ProviderSettingsToggleRowView: View {
     let toggle: ProviderSettingsToggleDescriptor
 
     var body: some View {
+        let isEnabled = self.toggle.isEnabled?() ?? true
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .firstTextBaseline, spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(L(self.toggle.title))
                         .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(isEnabled ? .primary : .tertiary)
                     Text(L(self.toggle.subtitle))
                         .font(.footnote)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(isEnabled ? .secondary : .tertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 8)
@@ -79,6 +81,7 @@ struct ProviderSettingsToggleRowView: View {
                 }
             }
         }
+        .disabled(!isEnabled)
         .onChange(of: self.toggle.binding.wrappedValue) { _, enabled in
             guard let onChange = self.toggle.onChange else { return }
             Task { @MainActor in

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -86,6 +86,7 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                 statusText: nil,
                 actions: [],
                 isVisible: nil,
+                isEnabled: { !context.settings.debugDisableKeychainAccess },
                 onChange: nil,
                 onAppDidBecomeActive: nil,
                 onAppearWhenEnabled: nil),

--- a/Sources/CodexBar/Providers/Shared/ProviderSettingsDescriptors.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderSettingsDescriptors.swift
@@ -82,6 +82,9 @@ struct ProviderSettingsToggleDescriptor: Identifiable {
     /// Optional runtime visibility gate.
     let isVisible: (() -> Bool)?
 
+    /// Optional runtime enabled gate.
+    let isEnabled: (() -> Bool)?
+
     /// Called whenever the toggle changes.
     let onChange: ((_ enabled: Bool) async -> Void)?
 
@@ -90,6 +93,32 @@ struct ProviderSettingsToggleDescriptor: Identifiable {
 
     /// Called when the view appears while the toggle is enabled.
     let onAppearWhenEnabled: (() async -> Void)?
+
+    init(
+        id: String,
+        title: String,
+        subtitle: String,
+        binding: Binding<Bool>,
+        statusText: (() -> String?)?,
+        actions: [ProviderSettingsActionDescriptor],
+        isVisible: (() -> Bool)?,
+        isEnabled: (() -> Bool)? = nil,
+        onChange: ((_ enabled: Bool) async -> Void)?,
+        onAppDidBecomeActive: (() async -> Void)?,
+        onAppearWhenEnabled: (() async -> Void)?)
+    {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.binding = binding
+        self.statusText = statusText
+        self.actions = actions
+        self.isVisible = isVisible
+        self.isEnabled = isEnabled
+        self.onChange = onChange
+        self.onAppDidBecomeActive = onAppDidBecomeActive
+        self.onAppearWhenEnabled = onAppearWhenEnabled
+    }
 }
 
 /// Shared text field descriptor rendered in the Providers settings pane.

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -127,6 +127,26 @@ struct ProviderSettingsDescriptorTests {
     }
 
     @Test
+    func `claude avoid keychain prompts toggle is disabled when global keychain disabled`() throws {
+        let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-claude-prompt-free-disabled")
+        fixture.settings.debugDisableKeychainAccess = true
+        fixture.settings.claudeOAuthPromptFreeCredentialsEnabled = true
+        let context = fixture.settingsContext(provider: .claude)
+
+        let toggles = ClaudeProviderImplementation().settingsToggles(context: context)
+        let promptFreeToggle = try #require(toggles.first(where: { $0.id == "claude-oauth-prompt-free-credentials" }))
+        #expect(promptFreeToggle.isEnabled?() == false)
+        #expect(promptFreeToggle.binding.wrappedValue == true)
+
+        promptFreeToggle.binding.wrappedValue = false
+        #expect(fixture.settings.claudeOAuthPromptFreeCredentialsEnabled == true)
+
+        fixture.settings.debugDisableKeychainAccess = false
+        #expect(promptFreeToggle.isEnabled?() == true)
+        #expect(promptFreeToggle.binding.wrappedValue == true)
+    }
+
+    @Test
     func `claude keychain prompt policy picker disabled when global keychain disabled`() throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-claude-keychain-disabled")
         fixture.settings.debugDisableKeychainAccess = true


### PR DESCRIPTION
## Summary
- Add an `isEnabled` gate to provider toggle descriptors and apply it in the shared provider toggle row.
- Disable and dim Claude's “Avoid Keychain prompts” row while global “Disable Keychain access” is enabled.
- Preserve the stored Claude preference while the row is inactive.
- Add focused regression coverage and maintainer changelog credit.

## Validation
Exact head: `55ac1b3bbbc627cc572f6cb0e497c80b3ea89b7e`

- rebased onto current main; changelog conflict resolved by preserving both the landed cost-chart entry and Claude contributor credit
- `swift test --filter ProviderSettingsDescriptorTests` — 19 tests passed
- `make check` — passed; SwiftFormat clean, SwiftLint 0 violations
- `make test` — all 41 groups passed on the exact rebased head
- exact branch autoreview — clean, 0.88 confidence
- screenshot inspected at full resolution — disabled title, subtitle, and toggle fit without clipping

## Screenshot
<img width="510" height="118" alt="Disabled Claude Avoid Keychain prompts setting" src="https://github.com/user-attachments/assets/0146d7be-bcd1-4fe0-906d-78d5180e1bdb" />
