### PR TITLE
fix: scope chart selection band to bar width and remove cost item detail lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 - Menu: align cost and utilization rows with provider content and use native bottom action items. Thanks @elijahfriedman!
+- Charts: keep hover selection on bar widths, preserve single-day details, and remove redundant cost-menu detail lines. Thanks @elijahfriedman!
 - Cost history: keep chart date labels aligned with their bars and visible without clipping. Thanks @elijahfriedman!
 - Claude settings: dim and disable Avoid Keychain prompts while global Keychain access is disabled. Thanks @Zihao-Qi!
 - Linux CLI: read OpenCode Go local SQLite usage in automatic mode and allow Command Code billing with a configured manual cookie.

--- a/Sources/CodexBar/ChartBarHoverSelection.swift
+++ b/Sources/CodexBar/ChartBarHoverSelection.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum ChartBarHoverSelection {
+    static func accepts(distanceFromBarCenter: CGFloat, barHalfWidth: CGFloat, selectableCount: Int) -> Bool {
+        selectableCount <= 1 || distanceFromBarCenter <= barHalfWidth
+    }
+
+    static func nextCalendarDay(after date: Date, calendar: Calendar = .current) -> Date {
+        calendar.date(byAdding: .day, value: 1, to: date) ?? date.addingTimeInterval(86400)
+    }
+}

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -416,7 +416,7 @@ struct CostHistoryChartMenuView: View {
         guard let x = proxy.position(forX: date) else { return nil }
 
         // Use the calendar day slot width so the band stays the same size regardless of data gaps.
-        let nextDayX = proxy.position(forX: date.addingTimeInterval(86400)) ?? (x + 20)
+        let nextDayX = proxy.position(forX: ChartBarHoverSelection.nextCalendarDay(after: date)) ?? (x + 20)
         let slotWidth = abs(nextDayX - x)
         let barHalfWidth = slotWidth * 0.25 + 2
 
@@ -447,9 +447,14 @@ struct CostHistoryChartMenuView: View {
         if let nearestEntry = model.dateKeys.first(where: { $0.key == nearest }),
            let barX = proxy.position(forX: nearestEntry.date)
         {
-            let nextDayX = proxy.position(forX: nearestEntry.date.addingTimeInterval(86400)) ?? (barX + 20)
+            let nextDayX = proxy.position(forX: ChartBarHoverSelection.nextCalendarDay(after: nearestEntry.date)) ??
+                (barX + 20)
             let slotWidth = abs(nextDayX - barX)
-            guard abs(location.x - (plotFrame.origin.x + barX)) <= slotWidth * 0.25 + 2 else { return }
+            guard ChartBarHoverSelection.accepts(
+                distanceFromBarCenter: abs(location.x - (plotFrame.origin.x + barX)),
+                barHalfWidth: slotWidth * 0.25 + 2,
+                selectableCount: model.dateKeys.count)
+            else { return }
         }
 
         if self.selectedDateKey != nearest {

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -415,32 +415,13 @@ struct CostHistoryChartMenuView: View {
         let date = model.dateKeys[index].date
         guard let x = proxy.position(forX: date) else { return nil }
 
-        func xForIndex(_ idx: Int) -> CGFloat? {
-            guard idx >= 0, idx < model.dateKeys.count else { return nil }
-            return proxy.position(forX: model.dateKeys[idx].date)
-        }
+        // Use the calendar day slot width so the band stays the same size regardless of data gaps.
+        let nextDayX = proxy.position(forX: date.addingTimeInterval(86400)) ?? (x + 20)
+        let slotWidth = abs(nextDayX - x)
+        let barHalfWidth = slotWidth * 0.25 + 2
 
-        let xPrev = xForIndex(index - 1)
-        let xNext = xForIndex(index + 1)
-
-        let leftInPlot: CGFloat = if let xPrev {
-            (xPrev + x) / 2
-        } else if let xNext {
-            x - (xNext - x) / 2
-        } else {
-            x - 8
-        }
-
-        let rightInPlot: CGFloat = if let xNext {
-            (xNext + x) / 2
-        } else if let xPrev {
-            x + (x - xPrev) / 2
-        } else {
-            x + 8
-        }
-
-        let left = plotFrame.origin.x + min(leftInPlot, rightInPlot)
-        let right = plotFrame.origin.x + max(leftInPlot, rightInPlot)
+        let left = plotFrame.origin.x + x - barHalfWidth
+        let right = plotFrame.origin.x + x + barHalfWidth
         return CGRect(x: left, y: plotFrame.origin.y, width: right - left, height: plotFrame.height)
     }
 
@@ -461,6 +442,15 @@ struct CostHistoryChartMenuView: View {
         let xInPlot = location.x - plotFrame.origin.x
         guard let date: Date = proxy.value(atX: xInPlot) else { return }
         guard let nearest = self.nearestDateKey(to: date, model: model) else { return }
+
+        // Stay on the last selected bar when cursor is in the gap between bars.
+        if let nearestEntry = model.dateKeys.first(where: { $0.key == nearest }),
+           let barX = proxy.position(forX: nearestEntry.date)
+        {
+            let nextDayX = proxy.position(forX: nearestEntry.date.addingTimeInterval(86400)) ?? (barX + 20)
+            let slotWidth = abs(nextDayX - barX)
+            guard abs(location.x - (plotFrame.origin.x + barX)) <= slotWidth * 0.25 + 2 else { return }
+        }
 
         if self.selectedDateKey != nearest {
             self.selectedDateKey = nearest

--- a/Sources/CodexBar/CreditsHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CreditsHistoryChartMenuView.swift
@@ -227,14 +227,6 @@ struct CreditsHistoryChartMenuView: View {
         let date = model.dayDates[index].date
         guard let x = proxy.position(forX: date) else { return nil }
 
-        func xForIndex(_ idx: Int) -> CGFloat? {
-            guard idx >= 0, idx < model.dayDates.count else { return nil }
-            return proxy.position(forX: model.dayDates[idx].date)
-        }
-
-        let xPrev = xForIndex(index - 1)
-        let xNext = xForIndex(index + 1)
-
         if model.dayDates.count <= 1 {
             return CGRect(
                 x: plotFrame.origin.x,
@@ -243,24 +235,14 @@ struct CreditsHistoryChartMenuView: View {
                 height: plotFrame.height)
         }
 
-        let leftInPlot: CGFloat = if let xPrev {
-            (xPrev + x) / 2
-        } else if let xNext {
-            x - (xNext - x) / 2
-        } else {
-            x - 8
-        }
+        // Use the calendar day slot width (always 1 day on the time axis) so the band is the
+        // same size for every bar regardless of gaps in the data.
+        let nextDayX = proxy.position(forX: date.addingTimeInterval(86400)) ?? (x + 20)
+        let slotWidth = abs(nextDayX - x)
+        let barHalfWidth = slotWidth * 0.25 + 2
 
-        let rightInPlot: CGFloat = if let xNext {
-            (xNext + x) / 2
-        } else if let xPrev {
-            x + (x - xPrev) / 2
-        } else {
-            x + 8
-        }
-
-        let left = plotFrame.origin.x + min(leftInPlot, rightInPlot)
-        let right = plotFrame.origin.x + max(leftInPlot, rightInPlot)
+        let left = plotFrame.origin.x + x - barHalfWidth
+        let right = plotFrame.origin.x + x + barHalfWidth
         return CGRect(x: left, y: plotFrame.origin.y, width: right - left, height: plotFrame.height)
     }
 
@@ -282,6 +264,16 @@ struct CreditsHistoryChartMenuView: View {
         let xInPlot = location.x - plotFrame.origin.x
         guard let date: Date = proxy.value(atX: xInPlot) else { return }
         guard let nearest = self.nearestDayKey(to: date, model: model) else { return }
+
+        // Stay on the last selected bar when cursor is in the gap between bars; only switch
+        // selection when the cursor is over the bar's own visual body.
+        if let nearestEntry = model.selectableDayDates.first(where: { $0.dayKey == nearest }),
+           let barX = proxy.position(forX: nearestEntry.date)
+        {
+            let nextDayX = proxy.position(forX: nearestEntry.date.addingTimeInterval(86400)) ?? (barX + 20)
+            let slotWidth = abs(nextDayX - barX)
+            guard abs(location.x - (plotFrame.origin.x + barX)) <= slotWidth * 0.25 + 2 else { return }
+        }
 
         if self.selectedDayKey != nearest {
             self.selectedDayKey = nearest

--- a/Sources/CodexBar/CreditsHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CreditsHistoryChartMenuView.swift
@@ -267,7 +267,10 @@ struct CreditsHistoryChartMenuView: View {
 
         // Stay on the last selected bar when cursor is in the gap between bars; only switch
         // selection when the cursor is over the bar's own visual body.
-        if let nearestEntry = model.selectableDayDates.first(where: { $0.dayKey == nearest }),
+        // Skip this gate for single-day charts: no gap exists, and selectionBandRect
+        // already covers the full plot width in that case.
+        if model.selectableDayDates.count > 1,
+           let nearestEntry = model.selectableDayDates.first(where: { $0.dayKey == nearest }),
            let barX = proxy.position(forX: nearestEntry.date)
         {
             let nextDayX = proxy.position(forX: nearestEntry.date.addingTimeInterval(86400)) ?? (barX + 20)

--- a/Sources/CodexBar/CreditsHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CreditsHistoryChartMenuView.swift
@@ -237,7 +237,7 @@ struct CreditsHistoryChartMenuView: View {
 
         // Use the calendar day slot width (always 1 day on the time axis) so the band is the
         // same size for every bar regardless of gaps in the data.
-        let nextDayX = proxy.position(forX: date.addingTimeInterval(86400)) ?? (x + 20)
+        let nextDayX = proxy.position(forX: ChartBarHoverSelection.nextCalendarDay(after: date)) ?? (x + 20)
         let slotWidth = abs(nextDayX - x)
         let barHalfWidth = slotWidth * 0.25 + 2
 
@@ -273,9 +273,14 @@ struct CreditsHistoryChartMenuView: View {
            let nearestEntry = model.selectableDayDates.first(where: { $0.dayKey == nearest }),
            let barX = proxy.position(forX: nearestEntry.date)
         {
-            let nextDayX = proxy.position(forX: nearestEntry.date.addingTimeInterval(86400)) ?? (barX + 20)
+            let nextDayX = proxy.position(forX: ChartBarHoverSelection.nextCalendarDay(after: nearestEntry.date)) ??
+                (barX + 20)
             let slotWidth = abs(nextDayX - barX)
-            guard abs(location.x - (plotFrame.origin.x + barX)) <= slotWidth * 0.25 + 2 else { return }
+            guard ChartBarHoverSelection.accepts(
+                distanceFromBarCenter: abs(location.x - (plotFrame.origin.x + barX)),
+                barHalfWidth: slotWidth * 0.25 + 2,
+                selectableCount: model.selectableDayDates.count)
+            else { return }
         }
 
         if self.selectedDayKey != nearest {

--- a/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
@@ -800,6 +800,14 @@ struct PlanUtilizationHistoryChartMenuView: View {
             }
         }
 
+        // Stay on the last selected bar when cursor is in the gap between bars; only switch
+        // selection when the cursor is over the bar's own visual body.
+        if let best, let bestPoint = model.pointsByID[best.id],
+           let barX = proxy.position(forX: Double(bestPoint.index))
+        {
+            guard abs(location.x - (plotFrame.origin.x + barX)) <= Layout.barWidth / 2 else { return }
+        }
+
         if self.selectedPointID != best?.id {
             self.selectedPointID = best?.id
         }

--- a/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
@@ -805,7 +805,11 @@ struct PlanUtilizationHistoryChartMenuView: View {
         if let best, let bestPoint = model.pointsByID[best.id],
            let barX = proxy.position(forX: Double(bestPoint.index))
         {
-            guard abs(location.x - (plotFrame.origin.x + barX)) <= Layout.barWidth / 2 else { return }
+            guard ChartBarHoverSelection.accepts(
+                distanceFromBarCenter: abs(location.x - (plotFrame.origin.x + barX)),
+                barHalfWidth: Layout.barWidth / 2,
+                selectableCount: model.points.count)
+            else { return }
         }
 
         if self.selectedPointID != best?.id {

--- a/Sources/CodexBar/StatusItemController+CostMenuCard.swift
+++ b/Sources/CodexBar/StatusItemController+CostMenuCard.swift
@@ -93,17 +93,7 @@ extension StatusItemController {
     }
 
     static func costMenuVisibleDetailLines(tokenUsage: UsageMenuCardView.Model.TokenUsageSection?) -> [String] {
-        let primaryLines = [
-            tokenUsage?.sessionLine,
-            tokenUsage?.monthLine,
-            tokenUsage?.errorLine,
-        ]
-            .compactMap(\.self)
-            .filter { !$0.isEmpty }
-        guard primaryLines.isEmpty else { return primaryLines }
-        return [tokenUsage?.hintLine]
-            .compactMap(\.self)
-            .filter { !$0.isEmpty }
+        []
     }
 
     static func costMenuFallbackAttributedTitle(visibleDetailLines: [String]) -> NSAttributedString {

--- a/Sources/CodexBar/StatusItemController+CostMenuCard.swift
+++ b/Sources/CodexBar/StatusItemController+CostMenuCard.swift
@@ -38,7 +38,9 @@ extension StatusItemController {
         width: CGFloat) -> NSMenuItem
     {
         let tooltipLines = Self.costMenuTooltipLines(tokenUsage: model.tokenUsage)
-        let visibleDetailLines = Self.costMenuVisibleDetailLines(tokenUsage: model.tokenUsage)
+        let visibleDetailLines = Self.costMenuVisibleDetailLines(
+            tokenUsage: model.tokenUsage,
+            hasSubmenu: submenu != nil)
         guard self.menuCardRenderingEnabledForController else {
             return Self.makeNativeCostMenuCardItem(
                 visibleDetailLines: visibleDetailLines,
@@ -92,8 +94,14 @@ extension StatusItemController {
             .filter { !$0.isEmpty }
     }
 
-    static func costMenuVisibleDetailLines(tokenUsage: UsageMenuCardView.Model.TokenUsageSection?) -> [String] {
-        []
+    static func costMenuVisibleDetailLines(
+        tokenUsage: UsageMenuCardView.Model.TokenUsageSection?,
+        hasSubmenu: Bool) -> [String]
+    {
+        guard !hasSubmenu else { return [] }
+        return [tokenUsage?.sessionLine, tokenUsage?.monthLine]
+            .compactMap(\.self)
+            .filter { !$0.isEmpty }
     }
 
     static func costMenuFallbackAttributedTitle(visibleDetailLines: [String]) -> NSAttributedString {

--- a/Sources/CodexBar/StatusItemController+CostMenuCard.swift
+++ b/Sources/CodexBar/StatusItemController+CostMenuCard.swift
@@ -99,7 +99,15 @@ extension StatusItemController {
         hasSubmenu: Bool) -> [String]
     {
         guard !hasSubmenu else { return [] }
-        return [tokenUsage?.sessionLine, tokenUsage?.monthLine]
+        let primaryLines = [
+            tokenUsage?.sessionLine,
+            tokenUsage?.monthLine,
+            tokenUsage?.errorLine,
+        ]
+            .compactMap(\.self)
+            .filter { !$0.isEmpty }
+        guard primaryLines.isEmpty else { return primaryLines }
+        return [tokenUsage?.hintLine]
             .compactMap(\.self)
             .filter { !$0.isEmpty }
     }

--- a/Sources/CodexBar/UsageBreakdownChartMenuView.swift
+++ b/Sources/CodexBar/UsageBreakdownChartMenuView.swift
@@ -301,7 +301,7 @@ struct UsageBreakdownChartMenuView: View {
 
         // Use the calendar day slot width (always 1 day on the time axis) so the band is the
         // same size for every bar regardless of gaps in the data.
-        let nextDayX = proxy.position(forX: date.addingTimeInterval(86400)) ?? (x + 20)
+        let nextDayX = proxy.position(forX: ChartBarHoverSelection.nextCalendarDay(after: date)) ?? (x + 20)
         let slotWidth = abs(nextDayX - x)
         let barHalfWidth = slotWidth * 0.25 + 2
 
@@ -337,9 +337,14 @@ struct UsageBreakdownChartMenuView: View {
            let nearestEntry = model.selectableDayDates.first(where: { $0.dayKey == nearest }),
            let barX = proxy.position(forX: nearestEntry.date)
         {
-            let nextDayX = proxy.position(forX: nearestEntry.date.addingTimeInterval(86400)) ?? (barX + 20)
+            let nextDayX = proxy.position(forX: ChartBarHoverSelection.nextCalendarDay(after: nearestEntry.date)) ??
+                (barX + 20)
             let slotWidth = abs(nextDayX - barX)
-            guard abs(location.x - (plotFrame.origin.x + barX)) <= slotWidth * 0.25 + 2 else { return }
+            guard ChartBarHoverSelection.accepts(
+                distanceFromBarCenter: abs(location.x - (plotFrame.origin.x + barX)),
+                barHalfWidth: slotWidth * 0.25 + 2,
+                selectableCount: model.selectableDayDates.count)
+            else { return }
         }
 
         if self.selectedDayKey != nearest {

--- a/Sources/CodexBar/UsageBreakdownChartMenuView.swift
+++ b/Sources/CodexBar/UsageBreakdownChartMenuView.swift
@@ -331,7 +331,10 @@ struct UsageBreakdownChartMenuView: View {
 
         // Stay on the last selected bar when cursor is in the gap between bars; only switch
         // selection when the cursor is over the bar's own visual body.
-        if let nearestEntry = model.selectableDayDates.first(where: { $0.dayKey == nearest }),
+        // Skip this gate for single-day charts: no gap exists, and selectionBandRect
+        // already covers the full plot width in that case.
+        if model.selectableDayDates.count > 1,
+           let nearestEntry = model.selectableDayDates.first(where: { $0.dayKey == nearest }),
            let barX = proxy.position(forX: nearestEntry.date)
         {
             let nextDayX = proxy.position(forX: nearestEntry.date.addingTimeInterval(86400)) ?? (barX + 20)

--- a/Sources/CodexBar/UsageBreakdownChartMenuView.swift
+++ b/Sources/CodexBar/UsageBreakdownChartMenuView.swift
@@ -291,14 +291,6 @@ struct UsageBreakdownChartMenuView: View {
         let date = model.dayDates[index].date
         guard let x = proxy.position(forX: date) else { return nil }
 
-        func xForIndex(_ idx: Int) -> CGFloat? {
-            guard idx >= 0, idx < model.dayDates.count else { return nil }
-            return proxy.position(forX: model.dayDates[idx].date)
-        }
-
-        let xPrev = xForIndex(index - 1)
-        let xNext = xForIndex(index + 1)
-
         if model.dayDates.count <= 1 {
             return CGRect(
                 x: plotFrame.origin.x,
@@ -307,24 +299,14 @@ struct UsageBreakdownChartMenuView: View {
                 height: plotFrame.height)
         }
 
-        let leftInPlot: CGFloat = if let xPrev {
-            (xPrev + x) / 2
-        } else if let xNext {
-            x - (xNext - x) / 2
-        } else {
-            x - 8
-        }
+        // Use the calendar day slot width (always 1 day on the time axis) so the band is the
+        // same size for every bar regardless of gaps in the data.
+        let nextDayX = proxy.position(forX: date.addingTimeInterval(86400)) ?? (x + 20)
+        let slotWidth = abs(nextDayX - x)
+        let barHalfWidth = slotWidth * 0.25 + 2
 
-        let rightInPlot: CGFloat = if let xNext {
-            (xNext + x) / 2
-        } else if let xPrev {
-            x + (x - xPrev) / 2
-        } else {
-            x + 8
-        }
-
-        let left = plotFrame.origin.x + min(leftInPlot, rightInPlot)
-        let right = plotFrame.origin.x + max(leftInPlot, rightInPlot)
+        let left = plotFrame.origin.x + x - barHalfWidth
+        let right = plotFrame.origin.x + x + barHalfWidth
         return CGRect(x: left, y: plotFrame.origin.y, width: right - left, height: plotFrame.height)
     }
 
@@ -346,6 +328,16 @@ struct UsageBreakdownChartMenuView: View {
         let xInPlot = location.x - plotFrame.origin.x
         guard let date: Date = proxy.value(atX: xInPlot) else { return }
         guard let nearest = self.nearestDayKey(to: date, model: model) else { return }
+
+        // Stay on the last selected bar when cursor is in the gap between bars; only switch
+        // selection when the cursor is over the bar's own visual body.
+        if let nearestEntry = model.selectableDayDates.first(where: { $0.dayKey == nearest }),
+           let barX = proxy.position(forX: nearestEntry.date)
+        {
+            let nextDayX = proxy.position(forX: nearestEntry.date.addingTimeInterval(86400)) ?? (barX + 20)
+            let slotWidth = abs(nextDayX - barX)
+            guard abs(location.x - (plotFrame.origin.x + barX)) <= slotWidth * 0.25 + 2 else { return }
+        }
 
         if self.selectedDayKey != nearest {
             self.selectedDayKey = nearest

--- a/Tests/CodexBarTests/ChartBarHoverSelectionTests.swift
+++ b/Tests/CodexBarTests/ChartBarHoverSelectionTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct ChartBarHoverSelectionTests {
+    @Test
+    func `single selectable bar accepts the full plot`() {
+        #expect(ChartBarHoverSelection.accepts(
+            distanceFromBarCenter: 120,
+            barHalfWidth: 5,
+            selectableCount: 1))
+    }
+
+    @Test
+    func `multiple selectable bars accept only the bar body`() {
+        #expect(ChartBarHoverSelection.accepts(
+            distanceFromBarCenter: 5,
+            barHalfWidth: 5,
+            selectableCount: 2))
+        #expect(!ChartBarHoverSelection.accepts(
+            distanceFromBarCenter: 5.1,
+            barHalfWidth: 5,
+            selectableCount: 2))
+    }
+
+    @Test
+    func `calendar day spacing follows daylight saving transitions`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        let springDate = try #require(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 3,
+            day: 7,
+            hour: 12)))
+        let fallDate = try #require(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 10,
+            day: 31,
+            hour: 12)))
+
+        let springNextDay = ChartBarHoverSelection.nextCalendarDay(after: springDate, calendar: calendar)
+        let fallNextDay = ChartBarHoverSelection.nextCalendarDay(after: fallDate, calendar: calendar)
+
+        #expect(calendar.component(.day, from: springNextDay) == 8)
+        #expect(springNextDay.timeIntervalSince(springDate) == 23 * 60 * 60)
+        #expect(calendar.component(.day, from: fallNextDay) == 1)
+        #expect(fallNextDay.timeIntervalSince(fallDate) == 25 * 60 * 60)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
@@ -31,7 +31,7 @@ struct StatusMenuCostMenuCardTests {
             sessionLine: "Today: $74.83 - 87M tokens",
             monthLine: "Last 30 days: $4,279.64 - 5.7B tokens",
             hintLine: "Costs are estimated from local usage.",
-            errorLine: nil,
+            errorLine: "Cost refresh failed.",
             errorCopyText: nil)
 
         let visibleLines = StatusItemController.costMenuVisibleDetailLines(
@@ -40,10 +40,13 @@ struct StatusMenuCostMenuCardTests {
         #expect(visibleLines == [
             "Today: $74.83 - 87M tokens",
             "Last 30 days: $4,279.64 - 5.7B tokens",
+            "Cost refresh failed.",
         ])
 
         let fallbackTitle = StatusItemController.costMenuFallbackAttributedTitle(visibleDetailLines: visibleLines)
-        #expect(fallbackTitle.string == "Cost  Today: $74.83 - 87M tokens | Last 30 days: $4,279.64 - 5.7B tokens")
+        #expect(fallbackTitle.string.contains("Today: $74.83 - 87M tokens"))
+        #expect(fallbackTitle.string.contains("Last 30 days: $4,279.64 - 5.7B tokens"))
+        #expect(fallbackTitle.string.contains("Cost refresh failed."))
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
@@ -16,11 +16,34 @@ struct StatusMenuCostMenuCardTests {
             errorLine: "Cost refresh failed.",
             errorCopyText: nil)
 
-        let visibleLines = StatusItemController.costMenuVisibleDetailLines(tokenUsage: tokenUsage)
+        let visibleLines = StatusItemController.costMenuVisibleDetailLines(
+            tokenUsage: tokenUsage,
+            hasSubmenu: true)
         #expect(visibleLines == [])
 
         let fallbackTitle = StatusItemController.costMenuFallbackAttributedTitle(visibleDetailLines: visibleLines)
         #expect(fallbackTitle.string == "Cost")
+    }
+
+    @Test
+    func `cost menu preserves summary lines without history submenu`() {
+        let tokenUsage = UsageMenuCardView.Model.TokenUsageSection(
+            sessionLine: "Today: $74.83 - 87M tokens",
+            monthLine: "Last 30 days: $4,279.64 - 5.7B tokens",
+            hintLine: "Costs are estimated from local usage.",
+            errorLine: nil,
+            errorCopyText: nil)
+
+        let visibleLines = StatusItemController.costMenuVisibleDetailLines(
+            tokenUsage: tokenUsage,
+            hasSubmenu: false)
+        #expect(visibleLines == [
+            "Today: $74.83 - 87M tokens",
+            "Last 30 days: $4,279.64 - 5.7B tokens",
+        ])
+
+        let fallbackTitle = StatusItemController.costMenuFallbackAttributedTitle(visibleDetailLines: visibleLines)
+        #expect(fallbackTitle.string == "Cost  Today: $74.83 - 87M tokens | Last 30 days: $4,279.64 - 5.7B tokens")
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
@@ -8,7 +8,7 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuCostMenuCardTests {
     @Test
-    func `cost menu fallback keeps visible details in attributed title`() {
+    func `cost menu shows no detail lines`() {
         let tokenUsage = UsageMenuCardView.Model.TokenUsageSection(
             sessionLine: "Today: $74.83 - 87M tokens",
             monthLine: "Last 30 days: $4,279.64 - 5.7B tokens",
@@ -17,17 +17,10 @@ struct StatusMenuCostMenuCardTests {
             errorCopyText: nil)
 
         let visibleLines = StatusItemController.costMenuVisibleDetailLines(tokenUsage: tokenUsage)
-        #expect(visibleLines == [
-            "Today: $74.83 - 87M tokens",
-            "Last 30 days: $4,279.64 - 5.7B tokens",
-            "Cost refresh failed.",
-        ])
+        #expect(visibleLines == [])
 
         let fallbackTitle = StatusItemController.costMenuFallbackAttributedTitle(visibleDetailLines: visibleLines)
-        #expect(fallbackTitle.string.contains("Cost"))
-        #expect(fallbackTitle.string.contains("Today: $74.83 - 87M tokens"))
-        #expect(fallbackTitle.string.contains("Last 30 days: $4,279.64 - 5.7B tokens"))
-        #expect(fallbackTitle.string.contains("Cost refresh failed."))
+        #expect(fallbackTitle.string == "Cost")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- shrink chart selection band from midpoint-to-midpoint to bar width: use calendar-day slot width so the grey highlight sits under the bar regardless of gaps in the data
- keep selection on the last hovered bar when cursor is between bars — no longer jumps to nearest at the midpoint
- keep a single selectable day active across the full plot; no inter-bar gap exists in that case
- apply the same fix to `CostHistoryChartMenuView`, `CreditsHistoryChartMenuView`, `UsageBreakdownChartMenuView`, and `PlanUtilizationHistoryChartMenuView`
- advance chart days with `Calendar` instead of fixed 86,400-second offsets so bar geometry remains correct across daylight-saving transitions
- remove redundant cost detail lines when cost history is available; preserve totals/errors when no history submenu exists

## Tests

- update `StatusMenuCostMenuCardTests` to assert the new cost-menu behavior
- add pure hover-selection regressions for single-bar, multi-bar, spring-forward, and fall-back behavior
- exact-head focused chart and cost-menu suites passed 18 tests, 0 failures
- prior range-identical stack passed all 42 sharded groups, 0 failures
- exact-head `make check` passed; SwiftFormat clean, SwiftLint 0 violations
- final whole-branch autoreview clean (0.82) after the no-history repair

## Verification

- built and ran locally; selection band visually confirmed to sit under bar body
- band renders identically for all bars including first/last and bars with large data gaps
- Cost menu item shows "Cost" with submenu arrow only when history is available; without history, it preserves the prior totals/error visibility policy
- final head `59500b56637eae10de3a4716b6c2ca447ae13592` is based on reviewed base `0260a9a707062b2cc2db0cc66a297683d83ebf4f`
- production/test commits range-diff exactly preserve the cleared stack; the sole rebase conflict retained both additive changelog credits

## Screenshots

Before:

<img width="625" height="775" alt="Screenshot 2026-06-19 at 5 57 26 PM" src="https://github.com/user-attachments/assets/d4441b6b-d6f4-4dd7-85c8-617b1cabf0ea" />

After:

<img width="621" height="742" alt="Screenshot 2026-06-19 at 5 56 43 PM" src="https://github.com/user-attachments/assets/089c857d-a71d-407e-ba59-83d3d260c7b6" />
