### PR TITLE
Improve Kimi Code usage reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - sub2api: add group-key usage with daily, weekly, and monthly quotas, multi-account switching, wallet balance, and expiry details. Thanks @weirdo-adam!
+- Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 
 ### Fixed
 - Startup: load persisted plan-utilization history away from the main thread so mature histories no longer delay app launch. Thanks @Yuxin-Qiao!
@@ -13,7 +14,6 @@
 ## 0.42.1 — 2026-07-12
 
 ### Added
-- Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 - Factory: add API-key usage authentication with API-first Auto mode and recoverable fallback to the existing web session path. Thanks @araa47!
 - Developer tooling: add an offline adaptive-refresh replay CLI for comparing policy behavior against caller-supplied JSONL traces, without collecting production data. Thanks @hhh2210!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## 0.42.1 — 2026-07-12
 
 ### Added
+- Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 - Factory: add API-key usage authentication with API-first Auto mode and recoverable fallback to the existing web session path. Thanks @araa47!
 - Developer tooling: add an offline adaptive-refresh replay CLI for comparing policy behavior against caller-supplied JSONL traces, without collecting production data. Thanks @hhh2210!
 

--- a/Sources/CodexBar/Providers/Kimi/KimiProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Kimi/KimiProviderImplementation.swift
@@ -75,7 +75,8 @@ struct KimiProviderImplementation: ProviderImplementation {
             ProviderSettingsPickerDescriptor(
                 id: "kimi-usage-source",
                 title: "Usage source",
-                subtitle: "Auto uses the Kimi Code API key first, then falls back to browser cookies.",
+                subtitle: "Auto tries your configured API key, then a signed-in Kimi Code CLI credential, " +
+                    "then browser cookies.",
                 binding: usageBinding,
                 options: usageOptions,
                 isVisible: nil,

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -711,7 +711,10 @@ extension CodexBarCLI {
         }
         if provider == .kimi,
            sourceMode == .auto,
-           environment.map({ ProviderTokenResolver.kimiAPIToken(environment: $0) != nil }) == true
+           environment.map({ environment in
+               ProviderTokenResolver.kimiAPIToken(environment: environment) != nil ||
+                   KimiSettingsReader.hasKimiCodeCredential(environment: environment)
+           }) == true
         {
             return false
         }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiAPIError.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiAPIError.swift
@@ -9,6 +9,7 @@ public enum KimiAPIError: LocalizedError, Sendable, Equatable {
     case networkError(String)
     case apiError(String)
     case parseFailed(String)
+    case expiredCodeCredential
 
     public var errorDescription: String? {
         switch self {
@@ -28,6 +29,9 @@ public enum KimiAPIError: LocalizedError, Sendable, Equatable {
             "Kimi API error: \(message)"
         case let .parseFailed(message):
             "Failed to parse Kimi usage data: \(message)"
+        case .expiredCodeCredential:
+            "Kimi Code CLI credential is expired. Sign in again with Kimi Code CLI or set KIMI_CODE_API_KEY; " +
+                "CodexBar does not refresh CLI-owned credentials."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiAPIError.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiAPIError.swift
@@ -10,6 +10,7 @@ public enum KimiAPIError: LocalizedError, Sendable, Equatable {
     case apiError(String)
     case parseFailed(String)
     case expiredCodeCredential
+    case invalidCodeCredential
 
     public var errorDescription: String? {
         switch self {
@@ -32,6 +33,9 @@ public enum KimiAPIError: LocalizedError, Sendable, Equatable {
         case .expiredCodeCredential:
             "Kimi Code CLI credential is expired. Sign in again with Kimi Code CLI or set KIMI_CODE_API_KEY; " +
                 "CodexBar does not refresh CLI-owned credentials."
+        case .invalidCodeCredential:
+            "Kimi Code CLI credential is invalid or expired. Sign in again with Kimi Code CLI or set " +
+                "KIMI_CODE_API_KEY; CodexBar does not refresh CLI-owned credentials."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -46,7 +46,7 @@ public enum KimiProviderDescriptor {
         case .web:
             [KimiWebFetchStrategy()]
         case .auto:
-            [KimiAPIFetchStrategy(), KimiWebFetchStrategy()]
+            [KimiAPIFetchStrategy(), KimiCLICredentialFetchStrategy(), KimiWebFetchStrategy()]
         case .cli, .oauth:
             []
         }
@@ -56,71 +56,105 @@ public enum KimiProviderDescriptor {
 struct KimiAPIFetchStrategy: ProviderFetchStrategy {
     let id: String = "kimi.api"
     let kind: ProviderFetchKind = .apiToken
+    private let transport: any ProviderHTTPTransport
+
+    init(transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) {
+        self.transport = transport
+    }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        if context.sourceMode == .api { return true }
-        return Self.resolveToken(environment: context.env) != nil ||
+        context.sourceMode == .api || KimiSettingsReader.apiKey(environment: context.env) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let apiKey = KimiSettingsReader.apiKey(environment: context.env) else {
+            throw KimiAPIError.missingAPIKey
+        }
+        let baseURL = try KimiSettingsReader.codeAPIBaseURL(environment: context.env)
+        let snapshot = try await KimiUsageFetcher.fetchCodeAPIUsage(
+            apiKey: apiKey,
+            baseURL: baseURL,
+            transport: self.transport)
+        return self.makeResult(
+            usage: snapshot.toUsageSnapshot(),
+            sourceLabel: "Kimi Code API key")
+    }
+
+    func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
+        KimiCodeAPIFallbackPolicy.shouldFallback(on: error, context: context)
+    }
+}
+
+struct KimiCLICredentialFetchStrategy: ProviderFetchStrategy {
+    let id: String = "kimi.cli"
+    let kind: ProviderFetchKind = .oauth
+    private let transport: any ProviderHTTPTransport
+
+    init(transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) {
+        self.transport = transport
+    }
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        context.sourceMode == .auto &&
             KimiSettingsReader.hasKimiCodeCredential(environment: context.env)
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let allowAuthFile = context.sourceMode != .api
-        guard let resolution = Self.resolveToken(
-            environment: context.env,
-            allowAuthFile: allowAuthFile)
-        else {
-            if allowAuthFile, KimiSettingsReader.hasKimiCodeCredential(environment: context.env) {
-                throw KimiAPIError.expiredCodeCredential
-            }
-            throw KimiAPIError.missingAPIKey
+        guard let token = KimiSettingsReader.kimiCodeAccessToken(environment: context.env) else {
+            throw KimiAPIError.expiredCodeCredential
         }
         let baseURL = try KimiSettingsReader.codeAPIBaseURL(environment: context.env)
-        let identityHeaders = resolution.source == .authFile
-            ? KimiSettingsReader.kimiCodeIdentityHeaders(environment: context.env)
-            : [:]
+        let identityHeaders = KimiSettingsReader.kimiCodeIdentityHeaders(environment: context.env)
         let snapshot: KimiUsageSnapshot
         do {
             snapshot = try await KimiUsageFetcher.fetchCodeAPIUsage(
-                apiKey: resolution.token,
+                apiKey: token,
                 baseURL: baseURL,
-                identityHeaders: identityHeaders)
+                identityHeaders: identityHeaders,
+                transport: self.transport)
         } catch {
-            throw Self.normalizedCodeAPIError(error, source: resolution.source)
+            throw Self.normalizedCodeAPIError(error)
         }
         return self.makeResult(
             usage: snapshot.toUsageSnapshot(),
-            sourceLabel: resolution.source == .authFile ? "Kimi Code CLI" : "Kimi Code API key")
+            sourceLabel: "Kimi Code CLI")
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
+        KimiCodeAPIFallbackPolicy.shouldFallback(on: error, context: context)
+    }
+
+    static func normalizedCodeAPIError(_ error: Error) -> Error {
+        guard case KimiAPIError.invalidAPIKey = error else { return error }
+        return KimiAPIError.invalidCodeCredential
+    }
+}
+
+private enum KimiCodeAPIFallbackPolicy {
+    static func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
         guard context.sourceMode == .auto else { return false }
-        if error is CancellationError { return false }
+        if error is CancellationError {
+            return false
+        }
         if let urlError = error as? URLError {
             return urlError.code != .cancelled
         }
-        if case KimiAPIError.missingAPIKey = error { return true }
-        if case KimiAPIError.expiredCodeCredential = error { return true }
-        if case KimiAPIError.invalidCodeCredential = error { return true }
-        if case KimiAPIError.invalidAPIKey = error { return true }
-        if case KimiAPIError.apiError = error { return true }
-        if error is DecodingError { return true }
-        return false
-    }
-
-    private static func resolveToken(
-        environment: [String: String],
-        allowAuthFile: Bool = true) -> ProviderTokenResolution?
-    {
-        if allowAuthFile {
-            return ProviderTokenResolver.kimiAPIResolution(environment: environment)
+        if case KimiAPIError.missingAPIKey = error {
+            return true
         }
-        guard let token = KimiSettingsReader.apiKey(environment: environment) else { return nil }
-        return ProviderTokenResolution(token: token, source: .environment)
-    }
-
-    static func normalizedCodeAPIError(_ error: Error, source: ProviderTokenSource) -> Error {
-        guard source == .authFile, case KimiAPIError.invalidAPIKey = error else { return error }
-        return KimiAPIError.invalidCodeCredential
+        if case KimiAPIError.expiredCodeCredential = error {
+            return true
+        }
+        if case KimiAPIError.invalidCodeCredential = error {
+            return true
+        }
+        if case KimiAPIError.invalidAPIKey = error {
+            return true
+        }
+        if case KimiAPIError.apiError = error {
+            return true
+        }
+        return error is DecodingError
     }
 }
 
@@ -159,8 +193,12 @@ struct KimiWebFetchStrategy: ProviderFetchStrategy {
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
-        if case KimiAPIError.missingToken = error { return false }
-        if case KimiAPIError.invalidToken = error { return false }
+        if case KimiAPIError.missingToken = error {
+            return false
+        }
+        if case KimiAPIError.invalidToken = error {
+            return false
+        }
         return true
     }
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -58,20 +58,33 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .apiToken
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        context.sourceMode == .api || Self.resolveToken(environment: context.env) != nil
+        if context.sourceMode == .api { return true }
+        return Self.resolveToken(environment: context.env) != nil ||
+            KimiSettingsReader.hasKimiCodeCredential(environment: context.env)
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        guard let apiKey = Self.resolveToken(environment: context.env) else {
+        let allowAuthFile = context.sourceMode != .api
+        guard let resolution = Self.resolveToken(
+            environment: context.env,
+            allowAuthFile: allowAuthFile)
+        else {
+            if allowAuthFile, KimiSettingsReader.hasKimiCodeCredential(environment: context.env) {
+                throw KimiAPIError.expiredCodeCredential
+            }
             throw KimiAPIError.missingAPIKey
         }
         let baseURL = try KimiSettingsReader.codeAPIBaseURL(environment: context.env)
+        let identityHeaders = resolution.source == .authFile
+            ? KimiSettingsReader.kimiCodeIdentityHeaders(environment: context.env)
+            : [:]
         let snapshot = try await KimiUsageFetcher.fetchCodeAPIUsage(
-            apiKey: apiKey,
-            baseURL: baseURL)
+            apiKey: resolution.token,
+            baseURL: baseURL,
+            identityHeaders: identityHeaders)
         return self.makeResult(
             usage: snapshot.toUsageSnapshot(),
-            sourceLabel: "api")
+            sourceLabel: resolution.source == .authFile ? "Kimi Code CLI" : "Kimi Code API key")
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
@@ -81,14 +94,22 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
             return urlError.code != .cancelled
         }
         if case KimiAPIError.missingAPIKey = error { return true }
+        if case KimiAPIError.expiredCodeCredential = error { return true }
         if case KimiAPIError.invalidAPIKey = error { return true }
         if case KimiAPIError.apiError = error { return true }
         if error is DecodingError { return true }
         return false
     }
 
-    private static func resolveToken(environment: [String: String]) -> String? {
-        ProviderTokenResolver.kimiAPIToken(environment: environment)
+    private static func resolveToken(
+        environment: [String: String],
+        allowAuthFile: Bool = true) -> ProviderTokenResolution?
+    {
+        if allowAuthFile {
+            return ProviderTokenResolver.kimiAPIResolution(environment: environment)
+        }
+        guard let token = KimiSettingsReader.apiKey(environment: environment) else { return nil }
+        return ProviderTokenResolution(token: token, source: .environment)
     }
 }
 
@@ -123,7 +144,7 @@ struct KimiWebFetchStrategy: ProviderFetchStrategy {
         let snapshot = try await KimiUsageFetcher.fetchUsage(authToken: token)
         return self.makeResult(
             usage: snapshot.toUsageSnapshot(),
-            sourceLabel: "web")
+            sourceLabel: "Kimi web cookie")
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -78,10 +78,15 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
         let identityHeaders = resolution.source == .authFile
             ? KimiSettingsReader.kimiCodeIdentityHeaders(environment: context.env)
             : [:]
-        let snapshot = try await KimiUsageFetcher.fetchCodeAPIUsage(
-            apiKey: resolution.token,
-            baseURL: baseURL,
-            identityHeaders: identityHeaders)
+        let snapshot: KimiUsageSnapshot
+        do {
+            snapshot = try await KimiUsageFetcher.fetchCodeAPIUsage(
+                apiKey: resolution.token,
+                baseURL: baseURL,
+                identityHeaders: identityHeaders)
+        } catch {
+            throw Self.normalizedCodeAPIError(error, source: resolution.source)
+        }
         return self.makeResult(
             usage: snapshot.toUsageSnapshot(),
             sourceLabel: resolution.source == .authFile ? "Kimi Code CLI" : "Kimi Code API key")
@@ -95,6 +100,7 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
         }
         if case KimiAPIError.missingAPIKey = error { return true }
         if case KimiAPIError.expiredCodeCredential = error { return true }
+        if case KimiAPIError.invalidCodeCredential = error { return true }
         if case KimiAPIError.invalidAPIKey = error { return true }
         if case KimiAPIError.apiError = error { return true }
         if error is DecodingError { return true }
@@ -110,6 +116,11 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
         }
         guard let token = KimiSettingsReader.apiKey(environment: environment) else { return nil }
         return ProviderTokenResolution(token: token, source: .environment)
+    }
+
+    static func normalizedCodeAPIError(_ error: Error, source: ProviderTokenSource) -> Error {
+        guard source == .authFile, case KimiAPIError.invalidAPIKey = error else { return error }
+        return KimiAPIError.invalidCodeCredential
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
@@ -3,7 +3,10 @@ import Foundation
 public enum KimiSettingsReader {
     public static let apiKeyEnvironmentKeys = ["KIMI_CODE_API_KEY"]
     public static let codeAPIBaseURLEnvironmentKey = "KIMI_CODE_BASE_URL"
+    public static let codeHomeEnvironmentKey = "KIMI_CODE_HOME"
+    public static let codeOAuthHostEnvironmentKeys = ["KIMI_CODE_OAUTH_HOST", "KIMI_OAUTH_HOST"]
     public static let defaultCodeAPIBaseURL = URL(string: "https://api.kimi.com")!
+    private static let codePlatform = "kimi_code_cli"
 
     public static func authToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         let raw = environment["KIMI_AUTH_TOKEN"] ?? environment["kimi_auth_token"]
@@ -34,6 +37,126 @@ public enum KimiSettingsReader {
         return url
     }
 
+    public static func kimiCodeAccessToken(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        now: Date = Date()) -> String?
+    {
+        guard !self.hasCodeEndpointOverride(environment: environment),
+              let credential = self.kimiCodeCredential(environment: environment)
+        else {
+            return nil
+        }
+        let token = credential.accessToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty, self.isKimiCodeCredentialFresh(credential, now: now) else { return nil }
+        return token
+    }
+
+    public static func hasKimiCodeCredential(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool
+    {
+        guard !self.hasCodeEndpointOverride(environment: environment),
+              let credential = self.kimiCodeCredential(environment: environment)
+        else {
+            return false
+        }
+        return self.cleaned(credential.accessToken) != nil || self.cleaned(credential.refreshToken) != nil
+    }
+
+    static func kimiCodeIdentityHeaders(environment: [String: String]) -> [String: String] {
+        let deviceID = self.kimiCodeDeviceID(environment: environment)
+        let version = self.asciiHeaderValue(
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "development")
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let osVersionString = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+        return [
+            "User-Agent": "CodexBar/\(version)",
+            "X-Msh-Platform": self.codePlatform,
+            "X-Msh-Version": version,
+            "X-Msh-Device-Name": self.asciiHeaderValue(ProcessInfo.processInfo.hostName),
+            "X-Msh-Device-Model": self.asciiHeaderValue(
+                "\(self.operatingSystemName) \(osVersionString) \(self.architectureName)"),
+            "X-Msh-Os-Version": self.asciiHeaderValue(osVersionString),
+            "X-Msh-Device-Id": deviceID,
+        ]
+    }
+
+    private static func hasCodeEndpointOverride(environment: [String: String]) -> Bool {
+        if self.cleaned(environment[self.codeAPIBaseURLEnvironmentKey]) != nil { return true }
+        return self.codeOAuthHostEnvironmentKeys.contains { self.cleaned(environment[$0]) != nil }
+    }
+
+    private static func kimiCodeCredential(environment: [String: String]) -> KimiCodeOAuthCredential? {
+        let url = self.kimiCodeHomeURL(environment: environment)
+            .appendingPathComponent("credentials", isDirectory: true)
+            .appendingPathComponent("kimi-code.json")
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(KimiCodeOAuthCredential.self, from: data)
+    }
+
+    private static func isKimiCodeCredentialFresh(_ credential: KimiCodeOAuthCredential, now: Date) -> Bool {
+        guard let expiresAt = credential.expiresAt, expiresAt.isFinite else { return false }
+        return expiresAt > now.addingTimeInterval(60).timeIntervalSince1970
+    }
+
+    private static func kimiCodeDeviceID(environment: [String: String]) -> String {
+        let home = self.kimiCodeHomeURL(environment: environment)
+        let url = home
+            .appendingPathComponent("device_id", isDirectory: false)
+        if let existing = self.cleaned(try? String(contentsOf: url, encoding: .utf8)) {
+            return existing
+        }
+
+        let deviceID = UUID().uuidString.lowercased()
+        do {
+            try FileManager.default.createDirectory(
+                at: home,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+            try deviceID.write(to: url, atomically: true, encoding: .utf8)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        } catch {
+            // The official client treats persistence as best-effort; this request can use the in-memory ID.
+        }
+        return deviceID
+    }
+
+    private static func kimiCodeHomeURL(environment: [String: String]) -> URL {
+        if let override = self.cleaned(environment[self.codeHomeEnvironmentKey]) {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".kimi-code", isDirectory: true)
+    }
+
+    private static func asciiHeaderValue(_ raw: String, fallback: String = "unknown") -> String {
+        var ascii = ""
+        for scalar in raw.unicodeScalars where (0x20...0x7E).contains(scalar.value) {
+            ascii.unicodeScalars.append(scalar)
+        }
+        let value = ascii.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? fallback : value
+    }
+
+    private static var operatingSystemName: String {
+        #if os(macOS)
+        "macOS"
+        #elseif os(Linux)
+        "Linux"
+        #else
+        "unknown"
+        #endif
+    }
+
+    private static var architectureName: String {
+        #if arch(arm64)
+        "arm64"
+        #elseif arch(x86_64)
+        "x86_64"
+        #else
+        "unknown"
+        #endif
+    }
+
     private static func cleaned(_ raw: String?) -> String? {
         guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
             return nil
@@ -47,5 +170,34 @@ public enum KimiSettingsReader {
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
+    }
+}
+
+private struct KimiCodeOAuthCredential: Decodable {
+    let accessToken: String
+    let refreshToken: String
+    let expiresAt: TimeInterval?
+
+    private enum CodingKeys: String, CodingKey {
+        case access = "access_token"
+        case refresh = "refresh_token"
+        case expiry = "expires_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.accessToken = (try? container.decode(String.self, forKey: .access)) ?? ""
+        self.refreshToken = (try? container.decode(String.self, forKey: .refresh)) ?? ""
+        self.expiresAt = Self.timeIntervalValue(in: container, forKey: .expiry)
+    }
+
+    private static func timeIntervalValue(
+        in container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys) -> TimeInterval?
+    {
+        if let value = try? container.decode(Double.self, forKey: key) { return value }
+        if let value = try? container.decode(Int64.self, forKey: key) { return TimeInterval(value) }
+        if let value = try? container.decode(String.self, forKey: key) { return TimeInterval(value) }
+        return nil
     }
 }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
@@ -15,7 +15,9 @@ public struct KimiUsageFetcher: Sendable {
     public static func fetchCodeAPIUsage(
         apiKey: String,
         baseURL: URL = KimiSettingsReader.defaultCodeAPIBaseURL,
-        now: Date = Date()) async throws -> KimiUsageSnapshot
+        identityHeaders: [String: String] = [:],
+        now: Date = Date(),
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> KimiUsageSnapshot
     {
         guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw KimiAPIError.missingAPIKey
@@ -28,10 +30,13 @@ public struct KimiUsageFetcher: Sendable {
         let endpoint = self.codeAPIUsageEndpoint(baseURL: validatedBaseURL)
         var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"
+        for (name, value) in identityHeaders {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let response = try await ProviderHTTPClient.shared.response(for: request)
+        let response = try await transport.response(for: request)
         let data = response.data
         guard response.statusCode == 200 else {
             let responseBody = String(data: data, encoding: .utf8) ?? "<binary data>"

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -304,7 +304,13 @@ public enum ProviderTokenResolver {
     public static func kimiAPIResolution(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
-        self.resolveEnv(KimiSettingsReader.apiKey(environment: environment))
+        if let resolution = self.resolveEnv(KimiSettingsReader.apiKey(environment: environment)) {
+            return resolution
+        }
+        if let token = KimiSettingsReader.kimiCodeAccessToken(environment: environment) {
+            return ProviderTokenResolution(token: token, source: .authFile)
+        }
+        return nil
     }
 
     public static func kimiK2Resolution(

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -304,13 +304,7 @@ public enum ProviderTokenResolver {
     public static func kimiAPIResolution(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
-        if let resolution = self.resolveEnv(KimiSettingsReader.apiKey(environment: environment)) {
-            return resolution
-        }
-        if let token = KimiSettingsReader.kimiCodeAccessToken(environment: environment) {
-            return ProviderTokenResolution(token: token, source: .authFile)
-        }
-        return nil
+        self.resolveEnv(KimiSettingsReader.apiKey(environment: environment))
     }
 
     public static func kimiK2Resolution(

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -438,6 +438,7 @@ final class CLIEntryTests: XCTestCase {
             .auto,
             provider: .kimi,
             environment: ["KIMI_CODE_API_KEY": "kimi-test"]))
+        try self.assertKimiCodeCredentialSourceMode(in: directory)
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
             .auto,
             provider: .mimo,
@@ -454,6 +455,24 @@ final class CLIEntryTests: XCTestCase {
             .auto,
             provider: .mimo,
             environment: ["MIMO_LOCAL_USAGE_PATH": directory.appendingPathComponent("missing.json").path]))
+    }
+
+    private func assertKimiCodeCredentialSourceMode(in directory: URL) throws {
+        let home = directory.appendingPathComponent("kimi-code", isDirectory: true)
+        let credentials = home.appendingPathComponent("credentials", isDirectory: true)
+        try FileManager.default.createDirectory(at: credentials, withIntermediateDirectories: true)
+        let payload: [String: Any] = [
+            "access_token": "expired",
+            "refresh_token": "refresh",
+            "expires_at": Date().addingTimeInterval(-60).timeIntervalSince1970,
+        ]
+        try JSONSerialization.data(withJSONObject: payload)
+            .write(to: credentials.appendingPathComponent("kimi-code.json"))
+
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .kimi,
+            environment: ["KIMI_CODE_HOME": home.path]))
     }
 
     func test_sourceModeRequiresWebSupportAllowsFactoryAPIKeyOnLinuxGate() {

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -16,8 +16,11 @@ private struct KimiStubClaudeFetcher: ClaudeUsageFetching {
     }
 }
 
-private func makeKimiFetchContext(sourceMode: ProviderSourceMode) -> ProviderFetchContext {
-    let env: [String: String] = [:]
+private func makeKimiFetchContext(
+    sourceMode: ProviderSourceMode,
+    environment: [String: String] = [:]) -> ProviderFetchContext
+{
+    let env = environment
     return ProviderFetchContext(
         runtime: .app,
         sourceMode: sourceMode,
@@ -30,6 +33,36 @@ private func makeKimiFetchContext(sourceMode: ProviderSourceMode) -> ProviderFet
         fetcher: UsageFetcher(environment: env),
         claudeFetcher: KimiStubClaudeFetcher(),
         browserDetection: BrowserDetection(cacheTTL: 0))
+}
+
+private func makeTemporaryKimiCodeHome() throws -> URL {
+    let home = FileManager.default.temporaryDirectory
+        .appendingPathComponent("CodexBar-KimiCode-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(
+        at: home,
+        withIntermediateDirectories: true,
+        attributes: [.posixPermissions: 0o700])
+    return home
+}
+
+private func writeKimiCodeCredential(
+    home: URL,
+    accessToken: String,
+    refreshToken: String = "refresh",
+    expiresAt: Any?) throws -> URL
+{
+    let credentials = home.appendingPathComponent("credentials", isDirectory: true)
+    try FileManager.default.createDirectory(at: credentials, withIntermediateDirectories: true)
+    var payload: [String: Any] = [
+        "access_token": accessToken,
+        "refresh_token": refreshToken,
+    ]
+    if let expiresAt {
+        payload["expires_at"] = expiresAt
+    }
+    let url = credentials.appendingPathComponent("kimi-code.json")
+    try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]).write(to: url)
+    return url
 }
 
 struct KimiSettingsReaderTests {
@@ -62,6 +95,82 @@ struct KimiSettingsReaderTests {
         ]
         let token = KimiSettingsReader.apiKey(environment: env)
         #expect(token == "kimi-code-token")
+    }
+
+    @Test
+    func `reuses fresh CLI credential without modifying it`() throws {
+        let home = try makeTemporaryKimiCodeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let credentialURL = try writeKimiCodeCredential(
+            home: home,
+            accessToken: "oauth",
+            expiresAt: now.addingTimeInterval(3600).timeIntervalSince1970)
+        let originalData = try Data(contentsOf: credentialURL)
+        let originalModificationDate = try #require(
+            FileManager.default.attributesOfItem(atPath: credentialURL.path)[.modificationDate] as? Date)
+        let environment = ["KIMI_CODE_HOME": home.path]
+
+        let resolution = ProviderTokenResolver.kimiAPIResolution(environment: environment)
+        let headers = KimiSettingsReader.kimiCodeIdentityHeaders(environment: environment)
+
+        #expect(resolution?.token == "oauth")
+        #expect(resolution?.source == .authFile)
+        #expect(headers["X-Msh-Platform"] == "kimi_code_cli")
+        #expect(headers["X-Msh-Device-Id"]?.isEmpty == false)
+        #expect(try Data(contentsOf: credentialURL) == originalData)
+        let finalModificationDate = try #require(
+            FileManager.default.attributesOfItem(atPath: credentialURL.path)[.modificationDate] as? Date)
+        #expect(finalModificationDate == originalModificationDate)
+
+        let deviceURL = home.appendingPathComponent("device_id")
+        let permissions = try #require(
+            FileManager.default.attributesOfItem(atPath: deviceURL.path)[.posixPermissions] as? NSNumber)
+        #expect(permissions.intValue & 0o777 == 0o600)
+    }
+
+    @Test
+    func `rejects expired or missing-expiry CLI credentials`() throws {
+        let now = Date()
+        for expiresAt: Any? in [now.addingTimeInterval(30).timeIntervalSince1970, nil, "not-a-time"] {
+            let home = try makeTemporaryKimiCodeHome()
+            defer { try? FileManager.default.removeItem(at: home) }
+            _ = try writeKimiCodeCredential(
+                home: home,
+                accessToken: "oauth",
+                expiresAt: expiresAt)
+            let environment = ["KIMI_CODE_HOME": home.path]
+
+            #expect(KimiSettingsReader.hasKimiCodeCredential(environment: environment))
+            #expect(KimiSettingsReader.kimiCodeAccessToken(environment: environment, now: now) == nil)
+            #expect(ProviderTokenResolver.kimiAPIResolution(environment: environment) == nil)
+        }
+    }
+
+    @Test
+    func `prefers explicit key and isolates CLI credential from endpoint overrides`() throws {
+        let home = try makeTemporaryKimiCodeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        _ = try writeKimiCodeCredential(
+            home: home,
+            accessToken: "oauth",
+            expiresAt: Date().addingTimeInterval(3600).timeIntervalSince1970)
+
+        let explicit = ProviderTokenResolver.kimiAPIResolution(environment: [
+            "KIMI_CODE_API_KEY": "explicit",
+            "KIMI_CODE_HOME": home.path,
+        ])
+        #expect(explicit?.token == "explicit")
+        #expect(explicit?.source == .environment)
+
+        for key in ["KIMI_CODE_BASE_URL", "KIMI_CODE_OAUTH_HOST", "KIMI_OAUTH_HOST"] {
+            let environment = [
+                "KIMI_CODE_HOME": home.path,
+                key: "https://proxy.example.com",
+            ]
+            #expect(KimiSettingsReader.hasKimiCodeCredential(environment: environment) == false)
+            #expect(ProviderTokenResolver.kimiAPIResolution(environment: environment) == nil)
+        }
     }
 
     @Test
@@ -140,6 +249,44 @@ struct KimiSettingsReaderTests {
 }
 
 struct KimiAPIFetchStrategyTests {
+    @Test
+    func `auto mode accepts CLI credential and reports expired remediation`() async throws {
+        let home = try makeTemporaryKimiCodeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        _ = try writeKimiCodeCredential(
+            home: home,
+            accessToken: "expired",
+            expiresAt: Date().addingTimeInterval(-60).timeIntervalSince1970)
+        let strategy = KimiAPIFetchStrategy()
+        let context = makeKimiFetchContext(
+            sourceMode: .auto,
+            environment: ["KIMI_CODE_HOME": home.path])
+
+        #expect(await strategy.isAvailable(context))
+        await #expect(throws: KimiAPIError.expiredCodeCredential) {
+            try await strategy.fetch(context)
+        }
+        #expect(strategy.shouldFallback(on: KimiAPIError.expiredCodeCredential, context: context))
+    }
+
+    @Test
+    func `explicit API mode ignores fresh CLI credential`() async throws {
+        let home = try makeTemporaryKimiCodeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        _ = try writeKimiCodeCredential(
+            home: home,
+            accessToken: "oauth",
+            expiresAt: Date().addingTimeInterval(3600).timeIntervalSince1970)
+        let strategy = KimiAPIFetchStrategy()
+        let context = makeKimiFetchContext(
+            sourceMode: .api,
+            environment: ["KIMI_CODE_HOME": home.path])
+
+        await #expect(throws: KimiAPIError.missingAPIKey) {
+            try await strategy.fetch(context)
+        }
+    }
+
     @Test
     func `auto mode falls back from invalid API key to web cookies`() {
         let strategy = KimiAPIFetchStrategy()
@@ -331,6 +478,43 @@ struct KimiUsageResponseParsingTests {
         #expect(abs((usage.secondary?.usedPercent ?? -1) - 9.5) < 0.001)
         #expect(usage.secondary?.windowMinutes == 300)
         #expect(usage.secondary?.resetDescription == "Rate: 19/200 per 5 hours")
+    }
+
+    @Test
+    func `sends CLI identity headers on the existing usage request`() async throws {
+        let baseURL = try #require(URL(string: "https://api.kimi.com"))
+        let identityHeaders = [
+            "User-Agent": "CodexBar/test",
+            "X-Msh-Platform": "kimi_code_cli",
+            "X-Msh-Device-Id": "test-device-id",
+        ]
+        let transport = ProviderHTTPTransportHandler { request in
+            #expect(request.url?.path == "/coding/v1/usages")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer oauth-token")
+            for (name, value) in identityHeaders {
+                #expect(request.value(forHTTPHeaderField: name) == value)
+            }
+            let response = try #require(HTTPURLResponse(
+                url: request.url ?? baseURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]))
+            let data = Data("""
+            {
+              "usage": {"limit": "100", "used": "25", "remaining": "75"},
+              "limits": []
+            }
+            """.utf8)
+            return (data, response)
+        }
+
+        let snapshot = try await KimiUsageFetcher.fetchCodeAPIUsage(
+            apiKey: "oauth-token",
+            baseURL: baseURL,
+            identityHeaders: identityHeaders,
+            transport: transport)
+
+        #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 25)
     }
 
     @Test
@@ -927,6 +1111,7 @@ struct KimiAPIErrorTests {
         #expect(KimiAPIError.invalidToken.errorDescription?.contains("invalid") == true)
         #expect(KimiAPIError.missingAPIKey.errorDescription?.contains("Settings > Providers > Kimi") == true)
         #expect(KimiAPIError.missingAPIKey.errorDescription?.contains("KIMI_CODE_API_KEY") == true)
+        #expect(KimiAPIError.expiredCodeCredential.errorDescription?.contains("does not refresh") == true)
         #expect(KimiAPIError.invalidAPIKey.errorDescription?.contains("API key") == true)
         #expect(KimiAPIError.invalidRequest("Bad request").errorDescription?.contains("Bad request") == true)
         #expect(KimiAPIError.networkError("Timeout").errorDescription?.contains("Timeout") == true)

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -288,6 +288,19 @@ struct KimiAPIFetchStrategyTests {
     }
 
     @Test
+    func `rejected CLI credential keeps CLI remediation`() {
+        let cliError = KimiAPIFetchStrategy.normalizedCodeAPIError(
+            KimiAPIError.invalidAPIKey,
+            source: .authFile)
+        let keyError = KimiAPIFetchStrategy.normalizedCodeAPIError(
+            KimiAPIError.invalidAPIKey,
+            source: .environment)
+
+        #expect(cliError as? KimiAPIError == .invalidCodeCredential)
+        #expect(keyError as? KimiAPIError == .invalidAPIKey)
+    }
+
+    @Test
     func `auto mode falls back from invalid API key to web cookies`() {
         let strategy = KimiAPIFetchStrategy()
         let context = makeKimiFetchContext(sourceMode: .auto)
@@ -1112,6 +1125,7 @@ struct KimiAPIErrorTests {
         #expect(KimiAPIError.missingAPIKey.errorDescription?.contains("Settings > Providers > Kimi") == true)
         #expect(KimiAPIError.missingAPIKey.errorDescription?.contains("KIMI_CODE_API_KEY") == true)
         #expect(KimiAPIError.expiredCodeCredential.errorDescription?.contains("does not refresh") == true)
+        #expect(KimiAPIError.invalidCodeCredential.errorDescription?.contains("Sign in again") == true)
         #expect(KimiAPIError.invalidAPIKey.errorDescription?.contains("API key") == true)
         #expect(KimiAPIError.invalidRequest("Bad request").errorDescription?.contains("Bad request") == true)
         #expect(KimiAPIError.networkError("Timeout").errorDescription?.contains("Timeout") == true)

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -65,6 +65,38 @@ private func writeKimiCodeCredential(
     return url
 }
 
+private actor KimiOrderedCredentialTransport: ProviderHTTPTransport {
+    private var headers: [String] = []
+
+    func authorizationHeaders() -> [String] {
+        self.headers
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let authorization = request.value(forHTTPHeaderField: "Authorization") ?? ""
+        self.headers.append(authorization)
+        let statusCode: Int
+        let body: String
+        switch authorization {
+        case "Bearer api-bad":
+            statusCode = 401
+            body = #"{"error":"unauthorized"}"#
+        case "Bearer cli-ok":
+            statusCode = 200
+            body = #"{"usage":{"limit":"100","used":"25","remaining":"75"},"limits":[]}"#
+        default:
+            throw URLError(.userAuthenticationRequired)
+        }
+        let url = try #require(request.url)
+        let response = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]))
+        return (Data(body.utf8), response)
+    }
+}
+
 struct KimiSettingsReaderTests {
     @Test
     func `reads token from environment variable`() {
@@ -111,11 +143,10 @@ struct KimiSettingsReaderTests {
             FileManager.default.attributesOfItem(atPath: credentialURL.path)[.modificationDate] as? Date)
         let environment = ["KIMI_CODE_HOME": home.path]
 
-        let resolution = ProviderTokenResolver.kimiAPIResolution(environment: environment)
+        let token = KimiSettingsReader.kimiCodeAccessToken(environment: environment, now: now)
         let headers = KimiSettingsReader.kimiCodeIdentityHeaders(environment: environment)
 
-        #expect(resolution?.token == "oauth")
-        #expect(resolution?.source == .authFile)
+        #expect(token == "oauth")
         #expect(headers["X-Msh-Platform"] == "kimi_code_cli")
         #expect(headers["X-Msh-Device-Id"]?.isEmpty == false)
         #expect(try Data(contentsOf: credentialURL) == originalData)
@@ -143,12 +174,11 @@ struct KimiSettingsReaderTests {
 
             #expect(KimiSettingsReader.hasKimiCodeCredential(environment: environment))
             #expect(KimiSettingsReader.kimiCodeAccessToken(environment: environment, now: now) == nil)
-            #expect(ProviderTokenResolver.kimiAPIResolution(environment: environment) == nil)
         }
     }
 
     @Test
-    func `prefers explicit key and isolates CLI credential from endpoint overrides`() throws {
+    func `keeps explicit key separate and isolates CLI credential from endpoint overrides`() throws {
         let home = try makeTemporaryKimiCodeHome()
         defer { try? FileManager.default.removeItem(at: home) }
         _ = try writeKimiCodeCredential(
@@ -162,6 +192,10 @@ struct KimiSettingsReaderTests {
         ])
         #expect(explicit?.token == "explicit")
         #expect(explicit?.source == .environment)
+        #expect(KimiSettingsReader.kimiCodeAccessToken(environment: [
+            "KIMI_CODE_API_KEY": "explicit",
+            "KIMI_CODE_HOME": home.path,
+        ]) == "oauth")
 
         for key in ["KIMI_CODE_BASE_URL", "KIMI_CODE_OAUTH_HOST", "KIMI_OAUTH_HOST"] {
             let environment = [
@@ -257,7 +291,7 @@ struct KimiAPIFetchStrategyTests {
             home: home,
             accessToken: "expired",
             expiresAt: Date().addingTimeInterval(-60).timeIntervalSince1970)
-        let strategy = KimiAPIFetchStrategy()
+        let strategy = KimiCLICredentialFetchStrategy()
         let context = makeKimiFetchContext(
             sourceMode: .auto,
             environment: ["KIMI_CODE_HOME": home.path])
@@ -289,15 +323,44 @@ struct KimiAPIFetchStrategyTests {
 
     @Test
     func `rejected CLI credential keeps CLI remediation`() {
-        let cliError = KimiAPIFetchStrategy.normalizedCodeAPIError(
-            KimiAPIError.invalidAPIKey,
-            source: .authFile)
-        let keyError = KimiAPIFetchStrategy.normalizedCodeAPIError(
-            KimiAPIError.invalidAPIKey,
-            source: .environment)
+        let cliError = KimiCLICredentialFetchStrategy.normalizedCodeAPIError(KimiAPIError.invalidAPIKey)
+        let keyError = KimiCLICredentialFetchStrategy.normalizedCodeAPIError(KimiAPIError.apiError("failed"))
 
         #expect(cliError as? KimiAPIError == .invalidCodeCredential)
-        #expect(keyError as? KimiAPIError == .invalidAPIKey)
+        #expect(keyError as? KimiAPIError == .apiError("failed"))
+    }
+
+    @Test
+    func `auto retries fresh CLI credential after rejected API key`() async throws {
+        let home = try makeTemporaryKimiCodeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        _ = try writeKimiCodeCredential(
+            home: home,
+            accessToken: "cli-ok",
+            expiresAt: Date().addingTimeInterval(3600).timeIntervalSince1970)
+        let transport = KimiOrderedCredentialTransport()
+        let pipeline = ProviderFetchPipeline { _ in
+            [
+                KimiAPIFetchStrategy(transport: transport),
+                KimiCLICredentialFetchStrategy(transport: transport),
+            ]
+        }
+        let context = makeKimiFetchContext(
+            sourceMode: .auto,
+            environment: [
+                "KIMI_CODE_API_KEY": "api-bad",
+                "KIMI_CODE_HOME": home.path,
+            ])
+
+        let outcome = await pipeline.fetch(context: context, provider: .kimi)
+        let result = try outcome.result.get()
+
+        #expect(result.sourceLabel == "Kimi Code CLI")
+        #expect(outcome.attempts.map(\.strategyID) == ["kimi.api", "kimi.cli"])
+        #expect(await transport.authorizationHeaders() == [
+            "Bearer api-bad",
+            "Bearer cli-ok",
+        ])
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -249,7 +249,14 @@ struct ProviderSettingsDescriptorTests {
         let pickers = implementation.settingsPickers(context: context)
         let fields = implementation.settingsFields(context: context)
 
-        #expect(pickers.contains(where: { $0.id == "kimi-usage-source" }))
+        let usagePicker = try #require(pickers.first(where: { $0.id == "kimi-usage-source" }))
+        #expect(usagePicker.options.map(\.id) == ["auto", "api", "web"])
+        #expect(usagePicker.subtitle ==
+            "Auto tries your configured API key, then a signed-in Kimi Code CLI credential, then browser cookies.")
+        #expect(usagePicker.placement == .connection)
+        #expect(usagePicker.trailingText?() == nil)
+        fixture.store.lastSourceLabels[.kimi] = "Kimi Code CLI"
+        #expect(usagePicker.trailingText?() == "Kimi Code CLI")
         #expect(pickers.contains(where: { $0.id == "kimi-cookie-source" }))
         #expect(fields.contains(where: { $0.id == "kimi-api-key" }))
         #expect(fields.contains(where: { $0.id == "kimi-cookie" }))

--- a/docs/kimi.md
+++ b/docs/kimi.md
@@ -14,12 +14,12 @@ Tracks usage for [Kimi For Coding](https://www.kimi.com/code) in CodexBar.
 
 - Displays weekly request quota (from membership tier)
 - Shows current 5-hour rate limit usage
-- API-key, automatic cookie, and manual cookie authentication methods
+- API-key, Kimi Code CLI, automatic cookie, and manual cookie authentication methods
 - Automatic refresh countdown
 
 ## Setup
 
-Choose one of three authentication methods:
+Choose one of four authentication methods:
 
 ### Method 1: Kimi Code API Key (Recommended)
 
@@ -36,9 +36,24 @@ export KIMI_CODE_API_KEY="kimi-code-api-key-here"
 ```
 
 CodexBar calls `GET https://api.kimi.com/coding/v1/usages` with the API key. Set
-`KIMI_CODE_BASE_URL` only when testing a compatible HTTPS proxy or alternate host.
+`KIMI_CODE_BASE_URL` only when testing a compatible HTTPS proxy or alternate host with an explicit API key.
+CodexBar never forwards a Kimi Code CLI credential to an endpoint override.
 
-### Method 2: Automatic Browser Import
+### Method 2: Kimi Code CLI
+
+If you are signed in with the official Kimi Code CLI, Auto mode can reuse its fresh access token from
+`~/.kimi-code/credentials/kimi-code.json`. CodexBar sends the same device identity headers as the CLI,
+including the local hostname, OS details, and stable `~/.kimi-code/device_id` value. If that device ID is
+missing, CodexBar creates it with private file permissions to match the official client.
+
+CodexBar treats CLI-owned authentication as read-only: it never uses the refresh token and never rewrites
+the credential file. When the access token expires, sign in again with Kimi Code CLI or configure an API
+key. Set `KIMI_CODE_HOME` only when the official CLI uses a non-default home directory.
+
+Custom `KIMI_CODE_BASE_URL`, `KIMI_CODE_OAUTH_HOST`, and `KIMI_OAUTH_HOST` values disable CLI credential
+reuse; use an explicit API key for endpoint-override testing.
+
+### Method 3: Automatic Browser Import
 
 **No setup needed!** If you're already logged in to Kimi in Arc, Chrome, Safari, Edge, Brave, or Chromium:
 
@@ -49,7 +64,7 @@ CodexBar calls `GET https://api.kimi.com/coding/v1/usages` with the API key. Set
 
 **Note**: Requires Full Disk Access to read browser cookies (System Settings → Privacy & Security → Full Disk Access → CodexBar).
 
-### Method 3: Manual Token Entry
+### Method 4: Manual Token Entry
 
 For advanced users or when automatic import fails:
 
@@ -74,9 +89,10 @@ export KIMI_AUTH_TOKEN="jwt-token-here"
 When multiple sources are available, CodexBar uses this order:
 
 1. API key (`providers[].apiKey` or `KIMI_CODE_API_KEY`) in Auto mode
-2. Manual cookie/token (from Settings UI) when web fallback is used
-3. Cookie environment variable (`KIMI_AUTH_TOKEN`)
-4. Browser cookies (Arc → Chrome → Safari → Edge → Brave → Chromium)
+2. Fresh Kimi Code CLI access token (`~/.kimi-code/credentials/kimi-code.json`)
+3. Manual cookie/token (from Settings UI) when web fallback is used
+4. Cookie environment variable (`KIMI_AUTH_TOKEN`)
+5. Browser cookies (Arc → Chrome → Safari → Edge → Brave → Chromium)
 
 **Note**: Browser cookie import requires Full Disk Access permission.
 
@@ -86,7 +102,7 @@ When multiple sources are available, CodexBar uses this order:
 
 **Endpoint**: `GET https://api.kimi.com/coding/v1/usages`
 
-**Authentication**: Bearer token (from `providers[].apiKey` or `KIMI_CODE_API_KEY`)
+**Authentication**: Bearer token (from `providers[].apiKey`, `KIMI_CODE_API_KEY`, or a fresh Kimi Code CLI credential)
 
 **Response**:
 ```json


### PR DESCRIPTION
## Summary

Reuses a fresh signed-in Kimi Code CLI credential for Kimi quota requests in Auto mode. This maintainer rewrite deliberately narrows the stale 40-file proposal to authentication only, preserving current `main` behavior for Kimi lanes, widgets, subscription quota, cost history, and provider attribution.

- Keeps explicit API mode API-key only and preserves API-key priority in Auto mode.
- Treats API-key and CLI-credential requests as separate ordered attempts, so a rejected key still retries the fresh CLI credential before cookies.
- Reads the official Kimi Code credential file without refreshing or rewriting it.
- Rejects missing, malformed, non-finite, and near-expiry credentials locally with CLI-specific remediation.
- Sends the official Kimi Code device identity headers only when a CLI credential is selected.
- Disables CLI credential reuse when API or OAuth endpoint overrides are present.
- Keeps browser cookies as the existing final Auto-mode fallback.
- Reports rejected CLI credentials as CLI re-authentication failures rather than invalid API keys.

## Security and ownership

CodexBar treats the Kimi Code CLI credential as read-only state. It never uses the refresh token, never changes credential bytes or modification time, and never forwards the access token to a custom API/OAuth host. The stable device identifier follows Kimi Code's create-if-absent behavior with private directory/file permissions.

Official contracts reviewed:

- [credential storage and permissions](https://github.com/MoonshotAI/kimi-code/blob/62999caca3b56d865bb44f1f0336bff942765d94/packages/oauth/src/storage.ts)
- [OAuth expiry and refresh ownership](https://github.com/MoonshotAI/kimi-code/blob/62999caca3b56d865bb44f1f0336bff942765d94/packages/oauth/src/oauth.ts)
- [device identity headers](https://github.com/MoonshotAI/kimi-code/blob/62999caca3b56d865bb44f1f0336bff942765d94/packages/oauth/src/identity.ts)
- [managed usage request](https://github.com/MoonshotAI/kimi-code/blob/62999caca3b56d865bb44f1f0336bff942765d94/packages/oauth/src/managed-usage.ts)

## Validation

Exact head: `fc616566188243faf5c71cc550b8d8b97a2352db`

- focused Kimi suite: 81 tests passed, including API 401 followed by CLI-credential success;
- CLI entry suite: 24 tests passed;
- provider settings descriptor suite: 20 tests passed;
- `make check`: passed;
- full `make test`: 633/633 selections, 53/53 groups first-pass, zero retries;
- structured autoreview: no accepted/actionable findings after splitting API-key and CLI-credential attempts;
- exact signed debug package: Developer ID verified, Gatekeeper accepted, embedded commit `fc616566`;
- real API-key call through the packaged CLI: usage returned from `Kimi Code API key`, no error;
- packaged expired-credential path: correct CLI remediation, nonzero exit, zero stderr, credential bytes and mtime unchanged;
- live rejected-credential path: Kimi rejected a future-dated invalid bearer, CodexBar returned CLI-specific re-login guidance, credential bytes and mtime stayed unchanged, and no bearer/header value appeared in logs.

Account-specific successful reuse of a fresh officially issued CLI credential remains unobserved because Kimi's phone login could not be completed in the authorized environment. The maintainer explicitly waived that remaining proof for landing after the exact packaged API-key, credential-preservation, rejection-classification, deterministic ordered-fallback, full-suite, and local review gates. Hosted exact-head CI is running in parallel.
