### PR TITLE
[security] fix(provider): harden Azure OpenAI endpoint overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Claude: pause background CLI usage probes briefly after rate limiting while keeping manual refresh available. Thanks @kiranmagic7!
 - Codex OAuth: publish refreshed `auth.json` credentials with private file permissions already applied. Thanks @Hinotoi-agent!
 - Provider endpoints: reject unsafe Deepgram, z.ai, and Xiaomi MiMo overrides before attaching credentials. Thanks @Hinotoi-agent!
+- Azure OpenAI: reject unsafe endpoint overrides before attaching API keys while keeping invalid configurations visible with an actionable error. Thanks @Hinotoi-agent!
 
 ## 0.37.1 — 2026-06-21
 

--- a/Sources/CodexBar/Providers/AzureOpenAI/AzureOpenAIProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/AzureOpenAI/AzureOpenAIProviderImplementation.swift
@@ -20,12 +20,12 @@ struct AzureOpenAIProviderImplementation: ProviderImplementation {
     func isAvailable(context: ProviderAvailabilityContext) -> Bool {
         let environment = context.environment
         let hasEnvironmentConfig = AzureOpenAISettingsReader.apiKey(environment: environment) != nil &&
-            AzureOpenAISettingsReader.endpoint(environment: environment) != nil &&
+            AzureOpenAISettingsReader.rawEndpoint(environment: environment) != nil &&
             AzureOpenAISettingsReader.deploymentName(environment: environment) != nil
         if hasEnvironmentConfig { return true }
 
         return !context.settings.azureOpenAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-            AzureOpenAISettingsReader.endpointURL(from: context.settings.azureOpenAIEndpoint) != nil &&
+            !context.settings.azureOpenAIEndpoint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
             !context.settings.azureOpenAIDeploymentName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIProviderDescriptor.swift
@@ -56,6 +56,7 @@ struct AzureOpenAIAPIFetchStrategy: ProviderFetchStrategy {
         guard let apiKey = Self.resolveAPIKey(environment: context.env) else {
             throw AzureOpenAIUsageError.missingAPIKey
         }
+        try AzureOpenAISettingsReader.validateEndpointOverrides(environment: context.env)
         guard let endpoint = Self.resolveEndpoint(environment: context.env) else {
             throw AzureOpenAIUsageError.missingEndpoint
         }

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift
@@ -27,15 +27,16 @@ public enum AzureOpenAISettingsReader {
     public static func endpointURL(from rawEndpoint: String) -> URL? {
         let trimmed = rawEndpoint.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
+        return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: trimmed)
+    }
 
-        let withScheme = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
-        guard let url = URL(string: withScheme),
-              let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !host.isEmpty
-        else {
-            return nil
+    public static func validateEndpointOverrides(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        guard let rawEndpoint = self.cleaned(environment[self.endpointEnvironmentKey]) else { return }
+        guard self.endpointURL(from: rawEndpoint) != nil else {
+            throw AzureOpenAISettingsError.invalidEndpointOverride(self.endpointEnvironmentKey)
         }
-        return url
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -59,6 +60,7 @@ public enum AzureOpenAISettingsError: LocalizedError, Sendable, Equatable {
     case missingEndpoint
     case missingDeploymentName
     case invalidEndpoint
+    case invalidEndpointOverride(String)
 
     public var errorDescription: String? {
         switch self {
@@ -71,6 +73,9 @@ public enum AzureOpenAISettingsError: LocalizedError, Sendable, Equatable {
                 "in Settings."
         case .invalidEndpoint:
             "Azure OpenAI endpoint is invalid."
+        case let .invalidEndpointOverride(key):
+            "Azure OpenAI endpoint override \(key) is not allowed. " +
+                "Use an HTTPS endpoint without user info or encoded host tricks."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift
@@ -12,8 +12,12 @@ public enum AzureOpenAISettingsReader {
     }
 
     public static func endpoint(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL? {
-        guard let rawEndpoint = self.cleaned(environment[self.endpointEnvironmentKey]) else { return nil }
+        guard let rawEndpoint = self.rawEndpoint(environment: environment) else { return nil }
         return self.endpointURL(from: rawEndpoint)
+    }
+
+    public static func rawEndpoint(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.cleaned(environment[self.endpointEnvironmentKey])
     }
 
     public static func deploymentName(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
@@ -33,7 +37,7 @@ public enum AzureOpenAISettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let rawEndpoint = self.cleaned(environment[self.endpointEnvironmentKey]) else { return }
+        guard let rawEndpoint = self.rawEndpoint(environment: environment) else { return }
         guard self.endpointURL(from: rawEndpoint) != nil else {
             throw AzureOpenAISettingsError.invalidEndpointOverride(self.endpointEnvironmentKey)
         }
@@ -59,7 +63,6 @@ public enum AzureOpenAISettingsError: LocalizedError, Sendable, Equatable {
     case missingAPIKey
     case missingEndpoint
     case missingDeploymentName
-    case invalidEndpoint
     case invalidEndpointOverride(String)
 
     public var errorDescription: String? {
@@ -71,8 +74,6 @@ public enum AzureOpenAISettingsError: LocalizedError, Sendable, Equatable {
         case .missingDeploymentName:
             "Azure OpenAI deployment not configured. Set AZURE_OPENAI_DEPLOYMENT_NAME or configure a deployment " +
                 "in Settings."
-        case .invalidEndpoint:
-            "Azure OpenAI endpoint is invalid."
         case let .invalidEndpointOverride(key):
             "Azure OpenAI endpoint override \(key) is not allowed. " +
                 "Use an HTTPS endpoint without user info or encoded host tricks."

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift
@@ -56,6 +56,7 @@ public enum AzureOpenAIUsageError: LocalizedError, Sendable, Equatable {
     case missingEndpoint
     case missingDeploymentName
     case invalidEndpoint
+    case invalidEndpointOverride(String)
     case invalidURL
     case networkError(String)
     case apiError(statusCode: Int, message: String)
@@ -71,6 +72,8 @@ public enum AzureOpenAIUsageError: LocalizedError, Sendable, Equatable {
             AzureOpenAISettingsError.missingDeploymentName.errorDescription
         case .invalidEndpoint:
             AzureOpenAISettingsError.invalidEndpoint.errorDescription
+        case let .invalidEndpointOverride(key):
+            AzureOpenAISettingsError.invalidEndpointOverride(key).errorDescription
         case .invalidURL:
             "Azure OpenAI validation URL is invalid."
         case let .networkError(message):
@@ -108,7 +111,9 @@ public enum AzureOpenAIUsageFetcher {
         let apiVersion = apiVersion.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !apiKey.isEmpty else { throw AzureOpenAIUsageError.missingAPIKey }
         guard !deploymentName.isEmpty else { throw AzureOpenAIUsageError.missingDeploymentName }
-        guard endpoint.host?.isEmpty == false else { throw AzureOpenAIUsageError.invalidEndpoint }
+        guard let endpoint = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: endpoint.absoluteString) else {
+            throw AzureOpenAIUsageError.invalidEndpointOverride(AzureOpenAISettingsReader.endpointEnvironmentKey)
+        }
         let effectiveAPIVersion = apiVersion.isEmpty ? AzureOpenAISettingsReader.defaultAPIVersion : apiVersion
 
         var request = try URLRequest(url: self.chatCompletionsURL(

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift
@@ -55,7 +55,6 @@ public enum AzureOpenAIUsageError: LocalizedError, Sendable, Equatable {
     case missingAPIKey
     case missingEndpoint
     case missingDeploymentName
-    case invalidEndpoint
     case invalidEndpointOverride(String)
     case invalidURL
     case networkError(String)
@@ -70,8 +69,6 @@ public enum AzureOpenAIUsageError: LocalizedError, Sendable, Equatable {
             AzureOpenAISettingsError.missingEndpoint.errorDescription
         case .missingDeploymentName:
             AzureOpenAISettingsError.missingDeploymentName.errorDescription
-        case .invalidEndpoint:
-            AzureOpenAISettingsError.invalidEndpoint.errorDescription
         case let .invalidEndpointOverride(key):
             AzureOpenAISettingsError.invalidEndpointOverride(key).errorDescription
         case .invalidURL:

--- a/Tests/CodexBarTests/AzureOpenAIUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AzureOpenAIUsageFetcherTests.swift
@@ -57,6 +57,28 @@ struct AzureOpenAIUsageFetcherTests {
     }
 
     @Test
+    func `invalid endpoint returns precise provider error before fetch`() async {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .azureopenai)
+        let outcome = await descriptor.fetchPlan.fetchOutcome(
+            context: self.makeContext(environment: [
+                AzureOpenAISettingsReader.apiKeyEnvironmentKey: "AZURE_CANARY_KEY",
+                AzureOpenAISettingsReader.endpointEnvironmentKey: "http://127.0.0.1:31337",
+                AzureOpenAISettingsReader.deploymentNameEnvironmentKey: "canary-deployment",
+            ]),
+            provider: .azureopenai)
+
+        guard case let .failure(error) = outcome.result else {
+            Issue.record("Expected invalid endpoint override to fail")
+            return
+        }
+
+        #expect(error as? AzureOpenAISettingsError == .invalidEndpointOverride(
+            AzureOpenAISettingsReader.endpointEnvironmentKey))
+        #expect(error.localizedDescription.contains("HTTPS endpoint"))
+        #expect(outcome.attempts.map(\.wasAvailable) == [true])
+    }
+
+    @Test
     func `fetcher validates deployment with chat completions request`() async throws {
         let endpoint = try #require(URL(string: "https://example-resource.openai.azure.com"))
         let updatedAt = Date(timeIntervalSince1970: 1_800_000_000)
@@ -177,6 +199,39 @@ struct AzureOpenAIUsageFetcherTests {
         #expect(
             url.absoluteString ==
                 "https://example-resource.openai.azure.com/openai/v1/chat/completions")
+    }
+}
+
+@MainActor
+struct AzureOpenAIProviderAvailabilityTests {
+    @Test
+    func `configured invalid endpoint remains visible for actionable error`() throws {
+        let suite = "AzureOpenAIProviderAvailabilityTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.azureOpenAIAPIKey = "AZURE_CANARY_KEY"
+        settings.azureOpenAIEndpoint = "http://127.0.0.1:31337"
+        settings.azureOpenAIDeploymentName = "canary-deployment"
+
+        let environment = ProviderRegistry.makeEnvironment(
+            base: [:],
+            provider: .azureopenai,
+            settings: settings,
+            tokenOverride: nil)
+        let context = ProviderAvailabilityContext(
+            provider: .azureopenai,
+            settings: settings,
+            environment: environment)
+
+        #expect(AzureOpenAISettingsReader.endpoint(environment: environment) == nil)
+        #expect(AzureOpenAIProviderImplementation().isAvailable(context: context))
     }
 }
 

--- a/TestsLinux/AzureEndpointOverrideSecurityTests.swift
+++ b/TestsLinux/AzureEndpointOverrideSecurityTests.swift
@@ -1,0 +1,71 @@
+import CodexBarCore
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+
+@Suite
+struct AzureEndpointOverrideSecurityTests {
+    @Test
+    func azureOpenAIEndpointOverrideMustBeHTTPSOrBareHost() throws {
+        let httpsURL = try #require(AzureOpenAISettingsReader.endpointURL(from: "https://proxy.example.com/base"))
+        #expect(httpsURL.absoluteString == "https://proxy.example.com/base")
+
+        let bareURL = try #require(AzureOpenAISettingsReader.endpointURL(from: "resource.openai.azure.com"))
+        #expect(bareURL.absoluteString == "https://resource.openai.azure.com")
+
+        let hostPortURL = try #require(AzureOpenAISettingsReader.endpointURL(from: "localhost:8443/openai"))
+        #expect(hostPortURL.absoluteString == "https://localhost:8443/openai")
+
+        let trimmedURL = try #require(AzureOpenAISettingsReader.endpointURL(from: " https://trimmed.example.com/base "))
+        #expect(trimmedURL.absoluteString == "https://trimmed.example.com/base")
+
+        #expect(AzureOpenAISettingsReader.endpointURL(from: "http://attacker.test") == nil)
+        #expect(AzureOpenAISettingsReader.endpointURL(from: "https://user:pass@proxy.example.com") == nil)
+        #expect(AzureOpenAISettingsReader.endpointURL(from: "https://proxy.example.com%2f.attacker.test") == nil)
+
+        #expect(throws: AzureOpenAISettingsError.invalidEndpointOverride(
+            AzureOpenAISettingsReader.endpointEnvironmentKey))
+        {
+            try AzureOpenAISettingsReader.validateEndpointOverrides(environment: [
+                AzureOpenAISettingsReader.endpointEnvironmentKey: "http://attacker.test",
+            ])
+        }
+    }
+
+    @Test
+    func azureOpenAIHTTPOverrideIsRejectedBeforeAPIKeyRequest() async throws {
+        let endpoint = try #require(URL(string: "http://127.0.0.1:31337"))
+        let transport = CapturingTransport { request in
+            Issue.record("Azure OpenAI should reject insecure endpoint overrides before sending api-key headers")
+            #expect(request.value(forHTTPHeaderField: "api-key") == nil)
+            throw CapturingTransportError.unexpectedRequest
+        }
+
+        do {
+            _ = try await AzureOpenAIUsageFetcher.fetchUsage(
+                apiKey: "AZURE_CANARY_KEY",
+                endpoint: endpoint,
+                deploymentName: "canary-deployment",
+                transport: transport,
+                updatedAt: Date(timeIntervalSince1970: 1_800_000_000))
+            Issue.record("Expected AzureOpenAIUsageError.invalidEndpointOverride")
+        } catch {
+            #expect(error as? AzureOpenAIUsageError == .invalidEndpointOverride(
+                AzureOpenAISettingsReader.endpointEnvironmentKey))
+        }
+    }
+}
+
+private enum CapturingTransportError: Error {
+    case unexpectedRequest
+}
+
+private struct CapturingTransport: ProviderHTTPTransport {
+    let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.handler(request)
+    }
+}

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -92,6 +92,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 
 ## Azure OpenAI
 - API key, endpoint, and deployment from `~/.codexbar/config.json` or `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, and `AZURE_OPENAI_DEPLOYMENT_NAME`.
+- `AZURE_OPENAI_ENDPOINT` and configured endpoint overrides must be HTTPS URLs or bare hosts normalized to HTTPS; explicit `http://` URLs, user info, and encoded host-delimiter tricks fail closed before `api-key` headers are attached.
 - Validates the configured deployment with a minimal chat-completions request; it does not expose Azure spend or quota history.
 - Use `AZURE_OPENAI_API_VERSION` to override the API version. Set it to `v1` for Azure's OpenAI-compatible v1 API path.
 - Status: Azure status page link.


### PR DESCRIPTION
## Summary

This PR hardens the Azure OpenAI provider endpoint boundary before CodexBar attaches the configured Azure OpenAI `api-key` header.

- Reuses the shared endpoint override validator for `AZURE_OPENAI_ENDPOINT` / configured Azure OpenAI endpoints.
- Preserves existing whitespace-trimming behavior for direct saved-settings input before validation.
- Allows HTTPS custom endpoints and bare hosts normalized to HTTPS for proxy/test compatibility.
- Rejects explicit `http://`, URL user info, and encoded host-delimiter tricks before any credentialed Azure OpenAI validation request is built.
- Adds Linux regression coverage and a contributor-environment CLI proof showing the real provider command fails closed before making an unsafe request.

## Security issues covered

| Issue | Impact | Severity |
| --- | --- | --- |
| Azure OpenAI endpoint override accepted explicit non-HTTPS destinations before credentialed validation | A malicious or unsafe endpoint override could receive the configured Azure OpenAI API key in the `api-key` header during deployment validation | High impact credential disclosure; conservative CVSS lower-bound: Medium |

## Before this PR

- `AzureOpenAISettingsReader.endpointURL(from:)` accepted any explicit URL scheme as long as the URL had a host.
- `AzureOpenAIUsageFetcher.fetchUsage(...)` trusted the supplied endpoint and then attached `api-key` to the chat-completions validation request.
- An endpoint such as `http://127.0.0.1:31337` could therefore become the credential destination for Azure OpenAI deployment validation.

## After this PR

- Azure OpenAI endpoints are parsed through `ProviderEndpointOverrideValidator.normalizedHTTPSURL(from:)` after preserving the previous whitespace trimming behavior.
- Bare hosts such as `resource.openai.azure.com` are still normalized to `https://resource.openai.azure.com`.
- Custom HTTPS proxy/test endpoints remain supported.
- Explicit `http://`, URL user info, and encoded host-delimiter tricks fail closed before `api-key` headers are attached.
- The provider fetch strategy validates `AZURE_OPENAI_ENDPOINT` before resolving the endpoint as usable configuration.

## Release-note context

Azure OpenAI now rejects explicit non-HTTPS endpoint overrides before attaching API key headers. Existing HTTPS endpoints and bare-host settings continue to work; local/proxy setups that intentionally used `http://` will need HTTPS or a maintainer-approved/documented loopback exception.

## Why this matters

Azure OpenAI API keys authorize access to a cloud-hosted model deployment. Endpoint override settings are useful for enterprise/proxy setups, but the destination for credentialed requests should be constrained before the request is constructed.

This matches the existing endpoint-hardening pattern used by sibling providers: keep compatible HTTPS overrides working, while rejecting URL forms that obviously redirect credentials to unsafe or ambiguous destinations.

## Attack flow

```text
Unsafe Azure OpenAI endpoint override
    -> AzureOpenAISettingsReader accepted the explicit endpoint URL
        -> AzureOpenAIUsageFetcher built a chat-completions validation request
            -> request included api-key for the configured Azure OpenAI key
                -> attacker-controlled endpoint could receive the API key
```

## Affected code

| Area | File |
| --- | --- |
| Endpoint parsing | `Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift` |
| Credentialed validation request | `Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift` |
| Provider fetch strategy | `Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIProviderDescriptor.swift` |
| Regression tests | `TestsLinux/AzureEndpointOverrideSecurityTests.swift` |
| Operator-facing docs | `docs/providers.md` |

## Root cause

- The Azure OpenAI settings reader normalized bare hosts but preserved explicit URL schemes, including `http://`.
- The usage fetcher only checked that the endpoint had a host before attaching the Azure OpenAI `api-key` header.
- The endpoint override was treated as a syntactically valid URL rather than a credential-destination policy decision.

## CVSS assessment

| Issue | CVSS v3.1 score / severity | Vector |
| --- | --- | --- |
| Azure OpenAI endpoint override can receive `api-key` header | 5.0 Medium, conservative lower bound | `CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:N/A:N` |

Rationale:

- Confidentiality impact is high because the exposed value is a cloud API key.
- The conservative vector assumes a local/configuration-assisted path where the attacker needs the endpoint override to be set by a user, config import, automation, or lower-trust setup instructions.
- Maintainers may calibrate severity differently depending on the intended trust boundary for endpoint overrides; the security invariant is that CodexBar should not attach API credentials to explicit non-HTTPS or parser-ambiguous destinations.

## Safe reproduction steps

No real Azure OpenAI credentials are needed.

1. Configure the Azure OpenAI provider with a canary API key, canary deployment, and an explicit HTTP endpoint override such as `http://127.0.0.1:31337`.
2. Run the real CLI provider path:

```bash
AZURE_OPENAI_API_KEY='[REDACTED]' \
AZURE_OPENAI_ENDPOINT='http://127.0.0.1:31337' \
AZURE_OPENAI_DEPLOYMENT_NAME='canary-deployment' \
swift run CodexBarCLI usage --provider azure-openai --source api --json-only
```

3. With this PR, the command fails closed before any Azure OpenAI validation request can be sent:

```text
[{"error":{"kind":"provider","message":"Azure OpenAI endpoint override AZURE_OPENAI_ENDPOINT is not allowed. Use an HTTPS endpoint without user info or encoded host tricks.","code":1},"provider":"azureopenai","source":"api"}]
```

The regression test also asserts the direct fetcher boundary: if an unsafe URL is passed directly to `AzureOpenAIUsageFetcher.fetchUsage(...)`, the stubbed transport records a test failure if it observes any request or `api-key` header.

## Real behavior proof

Contributor-environment after-fix CLI proof, run from the PR branch on macOS with a redacted canary key:

```text
$ AZURE_OPENAI_API_KEY='[REDACTED]' \
  AZURE_OPENAI_ENDPOINT='http://127.0.0.1:31337' \
  AZURE_OPENAI_DEPLOYMENT_NAME='canary-deployment' \
  swift run CodexBarCLI usage --provider azure-openai --source api --json-only
[{"error":{"kind":"provider","message":"Azure OpenAI endpoint override AZURE_OPENAI_ENDPOINT is not allowed. Use an HTTPS endpoint without user info or encoded host tricks.","code":1},"provider":"azureopenai","source":"api"}]
```

This exercises the production CLI/provider path rather than only a unit-test helper, and the command exits before making a credentialed request to the HTTP endpoint.

## Expected vulnerable behavior

Before this PR, `AZURE_OPENAI_ENDPOINT=http://127.0.0.1:31337` could be accepted as the Azure OpenAI endpoint and used as the destination for a validation request carrying the configured `api-key` header.

## Changes in this PR

- Routes Azure OpenAI endpoint parsing through the shared HTTPS endpoint override validator while preserving the previous direct-input trimming behavior.
- Adds `AzureOpenAISettingsReader.validateEndpointOverrides(...)` and a precise invalid-override error.
- Adds a second fail-closed check in `AzureOpenAIUsageFetcher.fetchUsage(...)` so direct callers cannot pass an unsafe URL and still trigger a credentialed request.
- Adds Linux regression tests for:
  - HTTPS endpoint support;
  - bare-host normalization to HTTPS;
  - whitespace-padded saved-settings compatibility;
  - rejection of explicit HTTP endpoints;
  - rejection of user-info and encoded host-delimiter tricks;
  - rejection before the HTTP transport can observe an `api-key` request.
- Documents the Azure OpenAI endpoint override policy in provider docs and keeps release-note context in this PR body.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Azure OpenAI settings | `Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift` | Uses shared HTTPS validator after trimming and exposes endpoint-override validation/error text |
| Azure OpenAI fetch | `Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift` | Rejects unsafe endpoint URLs before constructing credentialed requests |
| Provider strategy | `Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIProviderDescriptor.swift` | Validates endpoint overrides before treating config as usable |
| Tests | `TestsLinux/AzureEndpointOverrideSecurityTests.swift` | Adds Docker/Linux security regressions for Azure OpenAI endpoint overrides |
| Docs | `docs/providers.md` | Notes the HTTPS-or-bare-host policy and fail-closed behavior |

## Maintainer impact

- Existing Azure OpenAI HTTPS endpoints continue to work.
- Existing bare-host configuration continues to work by normalizing to HTTPS.
- Existing saved endpoint values with surrounding whitespace continue to work because direct endpoint parsing still trims before validation.
- Explicit `http://` Azure OpenAI endpoint overrides now fail closed before credentials are attached.
- If maintainers intentionally want a loopback-only HTTP exception for local tests, that should be documented as an explicit compatibility policy. This PR keeps the safer default aligned with sibling provider endpoint hardening.

## Fix rationale

The patch keeps the fix narrow and durable by reusing the shared provider endpoint validator rather than introducing Azure-specific URL parsing. It validates at both the settings/fetch-strategy boundary and the credentialed request boundary, so unsafe endpoints are rejected even if a future caller bypasses environment resolution and passes a `URL` directly.

## Type of change

- [x] Security fix
- [x] Regression tests
- [x] Documentation update
- [ ] UI change
- [ ] Dependency change

## Test plan

- [x] Contributor-environment CLI proof on macOS:

```bash
AZURE_OPENAI_API_KEY='[REDACTED]' \
AZURE_OPENAI_ENDPOINT='http://127.0.0.1:31337' \
AZURE_OPENAI_DEPLOYMENT_NAME='canary-deployment' \
swift run CodexBarCLI usage --provider azure-openai --source api --json-only
```

Result:

```text
[{"error":{"kind":"provider","message":"Azure OpenAI endpoint override AZURE_OPENAI_ENDPOINT is not allowed. Use an HTTPS endpoint without user info or encoded host tricks.","code":1},"provider":"azureopenai","source":"api"}]
```

- [x] Docker focused Azure OpenAI endpoint override tests and full Linux suite:

```bash
docker run --rm -v "$PWD":/workspace -w /workspace swift:6.2-noble bash -lc 'apt-get update >/dev/null && apt-get install -y libsqlite3-dev pkg-config >/dev/null && swift test --filter AzureEndpointOverrideSecurityTests && swift test'
```

Focused result:

```text
✔ Suite AzureEndpointOverrideSecurityTests passed after 0.001 seconds.
✔ Test run with 2 tests in 1 suite passed after 0.001 seconds.
```

Full Linux result:

```text
✔ Test run with 37 tests in 10 suites passed after 0.026 seconds.
```

- [x] Local build:

```bash
swift build --target CodexBarCore
```

Result:

```text
Build of target: 'CodexBarCore' complete!
```

- [x] Formatting and docs checks:

```bash
git diff --check
./Scripts/lint.sh format
node Scripts/check-documentation-links.mjs
node Scripts/docs-list.mjs
```

Results:

```text
0/1169 files formatted.
documentation links OK: 114 local links
```

## Disclosure notes

- This PR uses canary/redacted test data only; no real Azure OpenAI API keys are included.
- The fix is scoped to Azure OpenAI endpoint override handling and provider docs.
- The adjacent provider endpoint hardening pattern already exists in the repository; this PR applies the same credential-destination policy to Azure OpenAI.
