### PR TITLE
diagnostics: support redacted diagnose output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.37.2 — Unreleased
 
+### Added
+- Diagnostics: write redacted provider reports to a file with platform and app-version context. Thanks @Yuxin-Qiao!
+
 ## 0.37.1 — 2026-06-21
 
 ### Fixed

--- a/Sources/CodexBarCLI/CLIDiagnoseCommand.swift
+++ b/Sources/CodexBarCLI/CLIDiagnoseCommand.swift
@@ -33,6 +33,7 @@ extension CodexBarCLI {
         let providers = providerSelection.asList
         let pretty = values.flags.contains("pretty")
         let verbose = values.flags.contains("verbose")
+        let outputPath = values.options["output"]?.last
         let browserDetection = BrowserDetection()
         let baseFetcher = UsageFetcher()
 
@@ -72,7 +73,11 @@ extension CodexBarCLI {
             }
             var jsonString = String(data: data, encoding: .utf8) ?? "{}"
             jsonString = LogRedactor.redact(jsonString)
-            print(jsonString)
+            if let outputPath, !outputPath.isEmpty {
+                try Self.writeDiagnosticExport(jsonString, to: outputPath)
+            } else {
+                print(jsonString)
+            }
         } catch {
             Self.exit(
                 code: .failure,
@@ -82,6 +87,17 @@ extension CodexBarCLI {
         }
 
         Self.exit(code: .success, output: output, kind: .runtime)
+    }
+
+    static func writeDiagnosticExport(_ jsonString: String, to path: String) throws {
+        let url = URL(fileURLWithPath: path)
+        let parent = url.deletingLastPathComponent()
+        if !parent.path.isEmpty {
+            try FileManager.default.createDirectory(
+                at: parent,
+                withIntermediateDirectories: true)
+        }
+        try jsonString.write(to: url, atomically: true, encoding: .utf8)
     }
 }
 
@@ -138,7 +154,8 @@ extension CodexBarCLI {
                 account: account,
                 config: tokenContext.config.providerConfig(for: provider),
                 environment: env,
-                settings: settings)))
+                settings: settings),
+            appVersion: Self.currentVersion()))
     }
 
     static func diagnosticAuthSummary(

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -177,6 +177,7 @@ extension CodexBarCLI {
           codexbar diagnose --provider <name|all> --format json
                            [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>]
                            [-v|--verbose]
+                           [--redact] [--output <path>]
                            [--pretty]
 
         Description:
@@ -185,6 +186,7 @@ extension CodexBarCLI {
           account IDs, org IDs, raw responses, and billing-history records.
 
         Examples:
+          codexbar diagnose --provider minimax --format json --redact --output diagnostic.json
           codexbar diagnose --provider minimax --format json --pretty
           codexbar diagnose --provider claude --format json --pretty
           codexbar diagnose --provider all --format json
@@ -222,7 +224,7 @@ extension CodexBarCLI {
           codexbar config disable --provider <name>
           codexbar config set-api-key --provider <name> (--api-key <key>|--stdin)
           codexbar cache clear <--cookies|--cost|--all> [--provider <name>]
-          codexbar diagnose --provider <name|all> --format json [--pretty]
+          codexbar diagnose --provider <name|all> --format json [--redact] [--output <path>] [--pretty]
 
         Global flags:
           -h, --help      Show help
@@ -243,6 +245,7 @@ extension CodexBarCLI {
           codexbar config enable --provider grok
           codexbar config set-api-key --provider elevenlabs --stdin
           codexbar cache clear --cookies
+          codexbar diagnose --provider minimax --format json --redact --output diagnostic.json
           codexbar diagnose --provider minimax --format json --pretty
           codexbar diagnose --provider all --format json
         """

--- a/Sources/CodexBarCLI/DiagnoseOptions.swift
+++ b/Sources/CodexBarCLI/DiagnoseOptions.swift
@@ -18,6 +18,12 @@ struct DiagnoseOptions: CommanderParsable {
     @Option(name: .long("format"), help: "Output format: json")
     var format: String?
 
+    @Flag(name: .long("redact"), help: "Explicitly redact sensitive values (always enabled for diagnose)")
+    var redact: Bool = false
+
+    @Option(name: .long("output"), help: "Write redacted JSON diagnostic export to a file")
+    var output: String?
+
     @Flag(name: .long("pretty"), help: "Pretty-print JSON output")
     var pretty: Bool = false
 }

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -19,6 +19,8 @@ public struct ProviderDiagnosticBatchExport: Codable, Sendable {
 public struct ProviderDiagnosticExport: Codable, Sendable {
     public let schemaVersion: String
     public let timestamp: Date
+    public let platform: String
+    public let appVersion: String?
     public let provider: String
     public let displayName: String
     public let source: String
@@ -33,6 +35,8 @@ public struct ProviderDiagnosticExport: Codable, Sendable {
     public init(
         schemaVersion: String = "1.0",
         timestamp: Date,
+        platform: String = ProviderDiagnosticPlatform.current,
+        appVersion: String? = nil,
         provider: String,
         displayName: String,
         source: String,
@@ -46,6 +50,8 @@ public struct ProviderDiagnosticExport: Codable, Sendable {
     {
         self.schemaVersion = schemaVersion
         self.timestamp = timestamp
+        self.platform = platform
+        self.appVersion = appVersion
         self.provider = provider
         self.displayName = displayName
         self.source = source
@@ -56,6 +62,18 @@ public struct ProviderDiagnosticExport: Codable, Sendable {
         self.error = error
         self.settings = settings
         self.details = details
+    }
+}
+
+public enum ProviderDiagnosticPlatform {
+    public static var current: String {
+        #if os(macOS)
+        "macOS"
+        #elseif os(Linux)
+        "Linux"
+        #else
+        "unknown"
+        #endif
     }
 }
 
@@ -445,6 +463,7 @@ public enum ProviderDiagnosticExportBuilder {
         public let sourceMode: ProviderSourceMode
         public let settings: ProviderSettingsSnapshot?
         public let auth: ProviderDiagnosticAuthSummary
+        public let appVersion: String?
 
         public init(
             provider: UsageProvider,
@@ -452,7 +471,8 @@ public enum ProviderDiagnosticExportBuilder {
             outcome: ProviderFetchOutcome,
             sourceMode: ProviderSourceMode,
             settings: ProviderSettingsSnapshot?,
-            auth: ProviderDiagnosticAuthSummary)
+            auth: ProviderDiagnosticAuthSummary,
+            appVersion: String? = nil)
         {
             self.provider = provider
             self.descriptor = descriptor
@@ -460,6 +480,7 @@ public enum ProviderDiagnosticExportBuilder {
             self.sourceMode = sourceMode
             self.settings = settings
             self.auth = auth
+            self.appVersion = appVersion
         }
     }
 
@@ -474,6 +495,7 @@ public enum ProviderDiagnosticExportBuilder {
 
         return ProviderDiagnosticExport(
             timestamp: Date(),
+            appVersion: input.appVersion,
             provider: input.provider.rawValue,
             displayName: input.descriptor.metadata.displayName,
             source: input.outcome.sourceLabel,

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -32,6 +32,23 @@ public struct ProviderDiagnosticExport: Codable, Sendable {
     public let settings: ProviderDiagnosticSettingsSummary
     public let details: ProviderDiagnosticDetails?
 
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case timestamp
+        case platform
+        case appVersion
+        case provider
+        case displayName
+        case source
+        case sourceMode
+        case auth
+        case usage
+        case fetchAttempts
+        case error
+        case settings
+        case details
+    }
+
     public init(
         schemaVersion: String = "1.0",
         timestamp: Date,
@@ -62,6 +79,26 @@ public struct ProviderDiagnosticExport: Codable, Sendable {
         self.error = error
         self.settings = settings
         self.details = details
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            schemaVersion: container.decode(String.self, forKey: .schemaVersion),
+            timestamp: container.decode(Date.self, forKey: .timestamp),
+            platform: container.decodeIfPresent(String.self, forKey: .platform)
+                ?? ProviderDiagnosticPlatform.current,
+            appVersion: container.decodeIfPresent(String.self, forKey: .appVersion),
+            provider: container.decode(String.self, forKey: .provider),
+            displayName: container.decode(String.self, forKey: .displayName),
+            source: container.decode(String.self, forKey: .source),
+            sourceMode: container.decode(String.self, forKey: .sourceMode),
+            auth: container.decode(ProviderDiagnosticAuthSummary.self, forKey: .auth),
+            usage: container.decodeIfPresent(ProviderDiagnosticUsageSummary.self, forKey: .usage),
+            fetchAttempts: container.decode([ProviderDiagnosticFetchAttempt].self, forKey: .fetchAttempts),
+            error: container.decodeIfPresent(ProviderDiagnosticError.self, forKey: .error),
+            settings: container.decode(ProviderDiagnosticSettingsSummary.self, forKey: .settings),
+            details: container.decodeIfPresent(ProviderDiagnosticDetails.self, forKey: .details))
     }
 }
 

--- a/Tests/CodexBarTests/CLIArgumentParsingTests.swift
+++ b/Tests/CodexBarTests/CLIArgumentParsingTests.swift
@@ -84,4 +84,19 @@ struct CLIArgumentParsingTests {
             Issue.record("diagnose should not emit provider logs beside the safe JSON export")
         }
     }
+
+    @Test
+    func `diagnose accepts explicit redact and output path`() throws {
+        let signature = CodexBarCLI._diagnoseSignatureForTesting()
+        let parser = CommandParser(signature: signature)
+        let parsed = try parser.parse(arguments: [
+            "--provider", "minimax",
+            "--format", "json",
+            "--redact",
+            "--output", "diagnostic.json",
+        ])
+
+        #expect(parsed.flags.contains("redact"))
+        #expect(parsed.options["output"] == ["diagnostic.json"])
+    }
 }

--- a/Tests/CodexBarTests/CLIDiagnoseCommandTests.swift
+++ b/Tests/CodexBarTests/CLIDiagnoseCommandTests.swift
@@ -1,4 +1,5 @@
 import CodexBarCore
+import Foundation
 import Testing
 @testable import CodexBarCLI
 
@@ -9,8 +10,23 @@ struct CLIDiagnoseCommandTests {
 
         #expect(help.contains("codexbar diagnose --provider <name|all> --format json"))
         #expect(help.contains("codexbar diagnose --provider all --format json"))
+        #expect(help.contains("--redact"))
+        #expect(help.contains("--output <path>"))
         #expect(help.contains("safe JSON export"))
         #expect(help.contains("raw API tokens"))
+    }
+
+    @Test
+    func `diagnose output writer creates parent directories`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarDiagnoseTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let output = root.appendingPathComponent("nested/diagnostic.json")
+        try CodexBarCLI.writeDiagnosticExport(#"{"provider":"minimax"}"#, to: output.path)
+
+        let contents = try String(contentsOf: output, encoding: .utf8)
+        #expect(contents == #"{"provider":"minimax"}"#)
     }
 
     private func makeSettingsWithMiniMaxCookie(_ manualCookieHeader: String) -> ProviderSettingsSnapshot {

--- a/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
+++ b/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
@@ -49,6 +49,35 @@ struct ProviderDiagnosticExportTests {
     }
 
     @Test
+    func `diagnostic export decodes legacy schema without platform metadata`() throws {
+        let export = ProviderDiagnosticExport(
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            provider: "openai",
+            displayName: "OpenAI",
+            source: "api",
+            sourceMode: "auto",
+            auth: ProviderDiagnosticAuthSummary(configured: true, modes: ["api"]),
+            usage: nil,
+            fetchAttempts: [],
+            error: nil,
+            settings: ProviderDiagnosticSettingsSummary(sourceMode: .auto),
+            details: nil)
+        var object = try #require(
+            try JSONSerialization.jsonObject(with: Data(self.json(export).utf8)) as? [String: Any])
+        object.removeValue(forKey: "platform")
+        object.removeValue(forKey: "appVersion")
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(
+            ProviderDiagnosticExport.self,
+            from: JSONSerialization.data(withJSONObject: object))
+
+        #expect(decoded.platform == ProviderDiagnosticPlatform.current)
+        #expect(decoded.appVersion == nil)
+    }
+
+    @Test
     func `usage snapshot defaults legacy payloads to unknown confidence without reencoding unknown`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
+++ b/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
@@ -35,6 +35,7 @@ struct ProviderDiagnosticExportTests {
 
         #expect(json.contains("\"provider\""))
         #expect(json.contains("\"openai\""))
+        #expect(json.contains("\"platform\""))
         #expect(json.contains("\"auth\""))
         #expect(json.contains("\"dataConfidence\""))
         #expect(json.contains("\"unknown\""))
@@ -478,9 +479,12 @@ struct ProviderDiagnosticExportTests {
             outcome: outcome,
             sourceMode: .auto,
             settings: nil,
-            auth: ProviderDiagnosticAuthSummary(configured: true, modes: ["apiToken"])))
+            auth: ProviderDiagnosticAuthSummary(configured: true, modes: ["apiToken"]),
+            appVersion: "9.8.7"))
 
         #expect(diag.provider == "minimax")
+        #expect(diag.platform == ProviderDiagnosticPlatform.current)
+        #expect(diag.appVersion == "9.8.7")
         #expect(diag.source == "failed")
         #expect(diag.auth.configured == true)
         #expect(diag.usage == nil)


### PR DESCRIPTION
## Summary
- add explicit `codexbar diagnose --redact --output <path>` support for writing the already-redacted provider diagnostic JSON to a file
- include safe `platform` and `appVersion` fields in provider diagnostic exports for issue triage
- update diagnose help and focused CLI/export tests

## Real CLI proof
Ran the PR branch locally with a fake `SYNTHETIC_API_KEY` value to verify the output-file path detects API auth without writing the raw token:

```console
$ SYNTHETIC_API_KEY=<fake-token> GIT_OPTIONAL_LOCKS=0 swift run CodexBarCLI diagnose --provider synthetic --format json --redact --output /tmp/codexbar-diagnose-proof.json
[0/1] Planning build
Building for debugging...
Build of product 'CodexBarCLI' complete!\n\n$ ls -l /tmp/codexbar-diagnose-proof.json\n-rw-r--r--@ 1 yuxinqiao  wheel  423 Jun 21 10:30 /tmp/codexbar-diagnose-proof.json\n\n$ python3 -m json.tool /tmp/codexbar-diagnose-proof.json | sed -n '1,32p'\n{\n    "auth": {\n        "configured": true,\n        "modes": [\n            "api"\n        ]\n    },\n    "displayName": "Synthetic",\n    "error": {\n        "category": "auth",\n        "safeDescription": "Authentication or setup issue - check provider credentials"\n    },\n    "fetchAttempts": [\n        {\n            "errorCategory": "auth",\n            "kind": "api",\n            "wasAvailable": true\n        }\n    ],\n    "platform": "macOS",\n    "provider": "synthetic",\n    "schemaVersion": "1.0",\n\n$ rg -n "<fake-token>|SYNTHETIC_API_KEY|Bearer|Authorization|Cookie|password|secret" /tmp/codexbar-diagnose-proof.json\n# no matches\n```\n\nThis confirms `diagnose --redact --output` writes the diagnostic JSON to disk and the file keeps only safe auth metadata, not the raw token or sensitive headers.\n\n## Test\n- `swift test --filter 'CLIArgumentParsingTests|CLIDiagnoseCommandTests|ProviderDiagnosticExportTests'`