### PR TITLE
fix: distinguish sub-one usage percentages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - z.ai: support saved token-account team usage with account-scoped organization and project metadata. Thanks @zqbake!
 
 ### Fixed
+- Usage percentages: distinguish positive usage below 1% from true zero across menu and menu-bar labels. Thanks @Max0633!
 - Mistral: restore Vibe monthly-plan usage by forwarding only required console session cookies. Thanks @lfmundim!
 
 ## 0.37.3 — 2026-06-23

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -5,8 +5,7 @@ enum MenuBarDisplayText {
     static func percentText(window: RateWindow?, showUsed: Bool) -> String? {
         guard let window else { return nil }
         let percent = showUsed ? window.usedPercent : window.remainingPercent
-        let clamped = min(100, max(0, percent))
-        return String(format: "%.0f%%", clamped)
+        return UsageFormatter.percentLabel(percent)
     }
 
     static func paceText(pace: UsagePace?) -> String? {

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -304,8 +304,21 @@ extension UsageMenuCardView.Model {
             title: title,
             percentUsed: percentUsed,
             spendLine: "\(periodLabel): \(used) / \(limit)",
-            percentLine: String(format: L("%.0f%% used"), min(100, max(0, percentUsed))),
+            percentLine: self.localizedUsedPercentLine(percentUsed),
             personalSpendLine: personalSpendLine)
+    }
+
+    static func localizedUsedPercentLine(
+        _ percent: Double,
+        format: String = L("%.0f%% used")) -> String
+    {
+        let clamped = min(100, max(0, percent))
+        let label = UsageFormatter.percentLabel(clamped)
+        guard label == "<1%" else { return String(format: format, clamped) }
+
+        let stringFormat = format.replacingOccurrences(of: "%.0f", with: "%@")
+        guard stringFormat != format else { return label }
+        return String(format: stringFormat, String(label.dropLast()))
     }
 
     private static func localizedPeriodLabel(_ label: String) -> String {

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -682,7 +682,7 @@ extension UsageMenuCardView.Model {
         let afterNextRegen = showUsed ? max(0, 100 - afterNextRegenRemaining) : afterNextRegenRemaining
         let suffix = showUsed ? L("used after next regen") : L("after next regen")
         let ticksToFull = max(0, cost.used) / nextRegenAmount
-        let left = String(format: "%.0f%% %@", afterNextRegen, suffix)
+        let left = "\(UsageFormatter.percentLabel(afterNextRegen)) \(suffix)"
         let right = if ticksToFull <= 0.1 {
             L("Near full")
         } else if ticksToFull < 1.5 {
@@ -709,7 +709,7 @@ extension UsageMenuCardView.Model {
         let afterNextRegenRemaining = min(100, window.remainingPercent + nextRegenPercent)
         let afterNextRegen = showUsed ? max(0, 100 - afterNextRegenRemaining) : afterNextRegenRemaining
         let suffix = showUsed ? L("used after next regen") : L("after next regen")
-        let left = String(format: "%.0f%% %@", afterNextRegen, suffix)
+        let left = "\(UsageFormatter.percentLabel(afterNextRegen)) \(suffix)"
 
         let missingPercent = max(0, window.usedPercent)
         let ticksToFull = missingPercent / nextRegenPercent

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -70,7 +70,7 @@ struct UsageMenuCardView: View {
             }
 
             var percentLabel: String {
-                String(format: "%.0f%% %@", self.percent, self.percentStyle.labelSuffix)
+                "\(UsageFormatter.percentLabel(self.percent)) \(self.percentStyle.labelSuffix)"
             }
         }
 

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -78,13 +78,18 @@ public enum UsageFormatter {
         return String(format: format, locale: self.currentLocale(), arguments: args)
     }
 
+    public static func percentLabel(_ percent: Double) -> String {
+        let clamped = min(100, max(0, percent))
+        if clamped > 0, clamped < 1 { return "<1%" }
+        return String(format: "%.0f%%", clamped)
+    }
+
     public static func usageLine(remaining: Double, used: Double, showUsed: Bool) -> String {
         let percent = showUsed ? used : remaining
-        let clamped = min(100, max(0, percent))
         let suffix = showUsed
             ? self.localized("usage_percent_suffix_used")
             : self.localized("usage_percent_suffix_left")
-        return String(format: "%.0f%% %@", clamped, suffix)
+        return "\(self.percentLabel(percent)) \(suffix)"
     }
 
     public static func resetCountdownDescription(from date: Date, now: Date = .init()) -> String {

--- a/Tests/CodexBarTests/CursorMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/CursorMenuCardModelTests.swift
@@ -5,6 +5,55 @@ import Testing
 
 struct CursorMenuCardModelTests {
     @Test
+    func `provider cost distinguishes true zero from positive usage below one percent`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let metadata = try #require(ProviderDefaults.metadata[.cursor])
+
+        func percentLine(used: Double) -> String? {
+            let snapshot = UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                providerCost: ProviderCostSnapshot(
+                    used: used,
+                    limit: 100,
+                    currencyCode: "USD",
+                    updatedAt: now),
+                updatedAt: now)
+            return UsageMenuCardView.Model.make(.init(
+                provider: .cursor,
+                metadata: metadata,
+                snapshot: snapshot,
+                credits: nil,
+                creditsError: nil,
+                dashboard: nil,
+                dashboardError: nil,
+                tokenSnapshot: nil,
+                tokenError: nil,
+                account: AccountInfo(email: nil, plan: nil),
+                isRefreshing: false,
+                lastError: nil,
+                usageBarsShowUsed: true,
+                resetTimeDisplayStyle: .countdown,
+                tokenCostUsageEnabled: false,
+                showOptionalCreditsAndExtraUsage: true,
+                hidePersonalInfo: false,
+                now: now))
+                .providerCost?.percentLine
+        }
+
+        #expect(percentLine(used: 0) == "0% used")
+        #expect(percentLine(used: 0.49) == "<1% used")
+    }
+
+    @Test
+    func `provider cost preserves localized percent placement`() {
+        #expect(UsageMenuCardView.Model.localizedUsedPercentLine(0, format: "used %.0f%%") == "used 0%")
+        #expect(UsageMenuCardView.Model.localizedUsedPercentLine(0.49, format: "used %.0f%%") == "used <1%")
+        #expect(UsageMenuCardView.Model.localizedUsedPercentLine(50, format: "%%%.0f used") == "%50 used")
+        #expect(UsageMenuCardView.Model.localizedUsedPercentLine(0.49, format: "%%%.0f used") == "%<1 used")
+    }
+
+    @Test
     func `team pool shows personal spend and changes height fingerprint`() throws {
         let now = Date(timeIntervalSince1970: 0)
         let metadata = try #require(ProviderDefaults.metadata[.cursor])

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -216,6 +216,30 @@ struct MiMoProviderTests {
     }
 
     @Test
+    func `token plan preserves sub one usage for menu card labels`() throws {
+        let now = Date(timeIntervalSince1970: 1_742_771_200)
+        let metadata = try #require(ProviderDefaults.metadata[.mimo])
+        let usage = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            planCode: "standard",
+            tokenUsed: 980_000,
+            tokenLimit: 200_000_000,
+            tokenPercent: 0.0049,
+            updatedAt: now)
+            .toUsageSnapshot()
+
+        let model = Self.makeMenuCardModel(
+            snapshot: usage,
+            metadata: metadata,
+            now: now,
+            usageBarsShowUsed: true)
+
+        #expect(abs((usage.primary?.usedPercent ?? .nan) - 0.49) < 0.0001)
+        #expect(model.metrics.first?.percentLabel == "<1% used")
+    }
+
+    @Test
     func `menu card shows balance as status text with and without token plan`() throws {
         let now = Date(timeIntervalSince1970: 1_742_771_200)
         let metadata = try #require(ProviderDefaults.metadata[.mimo])
@@ -673,6 +697,7 @@ extension MiMoProviderTests {
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
         settings.statusChecksEnabled = false
+        settings.usageBarsShowUsed = true
 
         let store = UsageStore(
             fetcher: UsageFetcher(environment: [:]),
@@ -682,9 +707,9 @@ extension MiMoProviderTests {
             balance: 25.51,
             currency: "USD",
             planCode: "standard",
-            tokenUsed: 10,
-            tokenLimit: 100,
-            tokenPercent: 0.1,
+            tokenUsed: 980_000,
+            tokenLimit: 200_000_000,
+            tokenPercent: 0.0049,
             updatedAt: Date(timeIntervalSince1970: 1_742_771_200))
             .toUsageSnapshot()
         store._setSnapshotForTesting(snapshot, provider: .mimo)
@@ -703,8 +728,9 @@ extension MiMoProviderTests {
                 return text
             }
 
-        #expect(lines.contains("10 / 100 Credits"))
-        #expect(!lines.contains("Resets 10 / 100 Credits"))
+        #expect(lines.contains("Credits: <1% used"))
+        #expect(lines.contains("980,000 / 200,000,000 Credits"))
+        #expect(!lines.contains("Resets 980,000 / 200,000,000 Credits"))
     }
 
     @Test
@@ -1091,7 +1117,8 @@ extension MiMoProviderTests {
     private static func makeMenuCardModel(
         snapshot: UsageSnapshot,
         metadata: ProviderMetadata,
-        now: Date) -> UsageMenuCardView.Model
+        now: Date,
+        usageBarsShowUsed: Bool = false) -> UsageMenuCardView.Model
     {
         UsageMenuCardView.Model.make(.init(
             provider: .mimo,
@@ -1106,7 +1133,7 @@ extension MiMoProviderTests {
             account: AccountInfo(email: nil, plan: nil),
             isRefreshing: false,
             lastError: nil,
-            usageBarsShowUsed: false,
+            usageBarsShowUsed: usageBarsShowUsed,
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: false,
             showOptionalCreditsAndExtraUsage: true,

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -936,6 +936,17 @@ struct StatusItemAnimationTests {
     }
 
     @Test
+    func `menu bar display text distinguishes true zero from positive values below one`() {
+        let zero = RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
+        let subOne = RateWindow(usedPercent: 0.49, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
+        let nearlyFull = RateWindow(usedPercent: 99.51, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
+
+        #expect(MenuBarDisplayText.percentText(window: zero, showUsed: true) == "0%")
+        #expect(MenuBarDisplayText.percentText(window: subOne, showUsed: true) == "<1%")
+        #expect(MenuBarDisplayText.percentText(window: nearlyFull, showUsed: false) == "<1%")
+    }
+
+    @Test
     func `menu bar display text formats codex combined percent lanes`() {
         let sessionWindow = RateWindow(usedPercent: 7, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
         let weeklyWindow = RateWindow(usedPercent: 18, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -44,6 +44,27 @@ struct UsageFormatterTests {
     }
 
     @Test
+    func `percent labels distinguish true zero from positive values below one`() {
+        #expect(UsageFormatter.percentLabel(-1) == "0%")
+        #expect(UsageFormatter.percentLabel(0) == "0%")
+        #expect(UsageFormatter.percentLabel(0.01) == "<1%")
+        #expect(UsageFormatter.percentLabel(0.5) == "<1%")
+        #expect(UsageFormatter.percentLabel(0.96) == "<1%")
+        #expect(UsageFormatter.percentLabel(1) == "1%")
+        #expect(UsageFormatter.percentLabel(101) == "100%")
+    }
+
+    @Test
+    func `usage line preserves sub one distinction with localized suffixes`() {
+        UsageFormatter.clearLocalizationProvider()
+        UsageFormatter.clearLocaleProvider()
+
+        #expect(UsageFormatter.usageLine(remaining: 0, used: 0, showUsed: true) == "0% used")
+        #expect(UsageFormatter.usageLine(remaining: 99.51, used: 0.49, showUsed: true) == "<1% used")
+        #expect(UsageFormatter.usageLine(remaining: 0.49, used: 99.51, showUsed: false) == "<1% left")
+    }
+
+    @Test
     func `usage line respects injected localization provider`() {
         UsageFormatter.setLocalizationProvider { key in
             switch key {


### PR DESCRIPTION
## Summary

- add one shared percentage-label rule for menu, menu-card, and menu-bar surfaces
- keep true zero as `0%` while rendering every positive value below one percent as `<1%`
- preserve localized percent placement for provider-cost cards and cover MiMo plus shared display paths

Fixes #1734.

## Root cause

The affected surfaces independently rounded percentages to zero decimal places. Values below the rounding threshold therefore became indistinguishable from true zero. The reported `0.96%` sample would normally round to `1%`; the verified shared defect is the broader positive sub-one range, reproduced at `0.49%`.

## Validation

- focused Swift tests: 109 tests across `UsageFormatterTests`, `StatusItemAnimationTests`, `MiMoProviderTests`, and `CursorMenuCardModelTests`
- deterministic full matrix: all 511 non-account-scoped selections passed in 43 shards
- account-scoped refresh suite: all 76 cases passed as individual selections, avoiding the existing aggregate harness deadlock without omitting coverage
- `make check`: package/script/docs guards, SwiftFormat, and strict SwiftLint passed with zero violations
- autoreview: clean after preserving localized provider-cost formatting

## Packaged-app proof

Ad-hoc debug package built from `1196f9e1ed0b7ea5a67f0640975d914a79eceef7`; bundle commit metadata matched and `codesign --verify --deep --strict` passed. App executable SHA-256: `1d20295dacb6d9624f4ae2391fe6d4b85501969c32cda432fa55763b1d2c19eb`.

Using a controlled local CLI fixture through the packaged app:

- `0.49%` used rendered the status item as `99.51 · <1%` and the real menu card as `<1% used`
- paired true-zero input rendered the status item as `100 · 0%` and the same menu card as `0% used`
- both menu cards were rendered at the actual 310 x 162 card size; temporary preferences and fixture state were restored after proof

No live account data or credentials were used or recorded.

## Safety

Public Model Identifier Gate: PASS. The exact diff introduces no model identifiers, the packaged binary's existing model catalog is unchanged, and tests, screenshots, logs, and this public proof contain no private account data, cookie values, credentials, identifying profile paths, or non-public model identifiers.
