### PR TITLE
Show raw Codex credit totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.39.1 — Unreleased
 
 ### Added
+- Codex dashboard: show calendar-correct raw Today and 30-day credit totals without converting credits to billed dollars. Thanks @avenoxai!
 - Devin: show remaining extra-usage balance in menus, CLI, and widgets while respecting optional-usage visibility. Thanks @FNDEVVE!
 - Widgets: make Mistral available in provider selection and switching. Thanks @joeVenner!
 

--- a/Sources/CodexBar/UsageBreakdownChartMenuView.swift
+++ b/Sources/CodexBar/UsageBreakdownChartMenuView.swift
@@ -4,6 +4,12 @@ import SwiftUI
 
 @MainActor
 struct UsageBreakdownChartMenuView: View {
+    enum PresentationState: Equatable {
+        case empty
+        case totalsOnly
+        case chart
+    }
+
     private struct Point: Identifiable {
         let id: String
         let date: Date
@@ -42,13 +48,11 @@ struct UsageBreakdownChartMenuView: View {
             now: self.now,
             calendar: self.calendar)
         let model = Self.makeModel(from: summary.daily)
+        let presentationState = Self.presentationState(
+            hasSummary: !summary.daily.isEmpty,
+            hasChartPoints: !model.points.isEmpty)
         VStack(alignment: .leading, spacing: 10) {
-            if model.points.isEmpty {
-                Text(L("No usage breakdown data."))
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel(L("No usage breakdown data available."))
-            } else {
+            if presentationState != .empty {
                 HStack(alignment: .firstTextBaseline) {
                     self.summaryMetric(title: L("Today"), credits: summary.todayCredits)
                     Spacer(minLength: 12)
@@ -56,7 +60,14 @@ struct UsageBreakdownChartMenuView: View {
                         title: String(format: L("Last %d days"), summary.historyDays),
                         credits: summary.totalCredits)
                 }
+            }
 
+            if presentationState == .empty {
+                Text(L("No usage breakdown data."))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(L("No usage breakdown data available."))
+            } else if presentationState == .chart {
                 Chart {
                     ForEach(model.points) { point in
                         BarMark(
@@ -156,6 +167,12 @@ struct UsageBreakdownChartMenuView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
         .frame(minWidth: self.width, maxWidth: .infinity, alignment: .leading)
+    }
+
+    static func presentationState(hasSummary: Bool, hasChartPoints: Bool) -> PresentationState {
+        if hasChartPoints { return .chart }
+        if hasSummary { return .totalsOnly }
+        return .empty
     }
 
     private struct Model {

--- a/Sources/CodexBar/UsageBreakdownChartMenuView.swift
+++ b/Sources/CodexBar/UsageBreakdownChartMenuView.swift
@@ -19,16 +19,29 @@ struct UsageBreakdownChartMenuView: View {
     }
 
     private let breakdown: [OpenAIDashboardDailyBreakdown]
+    private let now: Date
+    private let calendar: Calendar
     private let width: CGFloat
     @State private var selectedDayKey: String?
 
-    init(breakdown: [OpenAIDashboardDailyBreakdown], width: CGFloat) {
+    init(
+        breakdown: [OpenAIDashboardDailyBreakdown],
+        now: Date = Date(),
+        calendar: Calendar = .current,
+        width: CGFloat)
+    {
         self.breakdown = breakdown
+        self.now = now
+        self.calendar = calendar
         self.width = width
     }
 
     var body: some View {
-        let model = Self.makeModel(from: self.breakdown)
+        let summary = OpenAIDashboardDailyBreakdown.recentUsageSummary(
+            from: self.breakdown,
+            now: self.now,
+            calendar: self.calendar)
+        let model = Self.makeModel(from: summary.daily)
         VStack(alignment: .leading, spacing: 10) {
             if model.points.isEmpty {
                 Text(L("No usage breakdown data."))
@@ -36,6 +49,14 @@ struct UsageBreakdownChartMenuView: View {
                     .foregroundStyle(.secondary)
                     .accessibilityLabel(L("No usage breakdown data available."))
             } else {
+                HStack(alignment: .firstTextBaseline) {
+                    self.summaryMetric(title: L("Today"), credits: summary.todayCredits)
+                    Spacer(minLength: 12)
+                    self.summaryMetric(
+                        title: String(format: L("Last %d days"), summary.historyDays),
+                        credits: summary.totalCredits)
+                }
+
                 Chart {
                     ForEach(model.points) { point in
                         BarMark(
@@ -153,6 +174,25 @@ struct UsageBreakdownChartMenuView: View {
     }
 
     private static let selectionBandColor = Color(nsColor: .labelColor).opacity(0.1)
+
+    private func summaryMetric(title: String, credits: Double?) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(Self.creditsString(credits))
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .monospacedDigit()
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private static func creditsString(_ credits: Double?) -> String {
+        guard let credits, credits.isFinite else { return "—" }
+        let value = credits.formatted(.number.precision(.fractionLength(0...2)))
+        return "\(value) \(L("credits"))"
+    }
 
     private static func makeModel(from breakdown: [OpenAIDashboardDailyBreakdown]) -> Model {
         let sorted = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(from: breakdown)

--- a/Sources/CodexBar/UsageBreakdownChartMenuView.swift
+++ b/Sources/CodexBar/UsageBreakdownChartMenuView.swift
@@ -76,12 +76,16 @@ struct UsageBreakdownChartMenuView: View {
                 .chartForegroundStyleScale(domain: model.services, range: model.serviceColors)
                 .chartYAxis(.hidden)
                 .chartXAxis {
-                    AxisMarks(values: model.axisDates) { _ in
+                    AxisMarks(values: model.axisDates) { value in
                         AxisGridLine().foregroundStyle(Color.clear)
                         AxisTick().foregroundStyle(Color.clear)
-                        AxisValueLabel(format: .dateTime.month(.abbreviated).day())
-                            .font(.caption2)
-                            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                        if let date = value.as(Date.self) {
+                            AxisValueLabel(anchor: Self.xAxisLabelAnchor(for: date, axisDates: model.axisDates)) {
+                                Text(date, format: .dateTime.month(.abbreviated).day())
+                                    .font(.caption2)
+                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                            }
+                        }
                     }
                 }
                 .chartLegend(.hidden)
@@ -300,6 +304,16 @@ struct UsageBreakdownChartMenuView: View {
             return [firstDate]
         }
         return [firstDate, lastDate]
+    }
+
+    private static func xAxisLabelAnchor(for date: Date, axisDates: [Date]) -> UnitPoint {
+        if let first = axisDates.first, Calendar.current.isDate(date, inSameDayAs: first) {
+            return .topLeading
+        }
+        if let last = axisDates.last, Calendar.current.isDate(date, inSameDayAs: last) {
+            return .topTrailing
+        }
+        return .top
     }
 
     private static func dateFromDayKey(_ key: String) -> Date? {

--- a/Sources/CodexBarCore/OpenAIDashboardModels.swift
+++ b/Sources/CodexBarCore/OpenAIDashboardModels.swift
@@ -193,6 +193,113 @@ public struct OpenAIDashboardDailyBreakdown: Codable, Equatable, Sendable {
                 totalCreditsUsed: total)
         }
     }
+
+    public static func recentUsageSummary(
+        from breakdown: [OpenAIDashboardDailyBreakdown],
+        historyDays: Int = 30,
+        now: Date = Date(),
+        calendar: Calendar = .current) -> OpenAIDashboardUsageBreakdownSummary
+    {
+        let days = max(1, min(historyDays, 365))
+        var dayCalendar = Calendar(identifier: .gregorian)
+        dayCalendar.timeZone = calendar.timeZone
+        let today = dayCalendar.startOfDay(for: now)
+        let start = dayCalendar.date(byAdding: .day, value: -(days - 1), to: today) ?? today
+        let startKey = Self.dayKey(from: start, calendar: dayCalendar)
+        let todayKey = Self.dayKey(from: today, calendar: dayCalendar)
+        let recent = self.removingSkillUsageServices(from: breakdown)
+            .compactMap { self.sanitized($0, startKey: startKey, todayKey: todayKey, calendar: dayCalendar) }
+            .sorted { $0.day < $1.day }
+        let todayCredits = recent.first(where: { $0.day == todayKey })?.totalCreditsUsed
+        let totalCredits = self.finiteSum(recent.map(\.totalCreditsUsed))
+        return OpenAIDashboardUsageBreakdownSummary(
+            historyDays: days,
+            todayCredits: todayCredits,
+            totalCredits: totalCredits,
+            daily: recent)
+    }
+
+    private static func sanitized(
+        _ day: OpenAIDashboardDailyBreakdown,
+        startKey: String,
+        todayKey: String,
+        calendar: Calendar) -> OpenAIDashboardDailyBreakdown?
+    {
+        guard self.date(fromDayKey: day.day, calendar: calendar) != nil,
+              day.day >= startKey,
+              day.day <= todayKey
+        else { return nil }
+
+        if day.services.isEmpty {
+            guard day.totalCreditsUsed.isFinite, day.totalCreditsUsed > 0 else { return nil }
+            return day
+        }
+
+        let services = day.services.filter { $0.creditsUsed.isFinite && $0.creditsUsed > 0 }
+        guard !services.isEmpty,
+              let total = self.finiteSum(services.map(\.creditsUsed)),
+              total > 0
+        else { return nil }
+        return OpenAIDashboardDailyBreakdown(day: day.day, services: services, totalCreditsUsed: total)
+    }
+
+    private static func finiteSum(_ values: [Double]) -> Double? {
+        var total = 0.0
+        for value in values {
+            let next = total + value
+            guard next.isFinite else { return nil }
+            total = next
+        }
+        return values.isEmpty ? nil : total
+    }
+
+    private static func date(fromDayKey key: String, calendar: Calendar) -> Date? {
+        let parts = key.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              let year = Int(parts[0]),
+              let month = Int(parts[1]),
+              let day = Int(parts[2])
+        else { return nil }
+        let components = DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: 12)
+        guard let date = calendar.date(from: components) else { return nil }
+        let resolved = calendar.dateComponents([.year, .month, .day], from: date)
+        guard resolved.year == year, resolved.month == month, resolved.day == day else { return nil }
+        return date
+    }
+
+    private static func dayKey(from date: Date, calendar: Calendar) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(
+            format: "%04d-%02d-%02d",
+            components.year ?? 0,
+            components.month ?? 0,
+            components.day ?? 0)
+    }
+}
+
+public struct OpenAIDashboardUsageBreakdownSummary: Equatable, Sendable {
+    public let historyDays: Int
+    public let todayCredits: Double?
+    public let totalCredits: Double?
+    public let daily: [OpenAIDashboardDailyBreakdown]
+
+    public init(
+        historyDays: Int,
+        todayCredits: Double?,
+        totalCredits: Double?,
+        daily: [OpenAIDashboardDailyBreakdown])
+    {
+        self.historyDays = historyDays
+        self.todayCredits = todayCredits
+        self.totalCredits = totalCredits
+        self.daily = daily
+    }
 }
 
 public struct OpenAIDashboardServiceUsage: Codable, Equatable, Sendable {

--- a/Sources/CodexBarCore/OpenAIDashboardModels.swift
+++ b/Sources/CodexBarCore/OpenAIDashboardModels.swift
@@ -211,6 +211,7 @@ public struct OpenAIDashboardDailyBreakdown: Codable, Equatable, Sendable {
             .compactMap { self.sanitized($0, startKey: startKey, todayKey: todayKey, calendar: dayCalendar) }
             .sorted { $0.day < $1.day }
         let todayCredits = recent.first(where: { $0.day == todayKey })?.totalCreditsUsed
+            ?? (recent.isEmpty ? nil : 0)
         let totalCredits = self.finiteSum(recent.map(\.totalCreditsUsed))
         return OpenAIDashboardUsageBreakdownSummary(
             historyDays: days,

--- a/Tests/CodexBarTests/OpenAIDashboardModelsTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardModelsTests.swift
@@ -3,6 +3,16 @@ import Foundation
 import Testing
 
 struct OpenAIDashboardModelsTests {
+    private static let utcCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }()
+
+    private static func utcDate(year: Int, month: Int, day: Int) -> Date {
+        self.utcCalendar.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
+    }
+
     @Test
     func `removes skill usage services from usage breakdown`() {
         let breakdown = [
@@ -90,5 +100,104 @@ struct OpenAIDashboardModelsTests {
                 services: [],
                 totalCreditsUsed: 4),
         ])
+    }
+
+    @Test
+    func `recent credit totals use calendar days and exclude future rows`() {
+        let summary = OpenAIDashboardDailyBreakdown.recentUsageSummary(
+            from: [
+                .init(day: "2026-05-31", services: [], totalCreditsUsed: 100),
+                .init(day: "2026-06-01", services: [], totalCreditsUsed: 1),
+                .init(day: "2026-06-29", services: [], totalCreditsUsed: 2),
+                .init(day: "2026-06-30", services: [], totalCreditsUsed: 3),
+                .init(day: "2026-07-01", services: [], totalCreditsUsed: 200),
+            ],
+            historyDays: 30,
+            now: Self.utcDate(year: 2026, month: 6, day: 30),
+            calendar: Self.utcCalendar)
+
+        #expect(summary.historyDays == 30)
+        #expect(summary.todayCredits == 3)
+        #expect(summary.totalCredits == 6)
+        #expect(summary.daily.map(\.day) == ["2026-06-01", "2026-06-29", "2026-06-30"])
+    }
+
+    @Test
+    func `recent credit totals preserve gaps and sanitize invalid values`() throws {
+        let summary = OpenAIDashboardDailyBreakdown.recentUsageSummary(
+            from: [
+                .init(
+                    day: "2026-06-20",
+                    services: [
+                        .init(service: "CLI", creditsUsed: 4),
+                        .init(service: "bad", creditsUsed: .nan),
+                        .init(service: "negative", creditsUsed: -2),
+                    ],
+                    totalCreditsUsed: 999),
+                .init(day: "2026-06-31", services: [], totalCreditsUsed: 9),
+                .init(day: "2026-06-30", services: [], totalCreditsUsed: .infinity),
+            ],
+            now: Self.utcDate(year: 2026, month: 6, day: 30),
+            calendar: Self.utcCalendar)
+
+        #expect(summary.todayCredits == nil)
+        #expect(summary.totalCredits == 4)
+        let day = try #require(summary.daily.first)
+        #expect(day.day == "2026-06-20")
+        #expect(day.totalCreditsUsed == 4)
+        #expect(day.services.map(\.service) == ["CLI"])
+    }
+
+    @Test
+    func `recent credit totals fail closed on overflow`() {
+        let summary = OpenAIDashboardDailyBreakdown.recentUsageSummary(
+            from: [
+                .init(
+                    day: "2026-06-30",
+                    services: [
+                        .init(service: "CLI", creditsUsed: Double.greatestFiniteMagnitude),
+                        .init(service: "Desktop App", creditsUsed: Double.greatestFiniteMagnitude),
+                    ],
+                    totalCreditsUsed: 1),
+            ],
+            now: Self.utcDate(year: 2026, month: 6, day: 30),
+            calendar: Self.utcCalendar)
+
+        #expect(summary.daily.isEmpty)
+        #expect(summary.todayCredits == nil)
+        #expect(summary.totalCredits == nil)
+    }
+
+    @Test
+    func `recent credit totals respect the selected timezone`() throws {
+        var pacific = Calendar(identifier: .gregorian)
+        pacific.timeZone = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        let now = try #require(ISO8601DateFormatter().date(from: "2026-07-01T06:30:00Z"))
+
+        let summary = OpenAIDashboardDailyBreakdown.recentUsageSummary(
+            from: [
+                .init(day: "2026-06-30", services: [], totalCreditsUsed: 7),
+                .init(day: "2026-07-01", services: [], totalCreditsUsed: 11),
+            ],
+            now: now,
+            calendar: pacific)
+
+        #expect(summary.todayCredits == 7)
+        #expect(summary.totalCredits == 7)
+        #expect(summary.daily.map(\.day) == ["2026-06-30"])
+    }
+
+    @Test
+    func `recent credit totals keep Gregorian dashboard keys with a non Gregorian system calendar`() throws {
+        var buddhist = Calendar(identifier: .buddhist)
+        buddhist.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+
+        let summary = OpenAIDashboardDailyBreakdown.recentUsageSummary(
+            from: [.init(day: "2026-06-30", services: [], totalCreditsUsed: 7)],
+            now: Self.utcDate(year: 2026, month: 6, day: 30),
+            calendar: buddhist)
+
+        #expect(summary.todayCredits == 7)
+        #expect(summary.totalCredits == 7)
     }
 }

--- a/Tests/CodexBarTests/OpenAIDashboardModelsTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardModelsTests.swift
@@ -140,12 +140,26 @@ struct OpenAIDashboardModelsTests {
             now: Self.utcDate(year: 2026, month: 6, day: 30),
             calendar: Self.utcCalendar)
 
-        #expect(summary.todayCredits == nil)
+        #expect(summary.todayCredits == 0)
         #expect(summary.totalCredits == 4)
         let day = try #require(summary.daily.first)
         #expect(day.day == "2026-06-20")
         #expect(day.totalCreditsUsed == 4)
         #expect(day.services.map(\.service) == ["CLI"])
+    }
+
+    @Test
+    func `recent credit totals report zero when history has no row for today`() {
+        let summary = OpenAIDashboardDailyBreakdown.recentUsageSummary(
+            from: [
+                .init(day: "2026-06-29", services: [], totalCreditsUsed: 4),
+            ],
+            now: Self.utcDate(year: 2026, month: 6, day: 30),
+            calendar: Self.utcCalendar)
+
+        #expect(summary.todayCredits == 0)
+        #expect(summary.totalCredits == 4)
+        #expect(summary.daily.map(\.day) == ["2026-06-29"])
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageBreakdownChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/UsageBreakdownChartMenuViewTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import CodexBar
+
+@Suite("Usage breakdown chart menu")
+@MainActor
+struct UsageBreakdownChartMenuViewTests {
+    @Test
+    func `valid totals remain visible when service rows are absent`() {
+        #expect(
+            UsageBreakdownChartMenuView.presentationState(
+                hasSummary: true,
+                hasChartPoints: false) == .totalsOnly)
+    }
+
+    @Test
+    func `service rows select the chart presentation`() {
+        #expect(
+            UsageBreakdownChartMenuView.presentationState(
+                hasSummary: true,
+                hasChartPoints: true) == .chart)
+    }
+
+    @Test
+    func `missing totals and service rows select the empty presentation`() {
+        #expect(
+            UsageBreakdownChartMenuView.presentationState(
+                hasSummary: false,
+                hasChartPoints: false) == .empty)
+    }
+}


### PR DESCRIPTION
## Summary

Shows calendar-correct raw Codex dashboard credit totals without pretending dashboard credits are billed dollars.

## Maintainer rewrite

- Adds compact `Today` and `Last 30 days` credit totals above the existing dashboard usage-breakdown chart.
- Keeps the chart and totals in native dashboard credits; removes the unsupported universal `25 credits = $1` conversion.
- Preserves local token-log costs, project/worktree rollups, and 7/30/90-day cost comparisons unchanged.
- Filters by an inclusive local-calendar window, excluding future and older rows instead of taking the latest 30 records.
- Uses Gregorian dashboard keys with the user's timezone, including non-Gregorian system-calendar configurations.
- Recomputes service totals after removing skill, invalid, negative, and non-finite values; overflow fails closed.
- Keeps both edge date labels fully visible instead of clipping the final chart date.
- Drops the debug-only packaged fixture and all production startup branches from the previous draft.

## Proof

- `swift test --filter OpenAIDashboardModelsTests`: 8 tests passed.
- `make check`: SwiftFormat clean; SwiftLint 0 violations; repository checks clean.
- `make test`: all 47 shards passed on the exact head.
- Structured autoreview found one Gregorian/system-calendar issue; fixed with regression coverage. A second review of the final chart-label change was clean.
- Deterministic production-view render verified the Today and Last 30 days totals, exclusion of a future row, stacked service bars, and fully visible first/last dates.
- `./Scripts/compile_and_run.sh`: fresh signed app packaged, launched, and remained running.

Exact head: `06e85486117a149dd622e336f3561b3e8f30af72`

## Contributor

Thanks @avenoxai for the original dashboard-credit totals direction. The rewrite preserves contributor credit while choosing raw, account-scoped credits over an unsupported dollar estimate.
