### PR TITLE
fix(mistral): restore ory_session cookie for vibe fetch, add console.mistral.ai to import domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.37.1 — Unreleased
 
 ### Fixed
+- Mistral: restore Vibe monthly-plan usage by forwarding only required console session cookies. Thanks @lfmundim!
 - Memory pressure: avoid actor-isolation crashes when system callbacks arrive on a utility queue. Thanks @Zihao-Qi!
 - Menu: remove extra separators and spacing around Storage, Cost, and Subscription Utilization rows. Thanks @elijahfriedman!
 - Antigravity: show limits as unavailable when OAuth identifies the account but quota endpoints deny access. Thanks @Yuxin-Qiao!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.37.1 — Unreleased
 
 ### Fixed
-- Mistral: restore Vibe monthly-plan usage by forwarding only required console session cookies. Thanks @lfmundim!
 - Memory pressure: avoid actor-isolation crashes when system callbacks arrive on a utility queue. Thanks @Zihao-Qi!
 - Menu: remove extra separators and spacing around Storage, Cost, and Subscription Utilization rows. Thanks @elijahfriedman!
 - Antigravity: show limits as unavailable when OAuth identifies the account but quota endpoints deny access. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
@@ -8,7 +8,7 @@ private let mistralCookieImportOrder: BrowserCookieImportOrder =
 
 public enum MistralCookieImporter {
     private static let cookieClient = BrowserCookieClient()
-    private static let cookieDomains = ["mistral.ai", "admin.mistral.ai", "auth.mistral.ai"]
+    private static let cookieDomains = ["mistral.ai", "admin.mistral.ai", "auth.mistral.ai", "console.mistral.ai"]
 
     public struct SessionInfo: Sendable {
         public let cookies: [HTTPCookie]

--- a/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
@@ -8,7 +8,7 @@ private let mistralCookieImportOrder: BrowserCookieImportOrder =
 
 public enum MistralCookieImporter {
     private static let cookieClient = BrowserCookieClient()
-    private static let cookieDomains = ["mistral.ai", "admin.mistral.ai", "auth.mistral.ai", "console.mistral.ai"]
+    static let cookieDomains = ["mistral.ai", "admin.mistral.ai", "auth.mistral.ai", "console.mistral.ai"]
 
     public struct SessionInfo: Sendable {
         public let cookies: [HTTPCookie]

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -92,6 +92,7 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
         let vibeResult: MistralUsageFetcher.MistralVibeUsageResult? = if let csrfToken, remaining > 0 {
             try await Self.fetchOptionalVibeUsage(
                 csrfToken: csrfToken,
+                cookieHeader: cookieHeader,
                 timeout: min(remaining, 4))
         } else {
             nil
@@ -101,6 +102,7 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
 
     static func fetchOptionalVibeUsage(
         csrfToken: String,
+        cookieHeader: String? = nil,
         timeout: TimeInterval,
         transport: ProviderHTTPTransport = ProviderHTTPClient.shared) async throws
         -> MistralUsageFetcher.MistralVibeUsageResult?
@@ -108,6 +110,7 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
         do {
             return try await MistralUsageFetcher.fetchVibeUsage(
                 csrfToken: csrfToken,
+                cookieHeader: cookieHeader,
                 timeout: timeout,
                 transport: transport)
         } catch {

--- a/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
@@ -117,10 +117,10 @@ public enum MistralUsageFetcher {
         try "csrftoken=\(self.validatedVibeCSRFToken(csrfToken))"
     }
 
-    // Builds a minimal Cookie header for console.mistral.ai.
-    // Only csrftoken + ory_session_* pass through; all other admin.mistral.ai cookies stay origin-bound.
+    /// Builds a minimal Cookie header for console.mistral.ai.
+    /// Only csrftoken + ory_session_* pass through; all other admin.mistral.ai cookies stay origin-bound.
     static func consoleCookieHeader(csrfToken: String, adminCookieHeader: String?) -> String {
-        var pairs: [String] = ["csrftoken=\(csrfToken)"]
+        var pairs = ["csrftoken=\(csrfToken)"]
         if let adminCookies = adminCookieHeader {
             let sessionPairs = CookieHeaderNormalizer.pairs(from: adminCookies)
                 .filter { $0.name.hasPrefix("ory_session_") }

--- a/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
@@ -59,6 +59,7 @@ public enum MistralUsageFetcher {
 
     public static func fetchVibeUsage(
         csrfToken: String,
+        cookieHeader: String? = nil,
         timeout: TimeInterval = 4,
         transport: ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> MistralVibeUsageResult
     {
@@ -68,11 +69,14 @@ public enum MistralUsageFetcher {
         }
 
         var request = URLRequest(url: url, timeoutInterval: timeout)
-        // The observed console request sends only csrftoken; keep admin Ory cookies origin-bound.
         request.httpShouldHandleCookies = false
         let validatedCSRFToken = try Self.validatedVibeCSRFToken(csrfToken)
         request.setValue("*/*", forHTTPHeaderField: "Accept")
-        request.setValue("csrftoken=\(validatedCSRFToken)", forHTTPHeaderField: "Cookie")
+        // Forward ory_session_* and csrftoken cookies — scoped to what console.mistral.ai needs.
+        let consoleCookie = Self.consoleCookieHeader(
+            csrfToken: validatedCSRFToken,
+            sourceCookieHeader: cookieHeader)
+        request.setValue(consoleCookie, forHTTPHeaderField: "Cookie")
         request.setValue(validatedCSRFToken, forHTTPHeaderField: "X-CSRFToken")
 
         let response = try await transport.response(for: request)
@@ -111,6 +115,19 @@ public enum MistralUsageFetcher {
 
     static func vibeCookieHeader(csrfToken: String) throws -> String {
         try "csrftoken=\(self.validatedVibeCSRFToken(csrfToken))"
+    }
+
+    // Builds a Cookie header for console.mistral.ai: csrftoken + any ory_session_* cookies
+    // from the admin cookie header. Keeps unrelated admin cookies origin-bound.
+    static func consoleCookieHeader(csrfToken: String, sourceCookieHeader: String?) -> String {
+        var pairs: [String] = ["csrftoken=\(csrfToken)"]
+        if let source = sourceCookieHeader {
+            let sessionPairs = CookieHeaderNormalizer.pairs(from: source)
+                .filter { $0.name.hasPrefix("ory_session_") }
+                .map { "\($0.name)=\($0.value)" }
+            pairs.append(contentsOf: sessionPairs)
+        }
+        return pairs.joined(separator: "; ")
     }
 
     private static func validatedVibeCSRFToken(_ csrfToken: String) throws -> String {

--- a/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
@@ -75,7 +75,7 @@ public enum MistralUsageFetcher {
         // Forward ory_session_* and csrftoken cookies — scoped to what console.mistral.ai needs.
         let consoleCookie = Self.consoleCookieHeader(
             csrfToken: validatedCSRFToken,
-            sourceCookieHeader: cookieHeader)
+            adminCookieHeader: cookieHeader)
         request.setValue(consoleCookie, forHTTPHeaderField: "Cookie")
         request.setValue(validatedCSRFToken, forHTTPHeaderField: "X-CSRFToken")
 
@@ -117,12 +117,12 @@ public enum MistralUsageFetcher {
         try "csrftoken=\(self.validatedVibeCSRFToken(csrfToken))"
     }
 
-    // Builds a Cookie header for console.mistral.ai: csrftoken + any ory_session_* cookies
-    // from the admin cookie header. Keeps unrelated admin cookies origin-bound.
-    static func consoleCookieHeader(csrfToken: String, sourceCookieHeader: String?) -> String {
+    // Builds a minimal Cookie header for console.mistral.ai.
+    // Only csrftoken + ory_session_* pass through; all other admin.mistral.ai cookies stay origin-bound.
+    static func consoleCookieHeader(csrfToken: String, adminCookieHeader: String?) -> String {
         var pairs: [String] = ["csrftoken=\(csrfToken)"]
-        if let source = sourceCookieHeader {
-            let sessionPairs = CookieHeaderNormalizer.pairs(from: source)
+        if let adminCookies = adminCookieHeader {
+            let sessionPairs = CookieHeaderNormalizer.pairs(from: adminCookies)
                 .filter { $0.name.hasPrefix("ory_session_") }
                 .map { "\($0.name)=\($0.value)" }
             pairs.append(contentsOf: sessionPairs)

--- a/Tests/CodexBarTests/MistralVibeUsageTests.swift
+++ b/Tests/CodexBarTests/MistralVibeUsageTests.swift
@@ -140,6 +140,40 @@ struct MistralVibeUsageTests {
         #expect(updated.extraRateWindows?.last?.window.usedPercent == 25)
     }
 
+    // MARK: - consoleCookieHeader allowlist
+
+    @Test
+    func `console cookie header contains only csrf when no admin header`() {
+        let cookie = MistralUsageFetcher.consoleCookieHeader(csrfToken: "tok", adminCookieHeader: nil)
+        #expect(cookie == "csrftoken=tok")
+    }
+
+    @Test
+    func `console cookie header forwards ory session alongside csrf`() {
+        let admin = "csrftoken=tok; ory_session_coolcurranf83m3srkfl=sess123; other_admin=secret"
+        let cookie = MistralUsageFetcher.consoleCookieHeader(csrfToken: "tok", adminCookieHeader: admin)
+        #expect(cookie == "csrftoken=tok; ory_session_coolcurranf83m3srkfl=sess123")
+    }
+
+    @Test
+    func `console cookie header excludes non-session admin cookies`() {
+        let admin = "csrftoken=tok; session_token=other; admin_secret=x"
+        let cookie = MistralUsageFetcher.consoleCookieHeader(csrfToken: "tok", adminCookieHeader: admin)
+        #expect(cookie == "csrftoken=tok")
+        #expect(!cookie.contains("admin_secret"))
+        #expect(!cookie.contains("session_token"))
+    }
+
+    @Test
+    func `console cookie header forwards multiple ory session cookies`() {
+        let admin = "ory_session_a=val1; ory_session_b=val2; unrelated=drop"
+        let cookie = MistralUsageFetcher.consoleCookieHeader(csrfToken: "tok", adminCookieHeader: admin)
+        #expect(cookie.contains("csrftoken=tok"))
+        #expect(cookie.contains("ory_session_a=val1"))
+        #expect(cookie.contains("ory_session_b=val2"))
+        #expect(!cookie.contains("unrelated"))
+    }
+
     private static func responseJSON(usagePercentage: Double) -> String {
         """
         [{"result":{"data":{"json":{

--- a/Tests/CodexBarTests/MistralVibeUsageTests.swift
+++ b/Tests/CodexBarTests/MistralVibeUsageTests.swift
@@ -19,6 +19,18 @@ private final class MistralRequestCapture: @unchecked Sendable {
 }
 
 struct MistralVibeUsageTests {
+    #if os(macOS)
+    @Test
+    func `cookie importer uses only accepted Mistral domains`() {
+        #expect(Set(MistralCookieImporter.cookieDomains) == [
+            "mistral.ai",
+            "admin.mistral.ai",
+            "auth.mistral.ai",
+            "console.mistral.ai",
+        ])
+    }
+    #endif
+
     @Test
     func `parses subscription percentage and reset`() throws {
         let data = Data(Self.responseJSON(usagePercentage: 2.8141356666666666).utf8)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -321,7 +321,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 ## Mistral
 - Session cookie (`ory_session_*`) from browser auto-import or manual `Cookie:` header.
 - CSRF token (`csrftoken` cookie) sent as `X-CSRFTOKEN` for billing and Vibe usage requests.
-- Domains: `admin.mistral.ai` for API billing and `console.mistral.ai` for optional Vibe subscription usage. Admin Ory cookies are never forwarded to the console origin.
+- Domains: `admin.mistral.ai` for API billing and `console.mistral.ai` for optional Vibe subscription usage. Console requests forward only `csrftoken` and `ory_session_*`; all other admin cookies stay origin-bound.
 - Reads monthly usage and pricing from the Mistral billing API.
 - Cost is computed client-side from token counts and response pricing.
 - Reads Vibe monthly-plan usage percentage and reset time when the console endpoint is available.


### PR DESCRIPTION
## Bug

Monthly Plan metric (introduced in #1635) stopped working after `08e19e386d83` — the app shows API spend instead of subscription usage percentage regardless of the selected metric.

<img width="372" height="330" alt="image" src="https://github.com/user-attachments/assets/4dc6c1f1-5652-4877-a9a0-9e93a01afb80" />

<img width="608" height="559" alt="image" src="https://github.com/user-attachments/assets/2f297098-59b1-4f6d-8e66-021adcd9dbbd" />

## Root cause

`08e19e386d83` (steipete's "fix: isolate Mistral console cookies", part of the #1635 merge) refactored the vibe fetch as a security improvement, stripping the request down to only `Cookie: csrftoken=<token>`. The intent was correct (keep admin.mistral.ai cookies origin-bound), but `console.mistral.ai` requires the `ory_session_*` session cookie in addition to the CSRF token to authenticate the request. Without it the endpoint returns 302, which `fetchOptionalVibeUsage` silently swallows and returns `nil` — so `extraRateWindows` is never populated and the Monthly Plan window never appears.

```sh
$ curl 'https://console.mistral.ai/api-ui/trpc/billing.vibeUsage?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%2C%22v%22%3A1%7D%7D%7D' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'Cookie: csrftoken=<REDACTED>;'
<html>
<head><title>302 Found</title></head>
<body>
<center><h1>302 Found</h1></center>
</body>
</html>
```

A second issue: `MistralCookieImporter.cookieDomains` did not include `console.mistral.ai`, meaning the `csrftoken` cookie (which may be set under that subdomain by the console frontend) was never imported in auto mode. This caused `csrfToken` to be `nil`, which short-circuits the vibe call entirely before it even starts.

## Fix

**`MistralUsageFetcher.fetchVibeUsage`** — accepts an optional `cookieHeader` and forwards a filtered cookie string to `console.mistral.ai` containing:
- `csrftoken=<token>` (required for CSRF validation)
- any `ory_session_*` cookies extracted from the source header (required for session auth)

```sh
$ curl 'https://console.mistral.ai/api-ui/trpc/billing.vibeUsage?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%2C%22v%22%3A1%7D%7D%7D' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'Cookie: csrftoken=<REDACTED>; ory_session_coolcurranf83m3srkfl="<REDACTED>"; '
[{"result":{"data":{"json":{"usage_percentage":4.518170666666666,"quota_changed_this_month":false,"payg_enabled":false,"reset_at":"2026-07-01T00:00:00Z"}}}}]
```

All other admin.mistral.ai cookies are excluded — the security intent of the original refactor is preserved; only the minimum set needed by the console endpoint is forwarded.

**`MistralCookieImporter.cookieDomains`** — added `console.mistral.ai` so the `csrftoken` cookie is captured during auto-import from browser cookies.

<img width="432" height="575" alt="image" src="https://github.com/user-attachments/assets/337dd557-a225-4747-8e2e-04a40136176b" />

<img width="750" height="559" alt="image" src="https://github.com/user-attachments/assets/a98dcf6b-a909-49ac-a570-8a962c2fdeb4" />


## Why this approach

The `ory_session_*` cookie is issued by Ory Kratos for `*.mistral.ai` and is valid across all Mistral subdomains by design. Forwarding it to `console.mistral.ai` doesn't expand the credential boundary beyond what the browser would do when a logged-in user visits the console. The alternative — scoping a separate console cookie import path — would require a new settings field and import flow with no meaningful security gain over filtering the existing cookie.

## Test plan

- [x] Manual cookie source with full cookie header: verify Monthly Plan shows usage %
- [x] Vibe API failure (invalid token): verify app falls back to spend display, no crash
- [x] Pay-as-you-go: verify spend display unaffected

Closes #1721 