### PR TITLE
fix: keep menu bar open on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Cost history: remove the redundant tooltip from submenu-backed Cost rows. Thanks @Zihao-Qi!
+- Menu refresh: keep the menu open and show in-place progress when Refresh is clicked. Thanks @elijahfriedman!
 - Menu: align provider usage-card spacing with the Overview layout. Thanks @Zihao-Qi!
 - Memory pressure: avoid actor-isolation crashes when system callbacks arrive on a utility queue. Thanks @Zihao-Qi!
 - Menu: remove extra separators and spacing around Storage, Cost, and Subscription Utilization rows. Thanks @elijahfriedman!

--- a/Sources/CodexBar/MenuContent.swift
+++ b/Sources/CodexBar/MenuContent.swift
@@ -162,6 +162,32 @@ struct MenuActions {
     let copyError: (String) -> Void
 }
 
+struct PersistentMenuActionRowView: View {
+    let title: String
+    let systemImageName: String?
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if let systemImageName {
+                Image(systemName: systemImageName)
+                    .imageScale(.medium)
+                    .frame(width: 18, alignment: .center)
+                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+            }
+            Text(self.title)
+                .font(.body)
+                .foregroundStyle(MenuHighlightStyle.primary(self.isHighlighted))
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(self.title)
+    }
+}
+
 @MainActor
 struct StatusIconView: View {
     @Bindable var store: UsageStore

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -10,6 +10,7 @@ extension StatusItemController {
     static let menuCardBaseWidth: CGFloat = 310
     private static let maxOverviewProviders = SettingsStore.mergedOverviewProviderLimit
     static let overviewRowIdentifierPrefix = "overviewRow-"
+    static let persistentRefreshMenuItemID = "persistentRefreshAction"
     private static let defaultMenuOpenRefreshDelay: Duration = .seconds(1.2)
     #if DEBUG
     private static var menuOpenRefreshDelayForTesting: Duration = .seconds(1.2)
@@ -38,8 +39,6 @@ extension StatusItemController {
 
     private func shortcut(for action: MenuDescriptor.MenuAction) -> (key: String, modifiers: NSEvent.ModifierFlags)? {
         switch action {
-        case .refresh:
-            ("r", [.command])
         case .settings:
             (",", [.command])
         case .quit:
@@ -47,6 +46,10 @@ extension StatusItemController {
         default:
             nil
         }
+    }
+
+    func isPersistentRefreshItem(_ item: NSMenuItem) -> Bool {
+        item.representedObject as? String == Self.persistentRefreshMenuItemID
     }
 
     func makeMenu() -> NSMenu {
@@ -797,6 +800,16 @@ extension StatusItemController {
                     }
                     menu.addItem(item)
                 case let .action(title, action):
+                    if action == .refresh {
+                        let item = self.makePersistentRefreshItem(
+                            title: L(title),
+                            action: action,
+                            menu: captureMenu ?? menu,
+                            width: width)
+                        menu.addItem(item)
+                        self.persistentRefreshItems.add(item)
+                        continue
+                    }
                     let localizedTitle = L(title)
                     let (selector, represented) = self.selector(for: action)
                     let item = NSMenuItem(title: localizedTitle, action: selector, keyEquivalent: "")
@@ -823,11 +836,6 @@ extension StatusItemController {
                     {
                         item.isEnabled = false
                         self.applySubtitle(subtitle, to: item, title: localizedTitle)
-                    }
-                    if action == .refresh {
-                        let targetMenu = captureMenu ?? menu
-                        item.isEnabled = !self.isRefreshActionInFlight(for: targetMenu)
-                        self.persistentRefreshItems.add(item)
                     }
                     menu.addItem(item)
                 case let .submenu(title, systemImageName, submenuItems):
@@ -863,6 +871,27 @@ extension StatusItemController {
                 menu.addItem(.separator())
             }
         }
+    }
+
+    private func makePersistentRefreshItem(
+        title: String,
+        action: MenuDescriptor.MenuAction,
+        menu: NSMenu,
+        width: CGFloat) -> NSMenuItem
+    {
+        let item = self.makeMenuCardItem(
+            PersistentMenuActionRowView(
+                title: title,
+                systemImageName: action.systemImageName),
+            id: Self.persistentRefreshMenuItemID,
+            width: width,
+            onClick: { [weak self, weak menu] in
+                guard let self, let menu else { return }
+                self.performPersistentRefreshAction(in: ObjectIdentifier(menu))
+            })
+        item.title = title
+        item.isEnabled = !self.isRefreshActionInFlight(for: menu)
+        return item
     }
 
     private func makeWrappedSecondaryTextItem(text: String, width: CGFloat) -> NSMenuItem {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -885,6 +885,7 @@ extension StatusItemController {
                 systemImageName: action.systemImageName),
             id: Self.persistentRefreshMenuItemID,
             width: width,
+            heightCacheFingerprint: "persistentRefreshAction:\(action.systemImageName ?? "")|\(title)",
             onClick: { [weak self, weak menu] in
                 guard let self, let menu else { return }
                 self.performPersistentRefreshAction(in: ObjectIdentifier(menu))

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -142,7 +142,6 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         if onClick != nil {
             self.installClickRecognizer()
         }
-        self.updateAccessibilityActivation()
     }
 
     /// Reuses this hosting view for a rebuilt card with the same identity: the replaced
@@ -156,17 +155,14 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         if onClick != nil, !self.hasClickRecognizer {
             self.installClickRecognizer()
         }
-        self.updateAccessibilityActivation()
     }
 
     /// `NSMenu` tracking consumes keyboard events before they reach a menu item's custom view, so
     /// the pointer `onClick` path has no native counterpart for assistive tech. Expose the row as an
     /// accessibility button whose press mirrors a click, giving VoiceOver an activation path that runs
     /// `onClick` (and therefore keeps the menu open) instead of regressing to mouse-only.
-    private func updateAccessibilityActivation() {
-        if self.onClick != nil {
-            self.setAccessibilityRole(.button)
-        }
+    override func accessibilityRole() -> NSAccessibility.Role? {
+        self.onClick == nil ? super.accessibilityRole() : .button
     }
 
     override func accessibilityPerformPress() -> Bool {

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -142,6 +142,7 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         if onClick != nil {
             self.installClickRecognizer()
         }
+        self.updateAccessibilityActivation()
     }
 
     /// Reuses this hosting view for a rebuilt card with the same identity: the replaced
@@ -155,6 +156,25 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         if onClick != nil, !self.hasClickRecognizer {
             self.installClickRecognizer()
         }
+        self.updateAccessibilityActivation()
+    }
+
+    /// `NSMenu` tracking consumes keyboard events before they reach a menu item's custom view, so
+    /// the pointer `onClick` path has no native counterpart for assistive tech. Expose the row as an
+    /// accessibility button whose press mirrors a click, giving VoiceOver an activation path that runs
+    /// `onClick` (and therefore keeps the menu open) instead of regressing to mouse-only.
+    private func updateAccessibilityActivation() {
+        if self.onClick != nil {
+            self.setAccessibilityRole(.button)
+        }
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        guard let onClick = self.onClick else {
+            return super.accessibilityPerformPress()
+        }
+        onClick()
+        return true
     }
 
     private func installClickRecognizer() {

--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -207,7 +207,7 @@ extension StatusItemController {
         if #available(macOS 14.4, *) {
             liveItem.subtitle = newItem.subtitle
         }
-        if liveItem.action == #selector(self.refreshMenuItem(_:)) {
+        if self.isPersistentRefreshItem(liveItem) {
             self.persistentRefreshItems.add(liveItem)
         }
     }

--- a/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
@@ -1,15 +1,16 @@
 import AppKit
 
 extension StatusItemController {
-    /// Updates native Refresh rows in place while their menus are tracking.
+    /// Updates persistent Refresh rows in place while their menus are tracking.
     func updatePersistentRefreshItemsEnabled() {
         for item in self.persistentRefreshItems.allObjects {
-            guard item.action == #selector(self.refreshMenuItem(_:)) else {
+            guard self.isPersistentRefreshItem(item) else {
                 self.persistentRefreshItems.remove(item)
                 continue
             }
             guard let menu = item.menu else { continue }
-            item.isEnabled = !self.isRefreshActionInFlight(for: menu)
+            let enabled = !self.isRefreshActionInFlight(for: menu)
+            item.isEnabled = enabled
         }
     }
 

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -126,7 +126,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var menuSession = MenuSessionCoordinator<ObjectIdentifier>()
     var menuReadinessSignatures: [ObjectIdentifier: String] = [:]
     let hostedSubviewRenderSignatures = NSMapTable<NSMenu, NSString>.weakToStrongObjects()
-    /// Native Refresh items are weakly tracked so their enabled state can change during menu tracking.
+    /// Persistent Refresh rows are weakly tracked so their enabled state can change during menu tracking.
     let persistentRefreshItems = NSHashTable<NSMenuItem>.weakObjects()
     var menuCardHeightCache: [MenuCardHeightCacheKey: CGFloat] = [:]
     var measuredStandardMenuWidthCache: [String: CGFloat] = [:]

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -632,6 +632,25 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `recycled card clears button role when click action is removed`() {
+        let highlightState = MenuCardHighlightState()
+        let hosting = MenuCardItemHostingView(
+            rootView: Text("clickable"),
+            highlightState: highlightState,
+            allowsMenuHighlight: true,
+            onClick: {})
+
+        #expect(hosting.accessibilityRole() == .button)
+
+        hosting.prepareForReuse(
+            rootView: Text("informational"),
+            allowsMenuHighlight: false,
+            onClick: nil)
+
+        #expect(hosting.accessibilityRole() == .group)
+    }
+
+    @Test
     func `harvesting a highlighted card clears its highlight and tracking entry`() {
         StatusItemController.setMenuRefreshEnabledForTesting(false)
         let previousRendering = StatusItemController.menuCardRenderingEnabled

--- a/Tests/CodexBarTests/StatusMenuMergedOverviewRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuMergedOverviewRefreshTests.swift
@@ -30,13 +30,12 @@ struct StatusMenuMergedOverviewRefreshTests {
         controller.updatePersistentRefreshItemsEnabled()
         #expect(controller.isRefreshActionInFlight(for: menu))
         let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
-        #expect(refreshItem.view == nil)
+        #expect(controller.isPersistentRefreshItem(refreshItem))
         #expect(!refreshItem.isEnabled)
 
         var requestCount = 0
         controller._test_manualRefreshOperation = { requestCount += 1 }
-        let refreshAction = try #require(refreshItem.action)
-        _ = controller.perform(refreshAction, with: refreshItem)
+        controller.performPersistentRefreshAction(in: ObjectIdentifier(menu))
         #expect(try menu.performKeyEquivalent(with: self.keyEvent("r", keyCode: 15)))
         for _ in 0..<20 {
             await Task.yield()

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -121,7 +121,11 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
-    func `refresh menu item is native so clicking it closes the menu`() throws {
+    func `refresh row is custom and appears above settings`() throws {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
@@ -132,15 +136,23 @@ struct StatusMenuPersistentRefreshTests {
         controller.menuWillOpen(menu)
 
         let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
-        #expect(refreshItem.action != nil)
-        #expect(refreshItem.target === controller)
-        #expect(refreshItem.view == nil)
-        #expect(refreshItem.keyEquivalent == "r")
-        #expect(refreshItem.keyEquivalentModifierMask == [.command])
+        let settingsItem = try #require(menu.items.first { $0.title == "Settings..." })
+        let refreshIndex = try #require(menu.items.firstIndex(where: { $0 === refreshItem }))
+        let settingsIndex = try #require(menu.items.firstIndex(where: { $0 === settingsItem }))
+
+        #expect(refreshItem.action == nil)
+        #expect(refreshItem.target == nil)
+        #expect(refreshItem.view != nil)
+        #expect(controller.isPersistentRefreshItem(refreshItem))
+        #expect(refreshIndex < settingsIndex)
     }
 
     @Test
-    func `persistent action items are native and install update has an icon`() throws {
+    func `refresh row is custom while remaining persistent action items stay native`() throws {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
@@ -150,10 +162,14 @@ struct StatusMenuPersistentRefreshTests {
         controller.menuWillOpen(menu)
 
         let updateItem = try #require(menu.items.first { $0.title == "Update ready, restart now?" })
+        let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
         #expect(MenuDescriptor.MenuAction.installUpdate.systemImageName == "arrow.down.circle")
         #expect(updateItem.image != nil)
+        #expect(refreshItem.view != nil)
+        #expect(refreshItem.action == nil)
+        #expect(controller.isPersistentRefreshItem(refreshItem))
 
-        for title in ["Update ready, restart now?", "Refresh", "Settings...", "About CodexBar", "Quit"] {
+        for title in ["Update ready, restart now?", "Settings...", "About CodexBar", "Quit"] {
             let item = try #require(menu.items.first { $0.title == title })
             #expect(item.view == nil, "'\(title)' should be a native NSMenuItem with no custom view")
             #expect(item.action != nil)
@@ -162,7 +178,11 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
-    func `native refresh item reflects scoped global and manual refresh state`() throws {
+    func `persistent refresh row reflects scoped global and manual refresh state`() throws {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
@@ -172,7 +192,8 @@ struct StatusMenuPersistentRefreshTests {
         controller.menuWillOpen(menu)
 
         let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
-        #expect(refreshItem.view == nil)
+        #expect(refreshItem.view != nil)
+        #expect(controller.isPersistentRefreshItem(refreshItem))
         #expect(controller.persistentRefreshItems.allObjects.contains { $0 === refreshItem })
         #expect(refreshItem.isEnabled)
 
@@ -200,7 +221,7 @@ struct StatusMenuPersistentRefreshTests {
         controller.updatePersistentRefreshItemsEnabled()
         #expect(refreshItem.isEnabled)
 
-        refreshItem.action = controller.selector(for: .settings).0
+        refreshItem.representedObject = "notRefresh"
         controller.manualRefreshTask = Task {}
         controller.updatePersistentRefreshItemsEnabled()
         #expect(refreshItem.isEnabled)
@@ -716,7 +737,7 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
-    func `provider menu mouse and command R refresh only that provider`() async throws {
+    func `provider menu persistent refresh row and command R refresh only that provider`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
@@ -739,15 +760,18 @@ struct StatusMenuPersistentRefreshTests {
             await mouseGate.wait()
         }
         let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
-        let refreshAction = try #require(refreshItem.action)
-        _ = controller.perform(refreshAction, with: refreshItem)
+        #expect(controller.isPersistentRefreshItem(refreshItem))
+        controller.performPersistentRefreshAction(in: ObjectIdentifier(menu))
+        for _ in 0..<20 where controller.manualRefreshTask == nil {
+            await Task.yield()
+        }
         let mouseTask = try #require(controller.manualRefreshTask)
         #expect(controller.manualRefreshProvider == .claude)
         #expect(controller.isRefreshActionInFlight(for: codexMenu))
         #expect(controller.isRefreshActionInFlight(for: NSMenu()))
         let codexRefreshItem = try #require(codexMenu.items.first { $0.title == "Refresh" })
-        let codexRefreshAction = try #require(codexRefreshItem.action)
-        _ = controller.perform(codexRefreshAction, with: codexRefreshItem)
+        #expect(controller.isPersistentRefreshItem(codexRefreshItem))
+        controller.performPersistentRefreshAction(in: ObjectIdentifier(codexMenu))
         await Task.yield()
         #expect(requestCount == 1)
         mouseGate.resume()
@@ -782,8 +806,8 @@ struct StatusMenuPersistentRefreshTests {
         controller._test_manualRefreshOperation = { requestCount += 1 }
 
         let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
-        let refreshAction = try #require(refreshItem.action)
-        _ = controller.perform(refreshAction, with: refreshItem)
+        #expect(controller.isPersistentRefreshItem(refreshItem))
+        controller.performPersistentRefreshAction(in: ObjectIdentifier(menu))
         #expect(try menu.performKeyEquivalent(with: self.keyEvent("r", keyCode: 15)))
         for _ in 0..<20 {
             await Task.yield()
@@ -811,8 +835,11 @@ struct StatusMenuPersistentRefreshTests {
         let overviewGate = ManualRefreshGate()
         controller._test_manualRefreshOperation = { await overviewGate.wait() }
         let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
-        let refreshAction = try #require(refreshItem.action)
-        _ = controller.perform(refreshAction, with: refreshItem)
+        #expect(controller.isPersistentRefreshItem(refreshItem))
+        controller.performPersistentRefreshAction(in: ObjectIdentifier(menu))
+        for _ in 0..<20 where controller.manualRefreshTask == nil {
+            await Task.yield()
+        }
         let overviewTask = try #require(controller.manualRefreshTask)
         #expect(controller.manualRefreshProvider == nil)
         overviewGate.resume()

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -755,7 +755,7 @@ struct StatusMenuTests {
     }
 
     @Test
-    func `overview tab omits contextual provider actions`() {
+    func `overview tab omits contextual provider actions`() throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -794,10 +794,9 @@ struct StatusMenuTests {
         #expect(titles.contains("About CodexBar"))
         #expect(titles.contains("Quit"))
 
-        let refreshItem = menu.items.first { $0.title == "Refresh" }
-        #expect(refreshItem != nil)
-        #expect(refreshItem?.keyEquivalent == "r")
-        #expect(refreshItem?.keyEquivalentModifierMask == [.command])
+        let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
+        #expect(controller.isPersistentRefreshItem(refreshItem))
+        #expect(refreshItem.keyEquivalent == "")
 
         let settingsItem = menu.items.first { $0.title == "Settings..." }
         #expect(settingsItem != nil)

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -796,7 +796,7 @@ struct StatusMenuTests {
 
         let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
         #expect(controller.isPersistentRefreshItem(refreshItem))
-        #expect(refreshItem.keyEquivalent == "")
+        #expect(refreshItem.keyEquivalent.isEmpty)
 
         let settingsItem = menu.items.first { $0.title == "Settings..." }
         #expect(settingsItem != nil)


### PR DESCRIPTION
Fixes #1678 because of #1661

## Summary

- convert the **Refresh** menu item from a native `NSMenuItem` to a custom `PersistentMenuActionRowView` so clicking it no longer closes the menu — refresh happens in place while the menu stays open
- route the row's click through `performPersistentRefreshAction(in:)` keyed by the menu's `ObjectIdentifier`, so it refreshes only the scoped provider (or the overview) just like the old action did
- identify persistent refresh rows by `representedObject == persistentRefreshMenuItemID` instead of by `#selector`, since the custom row has no action selector — used in reconciliation, in-place enable/disable, and tracking
- keep the **⌘R** key equivalent working via `performKeyEquivalent`; only the visible row changed, not the shortcut
- leave the other persistent action items (Update, Settings, About, Quit) as native `NSMenuItem`s that close the menu as before
- place the refresh row above Settings, matching the prior ordering
- give the persistent refresh row a stable, content-based height-cache fingerprint (`persistentRefreshAction:<icon>|<title>`) instead of the version-scoped default, so its measured height survives `invalidateMenus` rather than being pruned by `pruneVersionScopedMenuCardHeightCache`

## Tests

- update `StatusMenuPersistentRefreshTests` to assert the refresh row is now a custom view (no action/target, `isPersistentRefreshItem` true) and sits above Settings
- assert remaining persistent action items stay native with actions and the install-update icon
- drive refresh via `performPersistentRefreshAction(in:)` in scoped/overview/⌘R regressions instead of `perform(action:)`
- verify enabled-state tracking still flips correctly and ignores rows whose `representedObject` no longer marks them as refresh
-   - update `StatusMenuMergedOverviewRefreshTests` to drive refresh via `performPersistentRefreshAction(in:)` and assert `isPersistentRefreshItem` instead of the item's `action`
  - update `StatusMenuTests` ("overview tab omits contextual provider actions") to assert the refresh row is a persistent item with no `keyEquivalent` (⌘R now lives at the menu level, not on the item)
  - `StatusMenuHeightCacheTests` ("menu card height cache is reused for stable card content") now passes with the stable fingerprint — the refresh row's height entry persists across `invalidateMenus`

## Verification

- built and ran locally; clicking Refresh keeps the menu open and refreshes in place
- ⌘R still refreshes the scoped provider without closing the menu
- Settings/Quit/About/Update still close the menu as before
- full `make test` suite green across all shards

## Screenshots
Before:
<img width="309" height="692" alt="Screenshot 2026-06-21 at 1 30 00 PM" src="https://github.com/user-attachments/assets/0abd5f7c-a92e-4f23-929f-f7c0f5d82862" />
After:
<img width="311" height="685" alt="Screenshot 2026-06-21 at 1 31 15 PM" src="https://github.com/user-attachments/assets/62d7d48a-b049-485e-8b62-e79e80c43b5e" />


