### PR TITLE
Check blank localized strings

### DIFF
--- a/Scripts/check-app-locales.mjs
+++ b/Scripts/check-app-locales.mjs
@@ -45,6 +45,10 @@ function formatKeyList(keys, limit = 12) {
   return remaining > 0 ? `${shown}, ... +${remaining} more` : shown;
 }
 
+function blankKeys(catalog, referenceKeys) {
+  return referenceKeys.filter((key) => Object.hasOwn(catalog, key) && !catalog[key]?.trim());
+}
+
 function swiftInterpolationTokens(value) {
   const tokens = [];
   for (let index = 0; index < value.length - 1; index += 1) {
@@ -82,6 +86,10 @@ if (isTest) {
     formatKeyList(["alpha", "beta", "gamma", "delta"], 2),
     "alpha, beta, ... +2 more",
     "truncated key list");
+  assertEqual(
+    blankKeys({ alpha: "", beta: "  ", gamma: "ok" }, ["alpha", "beta", "gamma", "delta"]),
+    ["alpha", "beta"],
+    "blank keys");
   console.log("app locale checker tests OK");
   process.exit(0);
 }
@@ -106,6 +114,7 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
 
   checkedCount++;
   const catalogKeys = Object.keys(catalog);
+  const emptyKeys = blankKeys(catalog, englishKeys);
 
   // 1. Missing keys
   const missingKeys = englishKeys.filter((key) => !catalogKeys.includes(key));
@@ -134,15 +143,17 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
     }
   }
 
+  if (emptyKeys.length > 0) {
+    console.error(
+      `\x1b[31m[${locale}] Error: Blank values for ${emptyKeys.length} keys: ${formatKeyList(emptyKeys)}.\x1b[0m`);
+    hasErrors = true;
+  }
+
   // 2. Identical values count
   let identicalCount = 0;
 
   for (const key of englishKeys) {
     if (!catalog[key]?.trim()) {
-      if (strictLocales.includes(locale) && catalogKeys.includes(key)) {
-        console.error(`\x1b[31m[${locale}] Error: Blank value for strict locale key "${key}".\x1b[0m`);
-        hasErrors = true;
-      }
       continue;
     }
 

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -775,8 +775,8 @@
 "Quota" = "Hạn mức";
 "tokens" = "mã thông báo";
 "requests" = "yêu cầu";
-"Latest" = "";
-"Monthly" = "Mới nhất";
+"Latest" = "Mới nhất";
+"Monthly" = "Hàng tháng";
 "Sonnet" = "Sonnet";
 "Overages" = "Quá tải";
 "Activity" = "Hoạt động";


### PR DESCRIPTION
## Summary
- Treat blank localized values as app-locale checker errors for every locale, not only strict locales.
- Add self-test coverage for blank-key detection.
- Fill the Vietnamese popup labels for `Latest` and `Monthly`; `Latest` was empty and `Monthly` reused the latest-label wording.

## Proof
- `node --check Scripts/check-app-locales.mjs` passed.
- `node Scripts/check-app-locales.mjs --test` passed:

```text
app locale checker tests OK
```

- `node Scripts/check-app-locales.mjs` passed:

```text
App locales OK: Checked 20 catalogs against 1074 English keys.
```

- `git diff --check` passed.
- `./Scripts/lint.sh lint-macos` passed:

```text
app locale checker tests OK
App locales OK: Checked 20 catalogs against 1074 English keys.
0/1175 files require formatting.
```

- `./Scripts/lint.sh lint-linux` passed:

```text
Codex parser hash is current (800a06dead603ea7)
documentation links OK: 115 local links
llms index OK: docs/llms.txt
app/site locales OK: 21 locales, 50 site messages
Done linting! Found 0 violations, 0 serious in 1174 files.
```

## Risk
Low. The script change only fails future locale checks when an existing localized key has a blank value, and the resource change fills two Vietnamese popup strings.