### PR TITLE
Claude: add session usage + weekly pace menu bar metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Cost history: choose inline, submenu, or combined local-cost presentation. Thanks @Zihao-Qi!
 - z.ai: support saved token-account team usage with account-scoped organization and project metadata. Thanks @zqbake!
 - CLI: show session pace in text output, expose derived pace data in JSON, and honor the configured weekly work-day baseline. Thanks @kmatsunami!
-- Claude: add a combined "Session + Weekly" menu bar metric that shows the 5-hour session and weekly lanes together (paced on the weekly lane), matching Codex, and classify lanes by cadence so a weekly-only account is not mislabeled as a session.
+- Claude: add a combined "Session + Weekly" menu bar metric that shows the 5-hour session and weekly lanes together (paced on the weekly lane), matching Codex, and classify lanes by cadence so a weekly-only account is not mislabeled as a session. Thanks @Shengqiang-Zhang!
 
 ### Fixed
 - Keychain prompts: explain that macOS handles password entry, surface the existing opt-out path, and link to troubleshooting before access begins (fixes #1681). Thanks @someshfengde and @Yuxin-Qiao!
@@ -25,7 +25,7 @@
 - Overview: render row selection on the GPU to keep trackpad scrolling smooth. Thanks @hhh2210!
 - Codex cost history: count cache reads separately, deduplicate active and archived sessions at row level, and preserve cached days across narrow refreshes. Thanks @kiranmagic7!
 - Pi cost history: price Codex cache reads once using their true context size. Thanks @kiranmagic7!
-- Menu bar: in the combined "Session + Weekly" metric (Codex and Claude), pair the 5-hour session usage with the weekly pace in pace and both display modes instead of showing the busier (most-constrained) lane's usage, which mislabeled the readout as weekly usage + weekly pace.
+- Menu bar: in the combined "Session + Weekly" metric (Codex and Claude), pair the 5-hour session usage with the weekly pace in pace and both display modes instead of showing the busier (most-constrained) lane's usage, which mislabeled the readout as weekly usage + weekly pace. Thanks @Shengqiang-Zhang!
 - Menu bar: in the combined "Session + Weekly" metric, ignore Claude web's synthetic 0% five-hour placeholder (emitted for accounts with no live session window but a real weekly lane) so the readout shows the weekly lane instead of a non-existent `5h 0%`/`5h 100%` session.
 - Memory pressure: finish isolating utility-queue source reads from main-actor state to prevent the remaining callback crash. Thanks @Zihao-Qi!
 - Kiro: run account, usage, and context commands through a PTY so current CLI versions return usage without timing out. Thanks @sf-jin-ku!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Cost history: choose inline, submenu, or combined local-cost presentation. Thanks @Zihao-Qi!
 - z.ai: support saved token-account team usage with account-scoped organization and project metadata. Thanks @zqbake!
 - CLI: show session pace in text output, expose derived pace data in JSON, and honor the configured weekly work-day baseline. Thanks @kmatsunami!
+- Claude: add a combined "Session + Weekly" menu bar metric that shows the 5-hour session and weekly lanes together (paced on the weekly lane), matching Codex, and classify lanes by cadence so a weekly-only account is not mislabeled as a session.
 
 ### Fixed
 - Keychain prompts: explain that macOS handles password entry, surface the existing opt-out path, and link to troubleshooting before access begins (fixes #1681). Thanks @someshfengde and @Yuxin-Qiao!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Codex cost history: count cache reads separately, deduplicate active and archived sessions at row level, and preserve cached days across narrow refreshes. Thanks @kiranmagic7!
 - Pi cost history: price Codex cache reads once using their true context size. Thanks @kiranmagic7!
 - Menu bar: in the combined "Session + Weekly" metric (Codex and Claude), pair the 5-hour session usage with the weekly pace in pace and both display modes instead of showing the busier (most-constrained) lane's usage, which mislabeled the readout as weekly usage + weekly pace.
+- Menu bar: in the combined "Session + Weekly" metric, ignore Claude web's synthetic 0% five-hour placeholder (emitted for accounts with no live session window but a real weekly lane) so the readout shows the weekly lane instead of a non-existent `5h 0%`/`5h 100%` session.
 - Memory pressure: finish isolating utility-queue source reads from main-actor state to prevent the remaining callback crash. Thanks @Zihao-Qi!
 - Kiro: run account, usage, and context commands through a PTY so current CLI versions return usage without timing out. Thanks @sf-jin-ku!
 - OpenAI web: ignore stale profiles from removed browsers, discover registered installs outside standard app folders, and surface browser-profile access and cookie-load timeout diagnostics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Overview: render row selection on the GPU to keep trackpad scrolling smooth. Thanks @hhh2210!
 - Codex cost history: count cache reads separately, deduplicate active and archived sessions at row level, and preserve cached days across narrow refreshes. Thanks @kiranmagic7!
 - Pi cost history: price Codex cache reads once using their true context size. Thanks @kiranmagic7!
+- Menu bar: in the combined "Session + Weekly" metric (Codex and Claude), pair the 5-hour session usage with the weekly pace in pace and both display modes instead of showing the busier (most-constrained) lane's usage, which mislabeled the readout as weekly usage + weekly pace.
 - Memory pressure: finish isolating utility-queue source reads from main-actor state to prevent the remaining callback crash. Thanks @Zihao-Qi!
 - Kiro: run account, usage, and context commands through a PTY so current CLI versions return usage without timing out. Thanks @sf-jin-ku!
 - OpenAI web: ignore stale profiles from removed browsers, discover registered installs outside standard app folders, and surface browser-profile access and cookie-load timeout diagnostics.

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -16,7 +16,9 @@ enum MenuBarDisplayText {
         return "\(sign)\(deltaValue)%"
     }
 
-    static func codexCombinedPercentText(
+    /// Combined "session · weekly" menu-bar text shared by providers that expose both a
+    /// session (5h) and weekly (7d) lane, e.g. Codex and Claude.
+    static func combinedSessionWeeklyPercentText(
         sessionWindow: RateWindow?,
         weeklyWindow: RateWindow?,
         showUsed: Bool)
@@ -26,7 +28,7 @@ enum MenuBarDisplayText {
         if let sessionWindow,
            let session = self.percentText(window: sessionWindow, showUsed: showUsed)
         {
-            parts.append("\(self.codexSessionLabel(window: sessionWindow)) \(session)")
+            parts.append("\(self.sessionWindowLabel(window: sessionWindow)) \(session)")
         }
         if let weekly = self.percentText(window: weeklyWindow, showUsed: showUsed) {
             parts.append("W \(weekly)")
@@ -34,7 +36,7 @@ enum MenuBarDisplayText {
         return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 
-    private static func codexSessionLabel(window: RateWindow) -> String {
+    private static func sessionWindowLabel(window: RateWindow) -> String {
         guard let minutes = window.windowMinutes, minutes > 0 else { return "S" }
         guard minutes.isMultiple(of: 60) else { return "\(minutes)m" }
         return "\(minutes / 60)h"

--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -37,6 +37,12 @@ enum MenuBarMetricWindowResolver {
                 snapshot: snapshot,
                 lanes: Self.secondaryOrder(for: provider))
         case .primaryAndSecondary:
+            // Claude accounts that only expose an enterprise/extra-usage spend limit have no real
+            // session/weekly lanes; surface the spend limit (as `.automatic` does) instead of an empty
+            // or 0% placeholder lane.
+            if provider == .claude, let spendLimit = Self.claudeSpendLimitWindow(snapshot: snapshot) {
+                return spendLimit
+            }
             return Self.mostConstrainedWindow(
                 primary: snapshot.primary,
                 secondary: snapshot.secondary,
@@ -142,11 +148,8 @@ enum MenuBarMetricWindowResolver {
                 secondary: snapshot.secondary,
                 tertiary: snapshot.tertiary)
         }
-        if provider == .claude,
-           Self.shouldUseClaudeSpendLimit(providerCost: snapshot.providerCost, snapshot: snapshot),
-           let extraUsage = Self.extraUsageWindow(snapshot: snapshot)
-        {
-            return extraUsage
+        if provider == .claude, let spendLimit = Self.claudeSpendLimitWindow(snapshot: snapshot) {
+            return spendLimit
         }
         return snapshot.primary ?? snapshot.secondary
     }
@@ -242,6 +245,17 @@ enum MenuBarMetricWindowResolver {
 
         return ([total].compactMap(\.self) + usableSubquotaWindows)
             .max(by: { $0.usedPercent < $1.usedPercent })
+    }
+
+    /// The Claude spend-limit window when the account only exposes an enterprise/extra-usage spend limit
+    /// and has no real session/weekly quota lanes (`primary` nil, a `.spendLimit` window, or a 0% 5h
+    /// placeholder). Lets the automatic and combined metrics surface the spend limit instead of an empty
+    /// or 0% placeholder lane. Returns nil for accounts that expose genuine quota lanes.
+    static func claudeSpendLimitWindow(snapshot: UsageSnapshot) -> RateWindow? {
+        guard self.shouldUseClaudeSpendLimit(providerCost: snapshot.providerCost, snapshot: snapshot) else {
+            return nil
+        }
+        return self.extraUsageWindow(snapshot: snapshot)
     }
 
     private static func shouldUseClaudeSpendLimit(

--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -248,8 +248,8 @@ enum MenuBarMetricWindowResolver {
     }
 
     /// The Claude spend-limit window when the account only exposes an enterprise/extra-usage spend limit
-    /// and has no real session/weekly quota lanes (`primary` nil, a `.spendLimit` window, or a 0% 5h
-    /// placeholder). Lets the automatic and combined metrics surface the spend limit instead of an empty
+    /// and has no real session/weekly quota lanes (`primary` nil, a `.spendLimit` window, or an explicitly
+    /// marked placeholder). Lets the automatic and combined metrics surface the spend limit instead of an empty
     /// or 0% placeholder lane. Returns nil for accounts that expose genuine quota lanes.
     static func claudeSpendLimitWindow(snapshot: UsageSnapshot) -> RateWindow? {
         guard self.shouldUseClaudeSpendLimit(providerCost: snapshot.providerCost, snapshot: snapshot) else {
@@ -268,10 +268,7 @@ enum MenuBarMetricWindowResolver {
               snapshot.tertiary == nil
         else { return false }
         guard let primary = snapshot.primary else { return true }
-        return primary.usedPercent == 0
-            && primary.windowMinutes == 5 * 60
-            && primary.resetsAt == nil
-            && primary.resetDescription == nil
+        return primary.isSyntheticPlaceholder
     }
 
     private static func extraUsageWindow(snapshot: UsageSnapshot?) -> RateWindow? {

--- a/Sources/CodexBar/SettingsStore+MenuPreferences.swift
+++ b/Sources/CodexBar/SettingsStore+MenuPreferences.swift
@@ -93,7 +93,7 @@ extension SettingsStore {
     }
 
     func menuBarMetricSupportsPrimaryAndSecondary(for provider: UsageProvider) -> Bool {
-        provider == .codex
+        provider == .codex || provider == .claude
     }
 
     func menuBarMetricSupportsTertiary(for provider: UsageProvider) -> Bool {

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -747,6 +747,12 @@ extension StatusItemController {
             } else if provider == .abacus {
                 // Abacus has no secondary window; pace is computed on primary monthly credits
                 snapshot?.primary
+            } else if provider == .claude,
+                      self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .primaryAndSecondary
+            {
+                // Combined Session + Weekly metric paces on the weekly lane, matching Codex. Select by
+                // cadence so a five_hour-fallback snapshot (7-day window in `primary`) still paces weekly.
+                Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.weeklyWindowMinutes)
             } else {
                 percentWindow
             }
@@ -772,15 +778,24 @@ extension StatusItemController {
                     .creditsString(from: creditsRemaining)
                     .replacingOccurrences(of: " left", with: "")
         }
-        if provider == .codex,
+        if provider == .codex || provider == .claude,
            mode == .percent,
-           self.settings.menuBarMetricPreference(for: .codex, snapshot: snapshot) == .primaryAndSecondary,
-           let combinedText = MenuBarDisplayText.codexCombinedPercentText(
-               sessionWindow: codexProjection?.rateWindow(for: .session),
-               weeklyWindow: codexProjection?.rateWindow(for: .weekly),
-               showUsed: self.settings.usageBarsShowUsed)
+           self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .primaryAndSecondary
         {
-            return combinedText
+            // Codex resolves its lanes through the consumer projection. Providers without one (Claude)
+            // classify by window cadence so a 7-day window that the OAuth mapper parked in `primary`
+            // (the five_hour fallback) is not mislabeled as a 5-hour session lane.
+            let sessionLane = codexProjection?.rateWindow(for: .session)
+                ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.sessionWindowMinutes)
+            let weeklyLane = codexProjection?.rateWindow(for: .weekly)
+                ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.weeklyWindowMinutes)
+            if let combinedText = MenuBarDisplayText.combinedSessionWeeklyPercentText(
+                sessionWindow: sessionLane,
+                weeklyWindow: weeklyLane,
+                showUsed: self.settings.usageBarsShowUsed)
+            {
+                return combinedText
+            }
         }
         return MenuBarDisplayText.displayText(
             mode: mode,
@@ -991,6 +1006,18 @@ extension StatusItemController {
         -> RateWindow?
     {
         self.menuBarMetricWindow(for: provider, snapshot: snapshot)
+    }
+
+    private static let sessionWindowMinutes = 5 * 60
+    private static let weeklyWindowMinutes = 7 * 24 * 60
+
+    /// Returns the first session/weekly snapshot lane whose window cadence matches `minutes`.
+    /// Used by the combined Session + Weekly metric for providers without a Codex consumer
+    /// projection so a fallback weekly window parked in `primary` is not mislabeled as a session lane.
+    private static func rateWindow(in snapshot: UsageSnapshot?, matchingCadenceMinutes minutes: Int) -> RateWindow? {
+        [snapshot?.primary, snapshot?.secondary]
+            .compactMap(\.self)
+            .first { $0.windowMinutes == minutes }
     }
 
     func primaryProviderForUnifiedIcon() -> UsageProvider {

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -740,36 +740,20 @@ extension StatusItemController {
 
         // The combined "Session + Weekly" metric (Codex and Claude) shows both lanes in percent mode
         // ("5h 12% · W 45%") and, in pace/both modes, pairs the session usage with the weekly pace.
-        // Codex resolves its lanes through the consumer projection; Claude has none, so it classifies by
-        // window cadence — a 7-day window the OAuth mapper parked in `primary` (the five_hour fallback)
-        // must not be mislabeled as a 5-hour session lane.
-        let isCombinedSessionWeekly = (provider == .codex || provider == .claude)
-            && self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .primaryAndSecondary
-        let combinedSessionLane = isCombinedSessionWeekly
-            ? (codexProjection?.rateWindow(for: .session)
-                ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.sessionWindowMinutes))
-            : nil
-        let combinedWeeklyLane = isCombinedSessionWeekly
-            ? (codexProjection?.rateWindow(for: .weekly)
-                ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.weeklyWindowMinutes))
-            : nil
+        let combinedLanes = self.combinedSessionWeeklyLanes(
+            for: provider, snapshot: snapshot, projection: codexProjection)
 
         let pace: UsagePace?
         switch mode {
         case .percent:
             pace = nil
         case .pace, .both:
-            let paceWindow: RateWindow? = if let codexProjection {
-                codexProjection.rateWindow(for: .weekly)
-            } else if provider == .abacus {
-                // Abacus has no secondary window; pace is computed on primary monthly credits
-                snapshot?.primary
-            } else if isCombinedSessionWeekly {
-                // Combined Session + Weekly metric paces on the weekly lane, matching Codex.
-                combinedWeeklyLane
-            } else {
-                percentWindow
-            }
+            let paceWindow = self.menuBarPaceWindow(
+                for: provider,
+                snapshot: snapshot,
+                projection: codexProjection,
+                combinedLanes: combinedLanes,
+                percentWindow: percentWindow)
             pace = paceWindow.flatMap { window in
                 self.store.weeklyPace(provider: provider, window: window, now: now)
             }
@@ -792,30 +776,20 @@ extension StatusItemController {
                     .creditsString(from: creditsRemaining)
                     .replacingOccurrences(of: " left", with: "")
         }
-        if isCombinedSessionWeekly, mode == .percent {
+        if let combinedLanes, mode == .percent {
             if let combinedText = MenuBarDisplayText.combinedSessionWeeklyPercentText(
-                sessionWindow: combinedSessionLane,
-                weeklyWindow: combinedWeeklyLane,
+                sessionWindow: combinedLanes.session,
+                weeklyWindow: combinedLanes.weekly,
                 showUsed: self.settings.usageBarsShowUsed)
             {
                 return combinedText
             }
         }
 
-        // In pace/both modes the combined metric pairs the SESSION usage with the WEEKLY pace, so the
-        // usage component normally comes from the session lane — not the most-constrained lane that drives
-        // the icon/bar. Two exceptions: fall back to the weekly lane when the session lane is absent (the
-        // five_hour OAuth fallback), and surface the weekly lane when it is exhausted — it is then the
-        // binding cap with no pace to show, and a roomy session number would hide the spent weekly limit.
-        let displayPercentWindow: RateWindow?
-        if isCombinedSessionWeekly {
-            if let combinedWeeklyLane, combinedWeeklyLane.remainingPercent <= 0 {
-                displayPercentWindow = combinedWeeklyLane
-            } else {
-                displayPercentWindow = combinedSessionLane ?? combinedWeeklyLane ?? percentWindow
-            }
+        let displayPercentWindow: RateWindow? = if let combinedLanes {
+            Self.combinedDisplayPercentWindow(lanes: combinedLanes, fallback: percentWindow)
         } else {
-            displayPercentWindow = percentWindow
+            percentWindow
         }
         return MenuBarDisplayText.displayText(
             mode: mode,
@@ -1026,6 +1000,63 @@ extension StatusItemController {
         -> RateWindow?
     {
         self.menuBarMetricWindow(for: provider, snapshot: snapshot)
+    }
+
+    /// Resolves the session (5h) and weekly (7d) lanes for the combined "Session + Weekly" menu-bar
+    /// metric, or nil when that metric is not active for `provider`. Codex resolves its lanes through the
+    /// consumer projection; Claude has none, so it classifies by window cadence — a 7-day window the OAuth
+    /// mapper parked in `primary` (the five_hour fallback) must not be mislabeled as a 5-hour session lane.
+    private func combinedSessionWeeklyLanes(
+        for provider: UsageProvider,
+        snapshot: UsageSnapshot?,
+        projection: CodexConsumerProjection?) -> (session: RateWindow?, weekly: RateWindow?)?
+    {
+        guard provider == .codex || provider == .claude,
+              self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .primaryAndSecondary
+        else { return nil }
+        let session = projection?.rateWindow(for: .session)
+            ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.sessionWindowMinutes)
+        let weekly = projection?.rateWindow(for: .weekly)
+            ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.weeklyWindowMinutes)
+        return (session, weekly)
+    }
+
+    /// The window the weekly pace is computed on in pace/both modes. Codex paces on its projected weekly
+    /// lane; the combined Session + Weekly metric paces on the weekly lane too (matching Codex); Abacus
+    /// has no secondary window so it paces on the primary monthly credits; everything else paces on the
+    /// selected percent window.
+    private func menuBarPaceWindow(
+        for provider: UsageProvider,
+        snapshot: UsageSnapshot?,
+        projection: CodexConsumerProjection?,
+        combinedLanes: (session: RateWindow?, weekly: RateWindow?)?,
+        percentWindow: RateWindow?) -> RateWindow?
+    {
+        if let projection {
+            return projection.rateWindow(for: .weekly)
+        }
+        if provider == .abacus {
+            return snapshot?.primary
+        }
+        if let combinedLanes {
+            return combinedLanes.weekly
+        }
+        return percentWindow
+    }
+
+    /// The usage window shown for the combined metric in pace/both modes. It pairs the SESSION usage with
+    /// the weekly pace, so the usage component normally comes from the session lane — not the
+    /// most-constrained lane that drives the icon/bar. Two exceptions: fall back to the weekly lane when no
+    /// session lane exists (the five_hour OAuth fallback), and surface the weekly lane when it is exhausted
+    /// — it is then the binding cap with no pace to show, and a roomy session number would hide it.
+    private static func combinedDisplayPercentWindow(
+        lanes: (session: RateWindow?, weekly: RateWindow?),
+        fallback: RateWindow?) -> RateWindow?
+    {
+        if let weekly = lanes.weekly, weekly.remainingPercent <= 0 {
+            return weekly
+        }
+        return lanes.session ?? lanes.weekly ?? fallback
     }
 
     private static let sessionWindowMinutes = 5 * 60

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -1014,6 +1014,15 @@ extension StatusItemController {
         guard provider == .codex || provider == .claude,
               self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .primaryAndSecondary
         else { return nil }
+        // A Claude account that only exposes an enterprise/extra-usage spend limit has no real
+        // session/weekly lanes; defer to the resolver's spend-limit routing instead of rendering an
+        // empty or 0% placeholder lane under the combined metric.
+        if provider == .claude,
+           let snapshot,
+           MenuBarMetricWindowResolver.claudeSpendLimitWindow(snapshot: snapshot) != nil
+        {
+            return nil
+        }
         let session = projection?.rateWindow(for: .session)
             ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.sessionWindowMinutes)
         let weekly = projection?.rateWindow(for: .weekly)

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -1023,11 +1023,30 @@ extension StatusItemController {
         {
             return nil
         }
-        let session = projection?.rateWindow(for: .session)
-            ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.sessionWindowMinutes)
+        let session = Self.combinedSessionLane(snapshot: snapshot, projection: projection)
         let weekly = projection?.rateWindow(for: .weekly)
             ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.weeklyWindowMinutes)
         return (session, weekly)
+    }
+
+    /// The combined metric's session (5h) lane. Codex resolves it through the consumer projection; other
+    /// providers classify by window cadence. A 5-hour lane the provider only synthesized to stand in for an
+    /// absent session — Claude web's null `five_hour` placeholder, flagged at the boundary — is dropped so a
+    /// weekly-only account falls back to its weekly lane instead of rendering a phantom `5h 0%`/`5h 100%`
+    /// session. A genuine session (even one freshly reset to 0%) is not flagged, so it is kept.
+    private static func combinedSessionLane(
+        snapshot: UsageSnapshot?,
+        projection: CodexConsumerProjection?) -> RateWindow?
+    {
+        if let projected = projection?.rateWindow(for: .session) {
+            return projected
+        }
+        guard let session = Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.sessionWindowMinutes)
+        else { return nil }
+        if session.isSyntheticPlaceholder {
+            return nil
+        }
+        return session
     }
 
     /// The window the weekly pace is computed on in pace/both modes. Codex paces on its projected weekly
@@ -1056,7 +1075,8 @@ extension StatusItemController {
     /// The usage window shown for the combined metric in pace/both modes. It pairs the SESSION usage with
     /// the weekly pace, so the usage component normally comes from the session lane — not the
     /// most-constrained lane that drives the icon/bar. Two exceptions: fall back to the weekly lane when no
-    /// session lane exists (the five_hour OAuth fallback), and surface the weekly lane when it is exhausted
+    /// session lane exists (the five_hour OAuth fallback or Claude web's filtered null-session
+    /// placeholder), and surface the weekly lane when it is exhausted
     /// — it is then the binding cap with no pace to show, and a roomy session number would hide it.
     private static func combinedDisplayPercentWindow(
         lanes: (session: RateWindow?, weekly: RateWindow?),

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -737,6 +737,23 @@ extension StatusItemController {
             surface: .menuBar,
             snapshotOverride: snapshot,
             now: now)
+
+        // The combined "Session + Weekly" metric (Codex and Claude) shows both lanes in percent mode
+        // ("5h 12% · W 45%") and, in pace/both modes, pairs the session usage with the weekly pace.
+        // Codex resolves its lanes through the consumer projection; Claude has none, so it classifies by
+        // window cadence — a 7-day window the OAuth mapper parked in `primary` (the five_hour fallback)
+        // must not be mislabeled as a 5-hour session lane.
+        let isCombinedSessionWeekly = (provider == .codex || provider == .claude)
+            && self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .primaryAndSecondary
+        let combinedSessionLane = isCombinedSessionWeekly
+            ? (codexProjection?.rateWindow(for: .session)
+                ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.sessionWindowMinutes))
+            : nil
+        let combinedWeeklyLane = isCombinedSessionWeekly
+            ? (codexProjection?.rateWindow(for: .weekly)
+                ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.weeklyWindowMinutes))
+            : nil
+
         let pace: UsagePace?
         switch mode {
         case .percent:
@@ -747,12 +764,9 @@ extension StatusItemController {
             } else if provider == .abacus {
                 // Abacus has no secondary window; pace is computed on primary monthly credits
                 snapshot?.primary
-            } else if provider == .claude,
-                      self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .primaryAndSecondary
-            {
-                // Combined Session + Weekly metric paces on the weekly lane, matching Codex. Select by
-                // cadence so a five_hour-fallback snapshot (7-day window in `primary`) still paces weekly.
-                Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.weeklyWindowMinutes)
+            } else if isCombinedSessionWeekly {
+                // Combined Session + Weekly metric paces on the weekly lane, matching Codex.
+                combinedWeeklyLane
             } else {
                 percentWindow
             }
@@ -778,28 +792,34 @@ extension StatusItemController {
                     .creditsString(from: creditsRemaining)
                     .replacingOccurrences(of: " left", with: "")
         }
-        if provider == .codex || provider == .claude,
-           mode == .percent,
-           self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .primaryAndSecondary
-        {
-            // Codex resolves its lanes through the consumer projection. Providers without one (Claude)
-            // classify by window cadence so a 7-day window that the OAuth mapper parked in `primary`
-            // (the five_hour fallback) is not mislabeled as a 5-hour session lane.
-            let sessionLane = codexProjection?.rateWindow(for: .session)
-                ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.sessionWindowMinutes)
-            let weeklyLane = codexProjection?.rateWindow(for: .weekly)
-                ?? Self.rateWindow(in: snapshot, matchingCadenceMinutes: Self.weeklyWindowMinutes)
+        if isCombinedSessionWeekly, mode == .percent {
             if let combinedText = MenuBarDisplayText.combinedSessionWeeklyPercentText(
-                sessionWindow: sessionLane,
-                weeklyWindow: weeklyLane,
+                sessionWindow: combinedSessionLane,
+                weeklyWindow: combinedWeeklyLane,
                 showUsed: self.settings.usageBarsShowUsed)
             {
                 return combinedText
             }
         }
+
+        // In pace/both modes the combined metric pairs the SESSION usage with the WEEKLY pace, so the
+        // usage component normally comes from the session lane — not the most-constrained lane that drives
+        // the icon/bar. Two exceptions: fall back to the weekly lane when the session lane is absent (the
+        // five_hour OAuth fallback), and surface the weekly lane when it is exhausted — it is then the
+        // binding cap with no pace to show, and a roomy session number would hide the spent weekly limit.
+        let displayPercentWindow: RateWindow?
+        if isCombinedSessionWeekly {
+            if let combinedWeeklyLane, combinedWeeklyLane.remainingPercent <= 0 {
+                displayPercentWindow = combinedWeeklyLane
+            } else {
+                displayPercentWindow = combinedSessionLane ?? combinedWeeklyLane ?? percentWindow
+            }
+        } else {
+            displayPercentWindow = percentWindow
+        }
         return MenuBarDisplayText.displayText(
             mode: mode,
-            percentWindow: percentWindow,
+            percentWindow: displayPercentWindow,
             pace: pace,
             showUsed: self.settings.usageBarsShowUsed)
     }

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -47,7 +47,7 @@ extension UsageStore {
     {
         let effectivePreference = self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot)
         guard metricPercent >= 100 else { return false }
-        if provider == .codex, effectivePreference == .primaryAndSecondary {
+        if provider == .codex || provider == .claude, effectivePreference == .primaryAndSecondary {
             let percents = [snapshot.primary?.usedPercent, snapshot.secondary?.usedPercent].compactMap(\.self)
             guard !percents.isEmpty else { return true }
             return percents.allSatisfy { $0 >= 100 }

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -48,6 +48,13 @@ extension UsageStore {
         let effectivePreference = self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot)
         guard metricPercent >= 100 else { return false }
         if provider == .codex || provider == .claude, effectivePreference == .primaryAndSecondary {
+            // A Claude spend-limit-only snapshot has no real session/weekly lanes; the metric resolves to
+            // the spend-limit window, so reaching here (metricPercent >= 100) means the spend limit itself
+            // is exhausted. Mirror that resolver fallback and exclude, instead of inspecting the raw 0%
+            // placeholder primary that would otherwise keep it eligible.
+            if provider == .claude, MenuBarMetricWindowResolver.claudeSpendLimitWindow(snapshot: snapshot) != nil {
+                return true
+            }
             // Ignore synthesized placeholder lanes (e.g. Claude web's null `five_hour` 0% session) so a
             // fully exhausted weekly-only account is excluded rather than kept eligible by a phantom 0%.
             let percents = [snapshot.primary, snapshot.secondary]

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -48,7 +48,12 @@ extension UsageStore {
         let effectivePreference = self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot)
         guard metricPercent >= 100 else { return false }
         if provider == .codex || provider == .claude, effectivePreference == .primaryAndSecondary {
-            let percents = [snapshot.primary?.usedPercent, snapshot.secondary?.usedPercent].compactMap(\.self)
+            // Ignore synthesized placeholder lanes (e.g. Claude web's null `five_hour` 0% session) so a
+            // fully exhausted weekly-only account is excluded rather than kept eligible by a phantom 0%.
+            let percents = [snapshot.primary, snapshot.secondary]
+                .compactMap(\.self)
+                .filter { !$0.isSyntheticPlaceholder }
+                .map(\.usedPercent)
             guard !percents.isEmpty else { return true }
             return percents.allSatisfy { $0 >= 100 }
         }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -1153,6 +1153,22 @@ extension ClaudeUsageFetcher {
 
     // MARK: - Web API path (uses browser cookies)
 
+    /// The 5-hour session (`primary`) window for a Claude web usage payload.
+    ///
+    /// When `five_hour` is null the web fetcher reports a synthesized 0% session (an account with no live
+    /// session window). Flag that placeholder so lane classifiers — e.g. the combined Session + Weekly
+    /// menu-bar metric — surface the weekly lane instead of a phantom 5h session. The flag keys off the
+    /// reported presence of the session object, so a real session that is merely idle (0% used, possibly
+    /// with no reset) stays unflagged and keeps rendering.
+    static func webPrimaryWindow(from webData: ClaudeWebAPIFetcher.WebUsageData) -> RateWindow {
+        RateWindow(
+            usedPercent: webData.sessionPercentUsed,
+            windowMinutes: 5 * 60,
+            resetsAt: webData.sessionResetsAt,
+            resetDescription: webData.sessionResetsAt.map { Self.formatResetDate($0) },
+            isSyntheticPlaceholder: !webData.hasLiveSessionWindow)
+    }
+
     private func loadViaWebAPI() async throws -> ClaudeUsageSnapshot {
         let webData: ClaudeWebAPIFetcher.WebUsageData =
             if let header = self.manualCookieHeader {
@@ -1171,11 +1187,7 @@ extension ClaudeUsageFetcher {
                 }
             }
         // Convert web API data to ClaudeUsageSnapshot format
-        let primary = RateWindow(
-            usedPercent: webData.sessionPercentUsed,
-            windowMinutes: 5 * 60,
-            resetsAt: webData.sessionResetsAt,
-            resetDescription: webData.sessionResetsAt.map { Self.formatResetDate($0) })
+        let primary = Self.webPrimaryWindow(from: webData)
 
         let secondary: RateWindow? = webData.weeklyPercentUsed.map { pct in
             RateWindow(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -183,6 +183,12 @@ public enum ClaudeWebAPIFetcher {
         public let accountOrganization: String?
         public let accountEmail: String?
         public let loginMethod: String?
+        /// Whether the API reported a `five_hour` session object. When `false` (the API sent
+        /// `five_hour: null`, as enterprise/credit accounts with no live session do), `sessionPercentUsed`
+        /// is the synthesized `0` placeholder rather than a real reading. Distinguishing this from a real
+        /// session that happens to be at `0%` (with or without a reset) lets lane classifiers drop the
+        /// placeholder without hiding a genuine empty session.
+        public let hasLiveSessionWindow: Bool
 
         public init(
             sessionPercentUsed: Double,
@@ -194,7 +200,8 @@ public enum ClaudeWebAPIFetcher {
             extraUsageCost: ProviderCostSnapshot?,
             accountOrganization: String?,
             accountEmail: String?,
-            loginMethod: String?)
+            loginMethod: String?,
+            hasLiveSessionWindow: Bool = true)
         {
             self.sessionPercentUsed = sessionPercentUsed
             self.sessionResetsAt = sessionResetsAt
@@ -206,6 +213,7 @@ public enum ClaudeWebAPIFetcher {
             self.accountOrganization = accountOrganization
             self.accountEmail = accountEmail
             self.loginMethod = loginMethod
+            self.hasLiveSessionWindow = hasLiveSessionWindow
         }
     }
 
@@ -323,7 +331,8 @@ public enum ClaudeWebAPIFetcher {
                 extraUsageCost: extra,
                 accountOrganization: usage.accountOrganization,
                 accountEmail: usage.accountEmail,
-                loginMethod: usage.loginMethod)
+                loginMethod: usage.loginMethod,
+                hasLiveSessionWindow: usage.hasLiveSessionWindow)
         }
         if let account = await fetchAccountInfo(
             sessionKey: renewalTracker.sessionKey,
@@ -341,7 +350,8 @@ public enum ClaudeWebAPIFetcher {
                 extraUsageCost: usage.extraUsageCost,
                 accountOrganization: usage.accountOrganization,
                 accountEmail: account.email,
-                loginMethod: account.loginMethod)
+                loginMethod: account.loginMethod,
+                hasLiveSessionWindow: usage.hasLiveSessionWindow)
         }
         if usage.accountOrganization == nil, let name = organization.name {
             usage = WebUsageData(
@@ -354,7 +364,8 @@ public enum ClaudeWebAPIFetcher {
                 extraUsageCost: usage.extraUsageCost,
                 accountOrganization: name,
                 accountEmail: usage.accountEmail,
-                loginMethod: usage.loginMethod)
+                loginMethod: usage.loginMethod,
+                hasLiveSessionWindow: usage.hasLiveSessionWindow)
         }
         if let cacheSourceLabel {
             self.persistSessionKeyIfNeeded(
@@ -601,7 +612,8 @@ public enum ClaudeWebAPIFetcher {
         // Parse five_hour (session) usage
         var sessionPercent: Double?
         var sessionResets: Date?
-        if let fiveHour = json["five_hour"] as? [String: Any] {
+        let fiveHour = json["five_hour"] as? [String: Any]
+        if let fiveHour {
             if let utilization = fiveHour["utilization"] as? Int {
                 sessionPercent = Double(utilization)
             }
@@ -610,7 +622,10 @@ public enum ClaudeWebAPIFetcher {
             }
         }
         // Enterprise/credit-based accounts return null for five_hour; treat as 0% rather than an error.
+        // Track the object's presence so a real 0% session (with or without a reset) is not mistaken for
+        // the synthesized null-session placeholder downstream.
         let resolvedSessionPercent = sessionPercent ?? 0.0
+        let hasLiveSessionWindow = fiveHour != nil
 
         // Parse seven_day (weekly) usage
         var weeklyPercent: Double?
@@ -647,7 +662,8 @@ public enum ClaudeWebAPIFetcher {
             extraUsageCost: extraUsageCost,
             accountOrganization: nil,
             accountEmail: nil,
-            loginMethod: nil)
+            loginMethod: nil,
+            hasLiveSessionWindow: hasLiveSessionWindow)
     }
 
     private static func percentValue(from value: Any?) -> Double? {

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -8,19 +8,63 @@ public struct RateWindow: Codable, Equatable, Sendable {
     public let resetDescription: String?
     /// Optional percent restored on the next regeneration tick for providers with rolling recovery.
     public let nextRegenPercent: Double?
+    /// Whether this window was synthesized to stand in for a quota lane the provider did not actually
+    /// report, rather than being a real zero-usage window.
+    ///
+    /// Claude web returns a `0%` five-hour window when `five_hour` is `null` (an account with no live
+    /// session but a real weekly lane). Lane classifiers — e.g. the combined "Session + Weekly" menu-bar
+    /// metric — must treat such a window as "no session lane present" instead of surfacing a phantom
+    /// `5h 0%`/`5h 100%` session. A genuine session, even one freshly reset to 0%, is NOT a placeholder.
+    /// Missing values decode as `false` for older cached payloads.
+    public let isSyntheticPlaceholder: Bool
 
     public init(
         usedPercent: Double,
         windowMinutes: Int?,
         resetsAt: Date?,
         resetDescription: String?,
-        nextRegenPercent: Double? = nil)
+        nextRegenPercent: Double? = nil,
+        isSyntheticPlaceholder: Bool = false)
     {
         self.usedPercent = usedPercent
         self.windowMinutes = windowMinutes
         self.resetsAt = resetsAt
         self.resetDescription = resetDescription
         self.nextRegenPercent = nextRegenPercent
+        self.isSyntheticPlaceholder = isSyntheticPlaceholder
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case usedPercent
+        case windowMinutes
+        case resetsAt
+        case resetDescription
+        case nextRegenPercent
+        case isSyntheticPlaceholder
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.usedPercent = try container.decode(Double.self, forKey: .usedPercent)
+        self.windowMinutes = try container.decodeIfPresent(Int.self, forKey: .windowMinutes)
+        self.resetsAt = try container.decodeIfPresent(Date.self, forKey: .resetsAt)
+        self.resetDescription = try container.decodeIfPresent(String.self, forKey: .resetDescription)
+        self.nextRegenPercent = try container.decodeIfPresent(Double.self, forKey: .nextRegenPercent)
+        self.isSyntheticPlaceholder =
+            try container.decodeIfPresent(Bool.self, forKey: .isSyntheticPlaceholder) ?? false
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.usedPercent, forKey: .usedPercent)
+        try container.encodeIfPresent(self.windowMinutes, forKey: .windowMinutes)
+        try container.encodeIfPresent(self.resetsAt, forKey: .resetsAt)
+        try container.encodeIfPresent(self.resetDescription, forKey: .resetDescription)
+        try container.encodeIfPresent(self.nextRegenPercent, forKey: .nextRegenPercent)
+        // Only persist the flag when set, keeping payloads identical for the common (real-window) case.
+        if self.isSyntheticPlaceholder {
+            try container.encode(true, forKey: .isSyntheticPlaceholder)
+        }
     }
 
     public var remainingPercent: Double {
@@ -40,7 +84,10 @@ public struct RateWindow: Codable, Equatable, Sendable {
             windowMinutes: windowMinutes,
             resetsAt: cachedReset,
             resetDescription: self.resetDescription ?? cached?.resetDescription,
-            nextRegenPercent: self.nextRegenPercent)
+            nextRegenPercent: self.nextRegenPercent,
+            // Preserve the placeholder marker: backfilling a stale reset onto Claude web's null-session
+            // placeholder must not let it masquerade as a real session lane.
+            isSyntheticPlaceholder: self.isSyntheticPlaceholder)
     }
 }
 

--- a/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
+++ b/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
@@ -78,7 +78,75 @@ struct CodexCombinedMetricHighestUsageTests {
         #expect(highest?.usedPercent == 80)
     }
 
-    private func makeStore(suiteName: String) -> UsageStore {
+    @Test
+    func `combined claude metric stays eligible when only one lane is exhausted`() {
+        let store = self.makeStore(
+            suiteName: "CodexCombinedMetricHighestUsageTests-claude-one-exhausted",
+            claudeCombined: true)
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 50,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            provider: .codex)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 100, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 30,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            provider: .claude)
+
+        // Claude's session lane is exhausted but the weekly lane still has room, so the combined
+        // metric must keep Claude eligible (mirroring Codex) instead of dropping it from ranking.
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .claude)
+        #expect(highest?.usedPercent == 100)
+    }
+
+    @Test
+    func `combined claude metric is excluded when both lanes are exhausted`() {
+        let store = self.makeStore(
+            suiteName: "CodexCombinedMetricHighestUsageTests-claude-both-exhausted",
+            claudeCombined: true)
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 80, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 80,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            provider: .codex)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 100, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 100,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            provider: .claude)
+
+        // Both Claude lanes are exhausted, so the combined metric must drop Claude from ranking and
+        // surface Codex instead.
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 80)
+    }
+
+    private func makeStore(suiteName: String, claudeCombined: Bool = false) -> UsageStore {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: suiteName),
             zaiTokenStore: NoopZaiTokenStore(),
@@ -86,6 +154,9 @@ struct CodexCombinedMetricHighestUsageTests {
         settings.refreshFrequency = .manual
         settings.statusChecksEnabled = false
         settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
+        if claudeCombined {
+            settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+        }
 
         let registry = ProviderRegistry.shared
         if let codexMeta = registry.metadata[.codex] {

--- a/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
+++ b/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
@@ -203,10 +203,15 @@ struct CodexCombinedMetricHighestUsageTests {
                 updatedAt: Date()),
             provider: .codex)
         // Claude spend-limit-only account: exhausted providerCost, no secondary/tertiary, and an
-        // unflagged 0% 5h placeholder primary. The metric resolves to the (exhausted) spend-limit window.
+        // explicitly marked 0% 5h placeholder primary. The metric resolves to the exhausted spend-limit window.
         store._setSnapshotForTesting(
             UsageSnapshot(
-                primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                primary: RateWindow(
+                    usedPercent: 0,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil,
+                    isSyntheticPlaceholder: true),
                 secondary: nil,
                 providerCost: ProviderCostSnapshot(
                     used: 100,
@@ -218,7 +223,7 @@ struct CodexCombinedMetricHighestUsageTests {
             provider: .claude)
 
         // The spend limit is exhausted and there are no real lanes, so Claude must be excluded from
-        // ranking (the unflagged 0% placeholder must not keep it eligible); Codex surfaces instead.
+        // ranking (the marked 0% placeholder must not keep it eligible); Codex surfaces instead.
         let highest = store.providerWithHighestUsage()
         #expect(highest?.provider == .codex)
         #expect(highest?.usedPercent == 80)

--- a/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
+++ b/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
@@ -186,6 +186,44 @@ struct CodexCombinedMetricHighestUsageTests {
         #expect(highest?.usedPercent == 80)
     }
 
+    @Test
+    func `combined claude metric excludes an exhausted spend-limit-only account`() {
+        let store = self.makeStore(
+            suiteName: "CodexCombinedMetricHighestUsageTests-claude-spend-limit-exhausted",
+            claudeCombined: true)
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 80, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 80,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            provider: .codex)
+        // Claude spend-limit-only account: exhausted providerCost, no secondary/tertiary, and an
+        // unflagged 0% 5h placeholder primary. The metric resolves to the (exhausted) spend-limit window.
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                providerCost: ProviderCostSnapshot(
+                    used: 100,
+                    limit: 100,
+                    currencyCode: "USD",
+                    period: "Spend limit",
+                    updatedAt: Date()),
+                updatedAt: Date()),
+            provider: .claude)
+
+        // The spend limit is exhausted and there are no real lanes, so Claude must be excluded from
+        // ranking (the unflagged 0% placeholder must not keep it eligible); Codex surfaces instead.
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 80)
+    }
+
     private func makeStore(suiteName: String, claudeCombined: Bool = false) -> UsageStore {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: suiteName),

--- a/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
+++ b/Tests/CodexBarTests/CodexCombinedMetricHighestUsageTests.swift
@@ -146,6 +146,46 @@ struct CodexCombinedMetricHighestUsageTests {
         #expect(highest?.usedPercent == 80)
     }
 
+    @Test
+    func `combined claude metric excludes an exhausted weekly-only account with a synthetic placeholder`() {
+        let store = self.makeStore(
+            suiteName: "CodexCombinedMetricHighestUsageTests-claude-placeholder-exhausted",
+            claudeCombined: true)
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 80, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 80,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            provider: .codex)
+        // Claude web weekly-only account: a synthetic 0% session placeholder plus an exhausted weekly lane.
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 0,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil,
+                    isSyntheticPlaceholder: true),
+                secondary: RateWindow(
+                    usedPercent: 100,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            provider: .claude)
+
+        // The placeholder is not a real lane, so the only real Claude lane (weekly) is fully exhausted —
+        // Claude must be excluded from ranking, not kept eligible by the phantom 0% session.
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 80)
+    }
+
     private func makeStore(suiteName: String, claudeCombined: Bool = false) -> UsageStore {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: suiteName),

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -401,9 +401,14 @@ struct MenuBarMetricWindowResolverTests {
     }
 
     @Test
-    func `automatic metric uses claude web spend limit placeholder`() {
+    func `automatic metric uses marked claude web spend limit placeholder`() {
         let snapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            primary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil,
+                isSyntheticPlaceholder: true),
             secondary: nil,
             providerCost: ProviderCostSnapshot(
                 used: 67.03,
@@ -420,6 +425,52 @@ struct MenuBarMetricWindowResolverTests {
             supportsAverage: false)
 
         #expect(abs((window?.usedPercent ?? 0) - 6.703) < 0.0001)
+    }
+
+    @Test
+    func `combined metric keeps real zero claude session when spend limit exists`() {
+        let primary = RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+        let snapshot = UsageSnapshot(
+            primary: primary,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 67.03,
+                limit: 1000,
+                currencyCode: "USD",
+                period: "Monthly",
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .primaryAndSecondary,
+            provider: .claude,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window == primary)
+    }
+
+    @Test
+    func `automatic metric keeps real zero claude session when spend limit exists`() {
+        let primary = RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+        let snapshot = UsageSnapshot(
+            primary: primary,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 67.03,
+                limit: 1000,
+                currencyCode: "USD",
+                period: "Monthly",
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .claude,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window == primary)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -374,6 +374,17 @@ struct ProvidersPaneCoverageTests {
     }
 
     @Test
+    func `claude menu bar metric picker includes session plus weekly lane`() {
+        let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-claude-session-weekly-picker")
+        let store = Self.makeUsageStore(settings: settings)
+        let pane = ProvidersPane(settings: settings, store: store)
+
+        let picker = pane._test_menuBarMetricPicker(for: .claude)
+        let ids = picker?.options.map(\.id) ?? []
+        #expect(ids.contains(MenuBarMetricPreference.primaryAndSecondary.rawValue))
+    }
+
+    @Test
     func `zai menu bar metric picker omits tertiary lane when snapshot has no 5-hour metric`() {
         let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-zai-no-tertiary-picker")
         let store = Self.makeUsageStore(settings: settings)

--- a/Tests/CodexBarTests/RateWindowSyntheticPlaceholderTests.swift
+++ b/Tests/CodexBarTests/RateWindowSyntheticPlaceholderTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+/// Coverage for `RateWindow.isSyntheticPlaceholder` — the boundary marker that lets lane classifiers
+/// distinguish Claude web's `five_hour: null` placeholder from a real zero-usage session. Verifies the
+/// marker is set at the web boundary, survives Codable (with backward compatibility), and survives the
+/// reset backfill that previously defeated a shape-only heuristic.
+struct RateWindowSyntheticPlaceholderTests {
+    @Test
+    func `synthetic placeholder flag round-trips through Codable`() throws {
+        let window = RateWindow(
+            usedPercent: 0,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: nil,
+            isSyntheticPlaceholder: true)
+
+        let data = try JSONEncoder().encode(window)
+        let decoded = try JSONDecoder().decode(RateWindow.self, from: data)
+
+        #expect(decoded.isSyntheticPlaceholder == true)
+        #expect(decoded.usedPercent == 0)
+        #expect(decoded.windowMinutes == 300)
+    }
+
+    @Test
+    func `older payload without the flag decodes as not a placeholder`() throws {
+        // Cached payloads written before the flag existed have no `isSyntheticPlaceholder` key.
+        let json = #"{"usedPercent": 50, "windowMinutes": 300}"#
+        let decoded = try JSONDecoder().decode(RateWindow.self, from: Data(json.utf8))
+
+        #expect(decoded.isSyntheticPlaceholder == false)
+        #expect(decoded.usedPercent == 50)
+        #expect(decoded.windowMinutes == 300)
+    }
+
+    @Test
+    func `a real window omits the placeholder flag when encoded`() throws {
+        let window = RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+
+        let data = try JSONEncoder().encode(window)
+        let json = String(bytes: data, encoding: .utf8) ?? ""
+
+        // The flag is only persisted when true, so real windows keep their prior on-disk shape.
+        #expect(json.contains("isSyntheticPlaceholder") == false)
+    }
+
+    @Test
+    func `backfilling a reset preserves the synthetic placeholder flag`() {
+        // Regression: backfilling a still-future cached reset onto the placeholder (which has no reset)
+        // must NOT let it masquerade as a real session — the marker has to survive the backfill.
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let cached = RateWindow(
+            usedPercent: 12,
+            windowMinutes: 300,
+            resetsAt: now.addingTimeInterval(3600),
+            resetDescription: "Resets in 1h")
+        let placeholder = RateWindow(
+            usedPercent: 0,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: nil,
+            isSyntheticPlaceholder: true)
+
+        let result = placeholder.backfillingResetTime(from: cached, now: now)
+
+        #expect(result.resetsAt == now.addingTimeInterval(3600))
+        #expect(result.isSyntheticPlaceholder == true)
+    }
+
+    @Test
+    func `web mapping flags the null five-hour session as a synthetic placeholder`() throws {
+        let json = """
+        {
+          "five_hour": null,
+          "seven_day": { "utilization": 42, "resets_at": "2025-12-29T23:00:00.000Z" }
+        }
+        """
+        let webData = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(Data(json.utf8))
+        let primary = ClaudeUsageFetcher.webPrimaryWindow(from: webData)
+
+        #expect(primary.isSyntheticPlaceholder == true)
+        #expect(primary.usedPercent == 0)
+        #expect(primary.windowMinutes == 300)
+        #expect(primary.resetsAt == nil)
+    }
+
+    @Test
+    func `web mapping keeps a real five-hour session unflagged`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 11, "resets_at": "2025-12-29T20:00:00.000Z" },
+          "seven_day": { "utilization": 42, "resets_at": "2025-12-29T23:00:00.000Z" }
+        }
+        """
+        let webData = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(Data(json.utf8))
+        let primary = ClaudeUsageFetcher.webPrimaryWindow(from: webData)
+
+        #expect(primary.isSyntheticPlaceholder == false)
+        #expect(primary.usedPercent == 11)
+    }
+
+    @Test
+    func `web mapping keeps a real zero-usage session that omits a reset`() throws {
+        // A reported `five_hour` object at 0% with no `resets_at` is a real idle session, not the
+        // `five_hour: null` placeholder. The flag keys off object presence (not percent/reset), so this
+        // must stay unflagged — otherwise the combined metric would hide a genuine empty session.
+        let json = """
+        {
+          "five_hour": { "utilization": 0 },
+          "seven_day": { "utilization": 42, "resets_at": "2025-12-29T23:00:00.000Z" }
+        }
+        """
+        let webData = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(Data(json.utf8))
+        let primary = ClaudeUsageFetcher.webPrimaryWindow(from: webData)
+
+        #expect(primary.isSyntheticPlaceholder == false)
+        #expect(primary.usedPercent == 0)
+        #expect(primary.resetsAt == nil)
+    }
+}

--- a/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
@@ -79,8 +79,8 @@ struct SettingsStoreAdditionalTests {
         #expect(settings.menuBarMetricSupportsPrimaryAndSecondary(for: .codex))
 
         settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
-        #expect(settings.menuBarMetricPreference(for: .claude) == .automatic)
-        #expect(!settings.menuBarMetricSupportsPrimaryAndSecondary(for: .claude))
+        #expect(settings.menuBarMetricPreference(for: .claude) == .primaryAndSecondary)
+        #expect(settings.menuBarMetricSupportsPrimaryAndSecondary(for: .claude))
 
         settings.setMenuBarMetricPreference(.monthlyPlan, for: .codex)
         #expect(settings.menuBarMetricPreference(for: .codex) == .automatic)

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -940,19 +940,19 @@ struct StatusItemAnimationTests {
         let sessionWindow = RateWindow(usedPercent: 7, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
         let weeklyWindow = RateWindow(usedPercent: 18, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)
 
-        let remaining = MenuBarDisplayText.codexCombinedPercentText(
+        let remaining = MenuBarDisplayText.combinedSessionWeeklyPercentText(
             sessionWindow: sessionWindow,
             weeklyWindow: weeklyWindow,
             showUsed: false)
-        let used = MenuBarDisplayText.codexCombinedPercentText(
+        let used = MenuBarDisplayText.combinedSessionWeeklyPercentText(
             sessionWindow: sessionWindow,
             weeklyWindow: weeklyWindow,
             showUsed: true)
-        let weeklyOnly = MenuBarDisplayText.codexCombinedPercentText(
+        let weeklyOnly = MenuBarDisplayText.combinedSessionWeeklyPercentText(
             sessionWindow: nil,
             weeklyWindow: weeklyWindow,
             showUsed: false)
-        let nineHour = MenuBarDisplayText.codexCombinedPercentText(
+        let nineHour = MenuBarDisplayText.combinedSessionWeeklyPercentText(
             sessionWindow: RateWindow(
                 usedPercent: 7,
                 windowMinutes: 540,
@@ -960,7 +960,7 @@ struct StatusItemAnimationTests {
                 resetDescription: nil),
             weeklyWindow: weeklyWindow,
             showUsed: false)
-        let unknownSessionDuration = MenuBarDisplayText.codexCombinedPercentText(
+        let unknownSessionDuration = MenuBarDisplayText.combinedSessionWeeklyPercentText(
             sessionWindow: RateWindow(
                 usedPercent: 7,
                 windowMinutes: nil,
@@ -1061,6 +1061,161 @@ struct StatusItemAnimationTests {
         let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
 
         #expect(displayText == "20% · +60%")
+    }
+
+    @Test
+    func `claude combined menu bar metric shows session and weekly lanes`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-claude-combined"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = true
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+        #expect(settings.menuBarMetricPreference(for: .claude) == .primaryAndSecondary)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 12,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 45,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(24 * 60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        #expect(displayText == "5h 12% · W 45%")
+    }
+
+    @Test
+    func `claude combined menu bar metric shows weekly only when session lane is absent`() {
+        // Mirrors the Claude OAuth path where `five_hour` is missing: the mapper parks the 7-day
+        // window in BOTH `primary` and `secondary`. The combined metric must not relabel the
+        // weekly window as a session lane (e.g. "168h 42% · W 42%") — it should show weekly only.
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-claude-combined-no-session"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = true
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        let weekly = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: now.addingTimeInterval(24 * 60 * 60),
+            resetDescription: nil)
+        let snapshot = UsageSnapshot(primary: weekly, secondary: weekly, updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        #expect(displayText == "W 42%")
+    }
+
+    @Test
+    func `claude combined menu bar metric paces the weekly lane in both mode`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-claude-combined-pace"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarDisplayMode = .both
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        // Session lane is fully consumed, so its own pace is nil; the weekly lane still has room.
+        // The combined metric must pace the weekly lane, so a pace component must appear even though
+        // the displayed percent comes from the most-constrained (session) lane.
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 50,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        // "0% · ±N%": percent from the exhausted session lane, pace from the weekly lane.
+        #expect(displayText?.hasPrefix("0% · ") == true)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -1439,6 +1439,60 @@ struct StatusItemAnimationTests {
     }
 
     @Test
+    func `claude combined menu bar metric shows spend limit for a spend-limit-only account`() {
+        // A Claude account that only exposes an enterprise/extra-usage spend limit has no real
+        // session/weekly lanes (here a 0% 5h placeholder + a spend limit). With Session + Weekly selected,
+        // it must surface the spend-limit usage, not the meaningless "5h 0%" placeholder lane.
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-claude-combined-spend-limit"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = true
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 45,
+                limit: 100,
+                currencyCode: "USD",
+                period: "Spend limit",
+                updatedAt: now),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        // Spend-limit usage (45% of the cap), not the "5h 0%" placeholder lane.
+        #expect(displayText == "45%")
+        #expect(displayText?.contains("5h") == false)
+    }
+
+    @Test
     func `codex menu bar pace does not fall back to session when weekly projection is unavailable`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "StatusItemAnimationTests-codex-no-weekly-pace"),

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -1473,7 +1473,12 @@ struct StatusItemAnimationTests {
 
         let now = Date()
         let snapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            primary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil,
+                isSyntheticPlaceholder: true),
             secondary: nil,
             providerCost: ProviderCostSnapshot(
                 used: 45,

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -1196,7 +1196,7 @@ struct StatusItemAnimationTests {
         let now = Date()
         // Session lane is fully consumed, so its own pace is nil; the weekly lane still has room.
         // The combined metric must pace the weekly lane, so a pace component must appear even though
-        // the displayed percent comes from the most-constrained (session) lane.
+        // the displayed percent comes from the session lane (here fully consumed).
         let snapshot = UsageSnapshot(
             primary: RateWindow(
                 usedPercent: 100,
@@ -1214,8 +1214,228 @@ struct StatusItemAnimationTests {
 
         let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
 
-        // "0% · ±N%": percent from the exhausted session lane, pace from the weekly lane.
+        // "0% · ±N%": percent from the session lane (here exhausted), pace from the weekly lane.
         #expect(displayText?.hasPrefix("0% · ") == true)
+    }
+
+    @Test
+    func `claude combined menu bar metric pairs session usage with weekly pace`() {
+        // Regression: in pace/both modes the combined metric must pair the SESSION usage with the
+        // WEEKLY pace. Previously the usage component came from the most-constrained lane, so when the
+        // weekly lane was busier than the session lane it showed weekly usage + weekly pace.
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-claude-combined-session-pace"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarDisplayMode = .both
+        settings.usageBarsShowUsed = true
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        // Weekly lane (45%) is busier than the session lane (12%). The usage component must still be the
+        // session lane, while the pace is computed on the weekly lane (mostly elapsed → pace present).
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 12,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 45,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        // Usage is the session lane (12% used), not the most-constrained weekly lane (45%).
+        #expect(displayText?.hasPrefix("12% · ") == true)
+        #expect(displayText?.hasPrefix("45%") == false)
+    }
+
+    @Test
+    func `codex combined menu bar metric pairs session usage with weekly pace`() {
+        // The combined metric is shared with Codex, which resolves its lanes through the consumer
+        // projection. The session usage must headline the pace/both readout there too — not the busier
+        // weekly lane that drives the icon/bar.
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-codex-combined-session-pace"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.menuBarDisplayMode = .both
+        settings.usageBarsShowUsed = true
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .codex)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        // Weekly lane (91%) is busier than the session lane (12%), but neither is exhausted. The usage
+        // component must be the session lane while the pace is computed on the weekly lane.
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 12,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 91,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+
+        let displayText = controller.menuBarDisplayText(for: .codex, snapshot: snapshot)
+
+        #expect(displayText?.hasPrefix("12% · ") == true)
+        #expect(displayText?.hasPrefix("91%") == false)
+    }
+
+    @Test
+    func `claude combined menu bar metric surfaces an exhausted weekly lane in both mode`() {
+        // When the weekly lane is exhausted it is the binding cap and has no pace, so the combined metric
+        // must surface it instead of a roomy session number that would hide the spent weekly limit.
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-claude-combined-weekly-exhausted"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarDisplayMode = .both
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        // Session lane has room (88% remaining); weekly lane is fully consumed (0% remaining).
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 12,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        // Shows the exhausted weekly lane (0% remaining), not the roomy session lane (88%).
+        #expect(displayText == "0%")
+        #expect(displayText?.hasPrefix("88%") == false)
+    }
+
+    @Test
+    func `claude combined menu bar metric falls back to weekly lane in both mode when session absent`() {
+        // Five_hour OAuth fallback: the mapper parks the 7-day window in both primary and secondary, so no
+        // session lane exists. The pace/both usage component must land on the weekly lane, not collapse to
+        // nil.
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-claude-combined-no-session-both"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarDisplayMode = .both
+        settings.usageBarsShowUsed = true
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        let weekly = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: now.addingTimeInterval(60 * 60),
+            resetDescription: nil)
+        let snapshot = UsageSnapshot(primary: weekly, secondary: weekly, updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        // Usage lands on the weekly lane (42% used) rather than collapsing to nil.
+        #expect(displayText?.hasPrefix("42%") == true)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusItemCombinedMetricPlaceholderTests.swift
+++ b/Tests/CodexBarTests/StatusItemCombinedMetricPlaceholderTests.swift
@@ -1,0 +1,184 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+/// Regression coverage for the combined "Session + Weekly" menu-bar metric ignoring Claude web's
+/// synthetic `five_hour: null` session placeholder. Claude web parses an account with no live session
+/// (but a real `seven_day` lane) into a 0% 5-hour `primary` with no reset signal; the combined metric
+/// must drop that placeholder so the readout falls back to the weekly lane instead of rendering a
+/// non-existent `5h 0%`/`5h 100%` session. A genuine, freshly reset session (which still carries a
+/// `resetsAt`) must survive the filter.
+@MainActor
+@Suite(.serialized)
+struct StatusItemCombinedMetricPlaceholderTests {
+    private func makeStatusBarForTesting() -> NSStatusBar {
+        // Use the real system status bar in tests. Standalone NSStatusBar instances have caused
+        // AppKit teardown crashes under swiftpm-testing-helper.
+        .system
+    }
+
+    /// Builds a Claude-only controller with the combined Session + Weekly metric selected.
+    private func makeClaudeCombinedController(
+        suiteName: String,
+        displayMode: MenuBarDisplayMode,
+        showUsed: Bool) -> (controller: StatusItemController, store: UsageStore)
+    {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: suiteName),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarDisplayMode = displayMode
+        settings.usageBarsShowUsed = showUsed
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        return (controller, store)
+    }
+
+    @Test
+    func `combined metric ignores the claude web null-session placeholder in percent mode`() {
+        let (controller, store) = self.makeClaudeCombinedController(
+            suiteName: "StatusItemCombinedMetricPlaceholderTests-percent",
+            displayMode: .percent,
+            showUsed: true)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        // `primary` is the synthetic placeholder Claude web emits for `five_hour: null`: a 0% 5h window
+        // flagged `isSyntheticPlaceholder`. `secondary` is the real weekly lane.
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil,
+                isSyntheticPlaceholder: true),
+            secondary: RateWindow(
+                usedPercent: 42,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(24 * 60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        // Weekly lane only — the placeholder session is dropped (no "5h" component).
+        #expect(displayText == "W 42%")
+        #expect(displayText?.contains("5h") == false)
+    }
+
+    @Test
+    func `combined metric ignores the claude web null-session placeholder in both mode`() {
+        let (controller, store) = self.makeClaudeCombinedController(
+            suiteName: "StatusItemCombinedMetricPlaceholderTests-both",
+            displayMode: .both,
+            showUsed: false)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil,
+                isSyntheticPlaceholder: true),
+            secondary: RateWindow(
+                usedPercent: 42,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        // Percent comes from the weekly lane (58% remaining), not the placeholder session's 100%.
+        #expect(displayText?.hasPrefix("58%") == true)
+        #expect(displayText?.hasPrefix("100%") == false)
+        // The placeholder session lane never surfaces, so no "5h" label appears.
+        #expect(displayText?.contains("5h") == false)
+    }
+
+    @Test
+    func `combined metric keeps a real freshly reset claude session lane`() {
+        let (controller, store) = self.makeClaudeCombinedController(
+            suiteName: "StatusItemCombinedMetricPlaceholderTests-fresh",
+            displayMode: .percent,
+            showUsed: true)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        // A real, freshly reset session: 0% used but with a concrete reset time — unlike the placeholder.
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 42,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(24 * 60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        // The real session lane survives the filter, so both lanes render.
+        #expect(displayText == "5h 0% · W 42%")
+    }
+
+    @Test
+    func `combined metric keeps an unflagged zero-usage session sharing the placeholder shape`() {
+        // Precision guard: a real empty session can share the placeholder's exact RateWindow shape
+        // (0% used, 5h cadence, no reset) — e.g. the Claude CLI scrape, where session reset text can be
+        // absent. Because the drop keys on the explicit `isSyntheticPlaceholder` marker (set only at the
+        // Claude web boundary) rather than the shape, this unflagged session must be kept, not dropped.
+        let (controller, store) = self.makeClaudeCombinedController(
+            suiteName: "StatusItemCombinedMetricPlaceholderTests-unflagged-shape",
+            displayMode: .percent,
+            showUsed: true)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 42,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(24 * 60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        // Unflagged session is real, so it renders despite matching the placeholder shape.
+        #expect(displayText == "5h 0% · W 42%")
+    }
+}


### PR DESCRIPTION
> **Status: recommended to land once exact-head CI is green.** Rebased onto current main, all review findings resolved, complete local proof green.

## Product decision

**Recommendation: land.** This is an opt-in, read-only metric choice that mirrors Codex's established Session + Weekly interaction. It adds one persistent provider setting, but does not change the default; weekly-only, spend-limit-only, synthetic-placeholder, and real zero-usage session shapes now have explicit coverage.

Decline only if Claude's metric picker should remain intentionally smaller than Codex's.

## Summary

- Adds Claude **Session + Weekly** under Preferences → Providers → Claude → Menu bar metric.
- Shows the 5-hour session lane with weekly usage/pace; pace and both modes pair session usage with weekly pace.
- Uses explicit `isSyntheticPlaceholder` provenance for Claude web's null-session lane instead of shape-inference.
- Preserves genuine 0%-used sessions, including the exact 5-hour/no-reset shape.
- Keeps weekly-only and spend-limit-only snapshots readable; excludes exhausted combined lanes correctly from Show highest usage.

## Validation

- exact head: `73307c2c6be426938c375a3e64f329b075adf181`
- rebased onto current `origin/main`; contributor authorship preserved
- `MenuBarMetricWindowResolverTests`: 22 passed
- `StatusItemCombinedMetricPlaceholderTests`: 4 passed
- `CodexCombinedMetricHighestUsageTests`: 7 passed
- `StatusItemAnimationTests`: 38 passed
- complete `make test`: 44/44 shards passed
- `make check`: passed
- `CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh debug`: passed
- autoreview: clean; no accepted/actionable findings, patch correct at 0.86 confidence
- all review threads resolved with commit/file/line proof
- first-time CI workflow approved; exact-head run pending

No live Claude probe or Keychain-touching validation was run. Existing contributor screenshots cover the visible picker/readout; the final maintainer fix only changes resolver classification and is covered by deterministic tests.

## Existing contributor UI proof

![Providers pane — Session + Weekly metric selected](https://raw.githubusercontent.com/Shengqiang-Zhang/CodexBar/session-weekly-proof/settings-providers.png)

![Menu bar showing session usage with weekly pace](https://raw.githubusercontent.com/Shengqiang-Zhang/CodexBar/session-weekly-proof/menubar.png)
