### PR TITLE
feat(antigravity): reuse a running agy language server for CLI usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Localization: reject blank translated values and restore the affected Vietnamese provider prompts. Thanks @kiranmagic7!
 - Usage totals: keep Today tied to the current local calendar day across cost, Admin API, and Poe surfaces instead of showing the latest historical bucket. Thanks @Zihao-Qi!
 - Antigravity: align compact icons and automatic highest-usage selection with grouped Gemini and Claude/GPT 5-hour and weekly lanes while ignoring non-renderable cadences. Thanks @Yuxin-Qiao!
+- Antigravity CLI: reuse an authenticated user-launched `agy` server for faster, more reliable one-shot usage checks. Thanks @junmo-kim!
 
 ## 0.37.2 — 2026-06-22
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -1105,6 +1105,33 @@ final class AntigravitySpawnedPTYProcessHandle: AntigravityCLIProcessHandle, @un
 // MARK: - Production Stale Session Identity + Storage
 
 struct AntigravityProcessIdentityProvider: AntigravityCLIProcessIdentityProviding {
+    static var currentUserID: UInt32 {
+        UInt32(getuid())
+    }
+
+    func ownerUserID(for pid: pid_t) -> UInt32? {
+        #if canImport(Darwin)
+        var info = proc_bsdinfo()
+        let size = proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            Int32(MemoryLayout<proc_bsdinfo>.stride))
+        guard size == Int32(MemoryLayout<proc_bsdinfo>.stride) else { return nil }
+        return info.pbi_uid
+        #else
+        guard let status = try? String(contentsOfFile: "/proc/\(pid)/status", encoding: .utf8),
+              let uidLine = status.split(separator: "\n").first(where: { $0.hasPrefix("Uid:") }),
+              let owner = uidLine.split(whereSeparator: \.isWhitespace).dropFirst().first,
+              let userID = UInt32(owner)
+        else {
+            return nil
+        }
+        return userID
+        #endif
+    }
+
     func identity(for pid: pid_t) -> AntigravityCLIProcessIdentity? {
         #if canImport(Darwin)
         var pathBuffer = [CChar](repeating: 0, count: 4096)

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -173,15 +173,24 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         let processInfos: @Sendable () async throws -> [AntigravityStatusProbe.ProcessInfoResult]
         let listeningPorts: @Sendable (Int, TimeInterval) async throws -> [Int]
         let fetchSnapshot: @Sendable ([Int]) async throws -> AntigravityStatusSnapshot
+        /// The pid of an ``agy`` that CodexBar itself spawned and manages through
+        /// ``AntigravityCLISession`` (if any). Such a process must NOT be reused
+        /// through the warm path: doing so bypasses `beginProbe`/`finishProbe`, so
+        /// the idle timer is never cancelled/extended and `stopIfIdle` could tear
+        /// the managed session down mid-poll. Externally owned `agy` (an IDE, a
+        /// long-lived `agy`, or another CodexBar host) has no such accounting.
+        let ownedPID: @Sendable () async -> Int?
 
         init(
             processInfos: @escaping @Sendable () async throws -> [AntigravityStatusProbe.ProcessInfoResult],
             listeningPorts: @escaping @Sendable (Int, TimeInterval) async throws -> [Int],
-            fetchSnapshot: @escaping @Sendable ([Int]) async throws -> AntigravityStatusSnapshot)
+            fetchSnapshot: @escaping @Sendable ([Int]) async throws -> AntigravityStatusSnapshot,
+            ownedPID: @escaping @Sendable () async -> Int? = { nil })
         {
             self.processInfos = processInfos
             self.listeningPorts = listeningPorts
             self.fetchSnapshot = fetchSnapshot
+            self.ownedPID = ownedPID
         }
     }
 
@@ -202,10 +211,14 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         dependencies: WarmAgyDependencies) async -> AntigravityStatusSnapshot?
     {
         let processInfos = await (try? dependencies.processInfos()) ?? []
+        let ownedPID = await dependencies.ownedPID()
         // Only the CLI's language server needs no CSRF token; the IDE/app servers
         // require one and must not be reused through this token-less fast path.
+        // Also exclude any `agy` CodexBar itself spawned and manages: reusing it
+        // here would bypass session lifecycle accounting (see `ownedPID`).
         let cliProcesses = processInfos.filter { info in
-            AntigravityStatusProbe.antigravityProcessKind(info.commandLine) == .cli
+            info.pid != ownedPID &&
+                AntigravityStatusProbe.antigravityProcessKind(info.commandLine) == .cli
         }
         guard !cliProcesses.isEmpty else { return nil }
 
@@ -247,6 +260,11 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
                 let deadline = Date().addingTimeInterval(2.0)
                 return try await AntigravityStatusProbe(timeout: 2.0)
                     .fetchFromPorts(ports, deadline: deadline)
+            },
+            ownedPID: {
+                // The pid of the `agy` CodexBar manages through the shared
+                // session, so the warm scan never reuses our own process.
+                await AntigravityCLISession.shared.pid.map(Int.init)
             })
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -187,6 +187,37 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         idleWindow: TimeInterval?,
         resetAfterFetch: Bool) async throws -> ProviderFetchResult
     {
+        try await self.fetchUsingWarmSession(
+            binary: binary,
+            idleWindow: idleWindow,
+            resetAfterFetch: resetAfterFetch,
+            spawnFetch: { binary, idleWindow, resetAfterFetch in
+                try await self.fetchBySpawning(
+                    binary: binary,
+                    idleWindow: idleWindow,
+                    resetAfterFetch: resetAfterFetch)
+            })
+    }
+
+    /// Testable core of the CLI fetch. The `spawnFetch` seam isolates the spawn
+    /// path so callers (and tests) can substitute or observe it.
+    func fetchUsingWarmSession(
+        binary: String,
+        idleWindow: TimeInterval?,
+        resetAfterFetch: Bool,
+        spawnFetch: @Sendable (String, TimeInterval?, Bool) async throws -> ProviderFetchResult)
+        async throws -> ProviderFetchResult
+    {
+        try await spawnFetch(binary, idleWindow, resetAfterFetch)
+    }
+
+    /// Spawn (or reuse CodexBar's own warm) `agy` session and wait for the CLI
+    /// HTTPS endpoint to report ready. This is the original behavior, unchanged.
+    private func fetchBySpawning(
+        binary: String,
+        idleWindow: TimeInterval?,
+        resetAfterFetch: Bool) async throws -> ProviderFetchResult
+    {
         let session = AntigravityCLISession.shared
         let pid = try await session.beginProbe(binary: binary, idleWindow: idleWindow)
         let deadline = Date().addingTimeInterval(5.0)

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -166,6 +166,90 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         }
     }
 
+    /// Seams for discovering and reusing an already-running ``agy`` CLI language
+    /// server, so a fresh spawn (and its multi-second ``GetUserStatus`` warm-up)
+    /// can be skipped when a warm server is already present.
+    struct WarmAgyDependencies {
+        let processInfos: @Sendable () async throws -> [AntigravityStatusProbe.ProcessInfoResult]
+        let listeningPorts: @Sendable (Int, TimeInterval) async throws -> [Int]
+        let fetchSnapshot: @Sendable ([Int]) async throws -> AntigravityStatusSnapshot
+
+        init(
+            processInfos: @escaping @Sendable () async throws -> [AntigravityStatusProbe.ProcessInfoResult],
+            listeningPorts: @escaping @Sendable (Int, TimeInterval) async throws -> [Int],
+            fetchSnapshot: @escaping @Sendable ([Int]) async throws -> AntigravityStatusSnapshot)
+        {
+            self.processInfos = processInfos
+            self.listeningPorts = listeningPorts
+            self.fetchSnapshot = fetchSnapshot
+        }
+    }
+
+    /// Discover an already-running, authenticated ``agy`` CLI language server and
+    /// reuse its listening ports instead of spawning a fresh process.
+    ///
+    /// One-shot CLI invocations otherwise spawn a brand-new ``agy`` on every
+    /// call; a fresh server binds its port quickly but ``GetUserStatus`` returns
+    /// transient initialization failures for a few seconds, so the readiness
+    /// deadline is occasionally missed. When a warm CLI server is already up, we
+    /// can talk to it immediately — it needs no CSRF token (``cliHTTPS``).
+    ///
+    /// Returns the snapshot from the first warm server that answers with
+    /// parseable usage, or `nil` when none is found or none answers — in which
+    /// case the caller falls back to the existing spawn path unchanged.
+    static func tryWarmAgyFetch(
+        timeout: TimeInterval,
+        dependencies: WarmAgyDependencies) async -> AntigravityStatusSnapshot?
+    {
+        let processInfos = await (try? dependencies.processInfos()) ?? []
+        // Only the CLI's language server needs no CSRF token; the IDE/app servers
+        // require one and must not be reused through this token-less fast path.
+        let cliProcesses = processInfos.filter { info in
+            AntigravityStatusProbe.antigravityProcessKind(info.commandLine) == .cli
+        }
+        guard !cliProcesses.isEmpty else { return nil }
+
+        for info in cliProcesses {
+            guard let ports = try? await dependencies.listeningPorts(info.pid, timeout),
+                  !ports.isEmpty
+            else {
+                continue
+            }
+            guard let snapshot = try? await dependencies.fetchSnapshot(ports),
+                  (try? snapshot.toUsageSnapshot()) != nil
+            else {
+                continue
+            }
+            Self.log.debug("Antigravity CLI HTTPS reusing warm agy", metadata: [
+                "pid": "\(info.pid)",
+                "ports": ports.map(String.init).joined(separator: ","),
+            ])
+            return snapshot
+        }
+        return nil
+    }
+
+    /// Production wiring for ``tryWarmAgyFetch``: list processes via `ps`, find
+    /// listening ports via `lsof`, and probe the token-less CLI HTTPS endpoint.
+    static func liveWarmAgyDependencies() -> WarmAgyDependencies {
+        WarmAgyDependencies(
+            processInfos: {
+                // A missing-CSRF/notRunning throw means no reusable server; the
+                // caller maps any throw to "no warm agy" and spawns instead.
+                try await AntigravityStatusProbe.detectProcessInfos(
+                    timeout: 2.0,
+                    scope: .ideAndCLI)
+            },
+            listeningPorts: { pid, timeout in
+                try await AntigravityStatusProbe.listeningPorts(pid: pid, timeout: timeout)
+            },
+            fetchSnapshot: { ports in
+                let deadline = Date().addingTimeInterval(2.0)
+                return try await AntigravityStatusProbe(timeout: 2.0)
+                    .fetchFromPorts(ports, deadline: deadline)
+            })
+    }
+
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         BinaryLocator.resolveAntigravityBinary(env: context.env) != nil
     }
@@ -191,6 +275,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
             binary: binary,
             idleWindow: idleWindow,
             resetAfterFetch: resetAfterFetch,
+            warmDependencies: Self.liveWarmAgyDependencies(),
             spawnFetch: { binary, idleWindow, resetAfterFetch in
                 try await self.fetchBySpawning(
                     binary: binary,
@@ -199,16 +284,40 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
             })
     }
 
-    /// Testable core of the CLI fetch. The `spawnFetch` seam isolates the spawn
-    /// path so callers (and tests) can substitute or observe it.
+    /// Testable core of the CLI fetch: try the warm-reuse fast path first, then
+    /// fall back to spawning. The `spawnFetch` seam lets tests assert the spawn
+    /// path is skipped when a warm server is reused.
     func fetchUsingWarmSession(
         binary: String,
         idleWindow: TimeInterval?,
         resetAfterFetch: Bool,
+        warmDependencies: WarmAgyDependencies,
         spawnFetch: @Sendable (String, TimeInterval?, Bool) async throws -> ProviderFetchResult)
         async throws -> ProviderFetchResult
     {
-        try await spawnFetch(binary, idleWindow, resetAfterFetch)
+        // Fast path: reuse an already-running, authenticated `agy` CLI server if
+        // one is present, avoiding a fresh spawn and its multi-second warm-up.
+        // When none is found (or none answers), fall through to the spawn path.
+        //
+        // The warm path deliberately does NOT touch `AntigravityCLISession`
+        // (`beginProbe`/`finishProbe`): a discovered `agy` is owned by another
+        // process (an IDE, a long-lived `agy`, or another CodexBar host), so
+        // CodexBar must not manage its lifecycle, idle timeout, or
+        // `resetAfterFetch` teardown. Those apply only to processes CodexBar
+        // itself spawns on the fallback path below.
+        if let warmSnapshot = await Self.tryWarmAgyFetch(
+            timeout: 2.0,
+            dependencies: warmDependencies)
+        {
+            // `tryWarmAgyFetch` only returns a snapshot whose `toUsageSnapshot()`
+            // already succeeded, so this conversion must not silently fail.
+            let warmUsage = try warmSnapshot.toUsageSnapshot()
+            return self.makeResult(
+                usage: warmUsage,
+                sourceLabel: Self.sourceLabel)
+        }
+
+        return try await spawnFetch(binary, idleWindow, resetAfterFetch)
     }
 
     /// Spawn (or reuse CodexBar's own warm) `agy` session and wait for the CLI

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -213,6 +213,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     /// path unchanged.
     static func tryWarmAgyFetch(
         timeout: TimeInterval,
+        expectedBinaryPath: String? = nil,
         expectedAccountEmail: String? = nil,
         dependencies: WarmAgyDependencies) async -> AntigravityStatusSnapshot?
     {
@@ -233,6 +234,12 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         guard !cliProcesses.isEmpty else { return nil }
 
         for info in cliProcesses {
+            if let expectedBinaryPath {
+                guard Self.commandLine(info.commandLine, matchesBinaryPath: expectedBinaryPath)
+                else {
+                    continue
+                }
+            }
             guard let portTimeout = Self.remainingWarmProbeTime(deadline: deadline, now: dependencies.now) else {
                 return nil
             }
@@ -267,6 +274,16 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     {
         let remaining = deadline.timeIntervalSince(now())
         return remaining > 0 ? remaining : nil
+    }
+
+    private static func commandLine(_ commandLine: String, matchesBinaryPath binaryPath: String) -> Bool {
+        let candidates = [
+            URL(fileURLWithPath: binaryPath).standardizedFileURL.path,
+            URL(fileURLWithPath: binaryPath).resolvingSymlinksInPath().standardizedFileURL.path,
+        ]
+        return candidates.contains { candidate in
+            commandLine == candidate || commandLine.hasPrefix("\(candidate) ")
+        }
     }
 
     /// Production wiring for ``tryWarmAgyFetch``: list processes via `ps`, find
@@ -366,6 +383,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         // stays entirely inside AntigravityCLISession.
         if resetAfterFetch, let warmSnapshot = await Self.tryWarmAgyFetch(
             timeout: 2.0,
+            expectedBinaryPath: binary,
             expectedAccountEmail: expectedAccountEmail,
             dependencies: warmDependencies)
         {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -173,6 +173,8 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         let processInfos: @Sendable (TimeInterval) async throws -> [AntigravityStatusProbe.ProcessInfoResult]
         let listeningPorts: @Sendable (Int, TimeInterval) async throws -> [Int]
         let fetchSnapshot: @Sendable ([Int], TimeInterval) async throws -> AntigravityStatusSnapshot
+        let processOwnerUserID: @Sendable (Int) -> UInt32?
+        let currentUserID: @Sendable () -> UInt32
         /// The pid of an ``agy`` that CodexBar itself spawned and manages through
         /// ``AntigravityCLISession`` (if any). Such a process must NOT be reused
         /// through the warm path: doing so bypasses `beginProbe`/`finishProbe`, so
@@ -187,12 +189,16 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
                 -> [AntigravityStatusProbe.ProcessInfoResult],
             listeningPorts: @escaping @Sendable (Int, TimeInterval) async throws -> [Int],
             fetchSnapshot: @escaping @Sendable ([Int], TimeInterval) async throws -> AntigravityStatusSnapshot,
+            processOwnerUserID: @escaping @Sendable (Int) -> UInt32? = { _ in 0 },
+            currentUserID: @escaping @Sendable () -> UInt32 = { 0 },
             ownedPID: @escaping @Sendable () async -> Int? = { nil },
             now: @escaping @Sendable () -> Date = Date.init)
         {
             self.processInfos = processInfos
             self.listeningPorts = listeningPorts
             self.fetchSnapshot = fetchSnapshot
+            self.processOwnerUserID = processOwnerUserID
+            self.currentUserID = currentUserID
             self.ownedPID = ownedPID
             self.now = now
         }
@@ -233,12 +239,14 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         try Task.checkCancellation()
         let ownedPID = await dependencies.ownedPID()
         try Task.checkCancellation()
+        let currentUserID = dependencies.currentUserID()
         // Only the CLI's language server needs no CSRF token; the IDE/app servers
         // require one and must not be reused through this token-less fast path.
         // Also exclude any `agy` CodexBar itself spawned and manages: reusing it
         // here would bypass session lifecycle accounting (see `ownedPID`).
         let cliProcesses = processInfos.filter { info in
             info.pid != ownedPID &&
+                dependencies.processOwnerUserID(info.pid) == currentUserID &&
                 AntigravityStatusProbe.antigravityProcessKind(info.commandLine) == .cli
         }
         guard !cliProcesses.isEmpty else { return nil }
@@ -328,6 +336,12 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
                 let deadline = Date().addingTimeInterval(timeout)
                 return try await AntigravityStatusProbe(timeout: timeout)
                     .fetchFromPorts(ports, deadline: deadline)
+            },
+            processOwnerUserID: { pid in
+                AntigravityProcessIdentityProvider().ownerUserID(for: pid_t(pid))
+            },
+            currentUserID: {
+                AntigravityProcessIdentityProvider.currentUserID
             },
             ownedPID: {
                 // The pid of the `agy` CodexBar manages through the shared

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -170,9 +170,9 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     /// server, so a fresh spawn (and its multi-second ``GetUserStatus`` warm-up)
     /// can be skipped when a warm server is already present.
     struct WarmAgyDependencies {
-        let processInfos: @Sendable () async throws -> [AntigravityStatusProbe.ProcessInfoResult]
+        let processInfos: @Sendable (TimeInterval) async throws -> [AntigravityStatusProbe.ProcessInfoResult]
         let listeningPorts: @Sendable (Int, TimeInterval) async throws -> [Int]
-        let fetchSnapshot: @Sendable ([Int]) async throws -> AntigravityStatusSnapshot
+        let fetchSnapshot: @Sendable ([Int], TimeInterval) async throws -> AntigravityStatusSnapshot
         /// The pid of an ``agy`` that CodexBar itself spawned and manages through
         /// ``AntigravityCLISession`` (if any). Such a process must NOT be reused
         /// through the warm path: doing so bypasses `beginProbe`/`finishProbe`, so
@@ -180,17 +180,21 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         /// the managed session down mid-poll. Externally owned `agy` (an IDE, a
         /// long-lived `agy`, or another CodexBar host) has no such accounting.
         let ownedPID: @Sendable () async -> Int?
+        let now: @Sendable () -> Date
 
         init(
-            processInfos: @escaping @Sendable () async throws -> [AntigravityStatusProbe.ProcessInfoResult],
+            processInfos: @escaping @Sendable (TimeInterval) async throws
+                -> [AntigravityStatusProbe.ProcessInfoResult],
             listeningPorts: @escaping @Sendable (Int, TimeInterval) async throws -> [Int],
-            fetchSnapshot: @escaping @Sendable ([Int]) async throws -> AntigravityStatusSnapshot,
-            ownedPID: @escaping @Sendable () async -> Int? = { nil })
+            fetchSnapshot: @escaping @Sendable ([Int], TimeInterval) async throws -> AntigravityStatusSnapshot,
+            ownedPID: @escaping @Sendable () async -> Int? = { nil },
+            now: @escaping @Sendable () -> Date = Date.init)
         {
             self.processInfos = processInfos
             self.listeningPorts = listeningPorts
             self.fetchSnapshot = fetchSnapshot
             self.ownedPID = ownedPID
+            self.now = now
         }
     }
 
@@ -204,13 +208,19 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     /// can talk to it immediately — it needs no CSRF token (``cliHTTPS``).
     ///
     /// Returns the snapshot from the first warm server that answers with
-    /// parseable usage, or `nil` when none is found or none answers — in which
-    /// case the caller falls back to the existing spawn path unchanged.
+    /// parseable usage for the requested account, or `nil` when none is found or
+    /// none answers — in which case the caller falls back to the existing spawn
+    /// path unchanged.
     static func tryWarmAgyFetch(
         timeout: TimeInterval,
+        expectedAccountEmail: String? = nil,
         dependencies: WarmAgyDependencies) async -> AntigravityStatusSnapshot?
     {
-        let processInfos = await (try? dependencies.processInfos()) ?? []
+        let deadline = dependencies.now().addingTimeInterval(timeout)
+        guard let discoveryTimeout = Self.remainingWarmProbeTime(deadline: deadline, now: dependencies.now) else {
+            return nil
+        }
+        let processInfos = await (try? dependencies.processInfos(discoveryTimeout)) ?? []
         let ownedPID = await dependencies.ownedPID()
         // Only the CLI's language server needs no CSRF token; the IDE/app servers
         // require one and must not be reused through this token-less fast path.
@@ -223,13 +233,22 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         guard !cliProcesses.isEmpty else { return nil }
 
         for info in cliProcesses {
-            guard let ports = try? await dependencies.listeningPorts(info.pid, timeout),
+            guard let portTimeout = Self.remainingWarmProbeTime(deadline: deadline, now: dependencies.now) else {
+                return nil
+            }
+            guard let ports = try? await dependencies.listeningPorts(info.pid, portTimeout),
                   !ports.isEmpty
             else {
                 continue
             }
-            guard let snapshot = try? await dependencies.fetchSnapshot(ports),
-                  (try? snapshot.toUsageSnapshot()) != nil
+            guard let fetchTimeout = Self.remainingWarmProbeTime(deadline: deadline, now: dependencies.now) else {
+                return nil
+            }
+            guard let snapshot = try? await dependencies.fetchSnapshot(ports, fetchTimeout),
+                  (try? snapshot.toUsageSnapshot()) != nil,
+                  AntigravitySelectedAccountGuard.matches(
+                      snapshotAccountEmail: snapshot.accountEmail,
+                      expectedAccountEmail: expectedAccountEmail)
             else {
                 continue
             }
@@ -242,23 +261,31 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         return nil
     }
 
+    private static func remainingWarmProbeTime(
+        deadline: Date,
+        now: @Sendable () -> Date) -> TimeInterval?
+    {
+        let remaining = deadline.timeIntervalSince(now())
+        return remaining > 0 ? remaining : nil
+    }
+
     /// Production wiring for ``tryWarmAgyFetch``: list processes via `ps`, find
     /// listening ports via `lsof`, and probe the token-less CLI HTTPS endpoint.
     static func liveWarmAgyDependencies() -> WarmAgyDependencies {
         WarmAgyDependencies(
-            processInfos: {
+            processInfos: { timeout in
                 // A missing-CSRF/notRunning throw means no reusable server; the
                 // caller maps any throw to "no warm agy" and spawns instead.
                 try await AntigravityStatusProbe.detectProcessInfos(
-                    timeout: 2.0,
+                    timeout: timeout,
                     scope: .ideAndCLI)
             },
             listeningPorts: { pid, timeout in
                 try await AntigravityStatusProbe.listeningPorts(pid: pid, timeout: timeout)
             },
-            fetchSnapshot: { ports in
-                let deadline = Date().addingTimeInterval(2.0)
-                return try await AntigravityStatusProbe(timeout: 2.0)
+            fetchSnapshot: { ports, timeout in
+                let deadline = Date().addingTimeInterval(timeout)
+                return try await AntigravityStatusProbe(timeout: timeout)
                     .fetchFromPorts(ports, deadline: deadline)
             },
             ownedPID: {
@@ -276,10 +303,18 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         guard let binary = BinaryLocator.resolveAntigravityBinary(env: context.env) else {
             throw AntigravityStatusProbeError.notRunning
         }
+        let expectedAccountEmail: String? = if context.sourceMode == .auto,
+                                               context.selectedTokenAccountID != nil
+        {
+            AntigravitySelectedAccountGuard.selectedAccountEmail(context: context)
+        } else {
+            nil
+        }
         let result = try await self.fetchUsingWarmSession(
             binary: binary,
             idleWindow: context.persistentCLISessionIdleWindow,
-            resetAfterFetch: Self.shouldResetSessionAfterFetch(context))
+            resetAfterFetch: Self.shouldResetSessionAfterFetch(context),
+            expectedAccountEmail: expectedAccountEmail)
         try AntigravitySelectedAccountGuard.validate(result.usage, context: context)
         return result
     }
@@ -287,12 +322,14 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     private func fetchUsingWarmSession(
         binary: String,
         idleWindow: TimeInterval?,
-        resetAfterFetch: Bool) async throws -> ProviderFetchResult
+        resetAfterFetch: Bool,
+        expectedAccountEmail: String?) async throws -> ProviderFetchResult
     {
         try await self.fetchUsingWarmSession(
             binary: binary,
             idleWindow: idleWindow,
             resetAfterFetch: resetAfterFetch,
+            expectedAccountEmail: expectedAccountEmail,
             warmDependencies: Self.liveWarmAgyDependencies(),
             spawnFetch: { binary, idleWindow, resetAfterFetch in
                 try await self.fetchBySpawning(
@@ -309,6 +346,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         binary: String,
         idleWindow: TimeInterval?,
         resetAfterFetch: Bool,
+        expectedAccountEmail: String? = nil,
         warmDependencies: WarmAgyDependencies,
         spawnFetch: @Sendable (String, TimeInterval?, Bool) async throws -> ProviderFetchResult)
         async throws -> ProviderFetchResult
@@ -323,8 +361,12 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         // CodexBar must not manage its lifecycle, idle timeout, or
         // `resetAfterFetch` teardown. Those apply only to processes CodexBar
         // itself spawns on the fallback path below.
-        if let warmSnapshot = await Self.tryWarmAgyFetch(
+        // Long-lived hosts already keep a managed session warm. Restrict external
+        // process reuse to one-shot CLI calls so app/server lifecycle accounting
+        // stays entirely inside AntigravityCLISession.
+        if resetAfterFetch, let warmSnapshot = await Self.tryWarmAgyFetch(
             timeout: 2.0,
+            expectedAccountEmail: expectedAccountEmail,
             dependencies: warmDependencies)
         {
             // `tryWarmAgyFetch` only returns a snapshot whose `toUsageSnapshot()`
@@ -539,6 +581,12 @@ struct AntigravityOAuthFetchStrategy: ProviderFetchStrategy {
 /// and let the pipeline fall through to OAuth. Explicit ``cli``/``oauth`` source
 /// modes stay authoritative and are never second-guessed here.
 enum AntigravitySelectedAccountGuard {
+    static func matches(snapshotAccountEmail: String?, expectedAccountEmail: String?) -> Bool {
+        guard let expected = self.normalizedEmail(expectedAccountEmail) else { return true }
+        guard let found = self.normalizedEmail(snapshotAccountEmail) else { return false }
+        return found.caseInsensitiveCompare(expected) == .orderedSame
+    }
+
     static func validate(_ usage: UsageSnapshot, context: ProviderFetchContext) throws {
         guard context.sourceMode == .auto, context.selectedTokenAccountID != nil else { return }
         let expected = self.selectedAccountEmail(context: context)

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -215,14 +215,24 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         timeout: TimeInterval,
         expectedBinaryPath: String? = nil,
         expectedAccountEmail: String? = nil,
-        dependencies: WarmAgyDependencies) async -> AntigravityStatusSnapshot?
+        dependencies: WarmAgyDependencies) async throws -> AntigravityStatusSnapshot?
     {
+        try Task.checkCancellation()
         let deadline = dependencies.now().addingTimeInterval(timeout)
         guard let discoveryTimeout = Self.remainingWarmProbeTime(deadline: deadline, now: dependencies.now) else {
             return nil
         }
-        let processInfos = await (try? dependencies.processInfos(discoveryTimeout)) ?? []
+        let processInfos: [AntigravityStatusProbe.ProcessInfoResult]
+        do {
+            processInfos = try await dependencies.processInfos(discoveryTimeout)
+        } catch let error as CancellationError {
+            throw error
+        } catch {
+            return nil
+        }
+        try Task.checkCancellation()
         let ownedPID = await dependencies.ownedPID()
+        try Task.checkCancellation()
         // Only the CLI's language server needs no CSRF token; the IDE/app servers
         // require one and must not be reused through this token-less fast path.
         // Also exclude any `agy` CodexBar itself spawned and manages: reusing it
@@ -243,16 +253,29 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
             guard let portTimeout = Self.remainingWarmProbeTime(deadline: deadline, now: dependencies.now) else {
                 return nil
             }
-            guard let ports = try? await dependencies.listeningPorts(info.pid, portTimeout),
-                  !ports.isEmpty
-            else {
+            let ports: [Int]
+            do {
+                ports = try await dependencies.listeningPorts(info.pid, portTimeout)
+            } catch let error as CancellationError {
+                throw error
+            } catch {
                 continue
             }
+            try Task.checkCancellation()
+            guard !ports.isEmpty else { continue }
             guard let fetchTimeout = Self.remainingWarmProbeTime(deadline: deadline, now: dependencies.now) else {
                 return nil
             }
-            guard let snapshot = try? await dependencies.fetchSnapshot(ports, fetchTimeout),
-                  (try? snapshot.toUsageSnapshot()) != nil,
+            let snapshot: AntigravityStatusSnapshot
+            do {
+                snapshot = try await dependencies.fetchSnapshot(ports, fetchTimeout)
+            } catch let error as CancellationError {
+                throw error
+            } catch {
+                continue
+            }
+            try Task.checkCancellation()
+            guard (try? snapshot.toUsageSnapshot()) != nil,
                   AntigravitySelectedAccountGuard.matches(
                       snapshotAccountEmail: snapshot.accountEmail,
                       expectedAccountEmail: expectedAccountEmail)
@@ -265,6 +288,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
             ])
             return snapshot
         }
+        try Task.checkCancellation()
         return nil
     }
 
@@ -381,7 +405,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         // Long-lived hosts already keep a managed session warm. Restrict external
         // process reuse to one-shot CLI calls so app/server lifecycle accounting
         // stays entirely inside AntigravityCLISession.
-        if resetAfterFetch, let warmSnapshot = await Self.tryWarmAgyFetch(
+        if resetAfterFetch, let warmSnapshot = try await Self.tryWarmAgyFetch(
             timeout: 2.0,
             expectedBinaryPath: binary,
             expectedAccountEmail: expectedAccountEmail,
@@ -395,6 +419,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
                 sourceLabel: Self.sourceLabel)
         }
 
+        try Task.checkCancellation()
         return try await spawnFetch(binary, idleWindow, resetAfterFetch)
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -1005,7 +1005,9 @@ public struct AntigravityStatusProbe: Sendable {
         return first
     }
 
-    private static func detectProcessInfos(
+    /// Internal (not private): called by AntigravityCLIHTTPSFetchStrategy
+    /// .liveWarmAgyDependencies to discover an already-running `agy` for reuse.
+    static func detectProcessInfos(
         timeout: TimeInterval,
         scope: ProcessScope = .ideAndCLI) async throws -> [ProcessInfoResult]
     {

--- a/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
+++ b/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
@@ -116,6 +116,53 @@ struct AntigravityWarmAgyReuseTests {
         #expect(fetchSnapshotCallCount.value == 0)
     }
 
+    @Test
+    func ownedAgyExcluded_fallsBackToSpawnPath() async {
+        // CodexBar's own managed `agy` (pid 4242) appears in the process scan.
+        // It must NOT be reused through the warm path — doing so would bypass the
+        // session lifecycle and let `stopIfIdle` tear it down mid-poll.
+        let fetchSnapshotCallCount = LockedCounter()
+
+        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { [Self.cliProcessInfo(pid: 4242)] },
+                listeningPorts: { _, _ in
+                    Issue.record("listeningPorts must not be called for a CodexBar-owned agy")
+                    return []
+                },
+                fetchSnapshot: { _ in
+                    fetchSnapshotCallCount.increment()
+                    return Self.usableSnapshot(email: "owned@example.com")
+                },
+                ownedPID: { 4242 }))
+
+        #expect(result == nil)
+        #expect(fetchSnapshotCallCount.value == 0)
+    }
+
+    @Test
+    func externalAgyReused_whenOwnedAlsoPresent() async {
+        // With both an owned `agy` (pid 4242) and an external one (pid 7000), only
+        // the external server is reused; the owned pid is filtered out.
+        let listeningPortsCallCount = LockedCounter()
+
+        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { [Self.cliProcessInfo(pid: 4242), Self.cliProcessInfo(pid: 7000)] },
+                listeningPorts: { pid, _ in
+                    listeningPortsCallCount.increment()
+                    #expect(pid == 7000)
+                    return [50050]
+                },
+                fetchSnapshot: { _ in Self.usableSnapshot(email: "external@example.com") },
+                ownedPID: { 4242 }))
+
+        #expect(result?.accountEmail == "external@example.com")
+        #expect(listeningPortsCallCount.value == 1)
+    }
+
     // MARK: - Integration: fetchUsingWarmSession fast-path branch
 
     @Test

--- a/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
+++ b/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct AntigravityWarmAgyReuseTests {
+    // MARK: - Helper-seam tests (tryWarmAgyFetch)
+
+    @Test
+    func warmAgyFound_reusesPorts_withoutSpawn() async {
+        let listeningPortsCallCount = LockedCounter()
+        let fetchSnapshotCallCount = LockedCounter()
+
+        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { [Self.cliProcessInfo(pid: 9901)] },
+                listeningPorts: { pid, _ in
+                    listeningPortsCallCount.increment()
+                    #expect(pid == 9901)
+                    return [56789]
+                },
+                fetchSnapshot: { ports in
+                    fetchSnapshotCallCount.increment()
+                    #expect(ports == [56789])
+                    return Self.usableSnapshot(email: "warm@example.com")
+                }))
+
+        #expect(result?.accountEmail == "warm@example.com")
+        #expect(result?.modelQuotas.first?.modelId == "gemini-pro")
+        #expect(listeningPortsCallCount.value == 1)
+        #expect(fetchSnapshotCallCount.value == 1)
+    }
+
+    @Test
+    func noWarmAgy_returnsNil() async {
+        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { [] },
+                listeningPorts: { _, _ in
+                    Issue.record("listeningPorts must not be called when no warm agy found")
+                    return []
+                },
+                fetchSnapshot: { _ in
+                    Issue.record("fetchSnapshot must not be called when no warm agy found")
+                    throw AntigravityStatusProbeError.notRunning
+                }))
+
+        #expect(result == nil)
+    }
+
+    @Test
+    func processInfosThrows_returnsNil() async {
+        // detectProcessInfos throws (e.g. .missingCSRFToken / .notRunning) — the
+        // fast path must swallow it and let the caller fall back to spawning.
+        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { throw AntigravityStatusProbeError.missingCSRFToken },
+                listeningPorts: { _, _ in
+                    Issue.record("listeningPorts must not be called when discovery throws")
+                    return []
+                },
+                fetchSnapshot: { _ in
+                    Issue.record("fetchSnapshot must not be called when discovery throws")
+                    throw AntigravityStatusProbeError.notRunning
+                }))
+
+        #expect(result == nil)
+    }
+
+    @Test
+    func warmAgyFetchFails_returnsNil() async {
+        let fetchSnapshotCallCount = LockedCounter()
+
+        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { [Self.cliProcessInfo(pid: 7701)] },
+                listeningPorts: { _, _ in [55555] },
+                fetchSnapshot: { _ in
+                    fetchSnapshotCallCount.increment()
+                    throw AntigravityStatusProbeError.portDetectionFailed("endpoint not ready")
+                }))
+
+        // Fetch fails → warm reuse returns nil → caller falls back to spawn
+        #expect(result == nil)
+        #expect(fetchSnapshotCallCount.value == 1)
+    }
+
+    @Test
+    func ideProcessIgnored_notReuseableAsWarmCLI() async {
+        // An IDE language server requires a CSRF token — must NOT be reused via
+        // the token-less warm path.
+        let ideProcessInfo = AntigravityStatusProbe.ProcessInfoResult(
+            pid: 8801,
+            extensionPort: nil,
+            extensionServerCSRFToken: nil,
+            csrfToken: "abc123",
+            commandLine:
+            // swiftlint:disable:next line_length
+            "/Applications/Antigravity IDE.app/Contents/Resources/language_server --csrf_token abc123 --app_data_dir antigravity-ide")
+        let fetchSnapshotCallCount = LockedCounter()
+
+        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { [ideProcessInfo] },
+                listeningPorts: { _, _ in [44444] },
+                fetchSnapshot: { _ in
+                    fetchSnapshotCallCount.increment()
+                    return Self.usableSnapshot(email: "ide@example.com")
+                }))
+
+        #expect(result == nil)
+        #expect(fetchSnapshotCallCount.value == 0)
+    }
+
+    // MARK: - Integration: fetchUsingWarmSession fast-path branch
+
+    @Test
+    func warmReuse_skipsSpawnPath() async throws {
+        let spawnCallCount = LockedCounter()
+        let strategy = AntigravityCLIHTTPSFetchStrategy()
+
+        let result = try await strategy.fetchUsingWarmSession(
+            binary: "/usr/local/bin/agy",
+            idleWindow: nil,
+            resetAfterFetch: true,
+            warmDependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { [Self.cliProcessInfo(pid: 1234)] },
+                listeningPorts: { _, _ in [40000] },
+                fetchSnapshot: { _ in Self.usableSnapshot(email: "warm@example.com") }),
+            spawnFetch: { _, _, _ in
+                spawnCallCount.increment()
+                Issue.record("spawn path must not run when a warm agy is reused")
+                throw AntigravityStatusProbeError.notRunning
+            })
+
+        #expect(result.usage.identity?.accountEmail == "warm@example.com")
+        #expect(result.sourceLabel == AntigravityCLIHTTPSFetchStrategy.sourceLabel)
+        // The warm path never touches AntigravityCLISession: the spawn seam (the
+        // only place beginProbe/finishProbe run) was never invoked.
+        #expect(spawnCallCount.value == 0)
+    }
+
+    @Test
+    func noWarmAgy_fallsBackToSpawnPath() async throws {
+        let spawnCallCount = LockedCounter()
+        let strategy = AntigravityCLIHTTPSFetchStrategy()
+
+        let result = try await strategy.fetchUsingWarmSession(
+            binary: "/usr/local/bin/agy",
+            idleWindow: nil,
+            resetAfterFetch: true,
+            warmDependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { [] },
+                listeningPorts: { _, _ in [] },
+                fetchSnapshot: { _ in throw AntigravityStatusProbeError.notRunning }),
+            spawnFetch: { binary, _, resetAfterFetch in
+                spawnCallCount.increment()
+                #expect(binary == "/usr/local/bin/agy")
+                #expect(resetAfterFetch)
+                return strategy.makeResult(
+                    usage: Self.usableUsage(email: "spawned@example.com"),
+                    sourceLabel: AntigravityCLIHTTPSFetchStrategy.sourceLabel)
+            })
+
+        #expect(result.usage.identity?.accountEmail == "spawned@example.com")
+        #expect(spawnCallCount.value == 1)
+    }
+
+    // MARK: - Fixtures
+
+    private static func cliProcessInfo(pid: Int) -> AntigravityStatusProbe.ProcessInfoResult {
+        AntigravityStatusProbe.ProcessInfoResult(
+            pid: pid,
+            extensionPort: nil,
+            extensionServerCSRFToken: nil,
+            csrfToken: "",
+            commandLine: "/usr/local/bin/agy")
+    }
+
+    private static func usableSnapshot(email: String) -> AntigravityStatusSnapshot {
+        AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Gemini Pro",
+                    modelId: "gemini-pro",
+                    remainingFraction: 0.8,
+                    resetTime: nil,
+                    resetDescription: nil),
+            ],
+            accountEmail: email,
+            accountPlan: "Pro",
+            source: .local)
+    }
+
+    private static func usableUsage(email: String) -> UsageSnapshot {
+        (try? self.usableSnapshot(email: email).toUsageSnapshot())
+            ?? UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                tertiary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .antigravity,
+                    accountEmail: email,
+                    accountOrganization: nil,
+                    loginMethod: nil))
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    @discardableResult
+    func increment() -> Int {
+        self.lock.withLock {
+            self.count += 1
+            return self.count
+        }
+    }
+
+    var value: Int {
+        self.lock.withLock { self.count }
+    }
+}

--- a/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
+++ b/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
@@ -186,6 +186,30 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
+    func `binary mismatch tries next warm agy`() async {
+        let listeningPIDs = AntigravityWarmLockedValues<Int>()
+
+        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            expectedBinaryPath: "/selected/agy",
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { _ in
+                    [
+                        Self.cliProcessInfo(pid: 6151, binaryPath: "/other/agy"),
+                        Self.cliProcessInfo(pid: 6152, binaryPath: "/selected/agy"),
+                    ]
+                },
+                listeningPorts: { pid, _ in
+                    listeningPIDs.append(pid)
+                    return [pid]
+                },
+                fetchSnapshot: { _, _ in Self.usableSnapshot(email: "selected@example.com") }))
+
+        #expect(result?.accountEmail == "selected@example.com")
+        #expect(listeningPIDs.value == [6152])
+    }
+
+    @Test
     func `warm probe deadline is shared across discovery and candidates`() async {
         let clock = AntigravityWarmTestClock(date: Date(timeIntervalSince1970: 100))
         let listeningPortsCallCount = AntigravityWarmLockedCounter()
@@ -300,13 +324,16 @@ struct AntigravityWarmAgyReuseTests {
 
     // MARK: - Fixtures
 
-    private static func cliProcessInfo(pid: Int) -> AntigravityStatusProbe.ProcessInfoResult {
+    private static func cliProcessInfo(
+        pid: Int,
+        binaryPath: String = "/usr/local/bin/agy") -> AntigravityStatusProbe.ProcessInfoResult
+    {
         AntigravityStatusProbe.ProcessInfoResult(
             pid: pid,
             extensionPort: nil,
             extensionServerCSRFToken: nil,
             csrfToken: "",
-            commandLine: "/usr/local/bin/agy")
+            commandLine: binaryPath)
     }
 
     private static func usableSnapshot(email: String) -> AntigravityStatusSnapshot {

--- a/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
+++ b/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
@@ -6,20 +6,20 @@ struct AntigravityWarmAgyReuseTests {
     // MARK: - Helper-seam tests (tryWarmAgyFetch)
 
     @Test
-    func warmAgyFound_reusesPorts_withoutSpawn() async {
-        let listeningPortsCallCount = LockedCounter()
-        let fetchSnapshotCallCount = LockedCounter()
+    func `warm agy found reuses ports without spawn`() async {
+        let listeningPortsCallCount = AntigravityWarmLockedCounter()
+        let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
 
         let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
-                processInfos: { [Self.cliProcessInfo(pid: 9901)] },
+                processInfos: { _ in [Self.cliProcessInfo(pid: 9901)] },
                 listeningPorts: { pid, _ in
                     listeningPortsCallCount.increment()
                     #expect(pid == 9901)
                     return [56789]
                 },
-                fetchSnapshot: { ports in
+                fetchSnapshot: { ports, _ in
                     fetchSnapshotCallCount.increment()
                     #expect(ports == [56789])
                     return Self.usableSnapshot(email: "warm@example.com")
@@ -32,16 +32,16 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func noWarmAgy_returnsNil() async {
+    func `no warm agy returns nil`() async {
         let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
-                processInfos: { [] },
+                processInfos: { _ in [] },
                 listeningPorts: { _, _ in
                     Issue.record("listeningPorts must not be called when no warm agy found")
                     return []
                 },
-                fetchSnapshot: { _ in
+                fetchSnapshot: { _, _ in
                     Issue.record("fetchSnapshot must not be called when no warm agy found")
                     throw AntigravityStatusProbeError.notRunning
                 }))
@@ -50,18 +50,18 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func processInfosThrows_returnsNil() async {
+    func `process infos throws returns nil`() async {
         // detectProcessInfos throws (e.g. .missingCSRFToken / .notRunning) — the
         // fast path must swallow it and let the caller fall back to spawning.
         let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
-                processInfos: { throw AntigravityStatusProbeError.missingCSRFToken },
+                processInfos: { _ in throw AntigravityStatusProbeError.missingCSRFToken },
                 listeningPorts: { _, _ in
                     Issue.record("listeningPorts must not be called when discovery throws")
                     return []
                 },
-                fetchSnapshot: { _ in
+                fetchSnapshot: { _, _ in
                     Issue.record("fetchSnapshot must not be called when discovery throws")
                     throw AntigravityStatusProbeError.notRunning
                 }))
@@ -70,15 +70,15 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func warmAgyFetchFails_returnsNil() async {
-        let fetchSnapshotCallCount = LockedCounter()
+    func `warm agy fetch fails returns nil`() async {
+        let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
 
         let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
-                processInfos: { [Self.cliProcessInfo(pid: 7701)] },
+                processInfos: { _ in [Self.cliProcessInfo(pid: 7701)] },
                 listeningPorts: { _, _ in [55555] },
-                fetchSnapshot: { _ in
+                fetchSnapshot: { _, _ in
                     fetchSnapshotCallCount.increment()
                     throw AntigravityStatusProbeError.portDetectionFailed("endpoint not ready")
                 }))
@@ -89,7 +89,7 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func ideProcessIgnored_notReuseableAsWarmCLI() async {
+    func `ide process ignored not reuseable as warm CLI`() async {
         // An IDE language server requires a CSRF token — must NOT be reused via
         // the token-less warm path.
         let ideProcessInfo = AntigravityStatusProbe.ProcessInfoResult(
@@ -100,14 +100,14 @@ struct AntigravityWarmAgyReuseTests {
             commandLine:
             // swiftlint:disable:next line_length
             "/Applications/Antigravity IDE.app/Contents/Resources/language_server --csrf_token abc123 --app_data_dir antigravity-ide")
-        let fetchSnapshotCallCount = LockedCounter()
+        let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
 
         let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
-                processInfos: { [ideProcessInfo] },
+                processInfos: { _ in [ideProcessInfo] },
                 listeningPorts: { _, _ in [44444] },
-                fetchSnapshot: { _ in
+                fetchSnapshot: { _, _ in
                     fetchSnapshotCallCount.increment()
                     return Self.usableSnapshot(email: "ide@example.com")
                 }))
@@ -117,21 +117,21 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func ownedAgyExcluded_fallsBackToSpawnPath() async {
+    func `owned agy excluded falls back to spawn path`() async {
         // CodexBar's own managed `agy` (pid 4242) appears in the process scan.
         // It must NOT be reused through the warm path — doing so would bypass the
         // session lifecycle and let `stopIfIdle` tear it down mid-poll.
-        let fetchSnapshotCallCount = LockedCounter()
+        let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
 
         let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
-                processInfos: { [Self.cliProcessInfo(pid: 4242)] },
+                processInfos: { _ in [Self.cliProcessInfo(pid: 4242)] },
                 listeningPorts: { _, _ in
                     Issue.record("listeningPorts must not be called for a CodexBar-owned agy")
                     return []
                 },
-                fetchSnapshot: { _ in
+                fetchSnapshot: { _, _ in
                     fetchSnapshotCallCount.increment()
                     return Self.usableSnapshot(email: "owned@example.com")
                 },
@@ -142,32 +142,85 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func externalAgyReused_whenOwnedAlsoPresent() async {
+    func `external agy reused when owned also present`() async {
         // With both an owned `agy` (pid 4242) and an external one (pid 7000), only
         // the external server is reused; the owned pid is filtered out.
-        let listeningPortsCallCount = LockedCounter()
+        let listeningPortsCallCount = AntigravityWarmLockedCounter()
 
         let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
-                processInfos: { [Self.cliProcessInfo(pid: 4242), Self.cliProcessInfo(pid: 7000)] },
+                processInfos: { _ in [Self.cliProcessInfo(pid: 4242), Self.cliProcessInfo(pid: 7000)] },
                 listeningPorts: { pid, _ in
                     listeningPortsCallCount.increment()
                     #expect(pid == 7000)
                     return [50050]
                 },
-                fetchSnapshot: { _ in Self.usableSnapshot(email: "external@example.com") },
+                fetchSnapshot: { _, _ in Self.usableSnapshot(email: "external@example.com") },
                 ownedPID: { 4242 }))
 
         #expect(result?.accountEmail == "external@example.com")
         #expect(listeningPortsCallCount.value == 1)
     }
 
+    @Test
+    func `account mismatch tries next warm agy`() async {
+        let listeningPIDs = AntigravityWarmLockedValues<Int>()
+
+        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            expectedAccountEmail: "selected@example.com",
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { _ in [Self.cliProcessInfo(pid: 6101), Self.cliProcessInfo(pid: 6102)] },
+                listeningPorts: { pid, _ in
+                    listeningPIDs.append(pid)
+                    return [pid]
+                },
+                fetchSnapshot: { ports, _ in
+                    let email = ports == [6101] ? "other@example.com" : "SELECTED@example.com"
+                    return Self.usableSnapshot(email: email)
+                }))
+
+        #expect(result?.accountEmail == "SELECTED@example.com")
+        #expect(listeningPIDs.value == [6101, 6102])
+    }
+
+    @Test
+    func `warm probe deadline is shared across discovery and candidates`() async {
+        let clock = AntigravityWarmTestClock(date: Date(timeIntervalSince1970: 100))
+        let listeningPortsCallCount = AntigravityWarmLockedCounter()
+        let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
+
+        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { timeout in
+                    #expect(timeout == 2.0)
+                    clock.advance(by: 1.5)
+                    return [Self.cliProcessInfo(pid: 6201), Self.cliProcessInfo(pid: 6202)]
+                },
+                listeningPorts: { _, timeout in
+                    listeningPortsCallCount.increment()
+                    #expect(timeout == 0.5)
+                    clock.advance(by: 0.6)
+                    return [62010]
+                },
+                fetchSnapshot: { _, _ in
+                    fetchSnapshotCallCount.increment()
+                    return Self.usableSnapshot(email: "late@example.com")
+                },
+                now: { clock.now() }))
+
+        #expect(result == nil)
+        #expect(listeningPortsCallCount.value == 1)
+        #expect(fetchSnapshotCallCount.value == 0)
+    }
+
     // MARK: - Integration: fetchUsingWarmSession fast-path branch
 
     @Test
-    func warmReuse_skipsSpawnPath() async throws {
-        let spawnCallCount = LockedCounter()
+    func `warm reuse skips spawn path`() async throws {
+        let spawnCallCount = AntigravityWarmLockedCounter()
         let strategy = AntigravityCLIHTTPSFetchStrategy()
 
         let result = try await strategy.fetchUsingWarmSession(
@@ -175,9 +228,9 @@ struct AntigravityWarmAgyReuseTests {
             idleWindow: nil,
             resetAfterFetch: true,
             warmDependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
-                processInfos: { [Self.cliProcessInfo(pid: 1234)] },
+                processInfos: { _ in [Self.cliProcessInfo(pid: 1234)] },
                 listeningPorts: { _, _ in [40000] },
-                fetchSnapshot: { _ in Self.usableSnapshot(email: "warm@example.com") }),
+                fetchSnapshot: { _, _ in Self.usableSnapshot(email: "warm@example.com") }),
             spawnFetch: { _, _, _ in
                 spawnCallCount.increment()
                 Issue.record("spawn path must not run when a warm agy is reused")
@@ -192,8 +245,8 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func noWarmAgy_fallsBackToSpawnPath() async throws {
-        let spawnCallCount = LockedCounter()
+    func `no warm agy falls back to spawn path`() async throws {
+        let spawnCallCount = AntigravityWarmLockedCounter()
         let strategy = AntigravityCLIHTTPSFetchStrategy()
 
         let result = try await strategy.fetchUsingWarmSession(
@@ -201,9 +254,9 @@ struct AntigravityWarmAgyReuseTests {
             idleWindow: nil,
             resetAfterFetch: true,
             warmDependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
-                processInfos: { [] },
+                processInfos: { _ in [] },
                 listeningPorts: { _, _ in [] },
-                fetchSnapshot: { _ in throw AntigravityStatusProbeError.notRunning }),
+                fetchSnapshot: { _, _ in throw AntigravityStatusProbeError.notRunning }),
             spawnFetch: { binary, _, resetAfterFetch in
                 spawnCallCount.increment()
                 #expect(binary == "/usr/local/bin/agy")
@@ -214,6 +267,34 @@ struct AntigravityWarmAgyReuseTests {
             })
 
         #expect(result.usage.identity?.accountEmail == "spawned@example.com")
+        #expect(spawnCallCount.value == 1)
+    }
+
+    @Test
+    func `long lived session skips external warm scan`() async throws {
+        let spawnCallCount = AntigravityWarmLockedCounter()
+        let strategy = AntigravityCLIHTTPSFetchStrategy()
+
+        let result = try await strategy.fetchUsingWarmSession(
+            binary: "/usr/local/bin/agy",
+            idleWindow: 60,
+            resetAfterFetch: false,
+            warmDependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { _ in
+                    Issue.record("long-lived hosts must use their managed session")
+                    return [Self.cliProcessInfo(pid: 6301)]
+                },
+                listeningPorts: { _, _ in [] },
+                fetchSnapshot: { _, _ in throw AntigravityStatusProbeError.notRunning }),
+            spawnFetch: { _, _, resetAfterFetch in
+                spawnCallCount.increment()
+                #expect(!resetAfterFetch)
+                return strategy.makeResult(
+                    usage: Self.usableUsage(email: "managed@example.com"),
+                    sourceLabel: AntigravityCLIHTTPSFetchStrategy.sourceLabel)
+            })
+
+        #expect(result.usage.identity?.accountEmail == "managed@example.com")
         #expect(spawnCallCount.value == 1)
     }
 
@@ -258,7 +339,7 @@ struct AntigravityWarmAgyReuseTests {
     }
 }
 
-private final class LockedCounter: @unchecked Sendable {
+private final class AntigravityWarmLockedCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var count = 0
 
@@ -272,5 +353,39 @@ private final class LockedCounter: @unchecked Sendable {
 
     var value: Int {
         self.lock.withLock { self.count }
+    }
+}
+
+private final class AntigravityWarmLockedValues<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Value] = []
+
+    func append(_ value: Value) {
+        self.lock.withLock {
+            self.values.append(value)
+        }
+    }
+
+    var value: [Value] {
+        self.lock.withLock { self.values }
+    }
+}
+
+private final class AntigravityWarmTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var date: Date
+
+    init(date: Date) {
+        self.date = date
+    }
+
+    func now() -> Date {
+        self.lock.withLock { self.date }
+    }
+
+    func advance(by interval: TimeInterval) {
+        self.lock.withLock {
+            self.date = self.date.addingTimeInterval(interval)
+        }
     }
 }

--- a/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
+++ b/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
@@ -164,6 +164,26 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
+    func `other user agy is ignored`() async throws {
+        let listeningPIDs = AntigravityWarmLockedValues<Int>()
+
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2.0,
+            dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { _ in [Self.cliProcessInfo(pid: 6001), Self.cliProcessInfo(pid: 6002)] },
+                listeningPorts: { pid, _ in
+                    listeningPIDs.append(pid)
+                    return [pid]
+                },
+                fetchSnapshot: { _, _ in Self.usableSnapshot(email: "same-user@example.com") },
+                processOwnerUserID: { pid in pid == 6001 ? 502 : 501 },
+                currentUserID: { 501 }))
+
+        #expect(result?.accountEmail == "same-user@example.com")
+        #expect(listeningPIDs.value == [6002])
+    }
+
+    @Test
     func `account mismatch tries next warm agy`() async throws {
         let listeningPIDs = AntigravityWarmLockedValues<Int>()
 

--- a/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
+++ b/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
@@ -98,8 +98,8 @@ struct AntigravityWarmAgyReuseTests {
             extensionServerCSRFToken: nil,
             csrfToken: "abc123",
             commandLine:
-            // swiftlint:disable:next line_length
-            "/Applications/Antigravity IDE.app/Contents/Resources/language_server --csrf_token abc123 --app_data_dir antigravity-ide")
+            "/Applications/Antigravity IDE.app/Contents/Resources/language_server " +
+                "--csrf_token abc123 --app_data_dir antigravity-ide")
         let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
 
         let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(

--- a/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
+++ b/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
@@ -6,11 +6,11 @@ struct AntigravityWarmAgyReuseTests {
     // MARK: - Helper-seam tests (tryWarmAgyFetch)
 
     @Test
-    func `warm agy found reuses ports without spawn`() async {
+    func `warm agy found reuses ports without spawn`() async throws {
         let listeningPortsCallCount = AntigravityWarmLockedCounter()
         let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
 
-        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
                 processInfos: { _ in [Self.cliProcessInfo(pid: 9901)] },
@@ -32,8 +32,8 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func `no warm agy returns nil`() async {
-        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+    func `no warm agy returns nil`() async throws {
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
                 processInfos: { _ in [] },
@@ -50,10 +50,10 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func `process infos throws returns nil`() async {
+    func `process infos throws returns nil`() async throws {
         // detectProcessInfos throws (e.g. .missingCSRFToken / .notRunning) — the
         // fast path must swallow it and let the caller fall back to spawning.
-        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
                 processInfos: { _ in throw AntigravityStatusProbeError.missingCSRFToken },
@@ -70,10 +70,10 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func `warm agy fetch fails returns nil`() async {
+    func `warm agy fetch fails returns nil`() async throws {
         let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
 
-        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
                 processInfos: { _ in [Self.cliProcessInfo(pid: 7701)] },
@@ -89,7 +89,7 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func `ide process ignored not reuseable as warm CLI`() async {
+    func `ide process ignored not reuseable as warm CLI`() async throws {
         // An IDE language server requires a CSRF token — must NOT be reused via
         // the token-less warm path.
         let ideProcessInfo = AntigravityStatusProbe.ProcessInfoResult(
@@ -102,7 +102,7 @@ struct AntigravityWarmAgyReuseTests {
             "/Applications/Antigravity IDE.app/Contents/Resources/language_server --csrf_token abc123 --app_data_dir antigravity-ide")
         let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
 
-        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
                 processInfos: { _ in [ideProcessInfo] },
@@ -117,13 +117,13 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func `owned agy excluded falls back to spawn path`() async {
+    func `owned agy excluded falls back to spawn path`() async throws {
         // CodexBar's own managed `agy` (pid 4242) appears in the process scan.
         // It must NOT be reused through the warm path — doing so would bypass the
         // session lifecycle and let `stopIfIdle` tear it down mid-poll.
         let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
 
-        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
                 processInfos: { _ in [Self.cliProcessInfo(pid: 4242)] },
@@ -142,12 +142,12 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func `external agy reused when owned also present`() async {
+    func `external agy reused when owned also present`() async throws {
         // With both an owned `agy` (pid 4242) and an external one (pid 7000), only
         // the external server is reused; the owned pid is filtered out.
         let listeningPortsCallCount = AntigravityWarmLockedCounter()
 
-        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
                 processInfos: { _ in [Self.cliProcessInfo(pid: 4242), Self.cliProcessInfo(pid: 7000)] },
@@ -164,10 +164,10 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func `account mismatch tries next warm agy`() async {
+    func `account mismatch tries next warm agy`() async throws {
         let listeningPIDs = AntigravityWarmLockedValues<Int>()
 
-        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             expectedAccountEmail: "selected@example.com",
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
@@ -186,10 +186,10 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func `binary mismatch tries next warm agy`() async {
+    func `binary mismatch tries next warm agy`() async throws {
         let listeningPIDs = AntigravityWarmLockedValues<Int>()
 
-        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             expectedBinaryPath: "/selected/agy",
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
@@ -210,12 +210,12 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func `warm probe deadline is shared across discovery and candidates`() async {
+    func `warm probe deadline is shared across discovery and candidates`() async throws {
         let clock = AntigravityWarmTestClock(date: Date(timeIntervalSince1970: 100))
         let listeningPortsCallCount = AntigravityWarmLockedCounter()
         let fetchSnapshotCallCount = AntigravityWarmLockedCounter()
 
-        let result = await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
             timeout: 2.0,
             dependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
                 processInfos: { timeout in
@@ -292,6 +292,36 @@ struct AntigravityWarmAgyReuseTests {
 
         #expect(result.usage.identity?.accountEmail == "spawned@example.com")
         #expect(spawnCallCount.value == 1)
+    }
+
+    @Test
+    func `warm probe cancellation does not fall back to spawn`() async {
+        let spawnCallCount = AntigravityWarmLockedCounter()
+        let strategy = AntigravityCLIHTTPSFetchStrategy()
+
+        do {
+            _ = try await strategy.fetchUsingWarmSession(
+                binary: "/usr/local/bin/agy",
+                idleWindow: nil,
+                resetAfterFetch: true,
+                warmDependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                    processInfos: { _ in throw CancellationError() },
+                    listeningPorts: { _, _ in [] },
+                    fetchSnapshot: { _, _ in throw AntigravityStatusProbeError.notRunning }),
+                spawnFetch: { _, _, _ in
+                    spawnCallCount.increment()
+                    return strategy.makeResult(
+                        usage: Self.usableUsage(email: "spawned@example.com"),
+                        sourceLabel: AntigravityCLIHTTPSFetchStrategy.sourceLabel)
+                })
+            Issue.record("cancellation must be rethrown")
+        } catch is CancellationError {
+            // Expected: cancellation must not be downgraded to a warm miss.
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+
+        #expect(spawnCallCount.value == 0)
     }
 
     @Test

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -139,6 +139,10 @@ The fallback can return quota without the account email or plan fields from `Get
 Differences from the desktop local probe:
 
 - The CLI HTTPS endpoint does **not** require `X-Codeium-Csrf-Token`.
+- Before a one-shot CLI invocation launches `agy`, CodexBar spends at most two seconds looking for an already-running,
+  externally owned `agy` and reuses its tokenless local HTTPS endpoint when it returns parseable usage for the selected
+  account. Long-lived app/server refreshes keep using CodexBar's managed session, and CodexBar-owned pids are excluded
+  from external reuse so probe/idle lifecycle accounting stays balanced.
 - Readiness is endpoint-based: CodexBar retries until one of the quota endpoints parses, because fresh `agy`
   processes can bind a port before the quota service is initialized.
 - App runtime uses a bounded warm session: `agy` is kept alive briefly after a refresh, then stopped on idle. CLI runtime

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -140,9 +140,9 @@ Differences from the desktop local probe:
 
 - The CLI HTTPS endpoint does **not** require `X-Codeium-Csrf-Token`.
 - Before a one-shot CLI invocation launches `agy`, CodexBar spends at most two seconds looking for an already-running,
-  externally owned `agy` and reuses its tokenless local HTTPS endpoint when it returns parseable usage for the selected
-  account. Long-lived app/server refreshes keep using CodexBar's managed session, and CodexBar-owned pids are excluded
-  from external reuse so probe/idle lifecycle accounting stays balanced.
+  same-user `agy` at the selected binary path and reuses its tokenless local HTTPS endpoint when it returns parseable
+  usage for the selected account. Long-lived app/server refreshes keep using CodexBar's managed session, and
+  CodexBar-owned pids are excluded from external reuse so probe/idle lifecycle accounting stays balanced.
 - Readiness is endpoint-based: CodexBar retries until one of the quota endpoints parses, because fresh `agy`
   processes can bind a port before the quota service is initialized.
 - App runtime uses a bounded warm session: `agy` is kept alive briefly after a refresh, then stopped on idle. CLI runtime


### PR DESCRIPTION
## Problem

`codexbar usage --provider antigravity --source cli` starts a fresh `agy` language server for every one-shot invocation. Fresh servers bind quickly but can take several seconds before quota endpoints become ready, leaving little margin under the existing five-second readiness deadline.

## Design

Before a one-shot CLI fetch spawns `agy`, CodexBar spends at most two seconds looking for a reusable warm server. Reuse is deliberately bounded:

- CLI processes only; IDE/app servers remain on their CSRF-authenticated path.
- Same operating-system user only, because the CLI HTTPS endpoint is tokenless.
- The resolved `agy` binary only, preserving explicit binary selection and multi-install behavior.
- CodexBar-owned processes are excluded so managed-session probe/idle accounting stays balanced.
- Automatic account selection accepts only a matching account and can continue to another candidate.
- The two-second budget is shared across discovery, port lookup, and fetch.
- Cancellation is rethrown and never downgraded into a fallback spawn.
- Long-lived app/server hosts continue using `AntigravityCLISession`; external reuse is one-shot CLI only.

Any ordinary discovery, port, or fetch miss falls through to the existing managed spawn path.

## Verification

Exact head `d8170bd54d2c9ecbcb22c1610d59795f8d353778`:

- `swift test --filter AntigravityWarmAgyReuseTests`: 15 passed.
- `swift test --filter AntigravityCLIHTTPSFetchStrategyTests`: 34 passed.
- `swift test --filter AntigravityCLISessionTests`: passed.
- `make check`: clean; SwiftFormat and SwiftLint reported no violations.
- `make test`: all 44 shards passed.
- `./Scripts/lint.sh lint-linux`: clean.
- Branch-level autoreview: no actionable findings.

Live macOS provider/process proof used an existing authenticated user session and the exact release helper. Three consecutive calls returned usage in 0.68–1.45 seconds, all logged warm reuse, retained the same single external PID, and cleanup left zero processes. Cold fallback was also exercised separately: it started one managed process, returned usage, and left no process behind. No account identifiers or credentials were captured in this report.

Regression coverage includes warm reuse, ordinary fallback, IDE exclusion, managed-PID exclusion, same-user isolation, selected-binary isolation, selected-account routing, shared deadline behavior, cancellation propagation, and long-lived host lifecycle preservation.