### PR TITLE
feat: add live status component submenu for Claude, Codex, and Augment

### DIFF
--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -643,6 +643,7 @@
 
 /* Provider status */
 "status_operational" = "التشغيل";
+"status_degraded" = "أداء متدهور";
 "status_partial_outage" = "انقطاع جزئي";
 "status_major_outage" = "انقطاع كبير";
 "status_critical_issue" = "القضية الحرجة";
@@ -699,6 +700,7 @@
 "Add Account..." = "أضف حساب...";
 "Usage Dashboard" = "لوحة تحكم الاستخدام";
 "Status Page" = "صفحة الحالة";
+"Open Status Page" = "فتح صفحة الحالة";
 "Settings..." = "الإعدادات...";
 "About CodexBar" = "حول CodexBar";
 "Quit" = "استقال";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -632,6 +632,7 @@
 
 /* Provider status */
 "status_operational" = "Operatiu";
+"status_degraded" = "Rendiment degradat";
 "status_partial_outage" = "Interrupció parcial";
 "status_major_outage" = "Interrupció greu";
 "status_critical_issue" = "Problema crític";
@@ -1084,6 +1085,7 @@
 "Source" = "Origen";
 "State" = "Estat";
 "Status Page" = "Pàgina d'estat";
+"Open Status Page" = "Obre la pàgina d'estat";
 "Store multiple Antigravity Google OAuth accounts for quick switching." = "Deseu diversos comptes OAuth de Google d'Antigravity per canviar ràpidament.";
 "Store multiple DeepSeek API keys." = "Deseu diverses claus d'API de DeepSeek.";
 "Store multiple OpenAI API keys." = "Deseu diverses claus d'API d'OpenAI.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -643,6 +643,7 @@
 
 /* Provider status */
 "status_operational" = "Betriebsbereit";
+"status_degraded" = "Eingeschränkte Leistung";
 "status_partial_outage" = "Teilweiser Ausfall";
 "status_major_outage" = "Schwerwiegender Ausfall";
 "status_critical_issue" = "Kritisches Problem";
@@ -699,6 +700,7 @@
 "Add Account..." = "Konto hinzufügen...";
 "Usage Dashboard" = "Nutzungs-Dashboard";
 "Status Page" = "Statusseite";
+"Open Status Page" = "Statusseite öffnen";
 "Settings..." = "Einstellungen...";
 "About CodexBar" = "About CodexBar";
 "Quit" = "Beenden";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -643,6 +643,7 @@
 
 /* Provider status */
 "status_operational" = "Operational";
+"status_degraded" = "Degraded performance";
 "status_partial_outage" = "Partial outage";
 "status_major_outage" = "Major outage";
 "status_critical_issue" = "Critical issue";
@@ -699,6 +700,7 @@
 "Add Account..." = "Add Account...";
 "Usage Dashboard" = "Usage Dashboard";
 "Status Page" = "Status Page";
+"Open Status Page" = "Open Status Page";
 "Settings..." = "Settings...";
 "About CodexBar" = "About CodexBar";
 "Quit" = "Quit";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -632,6 +632,7 @@
 
 /* Provider status */
 "status_operational" = "Operativo";
+"status_degraded" = "Rendimiento degradado";
 "status_partial_outage" = "Interrupción parcial";
 "status_major_outage" = "Interrupción grave";
 "status_critical_issue" = "Problema crítico";
@@ -963,3 +964,4 @@
 "byte_unit_megabytes" = "megabytes";
 "byte_unit_gigabyte" = "gigabyte";
 "byte_unit_gigabytes" = "gigabytes";
+"Open Status Page" = "Abrir página de estado";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -643,6 +643,7 @@
 
 /* Provider status */
 "status_operational" = "عملیاتی";
+"status_degraded" = "کارایی کاهش‌یافته";
 "status_partial_outage" = "قطعی جزئی";
 "status_major_outage" = "قطعی عمده";
 "status_critical_issue" = "مسئله بحرانی";
@@ -699,6 +700,7 @@
 "Add Account..." = "افزودن حساب...";
 "Usage Dashboard" = "داشبورد استفاده";
 "Status Page" = "صفحه وضعیت";
+"Open Status Page" = "باز کردن صفحه وضعیت";
 "Settings..." = "محیط ها...";
 "About CodexBar" = "درباره CodexBar";
 "Quit" = "ترک کن";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -643,6 +643,7 @@
 
 /* Provider status */
 "status_operational" = "Opérationnel";
+"status_degraded" = "Performances dégradées";
 "status_partial_outage" = "Dégradation partielle";
 "status_major_outage" = "Panne majeure";
 "status_critical_issue" = "Problème critique";
@@ -699,6 +700,7 @@
 "Add Account..." = "Ajouter un compte...";
 "Usage Dashboard" = "Tableau de bord d'utilisation";
 "Status Page" = "Page d'état";
+"Open Status Page" = "Ouvrir la page d'état";
 "Settings..." = "Réglages…";
 "About CodexBar" = "À propos de CodexBar";
 "Quit" = "Quitter";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -645,6 +645,7 @@
 
 /* Provider status */
 "status_operational" = "Operasional";
+"status_degraded" = "Performa menurun";
 "status_partial_outage" = "Gangguan sebagian";
 "status_major_outage" = "Gangguan besar";
 "status_critical_issue" = "Masalah kritis";
@@ -701,6 +702,7 @@
 "Add Account..." = "Tambah Akun...";
 "Usage Dashboard" = "Dasbor Penggunaan";
 "Status Page" = "Halaman Status";
+"Open Status Page" = "Buka Halaman Status";
 "Settings..." = "Pengaturan...";
 "About CodexBar" = "Tentang CodexBar";
 "Quit" = "Keluar";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -645,6 +645,7 @@
 
 /* Provider status */
 "status_operational" = "Operativo";
+"status_degraded" = "Prestazioni ridotte";
 "status_partial_outage" = "Interruzione parziale";
 "status_major_outage" = "Interruzione grave";
 "status_critical_issue" = "Problema critico";
@@ -701,6 +702,7 @@
 "Add Account..." = "Aggiungi account...";
 "Usage Dashboard" = "Dashboard utilizzo";
 "Status Page" = "Pagina di stato";
+"Open Status Page" = "Apri pagina di stato";
 "Settings..." = "Impostazioni...";
 "About CodexBar" = "Informazioni su CodexBar";
 "Quit" = "Esci";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -640,6 +640,7 @@
 
 /* Provider status */
 "status_operational" = "正常稼働中";
+"status_degraded" = "パフォーマンス低下";
 "status_partial_outage" = "一部障害";
 "status_major_outage" = "重大な障害";
 "status_critical_issue" = "致命的な問題";
@@ -696,6 +697,7 @@
 "Add Account..." = "アカウントを追加...";
 "Usage Dashboard" = "使用状況ダッシュボード";
 "Status Page" = "ステータスページ";
+"Open Status Page" = "ステータスページを開く";
 "Settings..." = "設定...";
 "About CodexBar" = "CodexBar について";
 "Quit" = "終了";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -622,6 +622,7 @@
 "display_mode_both_desc" = "백분율과 사용 속도 모두 표시(예: 45% · +5%)";
 "display_mode_reset_time_desc" = "선택한 지표의 재설정 시간 표시(예: ↻ 오후 3:56)";
 "status_operational" = "정상 작동";
+"status_degraded" = "성능 저하";
 "status_partial_outage" = "부분 장애";
 "status_major_outage" = "주요 장애";
 "status_critical_issue" = "심각한 문제";
@@ -672,6 +673,7 @@
 "Add Account..." = "계정 추가...";
 "Usage Dashboard" = "사용량 대시보드";
 "Status Page" = "상태 페이지";
+"Open Status Page" = "상태 페이지 열기";
 "Settings..." = "설정...";
 "About CodexBar" = "CodexBar 정보";
 "Quit" = "종료";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -643,6 +643,7 @@
 
 /* Provider status */
 "status_operational" = "Operationeel";
+"status_degraded" = "Verminderde prestaties";
 "status_partial_outage" = "Gedeeltelijke uitval";
 "status_major_outage" = "Grote storing";
 "status_critical_issue" = "Kritieke kwestie";
@@ -699,6 +700,7 @@
 "Add Account..." = "Account toevoegen...";
 "Usage Dashboard" = "Gebruiksdashboard";
 "Status Page" = "Statuspagina";
+"Open Status Page" = "Statuspagina openen";
 "Settings..." = "Instellingen...";
 "About CodexBar" = "Over CodexBar";
 "Quit" = "Stoppen";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -645,6 +645,7 @@
 
 /* Provider status */
 "status_operational" = "Operacyjne";
+"status_degraded" = "Obniżona wydajność";
 "status_partial_outage" = "Częściowa awaria";
 "status_major_outage" = "Poważna awaria";
 "status_critical_issue" = "Krytyczny problem";
@@ -701,6 +702,7 @@
 "Add Account..." = "Dodaj konto...";
 "Usage Dashboard" = "Panel użycia";
 "Status Page" = "Strona statusu";
+"Open Status Page" = "Otwórz stronę stanu";
 "Settings..." = "Ustawienia...";
 "About CodexBar" = "O CodexBar";
 "Quit" = "Zakończ";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -640,6 +640,7 @@
 
 /* Provider status */
 "status_operational" = "Operacional";
+"status_degraded" = "Desempenho degradado";
 "status_partial_outage" = "Falha parcial";
 "status_major_outage" = "Falha geral";
 "status_critical_issue" = "Problema crítico";
@@ -696,6 +697,7 @@
 "Add Account..." = "Adicionar conta...";
 "Usage Dashboard" = "Dashboard de uso";
 "Status Page" = "Página de status";
+"Open Status Page" = "Abrir página de status";
 "Settings..." = "Ajustes...";
 "About CodexBar" = "Sobre o CodexBar";
 "Quit" = "Encerrar";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -642,6 +642,7 @@
 
 /* Provider status */
 "status_operational" = "Fungerar normalt";
+"status_degraded" = "Försämrad prestanda";
 "status_partial_outage" = "Delvis avbrott";
 "status_major_outage" = "Större avbrott";
 "status_critical_issue" = "Kritiskt problem";
@@ -698,6 +699,7 @@
 "Add Account..." = "Lägg till konto...";
 "Usage Dashboard" = "Användningsinstrumentpanel";
 "Status Page" = "Statussida";
+"Open Status Page" = "Öppna statussida";
 "Settings..." = "Inställningar...";
 "About CodexBar" = "Om CodexBar";
 "Quit" = "Avsluta";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -643,6 +643,7 @@
 
 /* Provider status */
 "status_operational" = "การดําเนินงาน";
+"status_degraded" = "ประสิทธิภาพลดลง";
 "status_partial_outage" = "ไฟฟ้าดับบางส่วน";
 "status_major_outage" = "ไฟฟ้าดับครั้งใหญ่";
 "status_critical_issue" = "ปัญหาสําคัญ";
@@ -699,6 +700,7 @@
 "Add Account..." = "เพิ่มบัญชี...";
 "Usage Dashboard" = "แดชบอร์ดการใช้งาน";
 "Status Page" = "หน้าสถานะ";
+"Open Status Page" = "เปิดหน้าสถานะ";
 "Settings..." = "การตั้งค่า...";
 "About CodexBar" = "เกี่ยวกับ CodexBar";
 "Quit" = "ออก";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -641,6 +641,7 @@
 
 /* Provider status */
 "status_operational" = "Çalışır durumda";
+"status_degraded" = "Düşük performans";
 "status_partial_outage" = "Kısmi kesinti";
 "status_major_outage" = "Büyük kesinti";
 "status_critical_issue" = "Kritik sorun";
@@ -697,6 +698,7 @@
 "Add Account..." = "Hesap Ekle...";
 "Usage Dashboard" = "Kullanım Paneli";
 "Status Page" = "Durum Sayfası";
+"Open Status Page" = "Durum Sayfasını Aç";
 "Settings..." = "Ayarlar...";
 "About CodexBar" = "CodexBar Hakkında";
 "Quit" = "Çık";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -643,6 +643,7 @@
 
 /* Provider status */
 "status_operational" = "Працює";
+"status_degraded" = "Знижена продуктивність";
 "status_partial_outage" = "Часткове відключення";
 "status_major_outage" = "Серйозний збій";
 "status_critical_issue" = "Критична проблема";
@@ -699,6 +700,7 @@
 "Add Account..." = "Додати обліковий запис...";
 "Usage Dashboard" = "Панель використання";
 "Status Page" = "Сторінка стану";
+"Open Status Page" = "Відкрити сторінку стану";
 "Settings..." = "Налаштування...";
 "About CodexBar" = "Про CodexBar";
 "Quit" = "Вийти";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -639,6 +639,7 @@
 
 /* Provider status */
 "status_operational" = "Hoạt động";
+"status_degraded" = "Hiệu suất giảm";
 "status_partial_outage" = "Mất điện một phần";
 "status_major_outage" = "Mất điện lớn";
 "status_critical_issue" = "Sự cố nghiêm trọng";
@@ -695,6 +696,7 @@
 "Add Account..." = "Thêm tài khoản...";
 "Usage Dashboard" = "Mức sử dụng Trang tổng quan";
 "Status Page" = "Trang trạng thái";
+"Open Status Page" = "Mở trang trạng thái";
 "Settings..." = "Cài đặt ...";
 "About CodexBar" = "Giới thiệu về CodexBar";
 "Quit" = "Thoát";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -617,6 +617,7 @@
 "display_mode_both_desc" = "同时显示百分比和进度（例如 45% · +5%）";
 "display_mode_reset_time_desc" = "显示所选指标的重置时间（例如 ↻ 3:56 PM）";
 "status_operational" = "正常运行";
+"status_degraded" = "性能下降";
 "status_partial_outage" = "部分中断";
 "status_major_outage" = "重大中断";
 "status_critical_issue" = "严重问题";
@@ -673,6 +674,7 @@
 "Add Account..." = "添加账户…";
 "Usage Dashboard" = "用量仪表盘";
 "Status Page" = "状态页";
+"Open Status Page" = "打开状态页";
 "Settings..." = "设置…";
 "About CodexBar" = "关于 CodexBar";
 "Quit" = "退出";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -628,6 +628,7 @@
 "display_mode_both_desc" = "同時顯示百分比和進度（例如 45% · +5%）";
 "display_mode_reset_time_desc" = "顯示所選指標的重置時間（例如 ↻ 3:56 PM）";
 "status_operational" = "運作正常";
+"status_degraded" = "效能下降";
 "status_partial_outage" = "部分服務中斷";
 "status_major_outage" = "重大服務中斷";
 "status_critical_issue" = "嚴重問題";
@@ -732,6 +733,7 @@
 "Add Account..." = "新增帳號…";
 "Usage Dashboard" = "使用量儀表板";
 "Status Page" = "狀態頁";
+"Open Status Page" = "打開狀態頁";
 "Settings..." = "設定…";
 "About CodexBar" = "關於 CodexBar";
 "Quit" = "結束";

--- a/Sources/CodexBar/StatusComponentsMenuView.swift
+++ b/Sources/CodexBar/StatusComponentsMenuView.swift
@@ -1,5 +1,17 @@
 import SwiftUI
 
+extension ProviderStatusIndicator {
+    /// Traffic-light color used for the per-component dot in the status submenu.
+    fileprivate var dotColor: Color {
+        switch self {
+        case .none: Color(red: 0.20, green: 0.78, blue: 0.35)
+        case .minor, .maintenance: Color(red: 0.96, green: 0.77, blue: 0.13)
+        case .major, .critical: Color(red: 0.91, green: 0.30, blue: 0.24)
+        case .unknown: Color.secondary
+        }
+    }
+}
+
 /// Renders the list of statuspage.io component rows inside the provider's status submenu.
 /// Each leaf row is: colored dot (far left) · service name · right-aligned status text.
 /// A component group renders as an expandable dropdown: the parent shows the group's own

--- a/Sources/CodexBar/StatusComponentsMenuView.swift
+++ b/Sources/CodexBar/StatusComponentsMenuView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// Renders the list of statuspage.io component rows inside the provider's status submenu.
+/// Each leaf row is: colored dot (far left) · service name · right-aligned status text.
+/// A component group renders as an expandable dropdown: the parent shows the group's own
+/// status, and a chevron reveals the individual child statuses indented beneath it
+/// (modeled on the "Other" disclosure in StorageBreakdownMenuView).
+struct StatusComponentsMenuView: View {
+    let components: [ProviderStatusComponent]
+    let width: CGFloat
+    /// Invoked after a group expands or collapses so the host can re-measure the row height.
+    let onToggle: (() -> Void)?
+
+    @State private var expandedGroupIDs: Set<String> = []
+
+    init(
+        components: [ProviderStatusComponent],
+        width: CGFloat,
+        onToggle: (() -> Void)? = nil)
+    {
+        self.components = components
+        self.width = width
+        self.onToggle = onToggle
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(self.components) { component in
+                if component.isGroup {
+                    self.groupRow(component)
+                } else {
+                    self.statusRow(component)
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .frame(width: self.width, alignment: .leading)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    /// A single leaf row: dot · name · right-aligned status.
+    private func statusRow(_ component: ProviderStatusComponent, indented: Bool = false) -> some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(component.indicator.dotColor)
+                .frame(width: 8, height: 8)
+            Text(component.name)
+                .font(.system(size: 13))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            Spacer(minLength: 16)
+            Text(component.statusLabel)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.leading, indented ? 17 : 0)
+    }
+
+    /// An expandable group: parent status row with a chevron, revealing children when expanded.
+    private func groupRow(_ group: ProviderStatusComponent) -> some View {
+        let isExpanded = self.expandedGroupIDs.contains(group.id)
+        return VStack(alignment: .leading, spacing: 6) {
+            Button {
+                if isExpanded {
+                    self.expandedGroupIDs.remove(group.id)
+                } else {
+                    self.expandedGroupIDs.insert(group.id)
+                }
+                self.onToggle?()
+            } label: {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(group.indicator.dotColor)
+                        .frame(width: 8, height: 8)
+                    Text(group.name)
+                        .font(.system(size: 13))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 16)
+                    Text(group.statusLabel)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(group.children) { child in
+                        self.statusRow(child, indented: true)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -327,7 +327,17 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         let preferred = self.lastMenuProvider
             ?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledProviders().first)
 
-        let provider = preferred ?? .codex
+        self.openStatusPage(for: preferred ?? .codex)
+    }
+
+    @objc func openStatusPageFromMenuItem(_ sender: NSMenuItem) {
+        let provider = (sender.identifier?.rawValue).flatMap(UsageProvider.init(rawValue:))
+            ?? self.lastMenuProvider
+            ?? .codex
+        self.openStatusPage(for: provider)
+    }
+
+    private func openStatusPage(for provider: UsageProvider) {
         let meta = self.store.metadata(for: provider)
         let urlString = meta.statusPageURL ?? meta.statusLinkURL
         guard let urlString, let url = URL(string: urlString) else { return }

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -547,14 +547,15 @@ extension StatusItemController {
 
         let linkItem = NSMenuItem(
             title: L("Open Status Page"),
-            action: #selector(self.openStatusPage),
+            action: #selector(self.openStatusPageFromMenuItem(_:)),
             keyEquivalent: "")
         linkItem.target = self
         // Tag the link with the chart identity so the menu is still recognized as a status
         // submenu (and re-hydrates) when the component list hasn't loaded yet and the link is the
-        // only row. openStatusPage resolves the provider via lastMenuProvider, not this object.
+        // only row. The identifier also scopes the action to this submenu's provider so a later
+        // menu selection change cannot open another provider's status page.
         linkItem.representedObject = Self.statusComponentsID
-        linkItem.toolTip = provider.rawValue
+        linkItem.identifier = NSUserInterfaceItemIdentifier(provider.rawValue)
         if let image = NSImage(systemSymbolName: "arrow.up.right.square", accessibilityDescription: nil) {
             image.isTemplate = true
             image.size = NSSize(width: 16, height: 16)

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -95,7 +95,7 @@ extension StatusItemController {
                 false
             }
         case Self.statusComponentsID:
-            if let providerRawValue = placeholder.toolTip,
+            if let providerRawValue = self.hostedSubviewProviderRawValue(for: placeholder),
                let provider = UsageProvider(rawValue: providerRawValue)
             {
                 self.appendStatusComponentsItem(to: menu, provider: provider, width: width)
@@ -196,13 +196,21 @@ extension StatusItemController {
     -> HostedSubviewIdentity? {
         for item in menu.items {
             guard let chartID = item.representedObject as? String else { continue }
-            let providerRawValue = item.toolTip
+            let providerRawValue = self.hostedSubviewProviderRawValue(for: item)
             return HostedSubviewIdentity(
                 chartID: chartID,
                 provider: providerRawValue.flatMap(UsageProvider.init(rawValue:)),
                 providerRawValue: providerRawValue)
         }
         return nil
+    }
+
+    private func hostedSubviewProviderRawValue(for item: NSMenuItem) -> String? {
+        if let providerRawValue = item.toolTip {
+            return providerRawValue
+        }
+        guard item.representedObject as? String == Self.statusComponentsID else { return nil }
+        return item.identifier?.rawValue
     }
 
     private func recordHostedSubviewRenderSignature(

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -278,7 +278,7 @@ extension StatusItemController {
         ].joined(separator: "|")
     }
 
-    private func statusComponentsRenderSignature(for provider: UsageProvider) -> String {
+    func statusComponentsRenderSignature(for provider: UsageProvider) -> String {
         let components = self.store.statusComponents(for: provider)
         guard !components.isEmpty else { return "none" }
         func signature(_ component: ProviderStatusComponent) -> String {

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -17,6 +17,7 @@ extension StatusItemController {
             Self.costHistoryChartID,
             Self.usageHistoryChartID,
             Self.storageBreakdownID,
+            Self.statusComponentsID,
             Self.zaiHourlyUsageChartID,
         ]
         return menu.items.contains { item in
@@ -93,6 +94,14 @@ extension StatusItemController {
             } else {
                 false
             }
+        case Self.statusComponentsID:
+            if let providerRawValue = placeholder.toolTip,
+               let provider = UsageProvider(rawValue: providerRawValue)
+            {
+                self.appendStatusComponentsItem(to: menu, provider: provider, width: width)
+            } else {
+                false
+            }
         case Self.zaiHourlyUsageChartID:
             if let providerRawValue = placeholder.toolTip,
                let provider = UsageProvider(rawValue: providerRawValue)
@@ -157,6 +166,12 @@ extension StatusItemController {
             } else {
                 false
             }
+        case Self.statusComponentsID:
+            if let provider = identity.provider {
+                self.appendStatusComponentsItem(to: menu, provider: provider, width: width)
+            } else {
+                false
+            }
         case Self.zaiHourlyUsageChartID:
             if let provider = identity.provider {
                 self.appendZaiHourlyUsageChartItem(to: menu, provider: provider, width: width)
@@ -216,6 +231,8 @@ extension StatusItemController {
             identity.provider.map(self.usageHistoryRenderSignature(for:)) ?? "missing-provider"
         case Self.storageBreakdownID:
             identity.provider.map(self.storageBreakdownRenderSignature(for:)) ?? "missing-provider"
+        case Self.statusComponentsID:
+            identity.provider.map(self.statusComponentsRenderSignature(for:)) ?? "missing-provider"
         case Self.zaiHourlyUsageChartID:
             identity.provider.map(self.zaiHourlyUsageRenderSignature(for:)) ?? "missing-provider"
         default:
@@ -251,6 +268,16 @@ extension StatusItemController {
             snapshot?.secondary == nil ? "0" : "1",
             snapshot?.tertiary == nil ? "0" : "1",
         ].joined(separator: "|")
+    }
+
+    private func statusComponentsRenderSignature(for provider: UsageProvider) -> String {
+        let components = self.store.statusComponents(for: provider)
+        guard !components.isEmpty else { return "none" }
+        func signature(_ component: ProviderStatusComponent) -> String {
+            let childSig = component.children.map(signature).joined(separator: ",")
+            return "\(component.id)=\(component.indicator.rawValue)[\(childSig)]"
+        }
+        return components.map(signature).joined(separator: ";")
     }
 
     private func storageBreakdownRenderSignature(for provider: UsageProvider) -> String {
@@ -464,6 +491,76 @@ extension StatusItemController {
         item.representedObject = Self.storageBreakdownID
         item.toolTip = provider.rawValue
         submenu.addItem(item)
+        return true
+    }
+
+    @discardableResult
+    func appendStatusComponentsItem(
+        to submenu: NSMenu,
+        provider: UsageProvider,
+        width: CGFloat) -> Bool
+    {
+        // The list of component rows is shown only once the provider's status has been fetched.
+        // Before the first fetch lands the submenu still renders (just the website link below), so
+        // every provider with a status feed gets the native submenu rather than a bare link; it
+        // re-hydrates with the live component list once data arrives (see makeStatusComponentsSubmenu).
+        let components = self.store.statusComponents(for: provider)
+        if !components.isEmpty {
+            if self.menuCardRenderingEnabledForController {
+                final class HostingRelay {
+                    weak var hosting: MenuHostingView<StatusComponentsMenuView>?
+                }
+                let relay = HostingRelay()
+                let listView = StatusComponentsMenuView(
+                    components: components,
+                    width: width,
+                    onToggle: {
+                        // Re-measure the live content after SwiftUI applies the expand/collapse so the
+                        // row grows/shrinks to fit exactly (no leftover blank space).
+                        DispatchQueue.main.async {
+                            guard let hosting = relay.hosting else { return }
+                            hosting.applyMeasuredHeight(
+                                width: width,
+                                height: hosting.measuredFittingHeight(width: width))
+                        }
+                    })
+                let hosting = MenuHostingView(rootView: listView)
+                relay.hosting = hosting
+                hosting.applyMeasuredHeight(width: width, height: hosting.measuredFittingHeight(width: width))
+
+                let listItem = NSMenuItem()
+                listItem.view = hosting
+                listItem.isEnabled = false
+                listItem.representedObject = Self.statusComponentsID
+                listItem.toolTip = provider.rawValue
+                submenu.addItem(listItem)
+            } else {
+                let placeholder = NSMenuItem()
+                placeholder.isEnabled = false
+                placeholder.representedObject = Self.statusComponentsID
+                placeholder.toolTip = provider.rawValue
+                submenu.addItem(placeholder)
+            }
+
+            submenu.addItem(.separator())
+        }
+
+        let linkItem = NSMenuItem(
+            title: L("Open Status Page"),
+            action: #selector(self.openStatusPage),
+            keyEquivalent: "")
+        linkItem.target = self
+        // Tag the link with the chart identity so the menu is still recognized as a status
+        // submenu (and re-hydrates) when the component list hasn't loaded yet and the link is the
+        // only row. openStatusPage resolves the provider via lastMenuProvider, not this object.
+        linkItem.representedObject = Self.statusComponentsID
+        linkItem.toolTip = provider.rawValue
+        if let image = NSImage(systemSymbolName: "arrow.up.right.square", accessibilityDescription: nil) {
+            image.isTemplate = true
+            image.size = NSSize(width: 16, height: 16)
+            linkItem.image = image
+        }
+        submenu.addItem(linkItem)
         return true
     }
 

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -36,6 +36,7 @@ extension StatusItemController {
     static let costHistoryChartID = "costHistoryChart"
     static let usageHistoryChartID = "usageHistoryChart"
     static let storageBreakdownID = "storageBreakdown"
+    static let statusComponentsID = "statusComponents"
 
     private func shortcut(for action: MenuDescriptor.MenuAction) -> (key: String, modifiers: NSEvent.ModifierFlags)? {
         switch action {
@@ -826,6 +827,11 @@ extension StatusItemController {
                         image.size = NSSize(width: 16, height: 16)
                         item.image = image
                     }
+                    self.attachStatusComponentsSubmenuIfNeeded(
+                        to: item,
+                        action: action,
+                        menu: captureMenu ?? menu,
+                        width: width)
                     if case let .switchAccount(targetProvider) = action,
                        let subtitle = self.switchAccountSubtitle(for: targetProvider)
                     {
@@ -1566,6 +1572,47 @@ extension StatusItemController {
                 width: width)
         }
         return self.makeHostedSubviewPlaceholderMenu(chartID: Self.storageBreakdownID, provider: provider)
+    }
+
+    /// Providers that surface the live component list as a native submenu. Every other provider
+    /// keeps the plain "Status Page" link that opens the website. Kept deliberately small: these
+    /// are the statuspage.io/incident.io feeds we actively curate and trust to render well.
+    static let statusComponentsSubmenuProviders: Set<UsageProvider> = [.claude, .codex, .augment]
+
+    /// Builds the status submenu (component rows + a website link) for the curated providers in
+    /// `statusComponentsSubmenuProviders`. Gated on the provider being in that allowlist (and
+    /// having a component feed) rather than on components being loaded yet: status is fetched
+    /// asynchronously, so gating on loaded components would leave the row as a plain link for any
+    /// provider whose first fetch hasn't landed at menu-build time. The submenu hydrates from the
+    /// live component list each time it opens (and shows just the website link until the first
+    /// fetch lands). Returns nil for all other providers, which keep the plain status-page link.
+    /// For curated providers, turns the "Status Page" row into a submenu of live component
+    /// statuses instead of a direct website link (the link moves to the bottom of the submenu).
+    func attachStatusComponentsSubmenuIfNeeded(
+        to item: NSMenuItem,
+        action: MenuDescriptor.MenuAction,
+        menu: NSMenu,
+        width: CGFloat)
+    {
+        guard action == .statusPage,
+              let statusProvider = self.menuProvider(for: menu) ?? self.lastMenuProvider,
+              let submenu = self.makeStatusComponentsSubmenu(provider: statusProvider, width: width)
+        else { return }
+        item.action = nil
+        item.submenu = submenu
+    }
+
+    func makeStatusComponentsSubmenu(provider: UsageProvider, width: CGFloat? = nil) -> NSMenu? {
+        guard self.store.statusChecksEnabled else { return nil }
+        guard Self.statusComponentsSubmenuProviders.contains(provider) else { return nil }
+        guard ProviderDescriptorRegistry.descriptor(for: provider).metadata.statusPageURL != nil else { return nil }
+        if let width {
+            return self.makeHostedSubviewPlaceholderMenu(
+                chartID: Self.statusComponentsID,
+                provider: provider,
+                width: width)
+        }
+        return self.makeHostedSubviewPlaceholderMenu(chartID: Self.statusComponentsID, provider: provider)
     }
 
     private func isOpenAIWebSubviewMenu(_ menu: NSMenu) -> Bool {

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -110,6 +110,21 @@ final class MenuHostingView<Content: View>: NSHostingView<Content> {
         self.layoutSubtreeIfNeeded()
         self.superview?.layoutSubtreeIfNeeded()
     }
+
+    /// Measures the true SwiftUI content height at `width`. The cached `measuredHeight` is routed
+    /// through `intrinsicContentSize`, so `fittingSize` would otherwise echo the stale cached value;
+    /// clearing it for the measurement lets the live content size drive the result. Used to resize
+    /// the row exactly when expandable content (e.g. status groups) toggles.
+    func measuredFittingHeight(width: CGFloat) -> CGFloat {
+        let saved = self.measuredHeight
+        self.measuredHeight = nil
+        self.frame = NSRect(origin: self.frame.origin, size: NSSize(width: width, height: 1))
+        self.invalidateIntrinsicContentSize()
+        self.layoutSubtreeIfNeeded()
+        let height = self.fittingSize.height
+        self.measuredHeight = saved
+        return height
+    }
 }
 
 @MainActor

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -128,6 +128,7 @@ extension StatusItemController {
                 [
                     provider.rawValue,
                     "token=\(tokenSignature)",
+                    "statusComponents=\(self.statusComponentsRenderSignature(for: provider))",
                     "refreshing=\(self.store.shouldShowRefreshingMenuCardIndicator(for: provider) ? "1" : "0")",
                     "usageHistory=\(usageHistoryVisible ? "1" : "0")",
                 ].joined(separator: ":"))

--- a/Sources/CodexBar/UsageStore+Accessors.swift
+++ b/Sources/CodexBar/UsageStore+Accessors.swift
@@ -82,6 +82,11 @@ extension UsageStore {
         self.status(for: provider)?.indicator ?? .none
     }
 
+    func statusComponents(for provider: UsageProvider) -> [ProviderStatusComponent] {
+        guard self.statusChecksEnabled else { return [] }
+        return self.statusComponents[provider] ?? []
+    }
+
     func accountInfo(for provider: UsageProvider) -> AccountInfo {
         let now = Date()
         let configRevision = self.settings.configRevision

--- a/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
+++ b/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
@@ -16,6 +16,7 @@ extension UsageStore {
         self.failureGates[provider]?.reset()
         self.tokenFailureGates[provider]?.reset()
         self.statuses.removeValue(forKey: provider)
+        self.statusComponents.removeValue(forKey: provider)
         self.lastKnownSessionRemaining.removeValue(forKey: provider)
         self.lastKnownSessionWindowSource.removeValue(forKey: provider)
         self.lastTokenFetchAt.removeValue(forKey: provider)

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -324,6 +324,7 @@ extension UsageStore {
             self.failureGates[provider]?.reset()
             self.tokenFailureGates[provider]?.reset()
             self.statuses.removeValue(forKey: provider)
+            self.statusComponents.removeValue(forKey: provider)
             self.lastKnownSessionRemaining.removeValue(forKey: provider)
             self.lastKnownSessionWindowSource.removeValue(forKey: provider)
             self.quotaWarningState = self.quotaWarningState.filter { $0.key.provider != provider }

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -117,15 +117,13 @@ extension UsageStore {
         var componentsRequest = URLRequest(url: baseURL.appendingPathComponent("api/v2/components.json"))
         componentsRequest.timeoutInterval = 10
 
-        async let summaryResult = transport.data(for: summaryRequest)
-        // Non-throwing sibling: component failures must not mask a healthy summary.
-        async let componentsResult: (Data, URLResponse)? = try? transport.data(for: componentsRequest)
-
-        let status = try await Self.parseStatuspageStatus(data: summaryResult.0)
-        let components: [ProviderStatusComponent] = if let (componentsData, _) = await componentsResult {
-            (try? Self.parseStatuspageComponents(data: componentsData)) ?? []
+        let (summaryData, _) = try await transport.data(for: summaryRequest)
+        let status = try Self.parseStatuspageStatus(data: summaryData)
+        let components: [ProviderStatusComponent]
+        if let (componentsData, _) = try? await transport.data(for: componentsRequest) {
+            components = (try? Self.parseStatuspageComponents(data: componentsData)) ?? []
         } else {
-            []
+            components = []
         }
         return (status, components)
     }

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -107,7 +107,15 @@ extension UsageStore {
             if let (data, _) = try? await transport.data(for: proxyRequest),
                let parsed = try? Self.parseIncidentIOSummary(data: data)
             {
-                return parsed
+                // The proxy feed derives the indicator from component leaves but carries no
+                // top-level description or timestamp; fetch the summary endpoint so callers
+                // get the full status banner.
+                let overlay = try? await Self.fetchStatus(from: baseURL, transport: transport)
+                let status = ProviderStatus(
+                    indicator: parsed.status.indicator,
+                    description: overlay?.description,
+                    updatedAt: overlay?.updatedAt)
+                return (status, parsed.components)
             }
         }
 

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -85,6 +85,245 @@ extension UsageStore {
             updatedAt: response.page?.updatedAt)
     }
 
+    /// Resolves the provider's status and component list.
+    ///
+    /// OpenAI's status page is powered by incident.io, whose native feed groups components
+    /// (APIs / ChatGPT / Codex / FedRAMP) — so we try that first. Classic Atlassian
+    /// statuspage.io pages (Claude, Cursor, GitHub) expose a flat `api/v2` feed, which we fall
+    /// back to. `components.json` is used for the flat list because `summary.json` omits unlisted
+    /// components such as "FedRAMP".
+    @concurrent
+    nonisolated static func fetchStatusSummary(
+        from baseURL: URL,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
+        async throws -> (status: ProviderStatus, components: [ProviderStatusComponent])
+    {
+        // incident.io native feed (grouped): https://<host>/proxy/<host>
+        if let host = baseURL.host,
+           let proxyURL = URL(string: "https://\(host)/proxy/\(host)")
+        {
+            var proxyRequest = URLRequest(url: proxyURL)
+            proxyRequest.timeoutInterval = 10
+            if let (data, _) = try? await transport.data(for: proxyRequest),
+               let parsed = try? Self.parseIncidentIOSummary(data: data)
+            {
+                return parsed
+            }
+        }
+
+        // Classic statuspage.io fallback.
+        var summaryRequest = URLRequest(url: baseURL.appendingPathComponent("api/v2/summary.json"))
+        summaryRequest.timeoutInterval = 10
+        var componentsRequest = URLRequest(url: baseURL.appendingPathComponent("api/v2/components.json"))
+        componentsRequest.timeoutInterval = 10
+
+        async let summaryResult = transport.data(for: summaryRequest)
+        async let componentsResult = transport.data(for: componentsRequest)
+
+        let status = try await Self.parseStatuspageStatus(data: summaryResult.0)
+        // Components are best-effort: a healthy overall status should still surface even if the
+        // component feed hiccups.
+        let components = await (try? Self.parseStatuspageComponents(data: componentsResult.0)) ?? []
+        return (status, components)
+    }
+
+    /// Parses incident.io's native status-page summary (`/proxy/<host>`). Groups come from
+    /// `structure.items`; per-component statuses come from `affected_components` (anything not
+    /// listed there is operational). A group's status aggregates the worst of its children.
+    nonisolated static func parseIncidentIOSummary(
+        data: Data)
+        throws -> (status: ProviderStatus, components: [ProviderStatusComponent])
+    {
+        // The incident.io payload mirrors a deeply nested JSON shape; the response models follow it
+        // 1:1 for clarity, which exceeds the default type-nesting depth.
+        // swiftlint:disable nesting
+        struct Response: Decodable {
+            struct Summary: Decodable {
+                struct AffectedComponent: Decodable {
+                    let componentID: String
+                    let status: String?
+                    private enum CodingKeys: String, CodingKey {
+                        case componentID = "component_id"
+                        case status
+                    }
+                }
+
+                struct Structure: Decodable {
+                    struct Item: Decodable {
+                        struct Group: Decodable {
+                            struct Child: Decodable {
+                                let componentID: String
+                                let name: String?
+                                let hidden: Bool?
+                                private enum CodingKeys: String, CodingKey {
+                                    case componentID = "component_id"
+                                    case name, hidden
+                                }
+                            }
+
+                            let id: String
+                            let name: String?
+                            let hidden: Bool?
+                            let components: [Child]?
+                        }
+
+                        struct Component: Decodable {
+                            let id: String
+                            let name: String?
+                            let hidden: Bool?
+                        }
+
+                        let group: Group?
+                        let component: Component?
+                    }
+
+                    let items: [Item]?
+                }
+
+                let affectedComponents: [AffectedComponent]?
+                let structure: Structure?
+                private enum CodingKeys: String, CodingKey {
+                    case affectedComponents = "affected_components"
+                    case structure
+                }
+            }
+
+            let summary: Summary?
+        }
+        // swiftlint:enable nesting
+
+        let response = try JSONDecoder().decode(Response.self, from: data)
+        guard let summary = response.summary,
+              let items = summary.structure?.items,
+              !items.isEmpty
+        else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        var statusByID: [String: String] = [:]
+        for affected in summary.affectedComponents ?? [] {
+            statusByID[affected.componentID] = affected.status
+        }
+
+        func leaf(id: String, name: String) -> ProviderStatusComponent {
+            let raw = statusByID[id] ?? "operational"
+            return ProviderStatusComponent(
+                id: id,
+                name: name,
+                indicator: ProviderStatusComponent.indicator(forStatuspageStatus: raw),
+                statusLabel: ProviderStatusComponent.label(forStatuspageStatus: raw))
+        }
+
+        var topLevel: [ProviderStatusComponent] = []
+        for item in items {
+            if let group = item.group, group.hidden != true {
+                let children = (group.components ?? [])
+                    .filter { $0.hidden != true }
+                    .map { leaf(id: $0.componentID, name: $0.name ?? "") }
+                let worst = children.max { Self.indicatorRank($0.indicator) < Self.indicatorRank($1.indicator) }
+                topLevel.append(ProviderStatusComponent(
+                    id: group.id,
+                    name: group.name ?? "",
+                    indicator: worst?.indicator ?? .none,
+                    statusLabel: worst?.statusLabel ?? ProviderStatusComponent
+                        .label(forStatuspageStatus: "operational"),
+                    children: children))
+            } else if let component = item.component, component.hidden != true {
+                topLevel.append(leaf(id: component.id, name: component.name ?? ""))
+            }
+        }
+
+        let leaves = topLevel.flatMap { $0.isGroup ? $0.children : [$0] }
+        let overall = leaves.max { Self.indicatorRank($0.indicator) < Self.indicatorRank($1.indicator) }
+        let status = ProviderStatus(
+            indicator: overall?.indicator ?? .none,
+            description: nil,
+            updatedAt: nil)
+        return (status, topLevel)
+    }
+
+    nonisolated static func parseStatuspageStatus(data: Data) throws -> ProviderStatus {
+        struct Response: Decodable {
+            struct Status: Decodable {
+                let indicator: String
+                let description: String?
+            }
+
+            struct Page: Decodable {
+                let updatedAt: Date?
+
+                private enum CodingKeys: String, CodingKey {
+                    case updatedAt = "updated_at"
+                }
+            }
+
+            let page: Page?
+            let status: Status
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = StatusFeedDateParser.decodingStrategy()
+        let response = try decoder.decode(Response.self, from: data)
+        let indicator = ProviderStatusIndicator(rawValue: response.status.indicator) ?? .unknown
+        return ProviderStatus(
+            indicator: indicator,
+            description: response.status.description,
+            updatedAt: response.page?.updatedAt)
+    }
+
+    nonisolated static func parseStatuspageComponents(data: Data) throws -> [ProviderStatusComponent] {
+        struct Response: Decodable {
+            struct Component: Decodable {
+                let id: String
+                let name: String
+                let status: String
+                let group: Bool?
+                let groupID: String?
+                let position: Int?
+
+                private enum CodingKeys: String, CodingKey {
+                    case id, name, status, group, position
+                    case groupID = "group_id"
+                }
+            }
+
+            let components: [Component]?
+        }
+
+        let response = try JSONDecoder().decode(Response.self, from: data)
+        let raw = (response.components ?? [])
+            .sorted { ($0.position ?? 0) < ($1.position ?? 0) }
+
+        func makeRow(
+            _ component: Response.Component,
+            children: [ProviderStatusComponent]) -> ProviderStatusComponent
+        {
+            ProviderStatusComponent(
+                id: component.id,
+                name: component.name,
+                indicator: ProviderStatusComponent.indicator(forStatuspageStatus: component.status),
+                statusLabel: ProviderStatusComponent.label(forStatuspageStatus: component.status),
+                children: children)
+        }
+
+        // Children keyed by their parent group id, preserving position order.
+        var childrenByGroup: [String: [ProviderStatusComponent]] = [:]
+        for component in raw where component.group != true {
+            guard let groupID = component.groupID else { continue }
+            childrenByGroup[groupID, default: []].append(makeRow(component, children: []))
+        }
+
+        // Top-level rows: groups (with their children) and ungrouped leaf components, in order.
+        return raw.compactMap { component in
+            if component.group == true {
+                return makeRow(component, children: childrenByGroup[component.id] ?? [])
+            }
+            // Skip leaves that belong to a group; they are rendered inside the group's dropdown.
+            if component.groupID != nil { return nil }
+            return makeRow(component, children: [])
+        }
+    }
+
     @concurrent
     nonisolated static func fetchWorkspaceStatus(
         productID: String,

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -225,7 +225,7 @@ extension UsageStore {
                 id: id,
                 name: name,
                 indicator: ProviderStatusComponent.indicator(forStatuspageStatus: raw),
-                statusLabel: ProviderStatusComponent.label(forStatuspageStatus: raw))
+                status: raw)
         }
 
         var topLevel: [ProviderStatusComponent] = []
@@ -243,8 +243,7 @@ extension UsageStore {
                     id: group.id,
                     name: groupName,
                     indicator: worst?.indicator ?? .none,
-                    statusLabel: worst?.statusLabel ?? ProviderStatusComponent
-                        .label(forStatuspageStatus: "operational"),
+                    status: worst?.status ?? "operational",
                     children: children))
             } else if let component = item.component,
                       component.hidden != true,
@@ -324,7 +323,7 @@ extension UsageStore {
                 id: component.id,
                 name: Self.normalizedStatusComponentName(component.name) ?? component.name,
                 indicator: ProviderStatusComponent.indicator(forStatuspageStatus: component.status),
-                statusLabel: ProviderStatusComponent.label(forStatuspageStatus: component.status),
+                status: component.status,
                 children: children)
         }
 

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -118,12 +118,15 @@ extension UsageStore {
         componentsRequest.timeoutInterval = 10
 
         async let summaryResult = transport.data(for: summaryRequest)
-        async let componentsResult = transport.data(for: componentsRequest)
+        // Non-throwing sibling: component failures must not mask a healthy summary.
+        async let componentsResult: (Data, URLResponse)? = try? transport.data(for: componentsRequest)
 
         let status = try await Self.parseStatuspageStatus(data: summaryResult.0)
-        // Components are best-effort: a healthy overall status should still surface even if the
-        // component feed hiccups.
-        let components = await (try? Self.parseStatuspageComponents(data: componentsResult.0)) ?? []
+        let components: [ProviderStatusComponent] = if let (componentsData, _) = await componentsResult {
+            (try? Self.parseStatuspageComponents(data: componentsData)) ?? []
+        } else {
+            []
+        }
         return (status, components)
     }
 

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -119,11 +119,12 @@ extension UsageStore {
 
         let (summaryData, _) = try await transport.data(for: summaryRequest)
         let status = try Self.parseStatuspageStatus(data: summaryData)
-        let components: [ProviderStatusComponent]
-        if let (componentsData, _) = try? await transport.data(for: componentsRequest) {
-            components = (try? Self.parseStatuspageComponents(data: componentsData)) ?? []
+        let components: [ProviderStatusComponent] = if let (componentsData, _) = try? await transport
+            .data(for: componentsRequest)
+        {
+            (try? Self.parseStatuspageComponents(data: componentsData)) ?? []
         } else {
-            components = []
+            []
         }
         return (status, components)
     }

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -96,7 +96,7 @@ extension UsageStore {
     nonisolated static func fetchStatusSummary(
         from baseURL: URL,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
-        async throws -> (status: ProviderStatus, components: [ProviderStatusComponent])
+        async throws -> (status: ProviderStatus, components: [ProviderStatusComponent]?)
     {
         // incident.io native feed (grouped): https://<host>/proxy/<host>
         if let host = baseURL.host,
@@ -127,12 +127,12 @@ extension UsageStore {
 
         let (summaryData, _) = try await transport.data(for: summaryRequest)
         let status = try Self.parseStatuspageStatus(data: summaryData)
-        let components: [ProviderStatusComponent] = if let (componentsData, _) = try? await transport
+        let components: [ProviderStatusComponent]? = if let (componentsData, _) = try? await transport
             .data(for: componentsRequest)
         {
-            (try? Self.parseStatuspageComponents(data: componentsData)) ?? []
+            try? Self.parseStatuspageComponents(data: componentsData)
         } else {
-            []
+            nil
         }
         return (status, components)
     }
@@ -229,17 +229,24 @@ extension UsageStore {
             if let group = item.group, group.hidden != true {
                 let children = (group.components ?? [])
                     .filter { $0.hidden != true }
-                    .map { leaf(id: $0.componentID, name: $0.name ?? "") }
+                    .compactMap { child -> ProviderStatusComponent? in
+                        guard let name = Self.normalizedStatusComponentName(child.name) else { return nil }
+                        return leaf(id: child.componentID, name: name)
+                    }
+                guard let groupName = Self.normalizedStatusComponentName(group.name) else { continue }
                 let worst = children.max { Self.indicatorRank($0.indicator) < Self.indicatorRank($1.indicator) }
                 topLevel.append(ProviderStatusComponent(
                     id: group.id,
-                    name: group.name ?? "",
+                    name: groupName,
                     indicator: worst?.indicator ?? .none,
                     statusLabel: worst?.statusLabel ?? ProviderStatusComponent
                         .label(forStatuspageStatus: "operational"),
                     children: children))
-            } else if let component = item.component, component.hidden != true {
-                topLevel.append(leaf(id: component.id, name: component.name ?? ""))
+            } else if let component = item.component,
+                      component.hidden != true,
+                      let name = Self.normalizedStatusComponentName(component.name)
+            {
+                topLevel.append(leaf(id: component.id, name: name))
             }
         }
 
@@ -302,6 +309,7 @@ extension UsageStore {
 
         let response = try JSONDecoder().decode(Response.self, from: data)
         let raw = (response.components ?? [])
+            .filter { Self.normalizedStatusComponentName($0.name) != nil }
             .sorted { ($0.position ?? 0) < ($1.position ?? 0) }
 
         func makeRow(
@@ -310,7 +318,7 @@ extension UsageStore {
         {
             ProviderStatusComponent(
                 id: component.id,
-                name: component.name,
+                name: Self.normalizedStatusComponentName(component.name) ?? component.name,
                 indicator: ProviderStatusComponent.indicator(forStatuspageStatus: component.status),
                 statusLabel: ProviderStatusComponent.label(forStatuspageStatus: component.status),
                 children: children)
@@ -332,6 +340,11 @@ extension UsageStore {
             if component.groupID != nil { return nil }
             return makeRow(component, children: [])
         }
+    }
+
+    private nonisolated static func normalizedStatusComponentName(_ name: String?) -> String? {
+        guard let name = name?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else { return nil }
+        return name
     }
 
     @concurrent

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -178,9 +178,13 @@ extension UsageStore {
                         }
 
                         struct Component: Decodable {
-                            let id: String
+                            let componentID: String
                             let name: String?
                             let hidden: Bool?
+                            private enum CodingKeys: String, CodingKey {
+                                case componentID = "component_id"
+                                case name, hidden
+                            }
                         }
 
                         let group: Group?
@@ -246,7 +250,7 @@ extension UsageStore {
                       component.hidden != true,
                       let name = Self.normalizedStatusComponentName(component.name)
             {
-                topLevel.append(leaf(id: component.id, name: name))
+                topLevel.append(leaf(id: component.componentID, name: name))
             }
         }
 

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -154,6 +154,7 @@ final class UsageStore {
     var debugForceAnimation = false
     var pathDebugInfo: PathDebugSnapshot = .empty
     var statuses: [UsageProvider: ProviderStatus] = [:]
+    var statusComponents: [UsageProvider: [ProviderStatusComponent]] = [:]
     var probeLogs: [UsageProvider: String] = [:]
     var historicalPaceRevision: Int = 0
     var planUtilizationHistoryRevision: Int = 0
@@ -880,16 +881,22 @@ final class UsageStore {
 
         do {
             let status: ProviderStatus
+            var components: [ProviderStatusComponent] = []
             if let override = self._test_providerStatusFetchOverride {
                 status = try await override(provider)
             } else if let urlString = meta.statusPageURL, let baseURL = URL(string: urlString) {
-                status = try await Self.fetchStatus(from: baseURL)
+                let summary = try await Self.fetchStatusSummary(from: baseURL)
+                status = summary.status
+                components = summary.components
             } else if let productID = meta.statusWorkspaceProductID {
                 status = try await Self.fetchWorkspaceStatus(productID: productID)
             } else {
                 return
             }
-            await MainActor.run { self.statuses[provider] = status }
+            await MainActor.run {
+                self.statuses[provider] = status
+                self.statusComponents[provider] = components
+            }
         } catch {
             self.recordStartupConnectivityRetryableFailure(error)
             // Keep the previous status to avoid flapping when the API hiccups.

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -881,7 +881,7 @@ final class UsageStore {
 
         do {
             let status: ProviderStatus
-            var components: [ProviderStatusComponent] = []
+            var components: [ProviderStatusComponent]?
             if let override = self._test_providerStatusFetchOverride {
                 status = try await override(provider)
             } else if let urlString = meta.statusPageURL, let baseURL = URL(string: urlString) {
@@ -895,7 +895,11 @@ final class UsageStore {
             }
             await MainActor.run {
                 self.statuses[provider] = status
-                self.statusComponents[provider] = components
+                // A component endpoint is best-effort. Preserve the last good list when the
+                // overall status succeeds but the component request or decoding fails.
+                if let components {
+                    self.statusComponents[provider] = components
+                }
             }
         } catch {
             self.recordStartupConnectivityRetryableFailure(error)

--- a/Sources/CodexBar/UsageStoreSupport.swift
+++ b/Sources/CodexBar/UsageStoreSupport.swift
@@ -1,5 +1,6 @@
 import CodexBarCore
 import Foundation
+import SwiftUI
 
 enum ProviderStatusIndicator: String {
     case none
@@ -26,12 +27,62 @@ enum ProviderStatusIndicator: String {
         case .unknown: L("status_unknown")
         }
     }
+
+    /// Traffic-light color used for the per-component dot in the status submenu.
+    var dotColor: Color {
+        switch self {
+        case .none: Color(red: 0.20, green: 0.78, blue: 0.35) // green
+        case .minor, .maintenance: Color(red: 0.96, green: 0.77, blue: 0.13) // yellow
+        case .major, .critical: Color(red: 0.91, green: 0.30, blue: 0.24) // red
+        case .unknown: Color.secondary
+        }
+    }
 }
 
 struct ProviderStatus {
     let indicator: ProviderStatusIndicator
     let description: String?
     let updatedAt: Date?
+}
+
+/// A single component/service row on a statuspage.io-style status page
+/// (e.g. "Codex API", "CLI", "FedRAMP") with its current state. A row with non-empty
+/// `children` is a component group and renders as an expandable dropdown.
+struct ProviderStatusComponent: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let indicator: ProviderStatusIndicator
+    /// Right-aligned status text shown for the row (e.g. "Operational").
+    let statusLabel: String
+    /// Child rows for a component group; empty for leaf components.
+    var children: [ProviderStatusComponent] = []
+
+    var isGroup: Bool {
+        !self.children.isEmpty
+    }
+
+    /// Maps a statuspage.io component `status` string to our indicator + display label.
+    static func indicator(forStatuspageStatus status: String) -> ProviderStatusIndicator {
+        switch status {
+        case "operational": .none
+        case "degraded_performance": .minor
+        case "partial_outage": .major
+        case "major_outage": .critical
+        case "under_maintenance": .maintenance
+        default: .unknown
+        }
+    }
+
+    static func label(forStatuspageStatus status: String) -> String {
+        switch status {
+        case "operational": L("status_operational")
+        case "degraded_performance": L("status_degraded")
+        case "partial_outage": L("status_partial_outage")
+        case "major_outage": L("status_major_outage")
+        case "under_maintenance": L("status_maintenance")
+        default: L("status_unknown")
+        }
+    }
 }
 
 /// Tracks consecutive failures so we can ignore a single flake when we previously had fresh data.

--- a/Sources/CodexBar/UsageStoreSupport.swift
+++ b/Sources/CodexBar/UsageStoreSupport.swift
@@ -41,13 +41,18 @@ struct ProviderStatusComponent: Identifiable, Equatable {
     let id: String
     let name: String
     let indicator: ProviderStatusIndicator
-    /// Right-aligned status text shown for the row (e.g. "Operational").
-    let statusLabel: String
+    /// Raw provider status. The display label is localized when the row renders so changing
+    /// the app language does not require another network refresh.
+    let status: String
     /// Child rows for a component group; empty for leaf components.
     var children: [ProviderStatusComponent] = []
 
     var isGroup: Bool {
         !self.children.isEmpty
+    }
+
+    var statusLabel: String {
+        Self.label(forStatuspageStatus: self.status)
     }
 
     /// Maps a statuspage.io component `status` string to our indicator + display label.

--- a/Sources/CodexBar/UsageStoreSupport.swift
+++ b/Sources/CodexBar/UsageStoreSupport.swift
@@ -1,6 +1,5 @@
 import CodexBarCore
 import Foundation
-import SwiftUI
 
 enum ProviderStatusIndicator: String {
     case none
@@ -25,16 +24,6 @@ enum ProviderStatusIndicator: String {
         case .critical: L("status_critical_issue")
         case .maintenance: L("status_maintenance")
         case .unknown: L("status_unknown")
-        }
-    }
-
-    /// Traffic-light color used for the per-component dot in the status submenu.
-    var dotColor: Color {
-        switch self {
-        case .none: Color(red: 0.20, green: 0.78, blue: 0.35) // green
-        case .minor, .maintenance: Color(red: 0.96, green: 0.77, blue: 0.13) // yellow
-        case .major, .critical: Color(red: 0.91, green: 0.30, blue: 0.24) // red
-        case .unknown: Color.secondary
         }
     }
 }

--- a/Sources/CodexBar/UsageStoreSupport.swift
+++ b/Sources/CodexBar/UsageStoreSupport.swift
@@ -56,7 +56,7 @@ struct ProviderStatusComponent: Identifiable, Equatable {
         case "operational": .none
         case "degraded_performance": .minor
         case "partial_outage": .major
-        case "major_outage": .critical
+        case "major_outage", "full_outage": .critical
         case "under_maintenance": .maintenance
         default: .unknown
         }
@@ -67,7 +67,7 @@ struct ProviderStatusComponent: Identifiable, Equatable {
         case "operational": L("status_operational")
         case "degraded_performance": L("status_degraded")
         case "partial_outage": L("status_partial_outage")
-        case "major_outage": L("status_major_outage")
+        case "major_outage", "full_outage": L("status_major_outage")
         case "under_maintenance": L("status_maintenance")
         default: L("status_unknown")
         }

--- a/Sources/CodexBarCore/Providers/Augment/AugmentProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AugmentProviderDescriptor.swift
@@ -46,8 +46,7 @@ public enum AugmentProviderDescriptor {
                 usesAccountFallback: false,
                 browserCookieOrder: browserOrder,
                 dashboardURL: "https://app.augmentcode.com/account/subscription",
-                statusPageURL: nil,
-                statusLinkURL: nil),
+                statusPageURL: "https://status.augmentcode.com"),
             branding: ProviderBranding(
                 iconStyle: .augment,
                 iconResourceName: "ProviderIcon-augment",

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -7,6 +7,37 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuHostedSubmenuRefreshTests {
     @Test
+    func `status components change open menu readiness`() {
+        let settings = Self.makeSettings()
+        settings.statusChecksEnabled = true
+        settings.setProviderEnabled(
+            provider: .claude,
+            metadata: ProviderDescriptorRegistry.descriptor(for: .claude).metadata,
+            enabled: true)
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let before = controller.menuAdjunctReadinessSignature()
+        store.statusComponents[.claude] = [
+            ProviderStatusComponent(
+                id: "api",
+                name: "API",
+                indicator: .none,
+                statusLabel: "Operational"),
+        ]
+
+        #expect(controller.menuAdjunctReadinessSignature() != before)
+    }
+
+    @Test
     func `status submenu link stays scoped to its provider`() throws {
         let settings = Self.makeSettings()
         settings.statusChecksEnabled = true

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -31,7 +31,7 @@ struct StatusMenuHostedSubmenuRefreshTests {
                 id: "api",
                 name: "API",
                 indicator: .none,
-                statusLabel: "Operational"),
+                status: "operational"),
         ]
 
         #expect(controller.menuAdjunctReadinessSignature() != before)

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -7,6 +7,33 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuHostedSubmenuRefreshTests {
     @Test
+    func `status submenu link stays scoped to its provider`() throws {
+        let settings = Self.makeSettings()
+        settings.statusChecksEnabled = true
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let submenu = NSMenu()
+        #expect(controller.appendStatusComponentsItem(
+            to: submenu,
+            provider: .claude,
+            width: StatusItemController.menuCardBaseWidth))
+
+        let link = try #require(submenu.items.last)
+        #expect(link.action == #selector(StatusItemController.openStatusPageFromMenuItem(_:)))
+        #expect(link.identifier?.rawValue == UsageProvider.claude.rawValue)
+        #expect(link.target === controller)
+    }
+
+    @Test
     func `storage native row preserves its plain menu title`() throws {
         let settings = Self.makeSettings()
         settings.providerStorageFootprintsEnabled = true

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -26,6 +26,7 @@ struct StatusMenuHostedSubmenuRefreshTests {
             to: submenu,
             provider: .claude,
             width: StatusItemController.menuCardBaseWidth))
+        #expect(controller.hydrateHostedSubviewMenuIfNeeded(submenu))
 
         let link = try #require(submenu.items.last)
         #expect(link.action == #selector(StatusItemController.openStatusPageFromMenuItem(_:)))

--- a/Tests/CodexBarTests/StatuspageSummaryTests.swift
+++ b/Tests/CodexBarTests/StatuspageSummaryTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import CodexBar
+@testable import CodexBarCore
 
 @MainActor
 struct StatuspageSummaryTests {
@@ -72,6 +73,32 @@ struct StatuspageSummaryTests {
     func `parse statuspage components tolerates missing components`() throws {
         let components = try UsageStore.parseStatuspageComponents(data: Data("{}".utf8))
         #expect(components.isEmpty)
+    }
+
+    @Test
+    func `fetchStatusSummary returns status with empty components when component feed fails`() async throws {
+        let summaryJSON = Data(#"""
+        {
+          "page": {"updated_at": "2026-06-18T19:41:22Z"},
+          "status": {"indicator": "minor", "description": "Partial Outage"}
+        }
+        """#.utf8)
+
+        let stub = ProviderHTTPTransportStub { request in
+            guard let path = request.url?.path else { throw URLError(.badURL) }
+            if path.hasSuffix("summary.json") {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (summaryJSON, response)
+            }
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let baseURL = try #require(URL(string: "https://status.example.test"))
+        let result = try await UsageStore.fetchStatusSummary(from: baseURL, transport: stub)
+
+        #expect(result.status.indicator == .minor)
+        #expect(result.status.description == "Partial Outage")
+        #expect(result.components.isEmpty)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatuspageSummaryTests.swift
+++ b/Tests/CodexBarTests/StatuspageSummaryTests.swift
@@ -76,6 +76,22 @@ struct StatuspageSummaryTests {
     }
 
     @Test
+    func `parse statuspage components drops blank names`() throws {
+        let data = Data(#"""
+        {
+          "components": [
+            {"id": "blank", "name": "   ", "status": "operational", "position": 1},
+            {"id": "api", "name": " API ", "status": "operational", "position": 2}
+          ]
+        }
+        """#.utf8)
+
+        let components = try UsageStore.parseStatuspageComponents(data: data)
+
+        #expect(components.map(\.name) == ["API"])
+    }
+
+    @Test
     func `fetchStatusSummary returns status with empty components when component feed fails`() async throws {
         let summaryJSON = Data(#"""
         {
@@ -98,7 +114,7 @@ struct StatuspageSummaryTests {
 
         #expect(result.status.indicator == .minor)
         #expect(result.status.description == "Partial Outage")
-        #expect(result.components.isEmpty)
+        #expect(result.components == nil)
     }
 
     @Test
@@ -135,7 +151,7 @@ struct StatuspageSummaryTests {
         #expect(result.status.indicator == .minor)
         #expect(result.status.description == "Elevated error rates")
         #expect(result.status.updatedAt != nil)
-        #expect(result.components.map(\.name) == ["API"])
+        #expect(result.components?.map(\.name) == ["API"])
     }
 
     @Test

--- a/Tests/CodexBarTests/StatuspageSummaryTests.swift
+++ b/Tests/CodexBarTests/StatuspageSummaryTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct StatuspageSummaryTests {
+    @Test
+    func `parse statuspage status decodes overall indicator`() throws {
+        let data = Data(#"""
+        {
+          "page": {"updated_at": "2026-06-18T19:41:22Z"},
+          "status": {"indicator": "minor", "description": "Partial System Degradation"}
+        }
+        """#.utf8)
+
+        let status = try UsageStore.parseStatuspageStatus(data: data)
+        #expect(status.indicator == .minor)
+        #expect(status.description == "Partial System Degradation")
+        #expect(status.updatedAt != nil)
+    }
+
+    @Test
+    func `parse statuspage components maps and sorts leaf rows`() throws {
+        // Mirrors components.json, which includes unlisted rows such as FedRAMP.
+        let data = Data(#"""
+        {
+          "components": [
+            {"id": "c-cli", "name": "CLI", "status": "operational", "position": 2},
+            {"id": "c-api", "name": "Codex API", "status": "major_outage", "position": 1},
+            {"id": "c-fed", "name": "FedRAMP", "status": "degraded_performance", "position": 25}
+          ]
+        }
+        """#.utf8)
+
+        let components = try UsageStore.parseStatuspageComponents(data: data)
+
+        #expect(components.map(\.name) == ["Codex API", "CLI", "FedRAMP"])
+        #expect(components.map(\.indicator) == [.critical, .none, .minor])
+        #expect(components.allSatisfy { !$0.isGroup })
+        #expect(components.last?.statusLabel == L("status_degraded"))
+    }
+
+    @Test
+    func `parse statuspage components nests children under their group`() throws {
+        let data = Data(#"""
+        {
+          "components": [
+            {"id": "g1", "name": "API", "status": "degraded_performance", "group": true, "position": 0},
+            {"id": "c-resp", "name": "Responses", "status": "operational", "group_id": "g1", "position": 2},
+            {"id": "c-chat", "name": "Chat Completions", "status": "major_outage", "group_id": "g1", "position": 1},
+            {"id": "c-cli", "name": "CLI", "status": "operational", "position": 3}
+          ]
+        }
+        """#.utf8)
+
+        let components = try UsageStore.parseStatuspageComponents(data: data)
+
+        // Top level: the group followed by the ungrouped leaf. Children are not promoted.
+        #expect(components.map(\.name) == ["API", "CLI"])
+
+        let group = try #require(components.first)
+        #expect(group.isGroup)
+        #expect(group.indicator == .minor) // group's own status (degraded)
+        // Children appear inside the group, sorted by position.
+        #expect(group.children.map(\.name) == ["Chat Completions", "Responses"])
+        #expect(group.children.map(\.indicator) == [.critical, .none])
+
+        #expect(components[1].isGroup == false)
+    }
+
+    @Test
+    func `parse statuspage components tolerates missing components`() throws {
+        let components = try UsageStore.parseStatuspageComponents(data: Data("{}".utf8))
+        #expect(components.isEmpty)
+    }
+
+    @Test
+    func `parse incident io summary builds groups with aggregated status`() throws {
+        // Shaped like status.openai.com/proxy/status.openai.com.
+        let data = Data(#"""
+        {
+          "summary": {
+            "affected_components": [
+              {"component_id": "c-fed", "status": "degraded_performance"}
+            ],
+            "structure": {
+              "items": [
+                {"group": {"id": "g-codex", "name": "Codex", "hidden": false, "components": [
+                  {"component_id": "c-cli", "name": "CLI", "hidden": false},
+                  {"component_id": "c-web", "name": "Codex Web", "hidden": false},
+                  {"component_id": "c-secret", "name": "Hidden", "hidden": true}
+                ]}},
+                {"group": {"id": "g-fed", "name": "FedRAMP", "hidden": false, "components": [
+                  {"component_id": "c-fed", "name": "FedRAMP", "hidden": false}
+                ]}},
+                {"component": {"id": "c-top", "name": "Standalone", "hidden": false}}
+              ]
+            }
+          }
+        }
+        """#.utf8)
+
+        let result = try UsageStore.parseIncidentIOSummary(data: data)
+
+        #expect(result.components.map(\.name) == ["Codex", "FedRAMP", "Standalone"])
+
+        let codex = result.components[0]
+        #expect(codex.isGroup)
+        #expect(codex.indicator == .none) // all children operational
+        #expect(codex.children.map(\.name) == ["CLI", "Codex Web"]) // hidden child dropped
+
+        let fedramp = result.components[1]
+        #expect(fedramp.isGroup)
+        #expect(fedramp.indicator == .minor) // aggregates the degraded child
+        #expect(fedramp.statusLabel == L("status_degraded"))
+
+        #expect(result.components[2].isGroup == false) // standalone component
+
+        // Overall page status reflects the worst leaf (FedRAMP degraded).
+        #expect(result.status.indicator == .minor)
+    }
+}

--- a/Tests/CodexBarTests/StatuspageSummaryTests.swift
+++ b/Tests/CodexBarTests/StatuspageSummaryTests.swift
@@ -102,7 +102,7 @@ struct StatuspageSummaryTests {
     }
 
     @Test
-    func `fetchStatusSummary overlays description and updatedAt from status endpoint when incident io succeeds`() async throws {
+    func `fetchStatusSummary overlays description and updatedAt when incident io succeeds`() async throws {
         let proxyJSON = Data(#"""
         {
           "summary": {

--- a/Tests/CodexBarTests/StatuspageSummaryTests.swift
+++ b/Tests/CodexBarTests/StatuspageSummaryTests.swift
@@ -38,6 +38,7 @@ struct StatuspageSummaryTests {
         #expect(components.map(\.name) == ["Codex API", "CLI", "FedRAMP"])
         #expect(components.map(\.indicator) == [.critical, .none, .minor])
         #expect(components.allSatisfy { !$0.isGroup })
+        #expect(components.last?.status == "degraded_performance")
         #expect(components.last?.statusLabel == L("status_degraded"))
     }
 
@@ -193,10 +194,12 @@ struct StatuspageSummaryTests {
         let fedramp = result.components[1]
         #expect(fedramp.isGroup)
         #expect(fedramp.indicator == .minor) // aggregates the degraded child
+        #expect(fedramp.status == "degraded_performance")
         #expect(fedramp.statusLabel == L("status_degraded"))
 
         #expect(result.components[2].isGroup == false) // standalone component
         #expect(result.components[2].indicator == .critical)
+        #expect(result.components[2].status == "full_outage")
         #expect(result.components[2].statusLabel == L("status_major_outage"))
 
         // Overall page status reflects the worst leaf (standalone full outage).

--- a/Tests/CodexBarTests/StatuspageSummaryTests.swift
+++ b/Tests/CodexBarTests/StatuspageSummaryTests.swift
@@ -102,6 +102,43 @@ struct StatuspageSummaryTests {
     }
 
     @Test
+    func `fetchStatusSummary overlays description and updatedAt from status endpoint when incident io succeeds`() async throws {
+        let proxyJSON = Data(#"""
+        {
+          "summary": {
+            "affected_components": [{"component_id": "c-api", "status": "degraded_performance"}],
+            "structure": {"items": [
+              {"component": {"id": "c-api", "name": "API", "hidden": false}}
+            ]}
+          }
+        }
+        """#.utf8)
+
+        let statusJSON = Data(#"""
+        {
+          "page": {"updated_at": "2026-06-20T10:00:00Z"},
+          "status": {"indicator": "minor", "description": "Elevated error rates"}
+        }
+        """#.utf8)
+
+        let stub = ProviderHTTPTransportStub { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            let ok = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            if url.path.contains("/proxy/") { return (proxyJSON, ok) }
+            if url.path.hasSuffix("status.json") { return (statusJSON, ok) }
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let baseURL = try #require(URL(string: "https://status.example.test"))
+        let result = try await UsageStore.fetchStatusSummary(from: baseURL, transport: stub)
+
+        #expect(result.status.indicator == .minor)
+        #expect(result.status.description == "Elevated error rates")
+        #expect(result.status.updatedAt != nil)
+        #expect(result.components.map(\.name) == ["API"])
+    }
+
+    @Test
     func `parse incident io summary builds groups with aggregated status`() throws {
         // Shaped like status.openai.com/proxy/status.openai.com.
         let data = Data(#"""

--- a/Tests/CodexBarTests/StatuspageSummaryTests.swift
+++ b/Tests/CodexBarTests/StatuspageSummaryTests.swift
@@ -124,7 +124,7 @@ struct StatuspageSummaryTests {
           "summary": {
             "affected_components": [{"component_id": "c-api", "status": "degraded_performance"}],
             "structure": {"items": [
-              {"component": {"id": "c-api", "name": "API", "hidden": false}}
+              {"component": {"component_id": "c-api", "name": "API", "hidden": false}}
             ]}
           }
         }
@@ -161,7 +161,8 @@ struct StatuspageSummaryTests {
         {
           "summary": {
             "affected_components": [
-              {"component_id": "c-fed", "status": "degraded_performance"}
+              {"component_id": "c-fed", "status": "degraded_performance"},
+              {"component_id": "c-top", "status": "full_outage"}
             ],
             "structure": {
               "items": [
@@ -173,7 +174,7 @@ struct StatuspageSummaryTests {
                 {"group": {"id": "g-fed", "name": "FedRAMP", "hidden": false, "components": [
                   {"component_id": "c-fed", "name": "FedRAMP", "hidden": false}
                 ]}},
-                {"component": {"id": "c-top", "name": "Standalone", "hidden": false}}
+                {"component": {"component_id": "c-top", "name": "Standalone", "hidden": false}}
               ]
             }
           }
@@ -195,8 +196,10 @@ struct StatuspageSummaryTests {
         #expect(fedramp.statusLabel == L("status_degraded"))
 
         #expect(result.components[2].isGroup == false) // standalone component
+        #expect(result.components[2].indicator == .critical)
+        #expect(result.components[2].statusLabel == L("status_major_outage"))
 
-        // Overall page status reflects the worst leaf (FedRAMP degraded).
-        #expect(result.status.indicator == .minor)
+        // Overall page status reflects the worst leaf (standalone full outage).
+        #expect(result.status.indicator == .critical)
     }
 }

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -282,7 +282,7 @@ struct UsageStoreCoverageTests {
         store._setErrorForTesting("stale", provider: .claude)
         store.statuses[.claude] = ProviderStatus(indicator: .major, description: "Outage", updatedAt: Date())
         store.statusComponents[.claude] = [
-            ProviderStatusComponent(id: "api", name: "API", indicator: .major, statusLabel: "Outage"),
+            ProviderStatusComponent(id: "api", name: "API", indicator: .major, status: "major_outage"),
         ]
 
         #expect(store.enabledProviders() == [.codex])
@@ -455,7 +455,7 @@ struct UsageStoreCoverageTests {
         store._setErrorForTesting("stale", provider: .synthetic)
         store.statuses[.synthetic] = ProviderStatus(indicator: .major, description: "Outage", updatedAt: Date())
         store.statusComponents[.synthetic] = [
-            ProviderStatusComponent(id: "api", name: "API", indicator: .major, statusLabel: "Outage"),
+            ProviderStatusComponent(id: "api", name: "API", indicator: .major, status: "major_outage"),
         ]
         store.tokenErrors[.synthetic] = "token stale"
 

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -281,6 +281,9 @@ struct UsageStoreCoverageTests {
         store._setSnapshotForTesting(staleSnapshot, provider: .claude)
         store._setErrorForTesting("stale", provider: .claude)
         store.statuses[.claude] = ProviderStatus(indicator: .major, description: "Outage", updatedAt: Date())
+        store.statusComponents[.claude] = [
+            ProviderStatusComponent(id: "api", name: "API", indicator: .major, statusLabel: "Outage"),
+        ]
 
         #expect(store.enabledProviders() == [.codex])
 
@@ -289,6 +292,7 @@ struct UsageStoreCoverageTests {
         #expect(store.snapshot(for: .claude) == nil)
         #expect(store.errors[.claude] == nil)
         #expect(store.statuses[.claude] == nil)
+        #expect(store.statusComponents(for: .claude).isEmpty)
     }
 
     @Test
@@ -450,6 +454,9 @@ struct UsageStoreCoverageTests {
         let store = Self.makeUsageStore(settings: settings)
         store._setErrorForTesting("stale", provider: .synthetic)
         store.statuses[.synthetic] = ProviderStatus(indicator: .major, description: "Outage", updatedAt: Date())
+        store.statusComponents[.synthetic] = [
+            ProviderStatusComponent(id: "api", name: "API", indicator: .major, statusLabel: "Outage"),
+        ]
         store.tokenErrors[.synthetic] = "token stale"
 
         #expect(store.enabledProvidersForDisplay() == [.synthetic])
@@ -461,6 +468,7 @@ struct UsageStoreCoverageTests {
         #expect(store.errors[.synthetic] == nil)
         #expect(store.tokenErrors[.synthetic] == nil)
         #expect(store.statuses[.synthetic] == nil)
+        #expect(store.statusComponents(for: .synthetic).isEmpty)
         #expect(store.enabledProvidersForBackgroundWork().isEmpty)
     }
 


### PR DESCRIPTION
## Summary

- add a live status-component submenu to the **Status Page** row for Claude, Codex, and Augment — the row now opens a submenu instead of directly launching the browser, with the website link moved to the bottom of the submenu
- fetch both the overall status and the per-component list in a single `fetchStatusSummary` call; try the incident.io native grouped feed (`/proxy/<host>`) first, fall back to classic statuspage.io `api/v2/summary.json` + `api/v2/components.json` in parallel
- add `parseIncidentIOSummary` for incident.io's grouped shape (used by Codex/OpenAI): builds a tree from `structure.items`, derives each group's status by aggregating the worst child, drops hidden entries, and derives the overall page indicator from the worst leaf
- add `parseStatuspageComponents` for Atlassian statuspage.io's flat `components.json` (Claude, Cursor, GitHub): nests children under their group by `group_id`, preserves `position` order, and promotes neither ungrouped leaves nor hidden entries
- introduce `ProviderStatusComponent` (with `id`, `name`, `indicator`, `statusLabel`, `children`) and `ProviderStatusIndicator.dotColor` (green / yellow / red / secondary) for rendering
- add `StatusComponentsMenuView`: a SwiftUI card showing colored dot · service name · right-aligned status text per leaf; component groups render as an expandable disclosure row (chevron) mirroring `StorageBreakdownMenuView` — toggling re-measures the `MenuHostingView` via a new `measuredFittingHeight(width:)` helper so the row grows/shrinks exactly
- store the fetched component list in `UsageStore.statusComponents[provider]` alongside the existing `statuses` dict; `statusComponents(for:)` returns `[]` when status checks are disabled
- wire `statusComponentsID` through the hosted-submenu pipeline (`appendStatusComponentsItem`, `statusComponentsRenderSignature`, placeholder and identity resolution in `StatusItemController+HostedSubmenus`)
- gate the submenu on `statusComponentsSubmenuProviders` (`[.claude, .codex, .augment]`) — all other providers keep the plain browser-link row; the submenu renders even before the first fetch lands (just the website link), then re-hydrates with the component list once data arrives
- enable Augment's status page by wiring in its `statusPageURL` (`status.augmentcode.com`), which was previously `nil`
- add `status_degraded` and `Open Status Page` localization keys across all 8 locale files

## Tests

- add `StatuspageSummaryTests` (5 cases):
  - `parse statuspage status decodes overall indicator` — verifies indicator + description + `updatedAt` round-trip through `parseStatuspageStatus`
  - `parse statuspage components maps and sorts leaf rows` — flat list sorted by position, `major_outage` → `.critical`, `degraded_performance` → `.minor`, correct `statusLabel`
  - `parse statuspage components nests children under their group` — group promoted to top level, children sorted by position, ungrouped leaf alongside, group's own indicator preserved
  - `parse statuspage components tolerates missing components` — returns `[]` on an empty JSON object
  - `parse incident io summary builds groups with aggregated status` — hidden children dropped, group indicator aggregates worst child, standalone leaf preserved, overall page status reflects worst leaf

## Verification

- built and ran locally; Status Page row for Claude, Codex, and Augment opens a submenu with live component rows
- component groups expand/collapse in place; the row resizes to fit without blank space
- "Open Status Page" at the bottom of the submenu still launches the browser
- providers outside the allowlist (e.g. GitHub, Cursor) keep the plain Status Page link
- full `make test` suite green across all shards

##Screenshots

Before:
<img width="309" height="674" alt="Screenshot 2026-06-22 at 8 39 25 PM" src="https://github.com/user-attachments/assets/e0a2fc5b-00b7-43dc-9d70-a5ece4073594" />

After:
<img width="613" height="205" alt="Screenshot 2026-06-22 at 8 40 57 PM" src="https://github.com/user-attachments/assets/979a2510-2efc-4382-b7a6-3786fb920aa0" />
<img width="612" height="426" alt="Screenshot 2026-06-22 at 8 41 24 PM" src="https://github.com/user-attachments/assets/029e55cb-7634-4c42-8048-d435850f6a7b" />

## Maintainer refinements

- Treat component feeds as best-effort: preserve the last known list on transient component-feed failures.
- Trim and drop blank component names.
- Keep status models UI-framework independent.
- Preserve provider identity through placeholder and link-only submenu hydration.
- Include component changes in open-menu readiness so live rows refresh without reopening.
- Decode incident.io standalone `component_id` entries and map `full_outage` to the critical state.
- Clear cached components whenever disabled or unavailable provider state is cleared.

## Maintainer validation

- 42 focused tests across `StatuspageSummaryTests`, `StatusMenuHostedSubmenuRefreshTests`, and `UsageStoreCoverageTests`
- `make check`
