### PR TITLE
Fix memory pressure handler isolation crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.37.1 — Unreleased
 
+### Fixed
+- Memory pressure: avoid actor-isolation crashes when system callbacks arrive on a utility queue. Thanks @Zihao-Qi!
+
 ## 0.37.0 — 2026-06-19
 
 ### Added

--- a/Sources/CodexBar/MemoryPressureMonitor.swift
+++ b/Sources/CodexBar/MemoryPressureMonitor.swift
@@ -63,16 +63,30 @@ final class MemoryPressureMonitor {
         let source = DispatchSource.makeMemoryPressureSource(
             eventMask: [.warning, .critical],
             queue: .global(qos: .utility))
-        source.setEventHandler { [weak self, weak source] in
-            let event = source?.data ?? []
-            let isWarning = event.contains(.warning)
-            let isCritical = event.contains(.critical)
-            Task { @MainActor [weak self] in
+        source.setEventHandler(handler: Self.makeEventHandler(
+            eventReader: { [weak source] in source?.data ?? [] },
+            handle: { [weak self] isWarning, isCritical in
                 self?.handleMemoryPressure(isWarning: isWarning, isCritical: isCritical)
-            }
-        }
+            }))
         self.source = source
         source.resume()
+    }
+
+    nonisolated static func makeEventHandler(
+        eventReader: @escaping @Sendable () -> DispatchSource.MemoryPressureEvent,
+        handle: @escaping @MainActor @Sendable (_ isWarning: Bool, _ isCritical: Bool) -> Void)
+        -> @Sendable () -> Void
+    {
+        // DispatchSource invokes this on the utility queue. Keep the handler
+        // nonisolated, then hop to MainActor for app-state cleanup.
+        { @Sendable in
+            let event = eventReader()
+            let isWarning = event.contains(.warning)
+            let isCritical = event.contains(.critical)
+            Task { @MainActor in
+                handle(isWarning, isCritical)
+            }
+        }
     }
 
     func stop() {

--- a/Tests/CodexBarTests/MemoryPressureCacheTrimTests.swift
+++ b/Tests/CodexBarTests/MemoryPressureCacheTrimTests.swift
@@ -29,6 +29,35 @@ struct MemoryPressureCacheTrimTests {
     }
 
     @Test
+    func `memory pressure event handler runs from utility queue and hops to main actor`() async {
+        let probe = MemoryPressureEventHandlerProbe()
+        let handler = MemoryPressureMonitor.makeEventHandler(
+            eventReader: { [.warning] },
+            handle: { isWarning, isCritical in
+                probe.record(
+                    isWarning: isWarning,
+                    isCritical: isCritical,
+                    handledOnMainThread: Thread.isMainThread)
+            })
+
+        DispatchQueue.global(qos: .utility).async {
+            probe.recordInvocationThread(isMainThread: Thread.isMainThread)
+            handler()
+        }
+
+        let completed = await Task.detached {
+            probe.wait(timeout: .now() + 2)
+        }.value
+        #expect(completed)
+
+        let snapshot = probe.snapshot()
+        #expect(snapshot.invokedOnMainThread == false)
+        #expect(snapshot.isWarning)
+        #expect(!snapshot.isCritical)
+        #expect(snapshot.handledOnMainThread)
+    }
+
+    @Test
     func `status controller trims rebuildable menu caches on memory pressure`() {
         let controller = self.makeController()
         defer { controller.releaseStatusItemsForTesting() }
@@ -139,5 +168,50 @@ private final class MemoryPressureReleaseProbe: @unchecked Sendable {
 
     func wait(timeout: DispatchTime) -> Bool {
         self.semaphore.wait(timeout: timeout) == .success
+    }
+}
+
+private final class MemoryPressureEventHandlerProbe: @unchecked Sendable {
+    struct Snapshot {
+        let invokedOnMainThread: Bool?
+        let isWarning: Bool
+        let isCritical: Bool
+        let handledOnMainThread: Bool
+    }
+
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var invokedOnMainThread: Bool?
+    private var isWarning = false
+    private var isCritical = false
+    private var handledOnMainThread = false
+
+    func recordInvocationThread(isMainThread: Bool) {
+        self.lock.withLock {
+            self.invokedOnMainThread = isMainThread
+        }
+    }
+
+    func record(isWarning: Bool, isCritical: Bool, handledOnMainThread: Bool) {
+        self.lock.withLock {
+            self.isWarning = isWarning
+            self.isCritical = isCritical
+            self.handledOnMainThread = handledOnMainThread
+        }
+        self.semaphore.signal()
+    }
+
+    func wait(timeout: DispatchTime) -> Bool {
+        self.semaphore.wait(timeout: timeout) == .success
+    }
+
+    func snapshot() -> Snapshot {
+        self.lock.withLock {
+            Snapshot(
+                invokedOnMainThread: self.invokedOnMainThread,
+                isWarning: self.isWarning,
+                isCritical: self.isCritical,
+                handledOnMainThread: self.handledOnMainThread)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a crash in `MemoryPressureMonitor` when the system memory-pressure `DispatchSource` fires on a background utility queue.

The handler is now built through a nonisolated `@Sendable` closure, then explicitly hops to `MainActor` before touching app state. This keeps the DispatchSource callback safe while preserving main-actor cleanup behavior.

## Why

Crash reports from local macOS DiagnosticReports showed `EXC_BREAKPOINT / SIGTRAP` in `MemoryPressureMonitor.start()`. The crashing callback was running on `com.apple.root.utility-qos`, which means the DispatchSource memory-pressure handler was being invoked off the main actor.

The previous implementation could inherit `@MainActor` isolation for that handler, so Swift inserted an isolation check at the closure entry point and trapped before the cleanup work could run.

## What Changed

- Extracted the memory-pressure event handler into a testable nonisolated helper.
- Kept event reading on the DispatchSource queue.
- Moved app-state cleanup back onto `MainActor`.
- Added a regression test that invokes the handler from a utility queue and verifies cleanup runs on the main thread.

## Testing

- `swift test --filter MemoryPressureCacheTrimTests`
- `make check`

## Maintainer Verification

Exact candidate: `844b8fdc`

- Rebasing onto current `main` completed without conflicts.
- `swift test --filter MemoryPressureCacheTrimTests`: 4 tests passed, including utility-queue invocation and main-actor handling.
- `make check`: SwiftFormat clean; SwiftLint reported 0 violations; repository checks passed.
- Packaged and launched the debug app with `./Scripts/compile_and_run.sh --debug-lldb`.
- Posted `com.steipete.codexbar.debug.simulateMemoryPressure` with seeded caches; unified logging recorded `System memory pressure (level=warning)` and the exact candidate process remained running.
- Codex autoreview: clean, no accepted/actionable findings.
- Public model identifier audit: PASS; the candidate adds no model identifiers.
