### PR TITLE
ci: run macOS tests on Apple Silicon to avoid build-timeout flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
   swift-test-macos:
     needs: changes
     if: ${{ needs.changes.outputs.macos-tests == 'true' }}
-    runs-on: macos-15-intel
+    runs-on: macos-15
     timeout-minutes: 40
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Problem
`swift-test-macos` shards intermittently fail with a **timeout, not a test failure**. In [run 28084754287](https://github.com/steipete/CodexBar/actions/runs/28084754287) (push to `main`), shard `(3,4)`'s `Swift Test` step (`timeout-minutes: 35`) spent ~20 min building the full GUI-inclusive test target + `swift test list` discovery on the Intel runner *before any test ran* (08:13:31 → 08:33:19), leaving too little time for the 127 sharded `swift test` groups (run with `CODEXBAR_TEST_GROUP_SIZE=1`). The step hit 35 min and was killed mid-run (log ends with `Terminate orphan process: pid (swift)`). No assertion failed.

Root cause: `swift-test-macos` runs on `macos-15-intel`, where the cold Swift build of the test target is slow and variable, and the build runs *inside* the 35-min test budget with no `.build` cache.

## Change
Run `swift-test-macos` on Apple Silicon (`macos-15`) instead of `macos-15-intel`. ARM runners build Swift substantially faster, so the build fits comfortably within the existing 35-min budget. One line in `.github/workflows/ci.yml`.

## Trade-off / notes
- This drops **x86_64 test coverage** in the CI matrix. The x86_64 **release binary is unaffected** — `release-cli.yml` still builds it on `macos-15-intel` (left untouched).
- If keeping Intel test coverage is preferred, lower-touch alternatives are caching `.build` (`actions/cache`) or moving `swift build --build-tests` into a separate step outside the 35-min timeout. Happy to switch to either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
