### PR TITLE
Scope most-used provider to Overview selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Linux CLI: keep Claude OAuth usage subprocess-free, skip version probes, and let Auto bypass unsupported web sources. Thanks @derekszen!
 - Usage display: make Usage widgets follow the used-versus-remaining preference already shared by menus and Overview rows (#1738). Thanks @OlegLustenko and @FrancoLan!
 - OpenCode Go: keep rolling usage available when the dashboard omits the optional weekly window. Thanks @mohkg1017!
+- Menu bar: make Show most-used provider rank only providers selected for Overview. Thanks @dstier-git!
 - Claude CLI: prevent logged-out background Auto fallbacks from opening browser OAuth during app refresh. Thanks @afarwind!
 
 ## 0.37.3 — 2026-06-28

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -1110,6 +1110,11 @@ extension StatusItemController {
             if let highest = self.store.providerWithHighestUsage(candidateProviders: overviewProviders) {
                 return highest.provider
             }
+            // A nonempty Overview selection remains authoritative while its providers are loading,
+            // unrankable, or exhausted. Only an explicitly empty Overview may use the broad fallback.
+            if let fallback = overviewProviders.first(where: { self.store.isEnabled($0) }) {
+                return fallback
+            }
         }
         if self.shouldMergeIcons, self.settings.mergedMenuLastSelectedWasOverview {
             let enabledProviders = self.store.enabledProvidersForDisplay()

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -1101,12 +1101,15 @@ extension StatusItemController {
     }
 
     func primaryProviderForUnifiedIcon() -> UsageProvider {
-        // When "show highest usage" is enabled, auto-select the provider closest to rate limit.
-        if self.settings.menuBarShowsHighestUsage,
-           self.shouldMergeIcons,
-           let highest = self.store.providerWithHighestUsage()
-        {
-            return highest.provider
+        // When "show highest usage" is enabled, rank the existing Overview subset by proximity to its limit.
+        if self.settings.menuBarShowsHighestUsage, self.shouldMergeIcons {
+            let activeProviders = self.store.enabledProvidersForDisplay()
+            let overviewProviders = self.settings.resolvedMergedOverviewProviders(
+                activeProviders: activeProviders,
+                maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
+            if let highest = self.store.providerWithHighestUsage(candidateProviders: overviewProviders) {
+                return highest.provider
+            }
         }
         if self.shouldMergeIcons, self.settings.mergedMenuLastSelectedWasOverview {
             let enabledProviders = self.store.enabledProvidersForDisplay()

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -3,11 +3,16 @@ import Foundation
 
 @MainActor
 extension UsageStore {
-    /// Returns the enabled provider with the highest usage percentage (closest to rate limit).
+    /// Returns the enabled candidate provider with the highest usage percentage (closest to rate limit).
     /// Excludes providers that are fully rate-limited.
-    func providerWithHighestUsage() -> (provider: UsageProvider, usedPercent: Double)? {
+    func providerWithHighestUsage(candidateProviders: [UsageProvider]? = nil)
+        -> (provider: UsageProvider, usedPercent: Double)?
+    {
+        let candidateSet = candidateProviders.map(Set.init)
         var highest: (provider: UsageProvider, usedPercent: Double)?
-        for provider in self.enabledProviders() {
+        for provider in self.enabledProviders()
+            where candidateSet?.contains(provider) ?? true
+        {
             guard let snapshot = self.snapshots[provider] else { continue }
             guard let window = self.menuBarMetricWindowForHighestUsage(provider: provider, snapshot: snapshot) else {
                 continue

--- a/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
@@ -454,6 +454,109 @@ struct StatusItemAnimationSignatureTests {
         #expect(controller.primaryProviderForUnifiedIcon() == .codex)
     }
 
+    @Test(arguments: [nil, 100.0] as [Double?])
+    func `highest usage icon keeps nonempty overview authoritative when unrankable`(
+        overviewUsedPercent: Double?) throws
+    {
+        let suite = "StatusItemAnimationSignatureTests-highest-usage-overview-fallback"
+        let settings = testSettingsStore(suiteName: suite)
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.menuBarShowsHighestUsage = true
+        settings.selectedMenuProvider = .claude
+        settings.mergedMenuLastSelectedWasOverview = false
+
+        let registry = ProviderRegistry.shared
+        let codexMeta = try #require(registry.metadata[.codex])
+        let claudeMeta = try #require(registry.metadata[.claude])
+        settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        settings.setMergedOverviewProviderSelection(
+            provider: .claude,
+            isSelected: false,
+            activeProviders: store.enabledProvidersForDisplay())
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: testStatusBar())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        if let overviewUsedPercent {
+            store._setSnapshotForTesting(
+                UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: overviewUsedPercent,
+                        windowMinutes: nil,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    secondary: nil,
+                    updatedAt: Date()),
+                provider: .codex)
+        }
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .claude)
+
+        #expect(store.providerWithHighestUsage(candidateProviders: [.codex]) == nil)
+        #expect(controller.primaryProviderForUnifiedIcon() == .codex)
+    }
+
+    @Test
+    func `highest usage icon allows broad fallback for explicit empty overview`() throws {
+        let suite = "StatusItemAnimationSignatureTests-highest-usage-empty-overview"
+        let settings = testSettingsStore(suiteName: suite)
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.menuBarShowsHighestUsage = true
+        settings.selectedMenuProvider = .claude
+
+        let registry = ProviderRegistry.shared
+        let codexMeta = try #require(registry.metadata[.codex])
+        let claudeMeta = try #require(registry.metadata[.claude])
+        settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let activeProviders = store.enabledProvidersForDisplay()
+        settings.setMergedOverviewProviderSelection(
+            provider: .codex,
+            isSelected: false,
+            activeProviders: activeProviders)
+        settings.setMergedOverviewProviderSelection(
+            provider: .claude,
+            isSelected: false,
+            activeProviders: activeProviders)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: testStatusBar())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        #expect(settings.resolvedMergedOverviewProviders(activeProviders: store.enabledProvidersForDisplay()) == [])
+        #expect(controller.primaryProviderForUnifiedIcon() == .claude)
+    }
+
     @Test
     func `merged icon follows overview provider order when first overview provider is loading`() {
         let suite = "StatusItemAnimationSignatureTests-merged-overview-provider-order"

--- a/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
@@ -405,6 +405,56 @@ struct StatusItemAnimationSignatureTests {
     }
 
     @Test
+    func `highest usage icon ranks only overview providers`() throws {
+        let suite = "StatusItemAnimationSignatureTests-highest-usage-overview-subset"
+        let settings = testSettingsStore(suiteName: suite)
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.menuBarShowsHighestUsage = true
+
+        let registry = ProviderRegistry.shared
+        let codexMeta = try #require(registry.metadata[.codex])
+        let claudeMeta = try #require(registry.metadata[.claude])
+        settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        settings.setMergedOverviewProviderSelection(
+            provider: .claude,
+            isSelected: false,
+            activeProviders: store.enabledProvidersForDisplay())
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: testStatusBar())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 25, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .codex)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .claude)
+
+        #expect(store.providerWithHighestUsage()?.provider == .claude)
+        #expect(controller.primaryProviderForUnifiedIcon() == .codex)
+    }
+
+    @Test
     func `merged icon follows overview provider order when first overview provider is loading`() {
         let suite = "StatusItemAnimationSignatureTests-merged-overview-provider-order"
         let settings = testSettingsStore(suiteName: suite)

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -40,6 +40,11 @@ struct UsageStoreHighestUsageTests {
         let highest = store.providerWithHighestUsage()
         #expect(highest?.provider == .claude)
         #expect(highest?.usedPercent == 60)
+
+        let overviewHighest = store.providerWithHighestUsage(candidateProviders: [.codex])
+        #expect(overviewHighest?.provider == .codex)
+        #expect(overviewHighest?.usedPercent == 25)
+        #expect(store.providerWithHighestUsage(candidateProviders: []) == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Use the existing Overview provider selection as the candidate set for **Show most-used provider**.
- Keep closest-to-rate-limit ranking inside that subset.
- Avoid a second provider filter, new persisted settings, and cross-provider token/dollar comparisons with incompatible windows.

Closes #1743.

## Behavior boundary

When Overview contains Codex and Claude, the unified icon ranks only Codex and Claude even when another enabled provider has a higher percentage.

A nonempty Overview selection remains authoritative when all selected providers are loading, unrankable, or exhausted: the icon falls back to the first enabled provider in that selected subset. Only an explicitly empty Overview selection uses the existing broad selected/enabled-provider fallback.

Issue #1777 remains separate. Token/spend ranking stays out of scope until comparable windows and provider eligibility are defined.

## Exact candidate

- Head: `e2f8be1a99c842b708a34f08e7a05b0232e3b4eb`
- Contributor credit: preserved through `Co-authored-by: dylanstieri <dystier@gmail.com>`
- Changelog: thanks `@dstier-git`

## Validation

- `swift test --filter 'StatusItemAnimationSignatureTests|UsageStoreHighestUsageTests'` — 33 tests passed
- `make check` — passed; SwiftFormat clean and SwiftLint reported 0 violations
- scoped autoreview on the fixed diff — clean, no accepted/actionable findings; patch correct (0.85)
- independent exact-head re-audit — CLEAN
- `make test` — all 44 shards passed on the exact head

Regression coverage includes nonempty Overview selections whose selected provider is loading or exhausted, plus the explicitly empty Overview broad-fallback boundary.

## Scope

The original broad settings/ranking implementation was rewritten to reuse the existing Overview selection. No new settings, storage migration, provider fetch behavior, or UI controls are introduced.
