### PR TITLE
feat: add combined Codex usage metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Widgets: add single-window and combined burn-down charts for Codex and Claude session/weekly limits. Thanks @jamesjlopez!
 - AWS Bedrock: show optional rolling 14-day Claude token and request totals from CloudWatch. Thanks @zyaiire!
+- Codex: optionally show both 5-hour and weekly percentages in the compact menu bar label. Thanks @thepraggyverse!
 - Cursor: show personal on-demand spend alongside the shared team pool. Thanks @yashiels!
 - Documentation: link the community KDE Plasma panel integration. Thanks @tylxr59!
 - Codex: expose explicitly configured profile homes as switchable accounts without copying their credentials. Thanks @kiranmagic7!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Widgets: add single-window and combined burn-down charts for Codex and Claude session/weekly limits. Thanks @jamesjlopez!
 - AWS Bedrock: show optional rolling 14-day Claude token and request totals from CloudWatch. Thanks @zyaiire!
-- Codex: optionally show both 5-hour and weekly percentages in the compact menu bar label. Thanks @thepraggyverse!
+- Codex: optionally show both session-window and weekly percentages in the compact menu bar label. Thanks @thepraggyverse!
 - Cursor: show personal on-demand spend alongside the shared team pool. Thanks @yashiels!
 - Documentation: link the community KDE Plasma panel integration. Thanks @tylxr59!
 - Codex: expose explicitly configured profile homes as switchable accounts without copying their credentials. Thanks @kiranmagic7!

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -16,6 +16,22 @@ enum MenuBarDisplayText {
         return "\(sign)\(deltaValue)%"
     }
 
+    static func codexCombinedPercentText(
+        sessionWindow: RateWindow?,
+        weeklyWindow: RateWindow?,
+        showUsed: Bool)
+        -> String?
+    {
+        var parts: [String] = []
+        if let session = self.percentText(window: sessionWindow, showUsed: showUsed) {
+            parts.append("5h \(session)")
+        }
+        if let weekly = self.percentText(window: weeklyWindow, showUsed: showUsed) {
+            parts.append("W \(weekly)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
     static func displayText(
         mode: MenuBarDisplayMode,
         percentWindow: RateWindow?,

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -23,13 +23,21 @@ enum MenuBarDisplayText {
         -> String?
     {
         var parts: [String] = []
-        if let session = self.percentText(window: sessionWindow, showUsed: showUsed) {
-            parts.append("5h \(session)")
+        if let sessionWindow,
+           let session = self.percentText(window: sessionWindow, showUsed: showUsed)
+        {
+            parts.append("\(self.codexSessionLabel(window: sessionWindow)) \(session)")
         }
         if let weekly = self.percentText(window: weeklyWindow, showUsed: showUsed) {
             parts.append("W \(weekly)")
         }
         return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private static func codexSessionLabel(window: RateWindow) -> String {
+        guard let minutes = window.windowMinutes, minutes > 0 else { return "S" }
+        guard minutes.isMultiple(of: 60) else { return "\(minutes)m" }
+        return "\(minutes / 60)h"
     }
 
     static func displayText(

--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -36,6 +36,11 @@ enum MenuBarMetricWindowResolver {
                 provider: provider,
                 snapshot: snapshot,
                 lanes: Self.secondaryOrder(for: provider))
+        case .primaryAndSecondary:
+            return Self.mostConstrainedWindow(
+                primary: snapshot.primary,
+                secondary: snapshot.secondary,
+                tertiary: nil)
         case .average:
             return Self.averageWindow(provider: provider, snapshot: snapshot, supportsAverage: supportsAverage)
         case .automatic:

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -595,6 +595,7 @@ struct ProvidersPane: View {
             let metadata = self.store.metadata(for: provider)
             let snapshot = self.store.snapshot(for: provider)
             let supportsAverage = self.settings.menuBarMetricSupportsAverage(for: provider)
+            let supportsPrimaryAndSecondary = self.settings.menuBarMetricSupportsPrimaryAndSecondary(for: provider)
             let supportsTertiary = self.settings.menuBarMetricSupportsTertiary(for: provider, snapshot: snapshot)
             let supportsExtraUsage = self.settings.menuBarMetricSupportsExtraUsage(for: provider, snapshot: snapshot)
             var metricOptions: [ProviderSettingsPickerOption] = [
@@ -606,6 +607,11 @@ struct ProvidersPane: View {
                     id: MenuBarMetricPreference.secondary.rawValue,
                     title: String(format: L("metric_secondary"), metadata.weeklyLabel)),
             ]
+            if supportsPrimaryAndSecondary {
+                metricOptions.append(ProviderSettingsPickerOption(
+                    id: MenuBarMetricPreference.primaryAndSecondary.rawValue,
+                    title: "\(L(metadata.sessionLabel)) + \(L(metadata.weeklyLabel))"))
+            }
             if supportsTertiary {
                 let tertiaryTitle = metadata.opusLabel ?? MenuBarMetricPreference.tertiary.label
                 metricOptions.append(ProviderSettingsPickerOption(

--- a/Sources/CodexBar/SettingsStore+MenuPreferences.swift
+++ b/Sources/CodexBar/SettingsStore+MenuPreferences.swift
@@ -12,7 +12,7 @@ extension SettingsStore {
             switch preference {
             case .automatic, .monthlyPlan:
                 return preference
-            case .primary, .secondary, .tertiary, .extraUsage, .average:
+            case .primary, .secondary, .primaryAndSecondary, .tertiary, .extraUsage, .average:
                 return .automatic
             }
         }
@@ -22,13 +22,16 @@ extension SettingsStore {
             switch preference {
             case .automatic, .primary:
                 return preference
-            case .secondary, .average, .tertiary, .extraUsage, .monthlyPlan:
+            case .secondary, .primaryAndSecondary, .average, .tertiary, .extraUsage, .monthlyPlan:
                 return .automatic
             }
         }
         let raw = self.menuBarMetricPreferencesRaw[provider.rawValue] ?? ""
         let preference = MenuBarMetricPreference(rawValue: raw) ?? .automatic
         if preference == .average, !self.menuBarMetricSupportsAverage(for: provider) {
+            return .automatic
+        }
+        if preference == .primaryAndSecondary, !self.menuBarMetricSupportsPrimaryAndSecondary(for: provider) {
             return .automatic
         }
         if preference == .tertiary, !self.menuBarMetricSupportsTertiary(for: provider) {
@@ -52,7 +55,7 @@ extension SettingsStore {
             switch preference {
             case .automatic, .monthlyPlan:
                 self.menuBarMetricPreferencesRaw[provider.rawValue] = preference.rawValue
-            case .primary, .secondary, .tertiary, .extraUsage, .average:
+            case .primary, .secondary, .primaryAndSecondary, .tertiary, .extraUsage, .average:
                 self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
             }
             return
@@ -61,9 +64,13 @@ extension SettingsStore {
             switch preference {
             case .automatic, .primary:
                 self.menuBarMetricPreferencesRaw[provider.rawValue] = preference.rawValue
-            case .secondary, .average, .tertiary, .extraUsage, .monthlyPlan:
+            case .secondary, .primaryAndSecondary, .average, .tertiary, .extraUsage, .monthlyPlan:
                 self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
             }
+            return
+        }
+        if preference == .primaryAndSecondary, !self.menuBarMetricSupportsPrimaryAndSecondary(for: provider) {
+            self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
             return
         }
         if preference == .tertiary, !self.menuBarMetricSupportsTertiary(for: provider) {
@@ -83,6 +90,10 @@ extension SettingsStore {
 
     func menuBarMetricSupportsAverage(for provider: UsageProvider) -> Bool {
         provider == .gemini
+    }
+
+    func menuBarMetricSupportsPrimaryAndSecondary(for provider: UsageProvider) -> Bool {
+        provider == .codex
     }
 
     func menuBarMetricSupportsTertiary(for provider: UsageProvider) -> Bool {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -42,6 +42,7 @@ enum MenuBarMetricPreference: String, CaseIterable, Identifiable {
     case automatic
     case primary
     case secondary
+    case primaryAndSecondary
     case tertiary
     case extraUsage
     case average
@@ -56,6 +57,7 @@ enum MenuBarMetricPreference: String, CaseIterable, Identifiable {
         case .automatic: L("metric_pref_automatic")
         case .primary: L("metric_pref_primary")
         case .secondary: L("metric_pref_secondary")
+        case .primaryAndSecondary: "\(L("metric_pref_primary")) + \(L("metric_pref_secondary"))"
         case .tertiary: L("metric_pref_tertiary")
         case .extraUsage: L("metric_pref_extra_usage")
         case .average: L("metric_pref_average")
@@ -498,7 +500,7 @@ extension SettingsStore {
             migrated[UsageProvider.antigravity.rawValue] = MenuBarMetricPreference.primary.rawValue
         case .tertiary:
             migrated[UsageProvider.antigravity.rawValue] = MenuBarMetricPreference.primary.rawValue
-        case .automatic, .extraUsage, .average, .monthlyPlan, .none:
+        case .automatic, .primaryAndSecondary, .extraUsage, .average, .monthlyPlan, .none:
             break
         }
         userDefaults.set(migrated, forKey: "menuBarMetricPreferences")

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -761,12 +761,6 @@ extension StatusItemController {
                 resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
                 now: now)
         }
-        let displayText = MenuBarDisplayText.displayText(
-            mode: mode,
-            percentWindow: percentWindow,
-            pace: pace,
-            showUsed: self.settings.usageBarsShowUsed)
-
         if mode == .percent,
            !self.settings.usageBarsShowUsed,
            codexProjection?.menuBarFallback == .creditsBalance,
@@ -778,8 +772,21 @@ extension StatusItemController {
                     .creditsString(from: creditsRemaining)
                     .replacingOccurrences(of: " left", with: "")
         }
-
-        return displayText
+        if provider == .codex,
+           mode == .percent,
+           self.settings.menuBarMetricPreference(for: .codex, snapshot: snapshot) == .primaryAndSecondary,
+           let combinedText = MenuBarDisplayText.codexCombinedPercentText(
+               sessionWindow: codexProjection?.rateWindow(for: .session),
+               weeklyWindow: codexProjection?.rateWindow(for: .weekly),
+               showUsed: self.settings.usageBarsShowUsed)
+        {
+            return combinedText
+        }
+        return MenuBarDisplayText.displayText(
+            mode: mode,
+            percentWindow: percentWindow,
+            pace: pace,
+            showUsed: self.settings.usageBarsShowUsed)
     }
 
     nonisolated static func deepSeekBalanceDisplayText(snapshot: UsageSnapshot?) -> String? {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -368,6 +368,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             let usedPercent = (primary.usedPercent + secondary.usedPercent) / 2
             return RateWindow(
                 usedPercent: usedPercent, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
+        case .primaryAndSecondary:
+            return [first, second].compactMap(\.self).max(by: { $0.usedPercent < $1.usedPercent })
         case .automatic, .primary, .monthlyPlan:
             return first
         }

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -50,6 +50,11 @@ extension UsageStore {
     {
         let effectivePreference = self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot)
         guard metricPercent >= 100 else { return false }
+        if provider == .codex, effectivePreference == .primaryAndSecondary {
+            let percents = [snapshot.primary?.usedPercent, snapshot.secondary?.usedPercent].compactMap(\.self)
+            guard !percents.isEmpty else { return true }
+            return percents.allSatisfy { $0 >= 100 }
+        }
         if provider == .antigravity, effectivePreference == .automatic {
             let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
             let percents = [windows.primary?.usedPercent, windows.secondary?.usedPercent].compactMap(\.self)

--- a/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
+++ b/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
@@ -7,24 +7,7 @@ import Testing
 struct CodexCombinedMetricHighestUsageTests {
     @Test
     func `combined codex metric uses weekly lane when ranking highest usage`() {
-        let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: "CodexCombinedMetricHighestUsageTests-weekly-ranking"),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
-        settings.refreshFrequency = .manual
-        settings.statusChecksEnabled = false
-        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
-
-        let registry = ProviderRegistry.shared
-        if let codexMeta = registry.metadata[.codex] {
-            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
-        }
-        if let claudeMeta = registry.metadata[.claude] {
-            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
-        }
-
-        let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let store = self.makeStore(suiteName: "CodexCombinedMetricHighestUsageTests-weekly-ranking")
 
         let codexSnapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 12, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
@@ -41,5 +24,78 @@ struct CodexCombinedMetricHighestUsageTests {
         let highest = store.providerWithHighestUsage()
         #expect(highest?.provider == .codex)
         #expect(highest?.usedPercent == 91)
+    }
+
+    @Test
+    func `combined codex metric stays eligible when only one lane is exhausted`() {
+        let store = self.makeStore(suiteName: "CodexCombinedMetricHighestUsageTests-one-exhausted")
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 100, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 30,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            provider: .codex)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .claude)
+
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 100)
+    }
+
+    @Test
+    func `combined codex metric is excluded when both lanes are exhausted`() {
+        let store = self.makeStore(suiteName: "CodexCombinedMetricHighestUsageTests-both-exhausted")
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 100, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 100,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            provider: .codex)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .claude)
+
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .claude)
+        #expect(highest?.usedPercent == 80)
+    }
+
+    private func makeStore(suiteName: String) -> UsageStore {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: suiteName),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        return UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
     }
 }

--- a/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
+++ b/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
@@ -1,0 +1,45 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct CodexCombinedMetricHighestUsageTests {
+    @Test
+    func `combined codex metric uses weekly lane when ranking highest usage`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "CodexCombinedMetricHighestUsageTests-weekly-ranking"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+
+        let codexSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 12, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 91, windowMinutes: 7 * 24 * 60, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+        let claudeSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(codexSnapshot, provider: .codex)
+        store._setSnapshotForTesting(claudeSnapshot, provider: .claude)
+
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 91)
+    }
+}

--- a/Tests/CodexBarTests/CodexConsumerProjectionCharacterizationTests.swift
+++ b/Tests/CodexBarTests/CodexConsumerProjectionCharacterizationTests.swift
@@ -48,6 +48,25 @@ struct CodexConsumerProjectionCharacterizationTests {
         return store
     }
 
+    private func enableCodexProvider(settings: SettingsStore) {
+        if let codexMeta = ProviderRegistry.shared.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+    }
+
+    private func makeMenuBarController(settings: SettingsStore) -> (UsageStore, StatusItemController) {
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: testStatusBar())
+        return (store, controller)
+    }
+
     @Test
     func `snapshot override menu card stays isolated from live codex extras`() throws {
         let settings = self.makeSettings()
@@ -112,20 +131,9 @@ struct CodexConsumerProjectionCharacterizationTests {
         settings.usageBarsShowUsed = true
         settings.setMenuBarMetricPreference(.primary, for: .codex)
 
-        let registry = ProviderRegistry.shared
-        if let codexMeta = registry.metadata[.codex] {
-            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
-        }
+        self.enableCodexProvider(settings: settings)
 
-        let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
-        let controller = StatusItemController(
-            store: store,
-            settings: settings,
-            account: fetcher.loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: testStatusBar())
+        let (store, controller) = self.makeMenuBarController(settings: settings)
         defer { controller.releaseStatusItemsForTesting() }
 
         let snapshot = UsageSnapshot(
@@ -140,5 +148,155 @@ struct CodexConsumerProjectionCharacterizationTests {
         let displayText = controller.menuBarDisplayText(for: .codex, snapshot: snapshot)
 
         #expect(displayText == "100%")
+    }
+
+    @Test
+    func `menu bar percent mode can show codex session and weekly together`() {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
+
+        self.enableCodexProvider(settings: settings)
+
+        let (store, controller) = self.makeMenuBarController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 7, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 18, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+        store.credits = CreditsSnapshot(remaining: 42.5, events: [], updatedAt: Date())
+
+        let displayText = controller.menuBarDisplayText(for: .codex, snapshot: snapshot)
+
+        #expect(displayText == "5h 93% · W 82%")
+    }
+
+    @Test
+    func `menu bar combined codex percent keeps available weekly lane when session is unavailable`() {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
+
+        self.enableCodexProvider(settings: settings)
+
+        let (store, controller) = self.makeMenuBarController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: RateWindow(usedPercent: 18, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+        store.credits = CreditsSnapshot(remaining: 42.5, events: [], updatedAt: Date())
+
+        let displayText = controller.menuBarDisplayText(for: .codex, snapshot: snapshot)
+
+        #expect(displayText == "W 82%")
+    }
+
+    @Test
+    func `menu bar combined codex percent falls back to credits when no percent lanes are available`() {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
+
+        self.enableCodexProvider(settings: settings)
+
+        let (store, controller) = self.makeMenuBarController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let snapshot = UsageSnapshot(primary: nil, secondary: nil, updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+        store.credits = CreditsSnapshot(remaining: 42.5, events: [], updatedAt: Date())
+
+        let displayText = controller.menuBarDisplayText(for: .codex, snapshot: snapshot)
+
+        #expect(displayText == "42.5")
+    }
+
+    @Test
+    func `menu bar combined codex percent keeps credits fallback when a lane is exhausted`() {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
+
+        self.enableCodexProvider(settings: settings)
+
+        let (store, controller) = self.makeMenuBarController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 100, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 18, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+        store.credits = CreditsSnapshot(remaining: 42.5, events: [], updatedAt: Date())
+
+        let displayText = controller.menuBarDisplayText(for: .codex, snapshot: snapshot)
+
+        #expect(displayText == "42.5")
+    }
+
+    @Test
+    func `menu bar combined codex option preserves single metric choices`() {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = false
+
+        self.enableCodexProvider(settings: settings)
+
+        let (store, controller) = self.makeMenuBarController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 7, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 18, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+
+        settings.setMenuBarMetricPreference(.primary, for: .codex)
+        let primaryText = controller.menuBarDisplayText(for: .codex, snapshot: snapshot)
+
+        settings.setMenuBarMetricPreference(.secondary, for: .codex)
+        let secondaryText = controller.menuBarDisplayText(for: .codex, snapshot: snapshot)
+
+        #expect(primaryText == "93%")
+        #expect(secondaryText == "82%")
     }
 }

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -39,6 +39,23 @@ struct MenuBarMetricWindowResolverTests {
     }
 
     @Test
+    func `combined primary and secondary metric uses the most constrained lane`() {
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 12, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 91, windowMinutes: 7 * 24 * 60, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .primaryAndSecondary,
+            provider: .codex,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.usedPercent == 91)
+        #expect(window?.windowMinutes == 7 * 24 * 60)
+    }
+
+    @Test
     func `automatic metric skips exhausted cursor subquota when total remains usable`() {
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 67, windowMinutes: 30 * 24 * 60, resetsAt: nil, resetDescription: "Total"),

--- a/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
@@ -74,6 +74,14 @@ struct SettingsStoreAdditionalTests {
         settings.setMenuBarMetricPreference(.average, for: .codex)
         #expect(settings.menuBarMetricPreference(for: .codex) == .automatic)
 
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
+        #expect(settings.menuBarMetricPreference(for: .codex) == .primaryAndSecondary)
+        #expect(settings.menuBarMetricSupportsPrimaryAndSecondary(for: .codex))
+
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+        #expect(settings.menuBarMetricPreference(for: .claude) == .automatic)
+        #expect(!settings.menuBarMetricSupportsPrimaryAndSecondary(for: .claude))
+
         settings.setMenuBarMetricPreference(.monthlyPlan, for: .codex)
         #expect(settings.menuBarMetricPreference(for: .codex) == .automatic)
 

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -952,10 +952,28 @@ struct StatusItemAnimationTests {
             sessionWindow: nil,
             weeklyWindow: weeklyWindow,
             showUsed: false)
+        let nineHour = MenuBarDisplayText.codexCombinedPercentText(
+            sessionWindow: RateWindow(
+                usedPercent: 7,
+                windowMinutes: 540,
+                resetsAt: nil,
+                resetDescription: nil),
+            weeklyWindow: weeklyWindow,
+            showUsed: false)
+        let unknownSessionDuration = MenuBarDisplayText.codexCombinedPercentText(
+            sessionWindow: RateWindow(
+                usedPercent: 7,
+                windowMinutes: nil,
+                resetsAt: nil,
+                resetDescription: nil),
+            weeklyWindow: weeklyWindow,
+            showUsed: false)
 
         #expect(remaining == "5h 93% · W 82%")
         #expect(used == "5h 7% · W 18%")
         #expect(weeklyOnly == "W 82%")
+        #expect(nineHour == "9h 93% · W 82%")
+        #expect(unknownSessionDuration == "S 93% · W 82%")
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -421,6 +421,47 @@ struct StatusItemAnimationTests {
     }
 
     @Test
+    func `combined codex menu bar metric window uses most constrained visible lane`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-codex-combined-window"),
+            zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 12, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 91, windowMinutes: 7 * 24 * 60, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+
+        let window = controller.menuBarMetricWindow(for: .codex, snapshot: snapshot)
+
+        #expect(window?.usedPercent == 91)
+        #expect(window?.windowMinutes == 7 * 24 * 60)
+    }
+
+    @Test
     func `menu bar percent automatic prefers rate limit for kimi`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "StatusItemAnimationTests-kimi-automatic"),
@@ -892,6 +933,29 @@ struct StatusItemAnimationTests {
         #expect(percent == "40%")
         #expect(pace == "+16%")
         #expect(both == "40% · +16%")
+    }
+
+    @Test
+    func `menu bar display text formats codex combined percent lanes`() {
+        let sessionWindow = RateWindow(usedPercent: 7, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+        let weeklyWindow = RateWindow(usedPercent: 18, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)
+
+        let remaining = MenuBarDisplayText.codexCombinedPercentText(
+            sessionWindow: sessionWindow,
+            weeklyWindow: weeklyWindow,
+            showUsed: false)
+        let used = MenuBarDisplayText.codexCombinedPercentText(
+            sessionWindow: sessionWindow,
+            weeklyWindow: weeklyWindow,
+            showUsed: true)
+        let weeklyOnly = MenuBarDisplayText.codexCombinedPercentText(
+            sessionWindow: nil,
+            weeklyWindow: weeklyWindow,
+            showUsed: false)
+
+        #expect(remaining == "5h 93% · W 82%")
+        #expect(used == "5h 7% · W 18%")
+        #expect(weeklyOnly == "W 82%")
     }
 
     @Test

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -24,6 +24,7 @@ read_when:
 - Loading animation runs at a bounded frame rate and has a hard continuous-duration ceiling so provider hangs cannot keep
   the menu bar redrawing forever.
 - Display → Menu bar: menu bar can show provider branding icons with a percent label instead of critter bars.
+- Providers → Codex → Menu bar metric can combine the 5-hour and weekly percentages in one compact label.
 
 ## Menu card
 - Provider-specific rows with resets (countdown by default; optional absolute clock display). Primary, secondary,

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -24,7 +24,7 @@ read_when:
 - Loading animation runs at a bounded frame rate and has a hard continuous-duration ceiling so provider hangs cannot keep
   the menu bar redrawing forever.
 - Display → Menu bar: menu bar can show provider branding icons with a percent label instead of critter bars.
-- Providers → Codex → Menu bar metric can combine the 5-hour and weekly percentages in one compact label.
+- Providers → Codex → Menu bar metric can combine the session-window and weekly percentages in one compact label.
 
 ## Menu card
 - Provider-specific rows with resets (countdown by default; optional absolute clock display). Primary, secondary,


### PR DESCRIPTION
## Summary

Adds a narrow Codex-only option for issue #1294: an opt-in `Session + Weekly` menu bar metric for percent mode.

The compact menu bar label shows both Codex percentage windows together, for example:

`5h 89% · W 80%`

## Scope

- Codex-only
- Opt-in setting under the Codex provider menu bar metric picker
- Percent mode renders both session and weekly percentages
- Existing Automatic, Primary, and Secondary behavior remains unchanged
- Falls back to the available lane if session or weekly is unavailable
- Preserves the existing credits fallback when no percent lane is available or a visible Codex lane is exhausted
- Uses the most constrained selected lane for shared menu-bar ranking, pace, reset, and countdown consumers
- Labels the session lane from its actual duration (`5h`, `9h`, minute fallback), or neutral `S` when duration metadata is unavailable

Refs #1294.

## Validation

- Exact head `b216a876666eb639daf6788c81978829468f8f91`, based on reviewed base `4b14d2ad911cfdeecb22d2e5b6c4870f2f8f5608`.
- Current exact head: 37 focused tests passed.
- Exact-head `make check`: green; 0 formatting changes and 0 lint violations.
- Prior range-identical repaired stack: all 41 groups / 490 selections green.
- Final whole-branch autoreview: clean (0.86).
- Prior bundle-level `./Scripts/compile_and_run.sh` proof: green.
