### PR TITLE
serve: report build version on /health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Diagnostics: write redacted provider reports to a file with platform and app-version context. Thanks @Yuxin-Qiao!
+- CLI server: report the startup build version from `/health` so clients can detect stale helper processes after updates. Thanks @enieuwy!
 
 ### Fixed
 - Claude: pause background CLI usage probes briefly after rate limiting while keeping manual refresh available. Thanks @kiranmagic7!

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -61,7 +61,7 @@ private struct ServeErrorPayload: Encodable {
     let error: String
 }
 
-struct ServeHealthPayload: Encodable {
+private struct ServeHealthPayload: Encodable {
     let status: String
     let version: String?
 

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -61,8 +61,20 @@ private struct ServeErrorPayload: Encodable {
     let error: String
 }
 
-private struct ServeHealthPayload: Encodable {
+struct ServeHealthPayload: Encodable {
     let status: String
+    let version: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case status
+        case version
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.status, forKey: .status)
+        try container.encodeIfPresent(self.version, forKey: .version)
+    }
 }
 
 struct CLIServeConfigSnapshot {
@@ -524,7 +536,7 @@ extension CodexBarCLI {
 
         switch route {
         case .health:
-            return Self.serveJSON(ServeHealthPayload(status: "ok"))
+            return Self.serveHealthResponse(version: Self.serveHealthVersion)
         case let .usage(provider):
             let snapshot: CLIServeConfigSnapshot
             do {
@@ -767,6 +779,12 @@ extension CodexBarCLI {
             throw CLIServeArgumentError.invalidProvider(rawProvider)
         }
         return selection
+    }
+
+    private static let serveHealthVersion: String? = currentVersion()
+
+    static func serveHealthResponse(version: String?) -> CLILocalHTTPResponse {
+        self.serveJSON(ServeHealthPayload(status: "ok", version: version))
     }
 
     private static func serveJSON(

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -82,6 +82,14 @@ struct CLIServeConfigSnapshot {
     let cacheToken: String
 }
 
+private struct ServeRuntime: Sendable {
+    let configStore: CodexBarConfigStore
+    let cache: CLIServeResponseCache
+    let refreshInterval: TimeInterval
+    let requestTimeout: TimeInterval
+    let healthVersion: String?
+}
+
 private final class CLIServeDeadlineState: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<CLILocalHTTPResponse, Never>?
@@ -444,15 +452,18 @@ extension CodexBarCLI {
                 kind: .args)
         }
 
-        let configStore = CodexBarConfigStore()
-        let cache = CLIServeResponseCache()
+        // Resolve the running build version once, at startup, before an in-place
+        // app/tarball update can replace the on-disk binary. Resolving it lazily
+        // per request would let a stale serve report the newly installed version
+        // and defeat the client stale-process detection this field exists for.
+        let runtime = ServeRuntime(
+            configStore: CodexBarConfigStore(),
+            cache: CLIServeResponseCache(),
+            refreshInterval: refreshInterval,
+            requestTimeout: requestTimeout,
+            healthVersion: Self.currentVersion())
         let server = CLILocalHTTPServer(host: "127.0.0.1", port: port) { request in
-            await Self.handleServeRequest(
-                request,
-                configStore: configStore,
-                cache: cache,
-                refreshInterval: refreshInterval,
-                requestTimeout: requestTimeout)
+            await Self.handleServeRequest(request, runtime: runtime)
         }
         let signalMonitor = CLITerminationSignalMonitor { _ in
             TTYCommandRunner.terminateActiveProcessesForAppShutdown()
@@ -517,10 +528,7 @@ extension CodexBarCLI {
 
     private static func handleServeRequest(
         _ request: CLILocalHTTPRequest,
-        configStore: CodexBarConfigStore,
-        cache: CLIServeResponseCache,
-        refreshInterval: TimeInterval,
-        requestTimeout: TimeInterval) async -> CLILocalHTTPResponse
+        runtime: ServeRuntime) async -> CLILocalHTTPResponse
     {
         let route: CLIServeRoute
         do {
@@ -536,37 +544,37 @@ extension CodexBarCLI {
 
         switch route {
         case .health:
-            return Self.serveHealthResponse(version: Self.serveHealthVersion)
+            return Self.serveHealthResponse(version: runtime.healthVersion)
         case let .usage(provider):
             let snapshot: CLIServeConfigSnapshot
             do {
-                snapshot = try Self.loadServeConfigSnapshot(configStore: configStore)
+                snapshot = try Self.loadServeConfigSnapshot(configStore: runtime.configStore)
             } catch {
                 return Self.serveError(status: .internalServerError, message: error.localizedDescription)
             }
             return await Self.cachedServeResponse(
                 key: Self.serveCacheKey(kind: "usage", provider: provider, configToken: snapshot.cacheToken),
-                cache: cache,
-                refreshInterval: refreshInterval,
-                requestTimeout: requestTimeout)
+                cache: runtime.cache,
+                refreshInterval: runtime.refreshInterval,
+                requestTimeout: runtime.requestTimeout)
             {
                 await Self.serveUsage(
                     provider: provider,
                     config: snapshot.config,
-                    refreshInterval: refreshInterval)
+                    refreshInterval: runtime.refreshInterval)
             }
         case let .cost(provider):
             let snapshot: CLIServeConfigSnapshot
             do {
-                snapshot = try Self.loadServeConfigSnapshot(configStore: configStore)
+                snapshot = try Self.loadServeConfigSnapshot(configStore: runtime.configStore)
             } catch {
                 return Self.serveError(status: .internalServerError, message: error.localizedDescription)
             }
             return await Self.cachedServeResponse(
                 key: Self.serveCacheKey(kind: "cost", provider: provider, configToken: snapshot.cacheToken),
-                cache: cache,
-                refreshInterval: refreshInterval,
-                requestTimeout: requestTimeout)
+                cache: runtime.cache,
+                refreshInterval: runtime.refreshInterval,
+                requestTimeout: runtime.requestTimeout)
             {
                 await Self.serveCost(provider: provider, config: snapshot.config)
             }
@@ -780,8 +788,6 @@ extension CodexBarCLI {
         }
         return selection
     }
-
-    private static let serveHealthVersion: String? = currentVersion()
 
     static func serveHealthResponse(version: String?) -> CLILocalHTTPResponse {
         self.serveJSON(ServeHealthPayload(status: "ok", version: version))

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -88,6 +88,24 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `health response reports ok status and build version`() throws {
+        let response = CodexBarCLI.serveHealthResponse(version: "1.2.3")
+        #expect(response.status == .ok)
+        let object = try JSONSerialization.jsonObject(with: response.body) as? [String: Any]
+        #expect(object?["status"] as? String == "ok")
+        #expect(object?["version"] as? String == "1.2.3")
+    }
+
+    @Test
+    func `health response omits version detail when unavailable`() throws {
+        let response = CodexBarCLI.serveHealthResponse(version: nil)
+        #expect(response.status == .ok)
+        let object = try JSONSerialization.jsonObject(with: response.body) as? [String: Any]
+        #expect(object?["status"] as? String == "ok")
+        #expect(object?.keys.contains("version") == false)
+    }
+
+    @Test
     func `serve numeric options reject malformed values`() {
         #expect(CodexBarCLI.decodeServePort(from: ParsedValues(
             positional: [],

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,6 +55,7 @@ See `docs/configuration.md` for the schema.
   - Transient refresh failures fall back to the last good response for up to ten refresh intervals (minimum five minutes) so polling clients do not flicker between data and errors; disabled when `--refresh-interval 0`.
   - v1 binds to `127.0.0.1` only and rejects non-loopback `Host` headers. It does not expose remote bind, auth, CORS, TLS, or daemon mode.
   - Endpoints: `GET /health`, `GET /usage`, `GET /usage?provider=<id|both|all>`, `GET /cost`, `GET /cost?provider=<id|both|all>`.
+  - `GET /health` returns `{"status":"ok"}` plus a `version` field with the running build (e.g. `"0.37.2"`) when resolvable; clients can compare it against `codexbar --version` to detect a `serve` process still running an older binary after an update.
   - Codex usage responses include every visible Codex account, matching the menu bar switcher.
 - `codexbar cache clear` clears local CodexBar caches.
   - `--cookies` removes cached browser-cookie headers from the CodexBar Keychain cache.


### PR DESCRIPTION
## Summary
Add a `version` field to the `codexbar serve` `GET /health` response so polling clients can detect a `serve` process still running an older binary after an app update.

## Motivation
A long-running `codexbar serve` keeps executing its in-memory binary image even after the on-disk binary is replaced by an update. Clients that reuse any healthy listener on the port (probing `/health`) can keep talking to a stale helper indefinitely.

In practice this can produce a SecurityAgent prompt storm: after an update rewrites the `CodexBar Cache` keychain ACL to the new binary's code signature, an orphaned older `serve` no longer matches the ACL and triggers an allow/deny dialog on every poll-driven cookie-cache access.

`/health` previously returned only `{"status":"ok"}`, giving clients no way to tell which build is answering. A short-lived `codexbar --version` always reflects the on-disk build, so exposing the running build on `/health` lets clients compare the two and recycle a stale `serve`.

## Changes
- `GET /health` now returns `{"status":"ok","version":"<build>"}`. The version is resolved once at `serve` startup (via a `ServeRuntime` context) from the existing `currentVersion()` (VERSION file → containing `.app` Info.plist → bundle). It is omitted (not `null`) when unresolvable, keeping the response backward-compatible.
- Added `CLIServeRouterTests` coverage for the payload (version present and omitted cases).
- Documented the field in `docs/cli.md`.

## Review feedback addressed
Codex flagged that resolving the version via a lazily-initialized `static let` would evaluate it on the **first** `/health` request. If that request lands after an in-place update replaced the on-disk binary, a stale `serve` would read and report the *newly installed* version — matching `codexbar --version` and defeating the detection this field exists for.

Fixed in `72c14f6`: the version is now resolved **once at `serve` startup** and reused for every `/health` response, so a stale process always reports its own running build.

## Real behavior proof
Built `codexbar serve` (`swift build`), started it with an on-disk build version of `0.37.2-startup`, then changed the on-disk version to `9.99.9-onDiskUpdate` **before the first `/health`** (simulating an in-place update), and queried it:

```
# on-disk VERSION at startup: 0.37.2-startup
$ codexbar serve --port 8077 &
CodexBar server listening on http://127.0.0.1:8077

# on-disk VERSION changed to 9.99.9-onDiskUpdate (simulated in-place update)
$ curl -s http://127.0.0.1:8077/health
{"status":"ok","version":"0.37.2-startup"}
$ curl -s http://127.0.0.1:8077/health
{"status":"ok","version":"0.37.2-startup"}

$ codexbar --version
CodexBar 9.99.9-onDiskUpdate
```

`/health` reports the **startup** build (`0.37.2-startup`) while a fresh `codexbar --version` reports the **on-disk** build (`9.99.9-onDiskUpdate`), so a client comparing the two correctly detects the stale `serve` and recycles it. (Version strings above are synthetic test values written to the binary's adjacent `VERSION` file; `/health` does not touch providers or the keychain.)

## Testing
- `swift test --filter CLIServeRouterTests` — 38 tests pass.
- `make check` — 0 lint violations; doc-link, generated-llms-index, and locale checks pass.
