### PR TITLE
fix: show unavailable Antigravity limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Memory pressure: avoid actor-isolation crashes when system callbacks arrive on a utility queue. Thanks @Zihao-Qi!
 - Menu: remove extra separators and spacing around Storage, Cost, and Subscription Utilization rows. Thanks @elijahfriedman!
+- Antigravity: show limits as unavailable when OAuth identifies the account but quota endpoints deny access. Thanks @Yuxin-Qiao!
 
 ## 0.37.0 — 2026-06-19
 

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -239,6 +239,9 @@ struct MenuDescriptor {
             }
 
             Self.appendProviderUsageSummaries(entries: &entries, snapshot: snap)
+            if snap.rateLimitsUnavailable(for: provider) {
+                entries.append(.text(L("Limits not available"), .secondary))
+            }
         } else {
             entries.append(.text(L("No usage yet"), .secondary))
         }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -327,6 +327,25 @@ struct AntigravityOAuthFetchStrategy: ProviderFetchStrategy {
         true
     }
 
+    static func usageSnapshot(
+        from snapshot: AntigravityStatusSnapshot,
+        updatedAt: Date = Date()) throws -> UsageSnapshot
+    {
+        if snapshot.modelQuotas.isEmpty {
+            return UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                tertiary: nil,
+                updatedAt: updatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .antigravity,
+                    accountEmail: snapshot.accountEmail,
+                    accountOrganization: nil,
+                    loginMethod: snapshot.accountPlan))
+        }
+        return try snapshot.toUsageSnapshot()
+    }
+
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         let fetcher = AntigravityRemoteUsageFetcher(
             environment: context.env,
@@ -340,20 +359,7 @@ struct AntigravityOAuthFetchStrategy: ProviderFetchStrategy {
                 await updater(.antigravity, accountID, token)
             })
         let snapshot = try await fetcher.fetch()
-        let usage = if snapshot.modelQuotas.isEmpty {
-            UsageSnapshot(
-                primary: nil,
-                secondary: nil,
-                tertiary: nil,
-                updatedAt: Date(),
-                identity: ProviderIdentitySnapshot(
-                    providerID: .antigravity,
-                    accountEmail: snapshot.accountEmail,
-                    accountOrganization: nil,
-                    loginMethod: snapshot.accountPlan))
-        } else {
-            try snapshot.toUsageSnapshot()
-        }
+        let usage = try Self.usageSnapshot(from: snapshot)
         return self.makeResult(
             usage: usage,
             sourceLabel: "oauth")

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -576,7 +576,7 @@ public enum UsageLimitsAvailability: Equatable, Sendable {
         account: AccountInfo? = nil,
         lastErrorDescription: String? = nil) -> Self
     {
-        if provider == .doubao {
+        if provider == .doubao || provider == .antigravity {
             guard let snapshot,
                   snapshot.identity(for: provider) != nil
             else {

--- a/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
@@ -1,6 +1,6 @@
-import CodexBarCore
 import Foundation
 import Testing
+@testable import CodexBarCore
 
 private actor AntigravityCredentialUpdateCapture {
     private var captured: [AntigravityOAuthCredentials] = []
@@ -1109,10 +1109,12 @@ struct AntigravityRemoteUsageFetcherTests {
             homeDirectory: env.homeURL.path,
             dataLoader: dataLoader)
             .fetch()
+        let usage = try AntigravityOAuthFetchStrategy.usageSnapshot(from: snapshot)
 
         #expect(snapshot.modelQuotas.isEmpty)
         #expect(snapshot.accountEmail == "user@example.com")
         #expect(snapshot.accountPlan == "Paid")
+        #expect(usage.rateLimitsUnavailable(for: .antigravity))
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuCardAntigravityTests.swift
+++ b/Tests/CodexBarTests/MenuCardAntigravityTests.swift
@@ -5,6 +5,47 @@ import Testing
 
 struct MenuCardAntigravityTests {
     @Test
+    func `antigravity identity only snapshot shows limits unavailable`() throws {
+        let now = Date(timeIntervalSince1970: 1_742_771_200)
+        let metadata = try #require(ProviderDefaults.metadata[.antigravity])
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .antigravity,
+                accountEmail: "user@example.com",
+                accountOrganization: nil,
+                loginMethod: "Paid"))
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .antigravity,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.isEmpty)
+        #expect(model.placeholder == "Limits not available")
+        #expect(model.subtitleStyle == .info)
+        #expect(model.email == "user@example.com")
+        #expect(model.planText == "Paid")
+    }
+
+    @Test
     func `antigravity metrics omit missing groups`() throws {
         let now = Date()
         let identity = ProviderIdentitySnapshot(

--- a/Tests/CodexBarTests/MenuDescriptorAntigravityTests.swift
+++ b/Tests/CodexBarTests/MenuDescriptorAntigravityTests.swift
@@ -6,6 +6,52 @@ import Testing
 @MainActor
 struct MenuDescriptorAntigravityTests {
     @Test
+    func `antigravity identity only snapshot shows limits unavailable`() throws {
+        let suite = "MenuDescriptorAntigravityTests-unavailable"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .antigravity,
+                accountEmail: "user@example.com",
+                accountOrganization: nil,
+                loginMethod: "Paid"))
+        store._setSnapshotForTesting(snapshot, provider: .antigravity)
+
+        let descriptor = MenuDescriptor.build(
+            provider: .antigravity,
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updateReady: false,
+            includeContextualActions: false)
+
+        let lines = descriptor.sections
+            .flatMap(\.entries)
+            .compactMap { entry -> String? in
+                guard case let .text(text, _) = entry else { return nil }
+                return text
+            }
+
+        #expect(lines.contains("Limits not available"))
+    }
+
+    @Test
     func `antigravity menu does not add unavailable notes for missing families`() throws {
         let suite = "MenuDescriptorAntigravityTests-missing-gemini"
         let defaults = try #require(UserDefaults(suiteName: suite))
@@ -56,5 +102,6 @@ struct MenuDescriptorAntigravityTests {
 
         #expect(!lines.contains("Gemini Pro unavailable."))
         #expect(!lines.contains("Gemini Flash unavailable."))
+        #expect(!lines.contains("Limits not available"))
     }
 }

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -33,6 +33,8 @@ it accepts the first account-matching source in Antigravity app -> `agy` CLI -> 
 when CodexBar has a selected/injected Google account or an existing shared credentials file. An all-100%
 `fetchAvailableModels` payload is only accepted after `retrieveUserQuota` echoes bucket fractions; this can be an
 availability-style fallback rather than the full Antigravity quota summary.
+When OAuth identifies the account but quota endpoints deny access, CodexBar shows `Limits not available` instead of an
+empty quota card.
 
 ## OAuth account switching
 


### PR DESCRIPTION
## Summary

- classify identity-only Antigravity OAuth results as unavailable limits
- preserve the authenticated account and plan while showing `Limits not available`
- keep windowed Antigravity snapshots unchanged
- cover the dual-403 OAuth path, menu card, and descriptor fallback

Fixes #1673.

## Verification

- exact head: `8cc0443cdc74b7ff504e91db24a480defd77136e`
- combined focused suites (31 tests)
- `make check`
- `./Scripts/compile_and_run.sh` (packaged app launched and remained running)
- structured autoreview: clean, no accepted/actionable findings

The dual-403 fixture exercises the exact remote failure mode and verifies that the OAuth strategy retains identity while marking limits unavailable. Live local Antigravity usage remains healthy. A fresh live OAuth-only proof was unavailable because this machine has no stored Antigravity OAuth credentials; UI automation was additionally blocked by the existing Chrome Safe Storage prompt and unavailable Accessibility control.
