### PR TITLE
Fix remaining memory pressure source isolation crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.37.3 — Unreleased
 
+### Fixed
+- Memory pressure: finish isolating utility-queue source reads from main-actor state to prevent the remaining callback crash. Thanks @Zihao-Qi!
+
 ## 0.37.2 — 2026-06-22
 
 ### Added

--- a/Sources/CodexBar/MemoryPressureMonitor.swift
+++ b/Sources/CodexBar/MemoryPressureMonitor.swift
@@ -64,12 +64,22 @@ final class MemoryPressureMonitor {
             eventMask: [.warning, .critical],
             queue: .global(qos: .utility))
         source.setEventHandler(handler: Self.makeEventHandler(
-            eventReader: { [weak source] in source?.data ?? [] },
+            source: source,
             handle: { [weak self] isWarning, isCritical in
                 self?.handleMemoryPressure(isWarning: isWarning, isCritical: isCritical)
             }))
         self.source = source
         source.resume()
+    }
+
+    nonisolated static func makeEventHandler(
+        source: DispatchSourceMemoryPressure,
+        handle: @escaping @MainActor @Sendable (_ isWarning: Bool, _ isCritical: Bool) -> Void)
+        -> @Sendable () -> Void
+    {
+        self.makeEventHandler(
+            eventReader: { [weak source] in source?.data ?? [] },
+            handle: handle)
     }
 
     nonisolated static func makeEventHandler(

--- a/Tests/CodexBarTests/MemoryPressureCacheTrimTests.swift
+++ b/Tests/CodexBarTests/MemoryPressureCacheTrimTests.swift
@@ -58,6 +58,40 @@ struct MemoryPressureCacheTrimTests {
     }
 
     @Test
+    func `memory pressure source event handler can read source data from utility queue`() async {
+        let source = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical],
+            queue: .global(qos: .utility))
+        source.setEventHandler {}
+        source.resume()
+        defer { source.cancel() }
+
+        let probe = MemoryPressureEventHandlerProbe()
+        let handler = MemoryPressureMonitor.makeEventHandler(
+            source: source,
+            handle: { isWarning, isCritical in
+                probe.record(
+                    isWarning: isWarning,
+                    isCritical: isCritical,
+                    handledOnMainThread: Thread.isMainThread)
+            })
+
+        DispatchQueue.global(qos: .utility).async {
+            probe.recordInvocationThread(isMainThread: Thread.isMainThread)
+            handler()
+        }
+
+        let completed = await Task.detached {
+            probe.wait(timeout: .now() + 2)
+        }.value
+        #expect(completed)
+
+        let snapshot = probe.snapshot()
+        #expect(snapshot.invokedOnMainThread == false)
+        #expect(snapshot.handledOnMainThread)
+    }
+
+    @Test
     func `status controller trims rebuildable menu caches on memory pressure`() {
         let controller = self.makeController()
         defer { controller.releaseStatusItemsForTesting() }


### PR DESCRIPTION
## Summary
- Move the real `DispatchSourceMemoryPressure.data` reader into a `nonisolated` source-based event-handler factory.
- Keep memory-pressure cleanup on `MainActor` after the dispatch-source callback reads the event flags.
- Add a regression test that builds the handler from an actual memory-pressure dispatch source and invokes it from a utility queue.

## Root Cause
PR #1668 fixed the outer memory-pressure dispatch-source callback by making the handler nonisolated and hopping back to `MainActor` for app-state cleanup.

The remaining crash path was one level deeper: `start()` still created the `eventReader` closure that reads `source.data` from inside the `@MainActor` context. The public 0.37.1 crash frame from #1704 symbolicates to that nested reader closure. When the system dispatch source invokes the callback on `com.apple.root.utility-qos`, Swift can still hit the actor-isolation check before cleanup runs.

This follow-up creates the real source reader inside a `nonisolated` overload, so both the dispatch-source callback and its source-data read are built outside main-actor isolation while preserving main-actor cleanup.

Fixes #1704.
Follow-up to #1668.

## Testing
- `swift test --filter MemoryPressureCacheTrimTests`
- `make check`
- `make test`