### PR TITLE
docs(providers): merge duplicate Xiaomi MiMo section

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -305,8 +305,10 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Status: `https://status.perplexity.com/` (link only, no auto-polling).
 
 ## Xiaomi MiMo
-- Browser cookies from automatic import or manual `Cookie:` header.
-- Reads balance and token-plan usage from `platform.xiaomimimo.com`.
+- Browser cookies from automatic import or manual `Cookie:` header for `platform.xiaomimimo.com` balance and token-plan endpoints.
+- Optional testing override via `MIMO_API_URL`; overrides must be HTTPS or bare hosts normalized to HTTPS, and invalid
+  overrides fail closed instead of falling back to local MiMo usage accounting.
+- Local MiMo token accounting is available only when the opt-in cache file exists.
 - Status: none yet.
 - Details: `docs/mimo.md`.
 
@@ -407,13 +409,6 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Optional API base URL override via `DEEPGRAM_API_URL`; overrides must be HTTPS or bare hosts normalized to HTTPS.
 - Reads Deepgram usage breakdowns for audio hours, agent hours, token totals, TTS characters, and requests.
 - Details: `docs/deepgram.md`.
-
-## Xiaomi MiMo
-- Browser cookies or manual Cookie header for `platform.xiaomimimo.com` balance and token-plan endpoints.
-- Optional testing override via `MIMO_API_URL`; overrides must be HTTPS or bare hosts normalized to HTTPS, and invalid
-  overrides fail closed instead of falling back to local MiMo usage accounting.
-- Local MiMo token accounting is available only when the opt-in cache file exists.
-- Details: `docs/mimo.md`.
 
 ## LiteLLM
 - API key from config or `LITELLM_API_KEY`; base URL from config `enterpriseHost` or `LITELLM_BASE_URL`.


### PR DESCRIPTION
`docs/providers.md` documented **Xiaomi MiMo** in two separate sections. This merges them into one entry while preserving the complete source notes: browser/manual cookie auth, `platform.xiaomimimo.com` balance and token-plan endpoints, the fail-closed `MIMO_API_URL` testing override, opt-in local accounting, status, and the detailed provider guide.

Docs-only; no runtime behavior changes.

### Validation

- Rebased onto current `main`; Xiaomi MiMo headings: 2 before, 1 after.
- Retained statements checked against `docs/mimo.md`, `MiMoUsageFetcher`, `MiMoProviderDescriptor`, and `MiMoLocalUsageFallback`.
- `node Scripts/check-documentation-links.mjs` — 137 local links pass.
- `node Scripts/check-site-locales.mjs` — 21 locales and 50 site messages pass.
- `node Scripts/generate-llms.mjs --check` — generated index is current.
- `make docs-list` and `make check` pass; SwiftFormat and SwiftLint report no violations.
- Focused MiMo parser/provider/local-fallback/script suite: 47 tests pass.
- Bounded live packaged-CLI check used a temporary invalid manual cookie, reached the Xiaomi MiMo provider, and returned the expected `Xiaomi MiMo login required.` No browser import or Keychain access was used.
- Bundled autoreview: no findings.
