### PR TITLE
Fix stale browser cookie discovery and diagnostics

### DIFF
--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -1268,6 +1268,7 @@ extension UsageStore {
                 }
             case .noCookiesFound,
                  .browserAccessDenied,
+                 .browserCookieLoadTimedOut,
                  .dashboardStillRequiresLogin,
                  .manualCookieHeaderInvalid:
                 self.logOpenAIWeb("[\(stamp)] import failed: \(err.localizedDescription)")

--- a/Sources/CodexBarCore/BrowserDetection.swift
+++ b/Sources/CodexBarCore/BrowserDetection.swift
@@ -1,7 +1,13 @@
 import Foundation
 #if os(macOS)
+import Darwin
 import os.lock
 import SweetCookieKit
+
+enum BrowserProfileAccessIssue: Equatable {
+    case accessDenied
+    case unreadable
+}
 
 /// Browser presence + profile heuristics.
 ///
@@ -16,6 +22,7 @@ public final class BrowserDetection: Sendable {
     private let now: @Sendable () -> Date
     private let fileExists: @Sendable (String) -> Bool
     private let directoryContents: @Sendable (String) -> [String]?
+    private let profileAccessIssue: @Sendable (String) -> BrowserProfileAccessIssue?
 
     private struct CachedResult {
         let value: Bool
@@ -33,7 +40,7 @@ public final class BrowserDetection: Sendable {
         let kind: ProbeKind
     }
 
-    public init(
+    public convenience init(
         homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path,
         cacheTTL: TimeInterval = BrowserDetection.defaultCacheTTL,
         now: @escaping @Sendable () -> Date = Date.init,
@@ -42,11 +49,29 @@ public final class BrowserDetection: Sendable {
             try? FileManager.default.contentsOfDirectory(atPath: path)
         })
     {
+        self.init(
+            homeDirectory: homeDirectory,
+            cacheTTL: cacheTTL,
+            now: now,
+            fileExists: fileExists,
+            directoryContents: directoryContents,
+            profileAccessIssue: Self.probeProfileAccessIssue)
+    }
+
+    init(
+        homeDirectory: String,
+        cacheTTL: TimeInterval,
+        now: @escaping @Sendable () -> Date,
+        fileExists: @escaping @Sendable (String) -> Bool,
+        directoryContents: @escaping @Sendable (String) -> [String]?,
+        profileAccessIssue: @escaping @Sendable (String) -> BrowserProfileAccessIssue?)
+    {
         self.homeDirectory = homeDirectory
         self.cacheTTL = cacheTTL
         self.now = now
         self.fileExists = fileExists
         self.directoryContents = directoryContents
+        self.profileAccessIssue = profileAccessIssue
     }
 
     public func isAppInstalled(_ browser: Browser) -> Bool {
@@ -62,8 +87,8 @@ public final class BrowserDetection: Sendable {
 
     /// Returns true when a cookie import attempt for this browser should be allowed.
     ///
-    /// This is intentionally stricter than `isAppInstalled`: for Chromium browsers, we only return true
-    /// when profile data exists (to avoid unnecessary Keychain prompts).
+    /// This is intentionally stricter than `isAppInstalled`: non-Safari browsers must still be installed,
+    /// and Chromium browsers must have profile data (to avoid stale sources and unnecessary Keychain prompts).
     public func isCookieSourceAvailable(_ browser: Browser) -> Bool {
         let homeURL = URL(fileURLWithPath: self.homeDirectory, isDirectory: true)
         guard BrowserCookieAccessGate.cookieStoreAccessDecision(homeDirectories: [homeURL]) == .allowed else {
@@ -75,12 +100,28 @@ public final class BrowserDetection: Sendable {
             return true
         }
 
+        // Do not cache app presence here: uninstalling a browser must remove it from the next import attempt.
+        guard self.detectAppInstalled(for: browser) else { return false }
+
         // For browsers that typically require keychain-backed decryption, ensure an actual cookie store exists.
         if self.requiresProfileValidation(browser) {
             return self.hasUsableCookieStore(browser)
         }
 
         return self.hasUsableProfileData(browser)
+    }
+
+    func cookieSourceProfileAccessIssue(_ browser: Browser) -> BrowserProfileAccessIssue? {
+        let homeURL = URL(fileURLWithPath: self.homeDirectory, isDirectory: true)
+        guard BrowserCookieAccessGate.cookieStoreAccessDecision(homeDirectories: [homeURL]) == .allowed,
+              browser != .safari,
+              self.detectAppInstalled(for: browser),
+              let profilePath = self.profilePath(for: browser, homeDirectory: self.homeDirectory)
+        else {
+            return nil
+        }
+
+        return self.profileAccessIssue(profilePath)
     }
 
     public func hasUsableProfileData(_ browser: Browser) -> Bool {
@@ -247,6 +288,40 @@ public final class BrowserDetection: Sendable {
         }
 
         return false
+    }
+
+    private static func probeProfileAccessIssue(_ path: String) -> BrowserProfileAccessIssue? {
+        do {
+            _ = try FileManager.default.contentsOfDirectory(atPath: path)
+            return nil
+        } catch {
+            if self.isPermissionError(error) {
+                return .accessDenied
+            }
+            let nsError = error as NSError
+            if nsError.domain == NSCocoaErrorDomain,
+               nsError.code == CocoaError.fileNoSuchFile.rawValue
+            {
+                return nil
+            }
+            return .unreadable
+        }
+    }
+
+    private static func isPermissionError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain,
+           nsError.code == CocoaError.fileReadNoPermission.rawValue
+        {
+            return true
+        }
+        if nsError.domain == NSPOSIXErrorDomain,
+           nsError.code == Int(EACCES) || nsError.code == Int(EPERM)
+        {
+            return true
+        }
+        guard let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error else { return false }
+        return Self.isPermissionError(underlying)
     }
 }
 

--- a/Sources/CodexBarCore/BrowserDetection.swift
+++ b/Sources/CodexBarCore/BrowserDetection.swift
@@ -1,5 +1,6 @@
 import Foundation
 #if os(macOS)
+@preconcurrency import AppKit
 import Darwin
 import os.lock
 import SweetCookieKit
@@ -22,6 +23,7 @@ public final class BrowserDetection: Sendable {
     private let now: @Sendable () -> Date
     private let fileExists: @Sendable (String) -> Bool
     private let directoryContents: @Sendable (String) -> [String]?
+    private let applicationURLs: @Sendable (String) -> [URL]
     private let profileAccessIssue: @Sendable (String) -> BrowserProfileAccessIssue?
 
     private struct CachedResult {
@@ -55,6 +57,7 @@ public final class BrowserDetection: Sendable {
             now: now,
             fileExists: fileExists,
             directoryContents: directoryContents,
+            applicationURLs: Self.registeredApplicationURLs,
             profileAccessIssue: Self.probeProfileAccessIssue)
     }
 
@@ -64,6 +67,7 @@ public final class BrowserDetection: Sendable {
         now: @escaping @Sendable () -> Date,
         fileExists: @escaping @Sendable (String) -> Bool,
         directoryContents: @escaping @Sendable (String) -> [String]?,
+        applicationURLs: @escaping @Sendable (String) -> [URL],
         profileAccessIssue: @escaping @Sendable (String) -> BrowserProfileAccessIssue?)
     {
         self.homeDirectory = homeDirectory
@@ -71,6 +75,7 @@ public final class BrowserDetection: Sendable {
         self.now = now
         self.fileExists = fileExists
         self.directoryContents = directoryContents
+        self.applicationURLs = applicationURLs
         self.profileAccessIssue = profileAccessIssue
     }
 
@@ -165,7 +170,9 @@ public final class BrowserDetection: Sendable {
         for path in appPaths where self.fileExists(path) {
             return true
         }
-        return false
+
+        guard let appName = self.applicationName(for: browser) else { return false }
+        return self.applicationURLs(appName).contains { self.fileExists($0.path) }
     }
 
     private func detectUsableProfileData(for browser: Browser) -> Bool {
@@ -208,6 +215,13 @@ public final class BrowserDetection: Sendable {
 
     private func applicationName(for browser: Browser) -> String? {
         browser.appBundleName
+    }
+
+    private static func registeredApplicationURLs(named appName: String) -> [URL] {
+        let probeURL = URL(string: "https://chatgpt.com")!
+        let bundleName = "\(appName).app"
+        return NSWorkspace.shared.urlsForApplications(toOpen: probeURL)
+            .filter { $0.lastPathComponent == bundleName }
     }
 
     private func profilePath(for browser: Browser, homeDirectory: String) -> String? {

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -179,10 +179,17 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         static func resolve(fileDescriptor: Int32) -> OutputTTYIdentity? {
             var info = stat()
             guard fstat(fileDescriptor, &info) == 0 else { return nil }
+            #if canImport(Darwin)
+            let device = SpawnedProcessGroup.darwinDeviceIdentifier(info.st_dev)
+            let rawDevice = SpawnedProcessGroup.darwinDeviceIdentifier(info.st_rdev)
+            #else
+            let device = UInt64(info.st_dev)
+            let rawDevice = UInt64(info.st_rdev)
+            #endif
             return OutputTTYIdentity(
-                device: UInt64(info.st_dev),
+                device: device,
                 inode: UInt64(info.st_ino),
-                rawDevice: UInt64(info.st_rdev))
+                rawDevice: rawDevice)
         }
 
         static func holderPIDs(for terminals: Set<OutputTTYIdentity>) -> Set<pid_t> {
@@ -260,6 +267,13 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         return entries.compactMap(pid_t.init)
         #endif
     }
+
+    #if canImport(Darwin)
+    /// Darwin exposes `stat` device IDs as signed values while vnode inspection uses the same bits unsigned.
+    package static func darwinDeviceIdentifier(_ value: Int32) -> UInt64 {
+        UInt64(UInt32(bitPattern: value))
+    }
+    #endif
 
     private static func processIDs(inProcessGroup processGroup: pid_t) -> [pid_t] {
         #if canImport(Darwin)

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -19,6 +19,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
     public enum ImportError: LocalizedError {
         case noCookiesFound
         case browserAccessDenied(details: String)
+        case browserCookieLoadTimedOut(details: String)
         case dashboardStillRequiresLogin
         case noMatchingAccount(found: [FoundAccount])
         case manualCookieHeaderInvalid
@@ -29,6 +30,8 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 return "No browser cookies found."
             case let .browserAccessDenied(details):
                 return "Browser cookie access denied. \(details)"
+            case let .browserCookieLoadTimedOut(details):
+                return "Browser cookie loading timed out. \(details)"
             case .dashboardStillRequiresLogin:
                 return "Browser cookies imported, but dashboard still requires login."
             case let .noMatchingAccount(found):
@@ -179,6 +182,13 @@ public struct OpenAIDashboardBrowserCookieImporter {
             log("Skipping cached cookie header; forcing fresh browser import")
         }
 
+        for browser in Self.cookieImportOrder {
+            guard let issue = self.browserDetection.cookieSourceProfileAccessIssue(browser) else { continue }
+            let hint = Self.browserProfileAccessHint(for: browser, issue: issue)
+            diagnostics.accessDeniedHints.append(hint)
+            log(hint)
+        }
+
         // Filter to cookie-eligible browsers to avoid unnecessary keychain prompts
         let installedBrowsers = Self.cookieImportOrder.cookieImportCandidates(using: self.browserDetection)
         for browserSource in installedBrowsers {
@@ -210,12 +220,61 @@ public struct OpenAIDashboardBrowserCookieImporter {
         }
 
         if !diagnostics.accessDeniedHints.isEmpty {
-            let details = diagnostics.accessDeniedHints.joined(separator: " ")
+            let details = Array(Set(diagnostics.accessDeniedHints)).sorted().joined(separator: " ")
             log("Cookie access denied: \(details)")
             throw ImportError.browserAccessDenied(details: details)
         }
 
         throw ImportError.noCookiesFound
+    }
+
+    nonisolated static func browserProfileAccessHint(
+        for browser: Browser,
+        issue: BrowserProfileAccessIssue,
+        processName: String = ProcessInfo.processInfo.processName,
+        executablePath: String? = Bundle.main.executablePath) -> String
+    {
+        let failure = switch issue {
+        case .accessDenied: "macOS denied"
+        case .unreadable: "macOS could not read"
+        }
+        let executable = executablePath?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let target: String = if let executable, !executable.isEmpty {
+            Self.fullDiskAccessTarget(processName: processName, executablePath: executable)
+        } else {
+            processName
+        }
+        return "\(failure) \(browser.displayName) profile access for \(target). " +
+            "Grant that exact component Full Disk Access, then quit and reopen it."
+    }
+
+    private nonisolated static func fullDiskAccessTarget(processName: String, executablePath: String) -> String {
+        guard processName != "CodexBarCLI",
+              let appSuffix = executablePath.range(of: ".app/")
+        else {
+            return "\(processName) (\(executablePath))"
+        }
+        let appPath = executablePath[..<appSuffix.upperBound].dropLast()
+        return "CodexBar.app (\(appPath))"
+    }
+
+    nonisolated static func browserCookieLoadTimeoutError(
+        for browser: Browser,
+        processName: String = ProcessInfo.processInfo.processName,
+        executablePath: String? = Bundle.main.executablePath) -> ImportError
+    {
+        let executable = executablePath?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let target: String = if let executable, !executable.isEmpty {
+            Self.fullDiskAccessTarget(processName: processName, executablePath: executable)
+        } else {
+            processName
+        }
+        let keychainHint = browser.usesKeychainForCookieDecryption
+            ? " If a macOS Keychain prompt is waiting, approve it."
+            : ""
+        let details = "\(browser.displayName) did not finish before the web timeout for \(target)." + keychainHint +
+            " If the timeout repeats, grant that exact component Full Disk Access, quit and reopen it, then retry."
+        return .browserCookieLoadTimedOut(details: details)
     }
 
     public func importManualCookies(
@@ -286,8 +345,15 @@ public struct OpenAIDashboardBrowserCookieImporter {
         // Safari first: avoids touching Keychain ("Chrome Safe Storage") when Safari already matches.
         do {
             let query = BrowserCookieQuery(domains: Self.cookieDomains)
-            let sources = try await Self.runBoundedCookieLoad(deadline: deadline) {
-                try Self.cookieClient.codexBarRecords(matching: query, in: .safari)
+            let sources: [BrowserCookieStoreRecords]
+            do {
+                sources = try await Self.runBoundedCookieLoad(deadline: deadline) {
+                    try Self.cookieClient.codexBarRecords(matching: query, in: .safari)
+                }
+            } catch let error as URLError where error.code == .timedOut {
+                let timeoutError = Self.browserCookieLoadTimeoutError(for: .safari)
+                log(timeoutError.localizedDescription)
+                throw timeoutError
             }
             _ = try Self.remainingTimeout(until: deadline)
             guard !sources.isEmpty else {
@@ -316,6 +382,8 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 }
             }
             return nil
+        } catch let error as ImportError {
+            throw error
         } catch let error as URLError where error.code == .timedOut {
             throw error
         } catch let error as BrowserCookieError {
@@ -342,8 +410,15 @@ public struct OpenAIDashboardBrowserCookieImporter {
     {
         do {
             let query = BrowserCookieQuery(domains: Self.cookieDomains)
-            let sources = try await Self.runBoundedCookieLoad(deadline: deadline) {
-                try Self.cookieClient.codexBarRecords(matching: query, in: browser)
+            let sources: [BrowserCookieStoreRecords]
+            do {
+                sources = try await Self.runBoundedCookieLoad(deadline: deadline) {
+                    try Self.cookieClient.codexBarRecords(matching: query, in: browser)
+                }
+            } catch let error as URLError where error.code == .timedOut {
+                let timeoutError = Self.browserCookieLoadTimeoutError(for: browser)
+                log(timeoutError.localizedDescription)
+                throw timeoutError
             }
             _ = try Self.remainingTimeout(until: deadline)
             guard !sources.isEmpty else {
@@ -371,6 +446,8 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 }
             }
             return nil
+        } catch let error as ImportError {
+            throw error
         } catch let error as URLError where error.code == .timedOut {
             throw error
         } catch let error as BrowserCookieError {
@@ -905,6 +982,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
     public enum ImportError: LocalizedError {
         case noCookiesFound
         case browserAccessDenied(details: String)
+        case browserCookieLoadTimedOut(details: String)
         case dashboardStillRequiresLogin
         case noMatchingAccount(found: [FoundAccount])
         case manualCookieHeaderInvalid
@@ -915,6 +993,8 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 return "No browser cookies found."
             case let .browserAccessDenied(details):
                 return "Browser cookie access denied. \(details)"
+            case let .browserCookieLoadTimedOut(details):
+                return "Browser cookie loading timed out. \(details)"
             case .dashboardStillRequiresLogin:
                 return "Browser cookies imported, but dashboard still requires login."
             case let .noMatchingAccount(found):

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -8,6 +8,22 @@ import SweetCookieKit
 
 @Suite(.serialized)
 struct BrowserDetectionTests {
+    private func detection(
+        homeDirectory: String,
+        installedBrowsers: Set<Browser>) -> BrowserDetection
+    {
+        let installedAppPaths = Set(installedBrowsers.map { "/Applications/\($0.appBundleName).app" })
+        return BrowserDetection(
+            homeDirectory: homeDirectory,
+            cacheTTL: 0,
+            fileExists: { path in
+                installedAppPaths.contains(path) || FileManager.default.fileExists(atPath: path)
+            },
+            directoryContents: { path in
+                try? FileManager.default.contentsOfDirectory(atPath: path)
+            })
+    }
+
     @Test(.disabled(
         if: ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] == "1",
         "Default-home cookie access is explicitly enabled for this test run."))
@@ -125,7 +141,7 @@ struct BrowserDetectionTests {
             atPath: firefoxProfile.appendingPathComponent("cookies.sqlite").path,
             contents: Data())
 
-        let detection = BrowserDetection(homeDirectory: temp.path, cacheTTL: 0)
+        let detection = self.detection(homeDirectory: temp.path, installedBrowsers: [.firefox])
         let browsers: [Browser] = [.firefox, .safari, .chrome]
         // Chrome is filtered out deterministically because it lacks usable on-disk profile/cookie store data.
         #expect(browsers.cookieImportCandidates(using: detection) == [.firefox, .safari])
@@ -137,7 +153,7 @@ struct BrowserDetectionTests {
         try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: temp) }
 
-        let detection = BrowserDetection(homeDirectory: temp.path, cacheTTL: 0)
+        let detection = self.detection(homeDirectory: temp.path, installedBrowsers: [.chrome])
         #expect(detection.isCookieSourceAvailable(.chrome) == false)
 
         let profile = temp
@@ -177,7 +193,7 @@ struct BrowserDetectionTests {
         try FileManager.default.createDirectory(at: cookiesDir, withIntermediateDirectories: true)
         FileManager.default.createFile(atPath: cookiesDir.appendingPathComponent("Cookies").path, contents: Data())
 
-        let detection = BrowserDetection(homeDirectory: temp.path, cacheTTL: 0)
+        let detection = self.detection(homeDirectory: temp.path, installedBrowsers: [.chrome])
         let browsers: [Browser] = [.chrome, .safari]
         #expect(browsers.cookieImportCandidates(using: detection) == [.safari])
     }
@@ -265,7 +281,7 @@ struct BrowserDetectionTests {
         try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: temp) }
 
-        let detection = BrowserDetection(homeDirectory: temp.path, cacheTTL: 0)
+        let detection = self.detection(homeDirectory: temp.path, installedBrowsers: [.dia])
         #expect(detection.isCookieSourceAvailable(.dia) == false)
 
         let profile = temp
@@ -283,6 +299,72 @@ struct BrowserDetectionTests {
     }
 
     @Test
+    func `removed browser with stale cookies is not a candidate`() throws {
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let cookies = temp
+            .appendingPathComponent("Library/Application Support/Dia/User Data/Default/Network/Cookies")
+        try FileManager.default.createDirectory(
+            at: cookies.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: cookies.path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let detection = self.detection(homeDirectory: temp.path, installedBrowsers: [])
+
+        #expect(detection.hasUsableProfileData(.dia))
+        #expect(!detection.isCookieSourceAvailable(.dia))
+        #expect([Browser.dia].cookieImportCandidates(using: detection).isEmpty)
+    }
+
+    @Test
+    func `browser uninstall invalidates cookie source immediately`() throws {
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let cookies = temp
+            .appendingPathComponent("Library/Application Support/Google/Chrome/Default/Network/Cookies")
+        try FileManager.default.createDirectory(
+            at: cookies.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: cookies.path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let installed = OSAllocatedUnfairLock(initialState: true)
+        let detection = BrowserDetection(
+            homeDirectory: temp.path,
+            cacheTTL: 600,
+            fileExists: { path in
+                if path == "/Applications/Google Chrome.app" {
+                    return installed.withLock { $0 }
+                }
+                return FileManager.default.fileExists(atPath: path)
+            },
+            directoryContents: { path in
+                try? FileManager.default.contentsOfDirectory(atPath: path)
+            })
+
+        #expect(detection.isCookieSourceAvailable(.chrome))
+        installed.withLock { $0 = false }
+        #expect(!detection.isCookieSourceAvailable(.chrome))
+    }
+
+    @Test
+    func `installed browser reports denied profile access`() {
+        let home = "/tmp/codexbar-denied-browser-profile"
+        let profileRoot = "\(home)/Library/Application Support/Google/Chrome"
+        let detection = BrowserDetection(
+            homeDirectory: home,
+            cacheTTL: 0,
+            now: Date.init,
+            fileExists: { path in
+                path == "/Applications/Google Chrome.app" || path == profileRoot
+            },
+            directoryContents: { _ in nil },
+            profileAccessIssue: { _ in .accessDenied })
+
+        #expect(detection.cookieSourceProfileAccessIssue(.chrome) == .accessDenied)
+        #expect(!detection.isCookieSourceAvailable(.chrome))
+    }
+
+    @Test
     func `firefox requires default profile dir`() throws {
         let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
@@ -295,7 +377,7 @@ struct BrowserDetectionTests {
             .appendingPathComponent("Profiles")
         try FileManager.default.createDirectory(at: profiles, withIntermediateDirectories: true)
 
-        let detection = BrowserDetection(homeDirectory: temp.path, cacheTTL: 0)
+        let detection = self.detection(homeDirectory: temp.path, installedBrowsers: [.firefox])
         #expect(detection.isCookieSourceAvailable(.firefox) == false)
 
         let profile = profiles.appendingPathComponent("abc.default-release")
@@ -317,7 +399,7 @@ struct BrowserDetectionTests {
             .appendingPathComponent("Profiles")
         try FileManager.default.createDirectory(at: profiles, withIntermediateDirectories: true)
 
-        let detection = BrowserDetection(homeDirectory: temp.path, cacheTTL: 0)
+        let detection = self.detection(homeDirectory: temp.path, installedBrowsers: [.zen])
         #expect(detection.isCookieSourceAvailable(.zen) == false)
 
         let profile = profiles.appendingPathComponent("abc.Default (release)")

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -347,6 +347,69 @@ struct BrowserDetectionTests {
     }
 
     @Test
+    func `registered browser outside Applications is a candidate`() throws {
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let cookies = temp
+            .appendingPathComponent("Library/Application Support/Google/Chrome/Default/Network/Cookies")
+        try FileManager.default.createDirectory(
+            at: cookies.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: cookies.path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let appURL = URL(fileURLWithPath: "/Volumes/Tools/Google Chrome.app")
+        let detection = BrowserDetection(
+            homeDirectory: temp.path,
+            cacheTTL: 0,
+            now: Date.init,
+            fileExists: { path in
+                path == appURL.path || FileManager.default.fileExists(atPath: path)
+            },
+            directoryContents: { path in
+                try? FileManager.default.contentsOfDirectory(atPath: path)
+            },
+            applicationURLs: { appName in
+                appName == Browser.chrome.appBundleName ? [appURL] : []
+            },
+            profileAccessIssue: { _ in nil })
+
+        #expect(detection.isCookieSourceAvailable(.chrome))
+    }
+
+    @Test
+    func `stale registered browser outside Applications is not a candidate`() throws {
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let cookies = temp
+            .appendingPathComponent("Library/Application Support/Google/Chrome/Default/Network/Cookies")
+        try FileManager.default.createDirectory(
+            at: cookies.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: cookies.path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let staleAppURL = URL(fileURLWithPath: "/Volumes/Removed/Google Chrome.app")
+        let detection = BrowserDetection(
+            homeDirectory: temp.path,
+            cacheTTL: 0,
+            now: Date.init,
+            fileExists: { path in
+                if path.hasSuffix("/Google Chrome.app") {
+                    return false
+                }
+                return FileManager.default.fileExists(atPath: path)
+            },
+            directoryContents: { path in
+                try? FileManager.default.contentsOfDirectory(atPath: path)
+            },
+            applicationURLs: { appName in
+                appName == Browser.chrome.appBundleName ? [staleAppURL] : []
+            },
+            profileAccessIssue: { _ in nil })
+
+        #expect(!detection.isCookieSourceAvailable(.chrome))
+    }
+
+    @Test
     func `installed browser reports denied profile access`() {
         let home = "/tmp/codexbar-denied-browser-profile"
         let profileRoot = "\(home)/Library/Application Support/Google/Chrome"
@@ -358,6 +421,7 @@ struct BrowserDetectionTests {
                 path == "/Applications/Google Chrome.app" || path == profileRoot
             },
             directoryContents: { _ in nil },
+            applicationURLs: { _ in [] },
             profileAccessIssue: { _ in .accessDenied })
 
         #expect(detection.cookieSourceProfileAccessIssue(.chrome) == .accessDenied)

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -16,12 +16,18 @@ struct BrowserDetectionTests {
         return BrowserDetection(
             homeDirectory: homeDirectory,
             cacheTTL: 0,
+            now: Date.init,
             fileExists: { path in
-                installedAppPaths.contains(path) || FileManager.default.fileExists(atPath: path)
+                if path.hasSuffix(".app") {
+                    return installedAppPaths.contains(path)
+                }
+                return FileManager.default.fileExists(atPath: path)
             },
             directoryContents: { path in
                 try? FileManager.default.contentsOfDirectory(atPath: path)
-            })
+            },
+            applicationURLs: { _ in [] },
+            profileAccessIssue: { _ in nil })
     }
 
     @Test(.disabled(

--- a/Tests/CodexBarTests/MenuDescriptorPoeTests.swift
+++ b/Tests/CodexBarTests/MenuDescriptorPoeTests.swift
@@ -73,18 +73,22 @@ struct MenuDescriptorPoeTests {
             settings: settings)
 
         let now = Date()
+        let calendar = Calendar.current
+        // Fixed calendar-day fixtures keep this stable around midnight.
+        let today = calendar.date(bySettingHour: 12, minute: 0, second: 0, of: now) ?? now
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today) ?? now.addingTimeInterval(-86400)
         let history = PoeUsageHistorySnapshot(
             entries: [
                 .init(
                     id: "a",
-                    createdAt: now.addingTimeInterval(-1000),
+                    createdAt: today,
                     model: "GPT-4o",
                     usageType: "chat",
                     points: 100,
                     costUSD: nil),
                 .init(
                     id: "b",
-                    createdAt: now.addingTimeInterval(-86000),
+                    createdAt: yesterday,
                     model: "Claude-3.7-Sonnet",
                     usageType: "chat",
                     points: 200,

--- a/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
@@ -65,6 +65,49 @@ private final class CookieTimeoutProbe: @unchecked Sendable {
 
 struct OpenAIDashboardBrowserCookieImporterTests {
     @Test
+    func `profile denial names exact running component`() {
+        let hint = OpenAIDashboardBrowserCookieImporter.browserProfileAccessHint(
+            for: .chrome,
+            issue: .accessDenied,
+            processName: "CodexBarCLI",
+            executablePath: "/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI")
+
+        #expect(hint.contains("macOS denied Chrome profile access"))
+        #expect(hint.contains("CodexBarCLI (/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI)"))
+        #expect(hint.contains("Full Disk Access"))
+    }
+
+    @Test
+    func `profile denial names app bundle for menu refresh`() {
+        let hint = OpenAIDashboardBrowserCookieImporter.browserProfileAccessHint(
+            for: .chrome,
+            issue: .accessDenied,
+            processName: "CodexBar",
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar")
+
+        #expect(hint.contains("CodexBar.app (/Applications/CodexBar.app)"))
+    }
+
+    @Test
+    func `browser cookie timeout remains distinct from permission denial`() {
+        let error = OpenAIDashboardBrowserCookieImporter.browserCookieLoadTimeoutError(
+            for: .chrome,
+            processName: "CodexBarCLI",
+            executablePath: "/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI")
+
+        if case .browserCookieLoadTimedOut = error {
+            // Expected: a shared deadline does not prove macOS denied access.
+        } else {
+            Issue.record("Expected browser cookie load timeout")
+        }
+        #expect(error.localizedDescription.contains("Chrome did not finish before the web timeout"))
+        #expect(!error.localizedDescription.contains("access denied"))
+        #expect(error.localizedDescription.contains("CodexBarCLI"))
+        #expect(error.localizedDescription.contains("Keychain prompt"))
+        #expect(error.localizedDescription.contains("Full Disk Access"))
+    }
+
+    @Test
     func `shared deadline clamps each local timeout to remaining budget`() throws {
         let start = Date(timeIntervalSinceReferenceDate: 1000)
         let deadline = start.addingTimeInterval(30)

--- a/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
+++ b/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
@@ -15,6 +15,13 @@ struct SpawnedProcessGroupTests {
         #expect(descriptors == [3, 4])
     }
 
+    #if canImport(Darwin)
+    @Test
+    func `Darwin device identifier preserves signed bit pattern`() {
+        #expect(SpawnedProcessGroup.darwinDeviceIdentifier(-805_306_367) == 3_489_660_929)
+    }
+    #endif
+
     @Test
     func `musl close-from selects numeric descriptors at or above minimum`() throws {
         let descriptors = try PosixSpawnFileActionsCloseFrom.descriptorsToClose(startingAt: 4) { path in


### PR DESCRIPTION
## Summary

- Require an installed browser app, including Launch Services registrations outside standard app folders, before treating leftover profile data as an import candidate.
- Diagnose unreadable browser profiles with the exact CodexBar component that needs access.
- Turn stalled local cookie loading into an actionable timeout without misclassifying it as permission denial.
- Preserve signed Darwin PTY device identifiers as their unsigned bit pattern, fixing the Intel CI crash exposed while validating the branch.
- Keep the Poe menu regression fixture stable across local-day boundaries after exact-head CI crossed UTC midnight.

Addresses #1749.

## Proof

- `swift test --filter BrowserDetectionTests`
- `swift test --filter OpenAIDashboardBrowserCookieImporterTests`
- `swift test --filter KiroStatusProbeTests`
- `swift test --filter TTYCommandRunnerEnvTests`
- `TZ=UTC swift test --filter MenuDescriptorPoeTests`
- `make check`
- `make test` (43/43 shards)
- Autoreview clean after both production deltas
- Regression coverage for nonstandard browser installs, stale Launch Services registrations, removed browsers, unreadable profiles, cookie-load timeouts, and negative Darwin device identifiers.
- Packaged app smoke test on macOS 26.5: Chrome was the sole Chromium candidate; removed Atlas, Comet, and Dia profiles were not attempted; a blocked Chrome cookie load named the exact helper and remediation.

No macOS 27 VM was available locally, so reporter confirmation on macOS 27 remains required.
