### PR TITLE
Remove redundant cost tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.37.1 — 2026-06-21
 
 ### Fixed
+- Cost history: remove the redundant tooltip from submenu-backed Cost rows. Thanks @Zihao-Qi!
 - Menu: align provider usage-card spacing with the Overview layout. Thanks @Zihao-Qi!
 - Memory pressure: avoid actor-isolation crashes when system callbacks arrive on a utility queue. Thanks @Zihao-Qi!
 - Menu: remove extra separators and spacing around Storage, Cost, and Subscription Utilization rows. Thanks @elijahfriedman!

--- a/Sources/CodexBar/StatusItemController+CostMenuCard.swift
+++ b/Sources/CodexBar/StatusItemController+CostMenuCard.swift
@@ -74,7 +74,11 @@ extension StatusItemController {
         item.isEnabled = true
         item.representedObject = "menuCardCost"
         item.submenu = submenu
-        item.toolTip = tooltipLines.joined(separator: "\n")
+        // Submenu cost rows already show these details; keep tooltips only for inline rows
+        // where they reveal truncated text and avoid flashes during in-place menu refreshes.
+        if submenu == nil {
+            item.toolTip = tooltipLines.joined(separator: "\n")
+        }
         if #available(macOS 14.4, *) {
             item.subtitle = visibleDetailLines.joined(separator: "\n")
         } else if !visibleDetailLines.isEmpty {

--- a/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
@@ -67,6 +67,40 @@ struct StatusMenuCostMenuCardTests {
     }
 
     @Test
+    func `cost menu with history submenu omits native tooltip`() {
+        let settings = self.makeSettings()
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let tokenUsage = UsageMenuCardView.Model.TokenUsageSection(
+            sessionLine: "Today: $1.00",
+            monthLine: "Last 30 days: $9.00",
+            hintLine: "Costs are estimated from local usage.",
+            errorLine: nil,
+            errorCopyText: nil)
+        let submenu = NSMenu()
+
+        let item = controller.makeCostMenuCardItem(
+            model: self.makeModel(tokenUsage: tokenUsage),
+            submenu: submenu,
+            width: StatusItemController.menuCardBaseWidth)
+
+        #expect(item.submenu === submenu)
+        #expect(item.toolTip == nil)
+    }
+
+    @Test
     func `rendered cost menu keeps long dynamic details inside fixed row width`() throws {
         let previousRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = true


### PR DESCRIPTION
## Summary

- Remove the native tooltip from cost menu rows when a cost history submenu is present
- Keep tooltips for inline cost rows, where they still help reveal truncated detail text
- Add regression coverage for submenu cost rows omitting the redundant tooltip

## Tests

- `swift test --filter StatusMenuCostMenuCardTests`
- `make check`

## Screenshots

<img width="618" height="194" alt="Screenshot 2026-06-21 at 09 45 09" src="https://github.com/user-attachments/assets/77521879-98e0-4ef3-bfd0-4347f41895fe" />

<img width="616" height="198" alt="Screenshot 2026-06-21 at 10 52 35" src="https://github.com/user-attachments/assets/e810f7a8-deef-4533-aacb-92834316a2f7" />
