### PR TITLE
Fix Antigravity quota summary lanes

### DIFF
--- a/Sources/CodexBar/IconRemainingResolver.swift
+++ b/Sources/CodexBar/IconRemainingResolver.swift
@@ -3,8 +3,7 @@ import CodexBarCore
 enum IconRemainingResolver {
     private static let visibleZeroPercent = 0.0001
     private static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
-    private static let antigravityGeminiQuotaBucketIDPrefix = "gemini-"
-    // Antigravity quota summaries currently expose exact 5-hour session and weekly buckets for the compact icon.
+    // Antigravity quota summaries expose exact 5-hour session and weekly buckets for the compact icon.
     private static let sessionWindowMinutes = 5 * 60
     private static let weeklyWindowMinutes = 7 * 24 * 60
 
@@ -38,13 +37,6 @@ enum IconRemainingResolver {
             } ?? []
         guard !quotaSummaryWindows.isEmpty else { return nil }
 
-        let geminiWindows = quotaSummaryWindows.filter(Self.isAntigravityGeminiQuotaSummaryWindow)
-        // The Antigravity menu-bar icon represents Gemini quotas. If any Gemini cadence is present,
-        // keep missing Gemini lanes empty instead of silently borrowing Claude + GPT quota.
-        if !geminiWindows.isEmpty {
-            return self.antigravityQuotaSummaryPair(in: geminiWindows.filter(\.usageKnown))
-                ?? (primary: nil, secondary: nil)
-        }
         return self.antigravityQuotaSummaryPair(in: quotaSummaryWindows.filter(\.usageKnown))
     }
 
@@ -56,15 +48,6 @@ enum IconRemainingResolver {
         let weekly = self.mostConstrainedWindow(in: windows, windowMinutes: Self.weeklyWindowMinutes)
         guard session != nil || weekly != nil else { return nil }
         return (primary: session, secondary: weekly)
-    }
-
-    private static func isAntigravityGeminiQuotaSummaryWindow(_ window: NamedRateWindow) -> Bool {
-        self.antigravityQuotaSummaryBucketID(for: window)?.hasPrefix(self.antigravityGeminiQuotaBucketIDPrefix) == true
-    }
-
-    private static func antigravityQuotaSummaryBucketID(for window: NamedRateWindow) -> String? {
-        guard window.id.hasPrefix(self.antigravityQuotaSummaryWindowIDPrefix) else { return nil }
-        return String(window.id.dropFirst(self.antigravityQuotaSummaryWindowIDPrefix.count))
     }
 
     /// Returns the highest-usage window for an exact Antigravity compact-icon cadence.

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -30,10 +30,7 @@ extension UsageStore {
     private func menuBarMetricWindowForHighestUsage(provider: UsageProvider, snapshot: UsageSnapshot) -> RateWindow? {
         let effectivePreference = self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot)
         if provider == .antigravity, effectivePreference == .automatic {
-            let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
-            return [windows.primary, windows.secondary]
-                .compactMap(\.self)
-                .max(by: { $0.usedPercent < $1.usedPercent })
+            return Self.mostConstrainedAntigravityQuotaSummaryWindow(snapshot: snapshot)
         }
         return MenuBarMetricWindowResolver.rateWindow(
             preference: effectivePreference,
@@ -56,9 +53,9 @@ extension UsageStore {
             return percents.allSatisfy { $0 >= 100 }
         }
         if provider == .antigravity, effectivePreference == .automatic {
-            let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
-            let percents = [windows.primary?.usedPercent, windows.secondary?.usedPercent].compactMap(\.self)
-            return percents.allSatisfy { $0 >= 100 }
+            let windows = Self.antigravityQuotaSummaryWindows(snapshot: snapshot)
+            guard !windows.isEmpty else { return true }
+            return windows.allSatisfy { $0.usedPercent >= 100 }
         }
         if provider == .copilot,
            effectivePreference == .automatic,
@@ -81,5 +78,27 @@ extension UsageStore {
         }
 
         return true
+    }
+
+    private nonisolated static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
+
+    private nonisolated static func mostConstrainedAntigravityQuotaSummaryWindow(
+        snapshot: UsageSnapshot)
+        -> RateWindow?
+    {
+        let windows = self.antigravityQuotaSummaryWindows(snapshot: snapshot)
+        guard !windows.isEmpty else { return nil }
+
+        let usableWindows = windows.filter { $0.usedPercent < 100 }
+        if let maxUsable = usableWindows.max(by: { $0.usedPercent < $1.usedPercent }) {
+            return maxUsable
+        }
+        return windows.max(by: { $0.usedPercent < $1.usedPercent })
+    }
+
+    private nonisolated static func antigravityQuotaSummaryWindows(snapshot: UsageSnapshot) -> [RateWindow] {
+        snapshot.extraRateWindows?
+            .filter { $0.usageKnown && $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix) }
+            .map(\.window) ?? []
     }
 }

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -53,7 +53,7 @@ extension UsageStore {
             return percents.allSatisfy { $0 >= 100 }
         }
         if provider == .antigravity, effectivePreference == .automatic {
-            let windows = Self.antigravityQuotaSummaryWindows(snapshot: snapshot)
+            let windows = Self.antigravityRenderedQuotaSummaryWindows(snapshot: snapshot)
             guard !windows.isEmpty else { return true }
             return windows.allSatisfy { $0.usedPercent >= 100 }
         }
@@ -80,13 +80,11 @@ extension UsageStore {
         return true
     }
 
-    private nonisolated static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
-
     private nonisolated static func mostConstrainedAntigravityQuotaSummaryWindow(
         snapshot: UsageSnapshot)
         -> RateWindow?
     {
-        let windows = self.antigravityQuotaSummaryWindows(snapshot: snapshot)
+        let windows = self.antigravityRenderedQuotaSummaryWindows(snapshot: snapshot)
         guard !windows.isEmpty else { return nil }
 
         let usableWindows = windows.filter { $0.usedPercent < 100 }
@@ -96,9 +94,11 @@ extension UsageStore {
         return windows.max(by: { $0.usedPercent < $1.usedPercent })
     }
 
-    private nonisolated static func antigravityQuotaSummaryWindows(snapshot: UsageSnapshot) -> [RateWindow] {
-        snapshot.extraRateWindows?
-            .filter { $0.usageKnown && $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix) }
-            .map(\.window) ?? []
+    private nonisolated static func antigravityRenderedQuotaSummaryWindows(
+        snapshot: UsageSnapshot)
+        -> [RateWindow]
+    {
+        let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
+        return [windows.primary, windows.secondary].compactMap(\.self)
     }
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -299,11 +299,25 @@ public struct AntigravityStatusSnapshot: Sendable {
 
     private static func displayTitle(forQuotaGroup group: AntigravityQuotaSummaryGroup) -> String {
         let title = group.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowercasedTitle = title.lowercased()
+        if lowercasedTitle.contains("gemini") {
+            return "Gemini"
+        }
+        if lowercasedTitle.contains("claude") || lowercasedTitle.contains("gpt") {
+            return "Claude/GPT"
+        }
         return title.isEmpty ? "Quota" : title
     }
 
     private static func displayTitle(forQuotaBucket bucket: AntigravityQuotaSummaryBucket) -> String {
-        bucket.displayName
+        switch self.quotaBucketKind(for: bucket) {
+        case .session:
+            "5-hour"
+        case .weekly:
+            "weekly"
+        case .other:
+            bucket.displayName
+        }
     }
 
     private static func windowMinutes(forQuotaBucket bucket: AntigravityQuotaSummaryBucket) -> Int? {

--- a/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
@@ -37,10 +37,10 @@ struct AntigravityQuotaSummaryTests {
             "antigravity-quota-summary-3p-weekly",
         ])
         #expect(windows.map(\.title) == [
-            "Gemini Models Five Hour Limit",
-            "Gemini Models Weekly Limit",
-            "Claude and GPT models Five Hour Limit",
-            "Claude and GPT models Weekly Limit",
+            "Gemini 5-hour",
+            "Gemini weekly",
+            "Claude/GPT 5-hour",
+            "Claude/GPT weekly",
         ])
         #expect(windows.map(\.window.windowMinutes) == [300, 10080, 300, 10080])
         #expect(windows.map { $0.window.remainingPercent.rounded() } == [91, 82, 73, 64])

--- a/Tests/CodexBarTests/CodexbarTests.swift
+++ b/Tests/CodexBarTests/CodexbarTests.swift
@@ -101,9 +101,9 @@ struct CodexBarTests {
         let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
 
         #expect(windows.primary?.windowMinutes == 300)
-        #expect(windows.primary?.remainingPercent == 3)
+        #expect(windows.primary?.remainingPercent == 2)
         #expect(windows.secondary?.windowMinutes == 10080)
-        #expect(windows.secondary?.remainingPercent == 16)
+        #expect(windows.secondary?.remainingPercent == 1)
     }
 
     @Test
@@ -139,7 +139,7 @@ struct CodexBarTests {
     }
 
     @Test
-    func `antigravity quota summary icon prefers gemini ids over display titles`() {
+    func `antigravity quota summary icon uses most constrained quota summary lanes`() {
         let snapshot = UsageSnapshot(
             primary: nil,
             secondary: nil,
@@ -166,12 +166,12 @@ struct CodexBarTests {
 
         let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
 
-        #expect(windows.primary?.remainingPercent == 60)
-        #expect(windows.secondary?.remainingPercent == 70)
+        #expect(windows.primary?.remainingPercent == 2)
+        #expect(windows.secondary?.remainingPercent == 1)
     }
 
     @Test
-    func `antigravity quota summary icon does not borrow missing gemini weekly from claude gpt`() {
+    func `antigravity quota summary icon can pair gemini session with claude gpt weekly`() {
         let snapshot = UsageSnapshot(
             primary: nil,
             secondary: nil,
@@ -191,11 +191,11 @@ struct CodexBarTests {
         let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
 
         #expect(windows.primary?.remainingPercent == 60)
-        #expect(windows.secondary == nil)
+        #expect(windows.secondary?.remainingPercent == 1)
     }
 
     @Test
-    func `antigravity quota summary icon treats unknown gemini rows as present`() {
+    func `antigravity quota summary icon ignores unknown rows while ranking known lanes`() {
         let snapshot = UsageSnapshot(
             primary: nil,
             secondary: nil,
@@ -216,7 +216,42 @@ struct CodexBarTests {
         let windows = IconRemainingResolver.resolvedWindows(snapshot: snapshot, style: .antigravity)
 
         #expect(windows.primary == nil)
-        #expect(windows.secondary == nil)
+        #expect(windows.secondary?.remainingPercent == 1)
+    }
+
+    @Test
+    func `antigravity used icon percent matches constrained claude gpt lane`() {
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-5h",
+                    title: "Gemini Session",
+                    window: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: nil, resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-weekly",
+                    title: "Gemini Weekly",
+                    window: RateWindow(usedPercent: 30, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-3p-5h",
+                    title: "Claude + GPT Session",
+                    window: RateWindow(usedPercent: 95, windowMinutes: 300, resetsAt: nil, resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-3p-weekly",
+                    title: "Claude + GPT Weekly",
+                    window: RateWindow(usedPercent: 40, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)),
+            ],
+            updatedAt: Date())
+
+        let percents = IconRemainingResolver.resolvedPercents(
+            snapshot: snapshot,
+            style: .antigravity,
+            showUsed: true)
+
+        #expect(percents.primary == 95)
+        #expect(percents.secondary == 40)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
@@ -138,7 +138,7 @@ struct StatusItemAnimationSignatureTests {
 
         #expect(signature.contains("provider=antigravity"))
         #expect(signature.contains("style=combined"))
-        #expect(signature.contains("primary=99.000"))
+        #expect(signature.contains("primary=98.000"))
         #expect(signature.contains("weekly=1.000"))
     }
 

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -242,9 +242,11 @@ struct UsageStoreHighestUsageTests {
         #expect(highest?.provider == .codex)
         #expect(highest?.usedPercent == 70)
     }
+}
 
+extension UsageStoreHighestUsageTests {
     @Test
-    func `automatic metric ranks antigravity by all quota summary lanes`() {
+    func `automatic metric ranks antigravity by rendered quota summary lanes across groups`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-all-summary"),
             zaiTokenStore: NoopZaiTokenStore(),
@@ -271,12 +273,21 @@ struct UsageStoreHighestUsageTests {
                 secondary: nil,
                 updatedAt: Date()),
             provider: .codex)
+        let antigravity = self.antigravityQuotaSummarySnapshot(
+            geminiSessionUsed: 10,
+            geminiWeeklyUsed: 20,
+            otherSessionUsed: 95,
+            otherWeeklyUsed: 90)
+        let unknownCadence = NamedRateWindow(
+            id: "antigravity-quota-summary-future-daily",
+            title: "Future daily lane",
+            window: RateWindow(
+                usedPercent: 99,
+                windowMinutes: 24 * 60,
+                resetsAt: nil,
+                resetDescription: nil))
         store._setSnapshotForTesting(
-            self.antigravityQuotaSummarySnapshot(
-                geminiSessionUsed: 10,
-                geminiWeeklyUsed: 20,
-                otherSessionUsed: 95,
-                otherWeeklyUsed: 90),
+            antigravity.with(extraRateWindows: (antigravity.extraRateWindows ?? []) + [unknownCadence]),
             provider: .antigravity)
 
         var highest = store.providerWithHighestUsage()

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -244,9 +244,9 @@ struct UsageStoreHighestUsageTests {
     }
 
     @Test
-    func `automatic metric ranks antigravity by rendered gemini quota summary lanes`() {
+    func `automatic metric ranks antigravity by all quota summary lanes`() {
         let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-rendered-gemini"),
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-all-summary"),
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
         settings.refreshFrequency = .manual
@@ -280,8 +280,8 @@ struct UsageStoreHighestUsageTests {
             provider: .antigravity)
 
         var highest = store.providerWithHighestUsage()
-        #expect(highest?.provider == .codex)
-        #expect(highest?.usedPercent == 80)
+        #expect(highest?.provider == .antigravity)
+        #expect(highest?.usedPercent == 95)
 
         store._setSnapshotForTesting(
             self.antigravityQuotaSummarySnapshot(
@@ -306,9 +306,9 @@ struct UsageStoreHighestUsageTests {
     }
 
     @Test
-    func `automatic metric keeps antigravity when one rendered lane has quota`() {
+    func `automatic metric skips exhausted antigravity quota summary lanes when another remains usable`() {
         let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-all-100"),
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-summary-usable"),
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
         settings.refreshFrequency = .manual
@@ -340,8 +340,8 @@ struct UsageStoreHighestUsageTests {
         store._setSnapshotForTesting(antigravitySnapshot, provider: .antigravity)
 
         let highest = store.providerWithHighestUsage()
-        #expect(highest?.provider == .antigravity)
-        #expect(highest?.usedPercent == 100)
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 80)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- rank Antigravity automatic menu bar usage from the rendered 5-hour and weekly quota lanes across both model groups
- ignore non-renderable quota cadences when choosing the automatic highest-usage provider
- keep Antigravity compact icon rendering aligned with the same most-constrained rendered lanes
- shorten Antigravity quota lane titles to match the new grouped Google UI (`Gemini 5-hour`, `Claude/GPT weekly`, etc.)
- update focused regression tests for the new quota grouping behavior

## Verification
- `swift test --filter 'CodexbarTests|AntigravityQuotaSummaryTests|MenuBarMetricWindowResolverTests|UsageStoreHighestUsageTests'`
- `swift test --skip-build --filter antigravity`
- `make check`
- manually launched the patched app and verified the menu shows the new grouped lanes without raw localization keys

## Screenshot Evidence
- Source UI: Google Antigravity settings now groups quota into Gemini Models and Claude/GPT models, each with weekly and 5-hour limits.
- Verified UI: CodexBar now renders `Gemini 5-hour`, `Gemini weekly`, `Claude/GPT 5-hour`, and `Claude/GPT weekly` with correct remaining percentages.

<img width="1310" height="1162" alt="Google Antigravity grouped model quota settings" src="https://github.com/user-attachments/assets/4a0d68a9-6cca-41a7-9b4d-a7847a815e17" />

<img width="626" height="1272" alt="CodexBar Antigravity grouped quota menu" src="https://github.com/user-attachments/assets/0350fbd1-1b85-4581-a95e-479317cd961d" />

Note: local screenshot files were used for verification but are not committed to the repo.
