### PR TITLE
Align provider card spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.37.1 — Unreleased
 
 ### Fixed
+- Menu: align provider usage-card spacing with the Overview layout. Thanks @Zihao-Qi!
 - Memory pressure: avoid actor-isolation crashes when system callbacks arrive on a utility queue. Thanks @Zihao-Qi!
 - Menu: remove extra separators and spacing around Storage, Cost, and Subscription Utilization rows. Thanks @elijahfriedman!
 - Antigravity: show limits as unavailable when OAuth identifies the account but quota endpoints deny access. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -2,15 +2,6 @@ import AppKit
 import CodexBarCore
 import SwiftUI
 
-enum UsageMenuCardLayout {
-    static let horizontalPadding: CGFloat = 20
-    static let headerOnlyVerticalPadding: CGFloat = 7
-    static let sectionTopPadding: CGFloat = 6
-    static let sectionBottomPadding: CGFloat = 6
-    static let headerLineSpacing: CGFloat = 4
-    static let headerColumnSpacing: CGFloat = 12
-}
-
 /// SwiftUI card used inside the NSMenu to mirror Apple's rich menu panels.
 struct UsageMenuCardView: View {
     struct Model {
@@ -143,11 +134,13 @@ struct UsageMenuCardView: View {
 
     var body: some View {
         let liveModel = self.liveModel
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 0) {
             UsageMenuCardHeaderView(model: self.layoutModel ?? self.model)
 
-            if self.hasDetails(model: liveModel) {
+            if Self.hasDetails(for: liveModel) {
                 Divider()
+                    .padding(.top, UsageMenuCardLayout.headerContentSpacing)
+                    .padding(.bottom, Self.dividerBottomPadding(for: liveModel))
             }
 
             if !liveModel.usesStackedDetailLayout {
@@ -156,6 +149,7 @@ struct UsageMenuCardView: View {
                 } else if !liveModel.usageNotes.isEmpty {
                     UsageNotesContent(notes: liveModel.usageNotes)
                 } else if let placeholder = liveModel.placeholder {
+                    // Non-stacked placeholders are standalone detail rows; stacked usage placeholders are gated below.
                     Text(placeholder)
                         .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
                         .font(.subheadline)
@@ -168,29 +162,7 @@ struct UsageMenuCardView: View {
 
                 VStack(alignment: .leading, spacing: 12) {
                     if hasUsage {
-                        VStack(alignment: .leading, spacing: 12) {
-                            ForEach(liveModel.metrics, id: \.id) { metric in
-                                MetricRow(
-                                    metric: metric,
-                                    title: Self.popupMetricTitle(provider: liveModel.provider, metric: metric),
-                                    progressColor: liveModel.progressColor)
-                            }
-                            if let resetCredits = liveModel.codexResetCreditsText {
-                                Divider()
-                                CodexResetCreditsContent(
-                                    text: resetCredits,
-                                    detailText: liveModel.codexResetCreditsDetailText)
-                            }
-                            if let dashboard = liveModel.inlineUsageDashboard {
-                                InlineUsageDashboardContent(model: dashboard)
-                            } else if !liveModel.usageNotes.isEmpty {
-                                UsageNotesContent(notes: liveModel.usageNotes)
-                            } else if let placeholder = liveModel.placeholder {
-                                Text(placeholder)
-                                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                                    .font(.subheadline)
-                            }
-                        }
+                        UsageMenuCardUsageContentView(model: liveModel, showBottomDivider: false)
                     }
                     if hasUsage, hasCredits || hasCost {
                         Divider()
@@ -245,18 +217,18 @@ struct UsageMenuCardView: View {
                         }
                     }
                 }
-                .padding(.bottom, liveModel.creditsText == nil ? 6 : 0)
             }
         }
         .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
         .padding(
             .top,
-            self.hasDetails(model: liveModel)
+            Self.hasDetails(for: liveModel)
                 ? UsageMenuCardLayout.sectionTopPadding
                 : UsageMenuCardLayout.headerOnlyVerticalPadding)
+        // AppKit's following separator row adds visual bottom space, so detail cards keep this inset tight.
         .padding(
             .bottom,
-            self.hasDetails(model: liveModel)
+            Self.hasDetails(for: liveModel)
                 ? UsageMenuCardLayout.sectionBottomPadding
                 : UsageMenuCardLayout.headerOnlyVerticalPadding)
         .frame(width: self.width, alignment: .leading)
@@ -267,8 +239,15 @@ struct UsageMenuCardView: View {
         return self.refreshMonitor?.model(for: self.model.provider, fallback: self.model) ?? self.model
     }
 
-    private func hasDetails(model: Model) -> Bool {
+    private static func hasDetails(for model: Model) -> Bool {
         model.hasUsageContent || model.usesStackedDetailLayout
+    }
+
+    static func dividerBottomPadding(for model: Model) -> CGFloat {
+        if model.usesStackedDetailLayout, model.hasUsageContent {
+            return UsageMenuCardLayout.postHeaderDividerContentSpacing
+        }
+        return UsageMenuCardLayout.sectionBottomPadding
     }
 }
 
@@ -531,7 +510,7 @@ struct UsageMenuCardHeaderSectionView: View {
     let width: CGFloat
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: UsageMenuCardLayout.headerContentSpacing) {
             UsageMenuCardHeaderView(model: self.model)
 
             if self.showDivider {
@@ -554,37 +533,33 @@ struct UsageMenuCardHeaderSectionView: View {
     }
 }
 
-struct UsageMenuCardUsageSectionView: View {
+private struct UsageMenuCardUsageContentView: View {
     let model: UsageMenuCardView.Model
     let showBottomDivider: Bool
-    let bottomPadding: CGFloat
-    let width: CGFloat
     @Environment(\.menuItemHighlighted) private var isHighlighted
-    @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
 
     var body: some View {
-        let liveModel = self.liveModel
         VStack(alignment: .leading, spacing: 12) {
-            ForEach(liveModel.metrics, id: \.id) { metric in
+            ForEach(self.model.metrics, id: \.id) { metric in
                 MetricRow(
                     metric: metric,
-                    title: UsageMenuCardView.popupMetricTitle(provider: liveModel.provider, metric: metric),
-                    progressColor: liveModel.progressColor)
+                    title: UsageMenuCardView.popupMetricTitle(provider: self.model.provider, metric: metric),
+                    progressColor: self.model.progressColor)
             }
-            if let resetCredits = liveModel.codexResetCreditsText {
-                if !liveModel.metrics.isEmpty {
+            if let resetCredits = self.model.codexResetCreditsText {
+                if !self.model.metrics.isEmpty {
                     Divider()
                 }
                 CodexResetCreditsContent(
                     text: resetCredits,
-                    detailText: liveModel.codexResetCreditsDetailText)
+                    detailText: self.model.codexResetCreditsDetailText)
             }
-            if let dashboard = liveModel.inlineUsageDashboard {
+            if let dashboard = self.model.inlineUsageDashboard {
                 InlineUsageDashboardContent(model: dashboard)
-            } else if !liveModel.usageNotes.isEmpty {
-                UsageNotesContent(notes: liveModel.usageNotes)
-            } else if let placeholder = liveModel.placeholder, liveModel.metrics.isEmpty,
-                      liveModel.codexResetCreditsText == nil
+            } else if !self.model.usageNotes.isEmpty {
+                UsageNotesContent(notes: self.model.usageNotes)
+            } else if let placeholder = self.model.placeholder, self.model.metrics.isEmpty,
+                      self.model.codexResetCreditsText == nil
             {
                 Text(placeholder)
                     .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
@@ -594,10 +569,23 @@ struct UsageMenuCardUsageSectionView: View {
                 Divider()
             }
         }
-        .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
-        .padding(.top, 10)
-        .padding(.bottom, self.bottomPadding)
-        .frame(width: self.width, alignment: .leading)
+    }
+}
+
+struct UsageMenuCardUsageSectionView: View {
+    let model: UsageMenuCardView.Model
+    let showBottomDivider: Bool
+    let bottomPadding: CGFloat
+    let width: CGFloat
+    @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
+
+    var body: some View {
+        let liveModel = self.liveModel
+        UsageMenuCardUsageContentView(model: liveModel, showBottomDivider: self.showBottomDivider)
+            .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
+            .padding(.top, UsageMenuCardLayout.usageSectionTopPadding)
+            .padding(.bottom, self.bottomPadding)
+            .frame(width: self.width, alignment: .leading)
     }
 
     private var liveModel: UsageMenuCardView.Model {

--- a/Sources/CodexBar/UsageMenuCardLayout.swift
+++ b/Sources/CodexBar/UsageMenuCardLayout.swift
@@ -1,0 +1,17 @@
+import CoreGraphics
+
+enum UsageMenuCardLayout {
+    static let horizontalPadding: CGFloat = 20
+    static let headerOnlyVerticalPadding: CGFloat = 6
+    static let headerContentSpacing: CGFloat = 6
+    static let sectionTopPadding: CGFloat = 6
+    static let usageSectionTopPadding: CGFloat = 10
+    static let sectionBottomPadding: CGFloat = 6
+    static let headerLineSpacing: CGFloat = 4
+    static let headerColumnSpacing: CGFloat = 12
+
+    static var postHeaderDividerContentSpacing: CGFloat {
+        // Reproduces Overview's header-bottom + usage-top gap so full cards align.
+        sectionBottomPadding + usageSectionTopPadding
+    }
+}

--- a/Tests/CodexBarTests/UsageMenuCardLayoutTests.swift
+++ b/Tests/CodexBarTests/UsageMenuCardLayoutTests.swift
@@ -6,27 +6,11 @@ import Testing
 
 @MainActor
 struct UsageMenuCardLayoutTests {
+    private static let heightTolerance: CGFloat = 1
+
     @Test
     func `header only menu card keeps comfortable padding`() {
-        let model = UsageMenuCardView.Model(
-            provider: .codex,
-            providerName: "Codex",
-            email: "steipete@gmail.com",
-            subtitleText: "Not fetched yet",
-            subtitleStyle: .info,
-            planText: "Pro 20x",
-            metrics: [],
-            usageNotes: [],
-            openAIAPIUsage: nil,
-            inlineUsageDashboard: nil,
-            creditsText: nil,
-            creditsRemaining: nil,
-            creditsHintText: nil,
-            creditsHintCopyText: nil,
-            providerCost: nil,
-            tokenUsage: nil,
-            placeholder: nil,
-            progressColor: .blue)
+        let model = Self.model()
         let width: CGFloat = 296
 
         let headerSize = NSHostingController(rootView: UsageMenuCardHeaderSectionView(
@@ -37,7 +21,94 @@ struct UsageMenuCardLayoutTests {
         let cardSize = NSHostingController(rootView: UsageMenuCardView(model: model, width: width))
             .sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
 
-        #expect(headerSize.height >= 46)
-        #expect(cardSize.height >= 46)
+        #expect(headerSize.height > 0)
+        #expect(abs(cardSize.height - headerSize.height) < Self.heightTolerance)
+    }
+
+    @Test
+    func `full provider card matches overview height`() {
+        let model = Self.model(metrics: [
+            UsageMenuCardView.Model.Metric(
+                id: "session",
+                title: "Session",
+                percent: 37,
+                percentStyle: .left,
+                resetText: "Resets in 41m",
+                detailText: nil,
+                detailLeftText: "24% in reserve",
+                detailRightText: "Lasts until reset",
+                pacePercent: nil,
+                paceOnTop: true),
+        ])
+        let width: CGFloat = 296
+
+        let fullCardSize = NSHostingController(rootView: UsageMenuCardView(model: model, width: width))
+            .sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
+        let overviewStyleSize = NSHostingController(rootView: UsageMenuCardHeaderAndUsageSectionView(
+            model: model,
+            layoutModel: model,
+            bottomPadding: UsageMenuCardLayout.sectionBottomPadding,
+            width: width))
+            .sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
+
+        #expect(UsageMenuCardLayout.postHeaderDividerContentSpacing == 16)
+        #expect(UsageMenuCardLayout.headerOnlyVerticalPadding == 6)
+        #expect(UsageMenuCardLayout.sectionTopPadding == 6)
+        #expect(UsageMenuCardLayout.sectionBottomPadding == 6)
+
+        #expect(abs(fullCardSize.height - overviewStyleSize.height) < Self.heightTolerance)
+    }
+
+    @Test
+    func `detail card keeps compact divider gap without usage section`() {
+        let metricsModel = Self.model(metrics: [
+            UsageMenuCardView.Model.Metric(
+                id: "session",
+                title: "Session",
+                percent: 37,
+                percentStyle: .left,
+                resetText: "Resets in 41m",
+                detailText: nil,
+                detailLeftText: "24% in reserve",
+                detailRightText: "Lasts until reset",
+                pacePercent: nil,
+                paceOnTop: true),
+        ])
+
+        #expect(UsageMenuCardView.dividerBottomPadding(for: metricsModel) ==
+            UsageMenuCardLayout.postHeaderDividerContentSpacing)
+        #expect(UsageMenuCardView.dividerBottomPadding(for: Self.model(creditsText: "$12.34 remaining")) ==
+            UsageMenuCardLayout.sectionBottomPadding)
+        #expect(UsageMenuCardView.dividerBottomPadding(for: Self.model(usageNotes: ["Waiting for data"])) ==
+            UsageMenuCardLayout.sectionBottomPadding)
+        #expect(UsageMenuCardView.dividerBottomPadding(for: Self.model(placeholder: "No usage yet")) ==
+            UsageMenuCardLayout.sectionBottomPadding)
+    }
+
+    private static func model(
+        metrics: [UsageMenuCardView.Model.Metric] = [],
+        usageNotes: [String] = [],
+        creditsText: String? = nil,
+        placeholder: String? = nil) -> UsageMenuCardView.Model
+    {
+        UsageMenuCardView.Model(
+            provider: .codex,
+            providerName: "Codex",
+            email: "steipete@gmail.com",
+            subtitleText: "Not fetched yet",
+            subtitleStyle: .info,
+            planText: "Pro 20x",
+            metrics: metrics,
+            usageNotes: usageNotes,
+            openAIAPIUsage: nil,
+            inlineUsageDashboard: nil,
+            creditsText: creditsText,
+            creditsRemaining: nil,
+            creditsHintText: nil,
+            creditsHintCopyText: nil,
+            providerCost: nil,
+            tokenUsage: nil,
+            placeholder: placeholder,
+            progressColor: .blue)
     }
 }


### PR DESCRIPTION
## Summary

Align provider usage cards with the Overview layout by sharing the usage metrics body and centralizing card spacing constants.

## Why

Overview and provider cards had drifted into subtly different vertical spacing even when they rendered the same usage content. That made the selected provider view feel lower/taller than Overview and made future spacing fixes easy to apply in one path but not the other.

This change makes the shared usage layout explicit, while preserving the visual compensation needed for provider cards inside `NSMenu`, where the following AppKit separator contributes visible bottom space.

## Details

- Extracts the repeated usage metrics body into a shared view used by both Overview and provider cards.
- Matches full provider usage-card height to the Overview header + usage-section layout.
- Uses compensated provider-card bottom spacing because the following AppKit separator contributes visible bottom space.
- Tightens header-only provider cards from 7pt top/bottom padding to 6pt top/bottom padding, making loading / “not fetched yet” states 2pt shorter overall.
- Uses the larger 16pt header-divider-to-usage gap only when the detail section starts with usage metrics.
- Keeps compact 6pt divider spacing for credits-only, notes, dashboard, and placeholder detail cards.
- Normalizes placeholder/reset-credit rendering so placeholder text does not appear alongside real usage/reset content and reset-credit dividers are not shown empty.

## Tests

- `swift build`
- `make check`
- `swift test --filter UsageMenuCardLayoutTests`

## Screenshots

Before:
<img width="310" height="273" alt="Screenshot 2026-06-20 at 08 49 16" src="https://github.com/user-attachments/assets/efecb5ef-a831-4ada-9066-9e515a0b480a" />

After:
<img width="311" height="263" alt="Screenshot 2026-06-20 at 08 49 02" src="https://github.com/user-attachments/assets/3481375b-7dbe-43f9-a06b-3284117398d0" />
