### PR TITLE
Fix OpenAI service-account key guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - CLI: show session pace in text output, expose derived pace data in JSON, and honor the configured weekly work-day baseline. Thanks @kmatsunami!
 
 ### Fixed
+- OpenAI API: explain that project service-account keys cannot read organization usage instead of surfacing a generic credit-balance HTTP 401 error (fixes #1792). Thanks @dhruv-anand-aintech!
 - Overview: render row selection on the GPU to keep trackpad scrolling smooth. Thanks @hhh2210!
 - Codex cost history: count cache reads separately, deduplicate active and archived sessions at row level, and preserve cached days across narrow refreshes. Thanks @kiranmagic7!
 - Pi cost history: price Codex cache reads once using their true context size. Thanks @kiranmagic7!

--- a/Sources/CodexBar/Providers/OpenAI/OpenAIAPIProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/OpenAI/OpenAIAPIProviderImplementation.swift
@@ -30,8 +30,8 @@ struct OpenAIAPIProviderImplementation: ProviderImplementation {
             ProviderSettingsFieldDescriptor(
                 id: "openai-api-key",
                 title: "Admin API key",
-                subtitle: "Stored in ~/.codexbar/config.json. OPENAI_ADMIN_KEY is preferred; " +
-                    "OPENAI_API_KEY still works.",
+                subtitle: "Stored in ~/.codexbar/config.json. OPENAI_ADMIN_KEY is required for organization usage; " +
+                    "legacy/user keys only get a best-effort balance fallback.",
                 kind: .secure,
                 placeholder: "sk-admin-...",
                 binding: context.stringBinding(\.openAIAPIKey),

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPICreditBalanceFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPICreditBalanceFetcher.swift
@@ -37,6 +37,7 @@ public enum OpenAIAPICreditBalanceError: LocalizedError, Sendable, Equatable {
     case missingCredentials
     case networkError(String)
     case apiError(Int)
+    case unauthorized
     case forbidden
     case parseFailed(String)
 
@@ -48,6 +49,9 @@ public enum OpenAIAPICreditBalanceError: LocalizedError, Sendable, Equatable {
             "OpenAI API credit balance network error: \(message)"
         case let .apiError(statusCode):
             "OpenAI API credit balance error: HTTP \(statusCode)"
+        case .unauthorized:
+            "OpenAI rejected this key for credit balance access (HTTP 401). Use an organization Admin API key " +
+                "for usage; project and service-account keys do not provide organization usage access."
         case .forbidden:
             "OpenAI API credit balance endpoint returned HTTP 403. Use a legacy/user API key with billing access; " +
                 "project keys may not expose credit grants."
@@ -142,10 +146,14 @@ public enum OpenAIAPICreditBalanceFetcher {
             throw OpenAIAPICreditBalanceError.networkError(error.localizedDescription)
         }
 
-        guard response.statusCode != 403 else {
+        switch response.statusCode {
+        case 200:
+            break
+        case 401:
+            throw OpenAIAPICreditBalanceError.unauthorized
+        case 403:
             throw OpenAIAPICreditBalanceError.forbidden
-        }
-        guard response.statusCode == 200 else {
+        default:
             throw OpenAIAPICreditBalanceError.apiError(response.statusCode)
         }
 

--- a/Tests/CodexBarTests/OpenAIAPICreditBalanceTests.swift
+++ b/Tests/CodexBarTests/OpenAIAPICreditBalanceTests.swift
@@ -96,6 +96,32 @@ struct OpenAIAPICreditBalanceTests {
     }
 
     @Test
+    func `maps unauthorized legacy balance to admin key guidance`() async {
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil)!
+            return (Data("{}".utf8), response)
+        }
+
+        do {
+            _ = try await OpenAIAPICreditBalanceFetcher.fetchBalance(
+                apiKey: "sk-test",
+                session: transport)
+            Issue.record("Expected credential rejection")
+        } catch let error as OpenAIAPICreditBalanceError {
+            #expect(error == .unauthorized)
+            #expect(error.errorDescription?.contains("organization Admin API key") == true)
+            #expect(error.errorDescription?.contains("service-account keys") == true)
+        } catch {
+            Issue.record("Expected OpenAIAPICreditBalanceError, got \(error)")
+        }
+    }
+
+    @Test
     func `falls back to legacy billing when admin usage rejects credentials`() async throws {
         let strategy = OpenAIAPIBalanceFetchStrategy(
             usageFetcher: { _, _ in

--- a/docs/openai.md
+++ b/docs/openai.md
@@ -17,7 +17,8 @@ CodexBar's OpenAI API provider targets the API Platform organization dashboard, 
    - Daily buckets use `bucket_width=1d`, costs are grouped by `line_item`, and completion usage is grouped by `model`.
    - Optional project scoping comes from `OPENAI_PROJECT_ID` or `providers[].workspaceID` for `openai`.
      Project-scoped requests add `project_ids=<project>` to both Admin API endpoints.
-2. Fallback: legacy `GET https://api.openai.com/v1/dashboard/billing/credit_grants` for normal API keys that cannot access organization usage.
+2. Best-effort fallback: legacy `GET https://api.openai.com/v1/dashboard/billing/credit_grants` for older user API
+   keys that cannot access organization usage. This endpoint is not part of OpenAI's current public API reference.
 
 ## Setup
 
@@ -30,6 +31,10 @@ printf '%s' "$OPENAI_ADMIN_KEY" | codexbar config set-api-key --provider openai 
 Settings → Providers → OpenAI writes the same `~/.codexbar/config.json` field. `OPENAI_ADMIN_KEY` is preferred over
 `OPENAI_API_KEY` because it unlocks organization costs and usage; a normal API key only supports the legacy balance
 fallback.
+
+Project service-account keys are project-scoped credentials for API workloads. They are not organization Admin API
+keys, so they cannot read the organization usage and cost endpoints used by CodexBar. Configure an organization Admin
+API key instead; CodexBar reports this distinction when a project or service-account key is rejected.
 
 To scope Admin API usage to a project, set the OpenAI Project ID field in Settings or add `workspaceID` to the `openai`
 provider config:


### PR DESCRIPTION
## Summary

- distinguish OpenAI credit-balance HTTP 401 failures from generic transport errors
- explain that project service-account keys cannot read organization usage/cost data
- clarify the Admin-key requirement in Settings and provider documentation

## Contract

OpenAI documents project service accounts as project-scoped API credentials, while the organization costs endpoint is authenticated with an organization Admin API key:

- https://developers.openai.com/api/reference/resources/admin/subresources/organization/subresources/projects/subresources/service_accounts/methods/create
- https://developers.openai.com/api/reference/resources/admin/subresources/organization/subresources/usage/methods/costs

The legacy credit-grants fallback remains best-effort for older user keys; it is not presented as a supported service-account path.

## Proof

- `swift test --filter OpenAIAPICreditBalanceTests`
- `make check`
- `CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh`
- packaged CLI, isolated temporary home, deliberately invalid key: exits 1 with the new organization Admin-key/service-account guidance after a real HTTP 401
- bundled autoreview: clean

Fixes #1792
