### PR TITLE
fix: remove dividers and extra spacing around Cost row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Memory pressure: avoid actor-isolation crashes when system callbacks arrive on a utility queue. Thanks @Zihao-Qi!
+- Menu: remove extra separators and spacing around Storage, Cost, and Subscription Utilization rows. Thanks @elijahfriedman!
 
 ## 0.37.0 — 2026-06-19
 

--- a/Sources/CodexBar/StatusItemController+CostMenuCard.swift
+++ b/Sources/CodexBar/StatusItemController+CostMenuCard.swift
@@ -1,32 +1,6 @@
 import AppKit
 import SwiftUI
 
-private struct CostMenuCardRowView: View {
-    let title: String
-    let detailLines: [String]
-    let width: CGFloat
-    @Environment(\.menuItemHighlighted) private var isHighlighted
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(self.title)
-                .font(.system(size: NSFont.menuFont(ofSize: 0).pointSize))
-                .lineLimit(1)
-            ForEach(self.detailLines.indices, id: \.self) { index in
-                Text(self.detailLines[index])
-                    .font(.system(size: NSFont.smallSystemFontSize))
-                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-        }
-        .padding(.leading, 20)
-        .padding(.trailing, 28)
-        .padding(.vertical, 6)
-        .frame(width: self.width, alignment: .leading)
-    }
-}
-
 extension StatusItemController {
     static var costMenuTitle: String {
         L("Cost")
@@ -34,35 +8,16 @@ extension StatusItemController {
 
     func makeCostMenuCardItem(
         model: UsageMenuCardView.Model,
-        submenu: NSMenu?,
-        width: CGFloat) -> NSMenuItem
+        submenu: NSMenu?) -> NSMenuItem
     {
         let tooltipLines = Self.costMenuTooltipLines(tokenUsage: model.tokenUsage)
         let visibleDetailLines = Self.costMenuVisibleDetailLines(
             tokenUsage: model.tokenUsage,
             hasSubmenu: submenu != nil)
-        guard self.menuCardRenderingEnabledForController else {
-            return Self.makeNativeCostMenuCardItem(
-                visibleDetailLines: visibleDetailLines,
-                tooltipLines: tooltipLines,
-                submenu: submenu)
-        }
-
-        let item = self.makeMenuCardItem(
-            CostMenuCardRowView(
-                title: Self.costMenuTitle,
-                detailLines: visibleDetailLines,
-                width: width),
-            id: "menuCardCost",
-            width: width,
-            heightCacheScope: model.provider.rawValue,
-            heightCacheFingerprint: "costMenuRow:\(visibleDetailLines.count)",
-            submenu: submenu,
-            submenuIndicatorAlignment: .trailing,
-            submenuIndicatorTopPadding: 0)
-        item.title = Self.costMenuTitle
-        item.toolTip = tooltipLines.joined(separator: "\n")
-        return item
+        return Self.makeNativeCostMenuCardItem(
+            visibleDetailLines: visibleDetailLines,
+            tooltipLines: tooltipLines,
+            submenu: submenu)
     }
 
     private static func makeNativeCostMenuCardItem(

--- a/Sources/CodexBar/StatusItemController+CostMenuCard.swift
+++ b/Sources/CodexBar/StatusItemController+CostMenuCard.swift
@@ -1,6 +1,32 @@
 import AppKit
 import SwiftUI
 
+private struct CostMenuCardRowView: View {
+    let title: String
+    let detailLines: [String]
+    let width: CGFloat
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(self.title)
+                .font(.system(size: NSFont.menuFont(ofSize: 0).pointSize))
+                .lineLimit(1)
+            ForEach(self.detailLines.indices, id: \.self) { index in
+                Text(self.detailLines[index])
+                    .font(.system(size: NSFont.smallSystemFontSize))
+                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding(.leading, 20)
+        .padding(.trailing, 28)
+        .padding(.vertical, 6)
+        .frame(width: self.width, alignment: .leading)
+    }
+}
+
 extension StatusItemController {
     static var costMenuTitle: String {
         L("Cost")
@@ -8,16 +34,35 @@ extension StatusItemController {
 
     func makeCostMenuCardItem(
         model: UsageMenuCardView.Model,
-        submenu: NSMenu?) -> NSMenuItem
+        submenu: NSMenu?,
+        width: CGFloat) -> NSMenuItem
     {
         let tooltipLines = Self.costMenuTooltipLines(tokenUsage: model.tokenUsage)
         let visibleDetailLines = Self.costMenuVisibleDetailLines(
             tokenUsage: model.tokenUsage,
             hasSubmenu: submenu != nil)
-        return Self.makeNativeCostMenuCardItem(
-            visibleDetailLines: visibleDetailLines,
-            tooltipLines: tooltipLines,
-            submenu: submenu)
+        guard visibleDetailLines.isEmpty == false, self.menuCardRenderingEnabledForController else {
+            return Self.makeNativeCostMenuCardItem(
+                visibleDetailLines: visibleDetailLines,
+                tooltipLines: tooltipLines,
+                submenu: submenu)
+        }
+
+        let item = self.makeMenuCardItem(
+            CostMenuCardRowView(
+                title: Self.costMenuTitle,
+                detailLines: visibleDetailLines,
+                width: width),
+            id: "menuCardCost",
+            width: width,
+            heightCacheScope: model.provider.rawValue,
+            heightCacheFingerprint: "costMenuRow:\(visibleDetailLines.count)",
+            submenu: submenu,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0)
+        item.title = Self.costMenuTitle
+        item.toolTip = tooltipLines.joined(separator: "\n")
+        return item
     }
 
     private static func makeNativeCostMenuCardItem(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -864,7 +864,7 @@ extension StatusItemController {
     }
 
     private func makeWrappedSecondaryTextItem(text: String, width: CGFloat) -> NSMenuItem {
-        let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        let item = NSMenuItem(title: L("Storage"), action: nil, keyEquivalent: "")
         let view = self.makeWrappedSecondaryTextView(text: text)
         let height = self.menuTextItemHeight(for: view, width: width)
         view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1298,7 +1298,8 @@ extension StatusItemController {
                 .makeCostHistorySubmenu(provider: provider, width: width) : nil
             menu.addItem(self.makeCostMenuCardItem(
                 model: model,
-                submenu: costSubmenu))
+                submenu: costSubmenu,
+                width: width))
         }
     }
 
@@ -1307,13 +1308,10 @@ extension StatusItemController {
         guard let storageText = self.store.storageFootprintText(for: provider) else { return false }
         let storageSubmenu = self.makeStorageBreakdownSubmenu(provider: provider, width: width)
         let menuFont = NSFont.menuFont(ofSize: 0)
-        let title = NSMutableAttributedString(
-            string: L("Storage"),
-            attributes: [.font: menuFont])
-        let detail = NSAttributedString(
+        let title = NSMutableAttributedString(string: L("Storage"), attributes: [.font: menuFont])
+        title.append(NSAttributedString(
             string: "  \(storageText)",
-            attributes: [.font: menuFont, .foregroundColor: NSColor.secondaryLabelColor])
-        title.append(detail)
+            attributes: [.font: menuFont, .foregroundColor: NSColor.secondaryLabelColor]))
         let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
         item.attributedTitle = title
         item.isEnabled = storageSubmenu != nil

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -714,6 +714,8 @@ extension StatusItemController {
             if context.hasCostHistory {
                 _ = self.addCostHistorySubmenu(to: menu, provider: currentProvider)
             }
+        }
+        if menu.items.last?.isSeparatorItem != true {
             menu.addItem(.separator())
         }
     }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -864,7 +864,7 @@ extension StatusItemController {
     }
 
     private func makeWrappedSecondaryTextItem(text: String, width: CGFloat) -> NSMenuItem {
-        let item = NSMenuItem(title: L("Storage"), action: nil, keyEquivalent: "")
+        let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
         let view = self.makeWrappedSecondaryTextView(text: text)
         let height = self.menuTextItemHeight(for: view, width: width)
         view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))
@@ -1206,6 +1206,10 @@ extension StatusItemController {
         let sectionSpacing = CGFloat(6)
         let usageBottomPadding = bottomPadding
         let creditsBottomPadding = bottomPadding
+        func addSectionSeparator() {
+            guard menu.items.last?.isSeparatorItem != true else { return }
+            menu.addItem(.separator())
+        }
 
         if hasUsageBlock {
             let usageView = UsageMenuCardHeaderAndUsageSectionView(
@@ -1241,18 +1245,18 @@ extension StatusItemController {
         }
 
         if hasStorage || hasCredits || hasExtraUsage || hasCost {
-            menu.addItem(.separator())
+            addSectionSeparator()
         }
 
         if self.addStorageMenuCardSection(to: menu, provider: provider, width: width),
            hasCredits || hasExtraUsage
         {
-            menu.addItem(.separator())
+            addSectionSeparator()
         }
 
         if hasCredits {
             if hasExtraUsage || hasCost {
-                menu.addItem(.separator())
+                addSectionSeparator()
             }
             let creditsView = UsageMenuCardCreditsSectionView(
                 model: model,
@@ -1274,7 +1278,7 @@ extension StatusItemController {
         }
         if hasExtraUsage {
             if hasCredits {
-                menu.addItem(.separator())
+                addSectionSeparator()
             }
             let extraUsageSubmenu = self.makeOpenAIAPIUsageSubmenu(provider: provider, width: width)
             let extraUsageView = UsageMenuCardExtraUsageSectionView(
@@ -1292,7 +1296,7 @@ extension StatusItemController {
         }
         if hasCost {
             if hasCredits || hasExtraUsage {
-                menu.addItem(.separator())
+                addSectionSeparator()
             }
             let costSubmenu = webItems.hasCostHistory ? self
                 .makeCostHistorySubmenu(provider: provider, width: width) : nil
@@ -1312,7 +1316,7 @@ extension StatusItemController {
         title.append(NSAttributedString(
             string: "  \(storageText)",
             attributes: [.font: menuFont, .foregroundColor: NSColor.secondaryLabelColor]))
-        let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        let item = NSMenuItem(title: L("Storage"), action: nil, keyEquivalent: "")
         item.attributedTitle = title
         item.isEnabled = storageSubmenu != nil
         item.representedObject = "menuCardStorage"

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -714,8 +714,8 @@ extension StatusItemController {
             if context.hasCostHistory {
                 _ = self.addCostHistorySubmenu(to: menu, provider: currentProvider)
             }
+            menu.addItem(.separator())
         }
-        menu.addItem(.separator())
     }
 
     func addPrimaryMenuContent(
@@ -1245,7 +1245,7 @@ extension StatusItemController {
         }
 
         if self.addStorageMenuCardSection(to: menu, provider: provider, width: width),
-           hasCredits || hasExtraUsage || hasCost
+           hasCredits || hasExtraUsage
         {
             menu.addItem(.separator())
         }
@@ -1298,27 +1298,28 @@ extension StatusItemController {
                 .makeCostHistorySubmenu(provider: provider, width: width) : nil
             menu.addItem(self.makeCostMenuCardItem(
                 model: model,
-                submenu: costSubmenu,
-                width: width))
+                submenu: costSubmenu))
         }
     }
 
     @discardableResult
     func addStorageMenuCardSection(to menu: NSMenu, provider: UsageProvider, width: CGFloat) -> Bool {
         guard let storageText = self.store.storageFootprintText(for: provider) else { return false }
-        let storageView = StorageMenuCardSectionView(
-            storageText: storageText,
-            topPadding: 6,
-            bottomPadding: 6,
-            width: width)
         let storageSubmenu = self.makeStorageBreakdownSubmenu(provider: provider, width: width)
-        menu.addItem(self.makeMenuCardItem(
-            storageView,
-            id: "menuCardStorage",
-            width: width,
-            heightCacheScope: provider.rawValue,
-            heightCacheFingerprint: UsageMenuCardView.Model.heightFingerprintField("storage", storageText),
-            submenu: storageSubmenu))
+        let menuFont = NSFont.menuFont(ofSize: 0)
+        let title = NSMutableAttributedString(
+            string: L("Storage"),
+            attributes: [.font: menuFont])
+        let detail = NSAttributedString(
+            string: "  \(storageText)",
+            attributes: [.font: menuFont, .foregroundColor: NSColor.secondaryLabelColor])
+        title.append(detail)
+        let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        item.attributedTitle = title
+        item.isEnabled = storageSubmenu != nil
+        item.representedObject = "menuCardStorage"
+        item.submenu = storageSubmenu
+        menu.addItem(item)
         return true
     }
 

--- a/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
+++ b/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
@@ -12,23 +12,10 @@ extension StatusItemController {
     @discardableResult
     func addUsageHistoryMenuItemIfNeeded(to menu: NSMenu, provider: UsageProvider, width: CGFloat) -> Bool {
         guard let submenu = self.makeUsageHistorySubmenu(provider: provider, width: width) else { return false }
-        let item = self.makeMenuCardItem(
-            HStack(spacing: 0) {
-                Text(L("Subscription Utilization"))
-                    .font(.system(size: NSFont.menuFont(ofSize: 0).pointSize))
-                    .lineLimit(1)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.leading, 20)
-                    .padding(.trailing, 28)
-                    .padding(.vertical, 6)
-            },
-            id: "usageHistorySubmenu",
-            width: width,
-            heightCacheScope: provider.rawValue,
-            heightCacheFingerprint: "usageHistorySubmenu:\(provider.rawValue)",
-            submenu: submenu,
-            submenuIndicatorAlignment: .trailing,
-            submenuIndicatorTopPadding: 0)
+        let item = NSMenuItem(title: L("Subscription Utilization"), action: nil, keyEquivalent: "")
+        item.isEnabled = true
+        item.representedObject = "usageHistorySubmenu"
+        item.submenu = submenu
         menu.addItem(item)
         return true
     }

--- a/Sources/CodexBar/StorageBreakdownMenuView.swift
+++ b/Sources/CodexBar/StorageBreakdownMenuView.swift
@@ -2,28 +2,6 @@ import AppKit
 import CodexBarCore
 import SwiftUI
 
-struct StorageMenuCardSectionView: View {
-    let storageText: String
-    let topPadding: CGFloat
-    let bottomPadding: CGFloat
-    let width: CGFloat
-
-    var body: some View {
-        HStack(spacing: 6) {
-            Text(L("Storage"))
-                .font(.body)
-            Text(self.storageText)
-                .font(.body)
-                .foregroundStyle(.secondary)
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
-        .padding(.top, self.topPadding)
-        .padding(.bottom, self.bottomPadding)
-        .frame(width: self.width, alignment: .leading)
-    }
-}
-
 struct StorageBreakdownMenuView: View {
     let footprint: ProviderStorageFootprint
     let width: CGFloat

--- a/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
@@ -67,7 +67,11 @@ struct StatusMenuCostMenuCardTests {
     }
 
     @Test
-    func `cost menu item has correct title tooltip and submenu`() {
+    func `rendered cost menu keeps long dynamic details inside fixed row width`() throws {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
         let settings = self.makeSettings()
         let fetcher = UsageFetcher()
         let store = UsageStore(
@@ -83,20 +87,27 @@ struct StatusMenuCostMenuCardTests {
             statusBar: .system)
         defer { controller.releaseStatusItemsForTesting() }
 
+        let width = StatusItemController.menuCardBaseWidth
         let tokenUsage = UsageMenuCardView.Model.TokenUsageSection(
-            sessionLine: "Today: $227.42 - 267M tokens",
-            monthLine: "Last 30 days: $52,431.09 - 77B tokens",
+            sessionLine: "Today: $227.42 - 267M tokens - " + String(repeating: "wide ", count: 20),
+            monthLine: "Last 30 days: $52,431.09 - 77B tokens - " + String(repeating: "wide ", count: 20),
             hintLine: "Costs are estimated from local usage.",
             errorLine: nil,
             errorCopyText: nil)
         let model = self.makeModel(tokenUsage: tokenUsage)
-        let submenu = NSMenu()
 
-        let item = controller.makeCostMenuCardItem(model: model, submenu: submenu)
+        // No history submenu — detail lines are visible and must be clipped to the row width.
+        let item = controller.makeCostMenuCardItem(
+            model: model,
+            submenu: nil,
+            width: width)
+        let view = try #require(item.view)
 
+        #expect(view is any MenuCardMeasuring)
+        #expect(abs(view.frame.width - width) <= 0.5)
         #expect(item.title == "Cost")
         #expect(item.toolTip?.contains("$52,431.09") == true)
-        #expect(item.submenu === submenu)
+        #expect(item.submenu == nil)
     }
 
     private func makeSettings() -> SettingsStore {

--- a/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
@@ -67,11 +67,7 @@ struct StatusMenuCostMenuCardTests {
     }
 
     @Test
-    func `rendered cost menu keeps long dynamic details inside fixed row width`() throws {
-        let previousRendering = StatusItemController.menuCardRenderingEnabled
-        StatusItemController.menuCardRenderingEnabled = true
-        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
-
+    func `cost menu item has correct title tooltip and submenu`() {
         let settings = self.makeSettings()
         let fetcher = UsageFetcher()
         let store = UsageStore(
@@ -87,29 +83,20 @@ struct StatusMenuCostMenuCardTests {
             statusBar: .system)
         defer { controller.releaseStatusItemsForTesting() }
 
-        let width = StatusItemController.menuCardBaseWidth
         let tokenUsage = UsageMenuCardView.Model.TokenUsageSection(
-            sessionLine: "Today: $227.42 - 267M tokens - " + String(repeating: "wide ", count: 20),
-            monthLine: "Last 30 days: $52,431.09 - 77B tokens - " + String(repeating: "wide ", count: 20),
+            sessionLine: "Today: $227.42 - 267M tokens",
+            monthLine: "Last 30 days: $52,431.09 - 77B tokens",
             hintLine: "Costs are estimated from local usage.",
             errorLine: nil,
             errorCopyText: nil)
         let model = self.makeModel(tokenUsage: tokenUsage)
         let submenu = NSMenu()
 
-        let item = controller.makeCostMenuCardItem(
-            model: model,
-            submenu: submenu,
-            width: width)
-        let view = try #require(item.view)
+        let item = controller.makeCostMenuCardItem(model: model, submenu: submenu)
 
-        #expect(view is any MenuCardMeasuring)
-        #expect(abs(view.frame.width - width) <= 0.5)
         #expect(item.title == "Cost")
         #expect(item.toolTip?.contains("$52,431.09") == true)
         #expect(item.submenu === submenu)
-        #expect(item.target === controller)
-        #expect(item.action.map(NSStringFromSelector) == "menuCardNoOp:")
     }
 
     private func makeSettings() -> SettingsStore {

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -7,6 +7,36 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuHostedSubmenuRefreshTests {
     @Test
+    func `storage native row preserves its plain menu title`() throws {
+        let settings = Self.makeSettings()
+        settings.providerStorageFootprintsEnabled = true
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        Self.seedStorageFootprint(in: store)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = NSMenu()
+        #expect(controller.addStorageMenuCardSection(
+            to: menu,
+            provider: .claude,
+            width: StatusItemController.menuCardBaseWidth))
+        let item = try #require(menu.items.first)
+        #expect(item.title.hasPrefix(L("Storage")))
+        #expect(item.title == item.attributedTitle?.string)
+        #expect(item.view == nil)
+        #expect(item.isEnabled)
+        #expect(item.submenu != nil)
+    }
+
+    @Test
     func `open parent menu defers data rebuild until parent tracking ends`() async throws {
         let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = true

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -43,11 +43,10 @@ struct StatusMenuHostedSubmenuRefreshTests {
         controller.menuVersions[parentKey] = controller.menuContentVersion
 
         let costItem = try #require(menu.items.first { ($0.representedObject as? String) == "menuCardCost" })
-        #expect(costItem.view is any MenuCardMeasuring)
+        #expect(costItem.view == nil)
+        #expect(costItem.title == StatusItemController.costMenuTitle)
+        #expect(costItem.isEnabled)
         let submenu = try #require(costItem.submenu)
-        let submenuAction = try #require(costItem.action)
-        #expect(NSStringFromSelector(submenuAction) == "menuCardNoOp:")
-        #expect(costItem.target === controller)
         #expect(submenu.items.first?.representedObject as? String == StatusItemController.costHistoryChartID)
         #expect(submenu.minimumWidth >= StatusItemController.menuCardBaseWidth)
         #expect(submenu.items.first?.view == nil)

--- a/Tests/CodexBarTests/StatusMenuNativeSectionSpacingTests.swift
+++ b/Tests/CodexBarTests/StatusMenuNativeSectionSpacingTests.swift
@@ -71,12 +71,18 @@ struct StatusMenuNativeSectionSpacingTests {
 
         let menu = controller.makeMenu(for: .codex)
         controller.menuWillOpen(menu)
-        let ids = menu.items.compactMap { $0.representedObject as? String }
-        let storageIndex = try #require(ids.firstIndex(of: "menuCardStorage"))
-        let creditsIndex = try #require(ids.firstIndex(of: "menuCardCredits"))
-        let costIndex = try #require(ids.firstIndex(of: "menuCardCost"))
+        let storageIndex = try #require(menu.items.firstIndex {
+            ($0.representedObject as? String) == "menuCardStorage"
+        })
+        let creditsIndex = try #require(menu.items.firstIndex {
+            ($0.representedObject as? String) == "menuCardCredits"
+        })
+        let costIndex = try #require(menu.items.firstIndex {
+            ($0.representedObject as? String) == "menuCardCost"
+        })
         #expect(storageIndex < creditsIndex)
         #expect(creditsIndex < costIndex)
+        #expect(menu.items[costIndex + 1].isSeparatorItem)
         #expect(!zip(menu.items, menu.items.dropFirst()).contains { first, second in
             first.isSeparatorItem && second.isSeparatorItem
         })

--- a/Tests/CodexBarTests/StatusMenuNativeSectionSpacingTests.swift
+++ b/Tests/CodexBarTests/StatusMenuNativeSectionSpacingTests.swift
@@ -1,0 +1,104 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuNativeSectionSpacingTests {
+    @Test
+    func `storage credits and cost never create adjacent separators`() throws {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.costUsageEnabled = true
+        settings.providerStorageFootprintsEnabled = true
+        self.enableOnlyCodex(settings)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let storageRoot = "/Users/test/.codex"
+        store.providerStorageFootprints[.codex] = ProviderStorageFootprint(
+            provider: .codex,
+            totalBytes: 1024,
+            paths: [storageRoot],
+            missingPaths: [],
+            unreadablePaths: [],
+            components: [.init(path: storageRoot, totalBytes: 1024)],
+            updatedAt: Date())
+        store.credits = CreditsSnapshot(remaining: 100, events: [], updatedAt: Date())
+        store.openAIDashboard = OpenAIDashboardSnapshot(
+            signedInEmail: "user@example.com",
+            codeReviewRemainingPercent: 100,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            updatedAt: Date())
+        store.openAIDashboardAttachmentAuthorized = true
+        store.openAIDashboardRequiresLogin = false
+        store._setTokenSnapshotForTesting(CostUsageTokenSnapshot(
+            sessionTokens: 123,
+            sessionCostUSD: 0.12,
+            last30DaysTokens: 123,
+            last30DaysCostUSD: 1.23,
+            daily: [
+                CostUsageDailyReport.Entry(
+                    date: "2025-12-23",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 123,
+                    costUSD: 1.23,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            updatedAt: Date()), provider: .codex)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        let ids = menu.items.compactMap { $0.representedObject as? String }
+        let storageIndex = try #require(ids.firstIndex(of: "menuCardStorage"))
+        let creditsIndex = try #require(ids.firstIndex(of: "menuCardCredits"))
+        let costIndex = try #require(ids.firstIndex(of: "menuCardCost"))
+        #expect(storageIndex < creditsIndex)
+        #expect(creditsIndex < costIndex)
+        #expect(!zip(menu.items, menu.items.dropFirst()).contains { first, second in
+            first.isSeparatorItem && second.isSeparatorItem
+        })
+    }
+
+    private func makeSettings() -> SettingsStore {
+        let suite = "StatusMenuNativeSectionSpacingTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.providerDetectionCompleted = true
+        return settings
+    }
+
+    private func enableOnlyCodex(_ settings: SettingsStore) {
+        for provider in UsageProvider.allCases {
+            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- remove `NSMenuItem.separator()` above and below the Cost row so Storage, Cost, and Subscription Utilization form one unbroken group
- convert Storage, Cost, and Subscription Utilization from custom SwiftUI-hosted items to native `NSMenuItem`s — eliminates the extra height from `basePadding`/view padding stacking
- render storage size in `secondaryLabelColor` via attributed title to preserve the greyed-out appearance

## Tests

- update `StatusMenuCostMenuCardTests` to reflect native item behavior (no custom view, no target/action)

## Verification

- built and ran locally; Storage, Cost, and Subscription Utilization rows are now compact and visually consistent with the rest of the menu
- Ran swift test --filter StatusMenuCostMenuCardTests, swift test --filter StatusMenuHostedSubmenuRefreshTests, and make check.

## Screenshots

Before: 

<img width="306" height="687" alt="Screenshot 2026-06-19 at 10 18 26 PM" src="https://github.com/user-attachments/assets/5ea03027-07e1-45a5-bfd6-88208501dfe1" />

After:

<img width="308" height="678" alt="Screenshot 2026-06-19 at 10 16 47 PM" src="https://github.com/user-attachments/assets/637716ba-8858-441e-8a34-069fc04ba462" />
<img width="304" height="656" alt="Screenshot 2026-06-19 at 10 17 07 PM" src="https://github.com/user-attachments/assets/43a2b28b-1647-47c0-82b9-c064ea184f0f" />

## Maintainer Verification

- exact head: `1813b493ea60ea08047ee26c91a8deba3afbd96d`
- rebased onto `main`; stale hosted-submenu assertions updated
- fixed Storage native-title accessibility, adjacent section separators, and the separator before action rows
- passed `swift test --filter StatusMenuCostMenuCardTests`
- passed `swift test --filter StatusMenuHostedSubmenuRefreshTests`
- passed `swift test --filter StatusMenuTests` (141 tests)
- passed `swift test --filter StatusMenuNativeSectionSpacingTests`
- passed `make check`
- packaged and launched with `./Scripts/compile_and_run.sh`; exact-head Peekaboo capture confirmed compact Cost/Subscription rows and the action-row separator
- autoreview clean after accepted findings were fixed
- public model identifier audit: PASS
