### PR TITLE
ci: add workflow summary observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     timeout-minutes: 5
     outputs:
       macos-tests: ${{ steps.macos-tests.outputs.macos-tests }}
+      macos-tests-reason: ${{ steps.macos-tests.outputs.macos-tests-reason }}
+      changed-path-count: ${{ steps.macos-tests.outputs.changed-path-count }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -48,6 +50,26 @@ jobs:
           printf 'Changed paths:\n'
           sed 's/^/- /' "$changed_paths"
           ./Scripts/ci_macos_test_gate.sh "$changed_paths"
+
+      - name: Summarize macOS test gate
+        if: ${{ always() }}
+        shell: bash
+        env:
+          MACOS_TESTS: ${{ steps.macos-tests.outputs.macos-tests }}
+          MACOS_TESTS_REASON: ${{ steps.macos-tests.outputs.macos-tests-reason }}
+          CHANGED_PATH_COUNT: ${{ steps.macos-tests.outputs.changed-path-count }}
+        run: |
+          set -euo pipefail
+          reason="${MACOS_TESTS_REASON:-<unset>}"
+          reason="${reason//|/\\|}"
+          {
+            printf '### macOS test gate\n\n'
+            printf '| Field | Value |\n'
+            printf '| --- | --- |\n'
+            printf '| macOS Swift tests required | `%s` |\n' "${MACOS_TESTS:-<unset>}"
+            printf '| Reason | %s |\n' "$reason"
+            printf '| Changed path entries | `%s` |\n' "${CHANGED_PATH_COUNT:-<unset>}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   lint:
     runs-on: ubuntu-latest
@@ -105,6 +127,26 @@ jobs:
             CODEXBAR_TEST_SHARD_COUNT=${{ matrix.shard-count }} \
             ./Scripts/test.sh
 
+      - name: Summarize macOS shard
+        if: ${{ always() }}
+        shell: bash
+        env:
+          SHARD_INDEX: ${{ matrix.shard-index }}
+          SHARD_COUNT: ${{ matrix.shard-count }}
+          RUNS_LINT_MACOS: ${{ matrix.shard-index == 0 }}
+        run: |
+          set -euo pipefail
+          xcode_version="$(/usr/bin/xcodebuild -version 2>/dev/null | tr '\n' ' ' || true)"
+          {
+            printf '### macOS Swift shard\n\n'
+            printf '| Field | Value |\n'
+            printf '| --- | --- |\n'
+            printf '| Shard | `%s / %s` |\n' "$SHARD_INDEX" "$SHARD_COUNT"
+            printf '| Runner | `%s` |\n' "${RUNNER_NAME:-unknown}"
+            printf '| Xcode | `%s` |\n' "${xcode_version:-unknown}"
+            printf '| Runs lint-macos | `%s` |\n' "$RUNS_LINT_MACOS"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   lint-build-test:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -123,6 +165,30 @@ jobs:
             "${{ needs.changes.result }}" \
             "${{ needs.changes.outputs.macos-tests }}" \
             "${{ needs.swift-test-macos.result }}"
+
+      - name: Summarize aggregate CI gate
+        if: ${{ always() }}
+        shell: bash
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          MACOS_TESTS: ${{ needs.changes.outputs.macos-tests }}
+          MACOS_TESTS_REASON: ${{ needs.changes.outputs.macos-tests-reason }}
+          MACOS_RESULT: ${{ needs.swift-test-macos.result }}
+        run: |
+          set -euo pipefail
+          reason="${MACOS_TESTS_REASON:-<unset>}"
+          reason="${reason//|/\\|}"
+          {
+            printf '### Aggregate CI gate\n\n'
+            printf '| Field | Value |\n'
+            printf '| --- | --- |\n'
+            printf '| lint result | `%s` |\n' "$LINT_RESULT"
+            printf '| changes result | `%s` |\n' "$CHANGES_RESULT"
+            printf '| macOS Swift tests required | `%s` |\n' "${MACOS_TESTS:-<unset>}"
+            printf '| macOS gate reason | %s |\n' "$reason"
+            printf '| swift-test-macos result | `%s` |\n' "$MACOS_RESULT"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   build-linux-cli:
     timeout-minutes: 20
@@ -212,3 +278,22 @@ jobs:
           fi
           "$BIN" usage --provider codex --web 2>&1 | tee /tmp/codexbarcli-stderr.txt >/dev/null || true
           grep -q "macOS" /tmp/codexbarcli-stderr.txt
+
+      - name: Summarize Linux CLI build
+        if: ${{ always() }}
+        shell: bash
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
+          MATRIX_RUNS_ON: ${{ matrix.runs-on }}
+          SWIFT_CACHE_HIT: ${{ steps.swift-toolchain-cache.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          {
+            printf '### Linux CLI build\n\n'
+            printf '| Field | Value |\n'
+            printf '| --- | --- |\n'
+            printf '| Matrix | `%s` |\n' "$MATRIX_NAME"
+            printf '| Runner label | `%s` |\n' "$MATRIX_RUNS_ON"
+            printf '| Swift version | `%s` |\n' "$SWIFT_VERSION"
+            printf '| Swift toolchain cache hit | `%s` |\n' "${SWIFT_CACHE_HIT:-false}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Scripts/ci_macos_test_gate.sh
+++ b/Scripts/ci_macos_test_gate.sh
@@ -86,8 +86,16 @@ if [[ "$path_count" -eq 0 ]]; then
   require_macos_tests '<empty diff>' 'no changed paths were reported'
 fi
 
+if [[ "$macos_tests" == true ]]; then
+  summary_reason="$macos_tests_reason"
+else
+  summary_reason="docs/site-only changes covered by portable checks"
+fi
+
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   printf 'macos-tests=%s\n' "$macos_tests" >> "$GITHUB_OUTPUT"
+  printf 'macos-tests-reason=%s\n' "$summary_reason" >> "$GITHUB_OUTPUT"
+  printf 'changed-path-count=%s\n' "$path_count" >> "$GITHUB_OUTPUT"
 fi
 
 if [[ "$macos_tests" == true ]]; then

--- a/Scripts/test_ci_path_gate.sh
+++ b/Scripts/test_ci_path_gate.sh
@@ -21,6 +21,26 @@ assert_gate() {
     printf '%s: expected macos-tests=%s, got %s\n' "$name" "$expected" "${actual:-<empty>}" >&2
     exit 1
   fi
+
+  local reason
+  reason="$(sed -n 's/^macos-tests-reason=//p' "$output_file")"
+  if [[ -z "$reason" ]]; then
+    printf '%s: expected macos-tests-reason output\n' "$name" >&2
+    exit 1
+  fi
+
+  local path_count
+  path_count="$(sed -n 's/^changed-path-count=//p' "$output_file")"
+  if ! [[ "$path_count" =~ ^[0-9]+$ ]]; then
+    printf '%s: expected numeric changed-path-count output, got %s\n' \
+      "$name" "${path_count:-<empty>}" >&2
+    exit 1
+  fi
+
+  if [[ "$expected" == false && "$reason" != "docs/site-only changes covered by portable checks" ]]; then
+    printf '%s: expected docs/site skip reason, got %s\n' "$name" "$reason" >&2
+    exit 1
+  fi
 }
 
 assert_gate false docs-only $'M\tdocs/providers.md' $'M\tREADME.md'


### PR DESCRIPTION
## Summary
- add GitHub Actions step summaries for the macOS test gate, macOS shards, Linux CLI builds, and the aggregate CI gate
- expose the macOS gate reason and changed path count as job outputs for downstream summaries
- extend focused path-gate tests to verify the new observability outputs

## No behavior change
- does not change CI pass/fail rules
- does not change macOS sharding, runner labels, timeouts, or skip policy
- does not add GitHub API calls or queue-time polling

## Real GitHub Actions proof
Exact-head workflow run completed successfully for `924046af311d24fa13e1b6c88e2764e0d1782207`:

- Run: https://github.com/steipete/CodexBar/actions/runs/27998678712
- Overall conclusion: `success`
- `changes`: success; `Summarize macOS test gate` completed successfully
  - https://github.com/steipete/CodexBar/actions/runs/27998678712/job/82866136046
- `build-linux-cli (linux-x64, ubuntu-24.04)`: success; `Summarize Linux CLI build` completed successfully
  - https://github.com/steipete/CodexBar/actions/runs/27998678712/job/82866136053
- `build-linux-cli (linux-arm64, ubuntu-24.04-arm)`: success; `Summarize Linux CLI build` completed successfully
  - https://github.com/steipete/CodexBar/actions/runs/27998678712/job/82866136075
- `swift-test-macos (0, 4)`: success; `Summarize macOS shard` completed successfully
  - https://github.com/steipete/CodexBar/actions/runs/27998678712/job/82866156399
- `swift-test-macos (1, 4)`: success; `Summarize macOS shard` completed successfully
  - https://github.com/steipete/CodexBar/actions/runs/27998678712/job/82866156391
- `swift-test-macos (2, 4)`: success; `Summarize macOS shard` completed successfully
  - https://github.com/steipete/CodexBar/actions/runs/27998678712/job/82866156405
- `swift-test-macos (3, 4)`: success; `Summarize macOS shard` completed successfully
  - https://github.com/steipete/CodexBar/actions/runs/27998678712/job/82866156403
- `lint-build-test`: success; `Summarize aggregate CI gate` completed successfully
  - https://github.com/steipete/CodexBar/actions/runs/27998678712/job/82869303858

This verifies the added summary steps run in the real PR workflow, not only in local shell checks.

## Validation
- `bash -n Scripts/ci_macos_test_gate.sh`
- `bash -n Scripts/test_ci_path_gate.sh`
- `./Scripts/test_ci_path_gate.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`\n- `git diff --check`