### PR TITLE
Fix sub-percent usage display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Mistral: restore Vibe monthly-plan usage by forwarding only required console session cookies. Thanks @lfmundim!
+- Usage display: keep positive values below one percent visible instead of rounding them to zero. Thanks @Max0633!
 
 ## 0.37.3 — 2026-06-23
 

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -5,8 +5,7 @@ enum MenuBarDisplayText {
     static func percentText(window: RateWindow?, showUsed: Bool) -> String? {
         guard let window else { return nil }
         let percent = showUsed ? window.usedPercent : window.remainingPercent
-        let clamped = min(100, max(0, percent))
-        return String(format: "%.0f%%", clamped)
+        return UsageFormatter.percentString(percent)
     }
 
     static func paceText(pace: UsagePace?) -> String? {

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -70,7 +70,7 @@ struct UsageMenuCardView: View {
             }
 
             var percentLabel: String {
-                String(format: "%.0f%% %@", self.percent, self.percentStyle.labelSuffix)
+                "\(UsageFormatter.percentString(self.percent)) \(self.percentStyle.labelSuffix)"
             }
         }
 

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -80,11 +80,16 @@ public enum UsageFormatter {
 
     public static func usageLine(remaining: Double, used: Double, showUsed: Bool) -> String {
         let percent = showUsed ? used : remaining
-        let clamped = min(100, max(0, percent))
         let suffix = showUsed
             ? self.localized("usage_percent_suffix_used")
             : self.localized("usage_percent_suffix_left")
-        return String(format: "%.0f%% %@", clamped, suffix)
+        return "\(self.percentString(percent)) \(suffix)"
+    }
+
+    public static func percentString(_ percent: Double) -> String {
+        let clamped = min(100, max(0, percent))
+        if clamped > 0, clamped < 1 { return "<1%" }
+        return String(format: "%.0f%%", clamped)
     }
 
     public static func resetCountdownDescription(from date: Date, now: Date = .init()) -> String {

--- a/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
+++ b/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
@@ -6,6 +6,23 @@ import Testing
 
 struct MenuCardProviderRegressionTests {
     @Test
+    func `menu card keeps positive sub percent usage visible`() {
+        let metric = UsageMenuCardView.Model.Metric(
+            id: "sub-percent",
+            title: "Monthly",
+            percent: 0.1,
+            percentStyle: .used,
+            resetText: nil,
+            detailText: nil,
+            detailLeftText: nil,
+            detailRightText: nil,
+            pacePercent: nil,
+            paceOnTop: false)
+
+        #expect(metric.percentLabel == "<1% used")
+    }
+
+    @Test
     func `elevenlabs progress color stays visible in light menus`() {
         #expect(UsageMenuCardView.Model.progressColor(for: .elevenlabs) == Color(nsColor: .labelColor))
     }

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -44,6 +44,22 @@ struct UsageFormatterTests {
     }
 
     @Test
+    func `positive sub percent usage stays visible`() {
+        #expect(UsageFormatter.percentString(-1) == "0%")
+        #expect(UsageFormatter.percentString(0) == "0%")
+        #expect(UsageFormatter.percentString(0.1) == "<1%")
+        #expect(UsageFormatter.percentString(0.96) == "<1%")
+        #expect(UsageFormatter.percentString(1) == "1%")
+        #expect(UsageFormatter.percentString(101) == "100%")
+        #expect(UsageFormatter.usageLine(remaining: 99.9, used: 0.1, showUsed: true) == "<1% used")
+
+        let usedWindow = RateWindow(usedPercent: 0.1, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
+        let leftWindow = RateWindow(usedPercent: 99.9, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
+        #expect(MenuBarDisplayText.percentText(window: usedWindow, showUsed: true) == "<1%")
+        #expect(MenuBarDisplayText.percentText(window: leftWindow, showUsed: false) == "<1%")
+    }
+
+    @Test
     func `usage line respects injected localization provider`() {
         UsageFormatter.setLocalizationProvider { key in
             switch key {


### PR DESCRIPTION
## Summary

- keep true zero usage at `0%`
- render every positive value below one percent as `<1%`
- share the formatter across menu, menu card, and menu bar displays
- add regression coverage and changelog credit

The existing integer formatter already rounds `0.96` to `1%`; the reproducible failure is for positive values below `0.5%`. This fixes that range and gives all positive sub-one-percent values one consistent, accurate label.

Fixes #1734

## Validation

- `swift test --filter 'UsageFormatterTests|StatusItemAnimationTests|MiMoProviderTests|MenuCardProviderRegressionTests'` (105 tests, 4 suites)
- `make check`
- `make test` (512 selections, 43 groups)
- autoreview: clean, no actionable findings (0.91 confidence)
