### PR TITLE
UI polish: improve visual hierarchy in Codex limit reset credits

### DIFF
--- a/Sources/CodexBar/MenuCardView+CodexResetCredits.swift
+++ b/Sources/CodexBar/MenuCardView+CodexResetCredits.swift
@@ -8,22 +8,22 @@ struct CodexResetCreditsContent: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
+            Text(L("Limit Reset Credits"))
+                .font(.body)
+                .fontWeight(.medium)
+                .lineLimit(1)
             HStack(alignment: .firstTextBaseline) {
-                Text(L("Limit Reset Credits"))
-                    .font(.body)
-                    .fontWeight(.medium)
-                    .lineLimit(1)
-                Spacer()
                 Text(self.text)
                     .font(.footnote)
-                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    .foregroundStyle(MenuHighlightStyle.primary(self.isHighlighted))
                     .lineLimit(1)
-            }
-            if let detailText, !detailText.isEmpty {
-                Text(detailText)
-                    .font(.footnote)
-                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                    .lineLimit(1)
+                Spacer()
+                if let detailText, !detailText.isEmpty {
+                    Text(detailText)
+                        .font(.footnote)
+                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                        .lineLimit(1)
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -47,9 +47,9 @@ extension UsageMenuCardView.Model {
         }
         let count = resetCredits.availableCount
         if count == 1 {
-            return L("1 manual reset available")
+            return L("1 available")
         }
-        return String(format: L("%d manual resets available"), count)
+        return String(format: L("%d available"), count)
     }
 
     static func codexResetCreditsDetailText(input: Input) -> String? {

--- a/Sources/CodexBar/MenuCardView+CodexResetCredits.swift
+++ b/Sources/CodexBar/MenuCardView+CodexResetCredits.swift
@@ -14,9 +14,10 @@ struct CodexResetCreditsContent: View {
                 .lineLimit(1)
             HStack(alignment: .firstTextBaseline) {
                 Text(self.text)
-                    .font(.footnote)
+                    .font(.footnote.weight(.semibold))
                     .foregroundStyle(MenuHighlightStyle.primary(self.isHighlighted))
                     .lineLimit(1)
+                    .layoutPriority(1)
                 Spacer()
                 if let detailText, !detailText.isEmpty {
                     Text(detailText)

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1110,8 +1110,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "أرصدة إعادة تعيين الحد";
-"1 manual reset available" = "تتوفر إعادة تعيين يدوية واحدة";
-"%d manual resets available" = "تتوفر %d عمليات إعادة تعيين يدوية";
+"1 available" = "1 متاح";
+"%d available" = "%d متاح";
 "Next expires %@" = "تنتهي صلاحية التالية %@";
 "byte_unit_byte" = "بايت";
 "byte_unit_bytes" = "بايتات";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -961,8 +961,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Crèdits de restabliment del límit";
-"1 manual reset available" = "Hi ha 1 restabliment manual disponible";
-"%d manual resets available" = "Hi ha %d restabliments manuals disponibles";
+"1 available" = "1 disponible";
+"%d available" = "%d disponibles";
 "Next expires %@" = "El següent caduca %@";
 "Other (%d items)" = "Altres (%d elements)";
 "Expand" = "Amplia";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1104,8 +1104,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Credits zum Zurücksetzen des Limits";
-"1 manual reset available" = "1 manuelle Zurücksetzung verfügbar";
-"%d manual resets available" = "%d manuelle Zurücksetzungen verfügbar";
+"1 available" = "1 verfügbar";
+"%d available" = "%d verfügbar";
 "Next expires %@" = "Nächster Ablauf %@";
 "Other (%d items)" = "Andere (%d Elemente)";
 "Expand" = "Aufklappen";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1110,8 +1110,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Limit Reset Credits";
-"1 manual reset available" = "1 manual reset available";
-"%d manual resets available" = "%d manual resets available";
+"1 available" = "1 available";
+"%d available" = "%d available";
 "Next expires %@" = "Next expires %@";
 "byte_unit_byte" = "byte";
 "byte_unit_bytes" = "bytes";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -961,8 +961,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Créditos para restablecer límites";
-"1 manual reset available" = "1 restablecimiento manual disponible";
-"%d manual resets available" = "%d restablecimientos manuales disponibles";
+"1 available" = "1 disponible";
+"%d available" = "%d disponibles";
 "Next expires %@" = "El siguiente caduca %@";
 "Other (%d items)" = "Otros (%d elementos)";
 "Expand" = "Expandir";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1110,8 +1110,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "اعتبارهای بازنشانی محدودیت";
-"1 manual reset available" = "۱ بازنشانی دستی موجود است";
-"%d manual resets available" = "%d بازنشانی دستی موجود است";
+"1 available" = "۱ مورد موجود";
+"%d available" = "%d مورد موجود";
 "Next expires %@" = "مورد بعدی در %@ منقضی می‌شود";
 "byte_unit_byte" = "بایت";
 "byte_unit_bytes" = "بایت";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1102,8 +1102,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Crédits de réinitialisation de limite";
-"1 manual reset available" = "1 réinitialisation manuelle disponible";
-"%d manual resets available" = "%d réinitialisations manuelles disponibles";
+"1 available" = "1 disponible";
+"%d available" = "%d disponibles";
 "Next expires %@" = "Prochaine expiration %@";
 "Other (%d items)" = "Autres (%d éléments)";
 "Expand" = "Développer";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1109,8 +1109,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Kredit pengaturan ulang batas";
-"1 manual reset available" = "1 pengaturan ulang manual tersedia";
-"%d manual resets available" = "%d pengaturan ulang manual tersedia";
+"1 available" = "1 tersedia";
+"%d available" = "%d tersedia";
 "Next expires %@" = "Berikutnya kedaluwarsa %@";
 "byte_unit_byte" = "byte";
 "byte_unit_bytes" = "byte";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1109,8 +1109,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Crediti di reimpostazione limite";
-"1 manual reset available" = "1 reimpostazione manuale disponibile";
-"%d manual resets available" = "%d reimpostazioni manuali disponibili";
+"1 available" = "1 disponibile";
+"%d available" = "%d disponibili";
 "Next expires %@" = "La prossima scade %@";
 "byte_unit_byte" = "byte";
 "byte_unit_bytes" = "byte";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1103,8 +1103,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "上限リセットクレジット";
-"1 manual reset available" = "手動リセットが1回利用可能";
-"%d manual resets available" = "手動リセットが%d回利用可能";
+"1 available" = "1件利用可能";
+"%d available" = "%d件利用可能";
 "Next expires %@" = "次回の有効期限：%@";
 "Other (%d items)" = "その他（%d項目）";
 "Expand" = "展開";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1073,8 +1073,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "한도 재설정 크레딧";
-"1 manual reset available" = "수동 재설정 1회 사용 가능";
-"%d manual resets available" = "수동 재설정 %d회 사용 가능";
+"1 available" = "1회 사용 가능";
+"%d available" = "%d회 사용 가능";
 "Next expires %@" = "다음 만료: %@";
 "Other (%d items)" = "기타(%d개 항목)";
 "Expand" = "펼치기";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1102,8 +1102,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Limietresetcredits";
-"1 manual reset available" = "1 handmatige reset beschikbaar";
-"%d manual resets available" = "%d handmatige resets beschikbaar";
+"1 available" = "1 beschikbaar";
+"%d available" = "%d beschikbaar";
 "Next expires %@" = "Volgende verloopt %@";
 "Other (%d items)" = "Overig (%d onderdelen)";
 "Expand" = "Uitvouwen";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1109,8 +1109,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Kredyty resetowania limitu";
-"1 manual reset available" = "Dostępny 1 ręczny reset";
-"%d manual resets available" = "Dostępne ręczne resety: %d";
+"1 available" = "1 dostępny";
+"%d available" = "%d dostępne";
 "Next expires %@" = "Następny wygasa %@";
 "byte_unit_byte" = "bajt";
 "byte_unit_bytes" = "bajty";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1103,8 +1103,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Créditos de redefinição de limite";
-"1 manual reset available" = "1 redefinição manual disponível";
-"%d manual resets available" = "%d redefinições manuais disponíveis";
+"1 available" = "1 disponível";
+"%d available" = "%d disponíveis";
 "Next expires %@" = "Próximo expira %@";
 "Other (%d items)" = "Outros (%d itens)";
 "Expand" = "Expandir";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1101,8 +1101,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Krediter för gränsåterställning";
-"1 manual reset available" = "1 manuell återställning tillgänglig";
-"%d manual resets available" = "%d manuella återställningar tillgängliga";
+"1 available" = "1 tillgänglig";
+"%d available" = "%d tillgängliga";
 "Next expires %@" = "Nästa upphör %@";
 "Other (%d items)" = "Övrigt (%d objekt)";
 "Expand" = "Expandera";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1110,8 +1110,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "เครดิตรีเซ็ตขีดจำกัด";
-"1 manual reset available" = "มีการรีเซ็ตด้วยตนเอง 1 ครั้ง";
-"%d manual resets available" = "มีการรีเซ็ตด้วยตนเอง %d ครั้ง";
+"1 available" = "1 รายการ";
+"%d available" = "%d รายการ";
 "Next expires %@" = "รายการถัดไปหมดอายุ %@";
 "byte_unit_byte" = "ไบต์";
 "byte_unit_bytes" = "ไบต์";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1107,8 +1107,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Limit Sıfırlama Kredileri";
-"1 manual reset available" = "1 manuel sıfırlama kullanılabilir";
-"%d manual resets available" = "%d manuel sıfırlama kullanılabilir";
+"1 available" = "1 kullanılabilir";
+"%d available" = "%d kullanılabilir";
 "Next expires %@" = "Sonraki sona erme %@";
 "byte_unit_byte" = "bayt";
 "byte_unit_bytes" = "bayt";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1102,8 +1102,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Кредити скидання ліміту";
-"1 manual reset available" = "Доступне 1 ручне скидання";
-"%d manual resets available" = "Доступно ручних скидань: %d";
+"1 available" = "1 доступне";
+"%d available" = "%d доступно";
 "Next expires %@" = "Наступне спливає %@";
 "Other (%d items)" = "Інше (%d елементів)";
 "Expand" = "Розгорнути";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1103,8 +1103,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "Lượt đặt lại giới hạn";
-"1 manual reset available" = "Có 1 lần đặt lại thủ công";
-"%d manual resets available" = "Có %d lần đặt lại thủ công";
+"1 available" = "1 lượt";
+"%d available" = "%d lượt";
 "Next expires %@" = "Lượt tiếp theo hết hạn %@";
 "Other (%d items)" = "Khác (%d mục)";
 "Expand" = "Mở rộng";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1079,8 +1079,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "限额重置额度";
-"1 manual reset available" = "1 次手动重置可用";
-"%d manual resets available" = "%d 次手动重置可用";
+"1 available" = "1 次可用";
+"%d available" = "%d 次可用";
 "Next expires %@" = "下一个将于 %@ 到期";
 "Other (%d items)" = "其他（%d 项）";
 "Expand" = "展开";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -975,8 +975,8 @@
 "language_persian" = "فارسی";
 "language_thai" = "ไทย";
 "Limit Reset Credits" = "限額重設額度";
-"1 manual reset available" = "可使用 1 次手動重設";
-"%d manual resets available" = "可使用 %d 次手動重設";
+"1 available" = "1 次可用";
+"%d available" = "%d 次可用";
 "Next expires %@" = "下一個將於 %@ 到期";
 "Other (%d items)" = "其他（%d 個項目）";
 "Expand" = "展開";

--- a/Tests/CodexBarTests/CodexResetCreditsMenuCardTests.swift
+++ b/Tests/CodexBarTests/CodexResetCreditsMenuCardTests.swift
@@ -39,8 +39,56 @@ struct CodexResetCreditsMenuCardTests {
             showOptionalUsage: true,
             now: now))
 
-        #expect(model.codexResetCreditsText == "1 manual reset available")
+        #expect(model.codexResetCreditsText == "1 available")
         #expect(model.codexResetCreditsDetailText == "Next expires in 1d")
+    }
+
+    @Test
+    func `reset credits plural count uses trimmed copy`() throws {
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let now = Date(timeIntervalSince1970: 1_781_726_400)
+        let usage = UsageSnapshot(
+            primary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            codexResetCredits: CodexRateLimitResetCreditsSnapshot(
+                credits: [
+                    CodexRateLimitResetCredit(
+                        id: "reset-1",
+                        resetType: "codex_rate_limits",
+                        status: .available,
+                        grantedAt: now,
+                        expiresAt: now.addingTimeInterval(86400),
+                        redeemStartedAt: nil,
+                        redeemedAt: nil,
+                        title: "One free rate limit reset",
+                        description: nil),
+                    CodexRateLimitResetCredit(
+                        id: "reset-2",
+                        resetType: "codex_rate_limits",
+                        status: .available,
+                        grantedAt: now,
+                        expiresAt: now.addingTimeInterval(172_800),
+                        redeemStartedAt: nil,
+                        redeemedAt: nil,
+                        title: "One free rate limit reset",
+                        description: nil),
+                ],
+                availableCount: 2,
+                updatedAt: now),
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "user@example.com",
+                accountOrganization: nil,
+                loginMethod: "pro"))
+
+        let model = UsageMenuCardView.Model.make(Self.input(
+            metadata: metadata,
+            snapshot: usage,
+            showOptionalUsage: true,
+            now: now))
+
+        #expect(model.codexResetCreditsText == "2 available")
     }
 
     @Test


### PR DESCRIPTION
# Summary
Reworks the "Limit Reset Credits" section so the remaining-reset count is the visual hero, addressing the weak hierarchy described in #1791.

---
## Image proof 
(affected section shown below the weekly limit tracker in the Codex provider)

**Before PR**

<img width="296" height="170" alt="image" src="https://github.com/user-attachments/assets/d9af4f18-ef2a-49ef-b7fb-28151341e92c" />


**After PR**

<img width="302" height="149" alt="image" src="https://github.com/user-attachments/assets/52dac213-6a5f-41a9-ac7b-40f6ea6df3de" />

---

## Design decisions
- Moved the expiration detail to the right side to match the visual pattern of session + weekly trackers
- Bolded the numberr of remaining resets to draw attention there rather than the header alone or the expiration tracker
- Did not add a new divider between the section and the daily breakdown (retained current `main` behavior)

## Changes made
- Move the reset count off the header baseline onto its own footer row, removing the `.footnote`-next-to-`.body` baseline mismatch.
- Promote the count to full-strength `MenuHighlightStyle.primary`, keeping "Next expires …" as `.secondary` on the trailing edge (reuses the existing `MetricRow` color-weight idiom, no new font sizes or chrome).
- Trim the copy from "N manual resets available" to "N available" since the section title already says what they are; updated across all localized `Localizable.strings` keys.

## Test plan
- [x] `swift test --filter CodexResetCreditsMenuCardTests` (singular + new plural-count case pass)
- [x] `make check` (SwiftFormat + SwiftLint, 0 violations)
- [ ] Visual check in the menu bar card

Closes #1791