### PR TITLE
Handle Claude CLI usage rate limits

### DIFF
--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -441,11 +441,13 @@ extension UsageStore {
         generation: UInt64) async
     {
         let shouldNotifyPermissionPrompt = Self.isPermissionPromptWaiting(error)
+        let interaction = ProviderInteractionContext.current
         await MainActor.run {
             guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
             let hadPriorData = self.snapshots[provider] != nil
             let preservesPriorData = Self.shouldPreservePriorSnapshot(
                 after: error,
+                provider: provider,
                 hadPriorData: hadPriorData)
             let shouldSurface =
                 self.failureGates[provider]?
@@ -458,6 +460,21 @@ extension UsageStore {
                !shouldSurface
             {
                 self.errors[provider] = nil
+                return
+            }
+            if provider == .claude,
+               preservesPriorData,
+               interaction != .userInitiated,
+               Self.isClaudeCLIBackgroundCooldownBlock(error)
+            {
+                self.errors[provider] = nil
+                return
+            }
+            if provider == .claude,
+               preservesPriorData,
+               Self.isClaudeCLIRateLimit(error)
+            {
+                self.errors[provider] = error.localizedDescription
                 return
             }
             if provider == .claude,
@@ -491,10 +508,15 @@ extension UsageStore {
         }
     }
 
-    private static func shouldPreservePriorSnapshot(after error: Error, hadPriorData: Bool) -> Bool {
+    private static func shouldPreservePriorSnapshot(
+        after error: Error,
+        provider: UsageProvider,
+        hadPriorData: Bool) -> Bool
+    {
         guard hadPriorData else { return false }
         if error is CancellationError { return true }
         if self.isPreservableNetworkTransportError(error) { return true }
+        if provider == .claude, self.isClaudeCLIRateLimit(error) { return true }
 
         let message = error.localizedDescription.lowercased()
         return message.contains("timed out") ||
@@ -558,6 +580,14 @@ extension UsageStore {
     private static func isClaudeUsageProbeTimeout(_ error: Error) -> Bool {
         if case ClaudeStatusProbeError.timedOut = error { return true }
         return error.localizedDescription == ClaudeStatusProbeError.timedOut.localizedDescription
+    }
+
+    private static func isClaudeCLIRateLimit(_ error: Error) -> Bool {
+        ClaudeStatusProbeError.isTypedRateLimited(error)
+    }
+
+    private static func isClaudeCLIBackgroundCooldownBlock(_ error: Error) -> Bool {
+        ClaudeStatusProbeError.isBackgroundCooldownBlock(error)
     }
 
     private static func isClaudeWebSessionRefreshFailure(_ error: Error) -> Bool {

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -139,7 +139,6 @@ extension CodexBarCLI {
 
         for p in providerList {
             let status = includeStatus ? await Self.fetchStatus(for: p) : nil
-            // CLI usage should not clear Keychain cooldowns or attempt interactive Keychain prompts.
             let output = await ProviderInteractionContext.$current.withValue(.background) {
                 await Self.fetchUsageOutputs(
                     provider: p,
@@ -288,26 +287,21 @@ extension CodexBarCLI {
         }
         #endif
 
-        let fetchContext = ProviderFetchContext(
-            runtime: .cli,
-            sourceMode: effectiveSourceMode,
-            includeCredits: command.includeCredits,
-            webTimeout: command.webTimeout,
-            webDebugDumpHTML: command.webDebugDumpHTML,
-            verbose: command.verbose,
-            env: env,
-            settings: settings,
-            fetcher: tokenContext.fetcher(base: command.fetcher, provider: provider, env: env),
-            claudeFetcher: command.claudeFetcher,
-            browserDetection: command.browserDetection,
-            selectedTokenAccountID: account?.id,
-            tokenAccountTokenUpdater: tokenContext.tokenUpdater(for: account),
-            providerManualTokenUpdater: tokenContext.manualTokenUpdater(),
-            persistsCLISessions: Self.persistsCLISessions(provider: provider, command: command),
-            persistentCLISessionIdleWindow: command.persistentCLISessionIdleWindow)
-        let outcome = await Self.fetchProviderUsage(
+        let fetchContext = Self.makeProviderFetchContext(
             provider: provider,
-            context: fetchContext)
+            account: account,
+            sourceMode: effectiveSourceMode,
+            resolved: (env: env, settings: settings),
+            commandContext: (token: tokenContext, command: command))
+        let interaction = Self.providerInteraction(
+            provider: provider,
+            sourceMode: effectiveSourceMode,
+            command: command)
+        let outcome = await ProviderInteractionContext.$current.withValue(interaction) {
+            await Self.fetchProviderUsage(
+                provider: provider,
+                context: fetchContext)
+        }
         if command.verbose, !command.jsonOnly {
             Self.printFetchAttempts(provider: provider, attempts: outcome.attempts)
         }
@@ -407,6 +401,46 @@ extension CodexBarCLI {
         }
 
         return await Self.finishUsageOutput(output, provider: provider, command: command)
+    }
+
+    private static func makeProviderFetchContext(
+        provider: UsageProvider,
+        account: ProviderTokenAccount?,
+        sourceMode: ProviderSourceMode,
+        resolved: (env: [String: String], settings: ProviderSettingsSnapshot?),
+        commandContext: (token: TokenAccountCLIContext, command: UsageCommandContext)) -> ProviderFetchContext
+    {
+        let tokenContext = commandContext.token
+        let command = commandContext.command
+        return ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: sourceMode,
+            includeCredits: command.includeCredits,
+            webTimeout: command.webTimeout,
+            webDebugDumpHTML: command.webDebugDumpHTML,
+            verbose: command.verbose,
+            env: resolved.env,
+            settings: resolved.settings,
+            fetcher: tokenContext.fetcher(base: command.fetcher, provider: provider, env: resolved.env),
+            claudeFetcher: command.claudeFetcher,
+            browserDetection: command.browserDetection,
+            selectedTokenAccountID: account?.id,
+            tokenAccountTokenUpdater: tokenContext.tokenUpdater(for: account),
+            providerManualTokenUpdater: tokenContext.manualTokenUpdater(),
+            persistsCLISessions: self.persistsCLISessions(provider: provider, command: command),
+            persistentCLISessionIdleWindow: command.persistentCLISessionIdleWindow)
+    }
+
+    private static func providerInteraction(
+        provider: UsageProvider,
+        sourceMode: ProviderSourceMode,
+        command: UsageCommandContext) -> ProviderInteraction
+    {
+        if provider == .claude, sourceMode == .cli, !command.persistCLISessions {
+            return .userInitiated
+        }
+        // CLI usage should not clear Keychain cooldowns or attempt interactive Keychain prompts.
+        return .background
     }
 
     private static func holdsAntigravitySession(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLIRateLimitGate.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLIRateLimitGate.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public enum ClaudeCLIRateLimitGate {
+    private struct DefaultsBox: @unchecked Sendable {
+        let defaults: UserDefaults
+    }
+
+    private static let blockedUntilKey = "claudeCLIUsageRateLimitBlockedUntilV1"
+    private static let defaultCooldown: TimeInterval = 60 * 5
+    @TaskLocal private static var defaultsOverride: DefaultsBox?
+
+    private static var defaults: UserDefaults {
+        self.defaultsOverride?.defaults ?? .standard
+    }
+
+    public static func blockedUntil(
+        interaction: ProviderInteraction = ProviderInteractionContext.current,
+        now: Date = Date()) -> Date?
+    {
+        guard interaction != .userInitiated else { return nil }
+        return self.currentBlockedUntil(now: now)
+    }
+
+    public static func currentBlockedUntil(now: Date = Date()) -> Date? {
+        guard let raw = self.defaults.object(forKey: self.blockedUntilKey) as? Double else {
+            return nil
+        }
+
+        let blockedUntil = Date(timeIntervalSince1970: raw)
+        guard blockedUntil > now else {
+            self.defaults.removeObject(forKey: self.blockedUntilKey)
+            return nil
+        }
+        return blockedUntil
+    }
+
+    public static func recordRateLimit(now: Date = Date()) {
+        let blockedUntil = now.addingTimeInterval(self.defaultCooldown)
+        self.defaults.set(blockedUntil.timeIntervalSince1970, forKey: self.blockedUntilKey)
+    }
+
+    public static func recordSuccess() {
+        self.defaults.removeObject(forKey: self.blockedUntilKey)
+    }
+
+    #if DEBUG
+    public static func resetForTesting() {
+        self.defaults.removeObject(forKey: self.blockedUntilKey)
+    }
+
+    public static func withUserDefaultsForTesting<T>(
+        _ defaults: UserDefaults,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$defaultsOverride.withValue(DefaultsBox(defaults: defaults), operation: operation)
+    }
+    #endif
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -28,6 +28,7 @@ public struct ClaudeAccountIdentity: Sendable {
 public enum ClaudeStatusProbeError: LocalizedError, Sendable {
     case claudeNotInstalled
     case parseFailed(String)
+    case rateLimited(String)
     case timedOut
 
     public var errorDescription: String? {
@@ -36,9 +37,37 @@ public enum ClaudeStatusProbeError: LocalizedError, Sendable {
             "Claude CLI is not installed or not on PATH."
         case let .parseFailed(msg):
             "Could not parse Claude usage: \(msg)"
+        case let .rateLimited(msg):
+            msg
         case .timedOut:
             "Claude usage probe timed out."
         }
+    }
+
+    public static func isRateLimited(_ error: Error) -> Bool {
+        if self.isTypedRateLimited(error) {
+            return true
+        }
+        if case let .parseFailed(message) = error as? ClaudeUsageError {
+            return ClaudeStatusProbe.isUsageRateLimitMessage(message)
+        }
+        return ClaudeStatusProbe.isUsageRateLimitMessage(error.localizedDescription)
+    }
+
+    public static func isTypedRateLimited(_ error: Error) -> Bool {
+        if let probeError = error as? ClaudeStatusProbeError,
+           case .rateLimited = probeError
+        {
+            return true
+        }
+        return false
+    }
+
+    public static func isBackgroundCooldownBlock(_ error: Error) -> Bool {
+        if case let ClaudeStatusProbeError.rateLimited(message) = error {
+            return message.lowercased().contains("background refresh is paused")
+        }
+        return false
     }
 }
 
@@ -162,6 +191,9 @@ public struct ClaudeStatusProbe: Sendable {
                 reason: "usageError: \(usageError)",
                 usage: clean,
                 status: statusText)
+            if self.isUsageRateLimitMessage(usageError) {
+                throw ClaudeStatusProbeError.rateLimited(usageError)
+            }
             throw ClaudeStatusProbeError.parseFailed(usageError)
         }
 
@@ -457,6 +489,7 @@ public struct ClaudeStatusProbe: Sendable {
         }
         if lower.contains("rate_limit_error")
             || lower.contains("rate limited")
+            || lower.contains("rate limit")
             || compact.contains("ratelimited")
         {
             return "Claude CLI usage endpoint is rate limited right now. Please try again later."
@@ -471,6 +504,15 @@ public struct ClaudeStatusProbe: Sendable {
             return "Claude CLI could not load usage data. Open the CLI and retry `/usage`."
         }
         return nil
+    }
+
+    public static func isUsageRateLimitMessage(_ message: String) -> Bool {
+        let lower = message.lowercased()
+        let compact = lower.filter { !$0.isWhitespace }
+        return lower.contains("rate_limit_error") ||
+            lower.contains("rate limited") ||
+            lower.contains("rate limit") ||
+            compact.contains("ratelimited")
     }
 
     private static func isUsageStillLoading(text: String) -> Bool {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -553,25 +553,57 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
 
         private func loadViaAutoCLI(model: String) async throws -> ClaudeUsageSnapshot {
             do {
-                return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliAutoProbeTimeout)
+                return try await self.loadViaCLIRecordingRateLimit(
+                    model: model,
+                    timeout: ClaudeUsageFetcher.cliAutoProbeTimeout)
             } catch {
                 if error is CancellationError { throw error }
                 guard Self.shouldRetryCLIProbe(after: error) else { throw error }
-                return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliRetryProbeTimeout)
+                return try await self.loadViaCLIRecordingRateLimit(
+                    model: model,
+                    timeout: ClaudeUsageFetcher.cliRetryProbeTimeout)
             }
         }
 
         private func loadViaCLIWithRetry(model: String) async throws -> ClaudeUsageSnapshot {
             do {
-                return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliProbeTimeout)
+                return try await self.loadViaCLIRecordingRateLimit(
+                    model: model,
+                    timeout: ClaudeUsageFetcher.cliProbeTimeout)
             } catch {
                 if error is CancellationError { throw error }
                 guard Self.shouldRetryCLIProbe(after: error) else { throw error }
-                return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliRetryProbeTimeout)
+                return try await self.loadViaCLIRecordingRateLimit(
+                    model: model,
+                    timeout: ClaudeUsageFetcher.cliRetryProbeTimeout)
+            }
+        }
+
+        private func loadViaCLIRecordingRateLimit(model: String, timeout: TimeInterval) async throws
+            -> ClaudeUsageSnapshot
+        {
+            do {
+                let snapshot = try await self.loadViaCLI(model: model, timeout: timeout)
+                ClaudeCLIRateLimitGate.recordSuccess()
+                return snapshot
+            } catch {
+                if ClaudeStatusProbeError.isRateLimited(error),
+                   !Self.isCLIRateLimitCooldownBlock(error)
+                {
+                    ClaudeCLIRateLimitGate.recordRateLimit()
+                }
+                throw error
             }
         }
 
         private func loadViaCLI(model: String, timeout: TimeInterval) async throws -> ClaudeUsageSnapshot {
+            if let blockedUntil = ClaudeCLIRateLimitGate.blockedUntil() {
+                let seconds = max(1, Int(blockedUntil.timeIntervalSinceNow.rounded(.up)))
+                throw ClaudeStatusProbeError.rateLimited(
+                    "Claude CLI usage endpoint is rate limited right now. Background refresh is paused for "
+                        + "\(seconds)s; refresh manually to retry sooner.")
+            }
+
             var snapshot: ClaudeUsageSnapshot
             do {
                 snapshot = try await self.fetcher.loadViaPTY(model: model, timeout: timeout)
@@ -584,6 +616,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                         timeout: Self.directCLIUsageTimeout(for: timeout))
                 } catch let directError {
                     if directError is CancellationError { throw directError }
+                    if ClaudeStatusProbeError.isRateLimited(directError) {
+                        throw directError
+                    }
                     guard Self.directCLIErrorShouldReplacePTYError(directError) else { throw ptyError }
                     throw directError
                 }
@@ -607,6 +642,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         }
 
         private static func shouldTryDirectCLIUsage(after error: Error) -> Bool {
+            if ClaudeStatusProbeError.isRateLimited(error) { return false }
             if case ClaudeStatusProbeError.timedOut = error { return true }
             if case let ClaudeStatusProbeError.parseFailed(message) = error {
                 let lower = message.lowercased()
@@ -617,12 +653,17 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         }
 
         private static func shouldRetryCLIProbe(after error: Error) -> Bool {
+            if ClaudeStatusProbeError.isRateLimited(error) { return false }
             if case ClaudeStatusProbeError.timedOut = error { return true }
             if case let ClaudeStatusProbeError.parseFailed(message) = error {
                 return message.lowercased().contains("still loading usage")
             }
             let message = error.localizedDescription.lowercased()
             return message.contains("timed out") || message.contains("timeout")
+        }
+
+        private static func isCLIRateLimitCooldownBlock(_ error: Error) -> Bool {
+            ClaudeStatusProbeError.isBackgroundCooldownBlock(error)
         }
     }
 }
@@ -645,6 +686,10 @@ extension ClaudeUsageFetcher {
 
         if let ok = obj["ok"] as? Bool, !ok {
             let hint = obj["hint"] as? String ?? (obj["pane_preview"] as? String ?? "")
+            if ClaudeStatusProbe.isUsageRateLimitMessage(hint) {
+                throw ClaudeStatusProbeError.rateLimited(
+                    "Claude CLI usage endpoint is rate limited right now. Please try again later.")
+            }
             throw ClaudeUsageError.parseFailed(hint)
         }
 

--- a/Tests/CodexBarTests/ClaudeCLITimeoutRetryTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLITimeoutRetryTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import CodexBar
+@testable import CodexBarCLI
 @testable import CodexBarCore
 
 @Suite(.serialized)
@@ -37,8 +38,22 @@ struct ClaudeCLITimeoutRetryTests {
         }
     }
 
+    private func withIsolatedRateLimitGate<T>(_ operation: () async throws -> T) async throws -> T {
+        let suiteName = "ClaudeCLITimeoutRetryTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        return try await ClaudeCLIRateLimitGate.withUserDefaultsForTesting(defaults) {
+            ClaudeCLIRateLimitGate.resetForTesting()
+            return try await operation()
+        }
+    }
+
     @Test
     func `cli usage retries with longer timeout after transient probe failure`() async throws {
+        ClaudeCLIRateLimitGate.resetForTesting()
+        defer { ClaudeCLIRateLimitGate.resetForTesting() }
+
         let attempts = AttemptRecorder()
         let fetcher = ClaudeUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),
@@ -79,6 +94,9 @@ struct ClaudeCLITimeoutRetryTests {
 
     @Test
     func `auto cli usage does not retry unrecoverable parse failure`() async throws {
+        ClaudeCLIRateLimitGate.resetForTesting()
+        defer { ClaudeCLIRateLimitGate.resetForTesting() }
+
         let attempts = AttemptRecorder()
         let fetcher = ClaudeUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),
@@ -108,6 +126,9 @@ struct ClaudeCLITimeoutRetryTests {
 
     @Test
     func `auto cli usage retries loading panel before stale web fallback`() async throws {
+        ClaudeCLIRateLimitGate.resetForTesting()
+        defer { ClaudeCLIRateLimitGate.resetForTesting() }
+
         let attempts = AttemptRecorder()
         let webRequests = WebRequestRecorder()
         let fetcher = ClaudeUsageFetcher(
@@ -158,6 +179,9 @@ struct ClaudeCLITimeoutRetryTests {
 
     @Test
     func `auto cli usage retries timeout when cli is final source`() async throws {
+        ClaudeCLIRateLimitGate.resetForTesting()
+        defer { ClaudeCLIRateLimitGate.resetForTesting() }
+
         let attempts = AttemptRecorder()
         let fetcher = ClaudeUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),
@@ -201,6 +225,9 @@ struct ClaudeCLITimeoutRetryTests {
 
     @Test
     func `cli usage does not retry cancelled probe`() async throws {
+        ClaudeCLIRateLimitGate.resetForTesting()
+        defer { ClaudeCLIRateLimitGate.resetForTesting() }
+
         let attempts = AttemptRecorder()
         let fetcher = ClaudeUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),
@@ -223,6 +250,188 @@ struct ClaudeCLITimeoutRetryTests {
         let recorded = await attempts.snapshot()
         #expect(recorded.count == 1)
         #expect(recorded.timeouts == [24])
+    }
+
+    @Test
+    func `cli usage records rate limit without retrying probe`() async throws {
+        try await self.withIsolatedRateLimitGate {
+            let attempts = AttemptRecorder()
+            let fetcher = ClaudeUsageFetcher(
+                browserDetection: BrowserDetection(cacheTTL: 0),
+                environment: [:],
+                dataSource: .cli)
+
+            let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, timeout, _ in
+                _ = await attempts.record(timeout: timeout)
+                throw ClaudeStatusProbeError.rateLimited(
+                    "Claude CLI usage endpoint is rate limited right now. Please try again later.")
+            }
+
+            await #expect(throws: ClaudeStatusProbeError.self) {
+                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                    try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                        try await fetcher.loadLatestUsage(model: "sonnet")
+                    }
+                }
+            }
+
+            let recorded = await attempts.snapshot()
+            #expect(recorded.count == 1)
+            #expect(recorded.timeouts == [24])
+            #expect(ClaudeCLIRateLimitGate.currentBlockedUntil() != nil)
+        }
+    }
+
+    @Test
+    func `cli rate limit gate blocks background and allows user retry`() async throws {
+        try await self.withIsolatedRateLimitGate {
+            let attempts = AttemptRecorder()
+            let fetcher = ClaudeUsageFetcher(
+                browserDetection: BrowserDetection(cacheTTL: 0),
+                environment: [:],
+                dataSource: .cli)
+
+            ClaudeCLIRateLimitGate.recordRateLimit()
+
+            let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, timeout, _ in
+                _ = await attempts.record(timeout: timeout)
+                return ClaudeStatusSnapshot(
+                    sessionPercentLeft: 80,
+                    weeklyPercentLeft: 70,
+                    opusPercentLeft: nil,
+                    accountEmail: "manual@example.com",
+                    accountOrganization: "Manual Org",
+                    loginMethod: "cli",
+                    primaryResetDescription: nil,
+                    secondaryResetDescription: nil,
+                    opusResetDescription: nil,
+                    rawText: "probe raw")
+            }
+
+            await #expect(throws: ClaudeStatusProbeError.self) {
+                try await ProviderInteractionContext.$current.withValue(.background) {
+                    try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                        try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                            try await fetcher.loadLatestUsage(model: "sonnet")
+                        }
+                    }
+                }
+            }
+            #expect(await attempts.snapshot().timeouts.isEmpty)
+            #expect(ClaudeCLIRateLimitGate.currentBlockedUntil() != nil)
+
+            let snapshot = try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                    try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                        try await fetcher.loadLatestUsage(model: "sonnet")
+                    }
+                }
+            }
+
+            let recorded = await attempts.snapshot()
+            #expect(recorded.count == 1)
+            #expect(snapshot.primary.usedPercent == 20)
+            #expect(ClaudeCLIRateLimitGate.currentBlockedUntil() == nil)
+        }
+    }
+
+    @Test
+    func `manual cli rate limit refresh extends existing cooldown`() async throws {
+        try await self.withIsolatedRateLimitGate {
+            let attempts = AttemptRecorder()
+            let fetcher = ClaudeUsageFetcher(
+                browserDetection: BrowserDetection(cacheTTL: 0),
+                environment: [:],
+                dataSource: .cli)
+
+            ClaudeCLIRateLimitGate.recordRateLimit(now: Date().addingTimeInterval(-295))
+            let originalBlockedUntil = try #require(ClaudeCLIRateLimitGate.currentBlockedUntil())
+
+            let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, timeout, _ in
+                _ = await attempts.record(timeout: timeout)
+                throw ClaudeStatusProbeError.rateLimited(
+                    "Claude CLI usage endpoint is rate limited right now. Please try again later.")
+            }
+
+            await #expect(throws: ClaudeStatusProbeError.self) {
+                try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                    try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                        try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                            try await fetcher.loadLatestUsage(model: "sonnet")
+                        }
+                    }
+                }
+            }
+
+            let recorded = await attempts.snapshot()
+            let refreshedBlockedUntil = try #require(ClaudeCLIRateLimitGate.currentBlockedUntil())
+            #expect(recorded.count == 1)
+            #expect(refreshedBlockedUntil > originalBlockedUntil.addingTimeInterval(250))
+        }
+    }
+
+    @Test
+    func `usage command configured CLI source bypasses background cooldown`() async throws {
+        try await self.withIsolatedRateLimitGate {
+            let attempts = AttemptRecorder()
+            ClaudeCLIRateLimitGate.recordRateLimit()
+
+            let browserDetection = BrowserDetection(cacheTTL: 0)
+            let command = UsageCommandContext(
+                format: .json,
+                includeCredits: true,
+                sourceModeOverride: nil,
+                antigravityPlanDebug: false,
+                augmentDebug: false,
+                webDebugDumpHTML: false,
+                webTimeout: 60,
+                verbose: false,
+                useColor: false,
+                resetStyle: .absolute,
+                jsonOnly: true,
+                includeAllCodexAccounts: false,
+                fetcher: UsageFetcher(environment: [:]),
+                claudeFetcher: ClaudeUsageFetcher(
+                    browserDetection: browserDetection,
+                    environment: [:]),
+                browserDetection: browserDetection)
+            let tokenContext = try TokenAccountCLIContext(
+                selection: TokenAccountCLISelection(label: nil, index: nil, allAccounts: false),
+                config: CodexBarConfig(providers: [ProviderConfig(id: .claude, source: .cli)]),
+                verbose: false)
+
+            let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, timeout, _ in
+                _ = await attempts.record(timeout: timeout)
+                return ClaudeStatusSnapshot(
+                    sessionPercentLeft: 80,
+                    weeklyPercentLeft: 70,
+                    opusPercentLeft: nil,
+                    accountEmail: "configured-cli@example.com",
+                    accountOrganization: "Configured CLI Org",
+                    loginMethod: "cli",
+                    primaryResetDescription: nil,
+                    secondaryResetDescription: nil,
+                    opusResetDescription: nil,
+                    rawText: "probe raw")
+            }
+
+            let output = await ProviderInteractionContext.$current.withValue(.background) {
+                await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                    await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                        await CodexBarCLI.fetchUsageOutputs(
+                            provider: .claude,
+                            status: nil,
+                            tokenContext: tokenContext,
+                            command: command)
+                    }
+                }
+            }
+
+            let recorded = await attempts.snapshot()
+            #expect(recorded.count == 1)
+            #expect(output.exitCode == .success)
+            #expect(ClaudeCLIRateLimitGate.currentBlockedUntil() == nil)
+        }
     }
 
     private func withNoOAuthCredentials<T>(operation: () async throws -> T) async rethrows -> T {

--- a/Tests/CodexBarTests/ClaudeOAuthTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthTests.swift
@@ -351,6 +351,14 @@ struct ClaudeOAuthTests {
     }
 
     @Test
+    func `O auth429 is not classified as CLI rate limit`() {
+        let error = ClaudeUsageError.oauthFailed(
+            ClaudeOAuthFetchError.rateLimited(retryAfter: nil).localizedDescription)
+
+        #expect(!ClaudeStatusProbeError.isTypedRateLimited(error))
+    }
+
+    @Test
     func `O auth429 usage fetch surfaces guidance without raw JSON`() async throws {
         let fetcher = ClaudeUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),

--- a/Tests/CodexBarTests/ClaudeResilienceTests.swift
+++ b/Tests/CodexBarTests/ClaudeResilienceTests.swift
@@ -196,6 +196,83 @@ struct ClaudeResilienceTests {
     }
 
     @Test
+    func `manual Claude CLI rate limit surfaces first failure while preserving prior snapshot`() async throws {
+        try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("missing-credentials.json")
+
+            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                let (store, prior) = try await MainActor.run {
+                    let settings = Self.makeSettingsStore(suite: "ClaudeResilienceTests-cli-rate-limit")
+                    settings.refreshFrequency = .manual
+                    settings.statusChecksEnabled = false
+                    settings.claudeUsageDataSource = .cli
+
+                    let metadata = ProviderRegistry.shared.metadata
+                    for provider in UsageProvider.allCases {
+                        try settings.setProviderEnabled(
+                            provider: provider,
+                            metadata: #require(metadata[provider]),
+                            enabled: provider == .claude)
+                    }
+
+                    let store = UsageStore(
+                        fetcher: UsageFetcher(environment: [:]),
+                        browserDetection: BrowserDetection(cacheTTL: 0),
+                        settings: settings,
+                        startupBehavior: .testing,
+                        environmentBase: [:])
+                    let prior = UsageSnapshot(
+                        primary: RateWindow(
+                            usedPercent: 12,
+                            windowMinutes: 300,
+                            resetsAt: nil,
+                            resetDescription: nil),
+                        secondary: nil,
+                        updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+                        identity: ProviderIdentitySnapshot(
+                            providerID: .claude,
+                            accountEmail: "claude@example.com",
+                            accountOrganization: nil,
+                            loginMethod: "Pro"))
+                    store._setSnapshotForTesting(prior, provider: .claude)
+
+                    let baseSpec = try #require(store.providerSpecs[.claude])
+                    let descriptor = ProviderDescriptor(
+                        id: .claude,
+                        metadata: baseSpec.descriptor.metadata,
+                        branding: baseSpec.descriptor.branding,
+                        tokenCost: baseSpec.descriptor.tokenCost,
+                        fetchPlan: ProviderFetchPlan(
+                            sourceModes: [.cli],
+                            pipeline: ProviderFetchPipeline { _ in [RateLimitFetchStrategy()] }),
+                        cli: baseSpec.descriptor.cli)
+                    store.providerSpecs[.claude] = ProviderSpec(
+                        style: baseSpec.style,
+                        isEnabled: baseSpec.isEnabled,
+                        descriptor: descriptor,
+                        makeFetchContext: baseSpec.makeFetchContext)
+                    return (store, prior)
+                }
+
+                await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                    await store.refreshProvider(.claude)
+                }
+                let result = await MainActor.run {
+                    (
+                        updatedAt: store.snapshot(for: .claude)?.updatedAt,
+                        error: store.error(for: .claude))
+                }
+
+                #expect(result.updatedAt == prior.updatedAt)
+                #expect(result.error?.localizedCaseInsensitiveContains("rate limit") == true)
+            }
+        }
+    }
+
+    @Test
     func `credentials change clears prior Claude snapshot for non transient failure`() async throws {
         try await KeychainCacheStore.withServiceOverrideForTesting("com.steipete.codexbar.cache.tests.\(UUID())") {
             KeychainCacheStore.setTestStoreForTesting(true)
@@ -1045,6 +1122,24 @@ private struct NetworkLostFetchStrategy: ProviderFetchStrategy {
 
     func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
         throw URLError(.networkConnectionLost)
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}
+
+private struct RateLimitFetchStrategy: ProviderFetchStrategy {
+    let id = "test.rate-limit"
+    let kind: ProviderFetchKind = .cli
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        throw ClaudeStatusProbeError.rateLimited(
+            "Claude CLI usage endpoint is rate limited right now. Please try again later.")
     }
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -458,7 +458,26 @@ struct StatusProbeTests {
         do {
             _ = try ClaudeStatusProbe.parse(text: sample)
             #expect(Bool(false), "Parsing should fail for rate limiting")
-        } catch let ClaudeStatusProbeError.parseFailed(message) {
+        } catch let ClaudeStatusProbeError.rateLimited(message) {
+            let lower = message.lowercased()
+            #expect(lower.contains("rate"))
+            #expect(lower.contains("limit"))
+        } catch {
+            #expect(Bool(false), "Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func `surfaces claude rate limit from failed load wording`() {
+        let sample = """
+        Settings: Status Config Usage
+        Error: Failed to load usage data: Rate limit exceeded
+        """
+
+        do {
+            _ = try ClaudeStatusProbe.parse(text: sample)
+            #expect(Bool(false), "Parsing should fail for rate limiting")
+        } catch let ClaudeStatusProbeError.rateLimited(message) {
             let lower = message.lowercased()
             #expect(lower.contains("rate"))
             #expect(lower.contains("limit"))


### PR DESCRIPTION
## Summary
- classify Claude CLI `/usage` rate-limit output as a temporary rate-limit error instead of a parse failure
- pause background CLI probes during a short cooldown while still allowing manual refresh to retry
- preserve prior Claude usage snapshots only for typed Claude CLI rate-limit failures, leaving OAuth/web rate-limit guidance visible

Fixes #1679

## After-fix behavior proof
Redacted local behavior proof from `GIT_OPTIONAL_LOCKS=0 swift test --jobs 1 --filter ClaudeCLITimeoutRetryTests`:

```text
✔ Test "cli usage records rate limit without retrying probe" passed
✔ Test "cli rate limit gate blocks background and allows user retry" passed
✔ Test "manual cli rate limit refresh extends existing cooldown" passed
✔ Test run with 8 tests in 1 suite passed
```

This exercises a simulated Claude CLI `/usage` rate-limit response with no account identifiers or secrets: the parser/fetch path classifies it as `rateLimited`, background refresh is blocked by the cooldown before invoking the CLI again, user-initiated refresh bypasses the synthetic cooldown, and a real user-initiated rate-limit response refreshes the cooldown.

OAuth regression coverage also confirms OAuth 429 guidance is not classified as a CLI rate-limit preservation path:

```text
✔ Test "O auth429 is not classified as CLI rate limit" passed
✔ Test "O auth429 usage fetch surfaces guidance without raw JSON" passed
```

## Tests
- `GIT_OPTIONAL_LOCKS=0 swift build --target CodexBarCore`
- `GIT_OPTIONAL_LOCKS=0 swift test --jobs 1 --filter 'ClaudeOAuthTests|ClaudeCLITimeoutRetryTests'`\n- `GIT_OPTIONAL_LOCKS=0 swift test --jobs 1 --filter 'StatusProbeTests|ClaudeCLITimeoutRetryTests|ClaudeOAuthTests'`\n- `GIT_OPTIONAL_LOCKS=0 make check`