### PR TITLE
Handle Claude CLI usage rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Diagnostics: write redacted provider reports to a file with platform and app-version context. Thanks @Yuxin-Qiao!
 
+### Fixed
+- Claude: pause background CLI usage probes briefly after rate limiting while keeping manual refresh available. Thanks @kiranmagic7!
+
 ## 0.37.1 — 2026-06-21
 
 ### Fixed

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -446,7 +446,10 @@ extension UsageStore {
             let hadPriorData = self.snapshots[provider] != nil
             let preservesPriorData = Self.shouldPreservePriorSnapshot(
                 after: error,
-                hadPriorData: hadPriorData)
+                hadPriorData: hadPriorData) ||
+                (provider == .claude &&
+                    hadPriorData &&
+                    Self.isClaudeCLIRateLimitFailure(error))
             let shouldSurface =
                 self.failureGates[provider]?
                     .shouldSurfaceError(onFailureWithPriorData: hadPriorData) ?? true
@@ -462,7 +465,7 @@ extension UsageStore {
             }
             if provider == .claude,
                preservesPriorData,
-               Self.isClaudeUsageProbeTimeout(error)
+               Self.isClaudeUsageProbeTimeout(error) || Self.isClaudeCLIRateLimitFailure(error)
             {
                 self.errors[provider] = nil
                 return
@@ -558,6 +561,10 @@ extension UsageStore {
     private static func isClaudeUsageProbeTimeout(_ error: Error) -> Bool {
         if case ClaudeStatusProbeError.timedOut = error { return true }
         return error.localizedDescription == ClaudeStatusProbeError.timedOut.localizedDescription
+    }
+
+    private static func isClaudeCLIRateLimitFailure(_ error: Error) -> Bool {
+        ClaudeUsageFetcher.isCLIRateLimitError(error)
     }
 
     private static func isClaudeWebSessionRefreshFailure(_ error: Error) -> Bool {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLIRateLimitGate.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLIRateLimitGate.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+enum ClaudeCLIRateLimitGate {
+    private static let blockedUntilKey = "claudeCLIUsageRateLimitBlockedUntilV1"
+    private static let defaultCooldown: TimeInterval = 60 * 5
+
+    static let message = "Claude CLI usage endpoint is rate limited right now. Please try again later."
+
+    static func blockedUntil(
+        interaction: ProviderInteraction = ProviderInteractionContext.current,
+        now: Date = Date()) -> Date?
+    {
+        guard interaction != .userInitiated else { return nil }
+        return self.currentBlockedUntil(now: now)
+    }
+
+    static func currentBlockedUntil(now: Date = Date()) -> Date? {
+        guard let raw = UserDefaults.standard.object(forKey: self.blockedUntilKey) as? Double else {
+            return nil
+        }
+
+        let blockedUntil = Date(timeIntervalSince1970: raw)
+        guard blockedUntil > now else {
+            UserDefaults.standard.removeObject(forKey: self.blockedUntilKey)
+            return nil
+        }
+        return blockedUntil
+    }
+
+    static func recordRateLimit(now: Date = Date()) {
+        UserDefaults.standard.set(
+            now.addingTimeInterval(self.defaultCooldown).timeIntervalSince1970,
+            forKey: self.blockedUntilKey)
+    }
+
+    static func recordSuccess() {
+        UserDefaults.standard.removeObject(forKey: self.blockedUntilKey)
+    }
+
+    static func isRateLimitError(_ error: Error) -> Bool {
+        if case let ClaudeStatusProbeError.parseFailed(message) = error {
+            return self.isRateLimitMessage(message, allowRawRateLimitToken: true)
+        }
+        if case let ClaudeUsageError.parseFailed(message) = error {
+            return self.isRateLimitMessage(message, allowRawRateLimitToken: true)
+        }
+        return self.isRateLimitMessage(error.localizedDescription, allowRawRateLimitToken: false)
+    }
+
+    private static func isRateLimitMessage(_ message: String, allowRawRateLimitToken: Bool) -> Bool {
+        let lower = message.lowercased()
+        return lower.contains(Self.message.lowercased()) ||
+            (allowRawRateLimitToken && lower.contains("rate_limit_error")) ||
+            (lower.contains("claude cli") &&
+                lower.contains("usage") &&
+                lower.contains("rate limited"))
+    }
+
+    #if DEBUG
+    static func resetForTesting() {
+        UserDefaults.standard.removeObject(forKey: self.blockedUntilKey)
+    }
+    #endif
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -572,11 +572,19 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         }
 
         private func loadViaCLI(model: String, timeout: TimeInterval) async throws -> ClaudeUsageSnapshot {
+            if ClaudeCLIRateLimitGate.blockedUntil() != nil {
+                throw ClaudeUsageError.parseFailed(ClaudeCLIRateLimitGate.message)
+            }
+
             var snapshot: ClaudeUsageSnapshot
             do {
                 snapshot = try await self.fetcher.loadViaPTY(model: model, timeout: timeout)
             } catch {
                 if error is CancellationError { throw error }
+                if ClaudeUsageFetcher.isCLIRateLimitError(error) {
+                    ClaudeCLIRateLimitGate.recordRateLimit()
+                    throw error
+                }
                 guard Self.shouldTryDirectCLIUsage(after: error) else { throw error }
                 let ptyError = error
                 do {
@@ -584,10 +592,15 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                         timeout: Self.directCLIUsageTimeout(for: timeout))
                 } catch let directError {
                     if directError is CancellationError { throw directError }
+                    if ClaudeUsageFetcher.isCLIRateLimitError(directError) {
+                        ClaudeCLIRateLimitGate.recordRateLimit()
+                        throw directError
+                    }
                     guard Self.directCLIErrorShouldReplacePTYError(directError) else { throw ptyError }
                     throw directError
                 }
             }
+            ClaudeCLIRateLimitGate.recordSuccess()
             snapshot = await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
             return snapshot
         }
@@ -757,6 +770,10 @@ extension ClaudeUsageFetcher {
 
     public func loadLatestUsage(model: String = "sonnet") async throws -> ClaudeUsageSnapshot {
         try await StepExecutor(fetcher: self).loadLatestUsage(model: model)
+    }
+
+    public static func isCLIRateLimitError(_ error: Error) -> Bool {
+        ClaudeCLIRateLimitGate.isRateLimitError(error)
     }
 }
 

--- a/Tests/CodexBarTests/ClaudeCLITimeoutRetryTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLITimeoutRetryTests.swift
@@ -225,6 +225,108 @@ struct ClaudeCLITimeoutRetryTests {
         #expect(recorded.timeouts == [24])
     }
 
+    @Test
+    func `cli usage records background cooldown after rate limit`() async {
+        ClaudeCLIRateLimitGate.resetForTesting()
+        defer { ClaudeCLIRateLimitGate.resetForTesting() }
+
+        let attempts = AttemptRecorder()
+        let fetcher = ClaudeUsageFetcher(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            environment: [:],
+            dataSource: .cli)
+
+        let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, timeout, _ in
+            _ = await attempts.record(timeout: timeout)
+            throw ClaudeStatusProbeError.parseFailed(ClaudeCLIRateLimitGate.message)
+        }
+
+        await ProviderInteractionContext.$current.withValue(.background) {
+            await #expect(throws: ClaudeStatusProbeError.self) {
+                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                    try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                        try await fetcher.loadLatestUsage(model: "sonnet")
+                    }
+                }
+            }
+        }
+
+        let recordedAfterRateLimit = await attempts.snapshot()
+        #expect(recordedAfterRateLimit.count == 1)
+        #expect(recordedAfterRateLimit.timeouts == [24])
+        #expect(ClaudeCLIRateLimitGate.currentBlockedUntil() != nil)
+
+        await ProviderInteractionContext.$current.withValue(.background) {
+            await #expect(throws: ClaudeUsageError.self) {
+                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                    try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                        try await fetcher.loadLatestUsage(model: "sonnet")
+                    }
+                }
+            }
+        }
+
+        let recordedAfterBlockedRetry = await attempts.snapshot()
+        #expect(recordedAfterBlockedRetry.count == 1)
+        #expect(recordedAfterBlockedRetry.timeouts == [24])
+    }
+
+    @Test
+    func `user initiated cli usage bypasses rate limit cooldown`() async throws {
+        ClaudeCLIRateLimitGate.resetForTesting()
+        defer { ClaudeCLIRateLimitGate.resetForTesting() }
+        ClaudeCLIRateLimitGate.recordRateLimit()
+
+        let attempts = AttemptRecorder()
+        let fetcher = ClaudeUsageFetcher(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            environment: [:],
+            dataSource: .cli)
+
+        let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, timeout, _ in
+            _ = await attempts.record(timeout: timeout)
+            return ClaudeStatusSnapshot(
+                sessionPercentLeft: 89,
+                weeklyPercentLeft: 83,
+                opusPercentLeft: nil,
+                accountEmail: "manual-cli@example.com",
+                accountOrganization: "Manual CLI Org",
+                loginMethod: "cli",
+                primaryResetDescription: nil,
+                secondaryResetDescription: nil,
+                opusResetDescription: nil,
+                rawText: "probe raw")
+        }
+
+        await ProviderInteractionContext.$current.withValue(.background) {
+            await #expect(throws: ClaudeUsageError.self) {
+                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                    try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                        try await fetcher.loadLatestUsage(model: "sonnet")
+                    }
+                }
+            }
+        }
+
+        #expect(await (attempts.snapshot()).timeouts.isEmpty)
+
+        let snapshot = try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+            try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                    try await fetcher.loadLatestUsage(model: "sonnet")
+                }
+            }
+        }
+
+        let recorded = await attempts.snapshot()
+        #expect(recorded.count == 1)
+        #expect(recorded.timeouts == [24])
+        #expect(snapshot.primary.usedPercent == 11)
+        #expect(snapshot.secondary?.usedPercent == 17)
+        #expect(snapshot.accountEmail == "manual-cli@example.com")
+        #expect(ClaudeCLIRateLimitGate.currentBlockedUntil() == nil)
+    }
+
     private func withNoOAuthCredentials<T>(operation: () async throws -> T) async rethrows -> T {
         let missingCredentialsURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("missing-claude-creds-\(UUID().uuidString).json")


### PR DESCRIPTION
## Summary
- add a short background cooldown when the Claude CLI usage probe reports the `/usage` endpoint is rate limited
- let user-initiated refreshes bypass that cooldown and clear it after a successful CLI snapshot
- preserve existing Claude usage data instead of surfacing the rate-limit parse error when stale data is available

Fixes #1679

## Tests
- `swift test --filter ClaudeCLITimeoutRetryTests`
- `swift test --filter StatusProbeTests`
- `swift test --filter ClaudeOAuthTests`
- `swift test --filter UsageStoreCoverageTests`
- `make check`