### PR TITLE
docs: add T3 Chat provider detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See [CLI configuration](docs/cli-configuration.md) for the full flow.
 - [z.ai](docs/zai.md) — API token for personal/team quota, MCP, 5-hour, and hourly usage windows.
 - [Manus](docs/manus.md) — Browser `session_id` auth for credit balance, monthly credits, and daily refresh tracking.
 - [MiniMax](docs/minimax.md) — API token, cookie header, or browser cookies for coding-plan usage.
-- [T3 Chat](docs/providers.md#t3-chat) — Browser cookies capture for Base and Overage usage buckets.
+- [T3 Chat](docs/t3chat.md) — Browser cookies capture for Base and Overage usage buckets.
 - [Kimi](docs/kimi.md) — Auth token (JWT from `kimi-auth` cookie) for weekly quota + 5‑hour rate limit.
 - [Kimi K2 (unofficial)](docs/kimi-k2.md) — Legacy API key flow for credit-based usage totals.
 - [Kilo](docs/kilo.md) — API token with CLI-auth fallback for Kilo Pass usage.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -278,6 +278,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Parses JSONL response lines and extracts customer data from the embedded tRPC payload.
 - Shows the 4-hour Base bucket and monthly Overage bucket documented in the T3 Chat FAQ.
 - Status: none yet.
+- Details: `docs/t3chat.md`.
 
 ## Ollama
 - Web settings page (`https://ollama.com/settings`) via browser cookies.

--- a/docs/t3chat.md
+++ b/docs/t3chat.md
@@ -40,17 +40,7 @@ To capture the cookie manually:
 4. Right-click → Copy → Copy as cURL.
 5. Paste the full `curl` command into the **T3 Chat cookie** field in CodexBar settings.
 
-Environment variable override:
-
-```bash
-export T3_CHAT_COOKIE="cookie-value-here"
-```
-
-Or pass it directly on the command line:
-
-```bash
-codexbar usage --provider t3chat --cookie "cookie-value-here"
-```
+T3 Chat does not support a standalone environment variable or a `--cookie` CLI flag. The only manual path is the Settings field above.
 
 ## Data Source
 

--- a/docs/t3chat.md
+++ b/docs/t3chat.md
@@ -21,8 +21,8 @@ The T3 Chat provider tracks the 4-hour Base and monthly Overage usage buckets fr
 CodexBar imports your browser session cookie automatically. CodexBar sends the cookie only to
 `https://t3.chat`.
 
-**Note**: Automatic import requires Full Disk Access to read browser cookies
-(System Settings → Privacy & Security → Full Disk Access → CodexBar).
+**Note**: Browser cookie import may require Full Disk Access (especially for Safari) or macOS
+Keychain approval (for Chromium-based browsers).
 
 ### Manual
 
@@ -90,7 +90,8 @@ codexbar usage --provider t3-chat
 codexbar usage --provider t3
 ```
 
-T3 Chat provides no token cost data; the `--format json` cost fields will be empty.
+T3 Chat provides no token-cost data. The `usage --format json` output contains usage and identity
+data, while `codexbar cost --provider t3chat` is unsupported.
 
 ## Common errors
 

--- a/docs/t3chat.md
+++ b/docs/t3chat.md
@@ -1,0 +1,122 @@
+---
+summary: "T3 Chat provider auth, tRPC endpoint, and quota windows."
+read_when:
+  - Adding or modifying the T3 Chat provider
+  - Debugging T3 Chat cookie import or usage parsing
+  - Explaining T3 Chat setup
+---
+
+# T3 Chat Provider
+
+The T3 Chat provider tracks the 4-hour Base and monthly Overage usage buckets from
+[t3.chat](https://t3.chat).
+
+## Setup
+
+### Automatic (recommended)
+
+1. Sign in to T3 Chat in any supported browser.
+2. Enable **T3 Chat** in **Settings → Providers**.
+
+CodexBar imports your browser session cookie automatically. CodexBar sends the cookie only to
+`https://t3.chat`.
+
+**Note**: Automatic import requires Full Disk Access to read browser cookies
+(System Settings → Privacy & Security → Full Disk Access → CodexBar).
+
+### Manual
+
+Set **Cookie source** to **Manual** in the T3 Chat provider settings, then paste either:
+
+- A bare `Cookie: ...` header value copied from a browser network request to `t3.chat`, or
+- A full `curl` command captured from the T3 Chat settings page (all `-H` flags are parsed;
+  only the `Cookie` header and a fixed set of safe request headers are forwarded).
+
+To capture the cookie manually:
+
+1. Open [t3.chat/settings/customization](https://t3.chat/settings/customization) in your browser.
+2. Open Developer Tools → Network tab.
+3. Reload the page and find a `getCustomerData` tRPC request.
+4. Right-click → Copy → Copy as cURL.
+5. Paste the full `curl` command into the **T3 Chat cookie** field in CodexBar settings.
+
+Environment variable override:
+
+```bash
+export T3_CHAT_COOKIE="cookie-value-here"
+```
+
+Or pass it directly on the command line:
+
+```bash
+codexbar usage --provider t3chat --cookie "cookie-value-here"
+```
+
+## Data Source
+
+CodexBar sends one GET request per refresh:
+
+```text
+GET https://t3.chat/api/trpc/getCustomerData?batch=1&input=...
+```
+
+The response is JSONL. CodexBar scans each line for the embedded `getCustomerData` tRPC result
+object and decodes it to a `T3ChatCustomerData` struct. No other T3 Chat endpoints are called.
+
+### Fields mapped to usage windows
+
+| Source field | CodexBar label | Notes |
+|---|---|---|
+| `usageFourHourPercentage` | **Base** (primary) | 4-hour rolling window; 0–100 |
+| `usageFourHourNextResetAt` | Base reset time | JavaScript epoch ms or Unix seconds |
+| `usageWindowNextResetAt` | Base reset time (fallback) | Used when `usageFourHourNextResetAt` is absent |
+| `usageMonthPercentage` | **Overage** (secondary) | Monthly overage window |
+| `usagePeriodPercentage` | Overage (fallback) | Used when `usageMonthPercentage` is absent |
+| `subscription.currentPeriodEnd` | Overage reset time | Billing period end; absent on some plans |
+| `usageBand` | Base label suffix | e.g. `"standard"` appended as "Base - standard" |
+| `subTier` / `subscription.productName` | Plan name | Shown as the account identity in the menu |
+
+Timestamps larger than 10 billion are treated as milliseconds; smaller values are treated as Unix
+seconds.
+
+## Usage Windows
+
+**Base window (primary)**: 4-hour rolling rate-limit bucket. Tracks the percentage of the hourly
+model-generation allowance consumed since the window opened. Resets approximately every 4 hours on
+T3 Chat's server clock.
+
+**Overage window (secondary)**: Monthly overage budget. Tracks spend beyond the included plan
+allowance. Reset timing comes from the active subscription's current-period end; if no subscription
+metadata is present, the reset time is shown as unknown.
+
+## CLI
+
+```bash
+# Show T3 Chat usage
+codexbar usage --provider t3chat
+
+# Or use the alias
+codexbar usage --provider t3-chat
+codexbar usage --provider t3
+```
+
+T3 Chat provides no token cost data; the `--format json` cost fields will be empty.
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `No T3 Chat cookies found` | No browser session for `t3.chat` | Sign in to T3 Chat in a supported browser and try automatic mode |
+| `T3 Chat session cookie is invalid or expired` | Stale or revoked session cookie | Sign out of T3 Chat, sign back in, then refresh CodexBar or repaste the cookie |
+| `T3 Chat returned a Vercel security challenge` | Manual Cookie header was used but T3 Chat requires additional Vercel request headers | Paste a full `curl` capture instead of a bare Cookie header |
+| `Could not parse T3 Chat usage` | T3 Chat changed its tRPC response shape | Open a CodexBar issue with a redacted response sample |
+| `HTTP 401` / `HTTP 403` | Session expired or account not found | Re-authenticate |
+| `HTTP 429` with `x-vercel-mitigated: challenge` | Rate-limited by Vercel edge | Wait a few minutes, then retry with a full cURL capture |
+
+## Key files
+
+- `Sources/CodexBarCore/Providers/T3Chat/T3ChatProviderDescriptor.swift` — provider metadata and fetch pipeline
+- `Sources/CodexBarCore/Providers/T3Chat/T3ChatUsageFetcher.swift` — tRPC request, cookie import, and cURL parsing
+- `Sources/CodexBarCore/Providers/T3Chat/T3ChatUsageSnapshot.swift` — response decoding and window mapping
+- `Sources/CodexBar/Providers/T3Chat/T3ChatProviderImplementation.swift` — settings pickers and bindings
+- `Sources/CodexBar/Providers/T3Chat/T3ChatSettingsStore.swift` — cookie source and header persistence


### PR DESCRIPTION
## Summary

Adds a dedicated T3 Chat provider guide and links it from the provider indexes.

The guide is derived from the current provider descriptor, fetcher, snapshot mapping, settings implementation, and CLI behavior. It covers automatic and manual cookie setup, the tRPC data source, quota fields, CLI aliases, and troubleshooting without documenting unsupported credential paths.

## Changes

- Add `docs/t3chat.md` with setup, data source, field mapping, usage windows, CLI, errors, and source pointers.
- Link the guide from `docs/providers.md` and `README.md`.
- Clarify browser-cookie permission behavior for Safari and Chromium-based browsers.
- Document that T3 Chat has no token-cost support and that `codexbar cost --provider t3chat` is unsupported.

## Validation

- `node Scripts/check-documentation-links.mjs`
- `node Scripts/check-site-locales.mjs`
- `node Scripts/generate-llms.mjs --check`
- `make docs-list`
- `swift test --filter T3ChatUsageFetcherTests` (12 tests passed)
- `make check` (0 lint violations)
- Ad-hoc `./Scripts/package_app.sh` package and packaged `CodexBarCLI` checks:
  - `config validate` passed.
  - T3 Chat provider selection reached the live fetch path and returned the expected missing-session error; no authenticated T3 Chat session was available on this machine.
  - `cost --provider t3chat` returned the documented unsupported-provider error.
- Autoreview: clean; no accepted/actionable findings.

## Live-proof limit

An authenticated T3 Chat usage response could not be exercised because this machine has no configured manual T3 cookie, the provider is disabled in local config, and no existing Chrome session was attachable. Request construction, JSONL parsing, quota mapping, cURL-header forwarding, invalid-auth handling, and Vercel-challenge handling are covered by the focused test suite.
