### PR TITLE
ci: skip macOS shards for docs site changes

### DIFF
--- a/Scripts/ci_macos_test_gate.sh
+++ b/Scripts/ci_macos_test_gate.sh
@@ -10,7 +10,18 @@ if [[ -z "$changed_paths_file" || ! -f "$changed_paths_file" ]]; then
 fi
 
 macos_tests=false
+macos_tests_reason=""
 path_count=0
+
+require_macos_tests() {
+  local path="$1"
+  local reason="$2"
+
+  macos_tests=true
+  if [[ -z "$macos_tests_reason" ]]; then
+    macos_tests_reason="${path}: ${reason}"
+  fi
+}
 
 classify_path() {
   local path="$1"
@@ -20,12 +31,16 @@ classify_path() {
 
   case "$path" in
     AGENTS.md|docs/configuration.md)
-      macos_tests=true
+      require_macos_tests "$path" "changes contributor or runtime configuration contracts"
       ;;
     *.md)
       ;;
+    docs/.nojekyll|docs/CNAME|docs/index.html|docs/llms.txt|docs/site-locales.mjs|docs/site.css|docs/site.js|docs/social.html|docs/social.png)
+      ;;
+    docs/*.png|docs/*.jpg|docs/*.jpeg|docs/*.webp|docs/*.ico|docs/*.svg)
+      ;;
     *)
-      macos_tests=true
+      require_macos_tests "$path" "not covered by portable docs/site checks"
       ;;
   esac
 }
@@ -68,7 +83,7 @@ if [[ "$invalid_row" == true ]]; then
 fi
 
 if [[ "$path_count" -eq 0 ]]; then
-  macos_tests=true
+  require_macos_tests '<empty diff>' 'no changed paths were reported'
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
@@ -76,7 +91,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
 fi
 
 if [[ "$macos_tests" == true ]]; then
-  printf 'macOS Swift tests required for this change set.\n'
+  printf 'macOS Swift tests required for this change set: %s.\n' "$macos_tests_reason"
 else
-  printf 'Skipping macOS Swift tests for docs/Markdown-only changes.\n'
+  printf 'Skipping macOS Swift tests for docs/site-only changes covered by portable checks.\n'
 fi

--- a/Scripts/ci_verify_test_jobs.sh
+++ b/Scripts/ci_verify_test_jobs.sh
@@ -22,7 +22,7 @@ case "${macos_tests_required}:${macos_test_result}" in
     printf 'Lint and macOS Swift test shards passed.\n'
     ;;
   false:skipped)
-    printf 'Lint passed; macOS Swift tests skipped for docs/Markdown-only changes.\n'
+    printf 'Lint passed; macOS Swift tests skipped for docs/site-only changes.\n'
     ;;
   *)
     printf 'macOS test gate/result mismatch: required=%s result=%s\n' \

--- a/Scripts/test_ci_path_gate.sh
+++ b/Scripts/test_ci_path_gate.sh
@@ -31,10 +31,16 @@ assert_gate true agents-contract $'M\tAGENTS.md'
 assert_gate true rename-to-agents-contract $'R100\tdocs/old.md\tAGENTS.md'
 assert_gate true rename-from-agents-contract $'R100\tAGENTS.md\tdocs/new.md'
 assert_gate true source $'M\tSources/CodexBar/App.swift'
-assert_gate true docs-code $'M\tdocs/site.js'
+assert_gate false docs-site $'M\tdocs/index.html' $'M\tdocs/site.css' $'M\tdocs/site.js' \
+  $'M\tdocs/site-locales.mjs' $'M\tdocs/social.html' $'M\tdocs/social.png' \
+  $'M\tdocs/CNAME' $'M\tdocs/.nojekyll' $'M\tdocs/llms.txt'
+assert_gate false docs-site-assets $'M\tdocs/icon.png' $'M\tdocs/provider-logo.svg'
+assert_gate true docs-unknown-code $'M\tdocs/custom-tool.js'
+assert_gate true docs-site-with-config $'M\tdocs/site.css' $'M\tdocs/configuration.md'
 assert_gate true empty
 assert_gate true source-to-docs $'R100\tSources/CodexBar/App.swift\tdocs/App.md'
 assert_gate true docs-to-source $'R100\tdocs/App.md\tSources/CodexBar/App.swift'
+assert_gate false docs-to-site $'R100\tdocs/old.md\tdocs/site.css'
 
 assert_gate_fails() {
   local name="$1"

--- a/Scripts/test_ci_path_gate.sh
+++ b/Scripts/test_ci_path_gate.sh
@@ -34,7 +34,7 @@ assert_gate true source $'M\tSources/CodexBar/App.swift'
 assert_gate false docs-site $'M\tdocs/index.html' $'M\tdocs/site.css' $'M\tdocs/site.js' \
   $'M\tdocs/site-locales.mjs' $'M\tdocs/social.html' $'M\tdocs/social.png' \
   $'M\tdocs/CNAME' $'M\tdocs/.nojekyll' $'M\tdocs/llms.txt'
-assert_gate false docs-site-assets $'M\tdocs/icon.png' $'M\tdocs/provider-logo.svg'
+assert_gate false docs-site-assets $'M\tdocs/icon.png' $'M\tdocs/logos/provider-logo.svg'
 assert_gate true docs-unknown-code $'M\tdocs/custom-tool.js'
 assert_gate true docs-site-with-config $'M\tdocs/site.css' $'M\tdocs/configuration.md'
 assert_gate true empty


### PR DESCRIPTION
## Summary
- extend the macOS path gate from Markdown-only changes to docs site static changes already covered by portable Linux checks
- keep contributor/runtime configuration contracts, unknown docs code, source, scripts, workflows, packages, and tests on macOS
- print the first path/reason when macOS shards are required so queued checks are easier to explain

## Safety
- `docs/site.js` remains covered by `node --check` in `lint-linux`
- docs links and site locale structure remain covered by portable checks
- unknown docs code like `docs/custom-tool.js` still requires macOS

## Validation
- `bash -n Scripts/ci_macos_test_gate.sh`
- `bash -n Scripts/test_ci_path_gate.sh`
- `./Scripts/test_ci_path_gate.sh`
- `git diff --check`
- `./Scripts/lint.sh lint-linux` ran portable checks and SwiftLint with 0 violations; local sandbox still returns nonzero when a tool tries to write a macOS plist cache outside the workspace after linting

## Behavior proof
- Proof PR: https://github.com/Yuxin-Qiao/CodexBar/pull/4
- Proof run: https://github.com/Yuxin-Qiao/CodexBar/actions/runs/27858321694
- Proof head: `cc5d993eff5ed911c69f71688b81ab7631fe8147`
- Proof diff changes only `docs/site.css` on top of this PR branch
- Proof checks: `changes`, `lint`, both Linux CLI builds, and `lint-build-test` passed; `swift-test-macos` completed as skipped
- This PR exact-head CI also passed on steipete/CodexBar: https://github.com/steipete/CodexBar/actions/runs/27858300924