### PR TITLE
[codex] Avoid CLI enrichment during usage-only OAuth refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Mistral: restore Vibe monthly-plan usage by forwarding only required console session cookies. Thanks @lfmundim!
 - Codex: show enterprise monthly credit limits across OAuth, CLI, menu, and widget surfaces. Thanks @ChenZiHong-Gavin!
+- Codex: avoid launching monthly-credit CLI enrichment during usage-only OAuth refreshes.
 - Usage display: keep positive values below one percent visible instead of rounding them to zero. Thanks @Max0633!
 
 ## 0.37.3 — 2026-06-23

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -292,6 +292,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
         cliStrategy: any ProviderFetchStrategy = CodexCLIUsageStrategy()) async throws -> ProviderFetchResult
     {
         guard context.sourceMode == .auto,
+              context.includeCredits,
               self.shouldTryCLIForMonthlyLimit(oauthResult)
         else { return oauthResult }
         guard await cliStrategy.isAvailable(context) else { return oauthResult }

--- a/Tests/CodexBarTests/CodexOAuthCreditLimitTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthCreditLimitTests.swift
@@ -23,12 +23,15 @@ struct CodexOAuthCreditLimitTests {
         }
     }
 
-    private func makeContext(sourceMode: ProviderSourceMode = .auto) -> ProviderFetchContext {
+    private func makeContext(
+        sourceMode: ProviderSourceMode = .auto,
+        includeCredits: Bool = true) -> ProviderFetchContext
+    {
         let browserDetection = BrowserDetection(cacheTTL: 0)
         return ProviderFetchContext(
             runtime: .app,
             sourceMode: sourceMode,
-            includeCredits: true,
+            includeCredits: includeCredits,
             webTimeout: 60,
             webDebugDumpHTML: false,
             verbose: false,
@@ -231,6 +234,27 @@ struct CodexOAuthCreditLimitTests {
         #expect(result.usage.primary == oauthResult.usage.primary)
         #expect(result.credits?.remaining == oauthResult.credits?.remaining)
         #expect(result.credits?.codexCreditLimit?.remaining == 750)
+    }
+
+    @Test
+    func `usage-only O auth refresh does not launch CLI monthly limit enrichment`() async throws {
+        let mappedOAuth = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(self.oauthZeroCreditRateWindowJSON().utf8),
+            credentials: self.makeCredentials(),
+            sourceMode: .auto)
+        let oauthResult = self.replacingIdentity(mappedOAuth, email: "owner@example.com")
+        let cliResult = self.makeCLIResult(
+            credits: self.makeMonthlyLimitCredits(),
+            email: "owner@example.com")
+
+        let result = try await CodexOAuthFetchStrategy._replaceWithCLIMonthlyLimitForTesting(
+            oauthResult: oauthResult,
+            context: self.makeContext(sourceMode: .auto, includeCredits: false),
+            cliStrategy: StubFetchStrategy(available: true, result: cliResult))
+
+        #expect(result.sourceLabel == "oauth")
+        #expect(result.usage.primary == oauthResult.usage.primary)
+        #expect(result.credits?.codexCreditLimit == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Gate opportunistic Codex CLI monthly-credit enrichment on credit-enabled refreshes.
- Keep usage-only OAuth refreshes on OAuth without launching `codex app-server`.
- Add regression coverage and document the repair in the unreleased changelog.

## Root cause

PR #1720 added an OAuth-success enrichment path for enterprise monthly credit limits. That path correctly preserved the OAuth usage and account identity, but it did not check `includeCredits`. Normal usage-only app refreshes therefore launched the CLI even though CodexBar refreshes credits separately.

The fix keeps enrichment at the existing Codex OAuth ownership boundary and adds the missing `includeCredits` invariant. Credit-enabled automatic refreshes retain the monthly-limit fallback unchanged.

## Validation

- `swift test --filter 'CodexOAuthCreditLimitTests|CodexBaselineCharacterizationTests|CodexUsageFetcherFallbackTests'` — 33 tests across 3 suites passed.
- `make check` — SwiftFormat, SwiftLint, locale, documentation, and repository checks passed.
- `make test` — 513 test selections across 43 groups passed.
- `CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh` — exact-head app package built successfully.
- Packaged `CodexBarCLI` with an isolated zero-credit OAuth fixture, `--source auto --no-credits`, and a sentinel `CODEX_CLI_PATH` — exit 0; no `app-server` invocation.
- Autoreview against `origin/main` — clean, no accepted/actionable findings; confidence 0.86.
- Public Model Identifier Gate — passed; this diff adds no model identifiers.

## Risk

Low. Three-file change: one guard, one focused regression test, one changelog line. No auth, storage, parsing, API, or account-reconciliation behavior changes. Credit-enabled monthly-limit enrichment remains covered by the existing matching-account tests.

Follow-up to #1720.
