### PR TITLE
Show missing locale keys in checker

### DIFF
--- a/Scripts/check-app-locales.mjs
+++ b/Scripts/check-app-locales.mjs
@@ -39,6 +39,12 @@ function tokenSignature(value) {
   return { printf, swift: swiftInterpolationTokens(value).sort() };
 }
 
+function formatKeyList(keys, limit = 12) {
+  const shown = keys.slice(0, limit).join(", ");
+  const remaining = keys.length - limit;
+  return remaining > 0 ? `${shown}, ... +${remaining} more` : shown;
+}
+
 function swiftInterpolationTokens(value) {
   const tokens = [];
   for (let index = 0; index < value.length - 1; index += 1) {
@@ -71,6 +77,11 @@ if (isTest) {
     tokenSignature("\\(self.store.metadata(for: self.provider).displayName) failed"),
     tokenSignature("\\(self.store.metadata(for: self.provider) failed"),
     "truncated Swift interpolation");
+  assertEqual(formatKeyList(["alpha", "beta"]), "alpha, beta", "short key list");
+  assertEqual(
+    formatKeyList(["alpha", "beta", "gamma", "delta"], 2),
+    "alpha, beta, ... +2 more",
+    "truncated key list");
   console.log("app locale checker tests OK");
   process.exit(0);
 }
@@ -99,11 +110,13 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
   // 1. Missing keys
   const missingKeys = englishKeys.filter((key) => !catalogKeys.includes(key));
   if (missingKeys.length > 0) {
+    const missingKeyList = formatKeyList(missingKeys);
     if (strictLocales.includes(locale)) {
-      console.error(`\x1b[31m[${locale}] Error: Missing ${missingKeys.length} keys in strict locale.\x1b[0m`);
+      console.error(
+        `\x1b[31m[${locale}] Error: Missing ${missingKeys.length} keys in strict locale: ${missingKeyList}.\x1b[0m`);
       hasErrors = true;
     } else {
-      console.warn(`\x1b[33m[${locale}] Warning: Missing ${missingKeys.length} keys.\x1b[0m`);
+      console.warn(`\x1b[33m[${locale}] Warning: Missing ${missingKeys.length} keys: ${missingKeyList}.\x1b[0m`);
     }
   }
 


### PR DESCRIPTION
## Summary
- make `Scripts/check-app-locales.mjs` include the actual missing localization keys in warnings/errors
- truncate long missing-key lists so large catalogs stay readable
- cover the new formatting helper in the script self-test

## Behavior proof
Before this change, the locale checker only reported counts, for example:

```text
[de] Warning: Missing 2 keys.
[es] Warning: Missing 142 keys.
```

After this change, the same check identifies the keys directly while truncating long lists:

```text
[de] Warning: Missing 2 keys: Individual credits, Workspace.
[es] Warning: Missing 142 keys: %@ is unavailable in the current environment., %@ left, %@ · %@, %@: %@ · %@ tokens, %@: %@%% used, %d more items, %d unreadable item(s) skipped, %d%% in deficit, %d%% in reserve, %dd, About CodexBar, Add Account..., ... +130 more.
[zh-Hans] Warning: Missing 2 keys: terminal_app_subtitle, terminal_app_title.
```

## Tests
- `node Scripts/check-app-locales.mjs --test`
- `node Scripts/check-app-locales.mjs`
- `git diff --check`
- `make check`

## Risk
- Developer-tooling output only; no app/runtime behavior changes.

## Review focus
- Whether the warning format gives enough detail without making large locale gaps too noisy.