### PR TITLE
Improve Kimi Code usage reporting

### DIFF
--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -62,16 +62,16 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        guard let apiKey = Self.resolveToken(environment: context.env) else {
+        guard let resolution = Self.resolveToken(environment: context.env) else {
             throw KimiAPIError.missingAPIKey
         }
         let baseURL = try KimiSettingsReader.codeAPIBaseURL(environment: context.env)
         let snapshot = try await KimiUsageFetcher.fetchCodeAPIUsage(
-            apiKey: apiKey,
+            apiKey: resolution.token,
             baseURL: baseURL)
         return self.makeResult(
             usage: snapshot.toUsageSnapshot(),
-            sourceLabel: "api")
+            sourceLabel: resolution.source == .authFile ? "kimi-code" : "api")
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
@@ -87,8 +87,8 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
         return false
     }
 
-    private static func resolveToken(environment: [String: String]) -> String? {
-        ProviderTokenResolver.kimiAPIToken(environment: environment)
+    private static func resolveToken(environment: [String: String]) -> ProviderTokenResolution? {
+        ProviderTokenResolver.kimiAPIResolution(environment: environment)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum KimiSettingsReader {
     public static let apiKeyEnvironmentKeys = ["KIMI_CODE_API_KEY"]
     public static let codeAPIBaseURLEnvironmentKey = "KIMI_CODE_BASE_URL"
+    public static let codeHomeEnvironmentKey = "KIMI_CODE_HOME"
     public static let defaultCodeAPIBaseURL = URL(string: "https://api.kimi.com")!
 
     public static func authToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
@@ -34,6 +35,44 @@ public enum KimiSettingsReader {
         return url
     }
 
+    public static func kimiCodeAccessToken(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        now: Date = Date()) -> String?
+    {
+        guard let url = self.kimiCodeCredentialsURL(environment: environment) else { return nil }
+        return self.kimiCodeAccessToken(credentialsURL: url, now: now)
+    }
+
+    public static func kimiCodeCredentialsURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
+    {
+        let home: URL = if let override = self.cleaned(environment[self.codeHomeEnvironmentKey]) {
+            URL(fileURLWithPath: override, isDirectory: true)
+        } else {
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".kimi-code", isDirectory: true)
+        }
+        return home
+            .appendingPathComponent("credentials", isDirectory: true)
+            .appendingPathComponent("kimi-code.json")
+    }
+
+    private static func kimiCodeAccessToken(credentialsURL: URL, now: Date) -> String? {
+        guard let data = try? Data(contentsOf: credentialsURL),
+              let credential = try? JSONDecoder().decode(KimiCodeOAuthCredential.self, from: data)
+        else {
+            return nil
+        }
+        let token = credential.accessToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { return nil }
+        if let expiresAt = credential.expiresAt,
+           expiresAt <= now.addingTimeInterval(60).timeIntervalSince1970
+        {
+            return nil
+        }
+        return token
+    }
+
     private static func cleaned(_ raw: String?) -> String? {
         guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
             return nil
@@ -47,5 +86,39 @@ public enum KimiSettingsReader {
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
+    }
+}
+
+private struct KimiCodeOAuthCredential: Decodable {
+    let accessToken: String
+    let expiresAt: TimeInterval?
+
+    private enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresAt = "expires_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.accessToken = (try? container.decode(String.self, forKey: .accessToken)) ?? ""
+        self.expiresAt = Self.timeIntervalValue(in: container, forKey: .expiresAt)
+    }
+
+    private static func timeIntervalValue(
+        in container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys) -> TimeInterval?
+    {
+        if let value = try? container.decode(Double.self, forKey: key) {
+            return value
+        }
+        if let value = try? container.decode(Int64.self, forKey: key) {
+            return TimeInterval(value)
+        }
+        if let value = try? container.decode(String.self, forKey: key),
+           let number = TimeInterval(value)
+        {
+            return number
+        }
+        return nil
     }
 }

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -294,7 +294,13 @@ public enum ProviderTokenResolver {
     public static func kimiAPIResolution(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
-        self.resolveEnv(KimiSettingsReader.apiKey(environment: environment))
+        if let resolution = self.resolveEnv(KimiSettingsReader.apiKey(environment: environment)) {
+            return resolution
+        }
+        if let token = KimiSettingsReader.kimiCodeAccessToken(environment: environment) {
+            return ProviderTokenResolution(token: token, source: .authFile)
+        }
+        return nil
     }
 
     public static func kimiK2Resolution(

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -16,8 +16,16 @@ private struct KimiStubClaudeFetcher: ClaudeUsageFetching {
     }
 }
 
-private func makeKimiFetchContext(sourceMode: ProviderSourceMode) -> ProviderFetchContext {
-    let env: [String: String] = [:]
+private func makeKimiFetchContext(
+    sourceMode: ProviderSourceMode,
+    environment: [String: String]? = nil) -> ProviderFetchContext
+{
+    let env = environment ?? [
+        "KIMI_CODE_HOME": URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("CodexBarMissingKimiCode-")
+            .appendingPathComponent(UUID().uuidString)
+            .path,
+    ]
     return ProviderFetchContext(
         runtime: .app,
         sourceMode: sourceMode,
@@ -30,6 +38,29 @@ private func makeKimiFetchContext(sourceMode: ProviderSourceMode) -> ProviderFet
         fetcher: UsageFetcher(environment: env),
         claudeFetcher: KimiStubClaudeFetcher(),
         browserDetection: BrowserDetection(cacheTTL: 0))
+}
+
+private func makeTemporaryKimiCodeHome() throws -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("CodexBarKimiCodeTests-")
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private func writeKimiCodeCredential(home: URL, accessToken: String, expiresAt: Date) throws {
+    let credentials = home.appendingPathComponent("credentials", isDirectory: true)
+    try FileManager.default.createDirectory(at: credentials, withIntermediateDirectories: true)
+    let payload: [String: Any] = [
+        "access_token": accessToken,
+        "refresh_token": "refresh-token",
+        "expires_at": expiresAt.timeIntervalSince1970,
+        "expires_in": 3600,
+        "scope": "",
+        "token_type": "Bearer",
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: credentials.appendingPathComponent("kimi-code.json"))
 }
 
 struct KimiSettingsReaderTests {
@@ -62,6 +93,69 @@ struct KimiSettingsReaderTests {
         ]
         let token = KimiSettingsReader.apiKey(environment: env)
         #expect(token == "kimi-code-token")
+    }
+
+    @Test
+    func `reads fresh Kimi Code OAuth credential from official home`() throws {
+        let home = try makeTemporaryKimiCodeHome()
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        try writeKimiCodeCredential(
+            home: home,
+            accessToken: "oauth-access-token",
+            expiresAt: now.addingTimeInterval(3600))
+
+        let token = KimiSettingsReader.kimiCodeAccessToken(
+            environment: ["KIMI_CODE_HOME": home.path],
+            now: now)
+
+        #expect(token == "oauth-access-token")
+    }
+
+    @Test
+    func `ignores expired Kimi Code OAuth credential`() throws {
+        let home = try makeTemporaryKimiCodeHome()
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        try writeKimiCodeCredential(
+            home: home,
+            accessToken: "expired-access-token",
+            expiresAt: now.addingTimeInterval(30))
+
+        let token = KimiSettingsReader.kimiCodeAccessToken(
+            environment: ["KIMI_CODE_HOME": home.path],
+            now: now)
+
+        #expect(token == nil)
+    }
+
+    @Test
+    func `resolves Kimi API token from Kimi Code OAuth credential`() throws {
+        let home = try makeTemporaryKimiCodeHome()
+        try writeKimiCodeCredential(
+            home: home,
+            accessToken: "oauth-access-token",
+            expiresAt: Date().addingTimeInterval(3600))
+
+        let resolution = ProviderTokenResolver.kimiAPIResolution(environment: ["KIMI_CODE_HOME": home.path])
+
+        #expect(resolution?.token == "oauth-access-token")
+        #expect(resolution?.source == .authFile)
+    }
+
+    @Test
+    func `prefers explicit Kimi Code API key over Kimi Code OAuth credential`() throws {
+        let home = try makeTemporaryKimiCodeHome()
+        try writeKimiCodeCredential(
+            home: home,
+            accessToken: "oauth-access-token",
+            expiresAt: Date().addingTimeInterval(3600))
+
+        let resolution = ProviderTokenResolver.kimiAPIResolution(environment: [
+            "KIMI_CODE_API_KEY": "explicit-api-key",
+            "KIMI_CODE_HOME": home.path,
+        ])
+
+        #expect(resolution?.token == "explicit-api-key")
+        #expect(resolution?.source == .environment)
     }
 
     @Test
@@ -140,6 +234,21 @@ struct KimiSettingsReaderTests {
 }
 
 struct KimiAPIFetchStrategyTests {
+    @Test
+    func `auto mode is available with Kimi Code OAuth credential`() async throws {
+        let home = try makeTemporaryKimiCodeHome()
+        try writeKimiCodeCredential(
+            home: home,
+            accessToken: "oauth-access-token",
+            expiresAt: Date().addingTimeInterval(3600))
+        let strategy = KimiAPIFetchStrategy()
+        let context = makeKimiFetchContext(
+            sourceMode: .auto,
+            environment: ["KIMI_CODE_HOME": home.path])
+
+        #expect(await strategy.isAvailable(context))
+    }
+
     @Test
     func `auto mode falls back from invalid API key to web cookies`() {
         let strategy = KimiAPIFetchStrategy()


### PR DESCRIPTION
## Summary

Improves Kimi Code usage reporting in CodexBar.

Main changes:

- Supports Kimi Code OAuth credentials from `~/.kimi-code/credentials/kimi-code.json`
- Refreshes expired Kimi Code OAuth access tokens
- Shows which Kimi source is active:
  - Kimi Code credential
  - Kimi Code API key
  - Kimi web cookie
- Preserves all Kimi quota windows from `limits[]`
- Shows Session before Weekly
- Adds daily Kimi token usage bars from local usage records:
  - Kimi Code `sessions/**/wire.jsonl`
  - Pi session records for Kimi providers
- Adds settings toggles for those local sources
- Estimates local Kimi usage cost with `pi-provider-kimi-code` pricing
- Shows Kimi membership tier and fast mode as:
  - `Tier: Allegretto`
  - `Tier: Allegretto / Fast`

This keeps Kimi Code separate from Moonshot, Kimi K2, and generic Kimi API providers.

## Privacy

Local session scanning only aggregates usage records. It does not display raw prompts or session content.

## Validation

- `./Scripts/lint.sh format`
- `swift test --filter "Kimi" --skip-update`
- `swift test --filter "PiSessionCostScannerTests|ProviderSettingsDescriptorTests|Kimi" --skip-update`
- `make check`
- `git diff --check`
- `./Scripts/compile_and_run.sh`
