### PR TITLE
Guard Claude background CLI fallback when logged out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Linux CLI: keep Claude OAuth usage subprocess-free, skip version probes, and let Auto bypass unsupported web sources. Thanks @derekszen!
 - Usage display: make Usage widgets follow the used-versus-remaining preference already shared by menus and Overview rows (#1738). Thanks @OlegLustenko and @FrancoLan!
 - OpenCode Go: keep rolling usage available when the dashboard omits the optional weekly window. Thanks @mohkg1017!
+- Claude CLI: prevent logged-out background Auto fallbacks from opening browser OAuth during app refresh. Thanks @afarwind!
 
 ## 0.37.3 — 2026-06-28
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLIAuthStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLIAuthStatusProbe.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum ClaudeCLIAuthStatusProbe {
+    private struct Response: Decodable {
+        let loggedIn: Bool
+    }
+
+    static func isLoggedIn(
+        binary: String,
+        environment: [String: String],
+        timeout: TimeInterval = 5) async -> Bool
+    {
+        do {
+            let result = try await SubprocessRunner.run(
+                binary: binary,
+                arguments: ["auth", "status", "--json"],
+                environment: ClaudeCLISession.launchEnvironment(baseEnv: environment),
+                timeout: timeout,
+                standardInput: FileHandle.nullDevice,
+                label: "claude-auth-status")
+            return self.parseLoggedIn(result.stdout)
+        } catch {
+            return false
+        }
+    }
+
+    static func parseLoggedIn(_ output: String) -> Bool {
+        guard let data = output.data(using: .utf8),
+              let response = try? JSONDecoder().decode(Response.self, from: data)
+        else {
+            return false
+        }
+        return response.loggedIn
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -200,7 +200,9 @@ private struct ClaudePlannedFetchStrategy: ProviderFetchStrategy {
             return await self.base.isAvailable(context)
         }
         guard self.plannedStep.isPlausiblyAvailable else { return false }
-        if context.runtime == .app, self.plannedStep.dataSource == .web {
+        if context.runtime == .app,
+           self.plannedStep.dataSource == .cli || self.plannedStep.dataSource == .web
+        {
             return await self.base.isAvailable(context)
         }
         return true
@@ -624,8 +626,17 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
     let browserDetection: BrowserDetection
     let hasWebFallback: Bool
 
-    func isAvailable(_: ProviderFetchContext) async -> Bool {
-        true
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        // The interactive Claude REPL can open browser OAuth when it starts logged out. Background Auto refreshes
+        // must establish CLI authentication through the non-interactive status command before starting that REPL.
+        guard context.runtime == .app,
+              context.sourceMode == .auto,
+              ProviderInteractionContext.current == .background
+        else {
+            return true
+        }
+        guard let binary = ClaudeCLIResolver.resolvedBinaryPath(environment: context.env) else { return false }
+        return await ClaudeCLIAuthStatusProbe.isLoggedIn(binary: binary, environment: context.env)
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {

--- a/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite(.serialized)
 struct ClaudeBaselineCharacterizationTests {
-    private func makeStubClaudeCLI() throws -> String {
+    private func makeStubClaudeCLI(loggedIn: Bool = true, invocationLog: URL? = nil) throws -> String {
         let sample = """
         Current session
         12% used  (Resets 11am)
@@ -15,8 +15,15 @@ struct ClaudeBaselineCharacterizationTests {
         Account: user@example.com
         Org: Example Org
         """
+        let recordInvocation = invocationLog.map { "printf '%s\\n' \"$*\" >> '\($0.path)'" } ?? ""
+        let loggedInJSON = loggedIn ? "true" : "false"
         let script = """
         #!/bin/sh
+        \(recordInvocation)
+        if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+          printf '%s\\n' '{"loggedIn":\(loggedInJSON)}'
+          exit 0
+        fi
         cat <<'EOF'
         \(sample)
         EOF
@@ -174,6 +181,53 @@ struct ClaudeBaselineCharacterizationTests {
                 }
             }
         }
+    }
+
+    @Test
+    func `app background auto does not start logged out Claude CLI`() async throws {
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .auto,
+            webExtrasEnabled: false,
+            cookieSource: .off,
+            manualCookieHeader: nil))
+        let invocationLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-invocations-\(UUID().uuidString).log")
+        let stubCLIPath = try self.makeStubClaudeCLI(loggedIn: false, invocationLog: invocationLog)
+        let env = ["CLAUDE_CLI_PATH": stubCLIPath]
+
+        await self.withNoOAuthCredentials {
+            let outcome = await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
+
+            #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli", "claude.web"])
+            #expect(outcome.attempts.map(\.wasAvailable) == [false, false, false])
+        }
+
+        let invocations = try String(contentsOf: invocationLog, encoding: .utf8)
+        #expect(invocations == "auth status --json\n")
+    }
+
+    @Test
+    func `app user initiated auto preserves CLI fallback without auth preflight`() async throws {
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .auto,
+            webExtrasEnabled: false,
+            cookieSource: .off,
+            manualCookieHeader: nil))
+        let invocationLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-invocations-\(UUID().uuidString).log")
+        let stubCLIPath = try self.makeStubClaudeCLI(loggedIn: false, invocationLog: invocationLog)
+        let env = ["CLAUDE_CLI_PATH": stubCLIPath]
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .claude)
+        let context = self.makeContext(runtime: .app, sourceMode: .auto, env: env, settings: settings)
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(context)
+        let cli = try #require(strategies.first { $0.id == "claude.cli" })
+
+        let cliAvailable = await ProviderInteractionContext.$current.withValue(.userInitiated) {
+            await cli.isAvailable(context)
+        }
+
+        #expect(cliAvailable)
+        #expect(!FileManager.default.fileExists(atPath: invocationLog.path))
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
@@ -5,6 +5,13 @@ import Testing
 @Suite(.serialized)
 struct ClaudeBaselineCharacterizationTests {
     private func makeStubClaudeCLI(loggedIn: Bool = true, invocationLog: URL? = nil) throws -> String {
+        let loggedInJSON = loggedIn ? "true" : "false"
+        return try self.makeStubClaudeCLI(
+            authStatusScript: "printf '%s\\n' '{\"loggedIn\":\(loggedInJSON)}'",
+            invocationLog: invocationLog)
+    }
+
+    private func makeStubClaudeCLI(authStatusScript: String, invocationLog: URL? = nil) throws -> String {
         let sample = """
         Current session
         12% used  (Resets 11am)
@@ -16,12 +23,11 @@ struct ClaudeBaselineCharacterizationTests {
         Org: Example Org
         """
         let recordInvocation = invocationLog.map { "printf '%s\\n' \"$*\" >> '\($0.path)'" } ?? ""
-        let loggedInJSON = loggedIn ? "true" : "false"
         let script = """
         #!/bin/sh
         \(recordInvocation)
         if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-          printf '%s\\n' '{"loggedIn":\(loggedInJSON)}'
+          \(authStatusScript)
           exit 0
         fi
         cat <<'EOF'
@@ -202,6 +208,59 @@ struct ClaudeBaselineCharacterizationTests {
             #expect(outcome.attempts.map(\.wasAvailable) == [false, false, false])
         }
 
+        let invocations = try String(contentsOf: invocationLog, encoding: .utf8)
+        #expect(invocations == "auth status --json\n")
+    }
+
+    @Test(arguments: ["nonzero", "timeout", "malformed"])
+    func `app background auto falls back to web when auth status is unusable`(
+        failureMode: String) async throws
+    {
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .auto,
+            webExtrasEnabled: false,
+            cookieSource: .manual,
+            manualCookieHeader: "sessionKey=sk-ant-session-token"))
+        let invocationLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-invocations-\(UUID().uuidString).log")
+        let authStatusScript = switch failureMode {
+        case "nonzero":
+            "exit 9"
+        case "timeout":
+            "sleep 6"
+        default:
+            "printf '%s\\n' 'not-json'"
+        }
+        let stubCLIPath = try self.makeStubClaudeCLI(
+            authStatusScript: authStatusScript,
+            invocationLog: invocationLog)
+        let env = ["CLAUDE_CLI_PATH": stubCLIPath]
+        let usageLoader: ClaudeWebFetchStrategy.UsageLoader = { _ in
+            ClaudeUsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 20,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                opus: nil,
+                updatedAt: Date(timeIntervalSince1970: 1_800_000_100),
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: nil,
+                rawText: nil)
+        }
+
+        let outcome = await self.withNoOAuthCredentials {
+            await ClaudeWebFetchStrategy.$usageLoaderOverrideForTesting.withValue(usageLoader) {
+                await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
+            }
+        }
+        let result = try outcome.result.get()
+
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli", "claude.web"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [false, false, true])
+        #expect(result.strategyID == "claude.web")
         let invocations = try String(contentsOf: invocationLog, encoding: .utf8)
         #expect(invocations == "auth status --json\n")
     }

--- a/Tests/CodexBarTests/ClaudeCLIAuthStatusProbeTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIAuthStatusProbeTests.swift
@@ -1,0 +1,16 @@
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeCLIAuthStatusProbeTests {
+    @Test
+    func `parses logged in status`() {
+        #expect(ClaudeCLIAuthStatusProbe.parseLoggedIn(#"{"loggedIn":true,"authMethod":"claude.ai"}"#))
+    }
+
+    @Test
+    func `rejects logged out and malformed status`() {
+        #expect(!ClaudeCLIAuthStatusProbe.parseLoggedIn(#"{"loggedIn":false,"authMethod":"none"}"#))
+        #expect(!ClaudeCLIAuthStatusProbe.parseLoggedIn("not-json"))
+        #expect(!ClaudeCLIAuthStatusProbe.parseLoggedIn(#"{"authMethod":"none"}"#))
+    }
+}

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -46,13 +46,14 @@ struct ClaudeWebFetchDeadlineTests {
     @Test
     func `stalled app auto browser probe does not delay CLI success`() async throws {
         let planningProbe = ClaudeWebPlanningAvailabilityProbe()
+        let cliPath = try Self.makeLoggedInClaudeCLI()
         let context = Self.makeContext(
             runtime: .app,
             sourceMode: .auto,
             webTimeout: 60,
             cookieSource: .auto,
             env: [
-                "CLAUDE_CLI_PATH": "/usr/bin/true",
+                "CLAUDE_CLI_PATH": cliPath,
                 ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
             ])
         let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
@@ -276,6 +277,18 @@ struct ClaudeWebFetchDeadlineTests {
                 await probe.waitUntilReleased()
                 return self.makeClaudeUsage()
             })
+    }
+
+    private static func makeLoggedInClaudeCLI() throws -> String {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-auth-status-\(UUID().uuidString)")
+        let script = """
+        #!/bin/sh
+        printf '%s\\n' '{"loggedIn":true}'
+        """
+        try Data(script.utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
     }
 
     private static func makeContext(


### PR DESCRIPTION
## Summary

- Before a background app Auto refresh starts Claude's interactive CLI fallback, ask Claude CLI for its own non-interactive `auth status --json` result.
- Skip that fallback when Claude CLI is missing, logged out, times out, or returns an unreadable result. Explicit CLI selection, user-initiated refreshes, and CLI runtime behavior remain unchanged.
- Drop the original Control Center defaults mutation. The observed `NSStatusItem Visible Item-*` keys are generic and cannot be safely attributed to CodexBar, so changing them could affect unrelated menu bar items.

## Relationship to #1811

#1811 repairs the explicit Claude Code sign-in action. This PR fixes the separate automated background-refresh path that can otherwise start Claude's interactive REPL while logged out.

## Validation

- `swift test --filter ClaudeBaselineCharacterizationTests` (13 tests, including nonzero, timeout, and malformed auth-status fallback-to-web cases)
- `swift test --filter ClaudeCLIAuthStatusProbeTests` (2 tests)
- `swift test --filter ClaudeWebFetchDeadlineTests` (8 tests)
- `make check` (SwiftFormat current; SwiftLint 0 violations)
- `make test` (all 44 shards)
- Bundled local and branch autoreviews: clean, no findings
- Exact-head packaged app (`e486c6c5f`) passed strict nested code-signature verification and embedded the same commit. Package SHA-256: `486fb43bd55ebf8c2526620a3932ba922d800a1b34b2d42ff0fa42efabedec8f`.
- macOS 26.5 exact-head packaged-app proof with isolated config, Keychain access disabled, and a logged-out fake Claude CLI: app stayed alive; the fake CLI received only `--version` and `auth status --json`; no `/usage`, interactive CLI marker, or browser process appeared. The baseline bundle did start the interactive `/usage` path under the same setup.
- Exact-head CI run [28534425933](https://github.com/steipete/CodexBar/actions/runs/28534425933): all 10 status checks passed, including the aggregate gate and GitGuardian.

Preserves @afarwind's bug report and contribution credit via co-authorship and the changelog thank-you.
