### PR TITLE
Improve Keychain prompt trust guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - CLI: show session pace in text output, expose derived pace data in JSON, and honor the configured weekly work-day baseline. Thanks @kmatsunami!
 
 ### Fixed
+- Keychain prompts: explain that macOS handles password entry, surface the existing opt-out path, and link to troubleshooting before access begins (fixes #1681). Thanks @someshfengde and @Yuxin-Qiao!
 - OpenAI API: explain that project service-account keys cannot read organization usage instead of surfacing a generic credit-balance HTTP 401 error (fixes #1792). Thanks @dhruv-anand-aintech!
 - Overview: render row selection on the GPU to keep trackpad scrolling smooth. Thanks @hhh2210!
 - Codex cost history: count cache reads separately, deduplicate active and archived sessions at row level, and preserve cached days across narrow refreshes. Thanks @kiranmagic7!

--- a/Sources/CodexBar/KeychainPromptCoordinator.swift
+++ b/Sources/CodexBar/KeychainPromptCoordinator.swift
@@ -54,9 +54,33 @@ private enum KeychainPromptMessage {
         "so it can fetch usage. Click OK to continue."
 }
 
+struct KeychainPromptAlertModel: Equatable {
+    let title: String
+    let message: String
+    let primaryButtonTitle: String
+    let learnMoreButtonTitle: String
+    let documentationURL: String
+}
+
+@MainActor
+private final class KeychainPromptLearnMoreTarget: NSObject {
+    private let documentationURL: String
+
+    init(documentationURL: String) {
+        self.documentationURL = documentationURL
+    }
+
+    @objc func openDocumentation() {
+        guard let url = URL(string: self.documentationURL) else { return }
+        NSWorkspace.shared.open(url)
+    }
+}
+
 enum KeychainPromptCoordinator {
     private static let promptLock = NSLock()
     private static let log = CodexBarLog.logger(LogCategories.keychainPrompt)
+    private static let documentationURL =
+        "https://github.com/steipete/CodexBar/blob/main/docs/keychain-prompts.md"
 
     static func install() {
         KeychainPromptHandler.handler = { context in
@@ -96,79 +120,103 @@ enum KeychainPromptCoordinator {
     }
 
     private static func presentKeychainPrompt(_ context: KeychainPromptContext) {
-        let (title, message) = self.keychainCopy(for: context)
+        let model = self.alertModel(for: context)
         self.log.info("Keychain prompt requested", metadata: ["kind": "\(context.kind)"])
-        self.presentAlert(title: title, message: message)
+        self.presentAlert(model)
     }
 
     private static func presentBrowserCookiePrompt(_ context: BrowserCookieKeychainPromptContext) {
-        let title = L("Keychain Access Required")
-        let message = L(
-            KeychainPromptMessage.browserCookie,
-            context.label)
+        let model = self.browserCookieAlertModel(label: context.label)
         self.log.info("Browser cookie keychain prompt requested", metadata: ["label": context.label])
-        self.presentAlert(title: title, message: message)
+        self.presentAlert(model)
     }
 
-    private static func keychainCopy(for context: KeychainPromptContext) -> (title: String, message: String) {
-        let title = L("Keychain Access Required")
-        switch context.kind {
+    static func alertModel(for context: KeychainPromptContext) -> KeychainPromptAlertModel {
+        let purpose = switch context.kind {
         case .claudeOAuth:
-            return (title, L(KeychainPromptMessage.claudeOAuth))
+            L(KeychainPromptMessage.claudeOAuth)
         case .codexCookie:
-            return (title, L(KeychainPromptMessage.codexCookie))
+            L(KeychainPromptMessage.codexCookie)
         case .claudeCookie:
-            return (title, L(KeychainPromptMessage.claudeCookie))
+            L(KeychainPromptMessage.claudeCookie)
         case .cursorCookie:
-            return (title, L(KeychainPromptMessage.cursorCookie))
+            L(KeychainPromptMessage.cursorCookie)
         case .opencodeCookie:
-            return (title, L(KeychainPromptMessage.openCodeCookie))
+            L(KeychainPromptMessage.openCodeCookie)
         case .factoryCookie:
-            return (title, L(KeychainPromptMessage.factoryCookie))
+            L(KeychainPromptMessage.factoryCookie)
         case .zaiToken:
-            return (title, L(KeychainPromptMessage.zaiToken))
+            L(KeychainPromptMessage.zaiToken)
         case .syntheticToken:
-            return (title, L(KeychainPromptMessage.syntheticToken))
+            L(KeychainPromptMessage.syntheticToken)
         case .copilotToken:
-            return (title, L(KeychainPromptMessage.copilotToken))
+            L(KeychainPromptMessage.copilotToken)
         case .kimiToken:
-            return (title, L(KeychainPromptMessage.kimiToken))
+            L(KeychainPromptMessage.kimiToken)
         case .kimiK2Token:
-            return (title, L(KeychainPromptMessage.kimiK2Token))
+            L(KeychainPromptMessage.kimiK2Token)
         case .minimaxCookie:
-            return (title, L(KeychainPromptMessage.minimaxCookie))
+            L(KeychainPromptMessage.minimaxCookie)
         case .minimaxToken:
-            return (title, L(KeychainPromptMessage.minimaxToken))
+            L(KeychainPromptMessage.minimaxToken)
         case .augmentCookie:
-            return (title, L(KeychainPromptMessage.augmentCookie))
+            L(KeychainPromptMessage.augmentCookie)
         case .ampCookie:
-            return (title, L(KeychainPromptMessage.ampCookie))
+            L(KeychainPromptMessage.ampCookie)
         }
+        return self.alertModel(purpose: purpose)
     }
 
-    private static func presentAlert(title: String, message: String) {
+    static func browserCookieAlertModel(label: String) -> KeychainPromptAlertModel {
+        self.alertModel(purpose: L(KeychainPromptMessage.browserCookie, label))
+    }
+
+    private static func alertModel(purpose: String) -> KeychainPromptAlertModel {
+        KeychainPromptAlertModel(
+            title: L("Keychain Access Required"),
+            message: "\(purpose)\n\n\(L("keychain_prompt_privacy_note"))",
+            primaryButtonTitle: L("OK"),
+            learnMoreButtonTitle: L("keychain_prompt_learn_more"),
+            documentationURL: self.documentationURL)
+    }
+
+    private static func presentAlert(_ model: KeychainPromptAlertModel) {
         self.promptLock.lock()
         defer { self.promptLock.unlock() }
 
         if Thread.isMainThread {
             MainActor.assumeIsolated {
-                self.showAlert(title: title, message: message)
+                self.showAlert(model)
             }
             return
         }
         DispatchQueue.main.sync {
             MainActor.assumeIsolated {
-                self.showAlert(title: title, message: message)
+                self.showAlert(model)
             }
         }
     }
 
     @MainActor
-    private static func showAlert(title: String, message: String) {
+    private static func showAlert(_ model: KeychainPromptAlertModel) {
         let alert = NSAlert()
-        alert.messageText = L(title)
-        alert.informativeText = L(message)
-        alert.addButton(withTitle: L("OK"))
-        _ = alert.runModal()
+        alert.messageText = model.title
+        alert.informativeText = model.message
+        alert.addButton(withTitle: model.primaryButtonTitle)
+
+        let learnMoreTarget = KeychainPromptLearnMoreTarget(documentationURL: model.documentationURL)
+        let learnMoreButton = NSButton(
+            title: model.learnMoreButtonTitle,
+            target: learnMoreTarget,
+            action: #selector(KeychainPromptLearnMoreTarget.openDocumentation))
+        learnMoreButton.isBordered = false
+        learnMoreButton.contentTintColor = .linkColor
+        learnMoreButton.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        learnMoreButton.sizeToFit()
+        alert.accessoryView = learnMoreButton
+
+        withExtendedLifetime(learnMoreTarget) {
+            _ = alert.runModal()
+        }
     }
 }

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -996,6 +996,8 @@
 "Enterprise host" = "مضيف مؤسسي";
 "Extra usage balance: %@" = "توازن الاستخدام الإضافي: %@";
 "Keychain Access Required" = "Keychain الوصول المطلوب";
+"keychain_prompt_learn_more" = "معرفة المزيد…";
+"keychain_prompt_privacy_note" = "يتولى macOS، وليس CodexBar، إدخال كلمة سر تسجيل الدخول إلى Mac. يمكنك تعطيل وصول سلسلة المفاتيح في أي وقت من الإعدادات ← متقدم.";
 "Kiro menu bar value" = "Kiro قيمة شريط القائمة";
 "Label" = "العلامة التجارية";
 "No organizations loaded. Click Refresh after setting your API key." = "لا توجد منظمات محملة. انقر على تحديث بعد تعيين مفتاح API.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -848,6 +848,8 @@
 "Enterprise host" = "Host Enterprise";
 "Extra usage balance: %@" = "Saldo d'ús extra: %@";
 "Keychain Access Required" = "Cal accés al Clauer";
+"keychain_prompt_learn_more" = "Més informació…";
+"keychain_prompt_privacy_note" = "macOS —no CodexBar— gestiona la introducció de la contrasenya d'inici de sessió del Mac. Pots desactivar l'accés al Clauer en qualsevol moment a Configuració → Avançat.";
 "Kiro menu bar value" = "Valor de Kiro a la barra de menús";
 "Label" = "Etiqueta";
 "No organizations loaded. Click Refresh after setting your API key." = "No hi ha organitzacions carregades. Feu clic a Actualitza després de configurar la clau API.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -993,6 +993,8 @@
 "Enterprise host" = "Unternehmenshost";
 "Extra usage balance: %@" = "Zusätzlicher Nutzungssaldo: %@";
 "Keychain Access Required" = "Schlüsselbundzugriff erforderlich";
+"keychain_prompt_learn_more" = "Weitere Informationen…";
+"keychain_prompt_privacy_note" = "Die Eingabe des Mac-Anmeldepassworts wird von macOS verarbeitet, nicht von CodexBar. Du kannst den Schlüsselbundzugriff jederzeit unter Einstellungen → Erweitert deaktivieren.";
 "Kiro menu bar value" = "Wert der Kiro-Menüleiste";
 "Label" = "Etikett";
 "No organizations loaded. Click Refresh after setting your API key." = "Keine Organisationen geladen. Klicken Sie auf Aktualisieren, nachdem Sie Ihren API-Schlüssel festgelegt haben.";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -996,6 +996,8 @@
 "Enterprise host" = "Enterprise host";
 "Extra usage balance: %@" = "Extra usage balance: %@";
 "Keychain Access Required" = "Keychain Access Required";
+"keychain_prompt_learn_more" = "Learn More…";
+"keychain_prompt_privacy_note" = "macOS—not CodexBar—handles any Mac login password entry. You can disable all Keychain access at any time in Settings → Advanced.";
 "Kiro menu bar value" = "Kiro menu bar value";
 "Label" = "Label";
 "No organizations loaded. Click Refresh after setting your API key." = "No organizations loaded. Click Refresh after setting your API key.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -848,6 +848,8 @@
 "Enterprise host" = "Host Enterprise";
 "Extra usage balance: %@" = "Saldo de uso extra: %@";
 "Keychain Access Required" = "Se requiere acceso a Llaveros";
+"keychain_prompt_learn_more" = "Más información…";
+"keychain_prompt_privacy_note" = "macOS, no CodexBar, gestiona la introducción de la contraseña de inicio de sesión del Mac. Puedes desactivar el acceso a Llaveros en cualquier momento en Ajustes → Avanzado.";
 "Kiro menu bar value" = "Valor de Kiro en la barra de menús";
 "Label" = "Etiqueta";
 "No organizations loaded. Click Refresh after setting your API key." = "No hay organizaciones cargadas. Haz clic en Actualizar después de configurar tu clave API.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -996,6 +996,8 @@
 "Enterprise host" = "میزبان سازمانی";
 "Extra usage balance: %@" = "تعادل استفاده اضافی: %@";
 "Keychain Access Required" = "دسترسی Keychain مورد نیاز است";
+"keychain_prompt_learn_more" = "بیشتر بدانید…";
+"keychain_prompt_privacy_note" = "macOS، نه CodexBar، ورود گذرواژهٔ Mac را مدیریت می‌کند. می‌توانید دسترسی به Keychain را هر زمان از تنظیمات ← پیشرفته غیرفعال کنید.";
 "Kiro menu bar value" = "Kiro مقدار نوار منو";
 "Label" = "برچسب";
 "No organizations loaded. Click Refresh after setting your API key." = "هیچ سازمانی بارگذاری نشده بود. پس از تنظیم کلید API روی «تازه سازی» کلیک کنید.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -993,6 +993,8 @@
 "Enterprise host" = "Hôte d'entreprise";
 "Extra usage balance: %@" = "Solde d'utilisation supplémentaire : %@";
 "Keychain Access Required" = "Accès au Trousseau requis";
+"keychain_prompt_learn_more" = "En savoir plus…";
+"keychain_prompt_privacy_note" = "La saisie du mot de passe de connexion au Mac est gérée par macOS, pas par CodexBar. Vous pouvez désactiver l'accès au Trousseau à tout moment dans Réglages → Avancé.";
 "Kiro menu bar value" = "Valeur de la barre de menu Kiro";
 "Label" = "Libellé";
 "No organizations loaded. Click Refresh after setting your API key." = "Aucune organisation chargée. Cliquez sur Actualiser après avoir défini votre clé API.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -998,6 +998,8 @@
 "Enterprise host" = "Host enterprise";
 "Extra usage balance: %@" = "Saldo penggunaan ekstra: %@";
 "Keychain Access Required" = "Akses Keychain Diperlukan";
+"keychain_prompt_learn_more" = "Pelajari Lebih Lanjut…";
+"keychain_prompt_privacy_note" = "macOS—bukan CodexBar—menangani pemasukan kata sandi masuk Mac. Anda dapat menonaktifkan semua akses Keychain kapan saja di Pengaturan → Lanjutan.";
 "Kiro menu bar value" = "Nilai menu bar Kiro";
 "Label" = "Label";
 "No organizations loaded. Click Refresh after setting your API key." = "Tidak ada organisasi dimuat. Klik Segarkan setelah mengatur kunci API Anda.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -998,6 +998,8 @@
 "Enterprise host" = "Host Enterprise";
 "Extra usage balance: %@" = "Saldo uso extra: %@";
 "Keychain Access Required" = "Accesso Portachiavi richiesto";
+"keychain_prompt_learn_more" = "Ulteriori informazioni…";
+"keychain_prompt_privacy_note" = "L'inserimento della password di accesso al Mac è gestito da macOS, non da CodexBar. Puoi disattivare l'accesso al Portachiavi in qualsiasi momento in Impostazioni → Avanzate.";
 "Kiro menu bar value" = "Valore barra menu Kiro";
 "Label" = "Etichetta";
 "No organizations loaded. Click Refresh after setting your API key." = "Nessuna organizzazione caricata. Fai clic su Aggiorna dopo aver impostato la chiave API.";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -990,6 +990,8 @@
 "Enterprise host" = "Enterprise ホスト";
 "Extra usage balance: %@" = "追加使用量の残高: %@";
 "Keychain Access Required" = "キーチェーンへのアクセスが必要です";
+"keychain_prompt_learn_more" = "詳しく見る…";
+"keychain_prompt_privacy_note" = "Macのログインパスワード入力を処理するのはCodexBarではなくmacOSです。キーチェーンへのアクセスは「設定」→「詳細」でいつでも無効にできます。";
 "Kiro menu bar value" = "Kiro メニューバー表示値";
 "Label" = "ラベル";
 "No organizations loaded. Click Refresh after setting your API key." = "組織が読み込まれていません。API キーを設定してから「更新」をクリックしてください。";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -960,6 +960,8 @@
 "Enterprise host" = "엔터프라이즈 호스트";
 "Extra usage balance: %@" = "추가 사용량 잔액: %@";
 "Keychain Access Required" = "키체인 접근 필요";
+"keychain_prompt_learn_more" = "더 알아보기…";
+"keychain_prompt_privacy_note" = "Mac 로그인 암호 입력은 CodexBar가 아닌 macOS에서 처리합니다. 설정 → 고급에서 언제든지 키체인 접근을 비활성화할 수 있습니다.";
 "Kiro menu bar value" = "Kiro 메뉴 막대 값";
 "Label" = "레이블";
 "No organizations loaded. Click Refresh after setting your API key." = "불러온 조직이 없습니다. API 키를 설정한 후 새로 고침을 클릭하세요.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -993,6 +993,8 @@
 "Enterprise host" = "Enterprise-host";
 "Extra usage balance: %@" = "Extra gebruikssaldo: %@";
 "Keychain Access Required" = "Toegang tot sleutelhanger vereist";
+"keychain_prompt_learn_more" = "Meer informatie…";
+"keychain_prompt_privacy_note" = "De invoer van het Mac-inlogwachtwoord wordt verwerkt door macOS, niet door CodexBar. Je kunt sleutelhanger toegang op elk moment uitschakelen via Instellingen → Geavanceerd.";
 "Kiro menu bar value" = "Waarde van de Kiro-menubalk";
 "Label" = "Label";
 "No organizations loaded. Click Refresh after setting your API key." = "Er zijn geen organisaties geladen. Klik op Vernieuwen nadat u uw API-sleutel hebt ingesteld.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -998,6 +998,8 @@
 "Enterprise host" = "Host Enterprise";
 "Extra usage balance: %@" = "Saldo dodatkowego użycia: %@";
 "Keychain Access Required" = "Wymagany dostęp do pęku kluczy";
+"keychain_prompt_learn_more" = "Dowiedz się więcej…";
+"keychain_prompt_privacy_note" = "Hasło logowania do Maca jest obsługiwane przez macOS, a nie CodexBar. Dostęp do pęku kluczy możesz wyłączyć w dowolnym momencie w Ustawienia → Zaawansowane.";
 "Kiro menu bar value" = "Wartość paska menu Kiro";
 "Label" = "Etykieta";
 "No organizations loaded. Click Refresh after setting your API key." = "Nie wczytano organizacji. Kliknij Odśwież po ustawieniu klucza API.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -990,6 +990,8 @@
 "Enterprise host" = "Host Enterprise";
 "Extra usage balance: %@" = "Saldo de uso extra: %@";
 "Keychain Access Required" = "Acesso ao Chaves necessário";
+"keychain_prompt_learn_more" = "Saiba mais…";
+"keychain_prompt_privacy_note" = "A digitação da senha de início de sessão do Mac é processada pelo macOS, não pelo CodexBar. Você pode desativar o acesso às Chaves a qualquer momento em Ajustes → Avançado.";
 "Kiro menu bar value" = "Valor do Kiro na barra de menu";
 "Label" = "Rótulo";
 "No organizations loaded. Click Refresh after setting your API key." = "Nenhuma organização carregada. Clique em Atualizar depois de definir sua chave API.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1054,6 +1054,8 @@
 "%@: %@ credits" = "%@: %@ krediter";
 "CodexBar will ask macOS Keychain for your Kimi auth token so it can fetch usage. Click OK to continue." = "CodexBar kommer att be macOS Nyckelring om din Kimi-autentiseringstoken så att användning kan hämtas. Klicka på OK för att fortsätta.";
 "Keychain Access Required" = "Åtkomst till Nyckelring krävs";
+"keychain_prompt_learn_more" = "Läs mer…";
+"keychain_prompt_privacy_note" = "Inmatningen av Mac-inloggningslösenordet hanteras av macOS, inte CodexBar. Du kan när som helst inaktivera åtkomst till Nyckelring under Inställningar → Avancerat.";
 "Username" = "Användarnamn";
 "CodexBar will ask macOS Keychain for your MiniMax cookie header so it can fetch usage. Click OK to continue." = "CodexBar kommer att be macOS Nyckelring om din MiniMax-cookie-header så att användning kan hämtas. Klicka på OK för att fortsätta.";
 "30d spend" = "30 d kostnad";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -996,6 +996,8 @@
 "Enterprise host" = "โฮสต์องค์กร";
 "Extra usage balance: %@" = "ยอดการใช้งานเพิ่มเติม: %@";
 "Keychain Access Required" = "Keychain ต้องเข้าถึง";
+"keychain_prompt_learn_more" = "ดูเพิ่มเติม…";
+"keychain_prompt_privacy_note" = "macOS เป็นผู้จัดการการป้อนรหัสผ่านเข้าสู่ระบบ Mac ไม่ใช่ CodexBar คุณปิดการเข้าถึง Keychain ได้ทุกเมื่อใน การตั้งค่า → ขั้นสูง";
 "Kiro menu bar value" = "ค่าแถบเมนู Kiro";
 "Label" = "ฉลาก";
 "No organizations loaded. Click Refresh after setting your API key." = "ไม่มีองค์กรโหลด คลิกรีเฟรชหลังจากตั้งค่าปุ่ม API";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -993,6 +993,8 @@
 "Enterprise host" = "Kurumsal sunucu";
 "Extra usage balance: %@" = "Ekstra kullanım bakiyesi: %@";
 "Keychain Access Required" = "Anahtarlık Erişimi Gerekli";
+"keychain_prompt_learn_more" = "Daha Fazla Bilgi…";
+"keychain_prompt_privacy_note" = "Mac oturum açma parolası girişini CodexBar değil macOS yönetir. Anahtarlık erişimini istediğiniz zaman Ayarlar → Gelişmiş bölümünden devre dışı bırakabilirsiniz.";
 "Kiro menu bar value" = "Kiro menü çubuğu değeri";
 "Label" = "Etiket";
 "No organizations loaded. Click Refresh after setting your API key." = "Kuruluş yüklenmedi. API anahtarınızı ayarladıktan sonra Yenile'ye tıklayın.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -993,6 +993,8 @@
 "Enterprise host" = "Корпоративний хост";
 "Extra usage balance: %@" = "Баланс додаткового використання: %@";
 "Keychain Access Required" = "Потрібен доступ до брелка";
+"keychain_prompt_learn_more" = "Докладніше…";
+"keychain_prompt_privacy_note" = "Введення пароля для входу на Mac обробляє macOS, а не CodexBar. Доступ до в'язки ключів можна будь-коли вимкнути в Налаштування → Розширені.";
 "Kiro menu bar value" = "Значення панелі меню Kiro";
 "Label" = "Мітка";
 "No organizations loaded. Click Refresh after setting your API key." = "Організації не завантажено. Натисніть «Оновити» після встановлення ключа API.";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -989,6 +989,8 @@
 "Enterprise host" = "Máy chủ doanh nghiệp";
 "Extra usage balance: %@" = "Extra usage balance: %@";
 "Keychain Access Required" = "Keychain Yêu cầu quyền truy cập";
+"keychain_prompt_learn_more" = "Tìm hiểu thêm…";
+"keychain_prompt_privacy_note" = "macOS, không phải CodexBar, xử lý việc nhập mật khẩu đăng nhập Mac. Bạn có thể tắt mọi quyền truy cập Keychain bất kỳ lúc nào trong Cài đặt → Nâng cao.";
 "Kiro menu bar value" = "Kiro thanh menu value";
 "Label" = "Nhãn";
 "No organizations loaded. Click Refresh after setting your API key." = "Chưa có tổ chức nào được tải. Nhấp vào Làm mới sau khi đặt khóa API của bạn.";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -964,6 +964,8 @@
 "Enterprise host" = "Enterprise 主机";
 "Extra usage balance: %@" = "额外使用量余额：%@";
 "Keychain Access Required" = "需要钥匙串访问权限";
+"keychain_prompt_learn_more" = "了解更多…";
+"keychain_prompt_privacy_note" = "Mac 登录密码由 macOS（而非 CodexBar）处理。你可以随时在“设置”→“高级”中停用所有钥匙串访问。";
 "Kiro menu bar value" = "Kiro 菜单栏数值";
 "Label" = "标签";
 "No organizations loaded. Click Refresh after setting your API key." = "尚未加载组织。设置 API 密钥后点击“刷新”。";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -859,6 +859,8 @@
 "Enterprise host" = "Enterprise 主機";
 "Extra usage balance: %@" = "額外使用量餘額：%@";
 "Keychain Access Required" = "需要鑰匙圈存取權";
+"keychain_prompt_learn_more" = "進一步瞭解…";
+"keychain_prompt_privacy_note" = "Mac 登入密碼由 macOS（而非 CodexBar）處理。你可以隨時在「設定」→「進階」中停用所有鑰匙圈存取。";
 "Kiro menu bar value" = "Kiro 選單列數值";
 "Label" = "標籤";
 "No organizations loaded. Click Refresh after setting your API key." = "尚未載入組織。設定 API 金鑰後按一下「重新整理」。";

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -393,7 +393,7 @@ public enum ClaudeOAuthCredentialsStore {
                     guard fallbackDecision.allowed else { return nil }
                 }
 
-                if ClaudeOAuthCredentialsStore.shouldShowClaudeKeychainPreAlert() {
+                if ClaudeOAuthCredentialsStore.shouldNotifyClaudeKeychainPreAlert() {
                     KeychainPromptHandler.notify(
                         KeychainPromptContext(
                             kind: .claudeOAuth,
@@ -2091,6 +2091,14 @@ extension ClaudeOAuthCredentialsStore {
         case .allowed, .notFound:
             false
         }
+    }
+
+    private static func shouldNotifyClaudeKeychainPreAlert() -> Bool {
+        let mode = ClaudeOAuthKeychainPromptPreference.current()
+        guard self.shouldAllowClaudeCodeKeychainAccess(mode: mode) else { return false }
+        // Attribute-only preflight can report success even when reading the secret will prompt. Explicit user
+        // actions are rare and intentional, so always explain the read before Security.framework can show UI.
+        return ProviderInteractionContext.current == .userInitiated || self.shouldShowClaudeKeychainPreAlert()
     }
 
     /// Refresh the access token using a refresh token.

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStorePromptPolicyTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStorePromptPolicyTests.swift
@@ -127,7 +127,7 @@ struct ClaudeOAuthCredentialsStorePromptPolicyTests {
     }
 
     @Test
-    func `does not show pre alert when claude keychain readable without interaction`() throws {
+    func `user initiated claude keychain read shows pre alert even when preflight allows`() throws {
         let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
         try KeychainCacheStore.withServiceOverrideForTesting(service) {
             try KeychainAccessGate.withTaskOverrideForTesting(false) {
@@ -180,7 +180,7 @@ struct ClaudeOAuthCredentialsStorePromptPolicyTests {
                             })
 
                         #expect(creds.accessToken == "keychain-token")
-                        #expect(preAlertHits == 0)
+                        #expect(preAlertHits >= 1)
                     }
                 }
             }

--- a/Tests/CodexBarTests/KeychainPromptCoordinatorTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import Testing
 @testable import CodexBar
 
@@ -36,5 +37,32 @@ struct KeychainPromptCoordinatorTests {
             "/Users/me/CodexBar/.build/debug/CodexBarCLI"))
         #expect(!KeychainPromptCoordinator.isUnbundledCodexBarExecutable(""))
         #expect(!KeychainPromptCoordinator.isUnbundledCodexBarExecutable("CodexBar"))
+    }
+
+    @Test
+    func `browser cookie alert explains password handling and opt out`() {
+        let model = KeychainPromptCoordinator.browserCookieAlertModel(label: "Chrome Safe Storage")
+
+        #expect(model.title == "Keychain Access Required")
+        #expect(model.message.contains("Chrome Safe Storage"))
+        #expect(model.message.contains("macOS—not CodexBar—handles any Mac login password entry"))
+        #expect(model.message.contains("Settings → Advanced"))
+        #expect(model.primaryButtonTitle == "OK")
+        #expect(model.learnMoreButtonTitle == "Learn More…")
+        #expect(model.documentationURL.hasSuffix("/docs/keychain-prompts.md"))
+    }
+
+    @Test
+    func `provider alert preserves the requested keychain purpose`() {
+        let context = KeychainPromptContext(
+            kind: .claudeOAuth,
+            service: "Claude Code-credentials",
+            account: nil)
+
+        let model = KeychainPromptCoordinator.alertModel(for: context)
+
+        #expect(model.message.contains("Claude Code OAuth token"))
+        #expect(model.message.contains("fetch your Claude usage"))
+        #expect(model.learnMoreButtonTitle == "Learn More…")
     }
 }

--- a/docs/keychain-prompts.md
+++ b/docs/keychain-prompts.md
@@ -16,6 +16,10 @@ CodexBar does not need your browser password. macOS owns the prompt, and the pro
 that is requesting access. For support reports, include that requesting app/path when possible and do not paste
 passwords, cookie headers, OAuth tokens, API keys, or Keychain item values.
 
+Before a Keychain read that may require interaction, CodexBar shows an explanation of the item and its purpose.
+**Learn More** opens this page without dismissing that explanation or starting the macOS prompt. Choose **OK** only
+when you are ready to continue, or use the opt-out below.
+
 ## If the prompt appears after uninstalling CodexBar
 
 Deleting `CodexBar.app` prevents a new process from launching from that bundle, but it does not terminate a process


### PR DESCRIPTION
## Summary

- Explain that macOS, not CodexBar, handles Mac login password entry and show the existing Settings → Advanced opt-out before Keychain access begins.
- Add a Learn More link that opens the Keychain troubleshooting guide without dismissing the explanation or starting the macOS prompt.
- Always show the explanation before an explicit user-triggered Claude credential read, because an attribute-only preflight can succeed even when reading the secret will prompt. Background and no-prompt policy remain unchanged.

## Tests

- `swift test --filter KeychainNoUIQueryTests`
- `swift test --filter KeychainPromptCoordinatorTests`
- `swift test --filter 'can read claude keychain on user action'`
- `swift test --filter 'user initiated claude keychain read shows pre alert'`
- `make check`
- `make test` (43/43 shards passed; one unrelated Kiro timing shard passed on the built-in retry)
- bundled autoreview helper: no actionable findings

## Live proof

- Packaged and ad-hoc signed the current app, then ran it in a Tart macOS 15.7.7 VM with a disposable `Claude Code-credentials` fixture.
- An explicit Refresh showed the CodexBar explanation before native Keychain access.
- Clicking Learn More opened `docs/keychain-prompts.md`, left the explanation open, and created no SecurityAgent window.
- No credential values were captured.

Fixes #1681
