### PR TITLE
Fix menu bar pace showing signed zero (+0%/-0%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Codex: show enterprise monthly credit limits across OAuth, CLI, menu, and widget surfaces. Thanks @ChenZiHong-Gavin!
 - Codex: avoid launching monthly-credit CLI enrichment during usage-only OAuth refreshes.
 - Usage display: keep positive values below one percent visible instead of rounding them to zero. Thanks @Max0633!
+- Menu bar: show pace as `0%` instead of a signed `+0%`/`-0%` when the pace delta rounds to zero. Thanks @devYRPauli!
 - Menu: match the persistent Refresh row to native menu styling without replacing keyboard-navigable Settings, About, and Quit actions. Thanks @Zihao-Qi!
 - Claude: stop installed-version checks from invoking a login shell and triggering unwanted Keychain prompts. Thanks @enieuwy!
 - Localization: reject blank translated values and restore the affected Vietnamese provider prompts. Thanks @kiranmagic7!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 - Codex: show enterprise monthly credit limits across OAuth, CLI, menu, and widget surfaces. Thanks @ChenZiHong-Gavin!
 - Codex: avoid launching monthly-credit CLI enrichment during usage-only OAuth refreshes.
 - Usage display: keep positive values below one percent visible instead of rounding them to zero. Thanks @Max0633!
-- Menu bar: show pace as `0%` instead of a signed `+0%`/`-0%` when the pace delta rounds to zero. Thanks @devYRPauli!
 - Menu: match the persistent Refresh row to native menu styling without replacing keyboard-navigable Settings, About, and Quit actions. Thanks @Zihao-Qi!
 - Claude: stop installed-version checks from invoking a login shell and triggering unwanted Keychain prompts. Thanks @enieuwy!
 - Localization: reject blank translated values and restore the affected Vietnamese provider prompts. Thanks @kiranmagic7!

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -11,6 +11,7 @@ enum MenuBarDisplayText {
     static func paceText(pace: UsagePace?) -> String? {
         guard let pace else { return nil }
         let deltaValue = Int(abs(pace.deltaPercent).rounded())
+        if deltaValue == 0 { return "0%" }
         let sign = pace.deltaPercent >= 0 ? "+" : "-"
         return "\(sign)\(deltaValue)%"
     }

--- a/Tests/CodexBarTests/MenuBarPaceTextTests.swift
+++ b/Tests/CodexBarTests/MenuBarPaceTextTests.swift
@@ -1,0 +1,32 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct MenuBarPaceTextTests {
+    private static func pace(deltaPercent: Double, stage: UsagePace.Stage) -> UsagePace {
+        UsagePace(
+            stage: stage,
+            deltaPercent: deltaPercent,
+            expectedUsedPercent: 50,
+            actualUsedPercent: 50 + deltaPercent,
+            etaSeconds: nil,
+            willLastToReset: true)
+    }
+
+    @Test
+    func `paceText drops the sign when the rounded delta is zero`() {
+        let slightlyAhead = Self.pace(deltaPercent: 0.3, stage: .onTrack)
+        let slightlyBehind = Self.pace(deltaPercent: -0.3, stage: .onTrack)
+
+        // A sub-half-percent delta rounds to 0; "+0%" / "-0%" is a nonsensical signed zero.
+        #expect(MenuBarDisplayText.paceText(pace: slightlyAhead) == "0%")
+        #expect(MenuBarDisplayText.paceText(pace: slightlyBehind) == "0%")
+    }
+
+    @Test
+    func `paceText keeps the sign for non-zero deltas`() {
+        #expect(MenuBarDisplayText.paceText(pace: Self.pace(deltaPercent: 3, stage: .ahead)) == "+3%")
+        #expect(MenuBarDisplayText.paceText(pace: Self.pace(deltaPercent: -3, stage: .behind)) == "-3%")
+    }
+}


### PR DESCRIPTION
`MenuBarDisplayText.paceText` builds its label as `"\(sign)\(deltaValue)%"` where `deltaValue = Int(abs(pace.deltaPercent).rounded())`. When `|deltaPercent| < 0.5` the value rounds to `0`, but the sign is still prepended, so the menu bar shows `+0%` or `-0%` for a state that is effectively on pace. The expanded detail view already renders "On pace" for the same input, so the compact status item is inconsistent with it.

This returns `0%` when the rounded delta is zero. Non-zero values and their sign are unchanged.

Companion to #1737, which cleaned up sub-one-percent display for `percentText` / `usageLine` but did not touch `paceText`.

### Test

Added `MenuBarPaceTextTests`:
- sub-half-percent deltas (`+0.3`, `-0.3`) now render `0%`
- non-zero deltas keep their sign (`+3%`, `-3%`)

`swift test --filter MenuBarPaceTextTests` fails before the change (`+0%` / `-0%`) and passes after.
