### PR TITLE
[security] fix(codex): keep OAuth auth.json private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Claude: pause background CLI usage probes briefly after rate limiting while keeping manual refresh available. Thanks @kiranmagic7!
+- Codex OAuth: publish refreshed `auth.json` credentials with private file permissions already applied. Thanks @Hinotoi-agent!
 
 ## 0.37.1 — 2026-06-21
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
@@ -139,6 +139,17 @@ public enum CodexOAuthCredentialsStore {
         let directory = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         try data.write(to: url, options: .atomic)
+        try self.applyPrivateFilePermissions(to: url)
+    }
+
+    private static func applyPrivateFilePermissions(to url: URL) throws {
+        #if os(macOS) || os(Linux)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o600))],
+            ofItemAtPath: url.path)
+        #else
+        _ = url
+        #endif
     }
 
     private static func parseLastRefresh(from raw: Any?) -> Date? {

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
@@ -1,3 +1,10 @@
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 import Foundation
 
 public struct CodexOAuthCredentials: Sendable {
@@ -138,18 +145,64 @@ public enum CodexOAuthCredentialsStore {
         let data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
         let directory = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        try data.write(to: url, options: .atomic)
-        try self.applyPrivateFilePermissions(to: url)
+        try self.writePrivateFile(data, to: url)
     }
 
-    private static func applyPrivateFilePermissions(to url: URL) throws {
-        #if os(macOS) || os(Linux)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: NSNumber(value: Int16(0o600))],
-            ofItemAtPath: url.path)
-        #else
-        _ = url
-        #endif
+    private static func writePrivateFile(
+        _ data: Data,
+        to url: URL,
+        beforePublish: ((URL) throws -> Void)? = nil) throws
+    {
+        let fileManager = FileManager.default
+        let stagedURL = url.deletingLastPathComponent().appendingPathComponent(
+            ".\(url.lastPathComponent).codexbar-staged-\(UUID().uuidString)",
+            isDirectory: false)
+        let stagedPath = stagedURL.path
+        let descriptor = stagedPath.withCString {
+            open($0, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, mode_t(0o600))
+        }
+        guard descriptor >= 0 else {
+            throw self.posixError(code: errno, path: stagedPath)
+        }
+
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        var handleIsOpen = true
+        do {
+            guard fchmod(descriptor, mode_t(0o600)) == 0 else {
+                throw self.posixError(code: errno, path: stagedPath)
+            }
+            try handle.write(contentsOf: data)
+            try handle.synchronize()
+            try handle.close()
+            handleIsOpen = false
+
+            try beforePublish?(stagedURL)
+            try self.renameItem(at: stagedURL, to: url)
+        } catch {
+            if handleIsOpen {
+                try? handle.close()
+            }
+            try? fileManager.removeItem(at: stagedURL)
+            throw error
+        }
+    }
+
+    private static func renameItem(at sourceURL: URL, to destinationURL: URL) throws {
+        let result = sourceURL.path.withCString { sourcePath in
+            destinationURL.path.withCString { destinationPath in
+                rename(sourcePath, destinationPath)
+            }
+        }
+        guard result == 0 else {
+            throw self.posixError(code: errno, path: destinationURL.path)
+        }
+    }
+
+    private static func posixError(code: Int32, path: String) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(code),
+            userInfo: [NSFilePathErrorKey: path])
     }
 
     private static func parseLastRefresh(from raw: Any?) -> Date? {
@@ -181,6 +234,14 @@ public enum CodexOAuthCredentialsStore {
 extension CodexOAuthCredentialsStore {
     static func _authFileURLForTesting(env: [String: String]) -> URL {
         self.authFilePath(env: env)
+    }
+
+    static func _writePrivateFileForTesting(
+        _ data: Data,
+        to url: URL,
+        beforePublish: @escaping (URL) throws -> Void) throws
+    {
+        try self.writePrivateFile(data, to: url, beforePublish: beforePublish)
     }
 }
 #endif

--- a/Tests/CodexBarTests/CodexOAuthCredentialsStorePermissionsTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthCredentialsStorePermissionsTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct CodexOAuthCredentialsStorePermissionsTests {
+    private enum PublishProbeError: Error, Equatable {
+        case stop
+    }
+
+    @Test
+    func `saving O auth credentials keeps auth json private`() throws {
+        #if os(macOS) || os(Linux)
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-oauth-permissions-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+
+        let credentials = CodexOAuthCredentials(
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            idToken: "id-token",
+            accountId: "account-123",
+            lastRefresh: Date())
+
+        try CodexOAuthCredentialsStore.save(credentials, env: ["CODEX_HOME": codexHome.path])
+
+        let authURL = codexHome.appendingPathComponent("auth.json")
+        let attributes = try FileManager.default.attributesOfItem(atPath: authURL.path)
+        let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+        #expect(permissions.intValue & 0o777 == 0o600)
+        #else
+        #expect(Bool(true))
+        #endif
+    }
+
+    @Test
+    func `auth json is private before atomic publication`() throws {
+        #if os(macOS) || os(Linux)
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-oauth-staging-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+
+        let authURL = codexHome.appendingPathComponent("auth.json")
+        let originalData = Data("original".utf8)
+        try originalData.write(to: authURL)
+
+        #expect(throws: PublishProbeError.stop) {
+            try CodexOAuthCredentialsStore._writePrivateFileForTesting(
+                Data("replacement".utf8),
+                to: authURL)
+            { stagedURL in
+                let attributes = try FileManager.default.attributesOfItem(atPath: stagedURL.path)
+                let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+                #expect(permissions.intValue & 0o777 == 0o600)
+                #expect(try Data(contentsOf: authURL) == originalData)
+                throw PublishProbeError.stop
+            }
+        }
+
+        #expect(try Data(contentsOf: authURL) == originalData)
+        let entries = try FileManager.default.contentsOfDirectory(atPath: codexHome.path)
+        #expect(entries == ["auth.json"])
+        #else
+        #expect(Bool(true))
+        #endif
+    }
+}

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -78,31 +78,6 @@ struct CodexOAuthTests {
     }
 
     @Test
-    func `saving O auth credentials keeps auth json private`() throws {
-        #if os(macOS) || os(Linux)
-        let codexHome = FileManager.default.temporaryDirectory
-            .appendingPathComponent("codex-oauth-permissions-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: codexHome) }
-
-        let credentials = CodexOAuthCredentials(
-            accessToken: "access-token",
-            refreshToken: "refresh-token",
-            idToken: "id-token",
-            accountId: "account-123",
-            lastRefresh: Date())
-
-        try CodexOAuthCredentialsStore.save(credentials, env: ["CODEX_HOME": codexHome.path])
-
-        let authURL = codexHome.appendingPathComponent("auth.json")
-        let attributes = try FileManager.default.attributesOfItem(atPath: authURL.path)
-        let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
-        #expect(permissions.intValue & 0o777 == 0o600)
-        #else
-        #expect(Bool(true))
-        #endif
-    }
-
-    @Test
     func `decodes credits balance string`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -78,6 +78,31 @@ struct CodexOAuthTests {
     }
 
     @Test
+    func `saving O auth credentials keeps auth json private`() throws {
+        #if os(macOS) || os(Linux)
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-oauth-permissions-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+
+        let credentials = CodexOAuthCredentials(
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            idToken: "id-token",
+            accountId: "account-123",
+            lastRefresh: Date())
+
+        try CodexOAuthCredentialsStore.save(credentials, env: ["CODEX_HOME": codexHome.path])
+
+        let authURL = codexHome.appendingPathComponent("auth.json")
+        let attributes = try FileManager.default.attributesOfItem(atPath: authURL.path)
+        let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+        #expect(permissions.intValue & 0o777 == 0o600)
+        #else
+        #expect(Bool(true))
+        #endif
+    }
+
+    @Test
     func `decodes credits balance string`() throws {
         let json = """
         {

--- a/TestsLinux/CodexOAuthCredentialsStoreLinuxTests.swift
+++ b/TestsLinux/CodexOAuthCredentialsStoreLinuxTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite
+struct CodexOAuthCredentialsStoreLinuxTests {
+    @Test
+    func saveKeepsAuthJSONPrivate() throws {
+        #if os(macOS) || os(Linux)
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-oauth-permissions-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+
+        let credentials = CodexOAuthCredentials(
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            idToken: "id-token",
+            accountId: "account-123",
+            lastRefresh: Date())
+
+        try CodexOAuthCredentialsStore.save(credentials, env: ["CODEX_HOME": codexHome.path])
+
+        let authURL = codexHome.appendingPathComponent("auth.json")
+        let attributes = try FileManager.default.attributesOfItem(atPath: authURL.path)
+        let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+        #expect(permissions.intValue & 0o777 == 0o600)
+        #else
+        #expect(Bool(true))
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
This PR hardens Codex OAuth credential persistence by ensuring `auth.json` is rewritten with private file permissions after atomic saves.

- Sets `0600` on `$CODEX_HOME/auth.json` / `~/.codex/auth.json` after `CodexOAuthCredentialsStore.save` performs its atomic write.
- Adds macOS and Linux regression coverage so future rewrites keep OAuth credentials private.
- Adds Linux test-target coverage so the permission behavior is validated in container-backed CI as well as the macOS test suite.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Codex OAuth `auth.json` can be rewritten with world-readable permissions | Local users who can traverse the Codex home path may read Codex OAuth access, refresh, and ID tokens | Medium |

## Before this PR

- `CodexOAuthCredentialsStore.save` wrote OAuth credentials with `Data.write(to:options: .atomic)`.
- The save path did not restore private POSIX permissions after the atomic replacement.
- Under a normal `umask 022`, the rewritten `auth.json` could be created as `0644`.
- Existing tests covered parsing and usage mapping, but not the file mode of the credential rewrite path.

## After this PR

- `CodexOAuthCredentialsStore.save` applies `0600` after each atomic write on macOS/Linux.
- The private-file behavior is covered in the existing macOS Codex OAuth tests.
- The same behavior is covered in the Linux test target for container-backed validation.

## Why this matters

Codex OAuth credentials include bearer-style access tokens, refresh tokens, optional ID tokens, and account metadata. These are sensitive authentication artifacts and should not become group- or world-readable after a routine refresh or account-selection save.

This is a local credential exposure issue rather than a remote takeover: exploitation requires local filesystem read access to the affected Codex home path. The impact is still meaningful because the exposed file contains reusable OAuth tokens.

## Attack flow

```text
Local user can read the victim's Codex home path
    -> CodexBar refreshes or rewrites Codex OAuth credentials
        -> atomic rewrite creates auth.json with process umask-derived mode
            -> auth.json may be 0644
                -> local user can read Codex OAuth tokens
```

## Affected code

| Issue | Files |
|-------|-------|
| Codex OAuth credential file permissions | `Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift` |

## Root cause

Codex OAuth `auth.json` permissions:
- Direct cause: the credential store used an atomic file replacement but did not apply a private mode afterward.
- Boundary failure: sensitive token persistence relied on the process umask instead of explicitly enforcing the credential-file invariant.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Codex OAuth `auth.json` can be rewritten world-readable | 5.5 Medium | `CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:N/A:N` |

Rationale:
- The affected asset is highly sensitive OAuth token material.
- The demonstrated attacker condition is local filesystem access, not remote reachability.
- The impact is confidentiality-only for the credential file contents.

## Safe reproduction steps

1. Use a normal permissive umask such as `022`.
2. Configure `CODEX_HOME` to point at a temporary directory.
3. Trigger `CodexOAuthCredentialsStore.save` with placeholder OAuth credentials.
4. Observe the pre-patch `auth.json` mode can be `0644` after the atomic rewrite.
5. Apply this PR and repeat the save.
6. Observe `auth.json` is `0600`.

No real tokens are required for the proof; the regression tests use placeholder values.

## Expected vulnerable behavior

- Pre-patch: an OAuth credential rewrite could leave `auth.json` readable by group/other users according to the process umask.
- Post-patch: the same rewrite leaves `auth.json` readable and writable only by the current user.

## Changes in this PR

- Adds `applyPrivateFilePermissions(to:)` and calls it after `CodexOAuthCredentialsStore.save` writes `auth.json`.
- Adds a macOS Swift Testing regression in `CodexOAuthTests`.
- Adds the same regression to `TestsLinux` so Linux/container validation covers the permission invariant.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Credential persistence | `Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift` | Applies `0600` after atomic credential writes |
| macOS tests | `Tests/CodexBarTests/CodexOAuthTests.swift` | Verifies saved Codex OAuth credentials use private permissions |
| Linux tests | `TestsLinux/CodexOAuthCredentialsStoreLinuxTests.swift` | Adds container-friendly regression coverage for the same invariant |

## Maintainer impact

- The patch is limited to Codex OAuth credential persistence and tests.
- It does not change token format, account selection, refresh behavior, or parsing semantics.
- The only compatibility change is that saved `auth.json` files become private after CodexBar rewrites them, matching the expected handling for sensitive credentials.

## Fix rationale

The credential store is the right boundary because every CodexBar rewrite of `auth.json` passes through this save path. Applying the file mode immediately after the atomic write ensures the final path has the intended permissions even when the temporary replacement file inherited a permissive mode from the current umask.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Docker/container focused Linux regression: `swift test --filter CodexOAuthCredentialsStoreLinuxTests/saveKeepsAuthJSONPrivate`
- [x] macOS CI test shards completed successfully: `swift-test-macos (0, 4)`, `(1, 4)`, `(2, 4)`, `(3, 4)`
- [x] macOS runtime proof using a temporary `CODEX_HOME` and the real `CodexOAuthCredentialsStore.save` API shows `auth.json` mode `0600`
- [x] `git diff --check`

Executed with:

```bash
docker run --rm -v "$PWD:/work" -w /work swift:6.2-noble bash -lc '
  set -e
  apt-get update >/dev/null
  apt-get install -y libsqlite3-dev >/dev/null
  swift test --filter CodexOAuthCredentialsStoreLinuxTests/saveKeepsAuthJSONPrivate
'

git diff --check
```

GitHub CI covered the macOS test path for this PR head (`2b697bbb527e`):

```text
swift-test-macos (0, 4): pass
swift-test-macos (1, 4): pass
swift-test-macos (2, 4): pass
swift-test-macos (3, 4): pass
```

The local focused macOS test command was also attempted:

```bash
swift test --filter CodexOAuthTests/saving_O_auth_credentials_keeps_auth_json_private
```

On my local machine, that command still fails before reaching the Codex OAuth test because the checked-out `KeyboardShortcuts` dependency fails to compile its SwiftUI `#Preview` macros (`PreviewsMacros` plugin not found). The same macOS test path is covered by the passing GitHub macOS CI shards above.

## After-fix runtime proof

I also ran a standalone macOS proof package against this PR head. It imports the real `CodexBarCore` product, creates a temporary `CODEX_HOME`, calls `CodexOAuthCredentialsStore.save` with placeholder credentials under `umask 022`, and inspects the resulting file mode.

Command:

```bash
CODEXBAR_PROOF_HEAD=$(git rev-parse --short=12 HEAD)   swift run --package-path /tmp/codexbar-auth-mode-proof CodexBarAuthModeProof
```

Redacted terminal output:

```text
CodexBar auth.json after-fix runtime proof
repo_head: 2b697bbb527e
umask: 022
operation: CodexOAuthCredentialsStore.save(..., env: [CODEX_HOME: <temp>/codexhome])
auth_json_path: <temp>/codexhome/auth.json
auth_json_mode: 600
auth_json_size: 238 bytes
redacted_auth_json:
{
  "last_refresh" : "2026-06-22T02:25:21Z",
  "tokens" : {
    "access_token" : "<redacted-access-token>",
    "account_id" : "acct_redacted",
    "id_token" : "<redacted-id-token>",
    "refresh_token" : "<redacted-refresh-token>"
  }
}
```

## Disclosure notes

- This PR is scoped to a local credential-file confidentiality issue.
- It does not claim remote exploitability or code execution.
- No real OAuth tokens are used in the tests or reproduction steps.
- No unrelated provider behavior is changed.
