### PR TITLE
feat: add refresh-on-open setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Menu: add an opt-in setting to refresh provider usage whenever the menu opens without changing the periodic refresh clock. Thanks @dstier-git!
+
 ### Fixed
 - Claude web usage: bound stale requests so Auto can reach CLI fallback instead of hanging indefinitely.
 - Claude history: keep OAuth utilization separate across account switches while preserving continuity through token refreshes.

--- a/Sources/CodexBar/MenuOpenRefreshPlan.swift
+++ b/Sources/CodexBar/MenuOpenRefreshPlan.swift
@@ -1,0 +1,34 @@
+import CodexBarCore
+
+struct MenuOpenRefreshPlan: Equatable {
+    struct Inputs {
+        let refreshAllOnOpen: Bool
+        let enabledProviders: [UsageProvider]
+        let visibleProviders: [UsageProvider]
+        let refreshingProviders: Set<UsageProvider>
+        let staleProviders: Set<UsageProvider>
+        let missingProviders: Set<UsageProvider>
+    }
+
+    enum Scheduling: Equatable {
+        case sequential
+        case concurrent
+    }
+
+    let providers: [UsageProvider]
+    let scheduling: Scheduling
+
+    static func resolve(_ inputs: Inputs) -> Self {
+        if inputs.refreshAllOnOpen {
+            return Self(providers: inputs.enabledProviders, scheduling: .concurrent)
+        }
+
+        let enabled = Set(inputs.enabledProviders)
+        let providers = inputs.visibleProviders.filter {
+            enabled.contains($0) &&
+                (inputs.refreshingProviders.contains($0) || inputs.staleProviders.contains($0) ||
+                    inputs.missingProviders.contains($0))
+        }
+        return Self(providers: providers, scheduling: .sequential)
+    }
+}

--- a/Sources/CodexBar/MenuOpenRefreshPlan.swift
+++ b/Sources/CodexBar/MenuOpenRefreshPlan.swift
@@ -17,10 +17,14 @@ struct MenuOpenRefreshPlan: Equatable {
 
     let providers: [UsageProvider]
     let scheduling: Scheduling
+    let refreshCodexDashboard: Bool
 
     static func resolve(_ inputs: Inputs) -> Self {
         if inputs.refreshAllOnOpen {
-            return Self(providers: inputs.enabledProviders, scheduling: .concurrent)
+            return Self(
+                providers: inputs.enabledProviders,
+                scheduling: .concurrent,
+                refreshCodexDashboard: inputs.enabledProviders.contains(.codex))
         }
 
         let enabled = Set(inputs.enabledProviders)
@@ -29,6 +33,9 @@ struct MenuOpenRefreshPlan: Equatable {
                 (inputs.refreshingProviders.contains($0) || inputs.staleProviders.contains($0) ||
                     inputs.missingProviders.contains($0))
         }
-        return Self(providers: providers, scheduling: .sequential)
+        return Self(
+            providers: providers,
+            scheduling: .sequential,
+            refreshCodexDashboard: false)
     }
 }

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -216,6 +216,10 @@ struct GeneralPane: View {
                         }
                     }
                     PreferenceToggleRow(
+                        title: L("refresh_on_open_title"),
+                        subtitle: L("refresh_on_open_subtitle"),
+                        binding: self.$settings.refreshAllProvidersOnMenuOpen)
+                    PreferenceToggleRow(
                         title: L("check_provider_status_title"),
                         subtitle: L("check_provider_status_subtitle"),
                         binding: self.$settings.statusChecksEnabled)

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -431,6 +431,8 @@
 "refresh_cadence_title" = "وتيرة التحديث";
 "refresh_cadence_subtitle" = "كم مرة CodexBar استطلاعات في الخلفية.";
 "manual_refresh_hint" = "التحديث التلقائي مغلق؛ استخدم أمر التحديث في القائمة.";
+"refresh_on_open_title" = "التحديث عند فتح القائمة";
+"refresh_on_open_subtitle" = "جلب أحدث بيانات الاستخدام لكل مزوّد في كل مرة تفتح فيها القائمة.";
 "check_provider_status_title" = "تحقق من حالة المزود";
 "check_provider_status_subtitle" = "استطلاعات OpenAI/Claude صفحات الحالة و Google مساحة العمل Gemini/Antigravity، وتظهر الحوادث في الأيقونة والقائمة.";
 "session_quota_notifications_title" = "إشعارات حصص الجلسة";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -429,6 +429,8 @@
 "refresh_cadence_title" = "Freqüència d'actualització";
 "refresh_cadence_subtitle" = "Amb quina freqüència el CodexBar consulta els proveïdors en segon pla.";
 "manual_refresh_hint" = "L'actualització automàtica està desactivada; feu servir l'ordre Actualitza del menú.";
+"refresh_on_open_title" = "Actualitza en obrir el menú";
+"refresh_on_open_subtitle" = "Obté l'ús més recent de cada proveïdor cada vegada que obres el menú.";
 "check_provider_status_title" = "Comproveu l'estat del proveïdor";
 "check_provider_status_subtitle" = "Consulta les pàgines d'estat d'OpenAI/Claude i Google Workspace per a Gemini/Antigravity, mostrant incidències a la icona i al menú.";
 "session_quota_notifications_title" = "Notificacions de quota de sessió";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -431,6 +431,8 @@
 "refresh_cadence_title" = "Aktualisierungsintervall";
 "refresh_cadence_subtitle" = "Wie oft CodexBar Anbieter im Hintergrund abfragt.";
 "manual_refresh_hint" = "Auto-Aktualisierung ist aus; nutze im Menü den Befehl „Aktualisieren“.";
+"refresh_on_open_title" = "Beim Öffnen des Menüs aktualisieren";
+"refresh_on_open_subtitle" = "Bei jedem Öffnen des Menüs die aktuelle Nutzung aller Anbieter abrufen.";
 "check_provider_status_title" = "Anbieterstatus prüfen";
 "check_provider_status_subtitle" = "Prüft OpenAI/Claude-Statusseiten und Google Workspace für Gemini/Antigravity und zeigt Vorfälle in Icon und Menü.";
 "session_quota_notifications_title" = "Sitzungs-Quota-Benachrichtigungen";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -431,6 +431,8 @@
 "refresh_cadence_title" = "Refresh cadence";
 "refresh_cadence_subtitle" = "How often CodexBar polls providers in the background.";
 "manual_refresh_hint" = "Auto-refresh is off; use the menu's Refresh command.";
+"refresh_on_open_title" = "Refresh when the menu opens";
+"refresh_on_open_subtitle" = "Fetch the latest usage for every provider each time you open the menu.";
 "check_provider_status_title" = "Check provider status";
 "check_provider_status_subtitle" = "Polls OpenAI/Claude status pages and Google Workspace for Gemini/Antigravity, surfacing incidents in the icon and menu.";
 "session_quota_notifications_title" = "Session quota notifications";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -429,6 +429,8 @@
 "refresh_cadence_title" = "Frecuencia de actualización";
 "refresh_cadence_subtitle" = "Con qué frecuencia CodexBar consulta a los proveedores en segundo plano.";
 "manual_refresh_hint" = "La actualización automática está desactivada; usa el comando Actualizar del menú.";
+"refresh_on_open_title" = "Actualizar al abrir el menú";
+"refresh_on_open_subtitle" = "Obtén el uso más reciente de cada proveedor cada vez que abres el menú.";
 "check_provider_status_title" = "Comprobar estado del proveedor";
 "check_provider_status_subtitle" = "Consulta las páginas de estado de OpenAI/Claude y Google Workspace para Gemini/Antigravity, mostrando incidencias en el icono y el menú.";
 "session_quota_notifications_title" = "Notificaciones de cuota de sesión";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -431,6 +431,8 @@
 "refresh_cadence_title" = "کادانس تازه سازی";
 "refresh_cadence_subtitle" = "چند وقت یکبار CodexBar ارائه دهندگان نظرسنجی در پس زمینه انجام می دهند.";
 "manual_refresh_hint" = "تازه سازی خودکار خاموش است؛ از فرمان تازه سازی منو استفاده کنید.";
+"refresh_on_open_title" = "بازخوانی هنگام باز کردن منو";
+"refresh_on_open_subtitle" = "هر بار که منو را باز می‌کنید، آخرین میزان مصرف هر ارائه‌دهنده دریافت می‌شود.";
 "check_provider_status_title" = "وضعیت ارائه دهنده را بررسی کنید";
 "check_provider_status_subtitle" = "نظرسنجی ها OpenAI/Claude صفحات وضعیت و Google Workspace برای Gemini/Antigravity که حوادث را در آیکون و منو نمایش می دهد.";
 "session_quota_notifications_title" = "اعلان های سهمیه نشست";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -431,6 +431,8 @@
 "refresh_cadence_title" = "Fréquence d'actualisation";
 "refresh_cadence_subtitle" = "Définit la fréquence à laquelle CodexBar interroge les fournisseurs en arrière-plan.";
 "manual_refresh_hint" = "L'actualisation automatique est désactivée ; utilisez la commande Actualiser du menu.";
+"refresh_on_open_title" = "Actualiser à l'ouverture du menu";
+"refresh_on_open_subtitle" = "Récupère l'utilisation la plus récente de chaque fournisseur à chaque ouverture du menu.";
 "check_provider_status_title" = "Vérifier l'état des fournisseurs";
 "check_provider_status_subtitle" = "Interroge les pages d'état OpenAI/Claude et Google Workspace pour Gemini/Antigravity, et affiche les incidents dans l'icône et le menu.";
 "session_quota_notifications_title" = "Notifications de quota de session";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -433,6 +433,8 @@
 "refresh_cadence_title" = "Frekuensi penyegaran";
 "refresh_cadence_subtitle" = "Seberapa sering CodexBar memeriksa penyedia di latar belakang.";
 "manual_refresh_hint" = "Penyegaran otomatis nonaktif; gunakan perintah Segarkan di menu.";
+"refresh_on_open_title" = "Segarkan saat menu dibuka";
+"refresh_on_open_subtitle" = "Ambil penggunaan terbaru untuk setiap penyedia setiap kali Anda membuka menu.";
 "check_provider_status_title" = "Periksa status penyedia";
 "check_provider_status_subtitle" = "Memeriksa halaman status OpenAI/Claude dan Google Workspace untuk Gemini/Antigravity, menampilkan insiden di ikon dan menu.";
 "session_quota_notifications_title" = "Notifikasi kuota sesi";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -433,6 +433,8 @@
 "refresh_cadence_title" = "Frequenza aggiornamento";
 "refresh_cadence_subtitle" = "Con quale frequenza CodexBar interroga i provider in background.";
 "manual_refresh_hint" = "Aggiornamento automatico disattivato; usa il comando Aggiorna nel menu.";
+"refresh_on_open_title" = "Aggiorna all'apertura del menu";
+"refresh_on_open_subtitle" = "Recupera l'utilizzo più recente di ogni provider ogni volta che apri il menu.";
 "check_provider_status_title" = "Controlla stato provider";
 "check_provider_status_subtitle" = "Controlla le pagine di stato OpenAI/Claude e Google Workspace per Gemini/Antigravity, mostrando incidenti in icona e menu.";
 "session_quota_notifications_title" = "Notifiche quota sessione";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -428,6 +428,8 @@
 "refresh_cadence_title" = "更新間隔";
 "refresh_cadence_subtitle" = "CodexBar がバックグラウンドでプロバイダをポーリングする頻度です。";
 "manual_refresh_hint" = "自動更新はオフです。メニューの「更新」コマンドを使用してください。";
+"refresh_on_open_title" = "メニューを開いたときに更新";
+"refresh_on_open_subtitle" = "メニューを開くたびに、すべてのプロバイダーの最新の使用状況を取得します。";
 "check_provider_status_title" = "プロバイダのステータスを確認";
 "check_provider_status_subtitle" = "OpenAI/Claude のステータスページと Gemini/Antigravity 用の Google Workspace をポーリングし、障害情報をアイコンとメニューに表示します。";
 "session_quota_notifications_title" = "セッションクォータ通知";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -428,6 +428,8 @@
 "refresh_cadence_title" = "새로 고침 주기";
 "refresh_cadence_subtitle" = "CodexBar가 백그라운드에서 공급자를 폴링하는 빈도입니다.";
 "manual_refresh_hint" = "자동 새로 고침이 꺼져 있습니다. 메뉴의 새로 고침 명령을 사용하세요.";
+"refresh_on_open_title" = "메뉴를 열 때 새로 고침";
+"refresh_on_open_subtitle" = "메뉴를 열 때마다 모든 공급자의 최신 사용량을 가져옵니다.";
 "check_provider_status_title" = "공급자 상태 확인";
 "check_provider_status_subtitle" = "OpenAI/Claude 상태 페이지와 Gemini/Antigravity용 Google Workspace를 폴링하여 아이콘과 메뉴에 문제를 표시합니다.";
 "session_quota_notifications_title" = "세션 할당량 알림";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -431,6 +431,8 @@
 "refresh_cadence_title" = "Cadans vernieuwen";
 "refresh_cadence_subtitle" = "Hoe vaak CodexBar providers op de achtergrond ondervraagt.";
 "manual_refresh_hint" = "Automatisch vernieuwen is uitgeschakeld; gebruik de opdracht Vernieuwen van het menu.";
+"refresh_on_open_title" = "Vernieuwen bij openen van menu";
+"refresh_on_open_subtitle" = "Haalt bij elke keer dat je het menu opent het meest recente gebruik van elke provider op.";
 "check_provider_status_title" = "Controleer de status van de provider";
 "check_provider_status_subtitle" = "Polls van OpenAI/Claude-statuspagina's en Google Workspace voor Gemini/Antigravity, waarbij incidenten in het pictogram en het menu worden weergegeven.";
 "session_quota_notifications_title" = "Meldingen over sessiequota";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -433,6 +433,8 @@
 "refresh_cadence_title" = "Częstotliwość odświeżania";
 "refresh_cadence_subtitle" = "Jak często CodexBar odpyta dostawców w tle.";
 "manual_refresh_hint" = "Auto-odświeżanie jest wyłączone; użyj polecenia Odśwież w menu.";
+"refresh_on_open_title" = "Odśwież po otwarciu menu";
+"refresh_on_open_subtitle" = "Pobiera najnowsze zużycie każdego dostawcy przy każdym otwarciu menu.";
 "check_provider_status_title" = "Sprawdzaj status dostawców";
 "check_provider_status_subtitle" = "Sprawdza status OpenAI/Claude oraz Google Workspace dla Gemini/Antigravity i pokazuje incydenty na ikonie i w menu.";
 "session_quota_notifications_title" = "Powiadomienia o limicie sesji";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -428,6 +428,8 @@
 "refresh_cadence_title" = "Cadência de atualização";
 "refresh_cadence_subtitle" = "Frequência com que o CodexBar consulta provedores em segundo plano.";
 "manual_refresh_hint" = "A atualização automática está desativada; use Atualizar no menu.";
+"refresh_on_open_title" = "Atualizar ao abrir o menu";
+"refresh_on_open_subtitle" = "Busca o uso mais recente de cada provedor sempre que você abre o menu.";
 "check_provider_status_title" = "Verificar status dos provedores";
 "check_provider_status_subtitle" = "Consulta páginas de status da OpenAI/Claude e o Google Workspace para Gemini/Antigravity, exibindo incidentes no ícone e no menu.";
 "session_quota_notifications_title" = "Notificações de cota de sessão";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -431,6 +431,8 @@
 "refresh_cadence_title" = "Uppdateringsintervall";
 "refresh_cadence_subtitle" = "Hur ofta CodexBar kontrollerar leverantörer i bakgrunden.";
 "manual_refresh_hint" = "Automatisk uppdatering är avstängd. Använd Uppdatera i menyn.";
+"refresh_on_open_title" = "Uppdatera när menyn öppnas";
+"refresh_on_open_subtitle" = "Hämtar den senaste användningen för varje leverantör varje gång du öppnar menyn.";
 "check_provider_status_title" = "Kontrollera leverantörsstatus";
 "check_provider_status_subtitle" = "Kontrollerar OpenAI/Claude-statussidor och Google Workspace för Gemini/Antigravity och visar incidenter i ikonen och menyn.";
 "session_quota_notifications_title" = "Aviseringar för sessionskvot";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -431,6 +431,8 @@
 "refresh_cadence_title" = "จังหวะการรีเฟรช";
 "refresh_cadence_subtitle" = "ความถี่ในการ CodexBar ผู้ให้บริการโพลในเบื้องหลัง";
 "manual_refresh_hint" = "การรีเฟรชอัตโนมัติปิดอยู่ ใช้คําสั่งรีเฟรชของเมนู";
+"refresh_on_open_title" = "รีเฟรชเมื่อเปิดเมนู";
+"refresh_on_open_subtitle" = "ดึงข้อมูลการใช้งานล่าสุดของผู้ให้บริการทุกรายทุกครั้งที่คุณเปิดเมนู";
 "check_provider_status_title" = "ตรวจสอบสถานะผู้ให้บริการ";
 "check_provider_status_subtitle" = "โพล OpenAI/Claude หน้าสถานะและ Google Workspace for Gemini/Antigravity โดยแสดงเหตุการณ์ในไอคอนและเมนู";
 "session_quota_notifications_title" = "การแจ้งเตือนโควต้าเซสชัน";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -431,6 +431,8 @@
 "refresh_cadence_title" = "Yenileme sıklığı";
 "refresh_cadence_subtitle" = "CodexBar'ın arka planda sağlayıcıları ne sıklıkla sorgulayacağı.";
 "manual_refresh_hint" = "Otomatik yenileme kapalı; menüdeki Yenile komutunu kullanın.";
+"refresh_on_open_title" = "Menü açıldığında yenile";
+"refresh_on_open_subtitle" = "Menüyü her açtığınızda her sağlayıcının en güncel kullanımını getirir.";
 "check_provider_status_title" = "Sağlayıcı durumunu denetle";
 "check_provider_status_subtitle" = "OpenAI/Claude durum sayfalarını ve Google Workspace'i (Gemini/Antigravity) sorgular, olayları simge ve menüde gösterir.";
 "session_quota_notifications_title" = "Oturum kota bildirimleri";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -431,6 +431,8 @@
 "refresh_cadence_title" = "Оновити каденцію";
 "refresh_cadence_subtitle" = "Як часто CodexBar опитує постачальників у фоновому режимі.";
 "manual_refresh_hint" = "Автооновлення вимкнено; скористайтеся командою меню «Оновити».";
+"refresh_on_open_title" = "Оновлювати при відкритті меню";
+"refresh_on_open_subtitle" = "Отримує найновіші дані про використання для кожного провайдера щоразу, коли ви відкриваєте меню.";
 "check_provider_status_title" = "Перевірте статус провайдера";
 "check_provider_status_subtitle" = "Опитує сторінки статусу OpenAI/Claude і Google Workspace для Gemini/Antigravity, виявляючи інциденти в значку та меню.";
 "session_quota_notifications_title" = "Сповіщення про квоту сеансу";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -427,6 +427,8 @@
 "refresh_cadence_title" = "Nhịp làm mới";
 "refresh_cadence_subtitle" = "Tần suất CodexBar thăm dò ý kiến ​​các nhà cung cấp trong nền.";
 "manual_refresh_hint" = "Tính năng tự động làm mới bị tắt; sử dụng lệnh Làm mới của menu.";
+"refresh_on_open_title" = "Làm mới khi mở menu";
+"refresh_on_open_subtitle" = "Tải mức sử dụng mới nhất của mọi nhà cung cấp mỗi khi bạn mở menu.";
 "check_provider_status_title" = "Kiểm tra Nhà cung cấp trạng thái";
 "check_provider_status_subtitle" = "Thăm dò ý kiến ​​OpenAI / Claude các trang trạng thái và Google Không gian làm việc dành cho Gemini /AntiGravity, phát hiện các sự cố trong biểu tượng và menu.";
 "session_quota_notifications_title" = "Thông báo về phiên Hạn mức";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -435,6 +435,8 @@
 "refresh_cadence_title" = "刷新频率";
 "refresh_cadence_subtitle" = "CodexBar 在后台轮询提供商的频率。";
 "manual_refresh_hint" = "自动刷新已关闭；请使用菜单中的“刷新”命令。";
+"refresh_on_open_title" = "打开菜单时刷新";
+"refresh_on_open_subtitle" = "每次打开菜单时获取每个提供商的最新用量。";
 "check_provider_status_title" = "检查提供商状态";
 "check_provider_status_subtitle" = "轮询 OpenAI/Claude 状态页面和 Google Workspace 的 Gemini/Antigravity，在图标和菜单中显示故障信息。";
 "session_quota_notifications_title" = "会话配额通知";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -435,6 +435,8 @@
 "refresh_cadence_title" = "重新整理頻率";
 "refresh_cadence_subtitle" = "CodexBar 在背景輪詢提供者的頻率。";
 "manual_refresh_hint" = "自動重新整理已關閉；請使用選單中的「重新整理」指令。";
+"refresh_on_open_title" = "開啟選單時重新整理";
+"refresh_on_open_subtitle" = "每次開啟選單時擷取每個供應商的最新用量。";
 "check_provider_status_title" = "檢查提供者狀態";
 "check_provider_status_subtitle" = "輪詢 OpenAI/Claude 狀態頁面和 Google Workspace 的 Gemini/Antigravity，並在圖示和選單中顯示服務異常資訊。";
 "session_quota_notifications_title" = "工作階段配額通知";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -13,8 +13,8 @@ extension SettingsStore {
         }
     }
 
-    /// When enabled, opening the menu refreshes usage for every enabled provider (on top of the
-    /// periodic refresh clock, which is left untouched). See `scheduleOpenMenuRefresh`.
+    /// When enabled, keeping the menu open through its short refresh delay fetches usage for every
+    /// enabled provider. The periodic refresh clock remains unchanged. See `scheduleOpenMenuRefresh`.
     var refreshAllProvidersOnMenuOpen: Bool {
         get { self.defaultsState.refreshAllProvidersOnMenuOpen }
         set {

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -13,6 +13,16 @@ extension SettingsStore {
         }
     }
 
+    /// When enabled, opening the menu refreshes usage for every enabled provider (on top of the
+    /// periodic refresh clock, which is left untouched). See `scheduleOpenMenuRefresh`.
+    var refreshAllProvidersOnMenuOpen: Bool {
+        get { self.defaultsState.refreshAllProvidersOnMenuOpen }
+        set {
+            self.defaultsState.refreshAllProvidersOnMenuOpen = newValue
+            self.userDefaults.set(newValue, forKey: "refreshAllProvidersOnMenuOpen")
+        }
+    }
+
     var launchAtLogin: Bool {
         get { self.defaultsState.launchAtLogin }
         set {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -369,6 +369,8 @@ extension SettingsStore {
         if Self.isRunningTests, refreshDefault == nil {
             userDefaults.set(refreshFrequency.rawValue, forKey: "refreshFrequency")
         }
+        let refreshAllProvidersOnMenuOpen = userDefaults.object(
+            forKey: "refreshAllProvidersOnMenuOpen") as? Bool ?? false
         let launchAtLogin = userDefaults.object(forKey: "launchAtLogin") as? Bool ?? false
         let debugMenuEnabled = userDefaults.object(forKey: "debugMenuEnabled") as? Bool ?? false
         let debugDisableKeychainAccess = Self.loadDebugDisableKeychainAccess(userDefaults: userDefaults)
@@ -456,6 +458,7 @@ extension SettingsStore {
         let appLanguageRaw = userDefaults.string(forKey: "appLanguage")
         return SettingsDefaultsState(
             refreshFrequency: refreshFrequency,
+            refreshAllProvidersOnMenuOpen: refreshAllProvidersOnMenuOpen,
             launchAtLogin: launchAtLogin,
             debugMenuEnabled: debugMenuEnabled,
             debugDisableKeychainAccess: debugDisableKeychainAccess,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct SettingsDefaultsState {
     var refreshFrequency: RefreshFrequency
+    var refreshAllProvidersOnMenuOpen: Bool
     var launchAtLogin: Bool
     var debugMenuEnabled: Bool
     var debugDisableKeychainAccess: Bool

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1142,6 +1142,7 @@ extension StatusItemController {
                 refreshingProviders: self.store.refreshingProviders,
                 staleProviders: Set(visibleProviders.filter { self.store.isStale(provider: $0) }),
                 missingProviders: Set(visibleProviders.filter { self.store.snapshot(for: $0) == nil })))
+            if plan.refreshCodexDashboard { self.deferOpenAIDashboardRefreshUntilMenuCloses(reason: "refresh all") }
             let retryProviders = plan.providers
             guard !retryProviders.isEmpty else {
                 self.clearSatisfiedDeferredMenuInteractionRefreshes(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1133,20 +1133,16 @@ extension StatusItemController {
             #endif
             guard self.openMenus[ObjectIdentifier(menu)] != nil else { return }
             let refreshAllOnOpen = self.settings.refreshAllProvidersOnMenuOpen
-            let availableProviders = Set(self.store.enabledProvidersForBackgroundWork())
-            // When "refresh all providers on open" is enabled, consider every enabled provider and refresh
-            // it regardless of freshness; otherwise keep the conservative stale/missing retry set scoped to
-            // the providers actually rendered in this menu.
-            let candidateProviders = refreshAllOnOpen
-                ? self.store.enabledProvidersForBackgroundWork()
-                : self.delayedRefreshRetryProviders(for: menu)
-            let retryProviders = candidateProviders.filter {
-                availableProviders.contains($0) &&
-                    (refreshAllOnOpen ||
-                        self.store.refreshingProviders.contains($0) ||
-                        self.store.isStale(provider: $0) ||
-                        self.store.snapshot(for: $0) == nil)
-            }
+            let enabledProviders = self.store.enabledProvidersForBackgroundWork()
+            let visibleProviders = self.delayedRefreshRetryProviders(for: menu)
+            let plan = MenuOpenRefreshPlan.resolve(.init(
+                refreshAllOnOpen: refreshAllOnOpen,
+                enabledProviders: enabledProviders,
+                visibleProviders: visibleProviders,
+                refreshingProviders: self.store.refreshingProviders,
+                staleProviders: Set(visibleProviders.filter { self.store.isStale(provider: $0) }),
+                missingProviders: Set(visibleProviders.filter { self.store.snapshot(for: $0) == nil })))
+            let retryProviders = plan.providers
             guard !retryProviders.isEmpty else {
                 self.clearSatisfiedDeferredMenuInteractionRefreshes(
                     for: self.delayedRefreshRetryProviders(for: menu))
@@ -1162,7 +1158,7 @@ extension StatusItemController {
             }
             self.deferMenuInteractionRefreshIfNeeded(providers: retryProviders)
             await ProviderInteractionContext.$current.withValue(.background) {
-                if refreshAllOnOpen {
+                if plan.scheduling == .concurrent {
                     // Refresh concurrently so one slow provider doesn't delay the rest, mirroring the
                     // periodic refresh in `UsageStore.runRefresh`. `coalesceIfRefreshing` makes each call
                     // wait for any in-flight refresh (e.g. a manual refresh) instead of overriding it.

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1112,6 +1112,9 @@ extension StatusItemController {
         // provider fetch failed and needs a retry; periodic freshness is handled by the refresh timer.
         // AppKit menu tracking is modal, so starting provider refreshes while it is active can make the menu
         // feel frozen and can block keyboard focus from returning.
+        // Exception: when `refreshAllProvidersOnMenuOpen` is enabled, every enabled provider is refreshed on
+        // open regardless of freshness — still after the delay below, and still via the light usage-only
+        // primitive so the OpenAI dashboard scrape stays deferred until the menu closes.
         let providersNeedingRetryAtOpen = self.delayedRefreshRetryProviders(for: menu).filter {
             self.store.isStale(provider: $0) || self.store.snapshot(for: $0) == nil
         }
@@ -1129,10 +1132,18 @@ extension StatusItemController {
             self.onDelayedMenuRefreshAttemptForTesting?()
             #endif
             guard self.openMenus[ObjectIdentifier(menu)] != nil else { return }
+            let refreshAllOnOpen = self.settings.refreshAllProvidersOnMenuOpen
             let availableProviders = Set(self.store.enabledProvidersForBackgroundWork())
-            let retryProviders = self.delayedRefreshRetryProviders(for: menu).filter {
+            // When "refresh all providers on open" is enabled, consider every enabled provider and refresh
+            // it regardless of freshness; otherwise keep the conservative stale/missing retry set scoped to
+            // the providers actually rendered in this menu.
+            let candidateProviders = refreshAllOnOpen
+                ? self.store.enabledProvidersForBackgroundWork()
+                : self.delayedRefreshRetryProviders(for: menu)
+            let retryProviders = candidateProviders.filter {
                 availableProviders.contains($0) &&
-                    (self.store.refreshingProviders.contains($0) ||
+                    (refreshAllOnOpen ||
+                        self.store.refreshingProviders.contains($0) ||
                         self.store.isStale(provider: $0) ||
                         self.store.snapshot(for: $0) == nil)
             }
@@ -1151,9 +1162,22 @@ extension StatusItemController {
             }
             self.deferMenuInteractionRefreshIfNeeded(providers: retryProviders)
             await ProviderInteractionContext.$current.withValue(.background) {
-                for provider in retryProviders {
-                    guard !Task.isCancelled else { return }
-                    await self.store.refreshProvider(provider, coalesceIfRefreshing: true)
+                if refreshAllOnOpen {
+                    // Refresh concurrently so one slow provider doesn't delay the rest, mirroring the
+                    // periodic refresh in `UsageStore.runRefresh`. `coalesceIfRefreshing` makes each call
+                    // wait for any in-flight refresh (e.g. a manual refresh) instead of overriding it.
+                    await withTaskGroup(of: Void.self) { group in
+                        for provider in retryProviders {
+                            group.addTask {
+                                await self.store.refreshProvider(provider, coalesceIfRefreshing: true)
+                            }
+                        }
+                    }
+                } else {
+                    for provider in retryProviders {
+                        guard !Task.isCancelled else { return }
+                        await self.store.refreshProvider(provider, coalesceIfRefreshing: true)
+                    }
                 }
             }
             let stillNeedsRetry = retryProviders.contains {

--- a/Tests/CodexBarTests/MenuOpenRefreshPlanTests.swift
+++ b/Tests/CodexBarTests/MenuOpenRefreshPlanTests.swift
@@ -1,0 +1,46 @@
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+struct MenuOpenRefreshPlanTests {
+    @Test
+    func `refresh all selects every enabled provider concurrently`() {
+        let plan = MenuOpenRefreshPlan.resolve(.init(
+            refreshAllOnOpen: true,
+            enabledProviders: [.codex, .claude, .factory],
+            visibleProviders: [.codex],
+            refreshingProviders: [],
+            staleProviders: [],
+            missingProviders: []))
+
+        #expect(plan.providers == [.codex, .claude, .factory])
+        #expect(plan.scheduling == .concurrent)
+    }
+
+    @Test
+    func `ordinary refresh selects only visible enabled retries sequentially`() {
+        let plan = MenuOpenRefreshPlan.resolve(.init(
+            refreshAllOnOpen: false,
+            enabledProviders: [.codex, .claude, .factory],
+            visibleProviders: [.factory, .codex, .claude, .cursor],
+            refreshingProviders: [.factory],
+            staleProviders: [.codex],
+            missingProviders: [.claude, .cursor]))
+
+        #expect(plan.providers == [.factory, .codex, .claude])
+        #expect(plan.scheduling == .sequential)
+    }
+
+    @Test
+    func `ordinary refresh skips fresh providers`() {
+        let plan = MenuOpenRefreshPlan.resolve(.init(
+            refreshAllOnOpen: false,
+            enabledProviders: [.codex],
+            visibleProviders: [.codex],
+            refreshingProviders: [],
+            staleProviders: [],
+            missingProviders: []))
+
+        #expect(plan.providers.isEmpty)
+    }
+}

--- a/Tests/CodexBarTests/MenuOpenRefreshPlanTests.swift
+++ b/Tests/CodexBarTests/MenuOpenRefreshPlanTests.swift
@@ -15,6 +15,21 @@ struct MenuOpenRefreshPlanTests {
 
         #expect(plan.providers == [.codex, .claude, .factory])
         #expect(plan.scheduling == .concurrent)
+        #expect(plan.refreshCodexDashboard)
+    }
+
+    @Test
+    func `refresh all skips dashboard refresh when codex is disabled`() {
+        let plan = MenuOpenRefreshPlan.resolve(.init(
+            refreshAllOnOpen: true,
+            enabledProviders: [.claude, .factory],
+            visibleProviders: [.claude],
+            refreshingProviders: [],
+            staleProviders: [],
+            missingProviders: []))
+
+        #expect(plan.providers == [.claude, .factory])
+        #expect(!plan.refreshCodexDashboard)
     }
 
     @Test
@@ -29,6 +44,7 @@ struct MenuOpenRefreshPlanTests {
 
         #expect(plan.providers == [.factory, .codex, .claude])
         #expect(plan.scheduling == .sequential)
+        #expect(!plan.refreshCodexDashboard)
     }
 
     @Test

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -87,6 +87,29 @@ struct SettingsStoreTests {
     }
 
     @Test
+    func `refresh on open defaults off and persists`() throws {
+        let suite = "SettingsStoreTests-refresh-on-open"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(store.refreshAllProvidersOnMenuOpen == false)
+        store.refreshAllProvidersOnMenuOpen = true
+
+        let reloaded = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        #expect(reloaded.refreshAllProvidersOnMenuOpen == true)
+    }
+
+    @Test
     func `weekly confetti setting defaults off and persists`() throws {
         let suite = "SettingsStoreTests-weekly-confetti"
         let defaultsA = try #require(UserDefaults(suiteName: suite))

--- a/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
+++ b/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
@@ -58,7 +58,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `menu open refreshes fresh providers when refresh-all-on-open is enabled`() async {
+    func `non codex menu refresh all also defers codex dashboard refresh`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -111,7 +111,7 @@ extension StatusMenuTests {
         defer { StatusItemController.resetMenuOpenRefreshDelayForTesting() }
 
         let expectedProviders = Set(store.enabledProvidersForBackgroundWork())
-        let menu = controller.makeMenu()
+        let menu = controller.makeMenu(for: .claude)
         controller.menuWillOpen(menu)
         defer { controller.menuDidClose(menu) }
 
@@ -120,10 +120,10 @@ extension StatusMenuTests {
         }
 
         // Every enabled provider is refreshed on open even though all snapshots were fresh.
-        #expect(refreshedProviders == expectedProviders)
-        #expect(expectedProviders.contains(.codex))
+        #expect(refreshedProviders == expectedProviders && expectedProviders.contains(.codex))
         #expect(!refreshInteractions.isEmpty)
         #expect(refreshInteractions.allSatisfy { $0 == .background })
+        #expect(controller.deferredOpenAIDashboardRefreshReason != nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
+++ b/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
@@ -58,6 +58,122 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `menu open refreshes fresh providers when refresh-all-on-open is enabled`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.refreshAllProvidersOnMenuOpen = true
+        // Enable several providers; only the available ones land in background work. The
+        // assertion below compares against that resolved set, so it stays robust regardless.
+        self.enableProvidersForInstantOpenTesting([.codex, .claude, .factory], settings: settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        // Give every enabled provider a fresh, non-stale snapshot so the ONLY reason to refresh on
+        // open is the new setting — not a stale/missing retry (which is the pre-existing behavior).
+        let now = Date()
+        for provider in store.enabledProvidersForBackgroundWork() {
+            store._setSnapshotForTesting(
+                UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: 20,
+                        windowMinutes: 300,
+                        resetsAt: now.addingTimeInterval(1800),
+                        resetDescription: nil),
+                    secondary: nil,
+                    updatedAt: now),
+                provider: provider)
+        }
+        var refreshedProviders: Set<UsageProvider> = []
+        var refreshInteractions: [ProviderInteraction] = []
+        store._test_providerRefreshOverride = { provider in
+            refreshedProviders.insert(provider)
+            refreshInteractions.append(ProviderInteractionContext.current)
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        StatusItemController.setDeferredMenuInteractionRefreshDelayForTesting(.zero)
+        defer { StatusItemController.resetDeferredMenuInteractionRefreshDelayForTesting() }
+        StatusItemController.setMenuOpenRefreshDelayForTesting(.zero)
+        defer { StatusItemController.resetMenuOpenRefreshDelayForTesting() }
+
+        let expectedProviders = Set(store.enabledProvidersForBackgroundWork())
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        for _ in 0..<80 where refreshedProviders != expectedProviders {
+            await Task.yield()
+        }
+
+        // Every enabled provider is refreshed on open even though all snapshots were fresh.
+        #expect(refreshedProviders == expectedProviders)
+        #expect(expectedProviders.contains(.codex))
+        #expect(!refreshInteractions.isEmpty)
+        #expect(refreshInteractions.allSatisfy { $0 == .background })
+    }
+
+    @Test
+    func `menu open leaves fresh provider untouched when refresh-all-on-open is disabled`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.refreshAllProvidersOnMenuOpen = false
+        self.enableOnlyCodexForInstantOpenTesting(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        var providerRefreshCount = 0
+        store._test_providerRefreshOverride = { _ in
+            providerRefreshCount += 1
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        StatusItemController.setDeferredMenuInteractionRefreshDelayForTesting(.zero)
+        defer { StatusItemController.resetDeferredMenuInteractionRefreshDelayForTesting() }
+        // Let the delayed open-refresh task actually fire; with the setting off and fresh data,
+        // it must still skip the refresh (today's stale/missing-only behavior).
+        StatusItemController.setMenuOpenRefreshDelayForTesting(.zero)
+        defer { StatusItemController.resetMenuOpenRefreshDelayForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+
+        #expect(providerRefreshCount == 0)
+    }
+
+    @Test
     func `delayed open refresh does not rebuild fresh menu after unrelated data invalidation`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()


### PR DESCRIPTION
Fixes #1732

## Summary

- Add a General preference to refresh enabled providers whenever the menu opens.
- Keep the option off by default; disabled behavior remains the existing visible-provider stale/missing refresh policy.
- Model the open-time decision as a pure refresh plan: opt-in refreshes enabled providers concurrently, while the default path preserves sequential visible-provider behavior and skips duplicate in-flight work.
- When refresh-all includes Codex from another provider's menu, defer its OpenAI dashboard refresh until menu tracking closes.
- Keep the periodic refresh clock unchanged.
- Localize the setting and thank @dstier-git in the changelog.

## Maintainer decision

Recommendation: merge. This is a bounded, reversible opt-in. The tradeoff is extra provider traffic each time the menu opens, made explicit in the setting copy; no background cadence or default behavior changes.

## Proof

- `make check`
- `swift test --filter MenuOpenRefreshPlanTests`
- exact non-Codex parent regression: refresh-all also defers the Codex dashboard refresh
- `swift test --filter StatusMenuTests`
- `swift test --filter SettingsStoreTests`
- `make test` (44/44 shards passed)
- branch-scoped autoreview (clean)
- exact-head ad-hoc package at `1f3bb5804812be23de990f1d1929919bf7aee23b`
- exact-head live Peekaboo verification: default-off copy and unchanged 5-minute cadence
- prior live verification also covered accessibility-targeted toggle and persisted enabled state after Settings close/reopen
- prior Tart VM proof remains supporting evidence

## Existing contributor media

Setting toggle:

<img width="370" height="51" alt="Refresh on menu open setting" src="https://github.com/user-attachments/assets/3842b16f-ba17-4d18-9f5f-e48051a081a5" />

Menu-open refresh demonstration:

<img width="338" height="270" alt="CodexBar refresh on menu open" src="https://github.com/user-attachments/assets/8a75a231-a873-447e-b0d6-a80dba8e160c" />
