### PR TITLE
[codex] Refine Claude stacked account menu

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CodexBarCore
 import SwiftUI
 
@@ -215,6 +216,19 @@ extension UsageMenuCardView.Model {
 
         let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
         return Color(red: color.red, green: color.green, blue: color.blue)
+    }
+
+    static func stackedAccountProgressColor(for provider: UsageProvider, index: Int) -> Color {
+        guard index > 0 else { return self.progressColor(for: provider) }
+
+        let palette: [NSColor] = [
+            .systemBlue,
+            .systemGreen,
+            .systemPurple,
+            .systemPink,
+            .systemTeal,
+        ]
+        return Color(nsColor: palette[(index - 1) % palette.count])
     }
 
     static func rateWindowLabels(

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -803,6 +803,7 @@ extension UsageMenuCardView.Model {
         let quotaWarningThresholds: [QuotaWarningWindow: [Int]]
         let workDaysPerWeek: Int?
         let usesLiveSubtitle: Bool
+        let progressColorOverride: Color?
         let now: Date
 
         init(
@@ -831,6 +832,7 @@ extension UsageMenuCardView.Model {
             quotaWarningThresholds: [QuotaWarningWindow: [Int]] = [:],
             workDaysPerWeek: Int? = nil,
             usesLiveSubtitle: Bool = false,
+            progressColorOverride: Color? = nil,
             now: Date)
         {
             self.provider = provider
@@ -858,6 +860,7 @@ extension UsageMenuCardView.Model {
             self.quotaWarningThresholds = quotaWarningThresholds
             self.workDaysPerWeek = workDaysPerWeek
             self.usesLiveSubtitle = usesLiveSubtitle
+            self.progressColorOverride = progressColorOverride
             self.now = now
         }
     }
@@ -936,7 +939,7 @@ extension UsageMenuCardView.Model {
             providerCost: providerCost,
             tokenUsage: tokenUsage,
             placeholder: placeholder,
-            progressColor: Self.progressColor(for: input.provider))
+            progressColor: input.progressColorOverride ?? Self.progressColor(for: input.provider))
     }
 
     private static func usageNotes(input: Input) -> [String] {

--- a/Sources/CodexBar/ProviderRegistry.swift
+++ b/Sources/CodexBar/ProviderRegistry.swift
@@ -41,9 +41,13 @@ struct ProviderRegistry {
                         provider: provider,
                         settings: settings,
                         override: nil)
-                    let sourceMode = ProviderCatalog.implementation(for: provider)?
+                    let baseSourceMode = ProviderCatalog.implementation(for: provider)?
                         .sourceMode(context: ProviderSourceModeContext(provider: provider, settings: settings))
                         ?? .auto
+                    let sourceMode = ProviderTokenAccountSourceModeResolver.effectiveSourceMode(
+                        base: baseSourceMode,
+                        provider: provider,
+                        account: account)
                     let snapshot = Self.makeSettingsSnapshot(settings: settings, tokenOverride: nil)
                     let env = Self.makeEnvironment(
                         base: environmentBase,

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -239,9 +239,17 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                                 let email = await ClaudeCredentialResolver
                                     .fetchAccountEmail(accessToken: creds.accessToken)
                                 if let email, !seenEmails.insert(email).inserted { continue }
+                                let plan = ClaudePlan.fromOAuthCredentials(
+                                    subscriptionType: creds.subscriptionType,
+                                    rateLimitTier: creds.rateLimitTier)?.compactLoginMethod
+                                let label: String = switch (email, plan) {
+                                case let (email?, plan?): "\(email) · \(plan)"
+                                case let (email?, nil): email
+                                default: account.label
+                                }
                                 context.settings.addTokenAccount(
                                     provider: .claude,
-                                    label: email ?? account.label,
+                                    label: label,
                                     token: token,
                                     externalIdentifier: email ?? token)
                             }

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -214,10 +214,24 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                         style: .bordered,
                         isVisible: { true },
                         perform: {
+                            // Self-cleaning: drop our own previously auto-discovered
+                            // (source-pointer) accounts and re-add only the live ones,
+                            // so stale/revoked Keychain leftovers don't pile up.
+                            // Manually pasted accounts (raw tokens) are left untouched.
+                            for stale in context.settings.tokenAccounts(for: .claude)
+                                where stale.token.hasPrefix(ClaudeCredentialSource.descriptorPrefix)
+                            {
+                                context.settings.removeTokenAccount(provider: .claude, accountID: stale.id)
+                            }
                             let existing = Set(context.settings.tokenAccounts(for: .claude).map(\.token))
                             for account in ClaudeAccountDiscovery.discover() {
                                 let token = account.source.encodedTokenValue()
                                 guard !existing.contains(token) else { continue }
+                                // Only keep accounts whose credential actually
+                                // reads/refreshes — skips stale/revoked leftovers.
+                                guard (try? await ClaudeCredentialResolver
+                                    .resolveCredentials(from: account.source)) != nil
+                                else { continue }
                                 context.settings.addTokenAccount(
                                     provider: .claude,
                                     label: account.label,

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -199,6 +199,36 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                 actions: [],
                 isVisible: nil,
                 onActivate: nil),
+            ProviderSettingsFieldDescriptor(
+                id: "claude-discover-accounts",
+                title: "Multiple accounts",
+                subtitle: "Find your Claude Code logins (~/.claude*) and track each as a separate "
+                    + "account, refreshed independently.",
+                kind: .plain,
+                placeholder: nil,
+                binding: .constant(""),
+                actions: [
+                    ProviderSettingsActionDescriptor(
+                        id: "claude-discover-accounts-action",
+                        title: "Discover accounts",
+                        style: .bordered,
+                        isVisible: { true },
+                        perform: {
+                            let existing = Set(context.settings.tokenAccounts(for: .claude).map(\.token))
+                            for account in ClaudeAccountDiscovery.discover() {
+                                let token = account.source.encodedTokenValue()
+                                guard !existing.contains(token) else { continue }
+                                context.settings.addTokenAccount(
+                                    provider: .claude,
+                                    label: account.label,
+                                    token: token,
+                                    externalIdentifier: token)
+                            }
+                            await context.store.refreshProvider(.claude, allowDisabled: true)
+                        }),
+                ],
+                isVisible: nil,
+                onActivate: nil),
         ]
     }
 

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -224,19 +224,26 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                                 context.settings.removeTokenAccount(provider: .claude, accountID: stale.id)
                             }
                             let existing = Set(context.settings.tokenAccounts(for: .claude).map(\.token))
+                            var seenEmails = Set<String>()
                             for account in ClaudeAccountDiscovery.discover() {
                                 let token = account.source.encodedTokenValue()
                                 guard !existing.contains(token) else { continue }
                                 // Only keep accounts whose credential actually
                                 // reads/refreshes — skips stale/revoked leftovers.
-                                guard (try? await ClaudeCredentialResolver
-                                    .resolveCredentials(from: account.source)) != nil
+                                guard let creds = try? await ClaudeCredentialResolver
+                                    .resolveCredentials(from: account.source)
                                 else { continue }
+                                // Collapse duplicate Keychain slots of the SAME
+                                // login (one account in several config dirs) and
+                                // label by the real email.
+                                let email = await ClaudeCredentialResolver
+                                    .fetchAccountEmail(accessToken: creds.accessToken)
+                                if let email, !seenEmails.insert(email).inserted { continue }
                                 context.settings.addTokenAccount(
                                     provider: .claude,
-                                    label: account.label,
+                                    label: email ?? account.label,
                                     token: token,
-                                    externalIdentifier: token)
+                                    externalIdentifier: email ?? token)
                             }
                             await context.store.refreshProvider(.claude, allowDisabled: true)
                         }),

--- a/Sources/CodexBar/Providers/Claude/ClaudeSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeSettingsStore.swift
@@ -124,6 +124,12 @@ extension SettingsStore {
     }
 
     private func claudeCredentialRouting(account: ProviderTokenAccount?) -> ClaudeCredentialRouting {
+        // A multi-account source pointer is OAuth-backed; the real (refreshed)
+        // token is resolved at fetch time, so the snapshot just needs OAuth mode
+        // (empty placeholder token — it is not used as the bearer).
+        if let token = account?.token, ClaudeCredentialSource.parse(token).isRefreshableSource {
+            return .oauth(accessToken: "")
+        }
         let manualCookieHeader = account == nil ? self.claudeCookieHeader : nil
         return ClaudeCredentialRouting.resolve(
             tokenAccountToken: account?.token,

--- a/Sources/CodexBar/Providers/Shared/ProviderTokenAccountSourceModeResolver.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderTokenAccountSourceModeResolver.swift
@@ -1,0 +1,42 @@
+import CodexBarCore
+import Foundation
+
+enum ProviderTokenAccountSourceModeResolver {
+    static func effectiveSourceMode(
+        base: ProviderSourceMode,
+        provider: UsageProvider,
+        account: ProviderTokenAccount?) -> ProviderSourceMode
+    {
+        guard provider == .claude, let account else { return base }
+
+        let routing = self.claudeCredentialRouting(account: account)
+        if base == .auto {
+            if routing.adminAPIKey != nil { return .api }
+            return routing.isOAuth ? .oauth : base
+        }
+
+        guard base == .cli else { return base }
+
+        // Claude CLI usage is ambient to the active local CLI profile, so per-account
+        // CLI reads can duplicate whichever account is currently active in Claude Code.
+        switch routing {
+        case .adminAPIKey:
+            return .api
+        case .oauth:
+            return .oauth
+        case .webCookie:
+            return .web
+        case .none:
+            return base
+        }
+    }
+
+    private static func claudeCredentialRouting(account: ProviderTokenAccount) -> ClaudeCredentialRouting {
+        if ClaudeCredentialSource.parse(account.token).isRefreshableSource {
+            return .oauth(accessToken: "")
+        }
+        return ClaudeCredentialRouting.resolve(
+            tokenAccountToken: account.token,
+            manualCookieHeader: nil)
+    }
+}

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -17,11 +17,6 @@ extension StatusItemController {
         let label: String
         let primary: String
         let weekly: String?
-
-        var compactValue: String {
-            guard let weekly else { return self.primary }
-            return "\(self.primary)/\(weekly)"
-        }
     }
 
     private struct MenuBarQuotaText: Equatable {
@@ -1057,7 +1052,11 @@ extension StatusItemController {
     }
 
     private static func menuBarStatsDisplayText(_ segments: [MenuBarStatSegment]) -> String {
-        segments.map { "\($0.label) \($0.compactValue)" }.joined(separator: " · ")
+        let primaryRow = segments.map { "\($0.label) \($0.primary)" }.joined(separator: " · ")
+        guard segments.contains(where: { $0.weekly != nil }) else { return primaryRow }
+
+        let weeklyRow = segments.map { $0.weekly ?? "-" }.joined(separator: " · ")
+        return "5h \(primaryRow) / 7d \(weeklyRow)"
     }
 
     private static func menuBarStatsImage(
@@ -1070,8 +1069,9 @@ extension StatusItemController {
         let canvasHeight: CGFloat = 22
         let iconSize: CGFloat = 15
         let iconGap: CGFloat = 4
-        let segmentGap: CGFloat = 7
+        let segmentGap: CGFloat = 8
         let trailingPadding: CGFloat = 1
+        let showsWeeklyRow = segments.contains { $0.weekly != nil }
         let topAttributes: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: 10.5, weight: .semibold),
             .foregroundColor: NSColor.black,
@@ -1080,6 +1080,10 @@ extension StatusItemController {
             .font: NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .medium),
             .foregroundColor: NSColor.black.withAlphaComponent(0.86),
         ]
+        let rowLabelAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedDigitSystemFont(ofSize: 8.5, weight: .semibold),
+            .foregroundColor: NSColor.black.withAlphaComponent(0.72),
+        ]
         let segmentSizes = segments.map { segment -> (top: CGSize, bottom: CGSize, width: CGFloat) in
             let topText = Self.menuBarStatsTopText(segment)
             let bottomText = segment.weekly ?? ""
@@ -1087,7 +1091,15 @@ extension StatusItemController {
             let bottomSize = Self.menuBarStatsTextSize(bottomText, attributes: bottomAttributes)
             return (topSize, bottomSize, ceil(max(topSize.width, bottomSize.width)))
         }
+        let rowLabelWidth: CGFloat = showsWeeklyRow
+            ? ceil(max(
+                Self.menuBarStatsTextSize("5h", attributes: rowLabelAttributes).width,
+                Self.menuBarStatsTextSize("7d", attributes: rowLabelAttributes).width))
+            : 0
+        let rowLabelGap: CGFloat = showsWeeklyRow ? 4 : 0
         let segmentsWidth = segmentSizes.reduce(CGFloat(0)) { $0 + $1.width } +
+            rowLabelWidth +
+            rowLabelGap +
             segmentGap * CGFloat(max(0, segments.count - 1))
         let width = ceil(iconSize + iconGap + segmentsWidth + trailingPadding)
         let size = NSSize(width: width, height: canvasHeight)
@@ -1109,6 +1121,18 @@ extension StatusItemController {
             fraction: 1.0)
 
         var x = iconSize + iconGap
+        if showsWeeklyRow {
+            Self.drawMenuBarStatsText(
+                "5h",
+                at: CGPoint(x: x, y: 11),
+                attributes: rowLabelAttributes)
+            Self.drawMenuBarStatsText(
+                "7d",
+                at: CGPoint(x: x, y: 1.8),
+                attributes: rowLabelAttributes)
+            x += rowLabelWidth + rowLabelGap
+        }
+
         for (index, segment) in segments.enumerated() {
             if index > 0 {
                 x += segmentGap

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -10,6 +10,44 @@ extension StatusItemController {
     static let loadingAnimationPhaseIncrement: Double =
         2.7 / StatusItemController.loadingAnimationFPS
     private static let loadingAnimationMaxContinuousDuration: TimeInterval = 30.0
+    private static let menuBarStackedAccountDisplayLimit = 3
+    private static let menuBarWeeklyWindowMinutes = 7 * 24 * 60
+
+    private struct MenuBarStatSegment: Equatable {
+        let label: String
+        let primary: String
+        let weekly: String?
+
+        var compactValue: String {
+            guard let weekly else { return self.primary }
+            return "\(self.primary)/\(weekly)"
+        }
+    }
+
+    private struct MenuBarQuotaText: Equatable {
+        let primary: String
+        let weekly: String?
+
+        var stackedValue: String {
+            guard let weekly else { return self.primary }
+            return "\(String(self.primary.dropLast()))(\(String(weekly.dropLast())))%"
+        }
+    }
+
+    private struct MergedBrandPercentIconInput {
+        let provider: UsageProvider
+        let snapshot: UsageSnapshot?
+        let brand: NSImage
+        let style: IconStyle
+        let primary: Double?
+        let weekly: Double?
+        let credits: Double?
+        let stale: Bool
+        let statusIndicator: ProviderStatusIndicator
+        let warningFlash: Bool
+        let needsAnimation: Bool
+    }
+
     func needsMenuBarIconAnimation() -> Bool {
         if self.shouldMergeIcons {
             let primaryProvider = self.primaryProviderForUnifiedIcon()
@@ -297,33 +335,20 @@ extension StatusItemController {
         if showBrandPercent,
            let brand = ProviderBrandIcon.image(for: primaryProvider)
         {
-            let displayText = self.menuBarDisplayText(for: primaryProvider, snapshot: snapshot)
-            let signature = [
-                "mode=brandPercent",
-                "provider=\(primaryProvider.rawValue)",
-                "style=\(String(describing: style))",
-                "primary=\(Self.iconSignatureValue(primary))",
-                "weekly=\(Self.iconSignatureValue(weekly))",
-                "credits=\(Self.iconSignatureValue(credits))",
-                "stale=\(stale ? "1" : "0")",
-                "status=\(statusIndicator.rawValue)",
-                "text=\(displayText ?? "nil")",
-                "warningFlash=\(warningFlash ? "1" : "0")",
-                "anim=\(needsAnimation ? "1" : "0")",
-                "hideCritters=\(self.settings.menuBarHidesCritters ? "1" : "0")",
-            ].joined(separator: "|")
-            if self.shouldSkipMergedIconRender(signature) {
-                // AppKit can lose button title/image-position state independently of the cached render signature.
-                // Keep the cheap title path self-healing even when the icon image itself can be skipped.
-                self.setButtonTitle(displayText, for: button)
-                self.noteIconPerfRender(skipped: true)
-                return true
-            }
-            self.setButtonImage(
-                warningFlash ? Self.quotaWarningFlashImage(base: brand) : brand, for: button)
-            self.setButtonTitle(displayText, for: button)
-            self.noteIconPerfRender(skipped: false)
-            return false
+            return self.applyMergedBrandPercentIcon(
+                input: MergedBrandPercentIconInput(
+                    provider: primaryProvider,
+                    snapshot: snapshot,
+                    brand: brand,
+                    style: style,
+                    primary: primary,
+                    weekly: weekly,
+                    credits: credits,
+                    stale: stale,
+                    statusIndicator: statusIndicator,
+                    warningFlash: warningFlash,
+                    needsAnimation: needsAnimation),
+                button: button)
         }
 
         self.setButtonTitle(nil, for: button)
@@ -382,6 +407,56 @@ extension StatusItemController {
                 hideCritters: self.settings.menuBarHidesCritters)
             self.setButtonImage(
                 warningFlash ? Self.quotaWarningFlashImage(base: image) : image, for: button)
+        }
+        self.noteIconPerfRender(skipped: false)
+        return false
+    }
+
+    private func applyMergedBrandPercentIcon(input: MergedBrandPercentIconInput, button: NSStatusBarButton) -> Bool {
+        let displaySegments = self.mergedCodexAndClaudeMenuBarDisplaySegments(
+            provider: input.provider,
+            snapshot: input.snapshot)
+        let displayText = displaySegments.map(Self.menuBarStatsDisplayText)
+            ?? self.menuBarDisplayText(for: input.provider, snapshot: input.snapshot)
+        let signature = [
+            "mode=brandPercent",
+            "provider=\(input.provider.rawValue)",
+            "style=\(String(describing: input.style))",
+            "primary=\(Self.iconSignatureValue(input.primary))",
+            "weekly=\(Self.iconSignatureValue(input.weekly))",
+            "credits=\(Self.iconSignatureValue(input.credits))",
+            "stale=\(input.stale ? "1" : "0")",
+            "status=\(input.statusIndicator.rawValue)",
+            "text=\(displayText ?? "nil")",
+            "warningFlash=\(input.warningFlash ? "1" : "0")",
+            "anim=\(input.needsAnimation ? "1" : "0")",
+            "hideCritters=\(self.settings.menuBarHidesCritters ? "1" : "0")",
+        ].joined(separator: "|")
+        let displayBrand = input.warningFlash ? Self.quotaWarningFlashImage(base: input.brand) : input.brand
+
+        if self.shouldSkipMergedIconRender(signature) {
+            if let displaySegments {
+                self.setButtonStatsImageIfNeeded(
+                    displaySegments,
+                    brand: displayBrand,
+                    for: button,
+                    force: button.image == nil)
+            } else {
+                self.setButtonTitle(displayText, for: button)
+            }
+            self.noteIconPerfRender(skipped: true)
+            return true
+        }
+
+        if let displaySegments {
+            self.setButtonStatsImageIfNeeded(
+                displaySegments,
+                brand: displayBrand,
+                for: button,
+                force: true)
+        } else {
+            self.setButtonImage(displayBrand, for: button)
+            self.setButtonTitle(displayText, for: button)
         }
         self.noteIconPerfRender(skipped: false)
         return false
@@ -662,12 +737,49 @@ extension StatusItemController {
         }
     }
 
+    private func setButtonStatsImageIfNeeded(
+        _ segments: [MenuBarStatSegment],
+        brand: NSImage,
+        for button: NSStatusBarButton,
+        force: Bool)
+    {
+        if force {
+            self.setButtonImage(Self.menuBarStatsImage(segments, brand: brand), for: button)
+        }
+        self.clearButtonTitle(for: button)
+        if button.imagePosition != .imageOnly {
+            button.imagePosition = .imageOnly
+        }
+    }
+
+    private func clearButtonTitle(for button: NSStatusBarButton) {
+        if !button.title.isEmpty {
+            button.title = ""
+        }
+        if button.attributedTitle.length > 0 {
+            button.attributedTitle = NSAttributedString(string: "")
+        }
+    }
+
     nonisolated static func buttonTitle(_ title: String?, hasImage: Bool) -> String {
         guard let title, !title.isEmpty else { return "" }
         return hasImage ? " \(title)" : title
     }
 
     func menuBarDisplayText(for provider: UsageProvider, snapshot: UsageSnapshot?) -> String? {
+        if let mergedText = self.mergedCodexAndClaudeMenuBarDisplayText(
+            provider: provider,
+            snapshot: snapshot)
+        {
+            return mergedText
+        }
+        if let stackedText = self.stackedAccountsMenuBarDisplayText(for: provider) {
+            return stackedText
+        }
+        return self.singleAccountMenuBarDisplayText(for: provider, snapshot: snapshot)
+    }
+
+    private func singleAccountMenuBarDisplayText(for provider: UsageProvider, snapshot: UsageSnapshot?) -> String? {
         let mode = self.settings.menuBarDisplayMode
         if provider == .openrouter,
            self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .automatic,
@@ -787,6 +899,261 @@ extension StatusItemController {
             percentWindow: percentWindow,
             pace: pace,
             showUsed: self.settings.usageBarsShowUsed)
+    }
+
+    private func mergedCodexAndClaudeMenuBarDisplayText(provider: UsageProvider, snapshot: UsageSnapshot?) -> String? {
+        self.mergedCodexAndClaudeMenuBarDisplaySegments(provider: provider, snapshot: snapshot)
+            .map(Self.menuBarStatsDisplayText)
+    }
+
+    private func mergedCodexAndClaudeMenuBarDisplaySegments(
+        provider: UsageProvider,
+        snapshot: UsageSnapshot?)
+        -> [MenuBarStatSegment]?
+    {
+        guard self.shouldMergeIcons,
+              self.settings.multiAccountMenuLayout == .stacked,
+              provider == .codex || provider == .claude
+        else {
+            return nil
+        }
+
+        let enabledProviders = self.store.enabledProvidersForDisplay()
+        guard enabledProviders.contains(.codex),
+              enabledProviders.contains(.claude)
+        else {
+            return nil
+        }
+
+        let codexSnapshot = provider == .codex ? snapshot : self.store.snapshot(for: .codex)
+        guard let codexSnapshot,
+              let codexQuota = self.stackedAccountMenuBarQuotaText(for: .codex, snapshot: codexSnapshot)
+        else {
+            return nil
+        }
+
+        let claudeQuotas = self.stackedAccountMenuBarQuotaTexts(
+            for: .claude,
+            limit: Self.menuBarStackedAccountDisplayLimit - 1)
+        guard !claudeQuotas.isEmpty else { return nil }
+
+        let claudeSegments = claudeQuotas.enumerated().map { index, quota in
+            MenuBarStatSegment(label: "C\(index + 1)", primary: quota.primary, weekly: quota.weekly)
+        }
+        return [MenuBarStatSegment(label: "Codex", primary: codexQuota.primary, weekly: codexQuota.weekly)] +
+            claudeSegments
+    }
+
+    private func stackedAccountsMenuBarDisplayText(for provider: UsageProvider) -> String? {
+        let accountTexts = self.stackedAccountMenuBarDisplayTexts(
+            for: provider,
+            limit: Self.menuBarStackedAccountDisplayLimit)
+        guard accountTexts.count > 1 else { return nil }
+        return accountTexts.joined(separator: " · ")
+    }
+
+    private func stackedAccountMenuBarDisplayTexts(for provider: UsageProvider, limit: Int) -> [String] {
+        self.stackedAccountMenuBarQuotaTexts(for: provider, limit: limit).map(\.stackedValue)
+    }
+
+    private func stackedAccountMenuBarQuotaTexts(for provider: UsageProvider, limit: Int) -> [MenuBarQuotaText] {
+        guard self.settings.multiAccountMenuLayout == .stacked else { return [] }
+        guard TokenAccountSupportCatalog.support(for: provider) != nil else { return [] }
+        let accounts = self.settings.tokenAccounts(for: provider)
+        guard accounts.count > 1 else { return [] }
+
+        let displayAccounts = Self.menuBarDisplayAccounts(
+            accounts,
+            selected: self.settings.selectedTokenAccount(for: provider),
+            limit: limit)
+        var snapshotsByAccountID: [UUID: TokenAccountUsageSnapshot] = [:]
+        for snapshot in self.store.accountSnapshots[provider] ?? [] {
+            snapshotsByAccountID[snapshot.account.id] = snapshot
+        }
+        return displayAccounts
+            .prefix(limit)
+            .compactMap { account -> MenuBarQuotaText? in
+                guard let snapshot = snapshotsByAccountID[account.id]?.snapshot else { return nil }
+                return self.stackedAccountMenuBarQuotaText(for: provider, snapshot: snapshot)
+            }
+    }
+
+    private func stackedAccountMenuBarDisplayText(for provider: UsageProvider, snapshot: UsageSnapshot) -> String? {
+        self.stackedAccountMenuBarQuotaText(for: provider, snapshot: snapshot)?.stackedValue
+    }
+
+    private func stackedAccountMenuBarQuotaText(
+        for provider: UsageProvider,
+        snapshot: UsageSnapshot)
+        -> MenuBarQuotaText?
+    {
+        let baseText = self.singleAccountMenuBarDisplayText(
+            for: provider,
+            snapshot: snapshot)
+        guard self.settings.menuBarDisplayMode == .percent,
+              let baseText,
+              baseText.hasSuffix("%"),
+              !baseText.contains("·"),
+              let weeklyWindow = self.stackedAccountWeeklyWindow(for: provider, snapshot: snapshot)
+        else {
+            return baseText.map { MenuBarQuotaText(primary: $0, weekly: nil) }
+        }
+
+        let weeklyPercent = Self.compactPercentNumber(
+            window: weeklyWindow,
+            showUsed: self.settings.usageBarsShowUsed)
+        return MenuBarQuotaText(primary: baseText, weekly: "\(weeklyPercent)%")
+    }
+
+    private func stackedAccountWeeklyWindow(for provider: UsageProvider, snapshot: UsageSnapshot) -> RateWindow? {
+        if provider == .codex {
+            let projection = self.store.codexConsumerProjectionIfNeeded(
+                for: provider,
+                surface: .menuBar,
+                snapshotOverride: snapshot,
+                now: snapshot.updatedAt)
+            if let weekly = projection?.rateWindow(for: .weekly) {
+                return weekly
+            }
+        }
+
+        let standardWindows = [
+            snapshot.secondary,
+            snapshot.tertiary,
+            snapshot.primary,
+        ]
+        if let weekly = standardWindows.compactMap(\.self).first(where: Self.isWeeklyWindow) {
+            return weekly
+        }
+        return snapshot.extraRateWindows?
+            .first { $0.usageKnown && Self.isWeeklyWindow($0.window) }?
+            .window
+    }
+
+    private static func isWeeklyWindow(_ window: RateWindow) -> Bool {
+        guard let minutes = window.windowMinutes else { return false }
+        return abs(minutes - Self.menuBarWeeklyWindowMinutes) <= 10
+    }
+
+    private static func compactPercentNumber(window: RateWindow, showUsed: Bool) -> String {
+        let percent = showUsed ? window.usedPercent : window.remainingPercent
+        let clamped = min(100, max(0, percent))
+        return String(format: "%.0f", clamped)
+    }
+
+    private static func menuBarDisplayAccounts(
+        _ accounts: [ProviderTokenAccount],
+        selected: ProviderTokenAccount?,
+        limit: Int) -> [ProviderTokenAccount]
+    {
+        guard limit > 0 else { return [] }
+        if accounts.count <= limit { return accounts }
+        var limited = Array(accounts.prefix(limit))
+        if let selected, !limited.contains(where: { $0.id == selected.id }) {
+            limited.removeLast()
+            limited.append(selected)
+        }
+        return limited
+    }
+
+    private static func menuBarStatsDisplayText(_ segments: [MenuBarStatSegment]) -> String {
+        segments.map { "\($0.label) \($0.compactValue)" }.joined(separator: " · ")
+    }
+
+    private static func menuBarStatsImage(
+        _ segments: [MenuBarStatSegment],
+        brand: NSImage)
+        -> NSImage
+    {
+        guard !segments.isEmpty else { return brand }
+
+        let canvasHeight: CGFloat = 22
+        let iconSize: CGFloat = 15
+        let iconGap: CGFloat = 4
+        let segmentGap: CGFloat = 7
+        let trailingPadding: CGFloat = 1
+        let topAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 10.5, weight: .semibold),
+            .foregroundColor: NSColor.black,
+        ]
+        let bottomAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .medium),
+            .foregroundColor: NSColor.black.withAlphaComponent(0.86),
+        ]
+        let segmentSizes = segments.map { segment -> (top: CGSize, bottom: CGSize, width: CGFloat) in
+            let topText = Self.menuBarStatsTopText(segment)
+            let bottomText = segment.weekly ?? ""
+            let topSize = Self.menuBarStatsTextSize(topText, attributes: topAttributes)
+            let bottomSize = Self.menuBarStatsTextSize(bottomText, attributes: bottomAttributes)
+            return (topSize, bottomSize, ceil(max(topSize.width, bottomSize.width)))
+        }
+        let segmentsWidth = segmentSizes.reduce(CGFloat(0)) { $0 + $1.width } +
+            segmentGap * CGFloat(max(0, segments.count - 1))
+        let width = ceil(iconSize + iconGap + segmentsWidth + trailingPadding)
+        let size = NSSize(width: width, height: canvasHeight)
+        let image = NSImage(size: size)
+
+        image.lockFocus()
+        NSColor.clear.setFill()
+        NSRect(origin: .zero, size: size).fill()
+
+        let iconRect = NSRect(
+            x: 0,
+            y: floor((canvasHeight - iconSize) / 2),
+            width: iconSize,
+            height: iconSize)
+        brand.draw(
+            in: iconRect,
+            from: NSRect(origin: .zero, size: brand.size),
+            operation: .sourceOver,
+            fraction: 1.0)
+
+        var x = iconSize + iconGap
+        for (index, segment) in segments.enumerated() {
+            if index > 0 {
+                x += segmentGap
+            }
+            let topText = Self.menuBarStatsTopText(segment)
+            let bottomText = segment.weekly ?? ""
+            let metrics = segmentSizes[index]
+            Self.drawMenuBarStatsText(
+                topText,
+                at: CGPoint(x: x, y: 10.5),
+                attributes: topAttributes)
+            if !bottomText.isEmpty {
+                let bottomX = x + floor((metrics.width - metrics.bottom.width) / 2)
+                Self.drawMenuBarStatsText(
+                    bottomText,
+                    at: CGPoint(x: bottomX, y: 1.5),
+                    attributes: bottomAttributes)
+            }
+            x += metrics.width
+        }
+
+        image.unlockFocus()
+        image.isTemplate = true
+        return image
+    }
+
+    private static func menuBarStatsTopText(_ segment: MenuBarStatSegment) -> String {
+        "\(segment.label) \(segment.primary)"
+    }
+
+    private static func menuBarStatsTextSize(
+        _ text: String,
+        attributes: [NSAttributedString.Key: Any])
+        -> CGSize
+    {
+        guard !text.isEmpty else { return .zero }
+        return (text as NSString).size(withAttributes: attributes)
+    }
+
+    private static func drawMenuBarStatsText(
+        _ text: String,
+        at point: CGPoint,
+        attributes: [NSAttributedString.Key: Any])
+    {
+        (text as NSString).draw(at: point, withAttributes: attributes)
     }
 
     nonisolated static func deepSeekBalanceDisplayText(snapshot: UsageSnapshot?) -> String? {

--- a/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
+++ b/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
@@ -27,7 +27,10 @@ extension StatusItemController {
                     snapshotOverride: accountSnapshot?.snapshot,
                     errorOverride: health.label,
                     forceOverrideCard: accountSnapshot == nil,
-                    accountOverride: self.accountInfo(for: account))
+                    accountOverride: self.accountInfo(for: account),
+                    progressColorOverride: UsageMenuCardView.Model.stackedAccountProgressColor(
+                        for: .codex,
+                        index: cardIndex))
                 guard let model else { continue }
                 menu.addItem(self.makeMenuCardItem(
                     UsageMenuCardView(model: model, width: context.menuWidth),

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -604,11 +604,15 @@ extension StatusItemController {
             let accountSnapshots = tokenAccountDisplay.snapshots
             let cards = accountSnapshots.isEmpty
                 ? []
-                : accountSnapshots.compactMap { accountSnapshot in
+                : accountSnapshots.enumerated().compactMap { index, accountSnapshot in
                     self.menuCardModel(
                         for: context.currentProvider,
                         snapshotOverride: accountSnapshot.snapshot,
-                        errorOverride: accountSnapshot.error)
+                        errorOverride: accountSnapshot.error,
+                        accountOverride: AccountInfo(email: accountSnapshot.account.label, plan: nil),
+                        progressColorOverride: UsageMenuCardView.Model.stackedAccountProgressColor(
+                            for: context.currentProvider,
+                            index: index))
                 }
             self.addStackedMenuCards(cards, to: menu, context: context)
             return false

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -1,5 +1,6 @@
 import CodexBarCore
 import Foundation
+import SwiftUI
 
 extension StatusItemController {
     func menuCardModel(
@@ -7,7 +8,8 @@ extension StatusItemController {
         snapshotOverride: UsageSnapshot? = nil,
         errorOverride: String? = nil,
         forceOverrideCard: Bool = false,
-        accountOverride: AccountInfo? = nil) -> UsageMenuCardView.Model?
+        accountOverride: AccountInfo? = nil,
+        progressColorOverride: Color? = nil) -> UsageMenuCardView.Model?
     {
         let target = provider ?? self.store.enabledProvidersForDisplay().first ?? .codex
         let metadata = self.store.metadata(for: target)
@@ -120,6 +122,7 @@ extension StatusItemController {
             ],
             workDaysPerWeek: self.settings.weeklyProgressWorkDays,
             usesLiveSubtitle: surface == .liveCard,
+            progressColorOverride: progressColorOverride,
             now: now)
         return UsageMenuCardView.Model.make(input)
     }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -440,6 +440,9 @@ extension UsageStore {
         var selectedOutcome: ProviderFetchOutcome?
         var selectedSnapshot: UsageSnapshot?
         var sawAnyNonCancellationOutcome = false
+        // Relabel discovered accounts to their real email once a fetch reveals
+        // it (so tabs read "name@email" instead of "acct5"/keychain-suffix).
+        var relabels: [(id: UUID, label: String)] = []
 
         let results = await self.fetchTokenAccountOutcomes(provider: provider, accounts: limitedAccounts)
         guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
@@ -465,6 +468,12 @@ extension UsageStore {
                 selectedOutcome = outcome
                 selectedSnapshot = resolved.usage
             }
+            if let email = resolved.usage?.identity(for: provider)?.accountEmail?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !email.isEmpty, email != account.label
+            {
+                relabels.append((account.id, email))
+            }
         }
 
         // If every fetch was cancelled (e.g. the user closed/reopened the menu mid-flight)
@@ -475,6 +484,14 @@ extension UsageStore {
         if !shouldPreservePriorState {
             await MainActor.run {
                 self.accountSnapshots[provider] = snapshots
+            }
+        }
+
+        if !relabels.isEmpty {
+            await MainActor.run {
+                for (id, label) in relabels {
+                    self.settings.updateTokenAccount(provider: provider, accountID: id, label: label)
+                }
             }
         }
 

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -676,7 +676,10 @@ extension UsageStore {
             provider: provider,
             settings: self.settings,
             override: override)
-        let sourceMode = self.sourceMode(for: provider)
+        let sourceMode = ProviderTokenAccountSourceModeResolver.effectiveSourceMode(
+            base: self.sourceMode(for: provider),
+            provider: provider,
+            account: account)
         let snapshot = ProviderRegistry.makeSettingsSnapshot(
             settings: self.settings,
             tokenOverride: override,

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeAccountDiscovery.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeAccountDiscovery.swift
@@ -1,0 +1,105 @@
+import Crypto
+import Foundation
+
+/// A Claude login discovered on this machine, expressed as a refreshable
+/// `ClaudeCredentialSource` so the fetch path can read AND refresh it per
+/// account (rather than all accounts sharing the single default login).
+public struct DiscoveredClaudeAccount: Sendable, Equatable {
+    public let source: ClaudeCredentialSource
+    public let label: String
+    public let configDirectory: String
+
+    public init(source: ClaudeCredentialSource, label: String, configDirectory: String) {
+        self.source = source
+        self.label = label
+        self.configDirectory = configDirectory
+    }
+}
+
+/// Finds the Claude Code logins on this machine by scanning `~/.claude*` config
+/// directories — the same layout Clawd Pet enumerates. Each directory maps to
+/// either a credentials file or a Keychain service.
+///
+/// Prompt-safety: discovery only checks directory/file existence and *computes*
+/// Keychain service names; it never reads a token, so it cannot trigger a
+/// Keychain prompt. The token read (and any prompt) happens later, per account,
+/// in `ClaudeCredentialResolver` at fetch time.
+public enum ClaudeAccountDiscovery {
+    /// Default (no CLAUDE_CONFIG_DIR) Keychain service used by Claude Code.
+    public static let defaultKeychainService = "Claude Code-credentials"
+    private static let credentialsFileName = ".credentials.json"
+
+    /// Keychain service Claude Code uses for a given config dir. `~/.claude`
+    /// uses the bare service; a CLAUDE_CONFIG_DIR uses
+    /// `"Claude Code-credentials-" + sha256(absolutePath)[0..<8]` (the scheme
+    /// Clawd Pet decodes). The path is hashed verbatim (no symlink resolution)
+    /// to match what Claude Code stored.
+    public static func keychainServiceName(
+        forConfigDirectory configDir: String,
+        defaultClaudeDirectory: String) -> String
+    {
+        if configDir == defaultClaudeDirectory {
+            return self.defaultKeychainService
+        }
+        let suffix = self.sha256Hex(configDir).prefix(8)
+        return "\(self.defaultKeychainService)-\(suffix)"
+    }
+
+    /// Enumerate Claude logins from `~/.claude*` config directories.
+    public static func discover(
+        homeDirectory: String = NSHomeDirectory(),
+        fileManager: FileManager = .default) -> [DiscoveredClaudeAccount]
+    {
+        let defaultClaudeDir = (homeDirectory as NSString).appendingPathComponent(".claude")
+        var seen = Set<String>()
+        var accounts: [DiscoveredClaudeAccount] = []
+        for dir in self.claudeConfigDirectories(homeDirectory: homeDirectory, fileManager: fileManager) {
+            let credsFile = (dir as NSString).appendingPathComponent(self.credentialsFileName)
+            let source: ClaudeCredentialSource = fileManager.fileExists(atPath: credsFile)
+                ? .credentialsFile(path: credsFile)
+                : .keychainService(
+                    service: self.keychainServiceName(
+                        forConfigDirectory: dir,
+                        defaultClaudeDirectory: defaultClaudeDir),
+                    account: nil)
+            guard seen.insert(source.encodedTokenValue()).inserted else { continue }
+            accounts.append(DiscoveredClaudeAccount(
+                source: source,
+                label: self.label(forConfigDirectory: dir, defaultClaudeDirectory: defaultClaudeDir),
+                configDirectory: dir))
+        }
+        return accounts
+    }
+
+    static func claudeConfigDirectories(
+        homeDirectory: String,
+        fileManager: FileManager) -> [String]
+    {
+        guard let entries = try? fileManager.contentsOfDirectory(atPath: homeDirectory) else {
+            return []
+        }
+        return entries
+            .filter { $0 == ".claude" || $0.hasPrefix(".claude-") }
+            .map { (homeDirectory as NSString).appendingPathComponent($0) }
+            .filter { path in
+                var isDir: ObjCBool = false
+                return fileManager.fileExists(atPath: path, isDirectory: &isDir) && isDir.boolValue
+            }
+            .sorted()
+    }
+
+    static func label(forConfigDirectory configDir: String, defaultClaudeDirectory: String) -> String {
+        if configDir == defaultClaudeDirectory {
+            return "Claude"
+        }
+        let name = (configDir as NSString).lastPathComponent
+        if let range = name.range(of: ".claude-") {
+            return String(name[range.upperBound...])
+        }
+        return name
+    }
+
+    private static func sha256Hex(_ string: String) -> String {
+        SHA256.hash(data: Data(string.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeAccountDiscovery.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeAccountDiscovery.swift
@@ -1,5 +1,8 @@
 import Crypto
 import Foundation
+#if os(macOS)
+import Security
+#endif
 
 /// A Claude login discovered on this machine, expressed as a refreshable
 /// `ClaudeCredentialSource` so the fetch path can read AND refresh it per
@@ -16,24 +19,123 @@ public struct DiscoveredClaudeAccount: Sendable, Equatable {
     }
 }
 
-/// Finds the Claude Code logins on this machine by scanning `~/.claude*` config
-/// directories — the same layout Clawd Pet enumerates. Each directory maps to
-/// either a credentials file or a Keychain service.
+/// Finds the Claude Code logins on this machine.
 ///
-/// Prompt-safety: discovery only checks directory/file existence and *computes*
-/// Keychain service names; it never reads a token, so it cannot trigger a
-/// Keychain prompt. The token read (and any prompt) happens later, per account,
-/// in `ClaudeCredentialResolver` at fetch time.
+/// Source of truth is the **Keychain itself**: it enumerates the real
+/// `Claude Code-credentials*` generic-password services (attributes only — no
+/// token data, so it does not prompt), newest first, instead of guessing
+/// service names from `~/.claude*` paths (which doesn't survive moved/renamed
+/// config dirs). `~/.claude*` dirs are used only to give matching accounts a
+/// friendly label and to pick up file-based credential stores.
+///
+/// The actual token read (and any Keychain prompt) happens later, per account,
+/// in `ClaudeCredentialResolver` at fetch time — only for accounts shown.
 public enum ClaudeAccountDiscovery {
-    /// Default (no CLAUDE_CONFIG_DIR) Keychain service used by Claude Code.
     public static let defaultKeychainService = "Claude Code-credentials"
     private static let credentialsFileName = ".credentials.json"
 
-    /// Keychain service Claude Code uses for a given config dir. `~/.claude`
-    /// uses the bare service; a CLAUDE_CONFIG_DIR uses
-    /// `"Claude Code-credentials-" + sha256(absolutePath)[0..<8]` (the scheme
-    /// Clawd Pet decodes). The path is hashed verbatim (no symlink resolution)
-    /// to match what Claude Code stored.
+    public static func discover(
+        homeDirectory: String = NSHomeDirectory(),
+        fileManager: FileManager = .default,
+        maxAccounts: Int = 4) -> [DiscoveredClaudeAccount]
+    {
+        let configDirs = self.claudeConfigDirectories(homeDirectory: homeDirectory, fileManager: fileManager)
+        let fileCredsDirs = configDirs.filter { dir in
+            fileManager.fileExists(
+                atPath: (dir as NSString).appendingPathComponent(self.credentialsFileName))
+        }
+        return self.assemble(
+            homeDirectory: homeDirectory,
+            configDirectories: configDirs,
+            fileCredsDirectories: fileCredsDirs,
+            keychainServicesNewestFirst: self.keychainServices(),
+            maxAccounts: maxAccounts)
+    }
+
+    /// Pure assembly (no Keychain / filesystem) so it is unit-testable: pick the
+    /// default store, any file-based stores, then the most-recently-used
+    /// remaining Keychain services up to `maxAccounts`, deduped, each labelled
+    /// from its matching `~/.claude*` dir when one exists.
+    static func assemble(
+        homeDirectory: String,
+        configDirectories: [String],
+        fileCredsDirectories: [String],
+        keychainServicesNewestFirst: [String],
+        maxAccounts: Int) -> [DiscoveredClaudeAccount]
+    {
+        let defaultClaudeDir = (homeDirectory as NSString).appendingPathComponent(".claude")
+        // computed service -> friendly dir label (best-effort)
+        var labelByService: [String: String] = [:]
+        for dir in configDirectories {
+            let service = self.keychainServiceName(
+                forConfigDirectory: dir, defaultClaudeDirectory: defaultClaudeDir)
+            labelByService[service] = self.label(
+                forConfigDirectory: dir, defaultClaudeDirectory: defaultClaudeDir)
+        }
+
+        var seen = Set<String>()
+        var accounts: [DiscoveredClaudeAccount] = []
+        func add(_ source: ClaudeCredentialSource, _ label: String, _ dir: String) {
+            guard seen.insert(source.encodedTokenValue()).inserted else { return }
+            accounts.append(DiscoveredClaudeAccount(source: source, label: label, configDirectory: dir))
+        }
+
+        // 1) file-based stores (rare on macOS, but authoritative when present)
+        for dir in fileCredsDirectories {
+            let path = (dir as NSString).appendingPathComponent(self.credentialsFileName)
+            add(.credentialsFile(path: path),
+                self.label(forConfigDirectory: dir, defaultClaudeDirectory: defaultClaudeDir), dir)
+        }
+
+        // 2) the default Keychain login, if present
+        if keychainServicesNewestFirst.contains(self.defaultKeychainService) {
+            add(.keychainService(service: self.defaultKeychainService, account: nil), "Claude", defaultClaudeDir)
+        }
+
+        // 3) remaining Keychain services, most-recently-used first, capped
+        for service in keychainServicesNewestFirst where service != self.defaultKeychainService {
+            if accounts.count >= max(1, maxAccounts) { break }
+            let label = labelByService[service] ?? self.shortSuffix(of: service)
+            add(.keychainService(service: service, account: nil), label, "")
+        }
+        return accounts
+    }
+
+    /// Real `Claude Code-credentials*` Keychain services, newest first.
+    /// Attributes-only query (no `kSecReturnData`) so it does not prompt.
+    static func keychainServices() -> [String] {
+        #if os(macOS)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let rows = result as? [[String: Any]]
+        else {
+            return []
+        }
+        var newestByService: [String: Date] = [:]
+        for row in rows {
+            guard let service = row[kSecAttrService as String] as? String,
+                  service.hasPrefix(self.defaultKeychainService)
+            else { continue }
+            let modified = (row[kSecAttrModificationDate as String] as? Date)
+                ?? (row[kSecAttrCreationDate as String] as? Date)
+                ?? .distantPast
+            if let existing = newestByService[service], existing >= modified { continue }
+            newestByService[service] = modified
+        }
+        return newestByService.sorted { $0.value > $1.value }.map(\.key)
+        #else
+        return []
+        #endif
+    }
+
+    /// Keychain service Claude Code uses for a config dir (used only for nice
+    /// labels now): `~/.claude` → bare service; else
+    /// `"Claude Code-credentials-" + sha256(absolutePath)[0..<8]`.
     public static func keychainServiceName(
         forConfigDirectory configDir: String,
         defaultClaudeDirectory: String) -> String
@@ -41,34 +143,7 @@ public enum ClaudeAccountDiscovery {
         if configDir == defaultClaudeDirectory {
             return self.defaultKeychainService
         }
-        let suffix = self.sha256Hex(configDir).prefix(8)
-        return "\(self.defaultKeychainService)-\(suffix)"
-    }
-
-    /// Enumerate Claude logins from `~/.claude*` config directories.
-    public static func discover(
-        homeDirectory: String = NSHomeDirectory(),
-        fileManager: FileManager = .default) -> [DiscoveredClaudeAccount]
-    {
-        let defaultClaudeDir = (homeDirectory as NSString).appendingPathComponent(".claude")
-        var seen = Set<String>()
-        var accounts: [DiscoveredClaudeAccount] = []
-        for dir in self.claudeConfigDirectories(homeDirectory: homeDirectory, fileManager: fileManager) {
-            let credsFile = (dir as NSString).appendingPathComponent(self.credentialsFileName)
-            let source: ClaudeCredentialSource = fileManager.fileExists(atPath: credsFile)
-                ? .credentialsFile(path: credsFile)
-                : .keychainService(
-                    service: self.keychainServiceName(
-                        forConfigDirectory: dir,
-                        defaultClaudeDirectory: defaultClaudeDir),
-                    account: nil)
-            guard seen.insert(source.encodedTokenValue()).inserted else { continue }
-            accounts.append(DiscoveredClaudeAccount(
-                source: source,
-                label: self.label(forConfigDirectory: dir, defaultClaudeDirectory: defaultClaudeDir),
-                configDirectory: dir))
-        }
-        return accounts
+        return "\(self.defaultKeychainService)-\(self.sha256Hex(configDir).prefix(8))"
     }
 
     static func claudeConfigDirectories(
@@ -97,6 +172,14 @@ public enum ClaudeAccountDiscovery {
             return String(name[range.upperBound...])
         }
         return name
+    }
+
+    static func shortSuffix(of service: String) -> String {
+        let prefix = self.defaultKeychainService + "-"
+        if service.hasPrefix(prefix) {
+            return "Claude " + String(service.dropFirst(prefix.count))
+        }
+        return "Claude"
     }
 
     private static func sha256Hex(_ string: String) -> String {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeAccountDiscovery.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeAccountDiscovery.swift
@@ -83,8 +83,10 @@ public enum ClaudeAccountDiscovery {
         // 1) file-based stores (rare on macOS, but authoritative when present)
         for dir in fileCredsDirectories {
             let path = (dir as NSString).appendingPathComponent(self.credentialsFileName)
-            add(.credentialsFile(path: path),
-                self.label(forConfigDirectory: dir, defaultClaudeDirectory: defaultClaudeDir), dir)
+            add(
+                .credentialsFile(path: path),
+                self.label(forConfigDirectory: dir, defaultClaudeDirectory: defaultClaudeDir),
+                dir)
         }
 
         // 2) the default Keychain login, if present

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialResolver.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialResolver.swift
@@ -50,6 +50,34 @@ public enum ClaudeCredentialResolver {
             scopes: [], rateLimitTier: nil)
     }
 
+    /// Best-effort account email for an access token, via the OAuth profile
+    /// endpoint. Used to label and de-duplicate discovered accounts. Returns nil
+    /// on any failure (network, scope, parse) — callers fall back gracefully.
+    public static func fetchAccountEmail(accessToken: String) async -> String? {
+        guard let url = URL(string: "https://api.anthropic.com/api/oauth/profile") else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.setValue("claude-code/2.1.5", forHTTPHeaderField: "User-Agent")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard (response as? HTTPURLResponse)?.statusCode == 200,
+                  let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+            if let account = obj["account"] as? [String: Any],
+               let email = account["email"] as? String, !email.isEmpty
+            {
+                return email
+            }
+            if let email = obj["email"] as? String, !email.isEmpty { return email }
+            return nil
+        } catch {
+            return nil
+        }
+    }
+
     static func refreshed(
         _ creds: ClaudeOAuthCredentials,
         persistTo source: ClaudeCredentialSource) async throws -> ClaudeOAuthCredentials

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialResolver.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialResolver.swift
@@ -1,0 +1,156 @@
+import Foundation
+#if os(macOS)
+import Security
+#endif
+
+/// Resolves a `ClaudeCredentialSource` into a live OAuth access token at fetch
+/// time, refreshing if the stored token has expired. This is what lets several
+/// Claude accounts each refresh from their own Keychain item / config dir,
+/// instead of all sharing the single default login.
+///
+/// Write-back policy (important): when a refresh rotates the refresh token, the
+/// new credential is persisted back to its source ONLY for **secondary** sources
+/// (a non-default Keychain service or a credentials file — i.e. CLAUDE_CONFIG_DIR
+/// accounts that Claude Code does not actively refresh). The default
+/// `"Claude Code-credentials"` item is left untouched so we never race Claude
+/// Code's own refresh of it (which is how token families get revoked).
+public enum ClaudeCredentialResolver {
+    /// Convenience: the access token from `resolveCredentials`.
+    public static func resolveAccessToken(
+        from source: ClaudeCredentialSource,
+        environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> String
+    {
+        try await self.resolveCredentials(from: source, environment: environment).accessToken
+    }
+
+    /// Read the credential for `source` and refresh if expired, returning live
+    /// credentials (scopes preserved, so downstream scope checks still pass).
+    public static func resolveCredentials(
+        from source: ClaudeCredentialSource,
+        environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> ClaudeOAuthCredentials
+    {
+        switch source {
+        case let .oauthToken(token):
+            return self.staticCredentials(token)
+        case let .environment(key):
+            let token = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !token.isEmpty else { throw ClaudeOAuthCredentialsError.notFound }
+            return self.staticCredentials(token)
+        case let .credentialsFile(path):
+            return try await self.refreshed(self.readCredentialsFile(path: path), persistTo: source)
+        case let .keychainService(service, account):
+            return try await self.refreshed(
+                self.readKeychain(service: service, account: account), persistTo: source)
+        }
+    }
+
+    private static func staticCredentials(_ token: String) -> ClaudeOAuthCredentials {
+        ClaudeOAuthCredentials(
+            accessToken: token, refreshToken: nil, expiresAt: nil,
+            scopes: [], rateLimitTier: nil)
+    }
+
+    static func refreshed(
+        _ creds: ClaudeOAuthCredentials,
+        persistTo source: ClaudeCredentialSource) async throws -> ClaudeOAuthCredentials
+    {
+        // Not expired, or nothing to refresh with — use as-is. (A stale token
+        // with no refresh token surfaces a clear auth error → reconnect.)
+        guard creds.isExpired, let refreshToken = creds.refreshToken, !refreshToken.isEmpty else {
+            return creds
+        }
+        let refreshed = try await ClaudeOAuthCredentialsStore.refreshAccessToken(
+            refreshToken: refreshToken,
+            existingScopes: creds.scopes,
+            existingRateLimitTier: creds.rateLimitTier,
+            existingSubscriptionType: creds.subscriptionType)
+        if self.shouldPersist(to: source) {
+            try? self.persist(refreshed, to: source)
+        }
+        return refreshed
+    }
+
+    /// Only write rotated credentials back to secondary sources (see type doc).
+    static func shouldPersist(to source: ClaudeCredentialSource) -> Bool {
+        switch source {
+        case .credentialsFile:
+            return true
+        case let .keychainService(service, _):
+            return service != ClaudeAccountDiscovery.defaultKeychainService
+        case .oauthToken, .environment:
+            return false
+        }
+    }
+
+    // MARK: - reading
+
+    static func readCredentialsFile(path: String) throws -> ClaudeOAuthCredentials {
+        let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+        let data = try Data(contentsOf: url)
+        return try ClaudeOAuthCredentials.parse(data: data)
+    }
+
+    static func readKeychain(service: String, account: String?) throws -> ClaudeOAuthCredentials {
+        #if os(macOS)
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        if let account, !account.isEmpty {
+            query[kSecAttrAccount as String] = account
+        }
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else {
+            throw ClaudeOAuthCredentialsError.keychainError(Int(status))
+        }
+        return try ClaudeOAuthCredentials.parse(data: data)
+        #else
+        throw ClaudeOAuthCredentialsError.notFound
+        #endif
+    }
+
+    // MARK: - write-back
+
+    static func persist(_ creds: ClaudeOAuthCredentials, to source: ClaudeCredentialSource) throws {
+        let json = try self.encodeCredentialsJSON(creds)
+        switch source {
+        case let .credentialsFile(path):
+            let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+            try json.write(to: url, options: .atomic)
+        case let .keychainService(service, account):
+            #if os(macOS)
+            var query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+            ]
+            if let account, !account.isEmpty {
+                query[kSecAttrAccount as String] = account
+            }
+            let attributes: [String: Any] = [kSecValueData as String: json]
+            let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+            guard status == errSecSuccess else {
+                throw ClaudeOAuthCredentialsError.keychainError(Int(status))
+            }
+            #endif
+        case .oauthToken, .environment:
+            break
+        }
+    }
+
+    /// Encode credentials in Claude Code's `{"claudeAiOauth": {…}}` shape so a
+    /// write-back is readable by both CodexBar and Claude Code.
+    static func encodeCredentialsJSON(_ creds: ClaudeOAuthCredentials) throws -> Data {
+        var oauth: [String: Any] = ["accessToken": creds.accessToken]
+        if let refreshToken = creds.refreshToken { oauth["refreshToken"] = refreshToken }
+        if let expiresAt = creds.expiresAt {
+            oauth["expiresAt"] = Int(expiresAt.timeIntervalSince1970 * 1000.0)
+        }
+        if !creds.scopes.isEmpty { oauth["scopes"] = creds.scopes }
+        if let tier = creds.rateLimitTier { oauth["rateLimitTier"] = tier }
+        if let sub = creds.subscriptionType { oauth["subscriptionType"] = sub }
+        return try JSONSerialization.data(withJSONObject: ["claudeAiOauth": oauth])
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialResolver.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialResolver.swift
@@ -46,8 +46,11 @@ public enum ClaudeCredentialResolver {
 
     private static func staticCredentials(_ token: String) -> ClaudeOAuthCredentials {
         ClaudeOAuthCredentials(
-            accessToken: token, refreshToken: nil, expiresAt: nil,
-            scopes: [], rateLimitTier: nil)
+            accessToken: token,
+            refreshToken: nil,
+            expiresAt: nil,
+            scopes: [],
+            rateLimitTier: nil)
     }
 
     /// Best-effort account email for an access token, via the OAuth profile
@@ -102,11 +105,11 @@ public enum ClaudeCredentialResolver {
     static func shouldPersist(to source: ClaudeCredentialSource) -> Bool {
         switch source {
         case .credentialsFile:
-            return true
+            true
         case let .keychainService(service, _):
-            return service != ClaudeAccountDiscovery.defaultKeychainService
+            service != ClaudeAccountDiscovery.defaultKeychainService
         case .oauthToken, .environment:
-            return false
+            false
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialSource.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialSource.swift
@@ -30,9 +30,9 @@ public enum ClaudeCredentialSource: Sendable, Equatable, Codable {
     public var isRefreshableSource: Bool {
         switch self {
         case .oauthToken:
-            return false
+            false
         case .keychainService, .credentialsFile, .environment:
-            return true
+            true
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialSource.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialSource.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Describes WHERE a Claude token account's live credential comes from.
+///
+/// A `ProviderTokenAccount.token` for Claude is either a raw OAuth/session
+/// token (legacy / manually pasted — classified directly by
+/// `ClaudeCredentialRouting`) or an encoded *source pointer* that the fetch
+/// path resolves — and refreshes — at fetch time. The pointer lets several
+/// Claude accounts each read and refresh from their own Keychain item or
+/// `~/.claude*` config dir, instead of all sharing the single default login.
+public enum ClaudeCredentialSource: Sendable, Equatable, Codable {
+    /// A literal credential value stored directly (no per-account refresh).
+    case oauthToken(String)
+    /// A macOS Keychain generic-password item (service + optional account).
+    case keychainService(service: String, account: String?)
+    /// A Claude credentials JSON file (e.g. `~/.claude-acct2/.credentials.json`).
+    case credentialsFile(path: String)
+    /// An environment variable holding the token.
+    case environment(key: String)
+
+    /// Marker prefix for encoded source pointers stored in a token-account token.
+    public static let descriptorPrefix = "claude-source:"
+
+    /// Environment variable that carries a source descriptor from the
+    /// token-account override into the Claude fetcher, where it is resolved and
+    /// refreshed per account at fetch time.
+    public static let environmentDescriptorKey = "CODEXBAR_CLAUDE_SOURCE"
+
+    /// True for sources that point at a refreshable store (vs a static token).
+    public var isRefreshableSource: Bool {
+        switch self {
+        case .oauthToken:
+            return false
+        case .keychainService, .credentialsFile, .environment:
+            return true
+        }
+    }
+
+    /// Encode for storage in a `ProviderTokenAccount.token`. A raw token stays
+    /// raw (back-compat: routing classifies it directly); pointers are encoded
+    /// as `claude-source:<base64 JSON>` so any service / path / email — even
+    /// with `:`, spaces, or `=` — round-trips intact.
+    public func encodedTokenValue() -> String {
+        if case let .oauthToken(token) = self {
+            return token
+        }
+        guard let data = try? JSONEncoder().encode(self), !data.isEmpty else {
+            return ""
+        }
+        return Self.descriptorPrefix + data.base64EncodedString()
+    }
+
+    /// Inverse of `encodedTokenValue()`. Anything without the marker prefix (or
+    /// that fails to decode) is treated as a legacy raw token.
+    public static func parse(_ tokenValue: String) -> ClaudeCredentialSource {
+        let trimmed = tokenValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix(Self.descriptorPrefix) else {
+            return .oauthToken(tokenValue)
+        }
+        let encoded = String(trimmed.dropFirst(Self.descriptorPrefix.count))
+        guard let data = Data(base64Encoded: encoded),
+              let decoded = try? JSONDecoder().decode(ClaudeCredentialSource.self, from: data)
+        else {
+            return .oauthToken(tokenValue)
+        }
+        return decoded
+    }
+
+    /// Short human label for menus / settings rows.
+    public func displayLabel() -> String {
+        switch self {
+        case .oauthToken:
+            return "Pasted token"
+        case let .keychainService(service, account):
+            if let account, !account.isEmpty {
+                return account
+            }
+            return service
+        case let .credentialsFile(path):
+            let parent = (path as NSString).deletingLastPathComponent
+            let name = (parent as NSString).lastPathComponent
+            return name.isEmpty ? path : name
+        case let .environment(key):
+            return key
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -261,10 +261,7 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
         sourceMode: ProviderSourceMode,
         environment: [String: String]) -> Bool
     {
-        let hasEnvironmentOAuthToken = !(environment[ClaudeOAuthCredentialsStore.environmentTokenKey]?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .isEmpty ?? true)
-        if hasEnvironmentOAuthToken {
+        if self.hasSelectedOAuthCredential(environment: environment) {
             return true
         }
 
@@ -348,7 +345,31 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
         // In Auto mode, fall back to the next strategy (cli/web) if OAuth fails (e.g. user cancels keychain prompt
         // or auth breaks).
-        context.runtime == .app && context.sourceMode == .auto
+        context.runtime == .app &&
+            context.sourceMode == .auto &&
+            !Self.hasSelectedOAuthAccount(context: context)
+    }
+
+    private static func hasSelectedOAuthAccount(context: ProviderFetchContext) -> Bool {
+        guard context.selectedTokenAccountID != nil else { return false }
+        return self.hasSelectedOAuthCredential(environment: context.env)
+    }
+
+    private static func hasSelectedOAuthCredential(environment: [String: String]) -> Bool {
+        let hasEnvironmentOAuthToken = !(environment[ClaudeOAuthCredentialsStore.environmentTokenKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty ?? true)
+        if hasEnvironmentOAuthToken {
+            return true
+        }
+
+        guard let descriptor = environment[ClaudeCredentialSource.environmentDescriptorKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !descriptor.isEmpty
+        else {
+            return false
+        }
+        return ClaudeCredentialSource.parse(descriptor).isRefreshableSource
     }
 
     fileprivate static func snapshot(from usage: ClaudeUsageSnapshot) -> UsageSnapshot {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -813,6 +813,15 @@ extension ClaudeUsageFetcher {
             return try await override(environment, allowKeychainPrompt, respectKeychainPromptCooldown)
         }
         #endif
+        // Multi-account: a token-account override injects a source descriptor;
+        // read + refresh THAT account's credential instead of the default login.
+        if let descriptor = environment[ClaudeCredentialSource.environmentDescriptorKey],
+           !descriptor.isEmpty
+        {
+            return try await ClaudeCredentialResolver.resolveCredentials(
+                from: ClaudeCredentialSource.parse(descriptor),
+                environment: environment)
+        }
         return try await ClaudeOAuthCredentialsStore.loadWithAutoRefresh(
             environment: environment,
             allowKeychainPrompt: allowKeychainPrompt,

--- a/Sources/CodexBarCore/TokenAccountSupport.swift
+++ b/Sources/CodexBarCore/TokenAccountSupport.swift
@@ -44,10 +44,14 @@ public enum TokenAccountSupportCatalog {
         case let .environment(key):
             return [key: token]
         case .cookieHeader:
-            if provider == .claude,
-               case let route = ClaudeCredentialRouting.resolve(tokenAccountToken: token, manualCookieHeader: nil)
-            {
-                switch route {
+            if provider == .claude {
+                // A refreshable source pointer (multi-account) is passed through
+                // verbatim; the Claude fetcher resolves + refreshes it per
+                // account at fetch time (it can't be refreshed synchronously here).
+                if ClaudeCredentialSource.parse(token).isRefreshableSource {
+                    return [ClaudeCredentialSource.environmentDescriptorKey: token]
+                }
+                switch ClaudeCredentialRouting.resolve(tokenAccountToken: token, manualCookieHeader: nil) {
                 case let .oauth(accessToken):
                     return [ClaudeOAuthCredentialsStore.environmentTokenKey: accessToken]
                 case let .adminAPIKey(apiKey):
@@ -75,6 +79,7 @@ public enum TokenAccountSupportCatalog {
         case .cookieHeader:
             guard provider == .claude else { return }
             environment.removeValue(forKey: ClaudeOAuthCredentialsStore.environmentTokenKey)
+            environment.removeValue(forKey: ClaudeCredentialSource.environmentDescriptorKey)
             for key in ClaudeAdminAPISettingsReader.apiKeyEnvironmentKeys {
                 environment.removeValue(forKey: key)
             }

--- a/Tests/CodexBarTests/ClaudeAccountDiscoveryTests.swift
+++ b/Tests/CodexBarTests/ClaudeAccountDiscoveryTests.swift
@@ -1,71 +1,69 @@
-import CodexBarCore
+@testable import CodexBarCore
 import Foundation
 import Testing
 
 struct ClaudeAccountDiscoveryTests {
     @Test
-    func `default claude dir maps to the bare keychain service`() {
-        let service = ClaudeAccountDiscovery.keychainServiceName(
+    func `default dir maps to the bare keychain service`() {
+        #expect(ClaudeAccountDiscovery.keychainServiceName(
             forConfigDirectory: "/Users/x/.claude",
-            defaultClaudeDirectory: "/Users/x/.claude")
-        #expect(service == "Claude Code-credentials")
+            defaultClaudeDirectory: "/Users/x/.claude") == "Claude Code-credentials")
     }
 
     @Test
-    func `config dir maps to a suffixed keychain service`() {
+    func `config dir maps to an 8-hex suffixed service`() {
         let service = ClaudeAccountDiscovery.keychainServiceName(
             forConfigDirectory: "/Users/x/.claude-acct2",
             defaultClaudeDirectory: "/Users/x/.claude")
         #expect(service.hasPrefix("Claude Code-credentials-"))
-        let suffix = service.dropFirst("Claude Code-credentials-".count)
-        #expect(suffix.count == 8)
-        #expect(suffix.allSatisfy { $0.isHexDigit && ($0.isNumber || $0.isLowercase) })
+        #expect(service.dropFirst("Claude Code-credentials-".count).count == 8)
     }
 
     @Test
-    func `service mapping is deterministic and dir-specific`() {
-        let a1 = ClaudeAccountDiscovery.keychainServiceName(
+    func `assemble lists default first, then recent services labelled from dirs`() {
+        let acct2 = ClaudeAccountDiscovery.keychainServiceName(
             forConfigDirectory: "/Users/x/.claude-acct2", defaultClaudeDirectory: "/Users/x/.claude")
-        let a2 = ClaudeAccountDiscovery.keychainServiceName(
-            forConfigDirectory: "/Users/x/.claude-acct2", defaultClaudeDirectory: "/Users/x/.claude")
-        let b = ClaudeAccountDiscovery.keychainServiceName(
-            forConfigDirectory: "/Users/x/.claude-acct3", defaultClaudeDirectory: "/Users/x/.claude")
-        #expect(a1 == a2)
-        #expect(a1 != b)
-    }
-
-    @Test
-    func `discover enumerates dirs as file or keychain sources`() throws {
-        let fm = FileManager.default
-        let home = fm.temporaryDirectory
-            .appendingPathComponent("cb-claude-discovery-\(UUID().uuidString)")
-        defer { try? fm.removeItem(at: home) }
-
-        // .claude (keychain — no file), .claude-acct2 (keychain), .claude-acct3 (file)
-        for sub in [".claude", ".claude-acct2", ".claude-acct3"] {
-            try fm.createDirectory(
-                at: home.appendingPathComponent(sub), withIntermediateDirectories: true)
-        }
-        let acct3Creds = home.appendingPathComponent(".claude-acct3/.credentials.json")
-        try Data("{}".utf8).write(to: acct3Creds)
-        // a non-claude dir must be ignored
-        try fm.createDirectory(
-            at: home.appendingPathComponent(".config"), withIntermediateDirectories: true)
-
-        let accounts = ClaudeAccountDiscovery.discover(homeDirectory: home.path, fileManager: fm)
+        let accounts = ClaudeAccountDiscovery.assemble(
+            homeDirectory: "/Users/x",
+            configDirectories: ["/Users/x/.claude", "/Users/x/.claude-acct2"],
+            fileCredsDirectories: [],
+            keychainServicesNewestFirst: ["Claude Code-credentials", acct2, "Claude Code-credentials-deadbeef"],
+            maxAccounts: 4)
         #expect(accounts.count == 3)
+        #expect(accounts[0].label == "Claude")
+        #expect(accounts[0].source == .keychainService(service: "Claude Code-credentials", account: nil))
+        #expect(accounts[1].source == .keychainService(service: acct2, account: nil))
+        #expect(accounts[1].label == "acct2")            // reverse-mapped from the dir
+        #expect(accounts[2].label == "Claude deadbeef")  // unknown service -> suffix label
+    }
 
-        let byLabel = Dictionary(uniqueKeysWithValues: accounts.map { ($0.label, $0.source) })
-        #expect(byLabel["Claude"] == .keychainService(service: "Claude Code-credentials", account: nil))
-        if case let .keychainService(service, _)? = byLabel["acct2"] {
-            #expect(service.hasPrefix("Claude Code-credentials-"))
-        } else {
-            Issue.record("acct2 should be a keychain source")
-        }
-        if case let .credentialsFile(path)? = byLabel["acct3"] {
-            #expect(path.hasSuffix(".claude-acct3/.credentials.json"))
-        } else {
-            Issue.record("acct3 should be a file source")
-        }
+    @Test
+    func `assemble caps the number of suffixed accounts`() {
+        let accounts = ClaudeAccountDiscovery.assemble(
+            homeDirectory: "/Users/x",
+            configDirectories: ["/Users/x/.claude"],
+            fileCredsDirectories: [],
+            keychainServicesNewestFirst: [
+                "Claude Code-credentials",
+                "Claude Code-credentials-aaaaaaaa",
+                "Claude Code-credentials-bbbbbbbb",
+                "Claude Code-credentials-cccccccc",
+            ],
+            maxAccounts: 2)
+        #expect(accounts.count == 2)             // default + 1 suffixed
+        #expect(accounts[0].label == "Claude")
+    }
+
+    @Test
+    func `assemble prefers a file source for a dir that has one`() {
+        let accounts = ClaudeAccountDiscovery.assemble(
+            homeDirectory: "/Users/x",
+            configDirectories: ["/Users/x/.claude-acct3"],
+            fileCredsDirectories: ["/Users/x/.claude-acct3"],
+            keychainServicesNewestFirst: [],
+            maxAccounts: 4)
+        #expect(accounts.count == 1)
+        #expect(accounts[0].source == .credentialsFile(path: "/Users/x/.claude-acct3/.credentials.json"))
+        #expect(accounts[0].label == "acct3")
     }
 }

--- a/Tests/CodexBarTests/ClaudeAccountDiscoveryTests.swift
+++ b/Tests/CodexBarTests/ClaudeAccountDiscoveryTests.swift
@@ -1,0 +1,71 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct ClaudeAccountDiscoveryTests {
+    @Test
+    func `default claude dir maps to the bare keychain service`() {
+        let service = ClaudeAccountDiscovery.keychainServiceName(
+            forConfigDirectory: "/Users/x/.claude",
+            defaultClaudeDirectory: "/Users/x/.claude")
+        #expect(service == "Claude Code-credentials")
+    }
+
+    @Test
+    func `config dir maps to a suffixed keychain service`() {
+        let service = ClaudeAccountDiscovery.keychainServiceName(
+            forConfigDirectory: "/Users/x/.claude-acct2",
+            defaultClaudeDirectory: "/Users/x/.claude")
+        #expect(service.hasPrefix("Claude Code-credentials-"))
+        let suffix = service.dropFirst("Claude Code-credentials-".count)
+        #expect(suffix.count == 8)
+        #expect(suffix.allSatisfy { $0.isHexDigit && ($0.isNumber || $0.isLowercase) })
+    }
+
+    @Test
+    func `service mapping is deterministic and dir-specific`() {
+        let a1 = ClaudeAccountDiscovery.keychainServiceName(
+            forConfigDirectory: "/Users/x/.claude-acct2", defaultClaudeDirectory: "/Users/x/.claude")
+        let a2 = ClaudeAccountDiscovery.keychainServiceName(
+            forConfigDirectory: "/Users/x/.claude-acct2", defaultClaudeDirectory: "/Users/x/.claude")
+        let b = ClaudeAccountDiscovery.keychainServiceName(
+            forConfigDirectory: "/Users/x/.claude-acct3", defaultClaudeDirectory: "/Users/x/.claude")
+        #expect(a1 == a2)
+        #expect(a1 != b)
+    }
+
+    @Test
+    func `discover enumerates dirs as file or keychain sources`() throws {
+        let fm = FileManager.default
+        let home = fm.temporaryDirectory
+            .appendingPathComponent("cb-claude-discovery-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: home) }
+
+        // .claude (keychain — no file), .claude-acct2 (keychain), .claude-acct3 (file)
+        for sub in [".claude", ".claude-acct2", ".claude-acct3"] {
+            try fm.createDirectory(
+                at: home.appendingPathComponent(sub), withIntermediateDirectories: true)
+        }
+        let acct3Creds = home.appendingPathComponent(".claude-acct3/.credentials.json")
+        try Data("{}".utf8).write(to: acct3Creds)
+        // a non-claude dir must be ignored
+        try fm.createDirectory(
+            at: home.appendingPathComponent(".config"), withIntermediateDirectories: true)
+
+        let accounts = ClaudeAccountDiscovery.discover(homeDirectory: home.path, fileManager: fm)
+        #expect(accounts.count == 3)
+
+        let byLabel = Dictionary(uniqueKeysWithValues: accounts.map { ($0.label, $0.source) })
+        #expect(byLabel["Claude"] == .keychainService(service: "Claude Code-credentials", account: nil))
+        if case let .keychainService(service, _)? = byLabel["acct2"] {
+            #expect(service.hasPrefix("Claude Code-credentials-"))
+        } else {
+            Issue.record("acct2 should be a keychain source")
+        }
+        if case let .credentialsFile(path)? = byLabel["acct3"] {
+            #expect(path.hasSuffix(".claude-acct3/.credentials.json"))
+        } else {
+            Issue.record("acct3 should be a file source")
+        }
+    }
+}

--- a/Tests/CodexBarTests/ClaudeAccountDiscoveryTests.swift
+++ b/Tests/CodexBarTests/ClaudeAccountDiscoveryTests.swift
@@ -1,6 +1,6 @@
-@testable import CodexBarCore
 import Foundation
 import Testing
+@testable import CodexBarCore
 
 struct ClaudeAccountDiscoveryTests {
     @Test
@@ -33,8 +33,8 @@ struct ClaudeAccountDiscoveryTests {
         #expect(accounts[0].label == "Claude")
         #expect(accounts[0].source == .keychainService(service: "Claude Code-credentials", account: nil))
         #expect(accounts[1].source == .keychainService(service: acct2, account: nil))
-        #expect(accounts[1].label == "acct2")            // reverse-mapped from the dir
-        #expect(accounts[2].label == "Claude deadbeef")  // unknown service -> suffix label
+        #expect(accounts[1].label == "acct2") // reverse-mapped from the dir
+        #expect(accounts[2].label == "Claude deadbeef") // unknown service -> suffix label
     }
 
     @Test
@@ -50,7 +50,7 @@ struct ClaudeAccountDiscoveryTests {
                 "Claude Code-credentials-cccccccc",
             ],
             maxAccounts: 2)
-        #expect(accounts.count == 2)             // default + 1 suffixed
+        #expect(accounts.count == 2) // default + 1 suffixed
         #expect(accounts[0].label == "Claude")
     }
 

--- a/Tests/CodexBarTests/ClaudeCredentialResolverTests.swift
+++ b/Tests/CodexBarTests/ClaudeCredentialResolverTests.swift
@@ -1,6 +1,6 @@
-@testable import CodexBarCore
 import Foundation
 import Testing
+@testable import CodexBarCore
 
 struct ClaudeCredentialResolverTests {
     @Test

--- a/Tests/CodexBarTests/ClaudeCredentialResolverTests.swift
+++ b/Tests/CodexBarTests/ClaudeCredentialResolverTests.swift
@@ -1,0 +1,75 @@
+@testable import CodexBarCore
+import Foundation
+import Testing
+
+struct ClaudeCredentialResolverTests {
+    @Test
+    func `raw oauth token resolves to itself without refresh`() async throws {
+        let token = try await ClaudeCredentialResolver.resolveAccessToken(
+            from: .oauthToken("sk-ant-oat-static"))
+        #expect(token == "sk-ant-oat-static")
+    }
+
+    @Test
+    func `environment source reads from the given environment`() async throws {
+        let token = try await ClaudeCredentialResolver.resolveAccessToken(
+            from: .environment(key: "MY_CLAUDE_TOKEN"),
+            environment: ["MY_CLAUDE_TOKEN": "sk-ant-oat-env"])
+        #expect(token == "sk-ant-oat-env")
+    }
+
+    @Test
+    func `missing environment variable throws`() async {
+        await #expect(throws: (any Error).self) {
+            _ = try await ClaudeCredentialResolver.resolveAccessToken(
+                from: .environment(key: "ABSENT_TOKEN"),
+                environment: [:])
+        }
+    }
+
+    @Test
+    func `reads a credentials file in the claudeAiOauth shape`() throws {
+        let fm = FileManager.default
+        let url = fm.temporaryDirectory.appendingPathComponent("cb-creds-\(UUID().uuidString).json")
+        defer { try? fm.removeItem(at: url) }
+        let future = Int(Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000)
+        let json = """
+        {"claudeAiOauth":{"accessToken":"sk-ant-oat-file","refreshToken":"rt-1",\
+        "expiresAt":\(future),"scopes":["user:profile"]}}
+        """
+        try Data(json.utf8).write(to: url)
+
+        let creds = try ClaudeCredentialResolver.readCredentialsFile(path: url.path)
+        #expect(creds.accessToken == "sk-ant-oat-file")
+        #expect(creds.refreshToken == "rt-1")
+        #expect(creds.isExpired == false)
+    }
+
+    @Test
+    func `encoded credentials round-trip through parse`() throws {
+        let original = ClaudeOAuthCredentials(
+            accessToken: "sk-ant-oat-rt",
+            refreshToken: "rt-2",
+            expiresAt: Date(timeIntervalSince1970: 1_800_000_000),
+            scopes: ["user:profile", "user:inference"],
+            rateLimitTier: "tier-x",
+            subscriptionType: "max")
+        let data = try ClaudeCredentialResolver.encodeCredentialsJSON(original)
+        let parsed = try ClaudeOAuthCredentials.parse(data: data)
+        #expect(parsed.accessToken == original.accessToken)
+        #expect(parsed.refreshToken == original.refreshToken)
+        #expect(parsed.scopes == original.scopes)
+        #expect(Int(parsed.expiresAt?.timeIntervalSince1970 ?? 0) == 1_800_000_000)
+    }
+
+    @Test
+    func `write-back targets only secondary sources`() {
+        #expect(ClaudeCredentialResolver.shouldPersist(
+            to: .keychainService(service: "Claude Code-credentials", account: nil)) == false)
+        #expect(ClaudeCredentialResolver.shouldPersist(
+            to: .keychainService(service: "Claude Code-credentials-deadbeef", account: nil)) == true)
+        #expect(ClaudeCredentialResolver.shouldPersist(
+            to: .credentialsFile(path: "/x/.credentials.json")) == true)
+        #expect(ClaudeCredentialResolver.shouldPersist(to: .oauthToken("x")) == false)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeCredentialSourceTests.swift
+++ b/Tests/CodexBarTests/ClaudeCredentialSourceTests.swift
@@ -1,0 +1,61 @@
+import CodexBarCore
+import Testing
+
+struct ClaudeCredentialSourceTests {
+    @Test
+    func `legacy raw token stays raw and parses as oauthToken`() {
+        let source = ClaudeCredentialSource.oauthToken("sk-ant-oat-abc")
+        #expect(source.encodedTokenValue() == "sk-ant-oat-abc")
+        #expect(ClaudeCredentialSource.parse("sk-ant-oat-abc") == .oauthToken("sk-ant-oat-abc"))
+        #expect(source.isRefreshableSource == false)
+    }
+
+    @Test
+    func `keychain source round-trips through encode and parse`() {
+        let source = ClaudeCredentialSource.keychainService(
+            service: "Claude Code-credentials-39eddfe1",
+            account: "alice@example.com")
+        let encoded = source.encodedTokenValue()
+        #expect(encoded.hasPrefix(ClaudeCredentialSource.descriptorPrefix))
+        #expect(ClaudeCredentialSource.parse(encoded) == source)
+        #expect(source.isRefreshableSource)
+    }
+
+    @Test
+    func `keychain source without account round-trips`() {
+        let source = ClaudeCredentialSource.keychainService(
+            service: "Claude Code-credentials",
+            account: nil)
+        #expect(ClaudeCredentialSource.parse(source.encodedTokenValue()) == source)
+    }
+
+    @Test
+    func `file source round-trips and preserves a full path`() {
+        let source = ClaudeCredentialSource.credentialsFile(
+            path: "/Users/x/.claude-acct2/.credentials.json")
+        #expect(ClaudeCredentialSource.parse(source.encodedTokenValue()) == source)
+        #expect(source.isRefreshableSource)
+    }
+
+    @Test
+    func `environment source round-trips`() {
+        let source = ClaudeCredentialSource.environment(key: "CODEXBAR_CLAUDE_OAUTH_TOKEN")
+        #expect(ClaudeCredentialSource.parse(source.encodedTokenValue()) == source)
+    }
+
+    @Test
+    func `garbage descriptor falls back to a raw token`() {
+        let raw = ClaudeCredentialSource.descriptorPrefix + "!!!not base64!!!"
+        #expect(ClaudeCredentialSource.parse(raw) == .oauthToken(raw))
+    }
+
+    @Test
+    func `display label prefers account, then config dir name`() {
+        #expect(
+            ClaudeCredentialSource.keychainService(service: "Svc", account: "bob@x.com")
+                .displayLabel() == "bob@x.com")
+        #expect(
+            ClaudeCredentialSource.credentialsFile(path: "/Users/x/.claude-acct2/.credentials.json")
+                .displayLabel() == ".claude-acct2")
+    }
+}

--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -21,7 +21,8 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
 
     private func makeContext(
         sourceMode: ProviderSourceMode,
-        env: [String: String] = [:]) -> ProviderFetchContext
+        env: [String: String] = [:],
+        selectedTokenAccountID: UUID? = nil) -> ProviderFetchContext
     {
         ProviderFetchContext(
             runtime: .app,
@@ -34,7 +35,8 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
             settings: nil,
             fetcher: UsageFetcher(environment: env),
             claudeFetcher: StubClaudeFetcher(),
-            browserDetection: BrowserDetection(cacheTTL: 0))
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            selectedTokenAccountID: selectedTokenAccountID)
     }
 
     private func expiredRecord(owner: ClaudeOAuthCredentialOwner = .claudeCLI) -> ClaudeOAuthCredentialRecord {
@@ -117,6 +119,38 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
         #expect(strategy.shouldFallback(
             on: ClaudeUsageError.oauthFailed("oauth failed"),
             context: context) == true)
+    }
+
+    @Test
+    func `auto mode source descriptor account is available without ambient OAuth`() async {
+        let descriptor = ClaudeCredentialSource.credentialsFile(
+            path: "/tmp/claude-account/.credentials.json")
+            .encodedTokenValue()
+        let context = self.makeContext(
+            sourceMode: .auto,
+            env: [ClaudeCredentialSource.environmentDescriptorKey: descriptor],
+            selectedTokenAccountID: UUID())
+        let strategy = ClaudeOAuthFetchStrategy()
+
+        let available = await strategy.isAvailable(context)
+
+        #expect(available == true)
+    }
+
+    @Test
+    func `auto mode selected source descriptor does not fallback to ambient account`() {
+        let descriptor = ClaudeCredentialSource.credentialsFile(
+            path: "/tmp/claude-account/.credentials.json")
+            .encodedTokenValue()
+        let context = self.makeContext(
+            sourceMode: .auto,
+            env: [ClaudeCredentialSource.environmentDescriptorKey: descriptor],
+            selectedTokenAccountID: UUID())
+        let strategy = ClaudeOAuthFetchStrategy()
+
+        #expect(strategy.shouldFallback(
+            on: ClaudeUsageError.oauthFailed("oauth failed"),
+            context: context) == false)
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeTokenAccountSourceModeTests.swift
+++ b/Tests/CodexBarTests/ClaudeTokenAccountSourceModeTests.swift
@@ -1,0 +1,45 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite(.serialized)
+@MainActor
+struct ClaudeTokenAccountSourceModeTests {
+    @Test
+    func `source pointer account reroutes explicit CLI source to OAuth in app`() {
+        let settings = testSettingsStore(suiteName: "ClaudeTokenAccountSourceModeTests-source-app")
+        settings.claudeUsageDataSource = .cli
+        let source = ClaudeCredentialSource.credentialsFile(path: "/tmp/claude-account/.credentials.json")
+        let token = source.encodedTokenValue()
+        settings.addTokenAccount(provider: .claude, label: "OAuth Source", token: token)
+        let store = Self.makeUsageStore(settings: settings)
+
+        let context = store.makeFetchContext(provider: .claude, override: nil)
+
+        #expect(context.sourceMode == .oauth)
+        #expect(context.selectedTokenAccountID == settings.selectedTokenAccount(for: .claude)?.id)
+        #expect(context.env[ClaudeCredentialSource.environmentDescriptorKey] == token)
+    }
+
+    @Test
+    func `session account reroutes explicit CLI source to Web in app`() {
+        let settings = testSettingsStore(suiteName: "ClaudeTokenAccountSourceModeTests-session-app")
+        settings.claudeUsageDataSource = .cli
+        settings.addTokenAccount(provider: .claude, label: "Session", token: "sk-ant-session-token")
+        let store = Self.makeUsageStore(settings: settings)
+
+        let context = store.makeFetchContext(provider: .claude, override: nil)
+
+        #expect(context.sourceMode == .web)
+        #expect(context.settings?.claude?.cookieSource == .manual)
+        #expect(context.settings?.claude?.manualCookieHeader == "sessionKey=sk-ant-session-token")
+    }
+
+    private static func makeUsageStore(settings: SettingsStore) -> UsageStore {
+        UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+    }
+}

--- a/Tests/CodexBarTests/ProviderEnvironmentResolverTests.swift
+++ b/Tests/CodexBarTests/ProviderEnvironmentResolverTests.swift
@@ -69,6 +69,27 @@ struct ProviderEnvironmentResolverTests {
     }
 
     @Test
+    func `Claude source account replaces incompatible credentials`() {
+        let source = ClaudeCredentialSource.credentialsFile(
+            path: "/Users/test/.claude-work/.credentials.json")
+            .encodedTokenValue()
+        let environment = ProviderEnvironmentResolver.resolve(
+            base: [
+                ClaudeAdminAPISettingsReader.alternateAdminAPIKeyEnvironmentKey: "ambient-admin",
+                ClaudeOAuthCredentialsStore.environmentTokenKey: "ambient-oauth",
+            ],
+            provider: .claude,
+            config: ProviderConfig(id: .claude, apiKey: "saved-admin"),
+            selectedAccount: Self.account(token: source))
+
+        for key in ClaudeAdminAPISettingsReader.apiKeyEnvironmentKeys {
+            #expect(environment[key] == nil)
+        }
+        #expect(environment[ClaudeOAuthCredentialsStore.environmentTokenKey] == nil)
+        #expect(environment[ClaudeCredentialSource.environmentDescriptorKey] == source)
+    }
+
+    @Test
     func `cookie account leaves unrelated provider environment intact`() {
         let base = ["FOO": "bar"]
         let environment = ProviderEnvironmentResolver.resolve(

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -1208,7 +1208,7 @@ struct StatusItemAnimationTests {
 
         let displayText = controller.menuBarDisplayText(for: .claude, snapshot: store.snapshot(for: .claude))
 
-        #expect(displayText == "Codex 70%/55% · C1 90%/80% · C2 80%/70%")
+        #expect(displayText == "5h Codex 70% · C1 90% · C2 80% / 7d 55% · 80% · 70%")
 
         controller.applyIcon(phase: nil)
 

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -1064,6 +1064,164 @@ struct StatusItemAnimationTests {
     }
 
     @Test
+    func `stacked Claude token accounts menu bar display shows three accounts and keeps selected visible`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-claude-stacked-menu-bar"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.multiAccountMenuLayout = .stacked
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+        for index in 1...4 {
+            settings.addTokenAccount(
+                provider: .claude,
+                label: "claude-\(index)@example.com",
+                token: "Bearer sk-ant-oat-\(index)")
+        }
+        settings.setActiveTokenAccountIndex(3, for: .claude)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let accounts = settings.tokenAccounts(for: .claude)
+        store.accountSnapshots[.claude] = accounts.enumerated().map { index, account in
+            TokenAccountUsageSnapshot(
+                account: account,
+                snapshot: UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: Double((index + 1) * 10),
+                        windowMinutes: 300,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    secondary: RateWindow(
+                        usedPercent: Double((index * 10) + 5),
+                        windowMinutes: 7 * 24 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    updatedAt: Date()),
+                error: nil,
+                sourceLabel: nil)
+        }
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: store.snapshot(for: .claude))
+
+        #expect(displayText == "90(95)% · 80(85)% · 60(65)%")
+    }
+
+    @Test
+    func `merged menu bar display shows codex and two stacked Claude accounts`() throws {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-codex-claude-stacked-menu-bar"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.multiAccountMenuLayout = .stacked
+        settings.menuBarShowsBrandIconWithPercent = true
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primary, for: .codex)
+        settings.setMenuBarMetricPreference(.primary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+        for index in 1...2 {
+            settings.addTokenAccount(
+                provider: .claude,
+                label: "claude-\(index)@example.com",
+                token: "Bearer sk-ant-oat-\(index)")
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 30,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 45,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+
+        let accounts = settings.tokenAccounts(for: .claude)
+        store.accountSnapshots[.claude] = accounts.enumerated().map { index, account in
+            TokenAccountUsageSnapshot(
+                account: account,
+                snapshot: UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: Double((index + 1) * 10),
+                        windowMinutes: 300,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    secondary: RateWindow(
+                        usedPercent: Double((index + 2) * 10),
+                        windowMinutes: 7 * 24 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    updatedAt: Date()),
+                error: nil,
+                sourceLabel: nil)
+        }
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: store.snapshot(for: .claude))
+
+        #expect(displayText == "Codex 70%/55% · C1 90%/80% · C2 80%/70%")
+
+        controller.applyIcon(phase: nil)
+
+        let button = try #require(controller.statusItem.button)
+        let image = try #require(button.image)
+        #expect(button.title.isEmpty)
+        #expect(button.attributedTitle.string.isEmpty)
+        #expect(button.imagePosition == .imageOnly)
+        #expect(image.isTemplate)
+        #expect(image.size.height == 22)
+    }
+
+    @Test
     func `codex menu bar pace does not fall back to session when weekly projection is unavailable`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "StatusItemAnimationTests-codex-no-weekly-pace"),

--- a/docs/claude-multi-account.md
+++ b/docs/claude-multi-account.md
@@ -1,0 +1,60 @@
+# Claude multi-account support (fork feature)
+
+Branch: `feat/claude-multi-account`
+
+Lets CodexBar track **several Claude accounts at once**, each read and refreshed
+independently — the way Copilot/Codex multi-account already works, now for Claude.
+Built on the existing token-account system; **single-account users are unaffected**
+(legacy raw tokens parse unchanged).
+
+## What it does
+
+- **Auto-discovery** — finds every Claude Code login on the machine by enumerating
+  the real `Claude Code-credentials*` Keychain services (attributes-only, so the
+  enumeration itself doesn't prompt) plus any `~/.claude*/.credentials.json` files.
+- **Per-account refresh** — each account is read **and OAuth-refreshed from its own
+  source** at fetch time, so secondary accounts don't go stale. Rotated tokens are
+  written back **only to secondary sources** (never the default `Claude
+  Code-credentials` item), so we never race Claude Code's own refresh of it.
+- **Email de-dup + labels** — many Keychain slots can hold the *same* login (one
+  account across several config dirs). Discover fetches each account's email
+  (OAuth profile endpoint), **collapses duplicate-email entries to one tab**, and
+  labels it `email · Plan` (e.g. `you@gmail.com · Max`). Revoked/stale entries are
+  skipped.
+- **Self-cleaning** — re-running Discover removes its own previously auto-added
+  entries and re-adds only the live ones; manually pasted accounts are preserved.
+
+## How to use
+
+Settings → **Providers → Claude → Multiple accounts → "Discover accounts"**.
+Approve the Keychain prompts. Set the menu layout to **stacked** to see all
+accounts at once; each tab is an account switcher.
+
+## How it works (key files)
+
+| File | Role |
+|------|------|
+| `CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeCredentialSource.swift` | Encodes a token-account `token` as either a raw token or a refreshable **source pointer** (Keychain service / file), base64-JSON round-trip-safe. |
+| `…/ClaudeAccountDiscovery.swift` | Enumerates real Keychain services + `~/.claude*` dirs → candidate accounts (pure `assemble()` is unit-tested). |
+| `…/ClaudeCredentialResolver.swift` | Reads + refreshes a source at fetch time; `fetchAccountEmail` for labels/de-dup; safe write-back. |
+| `CodexBarCore/TokenAccountSupport.swift` | `envOverride` passes a source descriptor via `CODEXBAR_CLAUDE_SOURCE`. |
+| `CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift` | OAuth load resolves the descriptor → per-account creds. |
+| `CodexBar/Providers/Claude/ClaudeSettingsStore.swift` | Treats a descriptor as OAuth in the settings snapshot. |
+| `CodexBar/Providers/Claude/ClaudeProviderImplementation.swift` | The "Discover accounts" button (discover → validate → de-dup by email → register). |
+
+Display/fetch/menu plumbing is reused unchanged — it's provider-agnostic.
+
+## Tests
+
+`swift test --filter "ClaudeCredential|ClaudeAccountDiscovery|TokenAccount"` —
+unit tests for the source encoding, discovery `assemble()`, the refresh-failure
+classifier, and write-back policy; full Claude/TokenAccount suite stays green.
+
+## Known limitations
+
+- **Cost / token chart is machine-wide, not per-account.** CodexBar estimates
+  Claude cost from local Claude Code logs, which aren't tagged by account, so the
+  same cost shows on every Claude tab. (Upstream behavior; not addressed here.)
+- **A revoked account must be re-logged in** (`CLAUDE_CONFIG_DIR=… claude` →
+  `/login`); no app can read a revoked refresh token. Once re-logged, Discover
+  picks it up.


### PR DESCRIPTION
## Summary

- Render merged Codex plus stacked Claude account percentages in the menu bar, including compact weekly context for the first two Claude accounts.
- Color stacked account cards consistently and keep selected accounts visible in compact menu bar output.
- Tighten Claude OAuth credential routing so selected refreshable account sources do not silently fall back to unrelated strategies.

## Validation

- `make check`
- `make test`