### PR TITLE
[codex] Scope Claude OAuth history by Keychain identity

### DIFF
--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -6,6 +6,7 @@ extension UsageStore {
     private nonisolated static let weeklyLimitResetDetectorDefaultsKey = "weeklyLimitResetDetectorStates"
     private nonisolated static let weeklyWindowMinutes = 7 * 24 * 60
     private nonisolated static let planUtilizationUnscopedPreferredKey = "__unscoped__"
+    private nonisolated static let claudeOAuthPlanUtilizationAccountKeyPrefix = "__claude_oauth__:"
 
     struct WeeklyLimitResetDetectorState: Codable, Equatable {
         let wasAboveThreshold: Bool
@@ -53,9 +54,12 @@ extension UsageStore {
         -> (accountKey: String?, histories: [PlanUtilizationSeriesHistory])
     {
         var providerBuckets = self.planUtilizationHistory[provider] ?? PlanUtilizationHistoryBuckets()
-        if provider == .claude, self.lastSourceLabels[provider] == "oauth" {
-            // Match the history view to the latest successful snapshot. OAuth provenance outranks an
-            // unrelated configured token account; the unscoped sentinel intentionally resolves to nil.
+        if provider == .claude,
+           providerBuckets.preferredAccountKey == Self.planUtilizationUnscopedPreferredKey
+           || Self.isClaudeOAuthPlanUtilizationAccountKey(providerBuckets.preferredAccountKey)
+        {
+            // Persisted OAuth provenance outranks an unrelated configured token account. The unscoped
+            // sentinel intentionally resolves to nil, including after the history store is reloaded.
             let accountKey = self.stickyPlanUtilizationAccountKey(providerBuckets: providerBuckets)
             return (accountKey, providerBuckets.histories(for: accountKey))
         }
@@ -608,7 +612,12 @@ extension UsageStore {
         else {
             return nil
         }
-        return self.sha256Hex("claude:oauth-keychain-persistent-ref:\(normalizedHash)")
+        let digest = self.sha256Hex("claude:oauth-keychain-persistent-ref:\(normalizedHash)")
+        return "\(self.claudeOAuthPlanUtilizationAccountKeyPrefix)\(digest)"
+    }
+
+    private nonisolated static func isClaudeOAuthPlanUtilizationAccountKey(_ accountKey: String?) -> Bool {
+        accountKey?.hasPrefix(self.claudeOAuthPlanUtilizationAccountKeyPrefix) == true
     }
 
     private nonisolated static func planUtilizationIdentityAccountKey(

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -53,6 +53,12 @@ extension UsageStore {
         -> (accountKey: String?, histories: [PlanUtilizationSeriesHistory])
     {
         var providerBuckets = self.planUtilizationHistory[provider] ?? PlanUtilizationHistoryBuckets()
+        if provider == .claude, self.lastSourceLabels[provider] == "oauth" {
+            // Match the history view to the latest successful snapshot. OAuth provenance outranks an
+            // unrelated configured token account; the unscoped sentinel intentionally resolves to nil.
+            let accountKey = self.stickyPlanUtilizationAccountKey(providerBuckets: providerBuckets)
+            return (accountKey, providerBuckets.histories(for: accountKey))
+        }
         let originalProviderBuckets = providerBuckets
         let accountKey = self.resolvePlanUtilizationAccountKey(
             provider: provider,

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -757,6 +757,23 @@ extension UsageStore {
                 && (providerBuckets.preferredAccountKey == Self.planUtilizationUnscopedPreferredKey
                     || !providerBuckets.accounts.isEmpty))
 
+        if provider == .claude, isClaudeOAuthSample {
+            if let oauthAccountKey = Self.claudeOAuthPlanUtilizationAccountKey(
+                persistentRefHash: claudeOAuthPersistentRefHash)
+            {
+                if shouldUpdatePreferredAccountKey {
+                    providerBuckets.preferredAccountKey = oauthAccountKey
+                }
+                // Existing unscoped or identity-keyed history can belong to another OAuth account.
+                // Preserve it in place rather than silently adopting it into this opaque account.
+                return oauthAccountKey
+            }
+            if shouldUpdatePreferredAccountKey {
+                providerBuckets.preferredAccountKey = Self.planUtilizationUnscopedPreferredKey
+            }
+            return nil
+        }
+
         let resolvedAccount = preferredAccount ?? self.settings.selectedTokenAccount(for: provider)
         if let tokenAccountKey = Self.planUtilizationAccountKey(provider: provider, account: resolvedAccount) {
             if shouldUpdatePreferredAccountKey {
@@ -769,19 +786,6 @@ extension UsageStore {
                     providerBuckets: &providerBuckets)
             }
             return tokenAccountKey
-        }
-
-        if provider == .claude,
-           isClaudeOAuthSample,
-           let oauthAccountKey = Self.claudeOAuthPlanUtilizationAccountKey(
-               persistentRefHash: claudeOAuthPersistentRefHash)
-        {
-            if shouldUpdatePreferredAccountKey {
-                providerBuckets.preferredAccountKey = oauthAccountKey
-            }
-            // Existing unscoped or identity-keyed history can belong to another OAuth account.
-            // Preserve it in place rather than silently adopting it into this opaque account.
-            return oauthAccountKey
         }
 
         if let snapshot,
@@ -802,13 +806,6 @@ extension UsageStore {
                     providerBuckets: &providerBuckets)
             }
             return resolvedIdentityAccountKey
-        }
-
-        if provider == .claude, isClaudeOAuthSample {
-            if shouldUpdatePreferredAccountKey {
-                providerBuckets.preferredAccountKey = Self.planUtilizationUnscopedPreferredKey
-            }
-            return nil
         }
 
         if let stickyAccountKey = self.stickyPlanUtilizationAccountKey(providerBuckets: providerBuckets) {

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -161,6 +161,7 @@ extension UsageStore {
         var snapshotToPersist: [UsageProvider: PlanUtilizationHistoryBuckets]?
         await MainActor.run {
             var providerBuckets = self.planUtilizationHistory[provider] ?? PlanUtilizationHistoryBuckets()
+            let originalProviderBuckets = providerBuckets
             let preferredAccount = account ?? self.settings.selectedTokenAccount(for: provider)
             let accountKey = self.resolvePlanUtilizationAccountKey(
                 provider: provider,
@@ -173,14 +174,14 @@ extension UsageStore {
                 providerBuckets: &providerBuckets)
             let histories = providerBuckets.histories(for: accountKey)
 
-            guard let updatedHistories = Self.updatedPlanUtilizationHistories(
+            if let updatedHistories = Self.updatedPlanUtilizationHistories(
                 existingHistories: histories,
                 samples: samples)
-            else {
-                return
+            {
+                providerBuckets.setHistories(updatedHistories, for: accountKey)
             }
 
-            providerBuckets.setHistories(updatedHistories, for: accountKey)
+            guard providerBuckets != originalProviderBuckets else { return }
             self.planUtilizationHistory[provider] = providerBuckets
             self.planUtilizationHistoryRevision &+= 1
             snapshotToPersist = self.planUtilizationHistory

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -750,12 +750,19 @@ extension UsageStore {
                 providerBuckets: &providerBuckets)
         }
 
+        // Claude's unscoped history is only safe to adopt during the first unambiguous migration.
+        // The sentinel marks identityless OAuth, while any scoped bucket proves multiple owners may exist.
+        let canAdoptUnscopedHistory = shouldAdoptUnscopedHistory
+            && !(provider == .claude
+                && (providerBuckets.preferredAccountKey == Self.planUtilizationUnscopedPreferredKey
+                    || !providerBuckets.accounts.isEmpty))
+
         let resolvedAccount = preferredAccount ?? self.settings.selectedTokenAccount(for: provider)
         if let tokenAccountKey = Self.planUtilizationAccountKey(provider: provider, account: resolvedAccount) {
             if shouldUpdatePreferredAccountKey {
                 providerBuckets.preferredAccountKey = tokenAccountKey
             }
-            if shouldAdoptUnscopedHistory {
+            if canAdoptUnscopedHistory {
                 self.adoptPlanUtilizationUnscopedHistoryIfNeeded(
                     into: tokenAccountKey,
                     provider: provider,
@@ -788,7 +795,7 @@ extension UsageStore {
             if shouldUpdatePreferredAccountKey {
                 providerBuckets.preferredAccountKey = resolvedIdentityAccountKey
             }
-            if shouldAdoptUnscopedHistory {
+            if canAdoptUnscopedHistory {
                 self.adoptPlanUtilizationUnscopedHistoryIfNeeded(
                     into: resolvedIdentityAccountKey,
                     provider: provider,

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -5,6 +5,7 @@ extension UsageStore {
     private nonisolated static let weeklyLimitResetThreshold = 1.0
     private nonisolated static let weeklyLimitResetDetectorDefaultsKey = "weeklyLimitResetDetectorStates"
     private nonisolated static let weeklyWindowMinutes = 7 * 24 * 60
+    private nonisolated static let planUtilizationUnscopedPreferredKey = "__unscoped__"
 
     struct WeeklyLimitResetDetectorState: Codable, Equatable {
         let wasAboveThreshold: Bool
@@ -117,6 +118,8 @@ extension UsageStore {
         provider: UsageProvider,
         snapshot: UsageSnapshot,
         account: ProviderTokenAccount? = nil,
+        claudeOAuthPersistentRefHash: String? = nil,
+        isClaudeOAuthSample: Bool = false,
         shouldUpdatePreferredAccountKey: Bool = true,
         shouldAdoptUnscopedHistory: Bool = true,
         now: Date = Date())
@@ -125,10 +128,14 @@ extension UsageStore {
         let samples = self.planUtilizationSeriesSamples(provider: provider, snapshot: snapshot, capturedAt: now)
         guard !samples.isEmpty else { return }
 
-        let detectorAccountKey = self.planUtilizationAccountKey(
-            for: provider,
-            snapshot: snapshot,
-            preferredAccount: account)
+        let detectorAccountKey = if provider == .claude, isClaudeOAuthSample {
+            Self.claudeOAuthPlanUtilizationAccountKey(persistentRefHash: claudeOAuthPersistentRefHash)
+        } else {
+            self.planUtilizationAccountKey(
+                for: provider,
+                snapshot: snapshot,
+                preferredAccount: account)
+        }
         await MainActor.run {
             self.postWeeklyLimitResetCelebrationIfNeeded(
                 provider: provider,
@@ -149,6 +156,8 @@ extension UsageStore {
                 provider: provider,
                 snapshot: snapshot,
                 preferredAccount: preferredAccount,
+                claudeOAuthPersistentRefHash: claudeOAuthPersistentRefHash,
+                isClaudeOAuthSample: isClaudeOAuthSample,
                 shouldUpdatePreferredAccountKey: shouldUpdatePreferredAccountKey,
                 shouldAdoptUnscopedHistory: shouldAdoptUnscopedHistory,
                 providerBuckets: &providerBuckets)
@@ -583,6 +592,19 @@ extension UsageStore {
         return self.sha256Hex("\(provider.rawValue):token-account:\(account.id.uuidString.lowercased())")
     }
 
+    private nonisolated static func claudeOAuthPlanUtilizationAccountKey(
+        persistentRefHash: String?) -> String?
+    {
+        guard let normalizedHash = persistentRefHash?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            !normalizedHash.isEmpty
+        else {
+            return nil
+        }
+        return self.sha256Hex("claude:oauth-keychain-persistent-ref:\(normalizedHash)")
+    }
+
     private nonisolated static func planUtilizationIdentityAccountKey(
         provider: UsageProvider,
         snapshot: UsageSnapshot) -> String?
@@ -714,6 +736,8 @@ extension UsageStore {
         provider: UsageProvider,
         snapshot: UsageSnapshot?,
         preferredAccount: ProviderTokenAccount?,
+        claudeOAuthPersistentRefHash: String? = nil,
+        isClaudeOAuthSample: Bool = false,
         shouldUpdatePreferredAccountKey: Bool = true,
         shouldAdoptUnscopedHistory: Bool = true,
         providerBuckets: inout PlanUtilizationHistoryBuckets) -> String?
@@ -740,6 +764,19 @@ extension UsageStore {
             return tokenAccountKey
         }
 
+        if provider == .claude,
+           isClaudeOAuthSample,
+           let oauthAccountKey = Self.claudeOAuthPlanUtilizationAccountKey(
+               persistentRefHash: claudeOAuthPersistentRefHash)
+        {
+            if shouldUpdatePreferredAccountKey {
+                providerBuckets.preferredAccountKey = oauthAccountKey
+            }
+            // Existing unscoped or identity-keyed history can belong to another OAuth account.
+            // Preserve it in place rather than silently adopting it into this opaque account.
+            return oauthAccountKey
+        }
+
         if let snapshot,
            let identityAccountKey = Self.planUtilizationIdentityAccountKey(provider: provider, snapshot: snapshot)
         {
@@ -758,6 +795,13 @@ extension UsageStore {
                     providerBuckets: &providerBuckets)
             }
             return resolvedIdentityAccountKey
+        }
+
+        if provider == .claude, isClaudeOAuthSample {
+            if shouldUpdatePreferredAccountKey {
+                providerBuckets.preferredAccountKey = Self.planUtilizationUnscopedPreferredKey
+            }
+            return nil
         }
 
         if let stickyAccountKey = self.stickyPlanUtilizationAccountKey(providerBuckets: providerBuckets) {
@@ -918,6 +962,9 @@ extension UsageStore {
     private func stickyPlanUtilizationAccountKey(
         providerBuckets: PlanUtilizationHistoryBuckets) -> String?
     {
+        if providerBuckets.preferredAccountKey == Self.planUtilizationUnscopedPreferredKey {
+            return nil
+        }
         let knownAccountKeys = self.knownPlanUtilizationAccountKeys(providerBuckets: providerBuckets)
         guard !knownAccountKeys.isEmpty else { return nil }
 
@@ -1153,6 +1200,12 @@ extension UsageStore {
         account: ProviderTokenAccount) -> String?
     {
         self.planUtilizationAccountKey(provider: provider, account: account)
+    }
+
+    nonisolated static func _claudeOAuthPlanUtilizationAccountKeyForTesting(
+        persistentRefHash: String?) -> String?
+    {
+        self.claudeOAuthPlanUtilizationAccountKey(persistentRefHash: persistentRefHash)
     }
 
     nonisolated static func _legacyClaudePlanUtilizationEmailAccountKeyForTesting(snapshot: UsageSnapshot) -> String? {

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -129,6 +129,7 @@ extension UsageStore {
         snapshot: UsageSnapshot,
         account: ProviderTokenAccount? = nil,
         claudeOAuthPersistentRefHash: String? = nil,
+        claudeOAuthHistoryOwnerIdentifier: String? = nil,
         isClaudeOAuthSample: Bool = false,
         shouldUpdatePreferredAccountKey: Bool = true,
         shouldAdoptUnscopedHistory: Bool = true,
@@ -139,12 +140,18 @@ extension UsageStore {
         guard !samples.isEmpty else { return }
 
         let detectorAccountKey = if provider == .claude, isClaudeOAuthSample {
-            Self.claudeOAuthPlanUtilizationAccountKey(persistentRefHash: claudeOAuthPersistentRefHash)
+            Self.claudeOAuthPlanUtilizationAccountKey(
+                historyOwnerIdentifier: claudeOAuthHistoryOwnerIdentifier,
+                corroboratingPersistentRefHash: claudeOAuthPersistentRefHash)
         } else {
             self.planUtilizationAccountKey(
                 for: provider,
                 snapshot: snapshot,
                 preferredAccount: account)
+        }
+        if provider == .claude, isClaudeOAuthSample, detectorAccountKey == nil {
+            // Persisting without a high-entropy owner would merge unrelated OAuth accounts into `unscoped`.
+            return
         }
         await MainActor.run {
             self.postWeeklyLimitResetCelebrationIfNeeded(
@@ -168,6 +175,7 @@ extension UsageStore {
                 snapshot: snapshot,
                 preferredAccount: preferredAccount,
                 claudeOAuthPersistentRefHash: claudeOAuthPersistentRefHash,
+                claudeOAuthHistoryOwnerIdentifier: claudeOAuthHistoryOwnerIdentifier,
                 isClaudeOAuthSample: isClaudeOAuthSample,
                 shouldUpdatePreferredAccountKey: shouldUpdatePreferredAccountKey,
                 shouldAdoptUnscopedHistory: shouldAdoptUnscopedHistory,
@@ -603,17 +611,22 @@ extension UsageStore {
         return self.sha256Hex("\(provider.rawValue):token-account:\(account.id.uuidString.lowercased())")
     }
 
+    /// The Keychain row reference is corroborating provenance, not principal identity. Excluding it from the
+    /// canonical key keeps one credential stable when its row is recreated, while requiring the credential
+    /// discriminator ensures an in-place login replacement cannot inherit the prior principal's history.
     private nonisolated static func claudeOAuthPlanUtilizationAccountKey(
-        persistentRefHash: String?) -> String?
+        historyOwnerIdentifier: String?,
+        corroboratingPersistentRefHash _: String? = nil) -> String?
     {
-        guard let normalizedHash = persistentRefHash?
+        guard let normalizedIdentifier = historyOwnerIdentifier?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased(),
-            !normalizedHash.isEmpty
+            normalizedIdentifier.count == 64,
+            normalizedIdentifier.allSatisfy(\.isHexDigit)
         else {
             return nil
         }
-        let digest = self.sha256Hex("claude:oauth-keychain-persistent-ref:\(normalizedHash)")
+        let digest = self.sha256Hex("claude:oauth-history-owner:v2:\(normalizedIdentifier)")
         return "\(self.claudeOAuthPlanUtilizationAccountKeyPrefix)\(digest)"
     }
 
@@ -753,6 +766,7 @@ extension UsageStore {
         snapshot: UsageSnapshot?,
         preferredAccount: ProviderTokenAccount?,
         claudeOAuthPersistentRefHash: String? = nil,
+        claudeOAuthHistoryOwnerIdentifier: String? = nil,
         isClaudeOAuthSample: Bool = false,
         shouldUpdatePreferredAccountKey: Bool = true,
         shouldAdoptUnscopedHistory: Bool = true,
@@ -775,7 +789,8 @@ extension UsageStore {
 
         if provider == .claude, isClaudeOAuthSample {
             if let oauthAccountKey = Self.claudeOAuthPlanUtilizationAccountKey(
-                persistentRefHash: claudeOAuthPersistentRefHash)
+                historyOwnerIdentifier: claudeOAuthHistoryOwnerIdentifier,
+                corroboratingPersistentRefHash: claudeOAuthPersistentRefHash)
             {
                 if shouldUpdatePreferredAccountKey {
                     providerBuckets.preferredAccountKey = oauthAccountKey
@@ -784,9 +799,8 @@ extension UsageStore {
                 // Preserve it in place rather than silently adopting it into this opaque account.
                 return oauthAccountKey
             }
-            if shouldUpdatePreferredAccountKey {
-                providerBuckets.preferredAccountKey = Self.planUtilizationUnscopedPreferredKey
-            }
+            // Never append identityless OAuth samples to the shared unscoped bucket. A future fetch with
+            // trustworthy ownership evidence can start a scoped history without inheriting this sample.
             return nil
         }
 
@@ -1223,9 +1237,12 @@ extension UsageStore {
     }
 
     nonisolated static func _claudeOAuthPlanUtilizationAccountKeyForTesting(
-        persistentRefHash: String?) -> String?
+        historyOwnerIdentifier: String?,
+        persistentRefHash: String? = nil) -> String?
     {
-        self.claudeOAuthPlanUtilizationAccountKey(persistentRefHash: persistentRefHash)
+        self.claudeOAuthPlanUtilizationAccountKey(
+            historyOwnerIdentifier: historyOwnerIdentifier,
+            corroboratingPersistentRefHash: persistentRefHash)
     }
 
     nonisolated static func _legacyClaudePlanUtilizationEmailAccountKeyForTesting(snapshot: UsageSnapshot) -> String? {

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -208,7 +208,8 @@ extension UsageStore {
             changedDuringFetch: claudeAuthChangedDuringFetch)
         let claudeOAuthHistoryPersistentRefHash = Self.stableClaudeKeychainPersistentRefHash(
             beforeFetch: claudeAuthStateBeforeFetch,
-            afterFetch: claudeKeychainPersistentRefHashAfterFetch)
+            afterFetchFingerprintToken: claudeAuthFingerprintAfterFetch,
+            afterFetchPersistentRefHash: claudeKeychainPersistentRefHashAfterFetch)
         guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
         await self.applyProviderRefreshOutcome(
             provider: provider,
@@ -426,15 +427,36 @@ extension UsageStore {
 
     private nonisolated static func stableClaudeKeychainPersistentRefHash(
         beforeFetch: ClaudeRefreshAuthState?,
-        afterFetch: String?) -> String?
+        afterFetchFingerprintToken: String?,
+        afterFetchPersistentRefHash: String?) -> String?
     {
-        guard let beforeFetch = beforeFetch?.keychainPersistentRefHash,
-              beforeFetch == afterFetch
+        guard let beforeFetch,
+              beforeFetch.fingerprintToken == afterFetchFingerprintToken,
+              let beforeFetchPersistentRefHash = beforeFetch.keychainPersistentRefHash,
+              beforeFetchPersistentRefHash == afterFetchPersistentRefHash
         else {
             return nil
         }
-        return beforeFetch
+        return beforeFetchPersistentRefHash
     }
+
+    #if DEBUG
+    nonisolated static func _stableClaudeKeychainPersistentRefHashForTesting(
+        beforeFetchFingerprintToken: String,
+        afterFetchFingerprintToken: String,
+        beforeFetchPersistentRefHash: String?,
+        afterFetchPersistentRefHash: String?) -> String?
+    {
+        self.stableClaudeKeychainPersistentRefHash(
+            beforeFetch: ClaudeRefreshAuthState(
+                fingerprintToken: beforeFetchFingerprintToken,
+                credentialsFileChanged: false,
+                keychainFingerprintChanged: false,
+                keychainPersistentRefHash: beforeFetchPersistentRefHash),
+            afterFetchFingerprintToken: afterFetchFingerprintToken,
+            afterFetchPersistentRefHash: afterFetchPersistentRefHash)
+    }
+    #endif
 
     private nonisolated static func invalidateClaudeCredentialsFileCacheIfChanged() async -> Bool {
         await withTaskGroup(of: Bool.self, returning: Bool.self) { group in

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -280,12 +280,18 @@ extension UsageStore {
             }
             let isClaudeOAuthSample = provider == .claude
                 && result.strategyKind == .oauth
+            let claudeOAuthPersistentRefHash: String? = if isClaudeOAuthSample,
+                                                           result.claudeOAuthKeychainPersistentRefHash == context
+                                                               .claudeOAuthHistoryPersistentRefHash
+            {
+                result.claudeOAuthKeychainPersistentRefHash
+            } else {
+                nil
+            }
             await self.recordPlanUtilizationHistorySample(
                 provider: provider,
                 snapshot: backfilled,
-                claudeOAuthPersistentRefHash: isClaudeOAuthSample
-                    ? context.claudeOAuthHistoryPersistentRefHash
-                    : nil,
+                claudeOAuthPersistentRefHash: claudeOAuthPersistentRefHash,
                 isClaudeOAuthSample: isClaudeOAuthSample)
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             if let runtime = self.providerRuntimes[provider] {

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -7,6 +7,7 @@ extension UsageStore {
         let codexExpectedGuard: CodexAccountScopedRefreshGuard?
         let claudeCredentialsChanged: Bool
         let shouldConsumeClaudeKeychainFingerprint: Bool
+        let claudeOAuthHistoryPersistentRefHash: String?
     }
 
     static func commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
@@ -191,6 +192,9 @@ extension UsageStore {
         let claudeAuthFingerprintAfterFetch = provider == .claude
             ? await Self.captureClaudeAuthFingerprintToken()
             : nil
+        let claudeKeychainPersistentRefHashAfterFetch = provider == .claude
+            ? await Self.captureClaudeKeychainPersistentRefHash()
+            : nil
         let claudeAuthChangedDuringFetch = Self.claudeAuthChangedDuringFetch(
             provider: provider,
             beforeFetch: claudeAuthStateBeforeFetch,
@@ -202,6 +206,9 @@ extension UsageStore {
         let shouldConsumeClaudeKeychainFingerprint = Self.shouldConsumeClaudeKeychainFingerprintChange(
             beforeFetch: claudeAuthStateBeforeFetch,
             changedDuringFetch: claudeAuthChangedDuringFetch)
+        let claudeOAuthHistoryPersistentRefHash = Self.stableClaudeKeychainPersistentRefHash(
+            beforeFetch: claudeAuthStateBeforeFetch,
+            afterFetch: claudeKeychainPersistentRefHashAfterFetch)
         guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
         await self.applyProviderRefreshOutcome(
             provider: provider,
@@ -210,7 +217,8 @@ extension UsageStore {
                 generation: generation,
                 codexExpectedGuard: codexExpectedGuard,
                 claudeCredentialsChanged: claudeCredentialsChanged,
-                shouldConsumeClaudeKeychainFingerprint: shouldConsumeClaudeKeychainFingerprint))
+                shouldConsumeClaudeKeychainFingerprint: shouldConsumeClaudeKeychainFingerprint,
+                claudeOAuthHistoryPersistentRefHash: claudeOAuthHistoryPersistentRefHash))
     }
 
     private func applyProviderRefreshOutcome(
@@ -270,9 +278,15 @@ extension UsageStore {
             if context.shouldConsumeClaudeKeychainFingerprint {
                 _ = await Self.consumeClaudeKeychainFingerprintChangeWithoutPrompt()
             }
+            let isClaudeOAuthSample = provider == .claude
+                && result.strategyKind == .oauth
             await self.recordPlanUtilizationHistorySample(
                 provider: provider,
-                snapshot: backfilled)
+                snapshot: backfilled,
+                claudeOAuthPersistentRefHash: isClaudeOAuthSample
+                    ? context.claudeOAuthHistoryPersistentRefHash
+                    : nil,
+                isClaudeOAuthSample: isClaudeOAuthSample)
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             if let runtime = self.providerRuntimes[provider] {
                 let context = ProviderRuntimeContext(
@@ -336,6 +350,7 @@ extension UsageStore {
         let fingerprintToken: String
         let credentialsFileChanged: Bool
         let keychainFingerprintChanged: Bool
+        let keychainPersistentRefHash: String?
     }
 
     private nonisolated static func claudeCredentialsChanged(
@@ -373,10 +388,13 @@ extension UsageStore {
                     : false
                 let keychainFingerprintChanged = ClaudeOAuthCredentialsStore
                     .claudeKeychainFingerprintChangedWithoutConsuming()
+                let keychainPersistentRefHash = ClaudeOAuthCredentialsStore
+                    .claudeKeychainPersistentRefHashWithoutPrompt()
                 return ClaudeRefreshAuthState(
                     fingerprintToken: fingerprintToken,
                     credentialsFileChanged: credentialsFileChanged,
-                    keychainFingerprintChanged: keychainFingerprintChanged)
+                    keychainFingerprintChanged: keychainFingerprintChanged,
+                    keychainPersistentRefHash: keychainPersistentRefHash)
             }
             return await group.next()!
         }
@@ -389,6 +407,27 @@ extension UsageStore {
             }
             return await group.next()!
         }
+    }
+
+    private nonisolated static func captureClaudeKeychainPersistentRefHash() async -> String? {
+        await withTaskGroup(of: String?.self, returning: String?.self) { group in
+            group.addTask {
+                ClaudeOAuthCredentialsStore.claudeKeychainPersistentRefHashWithoutPrompt()
+            }
+            return await group.next()!
+        }
+    }
+
+    private nonisolated static func stableClaudeKeychainPersistentRefHash(
+        beforeFetch: ClaudeRefreshAuthState?,
+        afterFetch: String?) -> String?
+    {
+        guard let beforeFetch = beforeFetch?.keychainPersistentRefHash,
+              beforeFetch == afterFetch
+        else {
+            return nil
+        }
+        return beforeFetch
     }
 
     private nonisolated static func invalidateClaudeCredentialsFileCacheIfChanged() async -> Bool {

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -293,6 +293,9 @@ extension UsageStore {
                 provider: provider,
                 snapshot: backfilled,
                 claudeOAuthPersistentRefHash: claudeOAuthPersistentRefHash,
+                claudeOAuthHistoryOwnerIdentifier: isClaudeOAuthSample
+                    ? result.claudeOAuthHistoryOwnerIdentifier
+                    : nil,
                 isClaudeOAuthSample: isClaudeOAuthSample)
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             if let runtime = self.providerRuntimes[provider] {

--- a/Sources/CodexBarCLI/CLIHelpers.swift
+++ b/Sources/CodexBarCLI/CLIHelpers.swift
@@ -248,11 +248,16 @@ extension CodexBarCLI {
         return nil
     }
 
-    static func decodeWebTimeout(from values: ParsedValues) -> TimeInterval? {
-        if let raw = values.options["webTimeout"]?.last, let seconds = Double(raw) {
-            return seconds
+    static func decodeWebTimeout(from values: ParsedValues) throws -> TimeInterval? {
+        guard let raw = values.options["webTimeout"]?.last else { return nil }
+        guard let seconds = Double(raw),
+              seconds.isFinite,
+              seconds >= 0,
+              seconds <= TimeInterval(Int64.max)
+        else {
+            throw CLIArgumentError("--web-timeout must be a finite, nonnegative number within the supported range.")
         }
-        return nil
+        return seconds
     }
 
     static func decodeSourceMode(from values: ParsedValues) -> ProviderSourceMode? {
@@ -397,8 +402,8 @@ extension CodexBarCLI {
         self.decodeFormat(from: values)
     }
 
-    static func _decodeWebTimeoutForTesting(from values: ParsedValues) -> TimeInterval? {
-        self.decodeWebTimeout(from: values)
+    static func _decodeWebTimeoutForTesting(from values: ParsedValues) throws -> TimeInterval? {
+        try self.decodeWebTimeout(from: values)
     }
 
     static func _decodeSourceModeForTesting(from values: ParsedValues) -> ProviderSourceMode? {

--- a/Sources/CodexBarCLI/CLIHelpers.swift
+++ b/Sources/CodexBarCLI/CLIHelpers.swift
@@ -302,6 +302,7 @@ extension CodexBarCLI {
         case CodexStatusProbeError.timedOut,
              TTYCommandRunner.Error.timedOut,
              GeminiStatusProbeError.timedOut,
+             ClaudeWebFetchStrategyError.timedOut,
              CostUsageError.timedOut:
             ExitCode(4)
         case ClaudeUsageError.parseFailed,

--- a/Sources/CodexBarCLI/CLIOptions.swift
+++ b/Sources/CodexBarCLI/CLIOptions.swift
@@ -63,7 +63,7 @@ struct UsageOptions: CommanderParsable {
     @Option(name: .long("source"), help: Self.sourceHelp)
     var source: String?
 
-    @Option(name: .long("web-timeout"), help: "Web fetch timeout (seconds) (Codex only; source=web)")
+    @Option(name: .long("web-timeout"), help: "Web fetch timeout (seconds; source=auto or web)")
     var webTimeout: Double?
 
     @Flag(name: .long("web-debug-dump-html"), help: "Dump HTML snapshots to /tmp when Codex dashboard data is missing")

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -62,7 +62,12 @@ extension CodexBarCLI {
         let antigravityPlanDebug = values.flags.contains("antigravityPlanDebug")
         let augmentDebug = values.flags.contains("augmentDebug")
         let webDebugDumpHTML = values.flags.contains("webDebugDumpHtml")
-        let webTimeout = Self.decodeWebTimeout(from: values) ?? 60
+        let webTimeout: TimeInterval
+        do {
+            webTimeout = try Self.decodeWebTimeout(from: values) ?? 60
+        } catch {
+            Self.exit(code: .failure, message: "Error: \(error.localizedDescription)", output: output, kind: .args)
+        }
         let verbose = values.flags.contains("verbose")
         let noColor = values.flags.contains("noColor")
         let useColor = Self.shouldUseColor(noColor: noColor, format: format)
@@ -580,6 +585,10 @@ extension CodexBarCLI {
             return false
         }
         if provider == .codex, sourceMode == .auto {
+            return false
+        }
+        if provider == .claude, sourceMode == .auto {
+            // Claude's cross-platform planner skips its unavailable web step and falls back to the CLI.
             return false
         }
         if provider == .opencodego {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
@@ -2,6 +2,8 @@ import Foundation
 
 #if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
 #endif
 
 #if os(macOS)
@@ -65,12 +67,8 @@ public struct ClaudeOAuthCredentials: Sendable {
     }
 
     private static func makeHistoryOwnerIdentifier(secretKind: String, secret: String) -> String? {
-        #if canImport(CryptoKit)
         let material = Data("codexbar:claude-oauth-history-owner:v1\0\(secretKind)\0\(secret)".utf8)
         return SHA256.hash(data: material).map { String(format: "%02x", $0) }.joined()
-        #else
-        return nil
-        #endif
     }
 
     static func normalizedHistoryOwnerIdentifier(_ identifier: String?) -> String? {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
@@ -49,24 +49,44 @@ public struct ClaudeOAuthCredentials: Sendable {
     /// risking that two identityless accounts share one. The source secret never leaves this computation.
     var historyOwnerIdentifier: String? {
         let normalizedRefreshToken = self.refreshToken?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let secretKind: String
-        let secret: String
         if let normalizedRefreshToken, !normalizedRefreshToken.isEmpty {
-            secretKind = "refresh"
-            secret = normalizedRefreshToken
-        } else {
-            let normalizedAccessToken = self.accessToken.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !normalizedAccessToken.isEmpty else { return nil }
-            secretKind = "access"
-            secret = normalizedAccessToken
+            return Self.makeHistoryOwnerIdentifier(secretKind: "refresh", secret: normalizedRefreshToken)
         }
 
+        let normalizedAccessToken = self.accessToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedAccessToken.isEmpty else { return nil }
+        return Self.makeHistoryOwnerIdentifier(secretKind: "access", secret: normalizedAccessToken)
+    }
+
+    static func historyOwnerIdentifier(forRefreshToken refreshToken: String) -> String? {
+        let normalized = refreshToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return nil }
+        return Self.makeHistoryOwnerIdentifier(secretKind: "refresh", secret: normalized)
+    }
+
+    private static func makeHistoryOwnerIdentifier(secretKind: String, secret: String) -> String? {
         #if canImport(CryptoKit)
         let material = Data("codexbar:claude-oauth-history-owner:v1\0\(secretKind)\0\(secret)".utf8)
         return SHA256.hash(data: material).map { String(format: "%02x", $0) }.joined()
         #else
         return nil
         #endif
+    }
+
+    static func normalizedHistoryOwnerIdentifier(_ identifier: String?) -> String? {
+        guard let identifier else { return nil }
+        let normalized = identifier.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard normalized.count == 64,
+              normalized.unicodeScalars.allSatisfy({ scalar in
+                  switch scalar.value {
+                  case 48...57, 97...102:
+                      true
+                  default:
+                      false
+                  }
+              })
+        else { return nil }
+        return normalized
     }
 
     public static func parse(data: Data) throws -> ClaudeOAuthCredentials {
@@ -161,6 +181,13 @@ public struct ClaudeOAuthCredentialRecord: Sendable {
     public let credentials: ClaudeOAuthCredentials
     public let owner: ClaudeOAuthCredentialOwner
     public let source: ClaudeOAuthCredentialSource
+    private let inheritedHistoryOwnerIdentifier: String?
+
+    /// An opaque, one-way owner identifier that survives a refresh-token rotation proven by a successful refresh.
+    /// Records from unrelated credential sources do not inherit this value and derive a fresh identifier instead.
+    var historyOwnerIdentifier: String? {
+        self.inheritedHistoryOwnerIdentifier ?? self.credentials.historyOwnerIdentifier
+    }
 
     public init(
         credentials: ClaudeOAuthCredentials,
@@ -170,6 +197,20 @@ public struct ClaudeOAuthCredentialRecord: Sendable {
         self.credentials = credentials
         self.owner = owner
         self.source = source
+        self.inheritedHistoryOwnerIdentifier = nil
+    }
+
+    init(
+        credentials: ClaudeOAuthCredentials,
+        owner: ClaudeOAuthCredentialOwner,
+        source: ClaudeOAuthCredentialSource,
+        historyOwnerIdentifier: String?)
+    {
+        self.credentials = credentials
+        self.owner = owner
+        self.source = source
+        self.inheritedHistoryOwnerIdentifier = ClaudeOAuthCredentials.normalizedHistoryOwnerIdentifier(
+            historyOwnerIdentifier)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
 #if os(macOS)
 import Security
 #endif
@@ -36,6 +40,33 @@ public struct ClaudeOAuthCredentials: Sendable {
     public var expiresIn: TimeInterval? {
         guard let expiresAt else { return nil }
         return expiresAt.timeIntervalSinceNow
+    }
+
+    /// A one-way discriminator for history owned by this credential.
+    ///
+    /// Prefer the refresh token because access tokens routinely rotate for the same principal. If a provider
+    /// supplies only an access token, rotating that token intentionally starts a new history bucket rather than
+    /// risking that two identityless accounts share one. The source secret never leaves this computation.
+    var historyOwnerIdentifier: String? {
+        let normalizedRefreshToken = self.refreshToken?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let secretKind: String
+        let secret: String
+        if let normalizedRefreshToken, !normalizedRefreshToken.isEmpty {
+            secretKind = "refresh"
+            secret = normalizedRefreshToken
+        } else {
+            let normalizedAccessToken = self.accessToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedAccessToken.isEmpty else { return nil }
+            secretKind = "access"
+            secret = normalizedAccessToken
+        }
+
+        #if canImport(CryptoKit)
+        let material = Data("codexbar:claude-oauth-history-owner:v1\0\(secretKind)\0\(secret)".utf8)
+        return SHA256.hash(data: material).map { String(format: "%02x", $0) }.joined()
+        #else
+        return nil
+        #endif
     }
 
     public static func parse(data: Data) throws -> ClaudeOAuthCredentials {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -47,6 +47,11 @@ public enum ClaudeOAuthCredentialsStore {
         let persistentRefHash: String?
     }
 
+    private struct ClaudeKeychainCredentialEvidence {
+        let credentials: ClaudeOAuthCredentials
+        let persistentRefHash: String
+    }
+
     struct CredentialsFileFingerprint: Codable, Equatable {
         let modifiedAtMs: Int?
         let size: Int
@@ -1311,15 +1316,109 @@ public enum ClaudeOAuthCredentialsStore {
     public static func matchingClaudeKeychainPersistentRefHashWithoutPrompt(
         for record: ClaudeOAuthCredentialRecord) -> String?
     {
-        guard record.owner == .claudeCLI,
-              let keychainData = try? self.loadFromClaudeKeychainNonInteractive(),
-              let keychainCredentials = try? ClaudeOAuthCredentials.parse(data: keychainData),
-              keychainCredentials.accessToken == record.credentials.accessToken
+        guard record.owner == .claudeCLI else { return nil }
+        return self.matchingClaudeKeychainPersistentRefHash(
+            for: record,
+            evidence: self.newestClaudeKeychainCredentialEvidenceWithoutPrompt())
+    }
+
+    private static func matchingClaudeKeychainPersistentRefHash(
+        for record: ClaudeOAuthCredentialRecord,
+        evidence: ClaudeKeychainCredentialEvidence?) -> String?
+    {
+        guard let evidence,
+              evidence.credentials.accessToken == record.credentials.accessToken
         else {
             return nil
         }
-        return self.claudeKeychainPersistentRefHashWithoutPrompt()
+        return evidence.persistentRefHash
     }
+
+    private static func newestClaudeKeychainCredentialEvidenceWithoutPrompt()
+        -> ClaudeKeychainCredentialEvidence?
+    {
+        #if DEBUG
+        if let store = self.taskClaudeKeychainOverrideStore {
+            return self.makeClaudeKeychainCredentialEvidence(
+                data: store.data,
+                persistentRefHash: store.fingerprint?.persistentRefHash)
+        }
+        let overrideData = self.taskClaudeKeychainDataOverride ?? self.claudeKeychainDataOverride
+        let overrideFingerprint = self.taskClaudeKeychainFingerprintOverride ?? self.claudeKeychainFingerprintOverride
+        if overrideData != nil || overrideFingerprint != nil {
+            return self.makeClaudeKeychainCredentialEvidence(
+                data: overrideData,
+                persistentRefHash: overrideFingerprint?.persistentRefHash)
+        }
+        if self.taskSecurityCLIReadOverride != nil || self.securityCLIReadOverride != nil {
+            // A security(1) result cannot be bound to a persistent reference without an exact candidate read.
+            return nil
+        }
+        #endif
+
+        #if os(macOS)
+        let promptMode = ClaudeOAuthKeychainPromptPreference.current()
+        let newest: ClaudeKeychainCandidate?
+        switch self.claudeKeychainCandidatesProbeWithoutPrompt(promptMode: promptMode) {
+        case .unavailable:
+            return nil
+        case let .value(candidates):
+            if let first = candidates.first {
+                newest = first
+            } else {
+                switch self.claudeKeychainLegacyCandidateProbeWithoutPrompt(promptMode: promptMode) {
+                case .unavailable:
+                    return nil
+                case let .value(candidate):
+                    newest = candidate
+                }
+            }
+        }
+        guard let newest,
+              let persistentRefHash = self.sha256Prefix(newest.persistentRef),
+              let data = try? self.loadClaudeKeychainData(
+                  candidate: newest,
+                  allowKeychainPrompt: false,
+                  promptMode: promptMode)
+        else {
+            return nil
+        }
+        return self.makeClaudeKeychainCredentialEvidence(
+            data: data,
+            persistentRefHash: persistentRefHash)
+        #else
+        return nil
+        #endif
+    }
+
+    private static func makeClaudeKeychainCredentialEvidence(
+        data: Data?,
+        persistentRefHash: String?) -> ClaudeKeychainCredentialEvidence?
+    {
+        guard let data,
+              let persistentRefHash,
+              let credentials = try? ClaudeOAuthCredentials.parse(data: data)
+        else {
+            return nil
+        }
+        return ClaudeKeychainCredentialEvidence(
+            credentials: credentials,
+            persistentRefHash: persistentRefHash)
+    }
+
+    #if DEBUG
+    static func _matchingClaudeKeychainPersistentRefHashForTesting(
+        record: ClaudeOAuthCredentialRecord,
+        candidateCredentials: ClaudeOAuthCredentials,
+        persistentRefHash: String) -> String?
+    {
+        self.matchingClaudeKeychainPersistentRefHash(
+            for: record,
+            evidence: ClaudeKeychainCredentialEvidence(
+                credentials: candidateCredentials,
+                persistentRefHash: persistentRefHash))
+    }
+    #endif
 
     private enum ClaudeKeychainProbe<Value> {
         case unavailable

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1107,6 +1107,18 @@ public enum ClaudeOAuthCredentialsStore {
         allowKeychainPrompt: Bool = true,
         respectKeychainPromptCooldown: Bool = false) async throws -> ClaudeOAuthCredentials
     {
+        try await self.loadRecordWithAutoRefresh(
+            environment: environment,
+            allowKeychainPrompt: allowKeychainPrompt,
+            respectKeychainPromptCooldown: respectKeychainPromptCooldown).credentials
+    }
+
+    /// Record-preserving variant used when callers must distinguish the credential that actually won routing.
+    public static func loadRecordWithAutoRefresh(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        allowKeychainPrompt: Bool = true,
+        respectKeychainPromptCooldown: Bool = false) async throws -> ClaudeOAuthCredentialRecord
+    {
         let context = self.currentCollaboratorContext()
         let repository = Repository(context: context)
         let refresher = Refresher(context: context)
@@ -1133,7 +1145,7 @@ public enum ClaudeOAuthCredentialsStore {
         // If not expired, return as-is
         guard isExpired else {
             self.log.debug("Claude OAuth credentials loaded for usage", metadata: expiryMetadata)
-            return credentials
+            return record
         }
 
         self.log.info("Claude OAuth credentials considered expired", metadata: expiryMetadata)
@@ -1165,7 +1177,10 @@ public enum ClaudeOAuthCredentialsStore {
                 existingRateLimitTier: credentials.rateLimitTier,
                 existingSubscriptionType: credentials.subscriptionType)
             self.log.info("Token refresh successful, expires in \(refreshed.expiresIn ?? 0) seconds")
-            return refreshed
+            return ClaudeOAuthCredentialRecord(
+                credentials: refreshed,
+                owner: .codexbar,
+                source: .memoryCache)
         } catch {
             self.log.error("Token refresh failed: \(error.localizedDescription)")
             throw error
@@ -1289,6 +1304,21 @@ public enum ClaudeOAuthCredentialsStore {
         case let .value(fingerprint):
             fingerprint?.persistentRefHash
         }
+    }
+
+    /// Returns the current Keychain item's persistent-reference hash only when it owns the credential
+    /// that actually won OAuth routing. Token material is compared in memory and is never hashed or persisted.
+    public static func matchingClaudeKeychainPersistentRefHashWithoutPrompt(
+        for record: ClaudeOAuthCredentialRecord) -> String?
+    {
+        guard record.owner == .claudeCLI,
+              let keychainData = try? self.loadFromClaudeKeychainNonInteractive(),
+              let keychainCredentials = try? ClaudeOAuthCredentials.parse(data: keychainData),
+              keychainCredentials.accessToken == record.credentials.accessToken
+        else {
+            return nil
+        }
+        return self.claudeKeychainPersistentRefHashWithoutPrompt()
     }
 
     private enum ClaudeKeychainProbe<Value> {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1279,6 +1279,18 @@ public enum ClaudeOAuthCredentialsStore {
         return "\(modifiedAt):\(createdAt):\(persistentRefHash)"
     }
 
+    /// Returns the current Claude Code Keychain item's opaque persistent-reference hash without
+    /// falling back to a stored fingerprint. History ownership must prefer no identity over a
+    /// potentially stale identity when a non-interactive Keychain probe is unavailable.
+    public static func claudeKeychainPersistentRefHashWithoutPrompt() -> String? {
+        switch self.probeClaudeKeychainFingerprintWithoutPrompt() {
+        case .unavailable:
+            nil
+        case let .value(fingerprint):
+            fingerprint?.persistentRefHash
+        }
+    }
+
     private enum ClaudeKeychainProbe<Value> {
         case unavailable
         case value(Value)

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -61,11 +61,19 @@ public enum ClaudeOAuthCredentialsStore {
         let data: Data
         let storedAt: Date
         let owner: ClaudeOAuthCredentialOwner?
+        let historyOwnerIdentifier: String?
 
-        init(data: Data, storedAt: Date, owner: ClaudeOAuthCredentialOwner? = nil) {
+        init(
+            data: Data,
+            storedAt: Date,
+            owner: ClaudeOAuthCredentialOwner? = nil,
+            historyOwnerIdentifier: String? = nil)
+        {
             self.data = data
             self.storedAt = storedAt
             self.owner = owner
+            self.historyOwnerIdentifier = ClaudeOAuthCredentials.normalizedHistoryOwnerIdentifier(
+                historyOwnerIdentifier)
         }
     }
 
@@ -201,7 +209,8 @@ public enum ClaudeOAuthCredentialsStore {
                     let record = ClaudeOAuthCredentialRecord(
                         credentials: cachedRecord.credentials,
                         owner: owner,
-                        source: .memoryCache)
+                        source: .memoryCache,
+                        historyOwnerIdentifier: cachedRecord.historyOwnerIdentifier)
                     if recovery.shouldAttemptFreshnessSyncFromClaudeKeychain(cached: record),
                        let synced = recovery.syncWithClaudeKeychainIfChanged(
                            cached: record,
@@ -223,7 +232,8 @@ public enum ClaudeOAuthCredentialsStore {
                         let record = ClaudeOAuthCredentialRecord(
                             credentials: creds,
                             owner: owner,
-                            source: .cacheKeychain)
+                            source: .cacheKeychain,
+                            historyOwnerIdentifier: entry.historyOwnerIdentifier)
                         if creds.isExpired {
                             expiredRecord = record
                         } else {
@@ -238,7 +248,8 @@ public enum ClaudeOAuthCredentialsStore {
                                 record: ClaudeOAuthCredentialRecord(
                                     credentials: creds,
                                     owner: owner,
-                                    source: .memoryCache),
+                                    source: .memoryCache,
+                                    historyOwnerIdentifier: record.historyOwnerIdentifier),
                                 timestamp: Date())
                             return record
                         }
@@ -337,7 +348,8 @@ public enum ClaudeOAuthCredentialsStore {
                     return ClaudeOAuthCredentialRecord(
                         credentials: cachedRecord.credentials,
                         owner: owner,
-                        source: .memoryCache)
+                        source: .memoryCache,
+                        historyOwnerIdentifier: cachedRecord.historyOwnerIdentifier)
                 }
                 if case let .found(entry) = KeychainCacheStore.load(
                     key: ClaudeOAuthCredentialsStore.cacheKey,
@@ -349,7 +361,8 @@ public enum ClaudeOAuthCredentialsStore {
                     return ClaudeOAuthCredentialRecord(
                         credentials: creds,
                         owner: owner,
-                        source: .cacheKeychain)
+                        source: .cacheKeychain,
+                        historyOwnerIdentifier: entry.historyOwnerIdentifier)
                 }
 
                 let promptMode = ClaudeOAuthKeychainPromptPreference.current()
@@ -973,7 +986,8 @@ public enum ClaudeOAuthCredentialsStore {
             refreshToken: String,
             existingScopes: [String],
             existingRateLimitTier: String?,
-            existingSubscriptionType: String? = nil) async throws -> ClaudeOAuthCredentials
+            existingSubscriptionType: String? = nil,
+            historyOwnerIdentifier: String?) async throws -> ClaudeOAuthCredentials
         {
             try await self.context.run {
                 let newCredentials = try await self.refreshAccessTokenCore(
@@ -982,12 +996,15 @@ public enum ClaudeOAuthCredentialsStore {
                     existingRateLimitTier: existingRateLimitTier,
                     existingSubscriptionType: existingSubscriptionType)
 
-                ClaudeOAuthCredentialsStore.saveRefreshedCredentialsToCache(newCredentials)
+                ClaudeOAuthCredentialsStore.saveRefreshedCredentialsToCache(
+                    newCredentials,
+                    historyOwnerIdentifier: historyOwnerIdentifier)
                 ClaudeOAuthCredentialsStore.writeMemoryCache(
                     record: ClaudeOAuthCredentialRecord(
                         credentials: newCredentials,
                         owner: .codexbar,
-                        source: .memoryCache),
+                        source: .memoryCache,
+                        historyOwnerIdentifier: historyOwnerIdentifier),
                     timestamp: Date())
                 ClaudeOAuthRefreshFailureGate.recordSuccess()
 
@@ -1180,12 +1197,14 @@ public enum ClaudeOAuthCredentialsStore {
                 refreshToken: refreshToken,
                 existingScopes: credentials.scopes,
                 existingRateLimitTier: credentials.rateLimitTier,
-                existingSubscriptionType: credentials.subscriptionType)
+                existingSubscriptionType: credentials.subscriptionType,
+                historyOwnerIdentifier: record.historyOwnerIdentifier)
             self.log.info("Token refresh successful, expires in \(refreshed.expiresIn ?? 0) seconds")
             return ClaudeOAuthCredentialRecord(
                 credentials: refreshed,
                 owner: .codexbar,
-                source: .memoryCache)
+                source: .memoryCache,
+                historyOwnerIdentifier: record.historyOwnerIdentifier)
         } catch {
             self.log.error("Token refresh failed: \(error.localizedDescription)")
             throw error
@@ -1193,7 +1212,10 @@ public enum ClaudeOAuthCredentialsStore {
     }
 
     /// Save refreshed credentials to CodexBar's keychain cache
-    private static func saveRefreshedCredentialsToCache(_ credentials: ClaudeOAuthCredentials) {
+    private static func saveRefreshedCredentialsToCache(
+        _ credentials: ClaudeOAuthCredentials,
+        historyOwnerIdentifier: String?)
+    {
         var oauth: [String: Any] = [
             "accessToken": credentials.accessToken,
             "expiresAt": (credentials.expiresAt?.timeIntervalSince1970 ?? 0) * 1000,
@@ -1217,7 +1239,10 @@ public enum ClaudeOAuthCredentialsStore {
             return
         }
 
-        self.saveToCacheKeychain(jsonData, owner: .codexbar)
+        self.saveToCacheKeychain(
+            jsonData,
+            owner: .codexbar,
+            historyOwnerIdentifier: historyOwnerIdentifier)
         self.log.debug("Saved refreshed credentials to CodexBar keychain cache")
     }
 
@@ -2037,8 +2062,16 @@ public enum ClaudeOAuthCredentialsStore {
     }
     #endif
 
-    private static func saveToCacheKeychain(_ data: Data, owner: ClaudeOAuthCredentialOwner? = nil) {
-        let entry = CacheEntry(data: data, storedAt: Date(), owner: owner)
+    private static func saveToCacheKeychain(
+        _ data: Data,
+        owner: ClaudeOAuthCredentialOwner? = nil,
+        historyOwnerIdentifier: String? = nil)
+    {
+        let entry = CacheEntry(
+            data: data,
+            storedAt: Date(),
+            owner: owner,
+            historyOwnerIdentifier: historyOwnerIdentifier)
         KeychainCacheStore.store(key: self.cacheKey, entry: entry)
     }
 
@@ -2242,11 +2275,13 @@ extension ClaudeOAuthCredentialsStore {
         existingRateLimitTier: String?,
         existingSubscriptionType: String? = nil) async throws -> ClaudeOAuthCredentials
     {
-        try await Refresher(context: self.currentCollaboratorContext()).refreshAccessToken(
+        let historyOwnerIdentifier = ClaudeOAuthCredentials.historyOwnerIdentifier(forRefreshToken: refreshToken)
+        return try await Refresher(context: self.currentCollaboratorContext()).refreshAccessToken(
             refreshToken: refreshToken,
             existingScopes: existingScopes,
             existingRateLimitTier: existingRateLimitTier,
-            existingSubscriptionType: existingSubscriptionType)
+            existingSubscriptionType: existingSubscriptionType,
+            historyOwnerIdentifier: historyOwnerIdentifier)
     }
 
     private enum RefreshFailureDisposition: String {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -67,7 +67,8 @@ public enum ClaudeProviderDescriptor {
                     useWebExtras: context.runtime == .app
                         && planningInput.webExtrasEnabled,
                     manualCookieHeader: manualCookieHeader,
-                    browserDetection: context.browserDetection)
+                    browserDetection: context.browserDetection,
+                    hasWebFallback: planningInput.hasWebSession)
             case .auto:
                 fatalError("Planner must not emit .auto as an executable step.")
             }
@@ -82,19 +83,46 @@ public enum ClaudeProviderDescriptor {
     private static func makePlanningInput(context: ProviderFetchContext) async -> ClaudeSourcePlanningInput {
         let webExtrasEnabled = context.settings?.claude?.webExtrasEnabled ?? false
         let needsOAuthAvailability = context.runtime == .app && context.sourceMode == .auto
+        let hasWebSession = await Self.hasWebSessionForPlanning(context: context)
 
         return ClaudeSourcePlanningInput(
             runtime: context.runtime,
             selectedDataSource: Self.sourceDataSource(from: context.sourceMode),
             webExtrasEnabled: webExtrasEnabled,
-            hasWebSession: ClaudeWebFetchStrategy.isAvailableForFallback(
-                context: context,
-                browserDetection: context.browserDetection),
+            hasWebSession: hasWebSession,
             hasCLI: ClaudeCLIResolver.isAvailable(environment: context.env),
             hasOAuthCredentials: needsOAuthAvailability && ClaudeOAuthPlanningAvailability.isAvailable(
                 runtime: context.runtime,
                 sourceMode: context.sourceMode,
                 environment: context.env))
+    }
+
+    private static func hasWebSessionForPlanning(context: ProviderFetchContext) async -> Bool {
+        switch context.sourceMode {
+        case .api, .oauth, .cli:
+            return false
+        case .web:
+            // Explicit web performs its cookie/session work inside the bounded fetch.
+            return context.settings?.claude?.cookieSource != .off
+        case .auto:
+            break
+        }
+
+        switch context.settings?.claude?.cookieSource {
+        case .off?:
+            return false
+        case .manual?:
+            return ClaudeWebFetchStrategy.hasManualSessionKey(context: context)
+        case .auto?, nil:
+            if context.runtime == .cli {
+                // CLI auto deliberately tries web before CLI. Defer browser-cookie inspection to the
+                // bounded web fetch so stale cookie/keychain work shares the web deadline.
+                return true
+            }
+            return await ClaudeWebFetchStrategy.hasBrowserSessionKey(
+                context: context,
+                before: context.webTimeout)
+        }
     }
 
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
@@ -376,6 +404,12 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
 struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     typealias UsageLoader = @Sendable (ProviderFetchContext) async throws -> ClaudeUsageSnapshot
 
+    #if DEBUG
+    @TaskLocal static var availabilityProbeOverrideForTesting:
+        (@Sendable (ProviderFetchContext, BrowserDetection) -> Bool)?
+    @TaskLocal static var usageLoaderOverrideForTesting: UsageLoader?
+    #endif
+
     let id: String = "claude.web"
     let kind: ProviderFetchKind = .web
     let browserDetection: BrowserDetection
@@ -390,7 +424,16 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        Self.isAvailableForFallback(context: context, browserDetection: self.browserDetection)
+        switch context.settings?.claude?.cookieSource {
+        case .off?:
+            false
+        case .manual?:
+            Self.hasManualSessionKey(context: context)
+        case .auto?, nil:
+            // Browser-cookie work can block on browser/Keychain access. Treat it as plausible and
+            // let fetch perform the real import under webTimeout.
+            true
+        }
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
@@ -413,15 +456,31 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         return context.runtime == .cli
     }
 
-    fileprivate static func isAvailableForFallback(
+    fileprivate static func hasManualSessionKey(context: ProviderFetchContext) -> Bool {
+        ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: self.manualCookieHeader(from: context))
+    }
+
+    fileprivate static func hasBrowserSessionKey(
         context: ProviderFetchContext,
-        browserDetection: BrowserDetection) -> Bool
+        before timeout: TimeInterval) async -> Bool
     {
-        if let header = self.manualCookieHeader(from: context) {
-            return ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: header)
+        guard let timeoutDuration = Self.timeoutDuration(timeout) else { return false }
+        let browserDetection = context.browserDetection
+        let sourceTask = Task<Bool, Error> {
+            #if DEBUG
+            if let override = Self.availabilityProbeOverrideForTesting {
+                return override(context, browserDetection)
+            }
+            #endif
+            return ClaudeWebAPIFetcher.hasSessionKey(browserDetection: browserDetection)
         }
-        guard context.settings?.claude?.cookieSource != .off else { return false }
-        return ClaudeWebAPIFetcher.hasSessionKey(browserDetection: browserDetection)
+        let race = BoundedTaskJoin(sourceTask: sourceTask)
+        switch await race.value(joinGrace: timeoutDuration) {
+        case let .value(isAvailable):
+            return isAvailable
+        case .failure, .timedOut:
+            return false
+        }
     }
 
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
@@ -433,16 +492,18 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         before timeout: TimeInterval,
         context: ProviderFetchContext) async throws -> ClaudeUsageSnapshot
     {
-        guard timeout.isFinite,
-              timeout >= 0,
-              timeout <= TimeInterval(Int64.max)
-        else {
+        guard let timeoutDuration = Self.timeoutDuration(timeout) else {
             throw ClaudeWebFetchStrategyError.invalidTimeout
         }
         let sourceTask = Task<ClaudeUsageSnapshot, Error> {
             if let usageLoader = self.usageLoader {
                 return try await usageLoader(context)
             }
+            #if DEBUG
+            if let usageLoader = Self.usageLoaderOverrideForTesting {
+                return try await usageLoader(context)
+            }
+            #endif
             let fetcher = ClaudeUsageFetcher(
                 browserDetection: self.browserDetection,
                 dataSource: .web,
@@ -452,7 +513,7 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             return try await fetcher.loadLatestUsage(model: "sonnet")
         }
         let race = BoundedTaskJoin(sourceTask: sourceTask)
-        switch await race.value(joinGrace: .seconds(timeout)) {
+        switch await race.value(joinGrace: timeoutDuration) {
         case let .value(usage):
             try Task.checkCancellation()
             return usage
@@ -462,6 +523,16 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             try Task.checkCancellation()
             throw ClaudeWebFetchStrategyError.timedOut(seconds: timeout)
         }
+    }
+
+    private static func timeoutDuration(_ timeout: TimeInterval) -> Duration? {
+        guard timeout.isFinite,
+              timeout >= 0,
+              timeout <= TimeInterval(Int64.max)
+        else {
+            return nil
+        }
+        return .seconds(timeout)
     }
 }
 
@@ -485,6 +556,7 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
     let useWebExtras: Bool
     let manualCookieHeader: String?
     let browserDetection: BrowserDetection
+    let hasWebFallback: Bool
 
     func isAvailable(_: ProviderFetchContext) async -> Bool {
         true
@@ -508,9 +580,7 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
         guard context.runtime == .app, context.sourceMode == .auto else { return false }
-        // Only fall through when web is actually available; otherwise preserve actionable CLI errors.
-        return ClaudeWebFetchStrategy.isAvailableForFallback(
-            context: context,
-            browserDetection: self.browserDetection)
+        // Reuse the bounded planning result instead of repeating browser/Keychain work after CLI failure.
+        return self.hasWebFallback
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -402,7 +402,12 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
         guard context.sourceMode == .auto else { return false }
-        _ = error
+        guard !Task.isCancelled,
+              !(error is CancellationError),
+              (error as? URLError)?.code != .cancelled
+        else {
+            return false
+        }
         // In CLI runtime auto mode, web comes before CLI so fallback is required.
         // In app runtime auto mode, web is terminal and should surface its concrete error.
         return context.runtime == .cli
@@ -428,6 +433,12 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         before timeout: TimeInterval,
         context: ProviderFetchContext) async throws -> ClaudeUsageSnapshot
     {
+        guard timeout.isFinite,
+              timeout >= 0,
+              timeout <= TimeInterval(Int64.max)
+        else {
+            throw ClaudeWebFetchStrategyError.invalidTimeout
+        }
         let sourceTask = Task<ClaudeUsageSnapshot, Error> {
             if let usageLoader = self.usageLoader {
                 return try await usageLoader(context)
@@ -441,7 +452,7 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             return try await fetcher.loadLatestUsage(model: "sonnet")
         }
         let race = BoundedTaskJoin(sourceTask: sourceTask)
-        switch await race.value(joinGrace: .seconds(max(0, timeout))) {
+        switch await race.value(joinGrace: .seconds(timeout)) {
         case let .value(usage):
             try Task.checkCancellation()
             return usage
@@ -455,10 +466,13 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
 }
 
 enum ClaudeWebFetchStrategyError: LocalizedError, Equatable, Sendable {
+    case invalidTimeout
     case timedOut(seconds: TimeInterval)
 
     var errorDescription: String? {
         switch self {
+        case .invalidTimeout:
+            "Claude web usage fetch timeout must be a finite, nonnegative value within the supported range."
         case let .timedOut(seconds):
             "Claude web usage fetch timed out after \(seconds.formatted()) seconds."
         }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -108,6 +108,8 @@ public enum ClaudeProviderDescriptor {
             break
         }
 
+        guard ClaudeWebFetchStrategy.isSupportedOnCurrentPlatform else { return false }
+
         switch context.settings?.claude?.cookieSource {
         case .off?:
             return false
@@ -401,8 +403,31 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
     }
 }
 
+private final class ClaudeWebFetchDeadlineState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deadline: ContinuousClock.Instant?
+
+    func remainingBudget(
+        fullBudget: Duration,
+        now: ContinuousClock.Instant) -> Duration
+    {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+
+        let deadline: ContinuousClock.Instant
+        if let existingDeadline = self.deadline {
+            deadline = existingDeadline
+        } else {
+            deadline = now.advanced(by: fullBudget)
+            self.deadline = deadline
+        }
+        return max(.zero, now.duration(to: deadline))
+    }
+}
+
 struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     typealias UsageLoader = @Sendable (ProviderFetchContext) async throws -> ClaudeUsageSnapshot
+    typealias DeadlineNow = @Sendable () -> ContinuousClock.Instant
 
     #if DEBUG
     @TaskLocal static var availabilityProbeOverrideForTesting:
@@ -414,24 +439,41 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .web
     let browserDetection: BrowserDetection
     private let usageLoader: UsageLoader?
+    private let deadlineState: ClaudeWebFetchDeadlineState
+    private let deadlineNow: DeadlineNow
 
     init(
         browserDetection: BrowserDetection,
-        usageLoader: UsageLoader? = nil)
+        usageLoader: UsageLoader? = nil,
+        deadlineNow: @escaping DeadlineNow = { ContinuousClock.now })
     {
         self.browserDetection = browserDetection
         self.usageLoader = usageLoader
+        self.deadlineState = ClaudeWebFetchDeadlineState()
+        self.deadlineNow = deadlineNow
     }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        switch context.settings?.claude?.cookieSource {
+        let appAutoRemainingBudget: Duration?
+        if context.runtime == .app, context.sourceMode == .auto {
+            guard let fullBudget = Self.timeoutDuration(context.webTimeout) else { return false }
+            let remainingBudget = self.deadlineState.remainingBudget(
+                fullBudget: fullBudget,
+                now: self.deadlineNow())
+            guard remainingBudget > .zero else { return false }
+            appAutoRemainingBudget = remainingBudget
+        } else {
+            appAutoRemainingBudget = nil
+        }
+
+        return switch context.settings?.claude?.cookieSource {
         case .off?:
             false
         case .manual?:
             Self.hasManualSessionKey(context: context)
         case .auto?, nil:
-            if context.runtime == .app, context.sourceMode == .auto {
-                await Self.hasBrowserSessionKey(context: context, before: context.webTimeout)
+            if let appAutoRemainingBudget {
+                await Self.hasBrowserSessionKey(context: context, before: appAutoRemainingBudget)
             } else {
                 // Explicit web and CLI auto perform the real browser import inside the bounded fetch.
                 true
@@ -465,9 +507,8 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
 
     fileprivate static func hasBrowserSessionKey(
         context: ProviderFetchContext,
-        before timeout: TimeInterval) async -> Bool
+        before timeout: Duration) async -> Bool
     {
-        guard let timeoutDuration = Self.timeoutDuration(timeout) else { return false }
         let browserDetection = context.browserDetection
         let sourceTask = Task<Bool, Error> {
             #if DEBUG
@@ -478,7 +519,7 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             return ClaudeWebAPIFetcher.hasSessionKey(browserDetection: browserDetection)
         }
         let race = BoundedTaskJoin(sourceTask: sourceTask)
-        switch await race.value(joinGrace: timeoutDuration) {
+        switch await race.value(joinGrace: timeout) {
         case let .value(isAvailable):
             return isAvailable
         case .failure, .timedOut:
@@ -498,6 +539,13 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         guard let timeoutDuration = Self.timeoutDuration(timeout) else {
             throw ClaudeWebFetchStrategyError.invalidTimeout
         }
+        let remainingBudget = self.deadlineState.remainingBudget(
+            fullBudget: timeoutDuration,
+            now: self.deadlineNow())
+        guard remainingBudget > .zero else {
+            try Task.checkCancellation()
+            throw ClaudeWebFetchStrategyError.timedOut(seconds: timeout)
+        }
         let sourceTask = Task<ClaudeUsageSnapshot, Error> {
             if let usageLoader = self.usageLoader {
                 return try await usageLoader(context)
@@ -516,7 +564,7 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             return try await fetcher.loadLatestUsage(model: "sonnet")
         }
         let race = BoundedTaskJoin(sourceTask: sourceTask)
-        switch await race.value(joinGrace: timeoutDuration) {
+        switch await race.value(joinGrace: remainingBudget) {
         case let .value(usage):
             try Task.checkCancellation()
             return usage
@@ -536,6 +584,14 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
             return nil
         }
         return .seconds(timeout)
+    }
+
+    fileprivate static var isSupportedOnCurrentPlatform: Bool {
+        #if os(macOS)
+        true
+        #else
+        false
+        #endif
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -50,7 +50,7 @@ public enum ClaudeProviderDescriptor {
             return [ClaudeAdminAPIFetchStrategy()]
         }
 
-        let planningInput = await Self.makePlanningInput(context: context)
+        let planningInput = Self.makePlanningInput(context: context)
         let plan = ClaudeSourcePlanner.resolve(input: planningInput)
         let manualCookieHeader = Self.manualCookieHeader(from: context)
 
@@ -80,10 +80,10 @@ public enum ClaudeProviderDescriptor {
         context.sourceMode == .auto && ClaudeAdminAPISettingsReader.apiKey(environment: context.env) != nil
     }
 
-    private static func makePlanningInput(context: ProviderFetchContext) async -> ClaudeSourcePlanningInput {
+    private static func makePlanningInput(context: ProviderFetchContext) -> ClaudeSourcePlanningInput {
         let webExtrasEnabled = context.settings?.claude?.webExtrasEnabled ?? false
         let needsOAuthAvailability = context.runtime == .app && context.sourceMode == .auto
-        let hasWebSession = await Self.hasWebSessionForPlanning(context: context)
+        let hasWebSession = Self.hasPlausibleWebSession(context: context)
 
         return ClaudeSourcePlanningInput(
             runtime: context.runtime,
@@ -97,7 +97,7 @@ public enum ClaudeProviderDescriptor {
                 environment: context.env))
     }
 
-    private static func hasWebSessionForPlanning(context: ProviderFetchContext) async -> Bool {
+    private static func hasPlausibleWebSession(context: ProviderFetchContext) -> Bool {
         switch context.sourceMode {
         case .api, .oauth, .cli:
             return false
@@ -114,14 +114,10 @@ public enum ClaudeProviderDescriptor {
         case .manual?:
             return ClaudeWebFetchStrategy.hasManualSessionKey(context: context)
         case .auto?, nil:
-            if context.runtime == .cli {
-                // CLI auto deliberately tries web before CLI. Defer browser-cookie inspection to the
-                // bounded web fetch so stale cookie/keychain work shares the web deadline.
-                return true
-            }
-            return await ClaudeWebFetchStrategy.hasBrowserSessionKey(
-                context: context,
-                before: context.webTimeout)
+            // Browser/Keychain inspection can block. Keep planning synchronous and let the web step
+            // perform the bounded availability check if app-auto actually reaches its last fallback.
+            // CLI auto continues to perform its real session import inside the bounded web fetch.
+            return true
         }
     }
 
@@ -198,10 +194,14 @@ private struct ClaudePlannedFetchStrategy: ProviderFetchStrategy {
     }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        if context.sourceMode == .auto {
-            return self.plannedStep.isPlausiblyAvailable
+        guard context.sourceMode == .auto else {
+            return await self.base.isAvailable(context)
         }
-        return await self.base.isAvailable(context)
+        guard self.plannedStep.isPlausiblyAvailable else { return false }
+        if context.runtime == .app, self.plannedStep.dataSource == .web {
+            return await self.base.isAvailable(context)
+        }
+        return true
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
@@ -430,9 +430,12 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         case .manual?:
             Self.hasManualSessionKey(context: context)
         case .auto?, nil:
-            // Browser-cookie work can block on browser/Keychain access. Treat it as plausible and
-            // let fetch perform the real import under webTimeout.
-            true
+            if context.runtime == .app, context.sourceMode == .auto {
+                await Self.hasBrowserSessionKey(context: context, before: context.webTimeout)
+            } else {
+                // Explicit web and CLI auto perform the real browser import inside the bounded fetch.
+                true
+            }
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -374,22 +374,27 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
 }
 
 struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
+    typealias UsageLoader = @Sendable (ProviderFetchContext) async throws -> ClaudeUsageSnapshot
+
     let id: String = "claude.web"
     let kind: ProviderFetchKind = .web
     let browserDetection: BrowserDetection
+    private let usageLoader: UsageLoader?
+
+    init(
+        browserDetection: BrowserDetection,
+        usageLoader: UsageLoader? = nil)
+    {
+        self.browserDetection = browserDetection
+        self.usageLoader = usageLoader
+    }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         Self.isAvailableForFallback(context: context, browserDetection: self.browserDetection)
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let fetcher = ClaudeUsageFetcher(
-            browserDetection: browserDetection,
-            dataSource: .web,
-            useWebExtras: false,
-            manualCookieHeader: Self.manualCookieHeader(from: context),
-            webOrganizationID: context.settings?.claude?.organizationID)
-        let usage = try await fetcher.loadLatestUsage(model: "sonnet")
+        let usage = try await self.loadUsage(before: context.webTimeout, context: context)
         return self.makeResult(
             usage: ClaudeOAuthFetchStrategy.snapshot(from: usage),
             sourceLabel: "web")
@@ -417,6 +422,46 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
         guard context.settings?.claude?.cookieSource == .manual else { return nil }
         return CookieHeaderNormalizer.normalize(context.settings?.claude?.manualCookieHeader)
+    }
+
+    private func loadUsage(
+        before timeout: TimeInterval,
+        context: ProviderFetchContext) async throws -> ClaudeUsageSnapshot
+    {
+        let sourceTask = Task<ClaudeUsageSnapshot, Error> {
+            if let usageLoader = self.usageLoader {
+                return try await usageLoader(context)
+            }
+            let fetcher = ClaudeUsageFetcher(
+                browserDetection: self.browserDetection,
+                dataSource: .web,
+                useWebExtras: false,
+                manualCookieHeader: Self.manualCookieHeader(from: context),
+                webOrganizationID: context.settings?.claude?.organizationID)
+            return try await fetcher.loadLatestUsage(model: "sonnet")
+        }
+        let race = BoundedTaskJoin(sourceTask: sourceTask)
+        switch await race.value(joinGrace: .seconds(max(0, timeout))) {
+        case let .value(usage):
+            try Task.checkCancellation()
+            return usage
+        case let .failure(error):
+            throw error
+        case .timedOut:
+            try Task.checkCancellation()
+            throw ClaudeWebFetchStrategyError.timedOut(seconds: timeout)
+        }
+    }
+}
+
+enum ClaudeWebFetchStrategyError: LocalizedError, Equatable, Sendable {
+    case timedOut(seconds: TimeInterval)
+
+    var errorDescription: String? {
+        switch self {
+        case let .timedOut(seconds):
+            "Claude web usage fetch timed out after \(seconds.formatted()) seconds."
+        }
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -370,9 +370,14 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
                 (context.sourceMode == .auto || context.sourceMode == .oauth),
             useWebExtras: false)
         let usage = try await fetcher.loadLatestUsage(model: "sonnet")
-        return self.makeResult(
+        return ProviderFetchResult(
             usage: Self.snapshot(from: usage),
-            sourceLabel: "oauth")
+            credits: nil,
+            dashboard: nil,
+            sourceLabel: "oauth",
+            strategyID: self.id,
+            strategyKind: self.kind,
+            claudeOAuthKeychainPersistentRefHash: usage.oauthKeychainPersistentRefHash)
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -465,11 +465,11 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     }
 }
 
-enum ClaudeWebFetchStrategyError: LocalizedError, Equatable, Sendable {
+public enum ClaudeWebFetchStrategyError: LocalizedError, Equatable, Sendable {
     case invalidTimeout
     case timedOut(seconds: TimeInterval)
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .invalidTimeout:
             "Claude web usage fetch timeout must be a finite, nonnegative value within the supported range."

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -377,7 +377,8 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
             sourceLabel: "oauth",
             strategyID: self.id,
             strategyKind: self.kind,
-            claudeOAuthKeychainPersistentRefHash: usage.oauthKeychainPersistentRefHash)
+            claudeOAuthKeychainPersistentRefHash: usage.oauthKeychainPersistentRefHash,
+            claudeOAuthHistoryOwnerIdentifier: usage.oauthHistoryOwnerIdentifier)
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -23,6 +23,8 @@ public struct ClaudeUsageSnapshot: Sendable {
     public let accountOrganization: String?
     public let loginMethod: String?
     public let rawText: String?
+    /// Present only when the credential used for this OAuth fetch matches the current Claude Keychain item.
+    public let oauthKeychainPersistentRefHash: String?
 
     public init(
         primary: RateWindow,
@@ -35,7 +37,8 @@ public struct ClaudeUsageSnapshot: Sendable {
         accountEmail: String?,
         accountOrganization: String?,
         loginMethod: String?,
-        rawText: String?)
+        rawText: String?,
+        oauthKeychainPersistentRefHash: String? = nil)
     {
         self.primary = primary
         self.primaryWindowKind = primaryWindowKind
@@ -48,6 +51,7 @@ public struct ClaudeUsageSnapshot: Sendable {
         self.accountOrganization = accountOrganization
         self.loginMethod = loginMethod
         self.rawText = rawText
+        self.oauthKeychainPersistentRefHash = oauthKeychainPersistentRefHash
     }
 }
 
@@ -280,17 +284,22 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     hasCache: hasCache,
                     startupBootstrapOverride: startupBootstrapOverride)
 
-                let credentials = try await ClaudeOAuthCredentialsStore.$allowBackgroundPromptBootstrap
+                let credentialRecord = try await ClaudeOAuthCredentialsStore.$allowBackgroundPromptBootstrap
                     .withValue(startupBootstrapOverride) {
-                        try await ClaudeUsageFetcher.loadOAuthCredentials(
+                        try await ClaudeUsageFetcher.loadOAuthCredentialRecord(
                             environment: self.fetcher.environment,
                             allowKeychainPrompt: allowKeychainPrompt,
                             respectKeychainPromptCooldown: promptPolicy.shouldRespectKeychainPromptCooldown)
                     }
+                let credentials = credentialRecord.credentials
 
                 try self.validateRequiredOAuthScope(credentials)
                 let usage = try await ClaudeUsageFetcher.fetchOAuthUsage(accessToken: credentials.accessToken)
-                return try ClaudeUsageFetcher.mapOAuthUsage(usage, credentials: credentials)
+                return try ClaudeUsageFetcher.mapOAuthUsage(
+                    usage,
+                    credentials: credentials,
+                    oauthKeychainPersistentRefHash: ClaudeOAuthCredentialsStore
+                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: credentialRecord))
             } catch let error as CancellationError {
                 throw error
             } catch let error as ClaudeUsageError {
@@ -405,10 +414,11 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                         ])
                 }
 
-                let refreshedCredentials = try await ClaudeUsageFetcher.loadOAuthCredentials(
+                let refreshedRecord = try await ClaudeUsageFetcher.loadOAuthCredentialRecord(
                     environment: self.fetcher.environment,
                     allowKeychainPrompt: retryAllowKeychainPrompt,
                     respectKeychainPromptCooldown: promptPolicy.shouldRespectKeychainPromptCooldown)
+                let refreshedCredentials = refreshedRecord.credentials
                 if ClaudeUsageFetcher.isClaudeOAuthFlowDebugEnabled {
                     ClaudeUsageFetcher.log.debug(
                         "Claude OAuth credential load (post-delegation retry)",
@@ -426,7 +436,11 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                 try self.validateRequiredOAuthScope(refreshedCredentials)
                 let usage = try await ClaudeUsageFetcher.fetchOAuthUsage(
                     accessToken: refreshedCredentials.accessToken)
-                return try ClaudeUsageFetcher.mapOAuthUsage(usage, credentials: refreshedCredentials)
+                return try ClaudeUsageFetcher.mapOAuthUsage(
+                    usage,
+                    credentials: refreshedCredentials,
+                    oauthKeychainPersistentRefHash: ClaudeOAuthCredentialsStore
+                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: refreshedRecord))
             } catch {
                 ClaudeUsageFetcher.log.debug(
                     "Claude OAuth post-delegation retry failed",
@@ -820,17 +834,20 @@ extension ClaudeUsageFetcher {
         try await OAuthExecutor(fetcher: self).load(allowDelegatedRetry: allowDelegatedRetry)
     }
 
-    private static func loadOAuthCredentials(
+    private static func loadOAuthCredentialRecord(
         environment: [String: String],
         allowKeychainPrompt: Bool,
-        respectKeychainPromptCooldown: Bool) async throws -> ClaudeOAuthCredentials
+        respectKeychainPromptCooldown: Bool) async throws -> ClaudeOAuthCredentialRecord
     {
         #if DEBUG
         if let override = loadOAuthCredentialsOverride {
-            return try await override(environment, allowKeychainPrompt, respectKeychainPromptCooldown)
+            return try await ClaudeOAuthCredentialRecord(
+                credentials: override(environment, allowKeychainPrompt, respectKeychainPromptCooldown),
+                owner: .environment,
+                source: .environment)
         }
         #endif
-        return try await ClaudeOAuthCredentialsStore.loadWithAutoRefresh(
+        return try await ClaudeOAuthCredentialsStore.loadRecordWithAutoRefresh(
             environment: environment,
             allowKeychainPrompt: allowKeychainPrompt,
             respectKeychainPromptCooldown: respectKeychainPromptCooldown)
@@ -940,7 +957,8 @@ extension ClaudeUsageFetcher {
 
     private static func mapOAuthUsage(
         _ usage: OAuthUsageResponse,
-        credentials: ClaudeOAuthCredentials) throws -> ClaudeUsageSnapshot
+        credentials: ClaudeOAuthCredentials,
+        oauthKeychainPersistentRefHash: String? = nil) throws -> ClaudeUsageSnapshot
     {
         func makeWindow(_ window: OAuthUsageWindow?, windowMinutes: Int?) -> RateWindow? {
             guard let window,
@@ -982,7 +1000,8 @@ extension ClaudeUsageFetcher {
                     accountEmail: nil,
                     accountOrganization: nil,
                     loginMethod: loginMethod,
-                    rawText: nil)
+                    rawText: nil,
+                    oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash)
             }
             throw ClaudeUsageError.parseFailed("missing session data")
         }
@@ -1003,7 +1022,8 @@ extension ClaudeUsageFetcher {
             accountEmail: nil,
             accountOrganization: nil,
             loginMethod: loginMethod,
-            rawText: nil)
+            rawText: nil,
+            oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash)
     }
 
     private static func oauthExtraUsageCost(
@@ -1279,7 +1299,8 @@ extension ClaudeUsageFetcher {
                     accountEmail: snapshot.accountEmail,
                     accountOrganization: snapshot.accountOrganization,
                     loginMethod: snapshot.loginMethod,
-                    rawText: snapshot.rawText)
+                    rawText: snapshot.rawText,
+                    oauthKeychainPersistentRefHash: snapshot.oauthKeychainPersistentRefHash)
             }
         } catch {
             Self.log.debug("Claude web extras fetch failed: \(error.localizedDescription)")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -25,6 +25,8 @@ public struct ClaudeUsageSnapshot: Sendable {
     public let rawText: String?
     /// Present only when the credential used for this OAuth fetch matches the current Claude Keychain item.
     public let oauthKeychainPersistentRefHash: String?
+    /// One-way, high-entropy ownership evidence derived from the exact credential used for this OAuth fetch.
+    public let oauthHistoryOwnerIdentifier: String?
 
     public init(
         primary: RateWindow,
@@ -38,7 +40,8 @@ public struct ClaudeUsageSnapshot: Sendable {
         accountOrganization: String?,
         loginMethod: String?,
         rawText: String?,
-        oauthKeychainPersistentRefHash: String? = nil)
+        oauthKeychainPersistentRefHash: String? = nil,
+        oauthHistoryOwnerIdentifier: String? = nil)
     {
         self.primary = primary
         self.primaryWindowKind = primaryWindowKind
@@ -52,6 +55,7 @@ public struct ClaudeUsageSnapshot: Sendable {
         self.loginMethod = loginMethod
         self.rawText = rawText
         self.oauthKeychainPersistentRefHash = oauthKeychainPersistentRefHash
+        self.oauthHistoryOwnerIdentifier = oauthHistoryOwnerIdentifier
     }
 }
 
@@ -960,6 +964,8 @@ extension ClaudeUsageFetcher {
         credentials: ClaudeOAuthCredentials,
         oauthKeychainPersistentRefHash: String? = nil) throws -> ClaudeUsageSnapshot
     {
+        let oauthHistoryOwnerIdentifier = credentials.historyOwnerIdentifier
+
         func makeWindow(_ window: OAuthUsageWindow?, windowMinutes: Int?) -> RateWindow? {
             guard let window,
                   let utilization = window.utilization
@@ -1001,7 +1007,8 @@ extension ClaudeUsageFetcher {
                     accountOrganization: nil,
                     loginMethod: loginMethod,
                     rawText: nil,
-                    oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash)
+                    oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash,
+                    oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier)
             }
             throw ClaudeUsageError.parseFailed("missing session data")
         }
@@ -1023,7 +1030,8 @@ extension ClaudeUsageFetcher {
             accountOrganization: nil,
             loginMethod: loginMethod,
             rawText: nil,
-            oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash)
+            oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash,
+            oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier)
     }
 
     private static func oauthExtraUsageCost(
@@ -1300,7 +1308,8 @@ extension ClaudeUsageFetcher {
                     accountOrganization: snapshot.accountOrganization,
                     loginMethod: snapshot.loginMethod,
                     rawText: snapshot.rawText,
-                    oauthKeychainPersistentRefHash: snapshot.oauthKeychainPersistentRefHash)
+                    oauthKeychainPersistentRefHash: snapshot.oauthKeychainPersistentRefHash,
+                    oauthHistoryOwnerIdentifier: snapshot.oauthHistoryOwnerIdentifier)
             }
         } catch {
             Self.log.debug("Claude web extras fetch failed: \(error.localizedDescription)")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -303,7 +303,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     usage,
                     credentials: credentials,
                     oauthKeychainPersistentRefHash: ClaudeOAuthCredentialsStore
-                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: credentialRecord))
+                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: credentialRecord),
+                    oauthHistoryOwnerIdentifier: credentialRecord.historyOwnerIdentifier)
             } catch let error as CancellationError {
                 throw error
             } catch let error as ClaudeUsageError {
@@ -444,7 +445,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     usage,
                     credentials: refreshedCredentials,
                     oauthKeychainPersistentRefHash: ClaudeOAuthCredentialsStore
-                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: refreshedRecord))
+                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: refreshedRecord),
+                    oauthHistoryOwnerIdentifier: refreshedRecord.historyOwnerIdentifier)
             } catch {
                 ClaudeUsageFetcher.log.debug(
                     "Claude OAuth post-delegation retry failed",
@@ -962,9 +964,11 @@ extension ClaudeUsageFetcher {
     private static func mapOAuthUsage(
         _ usage: OAuthUsageResponse,
         credentials: ClaudeOAuthCredentials,
-        oauthKeychainPersistentRefHash: String? = nil) throws -> ClaudeUsageSnapshot
+        oauthKeychainPersistentRefHash: String? = nil,
+        oauthHistoryOwnerIdentifier: String? = nil) throws -> ClaudeUsageSnapshot
     {
-        let oauthHistoryOwnerIdentifier = credentials.historyOwnerIdentifier
+        let oauthHistoryOwnerIdentifier = ClaudeOAuthCredentials.normalizedHistoryOwnerIdentifier(
+            oauthHistoryOwnerIdentifier) ?? credentials.historyOwnerIdentifier
 
         func makeWindow(_ window: OAuthUsageWindow?, windowMinutes: Int?) -> RateWindow? {
             guard let window,

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -201,9 +201,19 @@ public struct ProviderFetchPipeline: Sendable {
         attempts.reserveCapacity(strategies.count)
         var lastAvailableError: Error?
 
+        guard !Task.isCancelled else {
+            return ProviderFetchOutcome(result: .failure(CancellationError()), attempts: attempts)
+        }
+
         for strategy in strategies {
+            guard !Task.isCancelled else {
+                return ProviderFetchOutcome(result: .failure(CancellationError()), attempts: attempts)
+            }
             let available = await strategy.isAvailable(context)
 
+            guard !Task.isCancelled else {
+                return ProviderFetchOutcome(result: .failure(CancellationError()), attempts: attempts)
+            }
             guard available else {
                 attempts.append(ProviderFetchAttempt(
                     strategyID: strategy.id,
@@ -215,6 +225,7 @@ public struct ProviderFetchPipeline: Sendable {
 
             do {
                 let result = try await strategy.fetch(context)
+                try Task.checkCancellation()
                 attempts.append(ProviderFetchAttempt(
                     strategyID: strategy.id,
                     kind: strategy.kind,
@@ -228,6 +239,9 @@ public struct ProviderFetchPipeline: Sendable {
                     kind: strategy.kind,
                     wasAvailable: true,
                     errorDescription: error.localizedDescription))
+                if Task.isCancelled || error is CancellationError {
+                    return ProviderFetchOutcome(result: .failure(CancellationError()), attempts: attempts)
+                }
                 if strategy.shouldFallback(on: error, context: context) {
                     continue
                 }

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -101,6 +101,9 @@ public struct ProviderFetchResult: Sendable {
     public let sourceLabel: String
     public let strategyID: String
     public let strategyKind: ProviderFetchKind
+    /// Transient account ownership evidence for plan-utilization history.
+    /// The raw Keychain reference never enters the persisted usage snapshot.
+    public let claudeOAuthKeychainPersistentRefHash: String?
 
     public init(
         usage: UsageSnapshot,
@@ -108,7 +111,8 @@ public struct ProviderFetchResult: Sendable {
         dashboard: OpenAIDashboardSnapshot?,
         sourceLabel: String,
         strategyID: String,
-        strategyKind: ProviderFetchKind)
+        strategyKind: ProviderFetchKind,
+        claudeOAuthKeychainPersistentRefHash: String? = nil)
     {
         self.usage = usage
         self.credits = credits
@@ -116,6 +120,7 @@ public struct ProviderFetchResult: Sendable {
         self.sourceLabel = sourceLabel
         self.strategyID = strategyID
         self.strategyKind = strategyKind
+        self.claudeOAuthKeychainPersistentRefHash = claudeOAuthKeychainPersistentRefHash
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -104,6 +104,9 @@ public struct ProviderFetchResult: Sendable {
     /// Transient account ownership evidence for plan-utilization history.
     /// The raw Keychain reference never enters the persisted usage snapshot.
     public let claudeOAuthKeychainPersistentRefHash: String?
+    /// A one-way discriminator derived from the winning Claude OAuth credential.
+    /// Raw access and refresh tokens never enter the fetch result or persisted history.
+    public let claudeOAuthHistoryOwnerIdentifier: String?
 
     public init(
         usage: UsageSnapshot,
@@ -112,7 +115,8 @@ public struct ProviderFetchResult: Sendable {
         sourceLabel: String,
         strategyID: String,
         strategyKind: ProviderFetchKind,
-        claudeOAuthKeychainPersistentRefHash: String? = nil)
+        claudeOAuthKeychainPersistentRefHash: String? = nil,
+        claudeOAuthHistoryOwnerIdentifier: String? = nil)
     {
         self.usage = usage
         self.credits = credits
@@ -121,6 +125,7 @@ public struct ProviderFetchResult: Sendable {
         self.strategyID = strategyID
         self.strategyKind = strategyKind
         self.claudeOAuthKeychainPersistentRefHash = claudeOAuthKeychainPersistentRefHash
+        self.claudeOAuthHistoryOwnerIdentifier = claudeOAuthHistoryOwnerIdentifier
     }
 }
 

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -227,11 +227,18 @@ final class CLIEntryTests: XCTestCase {
         let signature = CodexBarCLI._usageSignatureForTesting()
         let parser = CommandParser(signature: signature)
         let parsed = try parser.parse(arguments: ["--web-timeout", "45", "--source", "oauth"])
-        XCTAssertEqual(CodexBarCLI._decodeWebTimeoutForTesting(from: parsed), 45)
+        XCTAssertEqual(try CodexBarCLI._decodeWebTimeoutForTesting(from: parsed), 45)
         XCTAssertEqual(CodexBarCLI._decodeSourceModeForTesting(from: parsed), .oauth)
 
         let parsedWeb = try parser.parse(arguments: ["--web"])
         XCTAssertEqual(CodexBarCLI._decodeSourceModeForTesting(from: parsedWeb), .web)
+    }
+
+    func test_rejectsUnsafeWebTimeoutOptions() throws {
+        for value in ["-1", "nan", "inf", "1e300"] {
+            let parsed = ParsedValues(positional: [], options: ["webTimeout": [value]], flags: [])
+            XCTAssertThrowsError(try CodexBarCLI._decodeWebTimeoutForTesting(from: parsed))
+        }
     }
 
     func test_shouldUseColorRespectsFormatAndFlags() {
@@ -319,6 +326,8 @@ final class CLIEntryTests: XCTestCase {
 
         XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .kilo))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .codex))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .claude))
+        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .claude))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .kilo))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .grok))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .grok))

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -159,6 +159,7 @@ final class CLIEntryTests: XCTestCase {
     func test_mapsErrorsToExitCodes() {
         XCTAssertEqual(CodexBarCLI.mapError(CodexStatusProbeError.codexNotInstalled), ExitCode(2))
         XCTAssertEqual(CodexBarCLI.mapError(CodexStatusProbeError.timedOut), ExitCode(4))
+        XCTAssertEqual(CodexBarCLI.mapError(ClaudeWebFetchStrategyError.timedOut(seconds: 1)), ExitCode(4))
         XCTAssertEqual(CodexBarCLI.mapError(UsageError.noRateLimitsFound), ExitCode(3))
     }
 

--- a/Tests/CodexBarTests/CLIWebFallbackTests.swift
+++ b/Tests/CodexBarTests/CLIWebFallbackTests.swift
@@ -165,24 +165,38 @@ struct CLIWebFallbackTests {
 
     @Test
     func `claude CLI fallback is enabled only for app auto`() {
-        let strategy = ClaudeCLIFetchStrategy(
+        let webAvailableStrategy = ClaudeCLIFetchStrategy(
             useWebExtras: false,
             manualCookieHeader: nil,
-            browserDetection: BrowserDetection(cacheTTL: 0))
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            hasWebFallback: true)
+        let webUnavailableStrategy = ClaudeCLIFetchStrategy(
+            useWebExtras: false,
+            manualCookieHeader: nil,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            hasWebFallback: false)
         let error = ClaudeUsageError.parseFailed("cli failed")
         let webAvailableSettings = self.makeClaudeSettingsSnapshot(cookieHeader: "sessionKey=sk-ant-test")
         let webUnavailableSettings = self.makeClaudeSettingsSnapshot(cookieHeader: "foo=bar")
 
-        #expect(strategy.shouldFallback(
+        #expect(webAvailableStrategy.shouldFallback(
             on: error,
             context: self.makeContext(runtime: .app, sourceMode: .auto, settings: webAvailableSettings)))
-        #expect(!strategy.shouldFallback(
+        #expect(!webUnavailableStrategy.shouldFallback(
             on: error,
             context: self.makeContext(runtime: .app, sourceMode: .auto, settings: webUnavailableSettings)))
-        #expect(!strategy.shouldFallback(on: error, context: self.makeContext(runtime: .app, sourceMode: .cli)))
-        #expect(!strategy.shouldFallback(on: error, context: self.makeContext(runtime: .app, sourceMode: .web)))
-        #expect(!strategy.shouldFallback(on: error, context: self.makeContext(runtime: .app, sourceMode: .oauth)))
-        #expect(!strategy.shouldFallback(on: error, context: self.makeContext(runtime: .cli, sourceMode: .auto)))
+        #expect(!webAvailableStrategy.shouldFallback(
+            on: error,
+            context: self.makeContext(runtime: .app, sourceMode: .cli)))
+        #expect(!webAvailableStrategy.shouldFallback(
+            on: error,
+            context: self.makeContext(runtime: .app, sourceMode: .web)))
+        #expect(!webAvailableStrategy.shouldFallback(
+            on: error,
+            context: self.makeContext(runtime: .app, sourceMode: .oauth)))
+        #expect(!webAvailableStrategy.shouldFallback(
+            on: error,
+            context: self.makeContext(runtime: .cli, sourceMode: .auto)))
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
@@ -176,6 +176,101 @@ struct ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests {
     }
 
     @Test
+    func `rotated refresh token preserves history owner through cache restart`() async throws {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        try await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+            ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
+            defer { ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting() }
+
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+            let fileURL = tempDir.appendingPathComponent("credentials.json")
+            let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+            defer { KeychainCacheStore.clear(key: cacheKey) }
+
+            try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+                try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                    try await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                        ClaudeOAuthCredentialsStore.invalidateCache()
+                        let expiredData = self.makeCredentialsData(
+                            accessToken: "access-before-rotation",
+                            expiresAt: Date(timeIntervalSinceNow: -3600),
+                            refreshToken: "refresh-before-rotation")
+                        let originalCredentials = try ClaudeOAuthCredentials.parse(data: expiredData)
+                        let originalHistoryOwner = try #require(originalCredentials.historyOwnerIdentifier)
+                        KeychainCacheStore.store(
+                            key: cacheKey,
+                            entry: ClaudeOAuthCredentialsStore.CacheEntry(
+                                data: expiredData,
+                                storedAt: Date(),
+                                owner: .codexbar))
+
+                        let refreshedRecord = try await ClaudeOAuthCredentialsStore
+                            .withIsolatedMemoryCacheForTesting {
+                                try await self.withClaudeOAuthTokenRefreshStub(handler: { request in
+                                    let response = try HTTPURLResponse(
+                                        url: #require(request.url),
+                                        statusCode: 200,
+                                        httpVersion: "HTTP/1.1",
+                                        headerFields: ["Content-Type": "application/json"])!
+                                    let json = """
+                                    {
+                                      "access_token": "access-after-rotation",
+                                      "refresh_token": "refresh-after-rotation",
+                                      "expires_in": 3600,
+                                      "token_type": "Bearer"
+                                    }
+                                    """
+                                    return (response, Data(json.utf8))
+                                }, operation: {
+                                    try await ClaudeOAuthRefreshFailureGate.$shouldAttemptOverride.withValue(true) {
+                                        try await ClaudeOAuthCredentialsStore.loadRecordWithAutoRefresh(
+                                            environment: [:],
+                                            allowKeychainPrompt: false,
+                                            respectKeychainPromptCooldown: true)
+                                    }
+                                })
+                            }
+
+                        let rotatedCredentialOwner = try #require(
+                            refreshedRecord.credentials.historyOwnerIdentifier)
+                        #expect(rotatedCredentialOwner != originalHistoryOwner)
+                        #expect(refreshedRecord.historyOwnerIdentifier == originalHistoryOwner)
+
+                        switch KeychainCacheStore.load(
+                            key: cacheKey,
+                            as: ClaudeOAuthCredentialsStore.CacheEntry.self)
+                        {
+                        case let .found(entry):
+                            #expect(entry.owner == .codexbar)
+                            #expect(entry.historyOwnerIdentifier == originalHistoryOwner)
+                        default:
+                            Issue.record("Expected refreshed cache entry with preserved history lineage")
+                        }
+
+                        let restartedRecord = try ClaudeOAuthCredentialsStore.withIsolatedMemoryCacheForTesting {
+                            try ClaudeOAuthCredentialsStore.loadRecord(
+                                environment: [:],
+                                allowKeychainPrompt: false,
+                                respectKeychainPromptCooldown: true,
+                                allowClaudeKeychainRepairWithoutPrompt: false)
+                        }
+                        #expect(restartedRecord.credentials.accessToken == "access-after-rotation")
+                        #expect(restartedRecord.credentials.refreshToken == "refresh-after-rotation")
+                        #expect(restartedRecord.source == .cacheKeychain)
+                        #expect(restartedRecord.historyOwnerIdentifier == originalHistoryOwner)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
     func `load record treats codexbar cache as claude CLI owned when credentials file exists`() throws {
         let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
         try KeychainCacheStore.withServiceOverrideForTesting(service) {

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreTests.swift
@@ -23,6 +23,34 @@ struct ClaudeOAuthCredentialsStoreTests {
     }
 
     @Test
+    func `persistent reference hash stays stable across keychain metadata refresh`() {
+        let first = ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint(
+            modifiedAt: 1,
+            createdAt: 1,
+            persistentRefHash: "opaque-ref")
+        let refreshed = ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint(
+            modifiedAt: 2,
+            createdAt: 1,
+            persistentRefHash: "opaque-ref")
+
+        let firstHash = ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+            data: nil,
+            fingerprint: first)
+        {
+            ClaudeOAuthCredentialsStore.claudeKeychainPersistentRefHashWithoutPrompt()
+        }
+        let refreshedHash = ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+            data: nil,
+            fingerprint: refreshed)
+        {
+            ClaudeOAuthCredentialsStore.claudeKeychainPersistentRefHashWithoutPrompt()
+        }
+
+        #expect(firstHash == "opaque-ref")
+        #expect(refreshedHash == firstHash)
+    }
+
+    @Test
     func `loads from keychain cache before expired file`() throws {
         let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
         try ProviderInteractionContext.$current.withValue(.background) {

--- a/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
@@ -51,6 +51,31 @@ struct ClaudeOAuthHistoryCredentialRoutingTests {
         }
     }
 
+    @Test
+    func `newest duplicate reference cannot label a different winning credential`() throws {
+        let winningCredentials = try ClaudeOAuthCredentials.parse(
+            data: self.makeCredentialsData(accessToken: "winning-token"))
+        let newestCandidateCredentials = try ClaudeOAuthCredentials.parse(
+            data: self.makeCredentialsData(accessToken: "newest-candidate-token"))
+        let winningRecord = ClaudeOAuthCredentialRecord(
+            credentials: winningCredentials,
+            owner: .claudeCLI,
+            source: .memoryCache)
+        let newestCandidateRecord = ClaudeOAuthCredentialRecord(
+            credentials: newestCandidateCredentials,
+            owner: .claudeCLI,
+            source: .claudeKeychain)
+
+        #expect(ClaudeOAuthCredentialsStore._matchingClaudeKeychainPersistentRefHashForTesting(
+            record: winningRecord,
+            candidateCredentials: newestCandidateCredentials,
+            persistentRefHash: "newest-candidate-ref") == nil)
+        #expect(ClaudeOAuthCredentialsStore._matchingClaudeKeychainPersistentRefHashForTesting(
+            record: newestCandidateRecord,
+            candidateCredentials: newestCandidateCredentials,
+            persistentRefHash: "newest-candidate-ref") == "newest-candidate-ref")
+    }
+
     private func makeCredentialsData(accessToken: String) -> Data {
         let expiresAt = Int(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000)
         return Data("""

--- a/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct ClaudeOAuthHistoryCredentialRoutingTests {
+    @Test
+    func `history keychain reference only matches the credential that won routing`() throws {
+        let keychainData = self.makeCredentialsData(accessToken: "keychain-token")
+        let keychainCredentials = try ClaudeOAuthCredentials.parse(data: keychainData)
+        let differentCredentials = try ClaudeOAuthCredentials.parse(
+            data: self.makeCredentialsData(accessToken: "different-token"))
+        let fingerprint = ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint(
+            modifiedAt: 1,
+            createdAt: 1,
+            persistentRefHash: "opaque-ref")
+
+        let matchingCLIRecord = ClaudeOAuthCredentialRecord(
+            credentials: keychainCredentials,
+            owner: .claudeCLI,
+            source: .memoryCache)
+        let differentCLIRecord = ClaudeOAuthCredentialRecord(
+            credentials: differentCredentials,
+            owner: .claudeCLI,
+            source: .credentialsFile)
+        let matchingEnvironmentRecord = ClaudeOAuthCredentialRecord(
+            credentials: keychainCredentials,
+            owner: .environment,
+            source: .environment)
+        let matchingCodexBarRecord = ClaudeOAuthCredentialRecord(
+            credentials: keychainCredentials,
+            owner: .codexbar,
+            source: .cacheKeychain)
+
+        ProviderInteractionContext.$current.withValue(.userInitiated) {
+            ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+                    data: keychainData,
+                    fingerprint: fingerprint)
+                {
+                    #expect(ClaudeOAuthCredentialsStore
+                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: matchingCLIRecord) == "opaque-ref")
+                    #expect(ClaudeOAuthCredentialsStore
+                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: differentCLIRecord) == nil)
+                    #expect(ClaudeOAuthCredentialsStore
+                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: matchingEnvironmentRecord) == nil)
+                    #expect(ClaudeOAuthCredentialsStore
+                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: matchingCodexBarRecord) == nil)
+                }
+            }
+        }
+    }
+
+    private func makeCredentialsData(accessToken: String) -> Data {
+        let expiresAt = Int(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000)
+        return Data("""
+        {
+          "claudeAiOauth": {
+            "accessToken": "\(accessToken)",
+            "expiresAt": \(expiresAt),
+            "scopes": ["user:profile"]
+          }
+        }
+        """.utf8)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
@@ -104,6 +104,30 @@ struct ClaudeOAuthHistoryCredentialRoutingTests {
         #expect(!replacementIdentifier.contains("replacement-access"))
     }
 
+    @Test
+    func `only an explicit refresh lineage can preserve a rotated credential owner`() throws {
+        let original = try ClaudeOAuthCredentials.parse(
+            data: self.makeCredentialsData(accessToken: "access-before", refreshToken: "refresh-before"))
+        let rotated = try ClaudeOAuthCredentials.parse(
+            data: self.makeCredentialsData(accessToken: "access-after", refreshToken: "refresh-after"))
+        let originalIdentifier = try #require(original.historyOwnerIdentifier)
+        let rotatedIdentifier = try #require(rotated.historyOwnerIdentifier)
+        #expect(originalIdentifier != rotatedIdentifier)
+
+        let refreshProvenRecord = ClaudeOAuthCredentialRecord(
+            credentials: rotated,
+            owner: .codexbar,
+            source: .memoryCache,
+            historyOwnerIdentifier: originalIdentifier)
+        let unrelatedReplacementRecord = ClaudeOAuthCredentialRecord(
+            credentials: rotated,
+            owner: .codexbar,
+            source: .cacheKeychain)
+
+        #expect(refreshProvenRecord.historyOwnerIdentifier == originalIdentifier)
+        #expect(unrelatedReplacementRecord.historyOwnerIdentifier == rotatedIdentifier)
+    }
+
     private func makeCredentialsData(accessToken: String, refreshToken: String? = nil) -> Data {
         let expiresAt = Int(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000)
         let refreshTokenJSON = refreshToken.map { "\n            \"refreshToken\": \"\($0)\"," } ?? ""

--- a/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
@@ -76,12 +76,42 @@ struct ClaudeOAuthHistoryCredentialRoutingTests {
             persistentRefHash: "newest-candidate-ref") == "newest-candidate-ref")
     }
 
-    private func makeCredentialsData(accessToken: String) -> Data {
+    @Test
+    func `history owner follows refresh credential across access token rotation`() throws {
+        let beforeRefresh = try ClaudeOAuthCredentials.parse(
+            data: self.makeCredentialsData(accessToken: "access-before", refreshToken: "stable-refresh"))
+        let afterRefresh = try ClaudeOAuthCredentials.parse(
+            data: self.makeCredentialsData(accessToken: "access-after", refreshToken: "stable-refresh"))
+
+        let beforeIdentifier = try #require(beforeRefresh.historyOwnerIdentifier)
+        let afterIdentifier = try #require(afterRefresh.historyOwnerIdentifier)
+        #expect(beforeIdentifier == afterIdentifier)
+        #expect(beforeIdentifier.count == 64)
+        #expect(!beforeIdentifier.contains("stable-refresh"))
+    }
+
+    @Test
+    func `access-only credential replacement rotates history owner`() throws {
+        let original = try ClaudeOAuthCredentials.parse(
+            data: self.makeCredentialsData(accessToken: "original-access"))
+        let replacement = try ClaudeOAuthCredentials.parse(
+            data: self.makeCredentialsData(accessToken: "replacement-access"))
+
+        let originalIdentifier = try #require(original.historyOwnerIdentifier)
+        let replacementIdentifier = try #require(replacement.historyOwnerIdentifier)
+        #expect(originalIdentifier != replacementIdentifier)
+        #expect(!originalIdentifier.contains("original-access"))
+        #expect(!replacementIdentifier.contains("replacement-access"))
+    }
+
+    private func makeCredentialsData(accessToken: String, refreshToken: String? = nil) -> Data {
         let expiresAt = Int(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000)
+        let refreshTokenJSON = refreshToken.map { "\n            \"refreshToken\": \"\($0)\"," } ?? ""
         return Data("""
         {
           "claudeAiOauth": {
             "accessToken": "\(accessToken)",
+            \(refreshTokenJSON)
             "expiresAt": \(expiresAt),
             "scopes": ["user:profile"]
           }

--- a/Tests/CodexBarTests/ClaudeOAuthTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthTests.swift
@@ -81,6 +81,7 @@ struct ClaudeOAuthTests {
         #expect(snap.opus?.usedPercent == 5)
         #expect(snap.primary.resetsAt != nil)
         #expect(snap.loginMethod == "Claude Pro")
+        #expect(snap.oauthHistoryOwnerIdentifier?.count == 64)
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -147,6 +147,49 @@ struct ClaudeWebFetchDeadlineTests {
     }
 
     @Test
+    func `app auto availability and fetch share one web deadline`() async {
+        let deadlineClock = ClaudeWebDeadlineClock()
+        let usageProbe = ClaudeWebDeadlineProbe()
+        let context = Self.makeContext(
+            runtime: .app,
+            sourceMode: .auto,
+            webTimeout: 1,
+            cookieSource: .auto)
+        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
+            deadlineClock.advance(by: .milliseconds(990))
+            return true
+        }
+        let strategy = ClaudeWebFetchStrategy(
+            browserDetection: context.browserDetection,
+            usageLoader: { _ in
+                await usageProbe.waitUntilReleased()
+                return Self.makeClaudeUsage()
+            },
+            deadlineNow: { deadlineClock.now() })
+
+        let available = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
+            availabilityOverride)
+        {
+            await strategy.isAvailable(context)
+        }
+        #expect(available)
+
+        let startedAt = ContinuousClock.now
+        do {
+            _ = try await strategy.fetch(context)
+            Issue.record("Expected the stalled load to consume only the remaining web deadline")
+        } catch let error as ClaudeWebFetchStrategyError {
+            #expect(error == .timedOut(seconds: 1))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        let elapsed = startedAt.duration(to: ContinuousClock.now)
+        await usageProbe.release()
+
+        #expect(elapsed < .milliseconds(300))
+    }
+
+    @Test
     func `CLI auto timeout cancels web and falls back to CLI`() async throws {
         let probe = ClaudeWebDeadlineProbe()
         let web = Self.makeTimedOutWebStrategy(probe: probe)
@@ -321,6 +364,23 @@ private final class ClaudeWebPlanningAvailabilityProbe: @unchecked Sendable {
 
     func release() {
         self.releaseSemaphore.signal()
+    }
+}
+
+private final class ClaudeWebDeadlineClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var instant = ContinuousClock.now
+
+    func now() -> ContinuousClock.Instant {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.instant
+    }
+
+    func advance(by duration: Duration) {
+        self.lock.lock()
+        self.instant = self.instant.advanced(by: duration)
+        self.lock.unlock()
     }
 }
 

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -4,6 +4,78 @@ import Testing
 
 struct ClaudeWebFetchDeadlineTests {
     @Test
+    func `CLI auto descriptor defers browser probe and falls back after web deadline`() async throws {
+        let planningProbe = ClaudeWebPlanningAvailabilityProbe()
+        let webProbe = ClaudeWebDeadlineProbe()
+        let context = Self.makeContext(
+            sourceMode: .auto,
+            webTimeout: 0.01,
+            cookieSource: .auto,
+            env: ["CLAUDE_CLI_PATH": "/usr/bin/true"])
+        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
+            planningProbe.stallAndReportUnavailable()
+        }
+        let usageLoader: ClaudeWebFetchStrategy.UsageLoader = { _ in
+            await webProbe.waitUntilReleased()
+            return Self.makeClaudeUsage()
+        }
+        let cliFetchOverride: @Sendable (String, TimeInterval, Bool) async throws -> ClaudeStatusSnapshot =
+            { _, _, _ in Self.makeClaudeStatus() }
+
+        let outcome = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
+            availabilityOverride)
+        {
+            await ClaudeWebFetchStrategy.$usageLoaderOverrideForTesting.withValue(usageLoader) {
+                await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
+                    await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                        context: context,
+                        provider: .claude)
+                }
+            }
+        }
+        await webProbe.release()
+        let result = try outcome.result.get()
+
+        #expect(!planningProbe.wasInvoked)
+        #expect(result.strategyID == "claude.cli")
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web", "claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [true, true])
+        #expect(outcome.attempts.first?.errorDescription?.contains("Claude web usage fetch timed out") == true)
+    }
+
+    @Test
+    func `app auto descriptor bounds and reuses browser availability`() async throws {
+        let planningProbe = ClaudeWebPlanningAvailabilityProbe()
+        let context = Self.makeContext(
+            runtime: .app,
+            sourceMode: .auto,
+            webTimeout: 0.1,
+            cookieSource: .auto,
+            env: [
+                "CLAUDE_CLI_PATH": "/usr/bin/true",
+                ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
+            ])
+        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
+            planningProbe.stallAndReportUnavailable()
+        }
+
+        let strategies = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
+            availabilityOverride)
+        {
+            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.pipeline.resolveStrategies(context)
+        }
+        planningProbe.release()
+        let cliStrategy = try #require(strategies.first(where: { $0.id == "claude.cli" }))
+        let shouldFallback = cliStrategy.shouldFallback(
+            on: ClaudeUsageError.parseFailed("cli failed"),
+            context: context)
+
+        #expect(planningProbe.invocationCount == 1)
+        #expect(!shouldFallback)
+        #expect(planningProbe.invocationCount == 1)
+    }
+
+    @Test
     func `CLI auto timeout cancels web and falls back to CLI`() async throws {
         let probe = ClaudeWebDeadlineProbe()
         let web = Self.makeTimedOutWebStrategy(probe: probe)
@@ -93,23 +165,26 @@ struct ClaudeWebFetchDeadlineTests {
     }
 
     private static func makeContext(
+        runtime: ProviderRuntime = .cli,
         sourceMode: ProviderSourceMode,
-        webTimeout: TimeInterval) -> ProviderFetchContext
+        webTimeout: TimeInterval,
+        cookieSource: ProviderCookieSource = .manual,
+        env: [String: String] = [:]) -> ProviderFetchContext
     {
         let browserDetection = BrowserDetection(cacheTTL: 0)
         return ProviderFetchContext(
-            runtime: .cli,
+            runtime: runtime,
             sourceMode: sourceMode,
             includeCredits: false,
             webTimeout: webTimeout,
             webDebugDumpHTML: false,
             verbose: false,
-            env: [:],
+            env: env,
             settings: ProviderSettingsSnapshot.make(claude: .init(
                 usageDataSource: sourceMode == .web ? .web : .auto,
                 webExtrasEnabled: false,
-                cookieSource: .manual,
-                manualCookieHeader: "sessionKey=sk-ant-session-token")),
+                cookieSource: cookieSource,
+                manualCookieHeader: cookieSource == .manual ? "sessionKey=sk-ant-session-token" : nil)),
             fetcher: UsageFetcher(),
             claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
             browserDetection: browserDetection)
@@ -129,6 +204,48 @@ struct ClaudeWebFetchDeadlineTests {
             accountOrganization: nil,
             loginMethod: nil,
             rawText: nil)
+    }
+
+    private static func makeClaudeStatus() -> ClaudeStatusSnapshot {
+        ClaudeStatusSnapshot(
+            sessionPercentLeft: 80,
+            weeklyPercentLeft: nil,
+            opusPercentLeft: nil,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: nil,
+            primaryResetDescription: nil,
+            secondaryResetDescription: nil,
+            opusResetDescription: nil,
+            rawText: "stub")
+    }
+}
+
+private final class ClaudeWebPlanningAvailabilityProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var invocations = 0
+
+    var invocationCount: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.invocations
+    }
+
+    var wasInvoked: Bool {
+        self.invocationCount > 0
+    }
+
+    func stallAndReportUnavailable() -> Bool {
+        self.lock.lock()
+        self.invocations += 1
+        self.lock.unlock()
+        _ = self.releaseSemaphore.wait(timeout: .now() + 1)
+        return false
+    }
+
+    func release() {
+        self.releaseSemaphore.signal()
     }
 }
 

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -38,6 +38,51 @@ struct ClaudeWebFetchDeadlineTests {
         #expect(outcome.attempts.map(\.strategyID) == ["claude.web"])
     }
 
+    @Test
+    func `caller cancellation does not fall back to CLI`() async {
+        let probe = ClaudeWebDeadlineProbe()
+        let web = Self.makeTimedOutWebStrategy(probe: probe)
+        let pipeline = ProviderFetchPipeline { _ in [web, ClaudeWebDeadlineCLIStrategy()] }
+        let context = Self.makeContext(sourceMode: .auto, webTimeout: 60)
+        let fetchTask = Task {
+            await pipeline.fetch(context: context, provider: .claude)
+        }
+
+        await probe.waitUntilStarted()
+        fetchTask.cancel()
+        let outcome = await fetchTask.value
+        await probe.release()
+
+        switch outcome.result {
+        case .success:
+            Issue.record("Expected caller cancellation to stop the fetch pipeline")
+        case let .failure(error):
+            #expect(error is CancellationError)
+        }
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web"])
+    }
+
+    @Test
+    func `unsafe timeout is rejected before starting web work`() async {
+        let strategy = ClaudeWebFetchStrategy(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            usageLoader: { _ in
+                Issue.record("Unsafe timeout should be rejected before invoking the loader")
+                return Self.makeClaudeUsage()
+            })
+
+        for timeout in [-1, .nan, .infinity, .greatestFiniteMagnitude] {
+            do {
+                _ = try await strategy.fetch(Self.makeContext(sourceMode: .web, webTimeout: timeout))
+                Issue.record("Expected timeout \(timeout) to be rejected")
+            } catch let error as ClaudeWebFetchStrategyError {
+                #expect(error == .invalidTimeout)
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
     private static func makeTimedOutWebStrategy(probe: ClaudeWebDeadlineProbe) -> ClaudeWebFetchStrategy {
         ClaudeWebFetchStrategy(
             browserDetection: BrowserDetection(cacheTTL: 0),
@@ -88,13 +133,27 @@ struct ClaudeWebFetchDeadlineTests {
 }
 
 private actor ClaudeWebDeadlineProbe {
+    private var started = false
     private var released = false
+    private var startWaiter: CheckedContinuation<Void, Never>?
     private var releaseWaiter: CheckedContinuation<Void, Never>?
 
     func waitUntilReleased() async {
+        if !self.started {
+            self.started = true
+            self.startWaiter?.resume()
+            self.startWaiter = nil
+        }
         guard !self.released else { return }
         await withCheckedContinuation { continuation in
             self.releaseWaiter = continuation
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard !self.started else { return }
+        await withCheckedContinuation { continuation in
+            self.startWaiter = continuation
         }
     }
 

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -76,6 +76,63 @@ struct ClaudeWebFetchDeadlineTests {
     }
 
     @Test
+    func `caller cancellation during app auto planning does not execute fallback`() async {
+        let planningProbe = ClaudeWebPlanningAvailabilityProbe()
+        let fallbackProbe = ClaudeWebPlanningAvailabilityProbe()
+        let context = Self.makeContext(
+            runtime: .app,
+            sourceMode: .auto,
+            webTimeout: 60,
+            cookieSource: .auto,
+            env: [
+                "CLAUDE_CLI_PATH": "/usr/bin/true",
+                ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
+            ])
+        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
+            planningProbe.stallAndReportUnavailable()
+        }
+        let oauthLoadOverride: (@Sendable (
+            [String: String],
+            Bool,
+            Bool) async throws -> ClaudeOAuthCredentials)? = { _, _, _ in
+            fallbackProbe.recordInvocation()
+            throw CancellationError()
+        }
+        let cliFetchOverride: @Sendable (String, TimeInterval, Bool) async throws -> ClaudeStatusSnapshot = { _, _, _ in
+            fallbackProbe.recordInvocation()
+            throw CancellationError()
+        }
+
+        let fetchTask = Task {
+            await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(availabilityOverride) {
+                await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(oauthLoadOverride) {
+                    await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
+                        await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                            context: context,
+                            provider: .claude)
+                    }
+                }
+            }
+        }
+
+        while !planningProbe.wasInvoked {
+            await Task.yield()
+        }
+        fetchTask.cancel()
+        let outcome = await fetchTask.value
+        planningProbe.release()
+
+        switch outcome.result {
+        case .success:
+            Issue.record("Expected caller cancellation to stop after availability planning")
+        case let .failure(error):
+            #expect(error is CancellationError)
+        }
+        #expect(outcome.attempts.isEmpty)
+        #expect(fallbackProbe.invocationCount == 0)
+    }
+
+    @Test
     func `CLI auto timeout cancels web and falls back to CLI`() async throws {
         let probe = ClaudeWebDeadlineProbe()
         let web = Self.makeTimedOutWebStrategy(probe: probe)
@@ -237,11 +294,15 @@ private final class ClaudeWebPlanningAvailabilityProbe: @unchecked Sendable {
     }
 
     func stallAndReportUnavailable() -> Bool {
+        self.recordInvocation()
+        _ = self.releaseSemaphore.wait(timeout: .now() + 1)
+        return false
+    }
+
+    func recordInvocation() {
         self.lock.lock()
         self.invocations += 1
         self.lock.unlock()
-        _ = self.releaseSemaphore.wait(timeout: .now() + 1)
-        return false
     }
 
     func release() {

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeWebFetchDeadlineTests {
+    @Test
+    func `CLI auto timeout cancels web and falls back to CLI`() async throws {
+        let probe = ClaudeWebDeadlineProbe()
+        let web = Self.makeTimedOutWebStrategy(probe: probe)
+        let pipeline = ProviderFetchPipeline { _ in [web, ClaudeWebDeadlineCLIStrategy()] }
+        let context = Self.makeContext(sourceMode: .auto, webTimeout: 0.01)
+
+        let outcome = await pipeline.fetch(context: context, provider: .claude)
+        await probe.release()
+        let result = try outcome.result.get()
+
+        #expect(result.strategyID == "claude.cli")
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web", "claude.cli"])
+        #expect(outcome.attempts.first?.errorDescription?.contains("Claude web usage fetch timed out") == true)
+    }
+
+    @Test
+    func `explicit web timeout surfaces without CLI fallback`() async {
+        let probe = ClaudeWebDeadlineProbe()
+        let web = Self.makeTimedOutWebStrategy(probe: probe)
+        let pipeline = ProviderFetchPipeline { _ in [web, ClaudeWebDeadlineCLIStrategy()] }
+        let context = Self.makeContext(sourceMode: .web, webTimeout: 0.01)
+
+        let outcome = await pipeline.fetch(context: context, provider: .claude)
+        await probe.release()
+
+        switch outcome.result {
+        case .success:
+            Issue.record("Expected the explicit web deadline to fail")
+        case let .failure(error):
+            #expect(error as? ClaudeWebFetchStrategyError == .timedOut(seconds: 0.01))
+        }
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web"])
+    }
+
+    private static func makeTimedOutWebStrategy(probe: ClaudeWebDeadlineProbe) -> ClaudeWebFetchStrategy {
+        ClaudeWebFetchStrategy(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            usageLoader: { _ in
+                await probe.waitUntilReleased()
+                return self.makeClaudeUsage()
+            })
+    }
+
+    private static func makeContext(
+        sourceMode: ProviderSourceMode,
+        webTimeout: TimeInterval) -> ProviderFetchContext
+    {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: sourceMode,
+            includeCredits: false,
+            webTimeout: webTimeout,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: ProviderSettingsSnapshot.make(claude: .init(
+                usageDataSource: sourceMode == .web ? .web : .auto,
+                webExtrasEnabled: false,
+                cookieSource: .manual,
+                manualCookieHeader: "sessionKey=sk-ant-session-token")),
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+
+    private static func makeClaudeUsage() -> ClaudeUsageSnapshot {
+        ClaudeUsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            opus: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_100),
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: nil,
+            rawText: nil)
+    }
+}
+
+private actor ClaudeWebDeadlineProbe {
+    private var released = false
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+
+    func waitUntilReleased() async {
+        guard !self.released else { return }
+        await withCheckedContinuation { continuation in
+            self.releaseWaiter = continuation
+        }
+    }
+
+    func release() {
+        self.released = true
+        self.releaseWaiter?.resume()
+        self.releaseWaiter = nil
+    }
+}
+
+private struct ClaudeWebDeadlineCLIStrategy: ProviderFetchStrategy {
+    let id = "claude.cli"
+    let kind: ProviderFetchKind = .cli
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        self.makeResult(
+            usage: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 20,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(timeIntervalSince1970: 1_800_000_100)),
+            sourceLabel: "claude")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -44,41 +44,8 @@ struct ClaudeWebFetchDeadlineTests {
     }
 
     @Test
-    func `app auto descriptor bounds and reuses browser availability`() async throws {
+    func `stalled app auto browser probe does not delay CLI success`() async throws {
         let planningProbe = ClaudeWebPlanningAvailabilityProbe()
-        let context = Self.makeContext(
-            runtime: .app,
-            sourceMode: .auto,
-            webTimeout: 0.1,
-            cookieSource: .auto,
-            env: [
-                "CLAUDE_CLI_PATH": "/usr/bin/true",
-                ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
-            ])
-        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
-            planningProbe.stallAndReportUnavailable()
-        }
-
-        let strategies = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
-            availabilityOverride)
-        {
-            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.pipeline.resolveStrategies(context)
-        }
-        planningProbe.release()
-        let cliStrategy = try #require(strategies.first(where: { $0.id == "claude.cli" }))
-        let shouldFallback = cliStrategy.shouldFallback(
-            on: ClaudeUsageError.parseFailed("cli failed"),
-            context: context)
-
-        #expect(planningProbe.invocationCount == 1)
-        #expect(!shouldFallback)
-        #expect(planningProbe.invocationCount == 1)
-    }
-
-    @Test
-    func `caller cancellation during app auto planning does not execute fallback`() async {
-        let planningProbe = ClaudeWebPlanningAvailabilityProbe()
-        let fallbackProbe = ClaudeWebPlanningAvailabilityProbe()
         let context = Self.makeContext(
             runtime: .app,
             sourceMode: .auto,
@@ -95,21 +62,68 @@ struct ClaudeWebFetchDeadlineTests {
             [String: String],
             Bool,
             Bool) async throws -> ClaudeOAuthCredentials)? = { _, _, _ in
-            fallbackProbe.recordInvocation()
-            throw CancellationError()
+            throw ClaudeUsageError.oauthFailed("stub OAuth failure")
+        }
+        let cliFetchOverride: @Sendable (String, TimeInterval, Bool) async throws -> ClaudeStatusSnapshot =
+            { _, _, _ in Self.makeClaudeStatus() }
+
+        let outcome = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
+            availabilityOverride)
+        {
+            await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(oauthLoadOverride) {
+                await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
+                    await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                        context: context,
+                        provider: .claude)
+                }
+            }
+        }
+        let result = try outcome.result.get()
+
+        #expect(result.strategyID == "claude.cli")
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli"])
+        #expect(!planningProbe.wasInvoked)
+    }
+
+    @Test
+    func `caller cancellation during deferred app auto browser probe stops web fallback`() async {
+        let planningProbe = ClaudeWebPlanningAvailabilityProbe()
+        let webFetchProbe = ClaudeWebPlanningAvailabilityProbe()
+        let context = Self.makeContext(
+            runtime: .app,
+            sourceMode: .auto,
+            webTimeout: 60,
+            cookieSource: .auto,
+            env: [
+                "CLAUDE_CLI_PATH": "/usr/bin/true",
+                ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
+            ])
+        let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
+            planningProbe.stallAndReportUnavailable()
+        }
+        let oauthLoadOverride: (@Sendable (
+            [String: String],
+            Bool,
+            Bool) async throws -> ClaudeOAuthCredentials)? = { _, _, _ in
+            throw ClaudeUsageError.oauthFailed("stub OAuth failure")
         }
         let cliFetchOverride: @Sendable (String, TimeInterval, Bool) async throws -> ClaudeStatusSnapshot = { _, _, _ in
-            fallbackProbe.recordInvocation()
-            throw CancellationError()
+            throw ClaudeUsageError.parseFailed("stub CLI failure")
+        }
+        let usageLoader: ClaudeWebFetchStrategy.UsageLoader = { _ in
+            webFetchProbe.recordInvocation()
+            return Self.makeClaudeUsage()
         }
 
         let fetchTask = Task {
             await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(availabilityOverride) {
-                await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(oauthLoadOverride) {
-                    await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
-                        await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
-                            context: context,
-                            provider: .claude)
+                await ClaudeWebFetchStrategy.$usageLoaderOverrideForTesting.withValue(usageLoader) {
+                    await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(oauthLoadOverride) {
+                        await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
+                            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                                context: context,
+                                provider: .claude)
+                        }
                     }
                 }
             }
@@ -124,12 +138,12 @@ struct ClaudeWebFetchDeadlineTests {
 
         switch outcome.result {
         case .success:
-            Issue.record("Expected caller cancellation to stop after availability planning")
+            Issue.record("Expected caller cancellation to stop the deferred web fallback")
         case let .failure(error):
             #expect(error is CancellationError)
         }
-        #expect(outcome.attempts.isEmpty)
-        #expect(fallbackProbe.invocationCount == 0)
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli"])
+        #expect(webFetchProbe.invocationCount == 0)
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -504,6 +504,23 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
     }
 
     @Test
+    func `claude oauth history scope requires full auth fingerprint stability`() {
+        let stablePersistentRefHash = UsageStore._stableClaudeKeychainPersistentRefHashForTesting(
+            beforeFetchFingerprintToken: "stable-fingerprint",
+            afterFetchFingerprintToken: "stable-fingerprint",
+            beforeFetchPersistentRefHash: "stable-ref",
+            afterFetchPersistentRefHash: "stable-ref")
+        let changedFingerprintPersistentRefHash = UsageStore._stableClaudeKeychainPersistentRefHashForTesting(
+            beforeFetchFingerprintToken: "before-fingerprint",
+            afterFetchFingerprintToken: "after-fingerprint",
+            beforeFetchPersistentRefHash: "stable-ref",
+            afterFetchPersistentRefHash: "stable-ref")
+
+        #expect(stablePersistentRefHash == "stable-ref")
+        #expect(changedFingerprintPersistentRefHash == nil)
+    }
+
+    @Test
     func `same claude email separates team and personal plan history keys`() throws {
         let team = UsageSnapshot(
             primary: nil,

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -201,7 +201,6 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_000_000))
         store._setSnapshotForTesting(snapshot, provider: .claude)
-        store.lastSourceLabels[.claude] = "oauth"
 
         let buckets = try #require(store.planUtilizationHistory[.claude])
         let selection = store.planUtilizationHistorySelection(for: .claude)
@@ -234,7 +233,6 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_000_000))
         store._setSnapshotForTesting(snapshot, provider: .claude)
-        store.lastSourceLabels[.claude] = "oauth"
 
         let buckets = try #require(store.planUtilizationHistory[.claude])
         let selection = store.planUtilizationHistorySelection(for: .claude)
@@ -245,6 +243,92 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         #expect(selection.accountKey == nil)
         #expect(findSeries(selection.histories, name: .session, windowMinutes: 300)?
             .entries.map(\.usedPercent) == [55])
+    }
+
+    @MainActor
+    @Test
+    func `reloaded scoped claude oauth preference wins over configured token account`() throws {
+        let oauthAccountKey = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "oauth-ref"))
+        let oauthHistory = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 45),
+        ])
+        let store = self.makeReloadedStoreWithConfiguredTokenAccount(
+            buckets: PlanUtilizationHistoryBuckets(
+                preferredAccountKey: oauthAccountKey,
+                accounts: [oauthAccountKey: [oauthHistory]]))
+
+        #expect(store.lastSourceLabels[.claude] == nil)
+        #expect(store.settings.selectedTokenAccount(for: .claude) != nil)
+
+        let selection = store.planUtilizationHistorySelection(for: .claude)
+
+        #expect(selection.accountKey == oauthAccountKey)
+        #expect(selection.histories == [oauthHistory])
+        #expect(store.planUtilizationHistory[.claude]?.preferredAccountKey == oauthAccountKey)
+    }
+
+    @MainActor
+    @Test
+    func `reloaded unscoped claude oauth preference wins over configured token account`() {
+        let oauthHistory = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 55),
+        ])
+        let store = self.makeReloadedStoreWithConfiguredTokenAccount(
+            buckets: PlanUtilizationHistoryBuckets(
+                preferredAccountKey: "__unscoped__",
+                unscoped: [oauthHistory]))
+
+        #expect(store.lastSourceLabels[.claude] == nil)
+        #expect(store.settings.selectedTokenAccount(for: .claude) != nil)
+
+        let selection = store.planUtilizationHistorySelection(for: .claude)
+
+        #expect(selection.accountKey == nil)
+        #expect(selection.histories == [oauthHistory])
+        #expect(store.planUtilizationHistory[.claude]?.preferredAccountKey == "__unscoped__")
+    }
+
+    @MainActor
+    @Test
+    func `later token account sample supersedes claude oauth preference`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        store.settings.addTokenAccount(provider: .claude, label: "Selected", token: "selected-token")
+        store.settings.setActiveTokenAccountIndex(0, for: .claude)
+        let selectedAccount = try #require(store.settings.selectedTokenAccount(for: .claude))
+        let tokenAccountKey = try #require(
+            UsageStore._planUtilizationTokenAccountKeyForTesting(provider: .claude, account: selectedAccount))
+        let oauthAccountKey = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "oauth-ref"))
+        let oauthSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 45, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: oauthSnapshot,
+            claudeOAuthPersistentRefHash: "oauth-ref",
+            isClaudeOAuthSample: true,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let tokenSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: tokenSnapshot,
+            account: selectedAccount,
+            now: Date(timeIntervalSince1970: 1_700_007_200))
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        let selection = store.planUtilizationHistorySelection(for: .claude)
+        #expect(buckets.preferredAccountKey == tokenAccountKey)
+        #expect(findSeries(buckets.accounts[oauthAccountKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [45])
+        #expect(selection.accountKey == tokenAccountKey)
+        #expect(findSeries(selection.histories, name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [20])
     }
 
     @MainActor
@@ -415,7 +499,8 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         #expect(first == refreshed)
         #expect(first != switched)
         #expect(first != "abc123")
-        #expect(first.count == 64)
+        #expect(first.hasPrefix("__claude_oauth__:"))
+        #expect(first.dropFirst("__claude_oauth__:".count).count == 64)
     }
 
     @Test
@@ -528,5 +613,30 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         #expect(buckets.accounts[legacyKey] == nil)
         #expect(buckets.accounts[accountKey] == [legacyWeekly])
         #expect(buckets.preferredAccountKey == accountKey)
+    }
+
+    @MainActor
+    private func makeReloadedStoreWithConfiguredTokenAccount(
+        buckets: PlanUtilizationHistoryBuckets) -> UsageStore
+    {
+        let suiteName = "UsageStorePlanUtilizationClaudeReload-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Failed to create isolated UserDefaults suite for tests")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName)
+        historyStore.save([.claude: buckets])
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suiteName),
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.addTokenAccount(provider: .claude, label: "Unrelated", token: "unrelated-token")
+        settings.setActiveTokenAccountIndex(0, for: .claude)
+        return UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: historyStore,
+            startupBehavior: .testing)
     }
 }

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -200,11 +200,17 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             claudeOAuthPersistentRefHash: "oauth-ref",
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_000_000))
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store.lastSourceLabels[.claude] = "oauth"
 
         let buckets = try #require(store.planUtilizationHistory[.claude])
+        let selection = store.planUtilizationHistorySelection(for: .claude)
         #expect(buckets.preferredAccountKey == oauthAccountKey)
         #expect(buckets.accounts[tokenAccountKey] == nil)
         #expect(findSeries(buckets.accounts[oauthAccountKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [45])
+        #expect(selection.accountKey == oauthAccountKey)
+        #expect(findSeries(selection.histories, name: .session, windowMinutes: 300)?
             .entries.map(\.usedPercent) == [45])
     }
 
@@ -227,11 +233,17 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             snapshot: snapshot,
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_000_000))
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store.lastSourceLabels[.claude] = "oauth"
 
         let buckets = try #require(store.planUtilizationHistory[.claude])
+        let selection = store.planUtilizationHistorySelection(for: .claude)
         #expect(buckets.preferredAccountKey != tokenAccountKey)
         #expect(buckets.accounts[tokenAccountKey] == nil)
         #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [55])
+        #expect(selection.accountKey == nil)
+        #expect(findSeries(selection.histories, name: .session, windowMinutes: 300)?
             .entries.map(\.usedPercent) == [55])
     }
 

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -180,6 +180,63 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
+    func `claude oauth persistent reference wins over configured token account`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        store.settings.addTokenAccount(provider: .claude, label: "Unrelated", token: "unrelated-token")
+        store.settings.setActiveTokenAccountIndex(0, for: .claude)
+        let selectedAccount = try #require(store.settings.selectedTokenAccount(for: .claude))
+        let tokenAccountKey = try #require(
+            UsageStore._planUtilizationTokenAccountKeyForTesting(provider: .claude, account: selectedAccount))
+        let oauthAccountKey = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "oauth-ref"))
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 45, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: snapshot,
+            claudeOAuthPersistentRefHash: "oauth-ref",
+            isClaudeOAuthSample: true,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(buckets.preferredAccountKey == oauthAccountKey)
+        #expect(buckets.accounts[tokenAccountKey] == nil)
+        #expect(findSeries(buckets.accounts[oauthAccountKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [45])
+    }
+
+    @MainActor
+    @Test
+    func `unscoped claude oauth wins over configured token account`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        store.settings.addTokenAccount(provider: .claude, label: "Unrelated", token: "unrelated-token")
+        store.settings.setActiveTokenAccountIndex(0, for: .claude)
+        let selectedAccount = try #require(store.settings.selectedTokenAccount(for: .claude))
+        let tokenAccountKey = try #require(
+            UsageStore._planUtilizationTokenAccountKeyForTesting(provider: .claude, account: selectedAccount))
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 55, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: snapshot,
+            isClaudeOAuthSample: true,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(buckets.preferredAccountKey != tokenAccountKey)
+        #expect(buckets.accounts[tokenAccountKey] == nil)
+        #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [55])
+    }
+
+    @MainActor
+    @Test
     func `first claude oauth persistent reference quarantines legacy unscoped history`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let legacy = planSeries(name: .session, windowMinutes: 300, entries: [

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -247,6 +247,84 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
+    func `coalesced scoped claude oauth sample still switches preferred account`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let accountAKey = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "account-a-ref"))
+        let accountBKey = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "account-b-ref"))
+        let hourStart = Date(timeIntervalSince1970: 1_700_000_000)
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.identitylessClaudeSnapshot(usedPercent: 70),
+            claudeOAuthPersistentRefHash: "account-a-ref",
+            isClaudeOAuthSample: true,
+            now: hourStart)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.identitylessClaudeSnapshot(usedPercent: 40),
+            claudeOAuthPersistentRefHash: "account-b-ref",
+            isClaudeOAuthSample: true,
+            now: hourStart.addingTimeInterval(5 * 60))
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.identitylessClaudeSnapshot(usedPercent: 60),
+            claudeOAuthPersistentRefHash: "account-a-ref",
+            isClaudeOAuthSample: true,
+            now: hourStart.addingTimeInterval(10 * 60))
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        let selection = store.planUtilizationHistorySelection(for: .claude)
+        #expect(buckets.preferredAccountKey == accountAKey)
+        #expect(findSeries(buckets.accounts[accountAKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [70])
+        #expect(findSeries(buckets.accounts[accountBKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [40])
+        #expect(selection.accountKey == accountAKey)
+        #expect(findSeries(selection.histories, name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [70])
+    }
+
+    @MainActor
+    @Test
+    func `coalesced unscoped claude oauth sample still switches preferred sentinel`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let scopedAccountKey = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "scoped-ref"))
+        let hourStart = Date(timeIntervalSince1970: 1_700_000_000)
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.identitylessClaudeSnapshot(usedPercent: 70),
+            isClaudeOAuthSample: true,
+            now: hourStart)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.identitylessClaudeSnapshot(usedPercent: 40),
+            claudeOAuthPersistentRefHash: "scoped-ref",
+            isClaudeOAuthSample: true,
+            now: hourStart.addingTimeInterval(5 * 60))
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.identitylessClaudeSnapshot(usedPercent: 60),
+            isClaudeOAuthSample: true,
+            now: hourStart.addingTimeInterval(10 * 60))
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        let selection = store.planUtilizationHistorySelection(for: .claude)
+        #expect(buckets.preferredAccountKey == "__unscoped__")
+        #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [70])
+        #expect(findSeries(buckets.accounts[scopedAccountKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [40])
+        #expect(selection.accountKey == nil)
+        #expect(findSeries(selection.histories, name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [70])
+    }
+
+    @MainActor
+    @Test
     func `reloaded scoped claude oauth preference wins over configured token account`() throws {
         let oauthAccountKey = try #require(
             UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "oauth-ref"))
@@ -630,6 +708,17 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         #expect(buckets.accounts[legacyKey] == nil)
         #expect(buckets.accounts[accountKey] == [legacyWeekly])
         #expect(buckets.preferredAccountKey == accountKey)
+    }
+
+    private func identitylessClaudeSnapshot(usedPercent: Double) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: usedPercent,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
     }
 
     @MainActor

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -247,6 +247,93 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         #expect(buckets.preferredAccountKey != accountAKey)
     }
 
+    @MainActor
+    @Test
+    func `claude oauth unscoped sentinel prevents first later identity adoption`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let identitylessOAuthSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 75, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: identitylessOAuthSnapshot,
+            isClaudeOAuthSample: true,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let identifiedSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+        let identifiedKey = try #require(
+            UsageStore._planUtilizationAccountKeyForTesting(provider: .claude, snapshot: identifiedSnapshot))
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: identifiedSnapshot,
+            now: Date(timeIntervalSince1970: 1_700_007_200))
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [75])
+        #expect(findSeries(buckets.accounts[identifiedKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [10])
+    }
+
+    @MainActor
+    @Test
+    func `claude oauth unscoped history remains quarantined after later scoped samples`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let identitylessOAuthSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 75, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: identitylessOAuthSnapshot,
+            isClaudeOAuthSample: true,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let refScopedSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 60, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        let refScopedKey = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "current-ref"))
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: refScopedSnapshot,
+            claudeOAuthPersistentRefHash: "current-ref",
+            isClaudeOAuthSample: true,
+            now: Date(timeIntervalSince1970: 1_700_007_200))
+
+        let identifiedSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+        let identifiedKey = try #require(
+            UsageStore._planUtilizationAccountKeyForTesting(provider: .claude, snapshot: identifiedSnapshot))
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: identifiedSnapshot,
+            now: Date(timeIntervalSince1970: 1_700_014_400))
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [75])
+        #expect(findSeries(buckets.accounts[refScopedKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [60])
+        #expect(findSeries(buckets.accounts[identifiedKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [10])
+    }
+
     @Test
     func `claude oauth history key is stable across fingerprint metadata changes`() throws {
         let first = try #require(

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -130,6 +130,138 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         #expect(findSeries(history, name: .weekly, windowMinutes: 10080)?.entries.last?.usedPercent == 20)
     }
 
+    @MainActor
+    @Test
+    func `claude oauth persistent reference separates switched account history`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let accountASnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+        let accountAKey = try #require(
+            UsageStore._planUtilizationAccountKeyForTesting(provider: .claude, snapshot: accountASnapshot))
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: accountASnapshot,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let accountBSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 70, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 80, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+        let accountBKey = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "account-b-ref"))
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: accountBSnapshot,
+            claudeOAuthPersistentRefHash: "account-b-ref",
+            isClaudeOAuthSample: true,
+            now: Date(timeIntervalSince1970: 1_700_007_200))
+        store._setSnapshotForTesting(accountBSnapshot, provider: .claude)
+
+        let selectedHistory = store.planUtilizationHistory(for: .claude)
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        let accountAHistory = try #require(buckets.accounts[accountAKey])
+        let accountBHistory = try #require(buckets.accounts[accountBKey])
+
+        #expect(buckets.preferredAccountKey == accountBKey)
+        #expect(buckets.unscoped.isEmpty)
+        #expect(findSeries(accountAHistory, name: .session, windowMinutes: 300)?.entries.last?.usedPercent == 10)
+        #expect(findSeries(accountAHistory, name: .weekly, windowMinutes: 10080)?.entries.last?.usedPercent == 20)
+        #expect(findSeries(accountBHistory, name: .session, windowMinutes: 300)?.entries.last?.usedPercent == 70)
+        #expect(findSeries(accountBHistory, name: .weekly, windowMinutes: 10080)?.entries.last?.usedPercent == 80)
+        #expect(findSeries(selectedHistory, name: .session, windowMinutes: 300)?.entries.last?.usedPercent == 70)
+    }
+
+    @MainActor
+    @Test
+    func `first claude oauth persistent reference quarantines legacy unscoped history`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let legacy = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 25),
+        ])
+        store.planUtilizationHistory[.claude] = PlanUtilizationHistoryBuckets(unscoped: [legacy])
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 60, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        let accountKey = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "current-ref"))
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: snapshot,
+            claudeOAuthPersistentRefHash: "current-ref",
+            isClaudeOAuthSample: true,
+            now: Date(timeIntervalSince1970: 1_700_007_200))
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        let scoped = try #require(buckets.accounts[accountKey])
+        #expect(buckets.unscoped == [legacy])
+        #expect(findSeries(scoped, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [60])
+        #expect(buckets.preferredAccountKey == accountKey)
+    }
+
+    @MainActor
+    @Test
+    func `claude oauth without persistent reference prefers unscoped over previous account`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let accountASnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+        let accountAKey = try #require(
+            UsageStore._planUtilizationAccountKeyForTesting(provider: .claude, snapshot: accountASnapshot))
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: accountASnapshot,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let identitylessOAuthSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 75, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: identitylessOAuthSnapshot,
+            isClaudeOAuthSample: true,
+            now: Date(timeIntervalSince1970: 1_700_007_200))
+        store._setSnapshotForTesting(identitylessOAuthSnapshot, provider: .claude)
+
+        let selectedHistory = store.planUtilizationHistory(for: .claude)
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        let accountAHistory = try #require(buckets.accounts[accountAKey])
+        #expect(findSeries(accountAHistory, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [10])
+        #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [75])
+        #expect(findSeries(selectedHistory, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [75])
+        #expect(buckets.preferredAccountKey != accountAKey)
+    }
+
+    @Test
+    func `claude oauth history key is stable across fingerprint metadata changes`() throws {
+        let first = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "ABC123"))
+        let refreshed = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: " abc123 "))
+        let switched = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "different-ref"))
+
+        #expect(first == refreshed)
+        #expect(first != switched)
+        #expect(first != "abc123")
+        #expect(first.count == 64)
+    }
+
     @Test
     func `same claude email separates team and personal plan history keys`() throws {
         let team = UsageSnapshot(

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -132,8 +132,9 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
-    func `claude oauth persistent reference separates switched account history`() async throws {
+    func `claude oauth credential owner separates switched account history`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
+        let accountBOwner = self.oauthOwnerIdentifier("b")
         let accountASnapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
             secondary: RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
@@ -155,11 +156,13 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             secondary: RateWindow(usedPercent: 80, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
             updatedAt: Date())
         let accountBKey = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "account-b-ref"))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+                historyOwnerIdentifier: accountBOwner))
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
             snapshot: accountBSnapshot,
             claudeOAuthPersistentRefHash: "account-b-ref",
+            claudeOAuthHistoryOwnerIdentifier: accountBOwner,
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_007_200))
         store._setSnapshotForTesting(accountBSnapshot, provider: .claude)
@@ -180,15 +183,17 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
-    func `claude oauth persistent reference wins over configured token account`() async throws {
+    func `claude oauth credential owner wins over configured token account`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
+        let oauthOwner = self.oauthOwnerIdentifier("a")
         store.settings.addTokenAccount(provider: .claude, label: "Unrelated", token: "unrelated-token")
         store.settings.setActiveTokenAccountIndex(0, for: .claude)
         let selectedAccount = try #require(store.settings.selectedTokenAccount(for: .claude))
         let tokenAccountKey = try #require(
             UsageStore._planUtilizationTokenAccountKeyForTesting(provider: .claude, account: selectedAccount))
         let oauthAccountKey = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "oauth-ref"))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+                historyOwnerIdentifier: oauthOwner))
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 45, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
             secondary: nil,
@@ -198,12 +203,13 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             provider: .claude,
             snapshot: snapshot,
             claudeOAuthPersistentRefHash: "oauth-ref",
+            claudeOAuthHistoryOwnerIdentifier: oauthOwner,
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_000_000))
         store._setSnapshotForTesting(snapshot, provider: .claude)
 
-        let buckets = try #require(store.planUtilizationHistory[.claude])
         let selection = store.planUtilizationHistorySelection(for: .claude)
+        let buckets = try #require(store.planUtilizationHistory[.claude])
         #expect(buckets.preferredAccountKey == oauthAccountKey)
         #expect(buckets.accounts[tokenAccountKey] == nil)
         #expect(findSeries(buckets.accounts[oauthAccountKey] ?? [], name: .session, windowMinutes: 300)?
@@ -215,7 +221,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
-    func `unscoped claude oauth wins over configured token account`() async throws {
+    func `claude oauth without credential ownership is not persisted`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
         store.settings.addTokenAccount(provider: .claude, label: "Unrelated", token: "unrelated-token")
         store.settings.setActiveTokenAccountIndex(0, for: .claude)
@@ -230,47 +236,52 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
             snapshot: snapshot,
+            claudeOAuthPersistentRefHash: "row-only-ref",
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_000_000))
         store._setSnapshotForTesting(snapshot, provider: .claude)
 
-        let buckets = try #require(store.planUtilizationHistory[.claude])
         let selection = store.planUtilizationHistorySelection(for: .claude)
-        #expect(buckets.preferredAccountKey != tokenAccountKey)
-        #expect(buckets.accounts[tokenAccountKey] == nil)
-        #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?
-            .entries.map(\.usedPercent) == [55])
-        #expect(selection.accountKey == nil)
-        #expect(findSeries(selection.histories, name: .session, windowMinutes: 300)?
-            .entries.map(\.usedPercent) == [55])
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(buckets.unscoped.isEmpty)
+        #expect(buckets.accounts.isEmpty)
+        #expect(selection.accountKey == tokenAccountKey)
+        #expect(selection.histories.isEmpty)
     }
 
     @MainActor
     @Test
-    func `coalesced scoped claude oauth sample still switches preferred account`() async throws {
+    func `coalesced claude oauth sample still switches preferred account`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
+        let accountAOwner = self.oauthOwnerIdentifier("a")
+        let accountBOwner = self.oauthOwnerIdentifier("b")
         let accountAKey = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "account-a-ref"))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+                historyOwnerIdentifier: accountAOwner))
         let accountBKey = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "account-b-ref"))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+                historyOwnerIdentifier: accountBOwner))
         let hourStart = Date(timeIntervalSince1970: 1_700_000_000)
 
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
             snapshot: self.identitylessClaudeSnapshot(usedPercent: 70),
             claudeOAuthPersistentRefHash: "account-a-ref",
+            claudeOAuthHistoryOwnerIdentifier: accountAOwner,
             isClaudeOAuthSample: true,
             now: hourStart)
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
             snapshot: self.identitylessClaudeSnapshot(usedPercent: 40),
             claudeOAuthPersistentRefHash: "account-b-ref",
+            claudeOAuthHistoryOwnerIdentifier: accountBOwner,
             isClaudeOAuthSample: true,
             now: hourStart.addingTimeInterval(5 * 60))
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
             snapshot: self.identitylessClaudeSnapshot(usedPercent: 60),
             claudeOAuthPersistentRefHash: "account-a-ref",
+            claudeOAuthHistoryOwnerIdentifier: accountAOwner,
             isClaudeOAuthSample: true,
             now: hourStart.addingTimeInterval(10 * 60))
 
@@ -288,10 +299,12 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
-    func `coalesced unscoped claude oauth sample still switches preferred sentinel`() async throws {
+    func `coalesced claude oauth sample without owner cannot switch preferred account`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
+        let scopedOwner = self.oauthOwnerIdentifier("c")
         let scopedAccountKey = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "scoped-ref"))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+                historyOwnerIdentifier: scopedOwner))
         let hourStart = Date(timeIntervalSince1970: 1_700_000_000)
 
         await store.recordPlanUtilizationHistorySample(
@@ -303,6 +316,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             provider: .claude,
             snapshot: self.identitylessClaudeSnapshot(usedPercent: 40),
             claudeOAuthPersistentRefHash: "scoped-ref",
+            claudeOAuthHistoryOwnerIdentifier: scopedOwner,
             isClaudeOAuthSample: true,
             now: hourStart.addingTimeInterval(5 * 60))
         await store.recordPlanUtilizationHistorySample(
@@ -313,21 +327,22 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
         let buckets = try #require(store.planUtilizationHistory[.claude])
         let selection = store.planUtilizationHistorySelection(for: .claude)
-        #expect(buckets.preferredAccountKey == "__unscoped__")
-        #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?
-            .entries.map(\.usedPercent) == [70])
+        #expect(buckets.preferredAccountKey == scopedAccountKey)
+        #expect(buckets.unscoped.isEmpty)
         #expect(findSeries(buckets.accounts[scopedAccountKey] ?? [], name: .session, windowMinutes: 300)?
             .entries.map(\.usedPercent) == [40])
-        #expect(selection.accountKey == nil)
+        #expect(selection.accountKey == scopedAccountKey)
         #expect(findSeries(selection.histories, name: .session, windowMinutes: 300)?
-            .entries.map(\.usedPercent) == [70])
+            .entries.map(\.usedPercent) == [40])
     }
 
     @MainActor
     @Test
     func `reloaded scoped claude oauth preference wins over configured token account`() throws {
+        let oauthOwner = self.oauthOwnerIdentifier("a")
         let oauthAccountKey = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "oauth-ref"))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+                historyOwnerIdentifier: oauthOwner))
         let oauthHistory = planSeries(name: .session, windowMinutes: 300, entries: [
             planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 45),
         ])
@@ -371,13 +386,15 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
     @Test
     func `later token account sample supersedes claude oauth preference`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
+        let oauthOwner = self.oauthOwnerIdentifier("a")
         store.settings.addTokenAccount(provider: .claude, label: "Selected", token: "selected-token")
         store.settings.setActiveTokenAccountIndex(0, for: .claude)
         let selectedAccount = try #require(store.settings.selectedTokenAccount(for: .claude))
         let tokenAccountKey = try #require(
             UsageStore._planUtilizationTokenAccountKeyForTesting(provider: .claude, account: selectedAccount))
         let oauthAccountKey = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "oauth-ref"))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+                historyOwnerIdentifier: oauthOwner))
         let oauthSnapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 45, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
             secondary: nil,
@@ -386,6 +403,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             provider: .claude,
             snapshot: oauthSnapshot,
             claudeOAuthPersistentRefHash: "oauth-ref",
+            claudeOAuthHistoryOwnerIdentifier: oauthOwner,
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_000_000))
 
@@ -411,8 +429,9 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
-    func `first claude oauth persistent reference quarantines legacy unscoped history`() async throws {
+    func `first claude oauth owner quarantines legacy unscoped history`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
+        let currentOwner = self.oauthOwnerIdentifier("c")
         let legacy = planSeries(name: .session, windowMinutes: 300, entries: [
             planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 25),
         ])
@@ -423,11 +442,13 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             secondary: nil,
             updatedAt: Date())
         let accountKey = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "current-ref"))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+                historyOwnerIdentifier: currentOwner))
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
             snapshot: snapshot,
             claudeOAuthPersistentRefHash: "current-ref",
+            claudeOAuthHistoryOwnerIdentifier: currentOwner,
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_007_200))
 
@@ -440,143 +461,101 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
-    func `claude oauth without persistent reference prefers unscoped over previous account`() async throws {
+    func `provenance-less claude oauth credentials stay isolated across restart`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
-        let accountASnapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            updatedAt: Date(),
-            identity: ProviderIdentitySnapshot(
-                providerID: .claude,
-                accountEmail: "alice@example.com",
-                accountOrganization: nil,
-                loginMethod: "max"))
-        let accountAKey = try #require(
-            UsageStore._planUtilizationAccountKeyForTesting(provider: .claude, snapshot: accountASnapshot))
-        await store.recordPlanUtilizationHistorySample(
-            provider: .claude,
-            snapshot: accountASnapshot,
-            now: Date(timeIntervalSince1970: 1_700_000_000))
+        let accountAOwner = self.oauthOwnerIdentifier("a")
+        let accountBOwner = self.oauthOwnerIdentifier("b")
+        let accountAKey = try #require(UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+            historyOwnerIdentifier: accountAOwner))
+        let accountBKey = try #require(UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+            historyOwnerIdentifier: accountBOwner))
 
-        let identitylessOAuthSnapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 75, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            updatedAt: Date())
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
-            snapshot: identitylessOAuthSnapshot,
+            snapshot: self.identitylessClaudeSnapshot(usedPercent: 10),
+            claudeOAuthHistoryOwnerIdentifier: accountAOwner,
+            isClaudeOAuthSample: true,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
+            claudeOAuthHistoryOwnerIdentifier: accountBOwner,
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_007_200))
-        store._setSnapshotForTesting(identitylessOAuthSnapshot, provider: .claude)
 
-        let selectedHistory = store.planUtilizationHistory(for: .claude)
         let buckets = try #require(store.planUtilizationHistory[.claude])
-        let accountAHistory = try #require(buckets.accounts[accountAKey])
-        #expect(findSeries(accountAHistory, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [10])
-        #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [75])
-        #expect(findSeries(selectedHistory, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [75])
-        #expect(buckets.preferredAccountKey != accountAKey)
+        #expect(buckets.unscoped.isEmpty)
+        #expect(findSeries(buckets.accounts[accountAKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [10])
+        #expect(findSeries(buckets.accounts[accountBKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [75])
+
+        let reloaded = self.makeReloadedStoreWithConfiguredTokenAccount(buckets: buckets)
+        let selection = reloaded.planUtilizationHistorySelection(for: .claude)
+        #expect(selection.accountKey == accountBKey)
+        #expect(findSeries(selection.histories, name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [75])
+        #expect(reloaded.planUtilizationHistory[.claude]?.accounts[accountAKey] != nil)
     }
 
     @MainActor
     @Test
-    func `claude oauth unscoped sentinel prevents first later identity adoption`() async throws {
+    func `same keychain reference credential replacement stays isolated across restart`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
-        let identitylessOAuthSnapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 75, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            updatedAt: Date())
+        let originalOwner = self.oauthOwnerIdentifier("c")
+        let replacementOwner = self.oauthOwnerIdentifier("d")
+        let originalKey = try #require(UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+            historyOwnerIdentifier: originalOwner,
+            persistentRefHash: "same-row-ref"))
+        let replacementKey = try #require(UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+            historyOwnerIdentifier: replacementOwner,
+            persistentRefHash: "same-row-ref"))
+
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
-            snapshot: identitylessOAuthSnapshot,
+            snapshot: self.identitylessClaudeSnapshot(usedPercent: 25),
+            claudeOAuthPersistentRefHash: "same-row-ref",
+            claudeOAuthHistoryOwnerIdentifier: originalOwner,
             isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_000_000))
-
-        let identifiedSnapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            updatedAt: Date(),
-            identity: ProviderIdentitySnapshot(
-                providerID: .claude,
-                accountEmail: "alice@example.com",
-                accountOrganization: nil,
-                loginMethod: "max"))
-        let identifiedKey = try #require(
-            UsageStore._planUtilizationAccountKeyForTesting(provider: .claude, snapshot: identifiedSnapshot))
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
-            snapshot: identifiedSnapshot,
+            snapshot: self.identitylessClaudeSnapshot(usedPercent: 80),
+            claudeOAuthPersistentRefHash: "same-row-ref",
+            claudeOAuthHistoryOwnerIdentifier: replacementOwner,
+            isClaudeOAuthSample: true,
             now: Date(timeIntervalSince1970: 1_700_007_200))
 
         let buckets = try #require(store.planUtilizationHistory[.claude])
-        #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [75])
-        #expect(findSeries(buckets.accounts[identifiedKey] ?? [], name: .session, windowMinutes: 300)?
-            .entries.map(\.usedPercent) == [10])
-    }
+        #expect(originalKey != replacementKey)
+        #expect(findSeries(buckets.accounts[originalKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [25])
+        #expect(findSeries(buckets.accounts[replacementKey] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [80])
 
-    @MainActor
-    @Test
-    func `claude oauth unscoped history remains quarantined after later scoped samples`() async throws {
-        let store = UsageStorePlanUtilizationTests.makeStore()
-        let identitylessOAuthSnapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 75, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            updatedAt: Date())
-        await store.recordPlanUtilizationHistorySample(
-            provider: .claude,
-            snapshot: identitylessOAuthSnapshot,
-            isClaudeOAuthSample: true,
-            now: Date(timeIntervalSince1970: 1_700_000_000))
-
-        let refScopedSnapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 60, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            updatedAt: Date())
-        let refScopedKey = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "current-ref"))
-        await store.recordPlanUtilizationHistorySample(
-            provider: .claude,
-            snapshot: refScopedSnapshot,
-            claudeOAuthPersistentRefHash: "current-ref",
-            isClaudeOAuthSample: true,
-            now: Date(timeIntervalSince1970: 1_700_007_200))
-
-        let identifiedSnapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            updatedAt: Date(),
-            identity: ProviderIdentitySnapshot(
-                providerID: .claude,
-                accountEmail: "alice@example.com",
-                accountOrganization: nil,
-                loginMethod: "max"))
-        let identifiedKey = try #require(
-            UsageStore._planUtilizationAccountKeyForTesting(provider: .claude, snapshot: identifiedSnapshot))
-        await store.recordPlanUtilizationHistorySample(
-            provider: .claude,
-            snapshot: identifiedSnapshot,
-            now: Date(timeIntervalSince1970: 1_700_014_400))
-
-        let buckets = try #require(store.planUtilizationHistory[.claude])
-        #expect(findSeries(buckets.unscoped, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [75])
-        #expect(findSeries(buckets.accounts[refScopedKey] ?? [], name: .session, windowMinutes: 300)?
-            .entries.map(\.usedPercent) == [60])
-        #expect(findSeries(buckets.accounts[identifiedKey] ?? [], name: .session, windowMinutes: 300)?
-            .entries.map(\.usedPercent) == [10])
+        let reloaded = self.makeReloadedStoreWithConfiguredTokenAccount(buckets: buckets)
+        let selection = reloaded.planUtilizationHistorySelection(for: .claude)
+        #expect(selection.accountKey == replacementKey)
+        #expect(findSeries(selection.histories, name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [80])
+        #expect(reloaded.planUtilizationHistory[.claude]?.accounts[originalKey] != nil)
     }
 
     @Test
-    func `claude oauth history key is stable across fingerprint metadata changes`() throws {
+    func `claude oauth history key is stable for one credential owner`() throws {
+        let owner = self.oauthOwnerIdentifier("a")
         let first = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "ABC123"))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: owner))
         let refreshed = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: " abc123 "))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+                historyOwnerIdentifier: " \(owner.uppercased()) "))
         let switched = try #require(
-            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(persistentRefHash: "different-ref"))
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
+                historyOwnerIdentifier: self.oauthOwnerIdentifier("b")))
 
         #expect(first == refreshed)
         #expect(first != switched)
-        #expect(first != "abc123")
+        #expect(first != owner)
         #expect(first.hasPrefix("__claude_oauth__:"))
         #expect(first.dropFirst("__claude_oauth__:".count).count == 64)
     }
@@ -708,6 +687,10 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         #expect(buckets.accounts[legacyKey] == nil)
         #expect(buckets.accounts[accountKey] == [legacyWeekly])
         #expect(buckets.preferredAccountKey == accountKey)
+    }
+
+    private func oauthOwnerIdentifier(_ character: Character) -> String {
+        String(repeating: String(character), count: 64)
     }
 
     private func identitylessClaudeSnapshot(usedPercent: Double) -> UsageSnapshot {

--- a/TestsLinux/ClaudeOAuthCredentialHistoryLinuxTests.swift
+++ b/TestsLinux/ClaudeOAuthCredentialHistoryLinuxTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeOAuthCredentialHistoryLinuxTests {
+    @Test
+    func historyOwnerIdentifierUsesSwiftCrypto() throws {
+        let first = ClaudeOAuthCredentials(
+            accessToken: "access-token-a",
+            refreshToken: "refresh-token-a",
+            expiresAt: Date(timeIntervalSinceNow: 3600),
+            scopes: ["user:profile"],
+            rateLimitTier: nil)
+        let second = ClaudeOAuthCredentials(
+            accessToken: "access-token-b",
+            refreshToken: "refresh-token-b",
+            expiresAt: Date(timeIntervalSinceNow: 3600),
+            scopes: ["user:profile"],
+            rateLimitTier: nil)
+
+        let firstIdentifier = try #require(first.historyOwnerIdentifier)
+        let secondIdentifier = try #require(second.historyOwnerIdentifier)
+        #expect(firstIdentifier.count == 64)
+        #expect(firstIdentifier != secondIdentifier)
+        #expect(firstIdentifier.allSatisfy { $0.isHexDigit })
+    }
+}

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -10,6 +10,12 @@ struct PlatformGatingTests {
     }
 
     @Test
+    func claudeAutoSource_allowsPlannerToFallBackToCLI() {
+        #expect(!CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .claude))
+        #expect(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .claude))
+    }
+
+    @Test
     func claudeWebFetcher_isNotSupportedOnLinux() async {
         #if os(Linux)
         let error = await #expect(throws: ClaudeWebAPIFetcher.FetchError.self) {

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -1,6 +1,6 @@
-import CodexBarCore
 import Testing
 @testable import CodexBarCLI
+@testable import CodexBarCore
 
 @Suite
 struct PlatformGatingTests {
@@ -13,6 +13,62 @@ struct PlatformGatingTests {
     func claudeAutoSource_allowsPlannerToFallBackToCLI() {
         #expect(!CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .claude))
         #expect(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .claude))
+    }
+
+    @Test
+    func claudeAutoPipeline_skipsUnsupportedWebAndUsesCLI() async throws {
+        #if os(Linux)
+        let context = self.makeClaudeAutoContext()
+        let cliFetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in
+            Self.makeClaudeStatus()
+        }
+        let outcome = await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+            await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
+                await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                    context: context,
+                    provider: .claude)
+            }
+        }
+        let result = try outcome.result.get()
+
+        #expect(result.strategyID == "claude.cli")
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web", "claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [false, true])
+        #else
+        #expect(Bool(true))
+        #endif
+    }
+
+    @Test
+    func claudeAutoPipeline_withoutCLIReportsNoAvailableStrategy() async {
+        #if os(Linux)
+        let context = self.makeClaudeAutoContext()
+        let outcome = await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(
+            "/definitely/missing/claude")
+        {
+            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                context: context,
+                provider: .claude)
+        }
+
+        switch outcome.result {
+        case .success:
+            Issue.record("Expected Claude auto without a CLI to report no available strategy")
+        case let .failure(error):
+            guard let fetchError = error as? ProviderFetchError else {
+                Issue.record("Expected ProviderFetchError, got \(error)")
+                return
+            }
+            switch fetchError {
+            case let .noAvailableStrategy(provider):
+                #expect(provider == .claude)
+            }
+        }
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web", "claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [false, false])
+        #else
+        #expect(Bool(true))
+        #endif
     }
 
     @Test
@@ -54,5 +110,39 @@ struct PlatformGatingTests {
         #else
         #expect(Bool(true))
         #endif
+    }
+
+    private func makeClaudeAutoContext() -> ProviderFetchContext {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: .auto,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: ProviderSettingsSnapshot.make(claude: .init(
+                usageDataSource: .auto,
+                webExtrasEnabled: false,
+                cookieSource: .auto,
+                manualCookieHeader: nil)),
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+
+    private static func makeClaudeStatus() -> ClaudeStatusSnapshot {
+        ClaudeStatusSnapshot(
+            sessionPercentLeft: 80,
+            weeklyPercentLeft: nil,
+            opusPercentLeft: nil,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: nil,
+            primaryResetDescription: nil,
+            secondaryResetDescription: nil,
+            opusResetDescription: nil,
+            rawText: "stub")
     }
 }


### PR DESCRIPTION
## Summary

- scope successful Claude OAuth utilization samples to an opaque owner key derived one-way from the credential that actually won routing
- carry that owner only across a proven successful refresh-token rotation, while account replacements start a separate history bucket
- treat the Keychain persistent reference as optional corroborating provenance rather than principal identity
- quarantine identityless OAuth samples instead of merging them into a configured token account or a previous OAuth account
- preserve the selected OAuth history bucket across coalesced samples and app restart

## Root cause

OAuth snapshots can lack email and organization identity. The generic history resolver therefore reused the persisted preferred account bucket, allowing a successful fetch after an account switch to append to the previous account's history.

The new canonical key is a namespaced SHA-256 digest of a high-entropy, one-way credential owner identifier. Raw access and refresh tokens never leave the credential layer and are never written to history storage. A successful refresh can explicitly inherit the prior owner identifier so normal token rotation does not fragment one account's history.

## Validation

- `swift test --filter UsageStorePlanUtilizationClaudeIdentityTests`
- `swift test --filter UsageStorePlanUtilizationTests`
- `swift test --filter ClaudeOAuthCredentialsStoreTests`
- `swift test --filter ClaudeOAuthHistoryCredentialRoutingTests`
- `swift test --filter ClaudeOAuthCredentialHistoryLinuxTests`
- `swift test --filter ClaudeResilienceTests`
- `make check`
- `make test`
- bundled branch autoreview: no accepted/actionable findings
- `git diff --check`

Closes #1785
