### PR TITLE
docs: correct Burn Down widget credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.36.2 — Unreleased
 
 ### Added
-- Widgets: add single-window and combined burn-down charts for Codex and Claude session/weekly limits. Thanks @StevanusPangau!
+- Widgets: add single-window and combined burn-down charts for Codex and Claude session/weekly limits. Thanks @jamesjlopez!
 - Cursor: show personal on-demand spend alongside the shared team pool. Thanks @yashiels!
 - Documentation: link the community KDE Plasma panel integration. Thanks @tylxr59!
 - Codex: expose explicitly configured profile homes as switchable accounts without copying their credentials. Thanks @kiranmagic7!


### PR DESCRIPTION
## Summary

- Correct the Burn Down widget changelog credit to the feature's author and preserved co-author, @jamesjlopez.
- Keep the unrelated Indonesian localization credit for @StevanusPangau unchanged.

## Verification

- `git diff --check origin/main...HEAD`
- Manual provenance audit of PR #1255 commits and co-authorship

Follow-up to #1255, which merged before the queued runtime-proof and credit closeout completed.
