### PR TITLE
[security] fix(provider): harden endpoint overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Claude: pause background CLI usage probes briefly after rate limiting while keeping manual refresh available. Thanks @kiranmagic7!
 - Codex OAuth: publish refreshed `auth.json` credentials with private file permissions already applied. Thanks @Hinotoi-agent!
+- Provider endpoints: reject unsafe Deepgram, z.ai, and Xiaomi MiMo overrides before attaching credentials. Thanks @Hinotoi-agent!
 
 ## 0.37.1 — 2026-06-21
 

--- a/Sources/CodexBarCore/Providers/Deepgram/DeepgramUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Deepgram/DeepgramUsageFetcher.swift
@@ -288,6 +288,8 @@ extension DeepgramUsageSnapshot {
 // MARK: - Fetcher
 
 public struct DeepgramUsageFetcher: Sendable {
+    public static let apiURLKey = "DEEPGRAM_API_URL"
+
     private static let log = CodexBarLog.logger(LogCategories.deepgramUsage)
     private static let defaultBaseURL = URL(string: "https://api.deepgram.com/v1")!
 
@@ -461,7 +463,7 @@ public struct DeepgramUsageFetcher: Sendable {
     }
 
     private static func apiURL(environment: [String: String]) -> URL {
-        if let raw = self.cleaned(environment["DEEPGRAM_API_URL"]),
+        if let raw = self.cleaned(environment[self.apiURLKey]),
            let url = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
         {
             return url
@@ -473,9 +475,9 @@ public struct DeepgramUsageFetcher: Sendable {
     public static func validateEndpointOverrides(environment: [String: String] = ProcessInfo.processInfo
         .environment) throws
     {
-        guard let raw = self.cleaned(environment["DEEPGRAM_API_URL"]) else { return }
+        guard let raw = self.cleaned(environment[self.apiURLKey]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
-        throw DeepgramUsageError.invalidEndpointOverride("DEEPGRAM_API_URL")
+        throw DeepgramUsageError.invalidEndpointOverride(self.apiURLKey)
     }
 
     private static func parseUsage(

--- a/Sources/CodexBarCore/Providers/Deepgram/DeepgramUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Deepgram/DeepgramUsageFetcher.swift
@@ -5,6 +5,7 @@ import FoundationNetworking
 
 public enum DeepgramUsageError: LocalizedError, Sendable {
     case missingAPIKey
+    case invalidEndpointOverride(String)
     case invalidCredentials
     case invalidProjectID
     case forbidden(String)
@@ -16,6 +17,8 @@ public enum DeepgramUsageError: LocalizedError, Sendable {
         switch self {
         case .missingAPIKey:
             "Missing Deepgram API key. Set apiKey in ~/.codexbar/config.json or DEEPGRAM_API_KEY."
+        case let .invalidEndpointOverride(key):
+            "Deepgram endpoint override \(key) must use HTTPS or a bare host."
         case .invalidCredentials:
             "Deepgram API key is invalid or expired."
         case .invalidProjectID:
@@ -309,6 +312,7 @@ public struct DeepgramUsageFetcher: Sendable {
         guard !cleanedAPIKey.isEmpty else {
             throw DeepgramUsageError.missingAPIKey
         }
+        try self.validateEndpointOverrides(environment: environment)
 
         let updatedAt = Date()
         let context = FetchContext(
@@ -457,14 +461,21 @@ public struct DeepgramUsageFetcher: Sendable {
     }
 
     private static func apiURL(environment: [String: String]) -> URL {
-        if let raw = environment["DEEPGRAM_API_URL"]?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !raw.isEmpty,
-           let url = URL(string: raw)
+        if let raw = self.cleaned(environment["DEEPGRAM_API_URL"]),
+           let url = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
         {
             return url
         }
 
         return self.defaultBaseURL
+    }
+
+    public static func validateEndpointOverrides(environment: [String: String] = ProcessInfo.processInfo
+        .environment) throws
+    {
+        guard let raw = self.cleaned(environment["DEEPGRAM_API_URL"]) else { return }
+        guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
+        throw DeepgramUsageError.invalidEndpointOverride("DEEPGRAM_API_URL")
     }
 
     private static func parseUsage(

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
@@ -62,8 +62,15 @@ struct MiMoWebFetchStrategy: ProviderFetchStrategy {
         try await self.fetchFromWeb(context)
     }
 
-    private static func shouldFallbackToLocal(error: Error) -> Bool {
-        if error is MiMoSettingsError { return true }
+    static func shouldFallbackToLocal(error: Error) -> Bool {
+        if let settingsError = error as? MiMoSettingsError {
+            switch settingsError {
+            case .missingCookie, .invalidCookie:
+                return true
+            case .invalidEndpointOverride:
+                return false
+            }
+        }
         guard let mimoError = error as? MiMoUsageError else { return false }
         switch mimoError {
         case .invalidCredentials, .loginRequired: return true

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift
@@ -6,6 +6,7 @@ import FoundationNetworking
 public enum MiMoSettingsError: LocalizedError, Sendable, Equatable {
     case missingCookie(details: String? = nil)
     case invalidCookie
+    case invalidEndpointOverride(String)
 
     public var errorDescription: String? {
         switch self {
@@ -18,6 +19,8 @@ public enum MiMoSettingsError: LocalizedError, Sendable, Equatable {
                 .joined(separator: " ")
         case .invalidCookie:
             "Xiaomi MiMo requires the api-platform_serviceToken and userId cookies."
+        case let .invalidEndpointOverride(key):
+            "Xiaomi MiMo endpoint override \(key) must use HTTPS or a bare host."
         }
     }
 }
@@ -46,13 +49,25 @@ public enum MiMoSettingsReader {
     public static let apiURLKey = "MIMO_API_URL"
 
     public static func apiURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
-        if let override = environment[self.apiURLKey],
-           let url = URL(string: override.trimmingCharacters(in: .whitespacesAndNewlines)),
-           let scheme = url.scheme, !scheme.isEmpty
+        if let override = self.cleaned(environment[self.apiURLKey]),
+           let url = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: override)
         {
             return url
         }
         return URL(string: "https://platform.xiaomimimo.com/api/v1")!
+    }
+
+    public static func validateEndpointOverrides(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        guard let override = self.cleaned(environment[self.apiURLKey]) else { return }
+        guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: override) == nil else { return }
+        throw MiMoSettingsError.invalidEndpointOverride(self.apiURLKey)
+    }
+
+    private static func cleaned(_ raw: String?) -> String? {
+        guard let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
     }
 }
 
@@ -68,6 +83,7 @@ public enum MiMoUsageFetcher {
         guard let normalizedCookie = MiMoCookieHeader.normalizedHeader(from: cookieHeader) else {
             throw MiMoSettingsError.invalidCookie
         }
+        try MiMoSettingsReader.validateEndpointOverrides(environment: environment)
 
         let balanceURL = MiMoSettingsReader.apiURL(environment: environment).appendingPathComponent("balance")
         let tokenDetailURL = MiMoSettingsReader.apiURL(environment: environment)

--- a/Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift
@@ -30,10 +30,28 @@ public struct ZaiSettingsReader: Sendable {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        for key in [self.apiHostKey, self.quotaURLKey] {
-            guard let raw = self.cleaned(environment[key]) else { continue }
-            guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { continue }
-            throw ZaiSettingsError.invalidEndpointOverride(key)
+        try self.validateQuotaEndpointOverride(environment: environment)
+    }
+
+    public static func validateQuotaEndpointOverride(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        if let raw = self.cleaned(environment[self.quotaURLKey]) {
+            guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) != nil else {
+                throw ZaiSettingsError.invalidEndpointOverride(self.quotaURLKey)
+            }
+            return
+        }
+
+        try self.validateAPIHostEndpointOverride(environment: environment)
+    }
+
+    public static func validateAPIHostEndpointOverride(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        guard let raw = self.cleaned(environment[self.apiHostKey]) else { return }
+        guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) != nil else {
+            throw ZaiSettingsError.invalidEndpointOverride(self.apiHostKey)
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift
@@ -31,6 +31,7 @@ public struct ZaiSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
         try self.validateQuotaEndpointOverride(environment: environment)
+        try self.validateAPIHostEndpointOverride(environment: environment)
     }
 
     public static func validateQuotaEndpointOverride(

--- a/Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift
@@ -24,10 +24,17 @@ public struct ZaiSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
         guard let raw = self.cleaned(environment[quotaURLKey]) else { return nil }
-        if let url = URL(string: raw), url.scheme != nil {
-            return url
+        return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
+    }
+
+    public static func validateEndpointOverrides(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        for key in [self.apiHostKey, self.quotaURLKey] {
+            guard let raw = self.cleaned(environment[key]) else { continue }
+            guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { continue }
+            throw ZaiSettingsError.invalidEndpointOverride(key)
         }
-        return URL(string: "https://\(raw)")
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -46,13 +53,16 @@ public struct ZaiSettingsReader: Sendable {
     }
 }
 
-public enum ZaiSettingsError: LocalizedError, Sendable {
+public enum ZaiSettingsError: LocalizedError, Sendable, Equatable {
     case missingToken
+    case invalidEndpointOverride(String)
 
     public var errorDescription: String? {
         switch self {
         case .missingToken:
             "z.ai API token not found. Set apiKey in ~/.codexbar/config.json or Z_AI_API_KEY."
+        case let .invalidEndpointOverride(key):
+            "z.ai endpoint override \(key) must use HTTPS or a bare host."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -333,7 +333,7 @@ public struct ZaiUsageFetcher: Sendable {
         guard !apiKey.isEmpty else {
             throw ZaiUsageError.invalidCredentials
         }
-        try ZaiSettingsReader.validateEndpointOverrides(environment: environment)
+        try ZaiSettingsReader.validateQuotaEndpointOverride(environment: environment)
 
         let quotaURL = self.resolveQuotaURL(region: region, environment: environment)
 
@@ -572,6 +572,7 @@ extension ZaiUsageFetcher {
         guard !apiKey.isEmpty else {
             throw ZaiUsageError.invalidCredentials
         }
+        try ZaiSettingsReader.validateAPIHostEndpointOverride(environment: environment)
 
         let baseURL: URL = if let host = ZaiSettingsReader.apiHost(environment: environment),
                               let resolved = Self.modelUsageURL(baseURLString: host)

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -662,6 +662,7 @@ extension ZaiUsageFetcher {
         region: ZaiAPIRegion = .global,
         environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> ZaiUsageSnapshot
     {
+        try ZaiSettingsReader.validateEndpointOverrides(environment: environment)
         let snapshot = try await Self.fetchUsage(apiKey: apiKey, region: region, environment: environment)
         let modelUsage: ZaiModelUsageData?
         do {

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -333,6 +333,7 @@ public struct ZaiUsageFetcher: Sendable {
         guard !apiKey.isEmpty else {
             throw ZaiUsageError.invalidCredentials
         }
+        try ZaiSettingsReader.validateEndpointOverrides(environment: environment)
 
         let quotaURL = self.resolveQuotaURL(region: region, environment: environment)
 
@@ -439,13 +440,13 @@ public struct ZaiUsageFetcher: Sendable {
     private static func quotaURL(baseURLString: String) -> URL? {
         guard let cleaned = ZaiSettingsReader.cleaned(baseURLString) else { return nil }
 
-        if let url = URL(string: cleaned), url.scheme != nil {
+        if let url = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: cleaned) {
             if url.path.isEmpty || url.path == "/" {
                 return url.appendingPathComponent(Self.quotaAPIPath)
             }
             return url
         }
-        guard let base = URL(string: "https://\(cleaned)") else { return nil }
+        guard let base = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: cleaned) else { return nil }
         if base.path.isEmpty || base.path == "/" {
             return base.appendingPathComponent(Self.quotaAPIPath)
         }

--- a/TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift
+++ b/TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift
@@ -46,10 +46,36 @@ struct ProviderEndpointOverrideSecurityLinuxTests {
     }
 
     @Test
-    func zaiRejectsInsecureAPIHostOverride() {
+    func zaiRejectsInsecureAPIHostOverrideWhenQuotaURLIsAbsent() {
         #expect(throws: ZaiSettingsError.invalidEndpointOverride(ZaiSettingsReader.apiHostKey)) {
             try ZaiSettingsReader.validateEndpointOverrides(
                 environment: [ZaiSettingsReader.apiHostKey: "http://attacker.test"])
+        }
+    }
+
+    @Test
+    func zaiQuotaURLPrecedenceIgnoresInvalidLowerPriorityAPIHost() throws {
+        let environment = [
+            ZaiSettingsReader.quotaURLKey: "https://zai-proxy.test/quota",
+            ZaiSettingsReader.apiHostKey: "http://attacker.test",
+        ]
+
+        try ZaiSettingsReader.validateEndpointOverrides(environment: environment)
+        #expect(ZaiUsageFetcher.resolveQuotaURL(region: .global, environment: environment).absoluteString ==
+            "https://zai-proxy.test/quota")
+    }
+
+    @Test
+    func zaiModelUsageRejectsInsecureAPIHostOverride() async {
+        do {
+            _ = try await ZaiUsageFetcher.fetchModelUsage(
+                apiKey: "zai-test-token",
+                environment: [ZaiSettingsReader.apiHostKey: "http://attacker.test"])
+            Issue.record("Expected ZaiSettingsError.invalidEndpointOverride")
+        } catch ZaiSettingsError.invalidEndpointOverride(ZaiSettingsReader.apiHostKey) {
+            // Expected.
+        } catch {
+            Issue.record("Expected ZaiSettingsError.invalidEndpointOverride, got \(error)")
         }
     }
 

--- a/TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift
+++ b/TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift
@@ -21,10 +21,10 @@ struct ProviderEndpointOverrideSecurityLinuxTests {
         do {
             _ = try await DeepgramUsageFetcher.fetchUsage(
                 apiKey: "dg-test-token",
-                environment: ["DEEPGRAM_API_URL": "http://attacker.test/v1"],
+                environment: [DeepgramUsageFetcher.apiURLKey: "http://attacker.test/v1"],
                 transport: transport)
             Issue.record("Expected DeepgramUsageError.invalidEndpointOverride")
-        } catch DeepgramUsageError.invalidEndpointOverride("DEEPGRAM_API_URL") {
+        } catch DeepgramUsageError.invalidEndpointOverride(DeepgramUsageFetcher.apiURLKey) {
             // Expected.
         } catch {
             Issue.record("Expected DeepgramUsageError.invalidEndpointOverride, got \(error)")
@@ -54,15 +54,29 @@ struct ProviderEndpointOverrideSecurityLinuxTests {
     }
 
     @Test
-    func zaiQuotaURLPrecedenceIgnoresInvalidLowerPriorityAPIHost() throws {
+    func zaiQuotaResolutionIgnoresInvalidLowerPriorityAPIHost() throws {
         let environment = [
             ZaiSettingsReader.quotaURLKey: "https://zai-proxy.test/quota",
             ZaiSettingsReader.apiHostKey: "http://attacker.test",
         ]
 
-        try ZaiSettingsReader.validateEndpointOverrides(environment: environment)
+        try ZaiSettingsReader.validateQuotaEndpointOverride(environment: environment)
         #expect(ZaiUsageFetcher.resolveQuotaURL(region: .global, environment: environment).absoluteString ==
             "https://zai-proxy.test/quota")
+    }
+
+    @Test
+    func zaiCombinedFetchRejectsInvalidAPIHostBeforeQuotaRequest() async {
+        let environment = [
+            ZaiSettingsReader.quotaURLKey: "https://127.0.0.1:31337/quota",
+            ZaiSettingsReader.apiHostKey: "http://127.0.0.1:31337",
+        ]
+
+        await #expect(throws: ZaiSettingsError.invalidEndpointOverride(ZaiSettingsReader.apiHostKey)) {
+            try await ZaiUsageFetcher.fetchUsageWithModelUsage(
+                apiKey: "ZAI_CANARY_KEY",
+                environment: environment)
+        }
     }
 
     @Test
@@ -97,7 +111,9 @@ struct ProviderEndpointOverrideSecurityLinuxTests {
 
     @Test
     func affectedProviderOverridesAcceptHTTPSAndBareHosts() throws {
-        try DeepgramUsageFetcher.validateEndpointOverrides(environment: ["DEEPGRAM_API_URL": "deepgram-proxy.test/v1"])
+        try DeepgramUsageFetcher.validateEndpointOverrides(environment: [
+            DeepgramUsageFetcher.apiURLKey: "deepgram-proxy.test/v1",
+        ])
         try ZaiSettingsReader
             .validateEndpointOverrides(environment: [ZaiSettingsReader.quotaURLKey: "https://zai-proxy.test/quota"])
         try ZaiSettingsReader.validateEndpointOverrides(environment: [ZaiSettingsReader.apiHostKey: "localhost:9443"])

--- a/TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift
+++ b/TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift
@@ -1,0 +1,87 @@
+import CodexBarCore
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+
+@Suite
+struct ProviderEndpointOverrideSecurityLinuxTests {
+    @Test
+    func deepgramRejectsInsecureOverrideBeforeSendingToken() async {
+        let transport = FailingTransport()
+        do {
+            _ = try await DeepgramUsageFetcher.fetchUsage(
+                apiKey: "dg-test-token",
+                environment: ["DEEPGRAM_API_URL": "http://attacker.test/v1"],
+                transport: transport)
+            Issue.record("Expected DeepgramUsageError.invalidEndpointOverride")
+        } catch DeepgramUsageError.invalidEndpointOverride("DEEPGRAM_API_URL") {
+            // Expected.
+        } catch {
+            Issue.record("Expected DeepgramUsageError.invalidEndpointOverride, got \(error)")
+        }
+    }
+
+    @Test
+    func zaiRejectsInsecureQuotaOverrideBeforeSendingToken() async {
+        do {
+            _ = try await ZaiUsageFetcher.fetchUsage(
+                apiKey: "zai-test-token",
+                environment: [ZaiSettingsReader.quotaURLKey: "http://attacker.test/quota"])
+            Issue.record("Expected ZaiSettingsError.invalidEndpointOverride")
+        } catch ZaiSettingsError.invalidEndpointOverride(ZaiSettingsReader.quotaURLKey) {
+            // Expected.
+        } catch {
+            Issue.record("Expected ZaiSettingsError.invalidEndpointOverride, got \(error)")
+        }
+    }
+
+    @Test
+    func zaiRejectsInsecureAPIHostOverride() {
+        #expect(throws: ZaiSettingsError.invalidEndpointOverride(ZaiSettingsReader.apiHostKey)) {
+            try ZaiSettingsReader.validateEndpointOverrides(
+                environment: [ZaiSettingsReader.apiHostKey: "http://attacker.test"])
+        }
+    }
+
+    @Test
+    func mimoRejectsInsecureOverrideBeforeSendingCookie() async {
+        let transport = FailingTransport()
+        do {
+            _ = try await MiMoUsageFetcher.fetchUsage(
+                cookieHeader: "api-platform_serviceToken=session-token; userId=user-1",
+                environment: [MiMoSettingsReader.apiURLKey: "http://attacker.test/api/v1"],
+                session: transport)
+            Issue.record("Expected MiMoSettingsError.invalidEndpointOverride")
+        } catch MiMoSettingsError.invalidEndpointOverride(MiMoSettingsReader.apiURLKey) {
+            // Expected.
+        } catch {
+            Issue.record("Expected MiMoSettingsError.invalidEndpointOverride, got \(error)")
+        }
+    }
+
+    @Test
+    func affectedProviderOverridesAcceptHTTPSAndBareHosts() throws {
+        try DeepgramUsageFetcher.validateEndpointOverrides(environment: ["DEEPGRAM_API_URL": "deepgram-proxy.test/v1"])
+        try ZaiSettingsReader
+            .validateEndpointOverrides(environment: [ZaiSettingsReader.quotaURLKey: "https://zai-proxy.test/quota"])
+        try ZaiSettingsReader.validateEndpointOverrides(environment: [ZaiSettingsReader.apiHostKey: "localhost:9443"])
+        try MiMoSettingsReader
+            .validateEndpointOverrides(environment: [MiMoSettingsReader.apiURLKey: "mimo-proxy.test/api/v1"])
+
+        #expect(ZaiSettingsReader.quotaURL(environment: [ZaiSettingsReader.quotaURLKey: "zai-proxy.test/quota"])?
+            .absoluteString == "https://zai-proxy.test/quota")
+        #expect(MiMoSettingsReader.apiURL(environment: [MiMoSettingsReader.apiURLKey: "mimo-proxy.test/api/v1"])
+            .absoluteString == "https://mimo-proxy.test/api/v1")
+    }
+}
+
+private struct FailingTransport: ProviderHTTPTransport {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        Issue
+            .record(
+                "Endpoint override validation should fail before any request is sent to \(request.url?.absoluteString ?? "<nil>")")
+        throw URLError(.badURL)
+    }
+}

--- a/TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift
+++ b/TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift
@@ -1,4 +1,4 @@
-import CodexBarCore
+@testable import CodexBarCore
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -7,6 +7,14 @@ import Testing
 
 @Suite
 struct ProviderEndpointOverrideSecurityLinuxTests {
+    @Test
+    func mimoInvalidEndpointOverrideDoesNotFallbackToLocalCache() {
+        #expect(MiMoWebFetchStrategy.shouldFallbackToLocal(
+            error: MiMoSettingsError.invalidEndpointOverride(MiMoSettingsReader.apiURLKey)) == false)
+        #expect(MiMoWebFetchStrategy.shouldFallbackToLocal(error: MiMoSettingsError.missingCookie()) == true)
+        #expect(MiMoWebFetchStrategy.shouldFallbackToLocal(error: MiMoSettingsError.invalidCookie) == true)
+    }
+
     @Test
     func deepgramRejectsInsecureOverrideBeforeSendingToken() async {
         let transport = FailingTransport()

--- a/docs/deepgram.md
+++ b/docs/deepgram.md
@@ -83,7 +83,10 @@ codexbar -p dg  # alias
 
 * **DEEPGRAM_API_KEY**: Your Deepgram API key. Required.
 * **DEEPGRAM_PROJECT_ID**: Optional Deepgram project UUID. Leave unset to aggregate all visible projects.
-* **DEEPGRAM_API_URL**: Override the base API URL. Optional, defaults to https://api.deepgram.com/v1.
+* **DEEPGRAM_API_URL**: Override the base API URL. Optional, defaults to `https://api.deepgram.com/v1`.
+  Override values must be explicit HTTPS URLs or bare hosts/paths that CodexBar normalizes to HTTPS. Explicit
+  `http://` URLs fail closed before the Deepgram API key is attached to a request. For local proxy testing, use an
+  HTTPS listener or omit the scheme and let CodexBar normalize the override to HTTPS.
 
 ## Permissions
 

--- a/docs/mimo.md
+++ b/docs/mimo.md
@@ -38,7 +38,9 @@ Safari cookie import may require granting CodexBar Full Disk Access in **System 
 - Fetches balance and token-plan detail/usage endpoints under `https://platform.xiaomimimo.com/api/v1`
 - Requires the `api-platform_serviceToken` and `userId` cookies
 - Accepts optional MiMo cookies like `api-platform_ph` and `api-platform_slh` when present
-- Supports `MIMO_API_URL` to override the base API URL for testing
+- Supports `MIMO_API_URL` to override the base API URL for testing. Override values must be explicit HTTPS URLs or
+  bare hosts/paths that CodexBar normalizes to HTTPS. Explicit `http://` values fail closed before MiMo cookies are
+  attached to a request, and invalid endpoint overrides do not fall back to local MiMo usage accounting.
 
 ## Limitations
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -108,6 +108,8 @@ headers, source selection, provider ordering, and token accounts are stored in `
 ## z.ai
 - API token from `~/.codexbar/config.json` (`providers[].apiKey`) or `Z_AI_API_KEY` env var.
 - Supports global and BigModel CN quota hosts; override with `Z_AI_API_HOST` or `Z_AI_QUOTA_URL`.
+- z.ai endpoint overrides must be HTTPS or bare hosts normalized to HTTPS. `Z_AI_QUOTA_URL` takes precedence for
+  quota requests; direct model-usage requests validate `Z_AI_API_HOST` before sending bearer auth.
 - Status: none yet.
 - Details: `docs/zai.md`.
 
@@ -393,8 +395,16 @@ headers, source selection, provider ordering, and token accounts are stored in `
 ## Deepgram
 - API key from config or `DEEPGRAM_API_KEY`.
 - Optional project ID from provider settings or `DEEPGRAM_PROJECT_ID`; otherwise aggregates all visible projects.
+- Optional API base URL override via `DEEPGRAM_API_URL`; overrides must be HTTPS or bare hosts normalized to HTTPS.
 - Reads Deepgram usage breakdowns for audio hours, agent hours, token totals, TTS characters, and requests.
 - Details: `docs/deepgram.md`.
+
+## Xiaomi MiMo
+- Browser cookies or manual Cookie header for `platform.xiaomimimo.com` balance and token-plan endpoints.
+- Optional testing override via `MIMO_API_URL`; overrides must be HTTPS or bare hosts normalized to HTTPS, and invalid
+  overrides fail closed instead of falling back to local MiMo usage accounting.
+- Local MiMo token accounting is available only when the opt-in cache file exists.
+- Details: `docs/mimo.md`.
 
 ## LiteLLM
 - API key from config or `LITELLM_API_KEY`; base URL from config `enterpriseHost` or `LITELLM_BASE_URL`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -109,7 +109,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - API token from `~/.codexbar/config.json` (`providers[].apiKey`) or `Z_AI_API_KEY` env var.
 - Supports global and BigModel CN quota hosts; override with `Z_AI_API_HOST` or `Z_AI_QUOTA_URL`.
 - z.ai endpoint overrides must be HTTPS or bare hosts normalized to HTTPS. `Z_AI_QUOTA_URL` takes precedence for
-  quota requests; direct model-usage requests validate `Z_AI_API_HOST` before sending bearer auth.
+  quota resolution; combined usage validates both configured endpoints before sending bearer auth.
 - Status: none yet.
 - Details: `docs/zai.md`.
 

--- a/docs/zai.md
+++ b/docs/zai.md
@@ -21,6 +21,10 @@ z.ai is API-token based. No browser cookies.
 - BigModel (China mainland) host: `https://open.bigmodel.cn`
 - Override host via Providers → z.ai → *API region* or `Z_AI_API_HOST=open.bigmodel.cn`.
 - Override the full quota URL (e.g. coding plan endpoint) via `Z_AI_QUOTA_URL=https://open.bigmodel.cn/api/coding/paas/v4`.
+- Endpoint overrides must be explicit HTTPS URLs or bare hosts/paths that CodexBar normalizes to HTTPS. Explicit
+  `http://` overrides fail closed before the bearer token is attached to a request. If both z.ai overrides are set,
+  `Z_AI_QUOTA_URL` has priority for quota requests; a stale lower-priority `Z_AI_API_HOST` is ignored for that quota
+  path, but direct model-usage requests still validate `Z_AI_API_HOST` before sending bearer auth.
 - Headers:
   - `authorization: Bearer <token>`
   - `accept: application/json`


### PR DESCRIPTION
## Summary
This PR hardens the provider endpoint boundary for usage probes that attach API tokens or browser cookies to outbound requests.

- Validates Deepgram, z.ai, and Xiaomi MiMo endpoint overrides before any provider credential is attached.
- Rejects explicit insecure `http://...` overrides while preserving HTTPS and bare-host overrides normalized to HTTPS.
- Preserves z.ai quota precedence so a valid `Z_AI_QUOTA_URL` is not blocked by a stale lower-priority `Z_AI_API_HOST`.
- Adds Linux regression coverage and provider documentation for the new override policy and compatibility impact.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Credentialed provider requests could be redirected to insecure override endpoints | A local launch/configuration context that can set provider endpoint override variables could cause CodexBar usage probes to send Deepgram/z.ai API credentials, or MiMo browser cookies, to an attacker-controlled HTTP endpoint. | Medium |

## Before this PR

- Deepgram accepted `DEEPGRAM_API_URL` through a raw URL parse before sending `Authorization: Token ...` usage requests.
- z.ai accepted `Z_AI_QUOTA_URL` / `Z_AI_API_HOST` values that could preserve explicit insecure schemes before sending bearer-token usage requests.
- Xiaomi MiMo accepted `MIMO_API_URL` with an explicit scheme before sending normalized browser cookie material to the configured host.
- MiMo invalid endpoint override errors could be hidden by automatic fallback to local usage accounting.
- Provider docs mentioned override variables without consistently documenting the HTTPS-or-bare-host policy or the `http://` compatibility break.

## After this PR

- Deepgram, z.ai, and MiMo validate endpoint overrides before constructing credentialed requests.
- Explicit `http://...` and malformed override values fail closed with provider-specific `invalidEndpointOverride` errors.
- HTTPS overrides remain supported, and bare-host overrides continue to work by normalizing to HTTPS.
- z.ai validates only the effective quota endpoint: `Z_AI_QUOTA_URL` first, then `Z_AI_API_HOST` only when the quota URL is absent.
- Direct z.ai model-usage requests still validate `Z_AI_API_HOST` before sending bearer auth.
- MiMo invalid endpoint overrides are terminal and do not fall back to local usage accounting.
- Provider docs and the unreleased changelog now describe the endpoint override policy and migration expectation.

## Explicit operator choice

This PR keeps the secure default as HTTPS-or-bare-host endpoint overrides only.

- Supported override forms:
  - explicit HTTPS URLs, such as `https://proxy.example/v1`
  - bare hosts or host/path values that CodexBar normalizes to HTTPS
- Blocked override form:
  - explicit `http://...` endpoints for Deepgram, z.ai, and MiMo credentialed usage paths
- Local proxy or test setups that currently rely on HTTP should migrate to HTTPS or bare-host normalization.
- If maintainers want to preserve HTTP loopback workflows, the safer follow-up would be a documented loopback-only exception with tests proving remote HTTP remains rejected.

## Why this matters

Provider endpoint overrides are useful for trusted proxy and test setups, but they define where CodexBar sends provider credentials. If those overrides can point at arbitrary insecure hosts, a local wrapper, launcher, or configuration context can redirect usage probes and collect API tokens or browser cookie material that were intended only for the provider.

## Attack flow

```text
attacker-controlled launch/configuration context sets an insecure provider override
    -> CodexBar usage probe resolves that override as the provider endpoint
        -> request is built with the user's provider credential or cookie header
            -> request is sent to the attacker-controlled HTTP listener
                -> credential material is exposed outside the intended provider boundary
```

## Affected code

| Issue | Files |
|-------|-------|
| Provider endpoint override credential redirection | `Sources/CodexBarCore/Providers/Deepgram/DeepgramUsageFetcher.swift`, `Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift`, `Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift`, `Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift`, `Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift` |

## Root cause

Issue: provider-specific override paths bypassed or inconsistently applied the shared endpoint override validator.

- Some providers accepted raw URL strings directly from environment overrides.
- Validation did not consistently happen before the endpoint was trusted as the destination for a credentialed request.
- The shared validator already expressed the intended HTTPS/bare-host boundary, but these sibling provider integrations did not consistently use it.
- MiMo fallback handling initially treated an invalid endpoint override like a normal web-session failure, which could hide a bad override by returning local usage data.
- z.ai has two override knobs with different precedence, so validation needed to follow the effective endpoint instead of rejecting an unused lower-priority value.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Credentialed provider requests could be redirected to insecure override endpoints | 5.0 Medium | `CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:N/A:N` |

Rationale:

- The attack is scoped to local/launch/configuration influence over CodexBar's provider override environment, not unauthenticated remote reachability.
- User interaction is modeled because the victim still has to run the affected usage probe with real provider credentials available.
- Confidentiality impact is high for the affected provider credential or cookie material.
- Integrity and availability impact are not claimed here.
- The score is intentionally conservative because endpoint overrides are a trusted/operator-oriented feature in many deployments.

## Safe reproduction steps

### 1. Deepgram override redirection

1. Build the CLI in a Linux container.
2. Run a local HTTP listener inside the same container namespace.
3. Run `CodexBarCLI usage --provider deepgram --format json` with `DEEPGRAM_API_URL` pointed at the listener and a dummy `DEEPGRAM_API_KEY`.
4. On vulnerable code, observe credential-bearing Deepgram usage requests reaching the listener.
5. On patched code, observe an endpoint override validation error before the listener receives a request.

### 2. z.ai override redirection

1. Build the CLI in a Linux container.
2. Run a local HTTP listener inside the same container namespace.
3. Run `CodexBarCLI usage --provider zai --format json` with `Z_AI_QUOTA_URL` pointed at the listener and a dummy `Z_AI_API_KEY`.
4. On vulnerable code, observe a credential-bearing z.ai quota request reaching the listener.
5. On patched code, observe an endpoint override validation error before the listener receives a request.

### 3. MiMo fail-closed regression

1. Configure `MIMO_API_URL` with an insecure `http://...` endpoint and provide a dummy MiMo cookie header in the test harness.
2. Run the focused regression test.
3. The patched code raises `MiMoSettingsError.invalidEndpointOverride` before the transport receives a request.
4. Automatic MiMo fallback does not hide the invalid endpoint override by returning local usage accounting.

### 4. z.ai precedence regression

1. Set a valid `Z_AI_QUOTA_URL` and a stale invalid lower-priority `Z_AI_API_HOST`.
2. Resolve the quota URL or run the focused regression test.
3. The patched code accepts the valid quota URL and ignores the unused host override for the quota path.
4. Direct model-usage requests still reject the invalid host before bearer auth is attached.

## Expected vulnerable behavior

- The pre-patch Deepgram path sent token-authenticated usage requests to the configured HTTP override endpoint.
- The pre-patch z.ai path sent a bearer-token-authenticated quota request to the configured HTTP override endpoint.
- The MiMo path accepted an insecure override by code review and is now covered by a regression proving the patched code rejects it before a cookie-bearing request can be sent.
- Invalid override values were not documented as a fail-closed compatibility break for existing local proxy or test setups.

## Changes in this PR

- Adds provider-specific `invalidEndpointOverride` errors for Deepgram, z.ai, and MiMo.
- Validates affected override environment variables before credentialed usage requests are constructed.
- Routes affected overrides through `ProviderEndpointOverrideValidator.normalizedHTTPSURL(from:)`.
- Preserves HTTPS and bare-host override support while rejecting insecure explicit schemes.
- Preserves z.ai quota endpoint precedence and validates `Z_AI_API_HOST` separately for model-usage requests.
- Keeps MiMo invalid endpoint overrides non-fallbackable while preserving local fallback for missing or invalid cookies.
- Adds Linux security regression tests for invalid overrides, accepted HTTPS/bare-host overrides, z.ai quota precedence, z.ai model-usage host validation, and MiMo invalid-override non-fallback behavior.
- Documents the HTTPS-or-bare-host override policy in provider docs and the unreleased changelog.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Deepgram hardening | `Sources/CodexBarCore/Providers/Deepgram/DeepgramUsageFetcher.swift` | Validates `DEEPGRAM_API_URL` before token-authenticated requests and normalizes accepted overrides through the shared validator. |
| z.ai hardening | `Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift`, `Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift` | Validates the effective quota endpoint before bearer-token quota requests, preserves `Z_AI_QUOTA_URL` precedence over lower-priority `Z_AI_API_HOST`, and validates `Z_AI_API_HOST` before model-usage requests. |
| MiMo hardening | `Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift`, `Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift` | Validates `MIMO_API_URL` before cookie-authenticated usage requests and prevents invalid endpoint override errors from falling back to local usage accounting. |
| Regression tests | `TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift` | Adds Linux coverage for fail-closed insecure overrides, accepted HTTPS/bare-host overrides, z.ai quota precedence, z.ai model-usage host validation, and MiMo invalid-override non-fallback behavior. |
| Documentation | `docs/deepgram.md`, `docs/zai.md`, `docs/mimo.md`, `docs/providers.md`, `CHANGELOG.md` | Documents the endpoint override policy, z.ai precedence behavior, MiMo fallback behavior, and the explicit `http://` compatibility break. |

## Maintainer impact

- The patch is limited to provider endpoint override handling for usage probes and related documentation.
- Default provider endpoints are unchanged.
- Trusted HTTPS proxy endpoints and bare-host overrides continue to work.
- Explicit insecure `http://...` provider overrides now fail closed instead of receiving provider credentials.
- Existing local proxy or test setups using HTTP need either HTTPS migration, bare-host normalization, or a maintainer-approved loopback-only exception.
- MiMo local usage fallback remains available for missing/invalid cookies, but it no longer masks invalid endpoint configuration.

## Fix rationale

- The endpoint override value is the trust boundary for where CodexBar sends provider credentials, so it should be validated before any credentialed request is built.
- Reusing the existing shared validator keeps behavior consistent with the rest of the provider stack and avoids adding a parallel URL policy.
- z.ai validation follows the same precedence as request routing, which avoids rejecting an unused lower-priority override.
- MiMo invalid override errors remain terminal because falling back would hide a misconfiguration at the credential-routing boundary.
- Documentation and changelog updates make the intentional compatibility break visible before release.
- Regression tests assert both sides of the boundary: insecure overrides are rejected and HTTPS/bare-host overrides remain supported.

## Type of change

- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Docker pre-fix reproduction: built `CodexBarCLI` in `swift:6.2-noble` and confirmed local listener receipt of credential-bearing Deepgram and z.ai requests when HTTP overrides were configured.
- [x] Docker post-fix reproduction: reran the same listener/CLI flow and confirmed the listeners received no requests; the CLI returned endpoint override validation errors instead.
- [x] Focused Docker regression suite passed with 8 tests in `ProviderEndpointOverrideSecurityLinuxTests`.
- [x] Docker full Linux test suite passed with 43 tests in 10 suites.
- [x] Local `swift build --target CodexBarCore` passed.
- [x] Local docs link validation passed.
- [x] Local docs index/list generation passed.
- [x] `git diff --check` passed.
- [x] `./Scripts/lint.sh format` passed with no files formatted.
- [ ] Local macOS `swift test` did not complete because the local dependency build fails before project tests on the existing `KeyboardShortcuts` / `PreviewsMacros` toolchain issue.
- [ ] Local SwiftLint through `make check` did not complete because SourceKitten could not load `sourcekitdInProc.framework` in this local environment.

Executed with:

- `docker run --rm -v "$PWD:/work" -w /work swift:6.2-noble bash -lc 'apt-get update >/dev/null && apt-get install -y libsqlite3-dev >/dev/null && swift test --filter ProviderEndpointOverrideSecurityLinuxTests'`
- `docker run --rm -v "$PWD:/work" -w /work swift:6.2-noble bash -lc 'apt-get update >/dev/null && apt-get install -y libsqlite3-dev >/dev/null && swift test'`
- `swift build --target CodexBarCore`
- `node Scripts/check-documentation-links.mjs`
- `node Scripts/docs-list.mjs`
- `git diff --check`
- `./Scripts/lint.sh format`

## Disclosure notes

- This PR is intentionally bounded to provider endpoint override handling for Deepgram, z.ai, and MiMo usage probes.
- It does not claim unauthenticated remote exploitability; the modeled attacker needs local launch/configuration influence over provider override variables.
- Reproduction used local listeners and dummy credentials only; no production provider credentials or endpoints were tested.
- The compatibility impact is intentional: explicit `http://...` overrides now fail closed unless maintainers choose to add a loopback-only exception in a follow-up.
- No unrelated application areas are changed.
