### PR TITLE
fix(test): wait for both sleeps in Antigravity replacement teardown test

### DIFF
--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -481,7 +481,11 @@ struct AntigravityCLISessionTests {
         let firstReplacement = Task {
             try await fixture.session.beginProbe(binary: "/new/agy")
         }
-        await fixture.sleeper?.waitForSleeps(1)
+        // Two sleeps register here: the lingering idle-timer sleep (armed by the prior finishProbe;
+        // the fake sleeper does not honor cancellation) and the teardown grace-period sleep. Wait for
+        // both before resuming — waiting for only one lets resumeAll() fire before the grace sleep
+        // parks, stranding it so teardown never completes and the suite hangs to the 120s timeout.
+        await fixture.sleeper?.waitForSleeps(2)
 
         let secondReplacement = Task {
             try await fixture.session.beginProbe(binary: "/new/agy")


### PR DESCRIPTION
## Problem
`AntigravityCLISessionTests` intermittently hangs the whole suite to the per-suite **120s timeout** (exit 124) on `swift-test-macos` (e.g. shard 3 on main, runs [28084754287](https://github.com/steipete/CodexBar/actions/runs/28084754287) and [28164706265](https://github.com/steipete/CodexBar/actions/runs/28164706265)). It is flaky (passes on most runs) and a **timeout, not an assertion failure**; the CI single-suite retry also hangs, so the job fails.

## Root cause (test-only)
The hang is in the test `replacement launch waits for in progress teardown`, not in production.

`AntigravityManualSleeper` (the test fake for `dependencies.sleep`) ignores task cancellation, unlike the real `Task.sleep`:
1. The initial `finishProbe` arms the idle timer (idleWindow 3600 > 0); its Task awaits the sleeper → continuation **S1** registers.
2. `beginProbe("/new/agy")` cancels the idle timer, but the fake ignores cancellation, so **S1 lingers** (in production `Task.sleep` throws on cancel and S1 vanishes).
3. `firstReplacement` enters the teardown grace-period loop (`terminateRootStopsProcess: false`, gracePeriod 1) and awaits the sleeper → continuation **S2** registers, while holding the lifecycle lock.
4. `await waitForSleeps(1)` can be satisfied by **S1 alone**, before S2 registers.
5. `resumeAll()` then resumes only the currently-registered continuations. If S2 hasn't registered yet it is never resumed → the grace loop never exits → the lifecycle lock is never released → the queued second replacement also hangs → 120s timeout. Whether S2 registers before `resumeAll()` is a scheduling race → intermittent.

## Fix
Wait for **both** sleeps before resuming: `waitForSleeps(1)` → `waitForSleeps(2)`. Both S1 (idle) and S2 (grace) deterministically register, so the count reaches 2 and `resumeAll()` cannot fire before S2 is parked — the race is structurally eliminated regardless of scheduling. One line + a comment in the test. **Production `AntigravityCLISession` is unchanged** — it is correct; the real `Task.sleep` is cancellation-aware.

## Verification

Production continuation/lock paths (lifecycle mutex, `exclusiveProbeWaiters`, idle timer, grace loops, `ensureStartedLocked`) were independently audited and found sound; only this test-fake fidelity gap can strand a continuation. Because the fix makes the rendezvous deterministic, the race cannot recur under any interleaving.

**The flake is rare / CI-only — it does not reproduce on a fast local machine (pre-fix, current code):**
```
# full suite, repeated
no hang in 150 no-parallel runs
no hang in 100 parallel runs
# the suspect test alone, repeated
no hang/failure in 150 single-test runs
# ThreadSanitizer (separate instrumented build)
0 ThreadSanitizer warnings;  ✔ Test run with 48 tests in 1 suite passed
```

**With the fix (`waitForSleeps(2)`):**
```
# focused loop ×40:  swift test --filter 'replacement launch waits for in progress teardown'
fixed single-test: 40/40 pass

# full suite:        swift test --filter 'AntigravityCLISessionTests'
✔ Suite AntigravityCLISessionTests passed after 0.016 seconds.
✔ Test run with 48 tests in 1 suite passed after 0.016 seconds.

# lint (pinned SwiftFormat 0.59.1 / SwiftLint 0.63.2)
swiftformat --lint  →  0/1 files require formatting
swiftlint --strict  →  exit 0 (clean)
```
(Re-verified on a fresh `origin/main`-based checkout: full suite passes, focused loop 10/10, swiftformat + `swiftlint --strict` clean.)

**Exact-head CI** ([run 28167296140](https://github.com/steipete/CodexBar/actions/runs/28167296140)): all jobs green — `lint`, both Linux CLI builds, and **all four `swift-test-macos` shards including `(3, 4)`** (the shard that runs this suite) passed with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
