### PR TITLE
docs: add missing docs-list metadata

### DIFF
--- a/docs/claude-comparison-since-0.18.0beta2.md
+++ b/docs/claude-comparison-since-0.18.0beta2.md
@@ -1,3 +1,11 @@
+---
+summary: "Claude fetch behavior comparison covering OAuth, web, CLI, and Keychain prompt changes."
+read_when:
+  - Reviewing Claude fetch regressions since 0.18.0 beta 2
+  - Changing Claude OAuth, web, CLI, or Keychain prompt behavior
+  - Comparing old and current Claude credential flows
+---
+
 # Claude Fetch Comparison (`7b79b2d` vs `HEAD`)
 
 This document compares Claude data fetching behavior between:

--- a/docs/model-pricing.md
+++ b/docs/model-pricing.md
@@ -1,3 +1,11 @@
+---
+summary: "models.dev pricing metadata pipeline, cache, lookup rules, and token-cost units."
+read_when:
+  - Updating models.dev pricing metadata support
+  - Debugging model-pricing cache refresh or lookup behavior
+  - Routing provider cost calculations through shared pricing metadata
+---
+
 # Model pricing metadata
 
 CodexBar has an additive models.dev pricing pipeline for future cost lookup work. Existing hardcoded pricing remains unchanged for now.

--- a/docs/perf-energy-issue-139-main-fix-validation-2026-02-19.md
+++ b/docs/perf-energy-issue-139-main-fix-validation-2026-02-19.md
@@ -1,3 +1,11 @@
+---
+summary: "Post-fix validation for issue #139 Codex CLI timeout and energy improvements."
+read_when:
+  - Validating Codex CLI timeout or retry changes
+  - Reviewing post-fix evidence for issue 139
+  - Investigating CodexBar CPU exposure under failed CLI probes
+---
+
 # CodexBar Issue #139 Main Fix Validation (Post-Fix vs Pre-Fix)
 
 Date: 2026-02-19

--- a/docs/perf-energy-issue-139-simulation-report-2026-02-19.md
+++ b/docs/perf-energy-issue-139-simulation-report-2026-02-19.md
@@ -1,3 +1,11 @@
+---
+summary: "Issue #139 performance and energy simulation report for Codex CLI subprocess failure paths."
+read_when:
+  - Investigating CodexBar CPU or energy regressions
+  - Changing Codex CLI PTY probe timing or retry behavior
+  - Reviewing issue 139 performance evidence
+---
+
 # CodexBar Issue #139 Performance/Energy Simulation Report
 
 Date: 2026-02-19

--- a/docs/quotio-comparison.md
+++ b/docs/quotio-comparison.md
@@ -1,3 +1,11 @@
+---
+summary: "Quotio comparison notes and possible CodexBar enhancement ideas."
+read_when:
+  - Evaluating Quotio-inspired UX or architecture ideas
+  - Planning provider quota-tracking roadmap items
+  - Comparing CodexBar scope against proxy-based quota tools
+---
+
 # Quotio Comparison & Enhancement Opportunities
 
 **Date:** 2026-01-04  

--- a/docs/session-keepalive-design.md
+++ b/docs/session-keepalive-design.md
@@ -1,3 +1,11 @@
+---
+summary: "Design notes for unified provider session keepalive scheduling and refresh control."
+read_when:
+  - Planning provider session keepalive work
+  - Refactoring Augment keepalive behavior
+  - Designing background session refresh scheduling
+---
+
 # Session Keepalive Enhancement Design
 
 **Date:** 2026-01-04  

--- a/docs/solutions/performance-issues/openai-web-extras-default-off-codexbar-20260307.md
+++ b/docs/solutions/performance-issues/openai-web-extras-default-off-codexbar-20260307.md
@@ -1,6 +1,11 @@
 ---
 module: CodexBar
 date: 2026-03-07
+summary: "OpenAI web extras battery-drain fix: default optional hidden WebView work off."
+read_when:
+  - Investigating OpenAI web extras battery or energy impact
+  - Changing Codex OpenAI web extras defaults
+  - Reviewing hidden WebView performance safeguards
 problem_type: performance_issue
 component: tooling
 symptoms:

--- a/docs/superpowers/plans/2026-05-11-kilo-organization-selection.md
+++ b/docs/superpowers/plans/2026-05-11-kilo-organization-selection.md
@@ -1,3 +1,11 @@
+---
+summary: "Implementation plan for Kilo organization selection and stacked organization usage cards."
+read_when:
+  - Implementing Kilo organization selection
+  - Updating Kilo organization-scoped usage fetching
+  - Planning stacked Kilo personal and organization menu cards
+---
+
 # Kilo Organization Selection Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/specs/2026-05-11-kilo-organization-selection-design.md
+++ b/docs/superpowers/specs/2026-05-11-kilo-organization-selection-design.md
@@ -1,3 +1,11 @@
+---
+summary: "Design spec for Kilo organization-scoped usage fetching, settings, and menu rendering."
+read_when:
+  - Designing or implementing Kilo organization support
+  - Changing Kilo scoped usage request headers
+  - Updating Kilo organization settings persistence
+---
+
 # Kilo Organization Selection & Usage — Design
 
 **Status:** approved

--- a/docs/venice.md
+++ b/docs/venice.md
@@ -1,3 +1,11 @@
+---
+summary: "Venice provider setup, API-key balance query, and DIEM/USD balance display."
+read_when:
+  - Adding or modifying the Venice provider
+  - Debugging Venice API-key balance fetching
+  - Explaining Venice setup or balance display
+---
+
 # Venice
 
 [Venice](https://venice.ai) is an AI inference platform that provides API access to various language models.


### PR DESCRIPTION
## Summary
- Add `summary` and `read_when` metadata to docs that `make docs-list` previously reported as missing front matter or a summary.
- Leave document body content unchanged; this only improves docs discoverability.

## Proof
- `make docs-list`
- `git diff --check HEAD^ HEAD`

## Risk
Docs metadata only; no runtime behavior changes.