### PR TITLE
[codex] Show reset credits with optional usage hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Usage display: make Usage widgets follow the used-versus-remaining preference already shared by menus and Overview rows (#1738). Thanks @OlegLustenko and @FrancoLan!
 - OpenCode Go: keep rolling usage available when the dashboard omits the optional weekly window. Thanks @mohkg1017!
 - Menu bar: make Show most-used provider rank only providers selected for Overview. Thanks @dstier-git!
+- Codex: show expiring reset-credit availability even when optional credits and extra usage are hidden, while preserving CLI `--no-credits`. Thanks @simon-ami!
 - Claude CLI: prevent logged-out background Auto fallbacks from opening browser OAuth during app refresh. Thanks @afarwind!
 
 ## 0.37.3 — 2026-06-28

--- a/Sources/CodexBar/MenuCardView+CodexResetCredits.swift
+++ b/Sources/CodexBar/MenuCardView+CodexResetCredits.swift
@@ -40,7 +40,6 @@ struct CodexResetCreditsContent: View {
 extension UsageMenuCardView.Model {
     static func codexResetCreditsText(input: Input) -> String? {
         guard input.provider == .codex,
-              input.showOptionalCreditsAndExtraUsage,
               let resetCredits = input.snapshot?.codexResetCredits,
               resetCredits.availableCount > 0
         else {
@@ -55,7 +54,6 @@ extension UsageMenuCardView.Model {
 
     static func codexResetCreditsDetailText(input: Input) -> String? {
         guard input.provider == .codex,
-              input.showOptionalCreditsAndExtraUsage,
               let resetCredits = input.snapshot?.codexResetCredits,
               let expiresAt = resetCredits.nextExpiringAvailableCredit?.expiresAt
         else {

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -195,8 +195,13 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
         return try await Self.replacingWithCLIMonthlyLimitIfAvailable(oauthResult, context: context)
     }
 
-    private static func shouldFetchResetCredits(_: ProviderFetchContext) -> Bool {
-        true
+    private static func shouldFetchResetCredits(_ context: ProviderFetchContext) -> Bool {
+        switch context.runtime {
+        case .app:
+            true
+        case .cli:
+            context.includeCredits
+        }
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -178,8 +178,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             accessToken: credentials.accessToken,
             accountId: credentials.accountId,
             env: context.env)
-        let shouldFetchResetCredits = context.includeOptionalUsage || context.includeCredits
-        let resetCredits: CodexRateLimitResetCreditsSnapshot? = if shouldFetchResetCredits {
+        let resetCredits: CodexRateLimitResetCreditsSnapshot? = if Self.shouldFetchResetCredits(context) {
             try? await CodexOAuthUsageFetcher.fetchRateLimitResetCredits(
                 accessToken: credentials.accessToken,
                 accountId: credentials.accountId,
@@ -194,6 +193,10 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             credentials: credentials,
             updatedAt: updatedAt)
         return try await Self.replacingWithCLIMonthlyLimitIfAvailable(oauthResult, context: context)
+    }
+
+    private static func shouldFetchResetCredits(_: ProviderFetchContext) -> Bool {
+        true
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
@@ -380,6 +383,10 @@ extension CodexOAuthFetchStrategy {
 
     static func _shouldTryCLIForMonthlyLimitForTesting(_ result: ProviderFetchResult) -> Bool {
         self.shouldTryCLIForMonthlyLimit(result)
+    }
+
+    static func _shouldFetchResetCreditsForTesting(_ context: ProviderFetchContext) -> Bool {
+        self.shouldFetchResetCredits(context)
     }
 }
 

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -4,13 +4,14 @@ import Testing
 
 struct CodexOAuthTests {
     private func makeContext(
+        runtime: ProviderRuntime = .app,
         sourceMode: ProviderSourceMode = .auto,
         includeCredits: Bool = true,
         includeOptionalUsage: Bool = true) -> ProviderFetchContext
     {
         let browserDetection = BrowserDetection(cacheTTL: 0)
         return ProviderFetchContext(
-            runtime: .app,
+            runtime: runtime,
             sourceMode: sourceMode,
             includeCredits: includeCredits,
             includeOptionalUsage: includeOptionalUsage,
@@ -777,10 +778,20 @@ struct CodexOAuthTests {
     }
 
     @Test
-    func `reset credits fetch is independent from optional usage display setting`() {
-        let context = self.makeContext(includeCredits: false, includeOptionalUsage: false)
+    func `reset credits fetch follows app runtime and CLI credits flag`() {
+        let appContext = self.makeContext(includeCredits: false, includeOptionalUsage: false)
+        let cliNoCreditsContext = self.makeContext(
+            runtime: .cli,
+            includeCredits: false,
+            includeOptionalUsage: true)
+        let cliCreditsContext = self.makeContext(
+            runtime: .cli,
+            includeCredits: true,
+            includeOptionalUsage: false)
 
-        #expect(CodexOAuthFetchStrategy._shouldFetchResetCreditsForTesting(context))
+        #expect(CodexOAuthFetchStrategy._shouldFetchResetCreditsForTesting(appContext))
+        #expect(CodexOAuthFetchStrategy._shouldFetchResetCreditsForTesting(cliNoCreditsContext) == false)
+        #expect(CodexOAuthFetchStrategy._shouldFetchResetCreditsForTesting(cliCreditsContext))
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -3,12 +3,17 @@ import Testing
 @testable import CodexBarCore
 
 struct CodexOAuthTests {
-    private func makeContext(sourceMode: ProviderSourceMode = .auto) -> ProviderFetchContext {
+    private func makeContext(
+        sourceMode: ProviderSourceMode = .auto,
+        includeCredits: Bool = true,
+        includeOptionalUsage: Bool = true) -> ProviderFetchContext
+    {
         let browserDetection = BrowserDetection(cacheTTL: 0)
         return ProviderFetchContext(
             runtime: .app,
             sourceMode: sourceMode,
-            includeCredits: true,
+            includeCredits: includeCredits,
+            includeOptionalUsage: includeOptionalUsage,
             webTimeout: 60,
             webDebugDumpHTML: false,
             verbose: false,
@@ -769,6 +774,13 @@ struct CodexOAuthTests {
         #expect(!strategy.shouldFallback(
             on: CodexTokenRefresher.RefreshError.networkError(URLError(.timedOut)),
             context: context))
+    }
+
+    @Test
+    func `reset credits fetch is independent from optional usage display setting`() {
+        let context = self.makeContext(includeCredits: false, includeOptionalUsage: false)
+
+        #expect(CodexOAuthFetchStrategy._shouldFetchResetCreditsForTesting(context))
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexResetCreditsMenuCardTests.swift
+++ b/Tests/CodexBarTests/CodexResetCreditsMenuCardTests.swift
@@ -92,14 +92,35 @@ struct CodexResetCreditsMenuCardTests {
     }
 
     @Test
-    func `reset credits hide with optional usage disabled`() throws {
+    func `reset credits render when optional usage is disabled`() throws {
         let metadata = try #require(ProviderDefaults.metadata[.codex])
         let now = Date(timeIntervalSince1970: 1_781_726_400)
         let usage = UsageSnapshot(
             primary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
             secondary: nil,
             codexResetCredits: CodexRateLimitResetCreditsSnapshot(
-                credits: [],
+                credits: [
+                    CodexRateLimitResetCredit(
+                        id: "reset-1",
+                        resetType: "codex_rate_limits",
+                        status: .available,
+                        grantedAt: now,
+                        expiresAt: now.addingTimeInterval(86400),
+                        redeemStartedAt: nil,
+                        redeemedAt: nil,
+                        title: "One free rate limit reset",
+                        description: nil),
+                    CodexRateLimitResetCredit(
+                        id: "reset-2",
+                        resetType: "codex_rate_limits",
+                        status: .available,
+                        grantedAt: now,
+                        expiresAt: now.addingTimeInterval(172_800),
+                        redeemStartedAt: nil,
+                        redeemedAt: nil,
+                        title: "One free rate limit reset",
+                        description: nil),
+                ],
                 availableCount: 2,
                 updatedAt: now),
             updatedAt: now)
@@ -110,8 +131,8 @@ struct CodexResetCreditsMenuCardTests {
             showOptionalUsage: false,
             now: now))
 
-        #expect(model.codexResetCreditsText == nil)
-        #expect(model.codexResetCreditsDetailText == nil)
+        #expect(model.codexResetCreditsText == "2 available")
+        #expect(model.codexResetCreditsDetailText == "Next expires in 1d")
     }
 
     private static func input(


### PR DESCRIPTION
## Decision

Land the always-visible app behavior without adding another preference. Expiring reset credits are quota operations rather than generic balance or spend detail, so the app keeps their count and next expiry visible when `Show credits + extra usage` is off.

The CLI contract remains separate: `codexbar usage --no-credits` continues to suppress reset-credit retrieval and output.

## Summary

- keep Codex reset-credit fetching independent from the optional credits/extra-usage display setting in app runtime
- render available Codex reset-credit count and expiry even when `Show credits + extra usage` is disabled
- preserve CLI `--no-credits` by requiring `includeCredits` for reset-credit fetches in CLI runtime
- cover the OAuth fetch-policy and stable menu-model boundaries

Fixes #1757.

## Root cause

The menu model hid reset-credit text behind `showOptionalCreditsAndExtraUsage`, and Codex OAuth refreshes skipped the reset-credit endpoint unless optional usage or credits were enabled.

Removing only the menu guard was insufficient because the app would no longer populate `UsageSnapshot.codexResetCredits` after the display toggle was disabled. The fix keeps reset-credit retrieval best-effort in app runtime while leaving generic credits and extra-usage display behavior unchanged.

## Exact-head validation

- exact candidate: `8541384905aefba09245df865d4723fb16878c34`
- rebased onto merged main: `ca7ecc82290b9598c74845af1bca16ad704b2c29`
- integrated-main run [`28548657276`](https://github.com/steipete/CodexBar/actions/runs/28548657276): terminal 9/9 success
- focused command: `swift test --filter 'CodexResetCreditsMenuCardTests|CodexOAuthTests|CodexRateLimitResetCreditsTests|CodexUsageFetcherFallbackTests'` — 53 tests in 4 suites passed
- `make check` — passed; SwiftFormat 0/1211 files, SwiftLint 0 violations
- `make test` — all 44 shards passed
- exact-branch autoreview against `origin/main` — clean, no accepted/actionable findings; patch-correct confidence 0.86
- rebase audit — source/test commits are range-diff identical to the independently reviewed candidate; only the changelog commit was replayed to retain the already-landed #1781 entry
- contributor attribution remains direct authorship; changelog thanks `@simon-ami`

## Synthetic visual proof

No real account, cookie, Keychain, email, or usage data is present. With optional credits/extra usage disabled, generic credits remain absent while the time-sensitive reset row remains visible as `2 available` / `Next expires in 1d`.

![Synthetic Codex menu card with optional credits and extra usage off while two reset credits remain visible](https://github.com/user-attachments/assets/52a72f88-778d-460a-b545-eaf2c1f6c714)

The screenshot was captured from the behavior-identical pre-rebase candidate. Range-diff confirms both source/test commits are unchanged on the current head; the rebase changed commit identities and changelog context only.

## Behavior boundary

| Surface | Optional credits hidden | Reset-credit fetch | Reset-credit row |
| --- | --- | --- | --- |
| App | Yes | Best-effort, enabled | Visible when available |
| CLI with `--no-credits` | Yes | Suppressed | Suppressed |
| CLI with credits enabled | No | Enabled | Included when available |

No new setting, dependency, credential storage, provider crossover, or account-identity behavior is introduced. Endpoint failures remain contained and do not fail normal Codex usage refreshes.

Exact-head hosted CI and manual merge remain the final landing gates; auto-merge is not enabled.
