### PR TITLE
Check generated llms index in lint

### DIFF
--- a/Scripts/generate-llms.mjs
+++ b/Scripts/generate-llms.mjs
@@ -5,10 +5,13 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const docsDir = path.join(repoRoot, "docs");
+const args = process.argv.slice(2);
+const mode = parseMode(args);
 const cname = fs.readFileSync(path.join(docsDir, "CNAME"), "utf8").trim();
 const origin = "https://" + cname;
 const productName = "CodexBar";
 const source = "https://github.com/steipete/CodexBar";
+const outputPath = path.join(docsDir, "llms.txt");
 
 const pages = allHtml(docsDir)
   .map((file) => {
@@ -42,9 +45,27 @@ const lines = [
   "- Fetch only the pages needed for the current task; this is an index, not a full-site corpus.",
   "",
 ];
+const output = lines.join("\n");
 
-fs.writeFileSync(path.join(docsDir, "llms.txt"), lines.join("\n"), "utf8");
-console.log("wrote " + path.relative(repoRoot, path.join(docsDir, "llms.txt")));
+if (mode === "check") {
+  const current = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, "utf8") : null;
+  if (current !== output) {
+    console.error(`${path.relative(repoRoot, outputPath)} is out of date; run node Scripts/generate-llms.mjs`);
+    process.exit(1);
+  }
+  console.log("llms index OK: " + path.relative(repoRoot, outputPath));
+} else {
+  fs.writeFileSync(outputPath, output, "utf8");
+  console.log("wrote " + path.relative(repoRoot, outputPath));
+}
+
+function parseMode(values) {
+  if (values.length === 0) return "write";
+  if (values.length === 1 && (values[0] === "write" || values[0] === "--write")) return "write";
+  if (values.length === 1 && (values[0] === "check" || values[0] === "--check")) return "check";
+  console.error("Usage: node Scripts/generate-llms.mjs [write|--write|check|--check]");
+  process.exit(2);
+}
 
 function allHtml(dir) {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -55,6 +55,10 @@ check_documentation_links() {
   node "${ROOT_DIR}/Scripts/check-documentation-links.mjs"
 }
 
+check_llms_index() {
+  node "${ROOT_DIR}/Scripts/generate-llms.mjs" --check
+}
+
 run_portable_checks() {
   check_codex_parser_hash
   check_package_product_paths
@@ -64,6 +68,7 @@ run_portable_checks() {
   check_swift_test_sharding
   check_ci_path_gate
   check_documentation_links
+  check_llms_index
   check_site_locales
 }
 


### PR DESCRIPTION
## Summary
- add check/write modes to `Scripts/generate-llms.mjs` while keeping the no-argument write behavior
- include the generated `docs/llms.txt` drift check in portable lint

## Why
`docs/llms.txt` is generated from the docs site, but lint did not verify that it matches the current HTML output. This keeps docs-site changes from leaving the generated index stale.

## Tests
- `node --check Scripts/generate-llms.mjs`
- `node Scripts/generate-llms.mjs --check`
- `bash -n Scripts/lint.sh`
- `git diff --check`
- `node Scripts/generate-llms.mjs --write`
- `node Scripts/generate-llms.mjs`
- `./Scripts/lint.sh lint-linux`

## Proof
```text
$ node Scripts/generate-llms.mjs --check
llms index OK: docs/llms.txt

$ node Scripts/generate-llms.mjs --write
wrote docs/llms.txt

$ node Scripts/generate-llms.mjs
wrote docs/llms.txt

$ git status --short
```

```text
$ ./Scripts/lint.sh lint-linux
Codex parser hash is current (800a06dead603ea7)
Package product path tests passed.
Package strip tests passed.
Release dSYM path tests passed.
Sparkle signing path tests passed.
Swift test sharding tests passed.
CI macOS path gate tests passed.
documentation links OK: 114 local links
llms index OK: docs/llms.txt
app/site locales OK: 21 locales, 50 site messages
==> Downloading SwiftLint 0.63.2
==> Installed lint tools to /Users/kiran/.openclaw/workspace/community-contributions/2026-06-22/CodexBar/.build/lint-tools/bin
0.63.2
Linting Swift files in current working directory
...
Done linting! Found 0 violations, 0 serious in 1171 files.
```

## Risk
Script-only. Default generator behavior still writes `docs/llms.txt`, and `--check` only compares the generated output with the checked-in file.

## Review focus
Please check the generator mode parsing and whether portable lint is the right place for this drift guard.