### PR TITLE
Keep rich Overview rows but move hover to AppKit

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -552,19 +552,24 @@ extension StatusItemController {
                 provider: row.provider,
                 model: row.model,
                 width: menuWidth)
-            let item = self.makeMenuCardItem(
-                OverviewMenuCardRowView(model: row.model, storageText: storageText, width: menuWidth),
+            let item = self.makeOverviewMenuRowItem(
+                OverviewMenuCardRowView(
+                    model: row.model,
+                    storageText: storageText,
+                    width: menuWidth,
+                    showsSubmenuIndicator: submenu != nil),
                 id: identifier,
-                width: menuWidth,
-                heightCacheScope: row.provider.rawValue,
-                heightCacheFingerprint: row.model.heightFingerprint(
-                    section: "overview",
-                    additional: [UsageMenuCardView.Model.heightFingerprintField("storage", storageText)]),
-                submenu: submenu,
-                onClick: { [weak self, weak interactionMenu] in
-                    guard let self, let interactionMenu else { return }
-                    self.selectOverviewProvider(row.provider, menu: interactionMenu)
-                })
+                configuration: OverviewMenuRowItemConfiguration(
+                    width: menuWidth,
+                    heightCacheScope: row.provider.rawValue,
+                    heightCacheFingerprint: row.model.heightFingerprint(
+                        section: "overview",
+                        additional: [UsageMenuCardView.Model.heightFingerprintField("storage", storageText)]),
+                    submenu: submenu,
+                    onClick: { [weak self, weak interactionMenu] in
+                        guard let self, let interactionMenu else { return }
+                        self.selectOverviewProvider(row.provider, menu: interactionMenu)
+                    }))
             if submenu == nil {
                 // Keep plain rows wired for keyboard activation and accessibility action paths.
                 item.target = self

--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -1,6 +1,14 @@
 import AppKit
 import SwiftUI
 
+struct OverviewMenuRowItemConfiguration {
+    let width: CGFloat
+    let heightCacheScope: String
+    let heightCacheFingerprint: String
+    let submenu: NSMenu?
+    let onClick: (() -> Void)?
+}
+
 extension StatusItemController {
     func refreshMenuCardHeights(in menu: NSMenu) {
         let width = self.renderedMenuWidth(for: menu)
@@ -95,6 +103,59 @@ extension StatusItemController {
         item.representedObject = id
         item.submenu = submenu
         if submenu != nil {
+            item.target = self
+            item.action = #selector(self.menuCardNoOp(_:))
+        }
+        return item
+    }
+
+    func makeOverviewMenuRowItem<RowContent: View>(
+        _ view: RowContent,
+        id: String,
+        configuration: OverviewMenuRowItemConfiguration) -> NSMenuItem
+    {
+        let allowsMenuHighlight = configuration.submenu != nil || configuration.onClick != nil
+        if !self.menuCardRenderingEnabledForController {
+            let item = NSMenuItem()
+            item.isEnabled = allowsMenuHighlight
+            item.representedObject = id
+            item.submenu = configuration.submenu
+            if configuration.submenu != nil {
+                item.target = self
+                item.action = #selector(self.menuCardNoOp(_:))
+            }
+            return item
+        }
+
+        let wrapped = OverviewMenuRowContainerView(refreshMonitor: self.menuCardRefreshMonitor) {
+            view
+        }
+        let hosting: OverviewMenuRowHostingView<OverviewMenuRowContainerView<RowContent>>
+        if let recycled = self.takeRecyclableMenuCardView(
+            for: id,
+            as: OverviewMenuRowHostingView<OverviewMenuRowContainerView<RowContent>>.self)
+        {
+            recycled.prepareForReuse(rootView: wrapped, onClick: configuration.onClick)
+            hosting = recycled
+        } else {
+            hosting = OverviewMenuRowHostingView(rootView: wrapped, onClick: configuration.onClick)
+        }
+        let height = self.cachedMenuCardHeight(
+            for: id,
+            scope: configuration.heightCacheScope,
+            width: configuration.width,
+            fingerprint: configuration.heightCacheFingerprint)
+        {
+            self.menuCardHeight(for: hosting, width: configuration.width)
+        }
+        hosting.frame = NSRect(origin: .zero, size: NSSize(width: configuration.width, height: height))
+
+        let item = NSMenuItem()
+        item.view = hosting
+        item.isEnabled = allowsMenuHighlight
+        item.representedObject = id
+        item.submenu = configuration.submenu
+        if configuration.submenu != nil {
             item.target = self
             item.action = #selector(self.menuCardNoOp(_:))
         }

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CodexBarCore
 import Observation
+import QuartzCore
 import SwiftUI
 
 extension StatusItemController {
@@ -197,6 +198,121 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
     }
 }
 
+@MainActor
+final class OverviewMenuRowHostingView<Content: View>: NSView, MenuCardHighlighting, MenuCardMeasuring {
+    private let hostingView: NSHostingView<Content>
+    private let selectionLayer = CALayer()
+    private var measuredHeight: CGFloat?
+    private var onClick: (() -> Void)?
+    private var hasClickRecognizer = false
+    private(set) var isHighlighted = false
+
+    var allowsMenuHighlight: Bool {
+        true
+    }
+
+    override var allowsVibrancy: Bool {
+        true
+    }
+
+    override var intrinsicContentSize: NSSize {
+        guard let measuredHeight else {
+            let size = self.hostingView.fittingSize
+            return NSSize(width: self.frame.width, height: size.height)
+        }
+        return NSSize(width: self.frame.width, height: measuredHeight)
+    }
+
+    init(rootView: Content, onClick: (() -> Void)? = nil) {
+        self.hostingView = NSHostingView(rootView: rootView)
+        self.onClick = onClick
+        super.init(frame: .zero)
+        self.configureView()
+        if onClick != nil {
+            self.installClickRecognizer()
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func prepareForReuse(rootView: Content, onClick: (() -> Void)?) {
+        self.hostingView.rootView = rootView
+        self.onClick = onClick
+        if onClick != nil, !self.hasClickRecognizer {
+            self.installClickRecognizer()
+        }
+        self.setHighlighted(false)
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        self.bounds.contains(point) ? self : nil
+    }
+
+    override func layout() {
+        super.layout()
+        self.hostingView.frame = self.bounds
+        self.selectionLayer.frame = self.bounds.insetBy(dx: 6, dy: 2)
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        guard newSize.height > 0 else { return }
+        let resolvedHeight = ceil(newSize.height)
+        guard self.measuredHeight != resolvedHeight else { return }
+        self.measuredHeight = resolvedHeight
+        self.invalidateIntrinsicContentSize()
+    }
+
+    func measuredHeight(width: CGFloat) -> CGFloat {
+        self.frame = NSRect(origin: self.frame.origin, size: NSSize(width: width, height: 1))
+        self.hostingView.frame = self.bounds
+        self.layoutSubtreeIfNeeded()
+        return self.hostingView.fittingSize.height
+    }
+
+    func setHighlighted(_ highlighted: Bool) {
+        guard self.isHighlighted != highlighted else { return }
+        self.isHighlighted = highlighted
+        self.selectionLayer.isHidden = !highlighted
+    }
+
+    private func configureView() {
+        self.wantsLayer = true
+        self.layer?.masksToBounds = false
+        self.selectionLayer.cornerRadius = 6
+        self.selectionLayer.cornerCurve = .continuous
+        self.selectionLayer.backgroundColor = NSColor.selectedContentBackgroundColor
+            .withAlphaComponent(0.16)
+            .cgColor
+        self.selectionLayer.isHidden = true
+        self.layer?.addSublayer(self.selectionLayer)
+
+        self.hostingView.translatesAutoresizingMaskIntoConstraints = true
+        self.hostingView.autoresizingMask = [.width, .height]
+        self.hostingView.frame = self.bounds
+        self.addSubview(self.hostingView)
+    }
+
+    private func installClickRecognizer() {
+        let recognizer = NSClickGestureRecognizer(target: self, action: #selector(self.handlePrimaryClick(_:)))
+        recognizer.buttonMask = 0x1
+        self.addGestureRecognizer(recognizer)
+        self.hasClickRecognizer = true
+    }
+
+    @objc private func handlePrimaryClick(_ recognizer: NSClickGestureRecognizer) {
+        guard recognizer.state == .ended else { return }
+        self.onClick?()
+    }
+}
+
 struct MenuCardSectionContainerView<Content: View>: View {
     @Bindable var highlightState: MenuCardHighlightState
     let showsSubmenuIndicator: Bool
@@ -227,5 +343,15 @@ struct MenuCardSectionContainerView<Content: View>: View {
                         .padding(.trailing, 10)
                 }
             }
+    }
+}
+
+struct OverviewMenuRowContainerView<Content: View>: View {
+    let refreshMonitor: MenuCardRefreshMonitor?
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        self.content()
+            .environment(\.menuCardRefreshMonitor, self.refreshMonitor)
     }
 }

--- a/Sources/CodexBar/StatusItemController+MenuTypes.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTypes.swift
@@ -17,7 +17,7 @@ struct OverviewMenuCardRowView: View {
     let model: UsageMenuCardView.Model
     let storageText: String?
     let width: CGFloat
-    @Environment(\.menuItemHighlighted) private var isHighlighted
+    var showsSubmenuIndicator = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -36,10 +36,10 @@ struct OverviewMenuCardRowView: View {
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text("\(L("Storage")):")
                         .font(.footnote)
-                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                        .foregroundStyle(MenuHighlightStyle.secondary(false))
                     Text(storageText)
                         .font(.footnote)
-                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                        .foregroundStyle(MenuHighlightStyle.secondary(false))
                         .lineLimit(1)
                     Spacer()
                 }
@@ -50,6 +50,15 @@ struct OverviewMenuCardRowView: View {
             }
         }
         .frame(width: self.width, alignment: .leading)
+        .overlay(alignment: .topTrailing) {
+            if self.showsSubmenuIndicator {
+                Image(systemName: "chevron.right")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(MenuHighlightStyle.secondary(false))
+                    .padding(.top, 8)
+                    .padding(.trailing, 10)
+            }
+        }
     }
 
     private var hasUsageBlock: Bool {

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -68,6 +68,46 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `overview row hosting consumes hit tests and highlights at appkit boundary`() {
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        let controller = self.makeRecyclingController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = NSMenu()
+        let item = controller.makeOverviewMenuRowItem(
+            Text("Overview"),
+            id: "\(StatusItemController.overviewRowIdentifierPrefix)codex",
+            configuration: OverviewMenuRowItemConfiguration(
+                width: 300,
+                heightCacheScope: "codex",
+                heightCacheFingerprint: "test",
+                submenu: NSMenu(),
+                onClick: {}))
+        menu.addItem(item)
+
+        guard let hosting = item.view as? OverviewMenuRowHostingView<OverviewMenuRowContainerView<Text>> else {
+            Issue.record("expected an overview row hosting view")
+            return
+        }
+
+        #expect(item.isEnabled)
+        #expect(hosting.hitTest(NSPoint(x: hosting.bounds.midX, y: hosting.bounds.midY)) === hosting)
+        #expect(!hosting.isHighlighted)
+
+        controller.menu(menu, willHighlight: item)
+        #expect(hosting.isHighlighted)
+
+        controller.menu(menu, willHighlight: nil)
+        #expect(!hosting.isHighlighted)
+    }
+
+    @Test
     func `embedded controls stay enabled without highlighting the card`() {
         StatusItemController.setMenuRefreshEnabledForTesting(false)
         let previousRendering = StatusItemController.menuCardRenderingEnabled

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -108,6 +108,53 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `recycled overview row keeps hosting view and clears appkit highlight state`() {
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        let controller = self.makeRecyclingController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = NSMenu()
+        let original = controller.makeOverviewMenuRowItem(
+            Text("Before"),
+            id: "\(StatusItemController.overviewRowIdentifierPrefix)codex",
+            configuration: OverviewMenuRowItemConfiguration(
+                width: 300,
+                heightCacheScope: "codex",
+                heightCacheFingerprint: "before",
+                submenu: nil,
+                onClick: {}))
+        menu.addItem(original)
+
+        guard let originalView = original.view as? OverviewMenuRowHostingView<OverviewMenuRowContainerView<Text>>
+        else {
+            Issue.record("expected an overview row hosting view")
+            return
+        }
+        originalView.setHighlighted(true)
+
+        controller.harvestRecyclableMenuCardViews(in: menu, fromIndex: 0, displacedSelection: nil)
+        defer { controller.clearMenuCardViewRecyclePool() }
+        let rebuilt = controller.makeOverviewMenuRowItem(
+            Text("After"),
+            id: "\(StatusItemController.overviewRowIdentifierPrefix)codex",
+            configuration: OverviewMenuRowItemConfiguration(
+                width: 300,
+                heightCacheScope: "codex",
+                heightCacheFingerprint: "after",
+                submenu: nil,
+                onClick: {}))
+
+        #expect(rebuilt.view === originalView)
+        #expect(!originalView.isHighlighted)
+    }
+
+    @Test
     func `embedded controls stay enabled without highlighting the card`() {
         StatusItemController.setMenuRefreshEnabledForTesting(false)
         let previousRendering = StatusItemController.menuCardRenderingEnabled


### PR DESCRIPTION
Refs #1674.

## Summary
- Add an Overview-only AppKit hosting wrapper for rich provider rows.
- Keep the current rich row content: header, usage section, storage text, submenu indicator, provider click behavior, and provider detail submenus.
- Move row hover highlight to a cheap `CALayer` on the AppKit boundary instead of propagating `menuItemHighlighted` through the full SwiftUI row tree.
- Preserve `menuCardRefreshMonitor` injection for live refresh subtitles.
- Follow-up after ClawBot: add a lifecycle regression test proving recycled Overview row hosting views are reused and stale AppKit highlight state is cleared before reuse.

## Behavior change
Overview rows no longer use the standard menu highlight. Because the AppKit host no longer injects `menuItemHighlighted` or the container-level `foregroundStyle`, hovered Overview rows show a faint translucent `CALayer` background with non-inverted text, instead of the system solid-blue-with-white-text selection used elsewhere in the menu. This is intentional (it is what removes the per-hover SwiftUI re-render) but it is a visible change and worth a maintainer's explicit sign-off.

## Why this direction
The scroll sample in #1674 suggests every scroll event can trigger expensive menu row layout/reconciliation work. This branch keeps the existing detailed Overview UI, but removes the most suspicious per-hover SwiftUI state propagation from Overview rows and makes hit testing/highlighting local to the AppKit host view.

This is an alternative to the lite-row PR; they are not meant to merge together.

## Tests
- `swift test --filter "overview row"`
- `swift test --filter "highlight"`
- `swift build`
- `make check`
- `git diff --check`

## Follow-up validation
Verified locally on macOS 27.0 (26A5353q), Swift 6.4 / arm64:

- `swift test --filter "overview row"` passed: 11 tests / 3 suites.
- `swift build` passed.
- `make check` passed.
- `CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh debug` passed and produced `CodexBar.app`.
- `codesign --verify --deep --strict --verbose=2 CodexBar.app` passed.

What this proves locally:
- Overview row content still renders through the rich SwiftUI row path.
- Overview rows keep provider selection and provider-detail submenu behavior.
- Scroll navigation still targets only Overview rows.
- Row hover/hit-test is handled at the AppKit container boundary.
- Overview row hosting views are recycled and clear stale AppKit highlight state before reuse.

## Runtime scroll sample
Captured an after-fix interactive `sample` while the freshly packaged PR app was running and the Overview menu was being scrolled:

- Branch/head: `codex/overview-rich-row` at `963ed4cf9941`.
- App: debug/ad-hoc package from this worktree, `CodexBar.app`, `com.steipete.codexbar.debug`.
- Runtime: macOS 27.0 (26A5353q), Swift 6.4 / arm64.
- Command: `sample 2921 8 1 -file ~/Desktop/codexbar-rich-row-after-scroll-sample.txt`.
- Sample header: `Version: 0.37.1 (91)`, `Path: /Users/USER/*/CodexBar.app/Contents/MacOS/CodexBar`, `Physical footprint: 174.2M`, peak `187.3M`.
- Main thread sample count: 3641.

Relevant before/after sample summary, comparing the v0.37.0 baseline sample attached in #1674 with this PR sample:

| Symbol / stack marker | v0.37.0 baseline | PR #1676 after-fix sample |
| --- | ---: | ---: |
| `@objc NSHostingView.hitTest(_:)` | 12 | below sample's >=5 summary threshold |
| `NSHostingView.hitTest(_:)` | 12 | below sample's >=5 summary threshold |
| `NSHostingView.hitTestingResponder()` | 9 | below sample's >=5 summary threshold |
| `-[NSView _hitTestForContext:point:preferPointOverContext:]` | 54 | below sample's >=5 summary threshold |
| `protocol witness ... LazyVGridLayout.lengthAndSpacing` | 9 | 5 |
| `ViewGraphRootValueUpdater.render(...)` | 23 | 30 |
| `-[NSView scrollWheel:]` | 6 | 6 |
| `-[NSContextMenuImpl _performOptimalSizePassUsingQueuesWithTitles:keyEquivalents:customViews:]` | below summary threshold | 9 |
| `-[NSContextMenuImpl _recalculateOptimalSize]` | below summary threshold | 5 |

The after-fix call graph also shows the PR-specific wrapper path in the sampled runtime:

- `StatusItemController.makeOverviewMenuRowItem<A>(_:id:configuration:)` at `StatusItemController+MenuCardItems.swift:143`.
- `OverviewMenuRowHostingView.measuredHeight(width:)` at `StatusItemController+MenuPresentation.swift:276`.
- `OverviewMenuRowHostingView.layout()` at `StatusItemController+MenuPresentation.swift:259`.

## Still not covered
- I still do not have a visual recording proving hover, provider click, and provider-detail submenu behavior under the same provider-heavy setup. The sample above is runtime scroll proof, not a complete UX recording.
- Maintainers still need to choose between this rich-row direction and #1675, since the two PRs are alternatives.
