### PR TITLE
tests: add provider quota fixture contract coverage

### DIFF
--- a/Tests/CodexBarTests/Fixtures/Providers/Claude/weekly-limit.json
+++ b/Tests/CodexBarTests/Fixtures/Providers/Claude/weekly-limit.json
@@ -1,0 +1,8 @@
+{
+  "ok": true,
+  "account_email": "user@example.com",
+  "login_method": "Claude Max",
+  "session_5h": { "pct_used": 7, "resets": "11am (Europe/Vienna)" },
+  "week_all_models": { "pct_used": 21, "resets": "Nov 21 at 5am (Europe/Vienna)" },
+  "week_sonnet": { "pct_used": 3, "resets": "Nov 21 at 5am (Europe/Vienna)" }
+}

--- a/Tests/CodexBarTests/Fixtures/Providers/MiniMax/token-plan-missing-reset.json
+++ b/Tests/CodexBarTests/Fixtures/Providers/MiniMax/token-plan-missing-reset.json
@@ -1,0 +1,17 @@
+{
+  "base_resp": { "status_code": 0, "status_msg": "success" },
+  "data": {
+    "current_subscribe_title": "Token Plan Plus",
+    "model_remains": [
+      {
+        "model_name": "general",
+        "current_interval_total_count": 100,
+        "current_interval_usage_count": 25,
+        "current_interval_remaining_percent": 75,
+        "current_weekly_total_count": 100,
+        "current_weekly_usage_count": 40,
+        "current_weekly_remaining_percent": 60
+      }
+    ]
+  }
+}

--- a/Tests/CodexBarTests/Fixtures/Providers/MiniMax/token-plan-normal.json
+++ b/Tests/CodexBarTests/Fixtures/Providers/MiniMax/token-plan-normal.json
@@ -1,0 +1,22 @@
+{
+  "base_resp": { "status_code": 0, "status_msg": "success" },
+  "data": {
+    "current_subscribe_title": "Token Plan Plus",
+    "points_balance": "14000",
+    "model_remains": [
+      {
+        "model_name": "general",
+        "current_interval_total_count": 0,
+        "current_interval_usage_count": 0,
+        "current_interval_remaining_percent": "96",
+        "start_time": 1780279200000,
+        "end_time": 1780297200000,
+        "current_weekly_total_count": 0,
+        "current_weekly_usage_count": 0,
+        "current_weekly_remaining_percent": "99",
+        "weekly_start_time": 1780243200000,
+        "weekly_end_time": 1780848000000
+      }
+    ]
+  }
+}

--- a/Tests/CodexBarTests/Fixtures/Providers/OpenAI/pro-normal.html
+++ b/Tests/CodexBarTests/Fixtures/Providers/OpenAI/pro-normal.html
@@ -1,0 +1,16 @@
+<html>
+<body>
+<script type="application/json" id="client-bootstrap">
+{"session":{"user":{"email":"user@example.com"}},"planType":"prolite"}
+</script>
+<main>
+Usage limits
+5h limit
+72% remaining
+Resets today at 2:15 PM
+Weekly limit
+41% remaining
+Resets Fri at 9:00 AM
+</main>
+</body>
+</html>

--- a/Tests/CodexBarTests/ProviderQuotaFixtureContractTests.swift
+++ b/Tests/CodexBarTests/ProviderQuotaFixtureContractTests.swift
@@ -4,212 +4,76 @@ import Testing
 @testable import CodexBarCore
 
 struct ProviderQuotaFixtureContractTests {
-    private struct ProviderFixtureCase: Sendable {
-        let provider: UsageProvider
-        let fixtureName: String
-        let fixtureExtension: String
-        let parser: Parser
-        let expectedPlan: String?
-        let expectedPrimary: ExpectedWindow
-        let expectedSecondary: ExpectedWindow
+    @Test
+    func `MiniMax fixture preserves quota windows and plan`() throws {
+        let data = try Self.fixtureData(provider: "MiniMax", name: "token-plan-normal", fileExtension: "json")
+        let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(
+            data: data,
+            now: Date(timeIntervalSince1970: 1_780_282_340))
+        let usage = snapshot.toUsageSnapshot()
 
-        var displayName: String {
-            "\(self.provider.rawValue)/\(self.fixtureName).\(self.fixtureExtension)"
-        }
-
-        var providerDirectory: String {
-            switch self.provider {
-            case .minimax:
-                "MiniMax"
-            case .openai:
-                "OpenAI"
-            case .claude:
-                "Claude"
-            default:
-                self.provider.rawValue
-            }
-        }
-    }
-
-    private enum Parser: Sendable {
-        case minimaxCodingPlanRemains(now: Date)
-        case openAIWebDashboard
-        case claudeCLIUsage
-    }
-
-    private struct ParsedFixture: Sendable {
-        let plan: String?
-        let primary: RateWindow?
-        let secondary: RateWindow?
-    }
-
-    private struct ExpectedWindow: Equatable, Sendable {
-        let usedPercent: Double?
-        let windowMinutes: Int?
-        let resetDescriptionContains: String?
-        let resetsAt: Date?
-        let resetAbsent: Bool
-
-        static let absent = ExpectedWindow(
-            usedPercent: nil,
-            windowMinutes: nil,
-            resetDescriptionContains: nil,
-            resetsAt: nil,
-            resetAbsent: false)
+        #expect(usage.identity(for: .minimax)?.loginMethod == "Token Plan Plus")
+        #expect(usage.primary?.usedPercent == 4)
+        #expect(usage.primary?.windowMinutes == 300)
+        #expect(usage.primary?.resetsAt == Date(timeIntervalSince1970: 1_780_297_200))
+        #expect(usage.secondary?.usedPercent == 1)
+        #expect(usage.secondary?.windowMinutes == 10080)
+        #expect(usage.secondary?.resetsAt == Date(timeIntervalSince1970: 1_780_848_000))
     }
 
     @Test
-    func `provider quota fixtures satisfy parsing contract`() throws {
-        for fixtureCase in Self.fixtureCases {
-            let parsed = try Self.parse(fixtureCase)
+    func `MiniMax fixture keeps windows when reset timestamps are absent`() throws {
+        let data = try Self.fixtureData(
+            provider: "MiniMax",
+            name: "token-plan-missing-reset",
+            fileExtension: "json")
+        let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(
+            data: data,
+            now: Date(timeIntervalSince1970: 1_780_282_340))
+        let usage = snapshot.toUsageSnapshot()
 
-            #expect(parsed.plan == fixtureCase.expectedPlan, "\(fixtureCase.displayName) plan")
-            try Self.expectWindow(
-                parsed.primary,
-                expected: fixtureCase.expectedPrimary,
-                fixtureName: "\(fixtureCase.displayName) primary")
-            try Self.expectWindow(
-                parsed.secondary,
-                expected: fixtureCase.expectedSecondary,
-                fixtureName: "\(fixtureCase.displayName) secondary")
-        }
+        #expect(usage.identity(for: .minimax)?.loginMethod == "Token Plan Plus")
+        #expect(usage.primary?.usedPercent == 25)
+        #expect(usage.primary?.resetsAt == nil)
+        #expect(usage.secondary?.usedPercent == 40)
+        #expect(usage.secondary?.windowMinutes == 10080)
+        #expect(usage.secondary?.resetsAt == nil)
     }
 
-    private static let fixtureCases: [ProviderFixtureCase] = [
-        ProviderFixtureCase(
-            provider: .minimax,
-            fixtureName: "token-plan-normal",
-            fixtureExtension: "json",
-            parser: .minimaxCodingPlanRemains(now: Date(timeIntervalSince1970: 1_780_282_340)),
-            expectedPlan: "Token Plan Plus",
-            expectedPrimary: ExpectedWindow(
-                usedPercent: 4,
-                windowMinutes: 300,
-                resetDescriptionContains: nil,
-                resetsAt: Date(timeIntervalSince1970: 1_780_297_200),
-                resetAbsent: false),
-            expectedSecondary: ExpectedWindow(
-                usedPercent: 1,
-                windowMinutes: 10080,
-                resetDescriptionContains: nil,
-                resetsAt: Date(timeIntervalSince1970: 1_780_848_000),
-                resetAbsent: false)),
-        ProviderFixtureCase(
-            provider: .minimax,
-            fixtureName: "token-plan-missing-reset",
-            fixtureExtension: "json",
-            parser: .minimaxCodingPlanRemains(now: Date(timeIntervalSince1970: 1_780_282_340)),
-            expectedPlan: "Token Plan Plus",
-            expectedPrimary: ExpectedWindow(
-                usedPercent: 25,
-                windowMinutes: nil,
-                resetDescriptionContains: nil,
-                resetsAt: nil,
-                resetAbsent: true),
-            expectedSecondary: ExpectedWindow(
-                usedPercent: 40,
-                windowMinutes: 10080,
-                resetDescriptionContains: nil,
-                resetsAt: nil,
-                resetAbsent: true)),
-        ProviderFixtureCase(
-            provider: .openai,
-            fixtureName: "pro-normal",
-            fixtureExtension: "html",
-            parser: .openAIWebDashboard,
-            expectedPlan: "Pro 5x",
-            expectedPrimary: ExpectedWindow(
-                usedPercent: 28,
-                windowMinutes: 300,
-                resetDescriptionContains: "resets",
-                resetsAt: nil,
-                resetAbsent: false),
-            expectedSecondary: ExpectedWindow(
-                usedPercent: 59,
-                windowMinutes: 10080,
-                resetDescriptionContains: nil,
-                resetsAt: nil,
-                resetAbsent: false)),
-        ProviderFixtureCase(
-            provider: .claude,
-            fixtureName: "weekly-limit",
-            fixtureExtension: "json",
-            parser: .claudeCLIUsage,
-            expectedPlan: "Claude Max",
-            expectedPrimary: ExpectedWindow(
-                usedPercent: 7,
-                windowMinutes: 300,
-                resetDescriptionContains: "Europe/Vienna",
-                resetsAt: nil,
-                resetAbsent: false),
-            expectedSecondary: ExpectedWindow(
-                usedPercent: 21,
-                windowMinutes: 10080,
-                resetDescriptionContains: "Europe/Vienna",
-                resetsAt: nil,
-                resetAbsent: false)),
-    ]
+    @Test
+    func `OpenAI fixture preserves quota windows and plan`() throws {
+        let data = try Self.fixtureData(provider: "OpenAI", name: "pro-normal", fileExtension: "html")
+        let body = try #require(String(data: data, encoding: .utf8))
+        let limits = OpenAIDashboardParser.parseRateLimits(bodyText: body)
 
-    private static func parse(_ fixtureCase: ProviderFixtureCase) throws -> ParsedFixture {
-        let data = try self.fixtureData(for: fixtureCase)
-
-        switch fixtureCase.parser {
-        case let .minimaxCodingPlanRemains(now):
-            let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: data, now: now)
-            let usage = snapshot.toUsageSnapshot()
-            return ParsedFixture(
-                plan: usage.identity(for: .minimax)?.loginMethod,
-                primary: usage.primary,
-                secondary: usage.secondary)
-
-        case .openAIWebDashboard:
-            let bodyText = try #require(String(data: data, encoding: .utf8))
-            let limits = OpenAIDashboardParser.parseRateLimits(bodyText: bodyText)
-            return ParsedFixture(
-                plan: OpenAIDashboardParser.parsePlanFromHTML(html: bodyText),
-                primary: limits.primary,
-                secondary: limits.secondary)
-
-        case .claudeCLIUsage:
-            let snapshot = try #require(ClaudeUsageFetcher.parse(json: data))
-            return ParsedFixture(
-                plan: snapshot.loginMethod,
-                primary: snapshot.primary,
-                secondary: snapshot.secondary)
-        }
+        #expect(OpenAIDashboardParser.parsePlanFromHTML(html: body) == "Pro 5x")
+        #expect(limits.primary?.usedPercent == 28)
+        #expect(limits.primary?.windowMinutes == 300)
+        #expect(limits.primary?.resetDescription?.localizedCaseInsensitiveContains("resets") == true)
+        #expect(limits.secondary?.usedPercent == 59)
+        #expect(limits.secondary?.windowMinutes == 10080)
+        #expect(limits.secondary?.resetDescription?.localizedCaseInsensitiveContains("resets") == true)
     }
 
-    private static func fixtureData(for fixtureCase: ProviderFixtureCase) throws -> Data {
-        let subdirectory = "Fixtures/Providers/\(fixtureCase.providerDirectory)"
+    @Test
+    func `Claude fixture preserves quota windows and plan`() throws {
+        let data = try Self.fixtureData(provider: "Claude", name: "weekly-limit", fileExtension: "json")
+        let snapshot = try #require(ClaudeUsageFetcher.parse(json: data))
+
+        #expect(snapshot.loginMethod == "Claude Max")
+        #expect(snapshot.primary.usedPercent == 7)
+        #expect(snapshot.primary.windowMinutes == 300)
+        #expect(snapshot.primary.resetDescription?.contains("Europe/Vienna") == true)
+        #expect(snapshot.secondary?.usedPercent == 21)
+        #expect(snapshot.secondary?.windowMinutes == 10080)
+        #expect(snapshot.secondary?.resetDescription?.contains("Europe/Vienna") == true)
+    }
+
+    private static func fixtureData(provider: String, name: String, fileExtension: String) throws -> Data {
         let url = try #require(Bundle.module.url(
-            forResource: fixtureCase.fixtureName,
-            withExtension: fixtureCase.fixtureExtension,
-            subdirectory: subdirectory))
+            forResource: name,
+            withExtension: fileExtension,
+            subdirectory: "Fixtures/Providers/\(provider)"))
         return try Data(contentsOf: url)
-    }
-
-    private static func expectWindow(
-        _ window: RateWindow?,
-        expected: ExpectedWindow,
-        fixtureName: String) throws
-    {
-        if expected == .absent {
-            #expect(window == nil, "\(fixtureName) should be absent")
-            return
-        }
-
-        let window = try #require(window, "\(fixtureName) should be present")
-        #expect(window.usedPercent == expected.usedPercent, "\(fixtureName) usedPercent")
-        #expect(window.windowMinutes == expected.windowMinutes, "\(fixtureName) windowMinutes")
-        if let resetDescriptionContains = expected.resetDescriptionContains {
-            #expect(
-                window.resetDescription?.localizedCaseInsensitiveContains(resetDescriptionContains) == true,
-                "\(fixtureName) resetDescription")
-        }
-        if expected.resetAbsent {
-            #expect(window.resetsAt == nil, "\(fixtureName) resetsAt should be absent")
-        } else if let resetsAt = expected.resetsAt {
-            #expect(window.resetsAt == resetsAt, "\(fixtureName) resetsAt")
-        }
     }
 }

--- a/Tests/CodexBarTests/ProviderQuotaFixtureContractTests.swift
+++ b/Tests/CodexBarTests/ProviderQuotaFixtureContractTests.swift
@@ -1,0 +1,215 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+struct ProviderQuotaFixtureContractTests {
+    private struct ProviderFixtureCase: Sendable {
+        let provider: UsageProvider
+        let fixtureName: String
+        let fixtureExtension: String
+        let parser: Parser
+        let expectedPlan: String?
+        let expectedPrimary: ExpectedWindow
+        let expectedSecondary: ExpectedWindow
+
+        var displayName: String {
+            "\(self.provider.rawValue)/\(self.fixtureName).\(self.fixtureExtension)"
+        }
+
+        var providerDirectory: String {
+            switch self.provider {
+            case .minimax:
+                "MiniMax"
+            case .openai:
+                "OpenAI"
+            case .claude:
+                "Claude"
+            default:
+                self.provider.rawValue
+            }
+        }
+    }
+
+    private enum Parser: Sendable {
+        case minimaxCodingPlanRemains(now: Date)
+        case openAIWebDashboard
+        case claudeCLIUsage
+    }
+
+    private struct ParsedFixture: Sendable {
+        let plan: String?
+        let primary: RateWindow?
+        let secondary: RateWindow?
+    }
+
+    private struct ExpectedWindow: Equatable, Sendable {
+        let usedPercent: Double?
+        let windowMinutes: Int?
+        let resetDescriptionContains: String?
+        let resetsAt: Date?
+        let resetAbsent: Bool
+
+        static let absent = ExpectedWindow(
+            usedPercent: nil,
+            windowMinutes: nil,
+            resetDescriptionContains: nil,
+            resetsAt: nil,
+            resetAbsent: false)
+    }
+
+    @Test
+    func `provider quota fixtures satisfy parsing contract`() throws {
+        for fixtureCase in Self.fixtureCases {
+            let parsed = try Self.parse(fixtureCase)
+
+            #expect(parsed.plan == fixtureCase.expectedPlan, "\(fixtureCase.displayName) plan")
+            try Self.expectWindow(
+                parsed.primary,
+                expected: fixtureCase.expectedPrimary,
+                fixtureName: "\(fixtureCase.displayName) primary")
+            try Self.expectWindow(
+                parsed.secondary,
+                expected: fixtureCase.expectedSecondary,
+                fixtureName: "\(fixtureCase.displayName) secondary")
+        }
+    }
+
+    private static let fixtureCases: [ProviderFixtureCase] = [
+        ProviderFixtureCase(
+            provider: .minimax,
+            fixtureName: "token-plan-normal",
+            fixtureExtension: "json",
+            parser: .minimaxCodingPlanRemains(now: Date(timeIntervalSince1970: 1_780_282_340)),
+            expectedPlan: "Token Plan Plus",
+            expectedPrimary: ExpectedWindow(
+                usedPercent: 4,
+                windowMinutes: 300,
+                resetDescriptionContains: nil,
+                resetsAt: Date(timeIntervalSince1970: 1_780_297_200),
+                resetAbsent: false),
+            expectedSecondary: ExpectedWindow(
+                usedPercent: 1,
+                windowMinutes: 10080,
+                resetDescriptionContains: nil,
+                resetsAt: Date(timeIntervalSince1970: 1_780_848_000),
+                resetAbsent: false)),
+        ProviderFixtureCase(
+            provider: .minimax,
+            fixtureName: "token-plan-missing-reset",
+            fixtureExtension: "json",
+            parser: .minimaxCodingPlanRemains(now: Date(timeIntervalSince1970: 1_780_282_340)),
+            expectedPlan: "Token Plan Plus",
+            expectedPrimary: ExpectedWindow(
+                usedPercent: 25,
+                windowMinutes: nil,
+                resetDescriptionContains: nil,
+                resetsAt: nil,
+                resetAbsent: true),
+            expectedSecondary: ExpectedWindow(
+                usedPercent: 40,
+                windowMinutes: 10080,
+                resetDescriptionContains: nil,
+                resetsAt: nil,
+                resetAbsent: true)),
+        ProviderFixtureCase(
+            provider: .openai,
+            fixtureName: "pro-normal",
+            fixtureExtension: "html",
+            parser: .openAIWebDashboard,
+            expectedPlan: "Pro 5x",
+            expectedPrimary: ExpectedWindow(
+                usedPercent: 28,
+                windowMinutes: 300,
+                resetDescriptionContains: "resets",
+                resetsAt: nil,
+                resetAbsent: false),
+            expectedSecondary: ExpectedWindow(
+                usedPercent: 59,
+                windowMinutes: 10080,
+                resetDescriptionContains: nil,
+                resetsAt: nil,
+                resetAbsent: false)),
+        ProviderFixtureCase(
+            provider: .claude,
+            fixtureName: "weekly-limit",
+            fixtureExtension: "json",
+            parser: .claudeCLIUsage,
+            expectedPlan: "Claude Max",
+            expectedPrimary: ExpectedWindow(
+                usedPercent: 7,
+                windowMinutes: 300,
+                resetDescriptionContains: "Europe/Vienna",
+                resetsAt: nil,
+                resetAbsent: false),
+            expectedSecondary: ExpectedWindow(
+                usedPercent: 21,
+                windowMinutes: 10080,
+                resetDescriptionContains: "Europe/Vienna",
+                resetsAt: nil,
+                resetAbsent: false)),
+    ]
+
+    private static func parse(_ fixtureCase: ProviderFixtureCase) throws -> ParsedFixture {
+        let data = try self.fixtureData(for: fixtureCase)
+
+        switch fixtureCase.parser {
+        case let .minimaxCodingPlanRemains(now):
+            let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: data, now: now)
+            let usage = snapshot.toUsageSnapshot()
+            return ParsedFixture(
+                plan: usage.identity(for: .minimax)?.loginMethod,
+                primary: usage.primary,
+                secondary: usage.secondary)
+
+        case .openAIWebDashboard:
+            let bodyText = try #require(String(data: data, encoding: .utf8))
+            let limits = OpenAIDashboardParser.parseRateLimits(bodyText: bodyText)
+            return ParsedFixture(
+                plan: OpenAIDashboardParser.parsePlanFromHTML(html: bodyText),
+                primary: limits.primary,
+                secondary: limits.secondary)
+
+        case .claudeCLIUsage:
+            let snapshot = try #require(ClaudeUsageFetcher.parse(json: data))
+            return ParsedFixture(
+                plan: snapshot.loginMethod,
+                primary: snapshot.primary,
+                secondary: snapshot.secondary)
+        }
+    }
+
+    private static func fixtureData(for fixtureCase: ProviderFixtureCase) throws -> Data {
+        let subdirectory = "Fixtures/Providers/\(fixtureCase.providerDirectory)"
+        let url = try #require(Bundle.module.url(
+            forResource: fixtureCase.fixtureName,
+            withExtension: fixtureCase.fixtureExtension,
+            subdirectory: subdirectory))
+        return try Data(contentsOf: url)
+    }
+
+    private static func expectWindow(
+        _ window: RateWindow?,
+        expected: ExpectedWindow,
+        fixtureName: String) throws
+    {
+        if expected == .absent {
+            #expect(window == nil, "\(fixtureName) should be absent")
+            return
+        }
+
+        let window = try #require(window, "\(fixtureName) should be present")
+        #expect(window.usedPercent == expected.usedPercent, "\(fixtureName) usedPercent")
+        #expect(window.windowMinutes == expected.windowMinutes, "\(fixtureName) windowMinutes")
+        if let resetDescriptionContains = expected.resetDescriptionContains {
+            #expect(
+                window.resetDescription?.localizedCaseInsensitiveContains(resetDescriptionContains) == true,
+                "\(fixtureName) resetDescription")
+        }
+        if expected.resetAbsent {
+            #expect(window.resetsAt == nil, "\(fixtureName) resetsAt should be absent")
+        } else if let resetsAt = expected.resetsAt {
+            #expect(window.resetsAt == resetsAt, "\(fixtureName) resetsAt")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a fixture-backed provider quota contract test covering MiniMax, OpenAI, and Claude parsing outputs
- add representative provider fixtures for normal quota windows, missing reset metadata, plan parsing, and weekly limits
- assert the stable contract fields CodexBar depends on: plan label, primary/secondary used percent, window duration, and reset metadata

This is a stability-maintenance PR. It does not change provider behavior; it adds fixture-backed contract coverage so provider quota parsing remains stable as the provider matrix grows.

## Test
- `HOME=<fixtures-dir>/.home CLANG_MODULE_CACHE_PATH=<fixtures-dir>/.clang-module-cache swift test --filter ProviderQuotaFixtureContractTests`
- `HOME=<fixtures-dir>/.home CLANG_MODULE_CACHE_PATH=<fixtures-dir>/.clang-module-cache swift test --filter 'ProviderQuotaFixtureContractTests|MiniMaxTokenPlanChangeTests|OpenAIDashboardParserTests|ClaudeUsageTests'`
