### PR TITLE
[codex] Bound Claude web fetch duration

### DIFF
--- a/Sources/CodexBarCLI/CLIHelpers.swift
+++ b/Sources/CodexBarCLI/CLIHelpers.swift
@@ -248,11 +248,16 @@ extension CodexBarCLI {
         return nil
     }
 
-    static func decodeWebTimeout(from values: ParsedValues) -> TimeInterval? {
-        if let raw = values.options["webTimeout"]?.last, let seconds = Double(raw) {
-            return seconds
+    static func decodeWebTimeout(from values: ParsedValues) throws -> TimeInterval? {
+        guard let raw = values.options["webTimeout"]?.last else { return nil }
+        guard let seconds = Double(raw),
+              seconds.isFinite,
+              seconds >= 0,
+              seconds <= TimeInterval(Int64.max)
+        else {
+            throw CLIArgumentError("--web-timeout must be a finite, nonnegative number within the supported range.")
         }
-        return nil
+        return seconds
     }
 
     static func decodeSourceMode(from values: ParsedValues) -> ProviderSourceMode? {
@@ -397,8 +402,8 @@ extension CodexBarCLI {
         self.decodeFormat(from: values)
     }
 
-    static func _decodeWebTimeoutForTesting(from values: ParsedValues) -> TimeInterval? {
-        self.decodeWebTimeout(from: values)
+    static func _decodeWebTimeoutForTesting(from values: ParsedValues) throws -> TimeInterval? {
+        try self.decodeWebTimeout(from: values)
     }
 
     static func _decodeSourceModeForTesting(from values: ParsedValues) -> ProviderSourceMode? {

--- a/Sources/CodexBarCLI/CLIHelpers.swift
+++ b/Sources/CodexBarCLI/CLIHelpers.swift
@@ -302,6 +302,7 @@ extension CodexBarCLI {
         case CodexStatusProbeError.timedOut,
              TTYCommandRunner.Error.timedOut,
              GeminiStatusProbeError.timedOut,
+             ClaudeWebFetchStrategyError.timedOut,
              CostUsageError.timedOut:
             ExitCode(4)
         case ClaudeUsageError.parseFailed,

--- a/Sources/CodexBarCLI/CLIOptions.swift
+++ b/Sources/CodexBarCLI/CLIOptions.swift
@@ -63,7 +63,7 @@ struct UsageOptions: CommanderParsable {
     @Option(name: .long("source"), help: Self.sourceHelp)
     var source: String?
 
-    @Option(name: .long("web-timeout"), help: "Web fetch timeout (seconds) (Codex only; source=web)")
+    @Option(name: .long("web-timeout"), help: "Web fetch timeout (seconds; source=auto or web)")
     var webTimeout: Double?
 
     @Flag(name: .long("web-debug-dump-html"), help: "Dump HTML snapshots to /tmp when Codex dashboard data is missing")

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -62,7 +62,12 @@ extension CodexBarCLI {
         let antigravityPlanDebug = values.flags.contains("antigravityPlanDebug")
         let augmentDebug = values.flags.contains("augmentDebug")
         let webDebugDumpHTML = values.flags.contains("webDebugDumpHtml")
-        let webTimeout = Self.decodeWebTimeout(from: values) ?? 60
+        let webTimeout: TimeInterval
+        do {
+            webTimeout = try Self.decodeWebTimeout(from: values) ?? 60
+        } catch {
+            Self.exit(code: .failure, message: "Error: \(error.localizedDescription)", output: output, kind: .args)
+        }
         let verbose = values.flags.contains("verbose")
         let noColor = values.flags.contains("noColor")
         let useColor = Self.shouldUseColor(noColor: noColor, format: format)
@@ -580,6 +585,10 @@ extension CodexBarCLI {
             return false
         }
         if provider == .codex, sourceMode == .auto {
+            return false
+        }
+        if provider == .claude, sourceMode == .auto {
+            // Claude's cross-platform planner skips its unavailable web step and falls back to the CLI.
             return false
         }
         if provider == .opencodego {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -67,7 +67,8 @@ public enum ClaudeProviderDescriptor {
                     useWebExtras: context.runtime == .app
                         && planningInput.webExtrasEnabled,
                     manualCookieHeader: manualCookieHeader,
-                    browserDetection: context.browserDetection)
+                    browserDetection: context.browserDetection,
+                    hasWebFallback: planningInput.hasWebSession)
             case .auto:
                 fatalError("Planner must not emit .auto as an executable step.")
             }
@@ -82,19 +83,46 @@ public enum ClaudeProviderDescriptor {
     private static func makePlanningInput(context: ProviderFetchContext) async -> ClaudeSourcePlanningInput {
         let webExtrasEnabled = context.settings?.claude?.webExtrasEnabled ?? false
         let needsOAuthAvailability = context.runtime == .app && context.sourceMode == .auto
+        let hasWebSession = await Self.hasWebSessionForPlanning(context: context)
 
         return ClaudeSourcePlanningInput(
             runtime: context.runtime,
             selectedDataSource: Self.sourceDataSource(from: context.sourceMode),
             webExtrasEnabled: webExtrasEnabled,
-            hasWebSession: ClaudeWebFetchStrategy.isAvailableForFallback(
-                context: context,
-                browserDetection: context.browserDetection),
+            hasWebSession: hasWebSession,
             hasCLI: ClaudeCLIResolver.isAvailable(environment: context.env),
             hasOAuthCredentials: needsOAuthAvailability && ClaudeOAuthPlanningAvailability.isAvailable(
                 runtime: context.runtime,
                 sourceMode: context.sourceMode,
                 environment: context.env))
+    }
+
+    private static func hasWebSessionForPlanning(context: ProviderFetchContext) async -> Bool {
+        switch context.sourceMode {
+        case .api, .oauth, .cli:
+            return false
+        case .web:
+            // Explicit web performs its cookie/session work inside the bounded fetch.
+            return context.settings?.claude?.cookieSource != .off
+        case .auto:
+            break
+        }
+
+        switch context.settings?.claude?.cookieSource {
+        case .off?:
+            return false
+        case .manual?:
+            return ClaudeWebFetchStrategy.hasManualSessionKey(context: context)
+        case .auto?, nil:
+            if context.runtime == .cli {
+                // CLI auto deliberately tries web before CLI. Defer browser-cookie inspection to the
+                // bounded web fetch so stale cookie/keychain work shares the web deadline.
+                return true
+            }
+            return await ClaudeWebFetchStrategy.hasBrowserSessionKey(
+                context: context,
+                before: context.webTimeout)
+        }
     }
 
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
@@ -376,6 +404,12 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
 struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     typealias UsageLoader = @Sendable (ProviderFetchContext) async throws -> ClaudeUsageSnapshot
 
+    #if DEBUG
+    @TaskLocal static var availabilityProbeOverrideForTesting:
+        (@Sendable (ProviderFetchContext, BrowserDetection) -> Bool)?
+    @TaskLocal static var usageLoaderOverrideForTesting: UsageLoader?
+    #endif
+
     let id: String = "claude.web"
     let kind: ProviderFetchKind = .web
     let browserDetection: BrowserDetection
@@ -390,7 +424,16 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        Self.isAvailableForFallback(context: context, browserDetection: self.browserDetection)
+        switch context.settings?.claude?.cookieSource {
+        case .off?:
+            false
+        case .manual?:
+            Self.hasManualSessionKey(context: context)
+        case .auto?, nil:
+            // Browser-cookie work can block on browser/Keychain access. Treat it as plausible and
+            // let fetch perform the real import under webTimeout.
+            true
+        }
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
@@ -413,15 +456,31 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         return context.runtime == .cli
     }
 
-    fileprivate static func isAvailableForFallback(
+    fileprivate static func hasManualSessionKey(context: ProviderFetchContext) -> Bool {
+        ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: self.manualCookieHeader(from: context))
+    }
+
+    fileprivate static func hasBrowserSessionKey(
         context: ProviderFetchContext,
-        browserDetection: BrowserDetection) -> Bool
+        before timeout: TimeInterval) async -> Bool
     {
-        if let header = self.manualCookieHeader(from: context) {
-            return ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: header)
+        guard let timeoutDuration = Self.timeoutDuration(timeout) else { return false }
+        let browserDetection = context.browserDetection
+        let sourceTask = Task<Bool, Error> {
+            #if DEBUG
+            if let override = Self.availabilityProbeOverrideForTesting {
+                return override(context, browserDetection)
+            }
+            #endif
+            return ClaudeWebAPIFetcher.hasSessionKey(browserDetection: browserDetection)
         }
-        guard context.settings?.claude?.cookieSource != .off else { return false }
-        return ClaudeWebAPIFetcher.hasSessionKey(browserDetection: browserDetection)
+        let race = BoundedTaskJoin(sourceTask: sourceTask)
+        switch await race.value(joinGrace: timeoutDuration) {
+        case let .value(isAvailable):
+            return isAvailable
+        case .failure, .timedOut:
+            return false
+        }
     }
 
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
@@ -433,16 +492,18 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         before timeout: TimeInterval,
         context: ProviderFetchContext) async throws -> ClaudeUsageSnapshot
     {
-        guard timeout.isFinite,
-              timeout >= 0,
-              timeout <= TimeInterval(Int64.max)
-        else {
+        guard let timeoutDuration = Self.timeoutDuration(timeout) else {
             throw ClaudeWebFetchStrategyError.invalidTimeout
         }
         let sourceTask = Task<ClaudeUsageSnapshot, Error> {
             if let usageLoader = self.usageLoader {
                 return try await usageLoader(context)
             }
+            #if DEBUG
+            if let usageLoader = Self.usageLoaderOverrideForTesting {
+                return try await usageLoader(context)
+            }
+            #endif
             let fetcher = ClaudeUsageFetcher(
                 browserDetection: self.browserDetection,
                 dataSource: .web,
@@ -452,7 +513,7 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             return try await fetcher.loadLatestUsage(model: "sonnet")
         }
         let race = BoundedTaskJoin(sourceTask: sourceTask)
-        switch await race.value(joinGrace: .seconds(timeout)) {
+        switch await race.value(joinGrace: timeoutDuration) {
         case let .value(usage):
             try Task.checkCancellation()
             return usage
@@ -462,6 +523,16 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             try Task.checkCancellation()
             throw ClaudeWebFetchStrategyError.timedOut(seconds: timeout)
         }
+    }
+
+    private static func timeoutDuration(_ timeout: TimeInterval) -> Duration? {
+        guard timeout.isFinite,
+              timeout >= 0,
+              timeout <= TimeInterval(Int64.max)
+        else {
+            return nil
+        }
+        return .seconds(timeout)
     }
 }
 
@@ -485,6 +556,7 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
     let useWebExtras: Bool
     let manualCookieHeader: String?
     let browserDetection: BrowserDetection
+    let hasWebFallback: Bool
 
     func isAvailable(_: ProviderFetchContext) async -> Bool {
         true
@@ -508,9 +580,7 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
         guard context.runtime == .app, context.sourceMode == .auto else { return false }
-        // Only fall through when web is actually available; otherwise preserve actionable CLI errors.
-        return ClaudeWebFetchStrategy.isAvailableForFallback(
-            context: context,
-            browserDetection: self.browserDetection)
+        // Reuse the bounded planning result instead of repeating browser/Keychain work after CLI failure.
+        return self.hasWebFallback
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -402,7 +402,12 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
         guard context.sourceMode == .auto else { return false }
-        _ = error
+        guard !Task.isCancelled,
+              !(error is CancellationError),
+              (error as? URLError)?.code != .cancelled
+        else {
+            return false
+        }
         // In CLI runtime auto mode, web comes before CLI so fallback is required.
         // In app runtime auto mode, web is terminal and should surface its concrete error.
         return context.runtime == .cli
@@ -428,6 +433,12 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         before timeout: TimeInterval,
         context: ProviderFetchContext) async throws -> ClaudeUsageSnapshot
     {
+        guard timeout.isFinite,
+              timeout >= 0,
+              timeout <= TimeInterval(Int64.max)
+        else {
+            throw ClaudeWebFetchStrategyError.invalidTimeout
+        }
         let sourceTask = Task<ClaudeUsageSnapshot, Error> {
             if let usageLoader = self.usageLoader {
                 return try await usageLoader(context)
@@ -441,7 +452,7 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             return try await fetcher.loadLatestUsage(model: "sonnet")
         }
         let race = BoundedTaskJoin(sourceTask: sourceTask)
-        switch await race.value(joinGrace: .seconds(max(0, timeout))) {
+        switch await race.value(joinGrace: .seconds(timeout)) {
         case let .value(usage):
             try Task.checkCancellation()
             return usage
@@ -455,10 +466,13 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
 }
 
 enum ClaudeWebFetchStrategyError: LocalizedError, Equatable, Sendable {
+    case invalidTimeout
     case timedOut(seconds: TimeInterval)
 
     var errorDescription: String? {
         switch self {
+        case .invalidTimeout:
+            "Claude web usage fetch timeout must be a finite, nonnegative value within the supported range."
         case let .timedOut(seconds):
             "Claude web usage fetch timed out after \(seconds.formatted()) seconds."
         }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -108,6 +108,8 @@ public enum ClaudeProviderDescriptor {
             break
         }
 
+        guard ClaudeWebFetchStrategy.isSupportedOnCurrentPlatform else { return false }
+
         switch context.settings?.claude?.cookieSource {
         case .off?:
             return false
@@ -401,8 +403,31 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
     }
 }
 
+private final class ClaudeWebFetchDeadlineState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deadline: ContinuousClock.Instant?
+
+    func remainingBudget(
+        fullBudget: Duration,
+        now: ContinuousClock.Instant) -> Duration
+    {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+
+        let deadline: ContinuousClock.Instant
+        if let existingDeadline = self.deadline {
+            deadline = existingDeadline
+        } else {
+            deadline = now.advanced(by: fullBudget)
+            self.deadline = deadline
+        }
+        return max(.zero, now.duration(to: deadline))
+    }
+}
+
 struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     typealias UsageLoader = @Sendable (ProviderFetchContext) async throws -> ClaudeUsageSnapshot
+    typealias DeadlineNow = @Sendable () -> ContinuousClock.Instant
 
     #if DEBUG
     @TaskLocal static var availabilityProbeOverrideForTesting:
@@ -414,24 +439,41 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .web
     let browserDetection: BrowserDetection
     private let usageLoader: UsageLoader?
+    private let deadlineState: ClaudeWebFetchDeadlineState
+    private let deadlineNow: DeadlineNow
 
     init(
         browserDetection: BrowserDetection,
-        usageLoader: UsageLoader? = nil)
+        usageLoader: UsageLoader? = nil,
+        deadlineNow: @escaping DeadlineNow = { ContinuousClock.now })
     {
         self.browserDetection = browserDetection
         self.usageLoader = usageLoader
+        self.deadlineState = ClaudeWebFetchDeadlineState()
+        self.deadlineNow = deadlineNow
     }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        switch context.settings?.claude?.cookieSource {
+        let appAutoRemainingBudget: Duration?
+        if context.runtime == .app, context.sourceMode == .auto {
+            guard let fullBudget = Self.timeoutDuration(context.webTimeout) else { return false }
+            let remainingBudget = self.deadlineState.remainingBudget(
+                fullBudget: fullBudget,
+                now: self.deadlineNow())
+            guard remainingBudget > .zero else { return false }
+            appAutoRemainingBudget = remainingBudget
+        } else {
+            appAutoRemainingBudget = nil
+        }
+
+        return switch context.settings?.claude?.cookieSource {
         case .off?:
             false
         case .manual?:
             Self.hasManualSessionKey(context: context)
         case .auto?, nil:
-            if context.runtime == .app, context.sourceMode == .auto {
-                await Self.hasBrowserSessionKey(context: context, before: context.webTimeout)
+            if let appAutoRemainingBudget {
+                await Self.hasBrowserSessionKey(context: context, before: appAutoRemainingBudget)
             } else {
                 // Explicit web and CLI auto perform the real browser import inside the bounded fetch.
                 true
@@ -465,9 +507,8 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
 
     fileprivate static func hasBrowserSessionKey(
         context: ProviderFetchContext,
-        before timeout: TimeInterval) async -> Bool
+        before timeout: Duration) async -> Bool
     {
-        guard let timeoutDuration = Self.timeoutDuration(timeout) else { return false }
         let browserDetection = context.browserDetection
         let sourceTask = Task<Bool, Error> {
             #if DEBUG
@@ -478,7 +519,7 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             return ClaudeWebAPIFetcher.hasSessionKey(browserDetection: browserDetection)
         }
         let race = BoundedTaskJoin(sourceTask: sourceTask)
-        switch await race.value(joinGrace: timeoutDuration) {
+        switch await race.value(joinGrace: timeout) {
         case let .value(isAvailable):
             return isAvailable
         case .failure, .timedOut:
@@ -498,6 +539,13 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         guard let timeoutDuration = Self.timeoutDuration(timeout) else {
             throw ClaudeWebFetchStrategyError.invalidTimeout
         }
+        let remainingBudget = self.deadlineState.remainingBudget(
+            fullBudget: timeoutDuration,
+            now: self.deadlineNow())
+        guard remainingBudget > .zero else {
+            try Task.checkCancellation()
+            throw ClaudeWebFetchStrategyError.timedOut(seconds: timeout)
+        }
         let sourceTask = Task<ClaudeUsageSnapshot, Error> {
             if let usageLoader = self.usageLoader {
                 return try await usageLoader(context)
@@ -516,7 +564,7 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             return try await fetcher.loadLatestUsage(model: "sonnet")
         }
         let race = BoundedTaskJoin(sourceTask: sourceTask)
-        switch await race.value(joinGrace: timeoutDuration) {
+        switch await race.value(joinGrace: remainingBudget) {
         case let .value(usage):
             try Task.checkCancellation()
             return usage
@@ -536,6 +584,14 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             return nil
         }
         return .seconds(timeout)
+    }
+
+    fileprivate static var isSupportedOnCurrentPlatform: Bool {
+        #if os(macOS)
+        true
+        #else
+        false
+        #endif
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -50,7 +50,7 @@ public enum ClaudeProviderDescriptor {
             return [ClaudeAdminAPIFetchStrategy()]
         }
 
-        let planningInput = await Self.makePlanningInput(context: context)
+        let planningInput = Self.makePlanningInput(context: context)
         let plan = ClaudeSourcePlanner.resolve(input: planningInput)
         let manualCookieHeader = Self.manualCookieHeader(from: context)
 
@@ -80,10 +80,10 @@ public enum ClaudeProviderDescriptor {
         context.sourceMode == .auto && ClaudeAdminAPISettingsReader.apiKey(environment: context.env) != nil
     }
 
-    private static func makePlanningInput(context: ProviderFetchContext) async -> ClaudeSourcePlanningInput {
+    private static func makePlanningInput(context: ProviderFetchContext) -> ClaudeSourcePlanningInput {
         let webExtrasEnabled = context.settings?.claude?.webExtrasEnabled ?? false
         let needsOAuthAvailability = context.runtime == .app && context.sourceMode == .auto
-        let hasWebSession = await Self.hasWebSessionForPlanning(context: context)
+        let hasWebSession = Self.hasPlausibleWebSession(context: context)
 
         return ClaudeSourcePlanningInput(
             runtime: context.runtime,
@@ -97,7 +97,7 @@ public enum ClaudeProviderDescriptor {
                 environment: context.env))
     }
 
-    private static func hasWebSessionForPlanning(context: ProviderFetchContext) async -> Bool {
+    private static func hasPlausibleWebSession(context: ProviderFetchContext) -> Bool {
         switch context.sourceMode {
         case .api, .oauth, .cli:
             return false
@@ -114,14 +114,10 @@ public enum ClaudeProviderDescriptor {
         case .manual?:
             return ClaudeWebFetchStrategy.hasManualSessionKey(context: context)
         case .auto?, nil:
-            if context.runtime == .cli {
-                // CLI auto deliberately tries web before CLI. Defer browser-cookie inspection to the
-                // bounded web fetch so stale cookie/keychain work shares the web deadline.
-                return true
-            }
-            return await ClaudeWebFetchStrategy.hasBrowserSessionKey(
-                context: context,
-                before: context.webTimeout)
+            // Browser/Keychain inspection can block. Keep planning synchronous and let the web step
+            // perform the bounded availability check if app-auto actually reaches its last fallback.
+            // CLI auto continues to perform its real session import inside the bounded web fetch.
+            return true
         }
     }
 
@@ -198,10 +194,14 @@ private struct ClaudePlannedFetchStrategy: ProviderFetchStrategy {
     }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        if context.sourceMode == .auto {
-            return self.plannedStep.isPlausiblyAvailable
+        guard context.sourceMode == .auto else {
+            return await self.base.isAvailable(context)
         }
-        return await self.base.isAvailable(context)
+        guard self.plannedStep.isPlausiblyAvailable else { return false }
+        if context.runtime == .app, self.plannedStep.dataSource == .web {
+            return await self.base.isAvailable(context)
+        }
+        return true
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
@@ -430,9 +430,12 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         case .manual?:
             Self.hasManualSessionKey(context: context)
         case .auto?, nil:
-            // Browser-cookie work can block on browser/Keychain access. Treat it as plausible and
-            // let fetch perform the real import under webTimeout.
-            true
+            if context.runtime == .app, context.sourceMode == .auto {
+                await Self.hasBrowserSessionKey(context: context, before: context.webTimeout)
+            } else {
+                // Explicit web and CLI auto perform the real browser import inside the bounded fetch.
+                true
+            }
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -374,22 +374,27 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
 }
 
 struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
+    typealias UsageLoader = @Sendable (ProviderFetchContext) async throws -> ClaudeUsageSnapshot
+
     let id: String = "claude.web"
     let kind: ProviderFetchKind = .web
     let browserDetection: BrowserDetection
+    private let usageLoader: UsageLoader?
+
+    init(
+        browserDetection: BrowserDetection,
+        usageLoader: UsageLoader? = nil)
+    {
+        self.browserDetection = browserDetection
+        self.usageLoader = usageLoader
+    }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         Self.isAvailableForFallback(context: context, browserDetection: self.browserDetection)
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let fetcher = ClaudeUsageFetcher(
-            browserDetection: browserDetection,
-            dataSource: .web,
-            useWebExtras: false,
-            manualCookieHeader: Self.manualCookieHeader(from: context),
-            webOrganizationID: context.settings?.claude?.organizationID)
-        let usage = try await fetcher.loadLatestUsage(model: "sonnet")
+        let usage = try await self.loadUsage(before: context.webTimeout, context: context)
         return self.makeResult(
             usage: ClaudeOAuthFetchStrategy.snapshot(from: usage),
             sourceLabel: "web")
@@ -417,6 +422,46 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
         guard context.settings?.claude?.cookieSource == .manual else { return nil }
         return CookieHeaderNormalizer.normalize(context.settings?.claude?.manualCookieHeader)
+    }
+
+    private func loadUsage(
+        before timeout: TimeInterval,
+        context: ProviderFetchContext) async throws -> ClaudeUsageSnapshot
+    {
+        let sourceTask = Task<ClaudeUsageSnapshot, Error> {
+            if let usageLoader = self.usageLoader {
+                return try await usageLoader(context)
+            }
+            let fetcher = ClaudeUsageFetcher(
+                browserDetection: self.browserDetection,
+                dataSource: .web,
+                useWebExtras: false,
+                manualCookieHeader: Self.manualCookieHeader(from: context),
+                webOrganizationID: context.settings?.claude?.organizationID)
+            return try await fetcher.loadLatestUsage(model: "sonnet")
+        }
+        let race = BoundedTaskJoin(sourceTask: sourceTask)
+        switch await race.value(joinGrace: .seconds(max(0, timeout))) {
+        case let .value(usage):
+            try Task.checkCancellation()
+            return usage
+        case let .failure(error):
+            throw error
+        case .timedOut:
+            try Task.checkCancellation()
+            throw ClaudeWebFetchStrategyError.timedOut(seconds: timeout)
+        }
+    }
+}
+
+enum ClaudeWebFetchStrategyError: LocalizedError, Equatable, Sendable {
+    case timedOut(seconds: TimeInterval)
+
+    var errorDescription: String? {
+        switch self {
+        case let .timedOut(seconds):
+            "Claude web usage fetch timed out after \(seconds.formatted()) seconds."
+        }
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -465,11 +465,11 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     }
 }
 
-enum ClaudeWebFetchStrategyError: LocalizedError, Equatable, Sendable {
+public enum ClaudeWebFetchStrategyError: LocalizedError, Equatable, Sendable {
     case invalidTimeout
     case timedOut(seconds: TimeInterval)
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .invalidTimeout:
             "Claude web usage fetch timeout must be a finite, nonnegative value within the supported range."

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -201,9 +201,19 @@ public struct ProviderFetchPipeline: Sendable {
         attempts.reserveCapacity(strategies.count)
         var lastAvailableError: Error?
 
+        guard !Task.isCancelled else {
+            return ProviderFetchOutcome(result: .failure(CancellationError()), attempts: attempts)
+        }
+
         for strategy in strategies {
+            guard !Task.isCancelled else {
+                return ProviderFetchOutcome(result: .failure(CancellationError()), attempts: attempts)
+            }
             let available = await strategy.isAvailable(context)
 
+            guard !Task.isCancelled else {
+                return ProviderFetchOutcome(result: .failure(CancellationError()), attempts: attempts)
+            }
             guard available else {
                 attempts.append(ProviderFetchAttempt(
                     strategyID: strategy.id,
@@ -215,6 +225,7 @@ public struct ProviderFetchPipeline: Sendable {
 
             do {
                 let result = try await strategy.fetch(context)
+                try Task.checkCancellation()
                 attempts.append(ProviderFetchAttempt(
                     strategyID: strategy.id,
                     kind: strategy.kind,
@@ -228,6 +239,9 @@ public struct ProviderFetchPipeline: Sendable {
                     kind: strategy.kind,
                     wasAvailable: true,
                     errorDescription: error.localizedDescription))
+                if Task.isCancelled || error is CancellationError {
+                    return ProviderFetchOutcome(result: .failure(CancellationError()), attempts: attempts)
+                }
                 if strategy.shouldFallback(on: error, context: context) {
                     continue
                 }

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -227,11 +227,18 @@ final class CLIEntryTests: XCTestCase {
         let signature = CodexBarCLI._usageSignatureForTesting()
         let parser = CommandParser(signature: signature)
         let parsed = try parser.parse(arguments: ["--web-timeout", "45", "--source", "oauth"])
-        XCTAssertEqual(CodexBarCLI._decodeWebTimeoutForTesting(from: parsed), 45)
+        XCTAssertEqual(try CodexBarCLI._decodeWebTimeoutForTesting(from: parsed), 45)
         XCTAssertEqual(CodexBarCLI._decodeSourceModeForTesting(from: parsed), .oauth)
 
         let parsedWeb = try parser.parse(arguments: ["--web"])
         XCTAssertEqual(CodexBarCLI._decodeSourceModeForTesting(from: parsedWeb), .web)
+    }
+
+    func test_rejectsUnsafeWebTimeoutOptions() throws {
+        for value in ["-1", "nan", "inf", "1e300"] {
+            let parsed = ParsedValues(positional: [], options: ["webTimeout": [value]], flags: [])
+            XCTAssertThrowsError(try CodexBarCLI._decodeWebTimeoutForTesting(from: parsed))
+        }
     }
 
     func test_shouldUseColorRespectsFormatAndFlags() {
@@ -319,6 +326,8 @@ final class CLIEntryTests: XCTestCase {
 
         XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .kilo))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .codex))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .claude))
+        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .claude))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .kilo))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .grok))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .grok))

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -159,6 +159,7 @@ final class CLIEntryTests: XCTestCase {
     func test_mapsErrorsToExitCodes() {
         XCTAssertEqual(CodexBarCLI.mapError(CodexStatusProbeError.codexNotInstalled), ExitCode(2))
         XCTAssertEqual(CodexBarCLI.mapError(CodexStatusProbeError.timedOut), ExitCode(4))
+        XCTAssertEqual(CodexBarCLI.mapError(ClaudeWebFetchStrategyError.timedOut(seconds: 1)), ExitCode(4))
         XCTAssertEqual(CodexBarCLI.mapError(UsageError.noRateLimitsFound), ExitCode(3))
     }
 

--- a/Tests/CodexBarTests/CLIWebFallbackTests.swift
+++ b/Tests/CodexBarTests/CLIWebFallbackTests.swift
@@ -165,24 +165,38 @@ struct CLIWebFallbackTests {
 
     @Test
     func `claude CLI fallback is enabled only for app auto`() {
-        let strategy = ClaudeCLIFetchStrategy(
+        let webAvailableStrategy = ClaudeCLIFetchStrategy(
             useWebExtras: false,
             manualCookieHeader: nil,
-            browserDetection: BrowserDetection(cacheTTL: 0))
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            hasWebFallback: true)
+        let webUnavailableStrategy = ClaudeCLIFetchStrategy(
+            useWebExtras: false,
+            manualCookieHeader: nil,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            hasWebFallback: false)
         let error = ClaudeUsageError.parseFailed("cli failed")
         let webAvailableSettings = self.makeClaudeSettingsSnapshot(cookieHeader: "sessionKey=sk-ant-test")
         let webUnavailableSettings = self.makeClaudeSettingsSnapshot(cookieHeader: "foo=bar")
 
-        #expect(strategy.shouldFallback(
+        #expect(webAvailableStrategy.shouldFallback(
             on: error,
             context: self.makeContext(runtime: .app, sourceMode: .auto, settings: webAvailableSettings)))
-        #expect(!strategy.shouldFallback(
+        #expect(!webUnavailableStrategy.shouldFallback(
             on: error,
             context: self.makeContext(runtime: .app, sourceMode: .auto, settings: webUnavailableSettings)))
-        #expect(!strategy.shouldFallback(on: error, context: self.makeContext(runtime: .app, sourceMode: .cli)))
-        #expect(!strategy.shouldFallback(on: error, context: self.makeContext(runtime: .app, sourceMode: .web)))
-        #expect(!strategy.shouldFallback(on: error, context: self.makeContext(runtime: .app, sourceMode: .oauth)))
-        #expect(!strategy.shouldFallback(on: error, context: self.makeContext(runtime: .cli, sourceMode: .auto)))
+        #expect(!webAvailableStrategy.shouldFallback(
+            on: error,
+            context: self.makeContext(runtime: .app, sourceMode: .cli)))
+        #expect(!webAvailableStrategy.shouldFallback(
+            on: error,
+            context: self.makeContext(runtime: .app, sourceMode: .web)))
+        #expect(!webAvailableStrategy.shouldFallback(
+            on: error,
+            context: self.makeContext(runtime: .app, sourceMode: .oauth)))
+        #expect(!webAvailableStrategy.shouldFallback(
+            on: error,
+            context: self.makeContext(runtime: .cli, sourceMode: .auto)))
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -147,6 +147,49 @@ struct ClaudeWebFetchDeadlineTests {
     }
 
     @Test
+    func `app auto availability and fetch share one web deadline`() async {
+        let deadlineClock = ClaudeWebDeadlineClock()
+        let usageProbe = ClaudeWebDeadlineProbe()
+        let context = Self.makeContext(
+            runtime: .app,
+            sourceMode: .auto,
+            webTimeout: 1,
+            cookieSource: .auto)
+        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
+            deadlineClock.advance(by: .milliseconds(990))
+            return true
+        }
+        let strategy = ClaudeWebFetchStrategy(
+            browserDetection: context.browserDetection,
+            usageLoader: { _ in
+                await usageProbe.waitUntilReleased()
+                return Self.makeClaudeUsage()
+            },
+            deadlineNow: { deadlineClock.now() })
+
+        let available = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
+            availabilityOverride)
+        {
+            await strategy.isAvailable(context)
+        }
+        #expect(available)
+
+        let startedAt = ContinuousClock.now
+        do {
+            _ = try await strategy.fetch(context)
+            Issue.record("Expected the stalled load to consume only the remaining web deadline")
+        } catch let error as ClaudeWebFetchStrategyError {
+            #expect(error == .timedOut(seconds: 1))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        let elapsed = startedAt.duration(to: ContinuousClock.now)
+        await usageProbe.release()
+
+        #expect(elapsed < .milliseconds(300))
+    }
+
+    @Test
     func `CLI auto timeout cancels web and falls back to CLI`() async throws {
         let probe = ClaudeWebDeadlineProbe()
         let web = Self.makeTimedOutWebStrategy(probe: probe)
@@ -321,6 +364,23 @@ private final class ClaudeWebPlanningAvailabilityProbe: @unchecked Sendable {
 
     func release() {
         self.releaseSemaphore.signal()
+    }
+}
+
+private final class ClaudeWebDeadlineClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var instant = ContinuousClock.now
+
+    func now() -> ContinuousClock.Instant {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.instant
+    }
+
+    func advance(by duration: Duration) {
+        self.lock.lock()
+        self.instant = self.instant.advanced(by: duration)
+        self.lock.unlock()
     }
 }
 

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -4,6 +4,78 @@ import Testing
 
 struct ClaudeWebFetchDeadlineTests {
     @Test
+    func `CLI auto descriptor defers browser probe and falls back after web deadline`() async throws {
+        let planningProbe = ClaudeWebPlanningAvailabilityProbe()
+        let webProbe = ClaudeWebDeadlineProbe()
+        let context = Self.makeContext(
+            sourceMode: .auto,
+            webTimeout: 0.01,
+            cookieSource: .auto,
+            env: ["CLAUDE_CLI_PATH": "/usr/bin/true"])
+        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
+            planningProbe.stallAndReportUnavailable()
+        }
+        let usageLoader: ClaudeWebFetchStrategy.UsageLoader = { _ in
+            await webProbe.waitUntilReleased()
+            return Self.makeClaudeUsage()
+        }
+        let cliFetchOverride: @Sendable (String, TimeInterval, Bool) async throws -> ClaudeStatusSnapshot =
+            { _, _, _ in Self.makeClaudeStatus() }
+
+        let outcome = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
+            availabilityOverride)
+        {
+            await ClaudeWebFetchStrategy.$usageLoaderOverrideForTesting.withValue(usageLoader) {
+                await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
+                    await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                        context: context,
+                        provider: .claude)
+                }
+            }
+        }
+        await webProbe.release()
+        let result = try outcome.result.get()
+
+        #expect(!planningProbe.wasInvoked)
+        #expect(result.strategyID == "claude.cli")
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web", "claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [true, true])
+        #expect(outcome.attempts.first?.errorDescription?.contains("Claude web usage fetch timed out") == true)
+    }
+
+    @Test
+    func `app auto descriptor bounds and reuses browser availability`() async throws {
+        let planningProbe = ClaudeWebPlanningAvailabilityProbe()
+        let context = Self.makeContext(
+            runtime: .app,
+            sourceMode: .auto,
+            webTimeout: 0.1,
+            cookieSource: .auto,
+            env: [
+                "CLAUDE_CLI_PATH": "/usr/bin/true",
+                ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
+            ])
+        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
+            planningProbe.stallAndReportUnavailable()
+        }
+
+        let strategies = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
+            availabilityOverride)
+        {
+            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.pipeline.resolveStrategies(context)
+        }
+        planningProbe.release()
+        let cliStrategy = try #require(strategies.first(where: { $0.id == "claude.cli" }))
+        let shouldFallback = cliStrategy.shouldFallback(
+            on: ClaudeUsageError.parseFailed("cli failed"),
+            context: context)
+
+        #expect(planningProbe.invocationCount == 1)
+        #expect(!shouldFallback)
+        #expect(planningProbe.invocationCount == 1)
+    }
+
+    @Test
     func `CLI auto timeout cancels web and falls back to CLI`() async throws {
         let probe = ClaudeWebDeadlineProbe()
         let web = Self.makeTimedOutWebStrategy(probe: probe)
@@ -93,23 +165,26 @@ struct ClaudeWebFetchDeadlineTests {
     }
 
     private static func makeContext(
+        runtime: ProviderRuntime = .cli,
         sourceMode: ProviderSourceMode,
-        webTimeout: TimeInterval) -> ProviderFetchContext
+        webTimeout: TimeInterval,
+        cookieSource: ProviderCookieSource = .manual,
+        env: [String: String] = [:]) -> ProviderFetchContext
     {
         let browserDetection = BrowserDetection(cacheTTL: 0)
         return ProviderFetchContext(
-            runtime: .cli,
+            runtime: runtime,
             sourceMode: sourceMode,
             includeCredits: false,
             webTimeout: webTimeout,
             webDebugDumpHTML: false,
             verbose: false,
-            env: [:],
+            env: env,
             settings: ProviderSettingsSnapshot.make(claude: .init(
                 usageDataSource: sourceMode == .web ? .web : .auto,
                 webExtrasEnabled: false,
-                cookieSource: .manual,
-                manualCookieHeader: "sessionKey=sk-ant-session-token")),
+                cookieSource: cookieSource,
+                manualCookieHeader: cookieSource == .manual ? "sessionKey=sk-ant-session-token" : nil)),
             fetcher: UsageFetcher(),
             claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
             browserDetection: browserDetection)
@@ -129,6 +204,48 @@ struct ClaudeWebFetchDeadlineTests {
             accountOrganization: nil,
             loginMethod: nil,
             rawText: nil)
+    }
+
+    private static func makeClaudeStatus() -> ClaudeStatusSnapshot {
+        ClaudeStatusSnapshot(
+            sessionPercentLeft: 80,
+            weeklyPercentLeft: nil,
+            opusPercentLeft: nil,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: nil,
+            primaryResetDescription: nil,
+            secondaryResetDescription: nil,
+            opusResetDescription: nil,
+            rawText: "stub")
+    }
+}
+
+private final class ClaudeWebPlanningAvailabilityProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var invocations = 0
+
+    var invocationCount: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.invocations
+    }
+
+    var wasInvoked: Bool {
+        self.invocationCount > 0
+    }
+
+    func stallAndReportUnavailable() -> Bool {
+        self.lock.lock()
+        self.invocations += 1
+        self.lock.unlock()
+        _ = self.releaseSemaphore.wait(timeout: .now() + 1)
+        return false
+    }
+
+    func release() {
+        self.releaseSemaphore.signal()
     }
 }
 

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -38,6 +38,51 @@ struct ClaudeWebFetchDeadlineTests {
         #expect(outcome.attempts.map(\.strategyID) == ["claude.web"])
     }
 
+    @Test
+    func `caller cancellation does not fall back to CLI`() async {
+        let probe = ClaudeWebDeadlineProbe()
+        let web = Self.makeTimedOutWebStrategy(probe: probe)
+        let pipeline = ProviderFetchPipeline { _ in [web, ClaudeWebDeadlineCLIStrategy()] }
+        let context = Self.makeContext(sourceMode: .auto, webTimeout: 60)
+        let fetchTask = Task {
+            await pipeline.fetch(context: context, provider: .claude)
+        }
+
+        await probe.waitUntilStarted()
+        fetchTask.cancel()
+        let outcome = await fetchTask.value
+        await probe.release()
+
+        switch outcome.result {
+        case .success:
+            Issue.record("Expected caller cancellation to stop the fetch pipeline")
+        case let .failure(error):
+            #expect(error is CancellationError)
+        }
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web"])
+    }
+
+    @Test
+    func `unsafe timeout is rejected before starting web work`() async {
+        let strategy = ClaudeWebFetchStrategy(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            usageLoader: { _ in
+                Issue.record("Unsafe timeout should be rejected before invoking the loader")
+                return Self.makeClaudeUsage()
+            })
+
+        for timeout in [-1, .nan, .infinity, .greatestFiniteMagnitude] {
+            do {
+                _ = try await strategy.fetch(Self.makeContext(sourceMode: .web, webTimeout: timeout))
+                Issue.record("Expected timeout \(timeout) to be rejected")
+            } catch let error as ClaudeWebFetchStrategyError {
+                #expect(error == .invalidTimeout)
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
     private static func makeTimedOutWebStrategy(probe: ClaudeWebDeadlineProbe) -> ClaudeWebFetchStrategy {
         ClaudeWebFetchStrategy(
             browserDetection: BrowserDetection(cacheTTL: 0),
@@ -88,13 +133,27 @@ struct ClaudeWebFetchDeadlineTests {
 }
 
 private actor ClaudeWebDeadlineProbe {
+    private var started = false
     private var released = false
+    private var startWaiter: CheckedContinuation<Void, Never>?
     private var releaseWaiter: CheckedContinuation<Void, Never>?
 
     func waitUntilReleased() async {
+        if !self.started {
+            self.started = true
+            self.startWaiter?.resume()
+            self.startWaiter = nil
+        }
         guard !self.released else { return }
         await withCheckedContinuation { continuation in
             self.releaseWaiter = continuation
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard !self.started else { return }
+        await withCheckedContinuation { continuation in
+            self.startWaiter = continuation
         }
     }
 

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -76,6 +76,63 @@ struct ClaudeWebFetchDeadlineTests {
     }
 
     @Test
+    func `caller cancellation during app auto planning does not execute fallback`() async {
+        let planningProbe = ClaudeWebPlanningAvailabilityProbe()
+        let fallbackProbe = ClaudeWebPlanningAvailabilityProbe()
+        let context = Self.makeContext(
+            runtime: .app,
+            sourceMode: .auto,
+            webTimeout: 60,
+            cookieSource: .auto,
+            env: [
+                "CLAUDE_CLI_PATH": "/usr/bin/true",
+                ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
+            ])
+        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
+            planningProbe.stallAndReportUnavailable()
+        }
+        let oauthLoadOverride: (@Sendable (
+            [String: String],
+            Bool,
+            Bool) async throws -> ClaudeOAuthCredentials)? = { _, _, _ in
+            fallbackProbe.recordInvocation()
+            throw CancellationError()
+        }
+        let cliFetchOverride: @Sendable (String, TimeInterval, Bool) async throws -> ClaudeStatusSnapshot = { _, _, _ in
+            fallbackProbe.recordInvocation()
+            throw CancellationError()
+        }
+
+        let fetchTask = Task {
+            await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(availabilityOverride) {
+                await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(oauthLoadOverride) {
+                    await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
+                        await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                            context: context,
+                            provider: .claude)
+                    }
+                }
+            }
+        }
+
+        while !planningProbe.wasInvoked {
+            await Task.yield()
+        }
+        fetchTask.cancel()
+        let outcome = await fetchTask.value
+        planningProbe.release()
+
+        switch outcome.result {
+        case .success:
+            Issue.record("Expected caller cancellation to stop after availability planning")
+        case let .failure(error):
+            #expect(error is CancellationError)
+        }
+        #expect(outcome.attempts.isEmpty)
+        #expect(fallbackProbe.invocationCount == 0)
+    }
+
+    @Test
     func `CLI auto timeout cancels web and falls back to CLI`() async throws {
         let probe = ClaudeWebDeadlineProbe()
         let web = Self.makeTimedOutWebStrategy(probe: probe)
@@ -237,11 +294,15 @@ private final class ClaudeWebPlanningAvailabilityProbe: @unchecked Sendable {
     }
 
     func stallAndReportUnavailable() -> Bool {
+        self.recordInvocation()
+        _ = self.releaseSemaphore.wait(timeout: .now() + 1)
+        return false
+    }
+
+    func recordInvocation() {
         self.lock.lock()
         self.invocations += 1
         self.lock.unlock()
-        _ = self.releaseSemaphore.wait(timeout: .now() + 1)
-        return false
     }
 
     func release() {

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeWebFetchDeadlineTests {
+    @Test
+    func `CLI auto timeout cancels web and falls back to CLI`() async throws {
+        let probe = ClaudeWebDeadlineProbe()
+        let web = Self.makeTimedOutWebStrategy(probe: probe)
+        let pipeline = ProviderFetchPipeline { _ in [web, ClaudeWebDeadlineCLIStrategy()] }
+        let context = Self.makeContext(sourceMode: .auto, webTimeout: 0.01)
+
+        let outcome = await pipeline.fetch(context: context, provider: .claude)
+        await probe.release()
+        let result = try outcome.result.get()
+
+        #expect(result.strategyID == "claude.cli")
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web", "claude.cli"])
+        #expect(outcome.attempts.first?.errorDescription?.contains("Claude web usage fetch timed out") == true)
+    }
+
+    @Test
+    func `explicit web timeout surfaces without CLI fallback`() async {
+        let probe = ClaudeWebDeadlineProbe()
+        let web = Self.makeTimedOutWebStrategy(probe: probe)
+        let pipeline = ProviderFetchPipeline { _ in [web, ClaudeWebDeadlineCLIStrategy()] }
+        let context = Self.makeContext(sourceMode: .web, webTimeout: 0.01)
+
+        let outcome = await pipeline.fetch(context: context, provider: .claude)
+        await probe.release()
+
+        switch outcome.result {
+        case .success:
+            Issue.record("Expected the explicit web deadline to fail")
+        case let .failure(error):
+            #expect(error as? ClaudeWebFetchStrategyError == .timedOut(seconds: 0.01))
+        }
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web"])
+    }
+
+    private static func makeTimedOutWebStrategy(probe: ClaudeWebDeadlineProbe) -> ClaudeWebFetchStrategy {
+        ClaudeWebFetchStrategy(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            usageLoader: { _ in
+                await probe.waitUntilReleased()
+                return self.makeClaudeUsage()
+            })
+    }
+
+    private static func makeContext(
+        sourceMode: ProviderSourceMode,
+        webTimeout: TimeInterval) -> ProviderFetchContext
+    {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: sourceMode,
+            includeCredits: false,
+            webTimeout: webTimeout,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: ProviderSettingsSnapshot.make(claude: .init(
+                usageDataSource: sourceMode == .web ? .web : .auto,
+                webExtrasEnabled: false,
+                cookieSource: .manual,
+                manualCookieHeader: "sessionKey=sk-ant-session-token")),
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+
+    private static func makeClaudeUsage() -> ClaudeUsageSnapshot {
+        ClaudeUsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            opus: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_100),
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: nil,
+            rawText: nil)
+    }
+}
+
+private actor ClaudeWebDeadlineProbe {
+    private var released = false
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+
+    func waitUntilReleased() async {
+        guard !self.released else { return }
+        await withCheckedContinuation { continuation in
+            self.releaseWaiter = continuation
+        }
+    }
+
+    func release() {
+        self.released = true
+        self.releaseWaiter?.resume()
+        self.releaseWaiter = nil
+    }
+}
+
+private struct ClaudeWebDeadlineCLIStrategy: ProviderFetchStrategy {
+    let id = "claude.cli"
+    let kind: ProviderFetchKind = .cli
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        self.makeResult(
+            usage: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 20,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(timeIntervalSince1970: 1_800_000_100)),
+            sourceLabel: "claude")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -44,41 +44,8 @@ struct ClaudeWebFetchDeadlineTests {
     }
 
     @Test
-    func `app auto descriptor bounds and reuses browser availability`() async throws {
+    func `stalled app auto browser probe does not delay CLI success`() async throws {
         let planningProbe = ClaudeWebPlanningAvailabilityProbe()
-        let context = Self.makeContext(
-            runtime: .app,
-            sourceMode: .auto,
-            webTimeout: 0.1,
-            cookieSource: .auto,
-            env: [
-                "CLAUDE_CLI_PATH": "/usr/bin/true",
-                ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
-            ])
-        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
-            planningProbe.stallAndReportUnavailable()
-        }
-
-        let strategies = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
-            availabilityOverride)
-        {
-            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.pipeline.resolveStrategies(context)
-        }
-        planningProbe.release()
-        let cliStrategy = try #require(strategies.first(where: { $0.id == "claude.cli" }))
-        let shouldFallback = cliStrategy.shouldFallback(
-            on: ClaudeUsageError.parseFailed("cli failed"),
-            context: context)
-
-        #expect(planningProbe.invocationCount == 1)
-        #expect(!shouldFallback)
-        #expect(planningProbe.invocationCount == 1)
-    }
-
-    @Test
-    func `caller cancellation during app auto planning does not execute fallback`() async {
-        let planningProbe = ClaudeWebPlanningAvailabilityProbe()
-        let fallbackProbe = ClaudeWebPlanningAvailabilityProbe()
         let context = Self.makeContext(
             runtime: .app,
             sourceMode: .auto,
@@ -95,21 +62,68 @@ struct ClaudeWebFetchDeadlineTests {
             [String: String],
             Bool,
             Bool) async throws -> ClaudeOAuthCredentials)? = { _, _, _ in
-            fallbackProbe.recordInvocation()
-            throw CancellationError()
+            throw ClaudeUsageError.oauthFailed("stub OAuth failure")
+        }
+        let cliFetchOverride: @Sendable (String, TimeInterval, Bool) async throws -> ClaudeStatusSnapshot =
+            { _, _, _ in Self.makeClaudeStatus() }
+
+        let outcome = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
+            availabilityOverride)
+        {
+            await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(oauthLoadOverride) {
+                await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
+                    await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                        context: context,
+                        provider: .claude)
+                }
+            }
+        }
+        let result = try outcome.result.get()
+
+        #expect(result.strategyID == "claude.cli")
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli"])
+        #expect(!planningProbe.wasInvoked)
+    }
+
+    @Test
+    func `caller cancellation during deferred app auto browser probe stops web fallback`() async {
+        let planningProbe = ClaudeWebPlanningAvailabilityProbe()
+        let webFetchProbe = ClaudeWebPlanningAvailabilityProbe()
+        let context = Self.makeContext(
+            runtime: .app,
+            sourceMode: .auto,
+            webTimeout: 60,
+            cookieSource: .auto,
+            env: [
+                "CLAUDE_CLI_PATH": "/usr/bin/true",
+                ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
+            ])
+        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
+            planningProbe.stallAndReportUnavailable()
+        }
+        let oauthLoadOverride: (@Sendable (
+            [String: String],
+            Bool,
+            Bool) async throws -> ClaudeOAuthCredentials)? = { _, _, _ in
+            throw ClaudeUsageError.oauthFailed("stub OAuth failure")
         }
         let cliFetchOverride: @Sendable (String, TimeInterval, Bool) async throws -> ClaudeStatusSnapshot = { _, _, _ in
-            fallbackProbe.recordInvocation()
-            throw CancellationError()
+            throw ClaudeUsageError.parseFailed("stub CLI failure")
+        }
+        let usageLoader: ClaudeWebFetchStrategy.UsageLoader = { _ in
+            webFetchProbe.recordInvocation()
+            return Self.makeClaudeUsage()
         }
 
         let fetchTask = Task {
             await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(availabilityOverride) {
-                await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(oauthLoadOverride) {
-                    await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
-                        await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
-                            context: context,
-                            provider: .claude)
+                await ClaudeWebFetchStrategy.$usageLoaderOverrideForTesting.withValue(usageLoader) {
+                    await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(oauthLoadOverride) {
+                        await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
+                            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                                context: context,
+                                provider: .claude)
+                        }
                     }
                 }
             }
@@ -124,12 +138,12 @@ struct ClaudeWebFetchDeadlineTests {
 
         switch outcome.result {
         case .success:
-            Issue.record("Expected caller cancellation to stop after availability planning")
+            Issue.record("Expected caller cancellation to stop the deferred web fallback")
         case let .failure(error):
             #expect(error is CancellationError)
         }
-        #expect(outcome.attempts.isEmpty)
-        #expect(fallbackProbe.invocationCount == 0)
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli"])
+        #expect(webFetchProbe.invocationCount == 0)
     }
 
     @Test

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -10,6 +10,12 @@ struct PlatformGatingTests {
     }
 
     @Test
+    func claudeAutoSource_allowsPlannerToFallBackToCLI() {
+        #expect(!CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .claude))
+        #expect(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .claude))
+    }
+
+    @Test
     func claudeWebFetcher_isNotSupportedOnLinux() async {
         #if os(Linux)
         let error = await #expect(throws: ClaudeWebAPIFetcher.FetchError.self) {

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -1,6 +1,6 @@
-import CodexBarCore
 import Testing
 @testable import CodexBarCLI
+@testable import CodexBarCore
 
 @Suite
 struct PlatformGatingTests {
@@ -13,6 +13,62 @@ struct PlatformGatingTests {
     func claudeAutoSource_allowsPlannerToFallBackToCLI() {
         #expect(!CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .claude))
         #expect(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .claude))
+    }
+
+    @Test
+    func claudeAutoPipeline_skipsUnsupportedWebAndUsesCLI() async throws {
+        #if os(Linux)
+        let context = self.makeClaudeAutoContext()
+        let cliFetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in
+            Self.makeClaudeStatus()
+        }
+        let outcome = await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+            await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
+                await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                    context: context,
+                    provider: .claude)
+            }
+        }
+        let result = try outcome.result.get()
+
+        #expect(result.strategyID == "claude.cli")
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web", "claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [false, true])
+        #else
+        #expect(Bool(true))
+        #endif
+    }
+
+    @Test
+    func claudeAutoPipeline_withoutCLIReportsNoAvailableStrategy() async {
+        #if os(Linux)
+        let context = self.makeClaudeAutoContext()
+        let outcome = await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(
+            "/definitely/missing/claude")
+        {
+            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                context: context,
+                provider: .claude)
+        }
+
+        switch outcome.result {
+        case .success:
+            Issue.record("Expected Claude auto without a CLI to report no available strategy")
+        case let .failure(error):
+            guard let fetchError = error as? ProviderFetchError else {
+                Issue.record("Expected ProviderFetchError, got \(error)")
+                return
+            }
+            switch fetchError {
+            case let .noAvailableStrategy(provider):
+                #expect(provider == .claude)
+            }
+        }
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web", "claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [false, false])
+        #else
+        #expect(Bool(true))
+        #endif
     }
 
     @Test
@@ -54,5 +110,39 @@ struct PlatformGatingTests {
         #else
         #expect(Bool(true))
         #endif
+    }
+
+    private func makeClaudeAutoContext() -> ProviderFetchContext {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: .auto,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: ProviderSettingsSnapshot.make(claude: .init(
+                usageDataSource: .auto,
+                webExtrasEnabled: false,
+                cookieSource: .auto,
+                manualCookieHeader: nil)),
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+
+    private static func makeClaudeStatus() -> ClaudeStatusSnapshot {
+        ClaudeStatusSnapshot(
+            sessionPercentLeft: 80,
+            weeklyPercentLeft: nil,
+            opusPercentLeft: nil,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: nil,
+            primaryResetDescription: nil,
+            secondaryResetDescription: nil,
+            opusResetDescription: nil,
+            rawText: "stub")
     }
 }


### PR DESCRIPTION
## Summary

- enforce `--web-timeout` around the complete Claude web usage strategy
- preserve Claude CLI auto ordering (`web -> cli`) while falling back after a bounded timeout
- surface the timeout directly for explicit `--source web`
- use the existing bounded task join so uncooperative cookie/network work cannot hold the caller open

## Root cause

Claude's web strategy ignored `ProviderFetchContext.webTimeout`. A stale browser session or blocked cookie/web operation could therefore prevent CLI auto mode from reaching its existing Claude CLI fallback.

## Validation

- `swift test --filter ClaudeWebFetchDeadlineTests`
- focused Claude planner/fallback/resilience suites (32 tests)
- `make check`
- `git diff --check`

Closes #1731
