### PR TITLE
fix: stop Claude version probe from triggering a keychain prompt

### DIFF
--- a/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
+++ b/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
@@ -16,7 +16,13 @@ public enum ProviderVersionDetector {
                 send: "",
                 options: TTYCommandRunner.Options(
                     timeout: 5.0,
-                    extraArgs: ["--allowed-tools", "", "--version"],
+                    // `--version` alone makes Claude Code print and exit before it
+                    // initializes its credential subsystem. Passing `--allowed-tools`
+                    // (even empty) makes it treat the invocation as a real session and
+                    // read the OAuth token from the macOS keychain ("Claude Code-credentials"),
+                    // which spawns `/usr/bin/security` and triggers a keychain prompt on
+                    // every probe when no ~/.claude/.credentials.json / env token exists.
+                    extraArgs: ["--version"],
                     initialDelay: 0.0,
                     useClaudeProbeWorkingDirectory: true)).text
             let trimmed = TextParsing.stripANSICodes(out).trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
## Problem

On every usage refresh, `codexbar serve` (and any Claude usage fetch) pops a macOS keychain prompt:

> **security** wants to access key **"Claude Code-credentials"** in your keychain.

This happens **regardless of the Claude usage source** (Web API / CLI / OAuth) and **regardless of CodexBar's "Keychain prompt policy"** — because the read is not performed by CodexBar's keychain reader. It is performed by the `claude` binary itself, which CodexBar invokes for **version detection**.

## Root cause

`ProviderVersionDetector.claudeVersion()` runs the CLI as:

```
claude --allowed-tools "" --version
```

The `--allowed-tools` flag makes Claude Code treat the invocation as a real session and initialize its credential subsystem, reading the OAuth token from the macOS keychain item `Claude Code-credentials` via `/usr/bin/security`. When the user has no `~/.claude/.credentials.json` file and no `CLAUDE_CODE_OAUTH_TOKEN` env var (keychain is then Claude Code's only credential store), this pops a `security`-subject keychain prompt on every probe — i.e. every usage refresh.

The `--allowed-tools ""` pattern is correct for the real usage probe (`claude /usage --allowed-tools ""`), but was copied into version detection where it is both unnecessary and harmful.

## Fix

Run plain `claude --version`, which prints the version and exits **before** any credential/keychain access — matching the `codex` / `gemini` detectors.

## Verification

Same machine, no `~/.claude/.credentials.json`, `CLAUDE_CODE_OAUTH_TOKEN` unset, invoked through a PTY:

| command | output | keychain prompts |
|---|---|---|
| `claude --allowed-tools "" --version` | `2.1.185 (Claude Code)` | 1 |
| `claude --version` | `2.1.185 (Claude Code)` | 0 |

Version detection still returns the version and no longer touches the keychain. `swift build` of `CodexBarCore` and `CodexBarCLI` is clean.
