### PR TITLE
ci: cache Linux Swift toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SWIFT_VERSION: 6.2.1
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -141,14 +144,27 @@ jobs:
           uname -a
           uname -m
 
-      - name: Install Swift 6.2.1 via swiftly
+      - name: Restore Swift toolchain cache
+        id: swift-toolchain-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/swiftly
+          key: swift-${{ runner.os }}-${{ runner.arch }}-${{ env.SWIFT_VERSION }}-v2
+
+      - name: Install Swift ${{ env.SWIFT_VERSION }} via swiftly
         shell: bash
         run: |
           set -euo pipefail
 
-          if ! command -v gpg >/dev/null 2>&1; then
+          missing_packages=()
+          for package in ca-certificates gpg libcurl4-openssl-dev; do
+            if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "install ok installed"; then
+              missing_packages+=("$package")
+            fi
+          done
+          if [[ "${#missing_packages[@]}" -gt 0 ]]; then
             sudo apt-get update
-            sudo apt-get install -y ca-certificates gpg
+            sudo apt-get install -y "${missing_packages[@]}"
           fi
 
           SWIFTLY_ARCH="$(uname -m)"
@@ -157,6 +173,7 @@ jobs:
           POST_INSTALL_SCRIPT="$(mktemp)"
 
           mkdir -p "$SWIFTLY_BIN_DIR"
+          echo "Swift toolchain cache hit: ${{ steps.swift-toolchain-cache.outputs.cache-hit }}"
           curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${SWIFTLY_ARCH}.tar.gz" -o /tmp/swiftly.tar.gz
           tar -xzf /tmp/swiftly.tar.gz -C /tmp
           /tmp/swiftly init --assume-yes --skip-install
@@ -166,7 +183,7 @@ jobs:
           echo "SWIFTLY_HOME_DIR=$SWIFTLY_HOME_DIR" >> "$GITHUB_ENV"
           echo "SWIFTLY_BIN_DIR=$SWIFTLY_BIN_DIR" >> "$GITHUB_ENV"
 
-          swiftly install 6.2.1 --use --assume-yes --post-install-file "$POST_INSTALL_SCRIPT"
+          swiftly install "$SWIFT_VERSION" --use --assume-yes --post-install-file "$POST_INSTALL_SCRIPT"
           if [[ -s "$POST_INSTALL_SCRIPT" ]]; then
             sudo apt-get update
             sudo bash "$POST_INSTALL_SCRIPT"


### PR DESCRIPTION
## Summary
- cache the Linux swiftly home/toolchain state used by the `build-linux-cli` matrix
- centralize the Swift version in workflow `env.SWIFT_VERSION`
- keep the swiftly bootstrap download/init on every run, so CI never executes a cached `swiftly` bootstrap binary
- install/verify Swift's Ubuntu prerequisites before `swiftly install`, independent of cache hit/miss behavior
- print the Actions cache-hit value in the Swift install step for easier CI diagnosis

## Why
Every PR runs the Linux x64 and arm64 CLI jobs, and each job currently installs Swift 6.2.1 through swiftly before building/testing the CLI. Caching `~/.local/share/swiftly` lets warm runs reuse Swift toolchain state while keeping the existing `swiftly install ... --use` command as the correctness gate.

This does not change test coverage or branch-protection behavior. Cold runs still follow the existing download/init/install path. Warm runs still fetch the official swiftly bootstrap, verify required Ubuntu packages first, then let swiftly reuse cached toolchain state.

## Safety
- Cache path is limited to `~/.local/share/swiftly`; `~/.local/bin/swiftly` is not cached.
- The install step always downloads the official swiftly bootstrap before running `swiftly install`.
- `ca-certificates`, `gpg`, and `libcurl4-openssl-dev` are checked with `dpkg-query` before swiftly runs; `apt-get update/install` only runs when one is missing.
- The `swiftly install "$SWIFT_VERSION" --use` call remains in place, so swiftly still validates/selects the requested toolchain.

## Validation
- workflow YAML parsed with `yaml.safe_load`
- checked the `build-linux-cli` job contains `actions/cache@v4` with an OS/arch/Swift-version scoped key
- checked the cache path is limited to `~/.local/share/swiftly`
- checked the install step contains the cache-independent prerequisite package check
- extracted the embedded Swift install shell step and ran `bash -n`
- `git diff --check`

## GitHub Actions proof
Warm-cache run for this commit: https://github.com/steipete/CodexBar/actions/runs/27857784562

- `changes`: success
- `lint`: success
- `build-linux-cli (linux-x64, ubuntu-24.04)`: success
  - `Restore Swift toolchain cache`: success
  - log: `Cache restored from key: swift-Linux-X64-6.2.1-v2`
  - log: `Swift toolchain cache hit: true`
  - log: `Setting up libcurl4-openssl-dev:amd64`
  - log: `Swift version 6.2.1 (swift-6.2.1-RELEASE)`
  - release build, Linux tests, and CLI smoke test: success
- `build-linux-cli (linux-arm64, ubuntu-24.04-arm)`: success
  - `Restore Swift toolchain cache`: success
  - log: `Cache restored from key: swift-Linux-ARM64-6.2.1-v2`
  - log: `Swift toolchain cache hit: true`
  - log: `Setting up libcurl4-openssl-dev:arm64`
  - log: `Swift version 6.2.1 (swift-6.2.1-RELEASE)`
  - release build, Linux tests, and CLI smoke test: success

This proves the warm-cache path still installs missing Ubuntu prerequisites before `swiftly install`, selects Swift 6.2.1, and completes the full Linux build/test/smoke matrix on both architectures.
