### PR TITLE
Fix usage display mode in widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Claude web usage: bound stale requests so Auto can reach CLI fallback instead of hanging indefinitely.
 - Claude history: keep OAuth utilization separate across account switches while preserving continuity through token refreshes.
 - Linux CLI: keep Claude OAuth usage subprocess-free, skip version probes, and let Auto bypass unsupported web sources. Thanks @derekszen!
+- Usage display: make Usage widgets follow the used-versus-remaining preference already shared by menus and Overview rows (#1738). Thanks @OlegLustenko and @FrancoLan!
 
 ## 0.37.3 — 2026-06-28
 

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -30,7 +30,11 @@ extension UsageStore {
         let entries = UsageProvider.allCases.compactMap { provider in
             self.makeWidgetEntry(for: provider)
         }
-        return WidgetSnapshot(entries: entries, enabledProviders: enabledProviders, generatedAt: Date())
+        return WidgetSnapshot(
+            entries: entries,
+            enabledProviders: enabledProviders,
+            usageBarsShowUsed: self.settings.usageBarsShowUsed,
+            generatedAt: Date())
     }
 
     private func makeWidgetEntry(for provider: UsageProvider) -> WidgetSnapshot.ProviderEntry? {

--- a/Sources/CodexBarCore/WidgetSnapshot.swift
+++ b/Sources/CodexBarCore/WidgetSnapshot.swift
@@ -120,17 +120,25 @@ public struct WidgetSnapshot: Codable, Sendable {
 
     public let entries: [ProviderEntry]
     public let enabledProviders: [UsageProvider]
+    public let usageBarsShowUsed: Bool
     public let generatedAt: Date
 
-    public init(entries: [ProviderEntry], enabledProviders: [UsageProvider]? = nil, generatedAt: Date) {
+    public init(
+        entries: [ProviderEntry],
+        enabledProviders: [UsageProvider]? = nil,
+        usageBarsShowUsed: Bool = false,
+        generatedAt: Date)
+    {
         self.entries = entries
         self.enabledProviders = enabledProviders ?? entries.map(\.provider)
+        self.usageBarsShowUsed = usageBarsShowUsed
         self.generatedAt = generatedAt
     }
 
     private enum CodingKeys: String, CodingKey {
         case entries
         case enabledProviders
+        case usageBarsShowUsed
         case generatedAt
     }
 
@@ -140,12 +148,14 @@ public struct WidgetSnapshot: Codable, Sendable {
         self.generatedAt = try container.decode(Date.self, forKey: .generatedAt)
         self.enabledProviders = try container.decodeIfPresent([UsageProvider].self, forKey: .enabledProviders)
             ?? self.entries.map(\.provider)
+        self.usageBarsShowUsed = try container.decodeIfPresent(Bool.self, forKey: .usageBarsShowUsed) ?? false
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.entries, forKey: .entries)
         try container.encode(self.enabledProviders, forKey: .enabledProviders)
+        try container.encode(self.usageBarsShowUsed, forKey: .usageBarsShowUsed)
         try container.encode(self.generatedAt, forKey: .generatedAt)
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -2,6 +2,10 @@ import CodexBarCore
 import SwiftUI
 import WidgetKit
 
+extension EnvironmentValues {
+    @Entry fileprivate var widgetUsageShowsUsed: Bool = false
+}
+
 struct CodexBarUsageWidgetView: View {
     @Environment(\.widgetFamily) private var family
     let entry: CodexBarWidgetEntry
@@ -17,6 +21,7 @@ struct CodexBarUsageWidgetView: View {
             }
         }
         .containerBackground(.fill.tertiary, for: .widget)
+        .environment(\.widgetUsageShowsUsed, self.entry.snapshot.usageBarsShowUsed)
     }
 
     @ViewBuilder
@@ -127,6 +132,7 @@ struct CodexBarSwitcherWidgetView: View {
             .padding(12)
         }
         .containerBackground(.fill.tertiary, for: .widget)
+        .environment(\.widgetUsageShowsUsed, self.entry.snapshot.usageBarsShowUsed)
     }
 
     @ViewBuilder
@@ -641,6 +647,14 @@ struct WidgetUsageRow: Identifiable, Equatable {
     }
 }
 
+enum WidgetUsageDisplay {
+    static func percent(fromRemaining remaining: Double?, showUsed: Bool) -> Double? {
+        guard let remaining else { return nil }
+        let clamped = max(0, min(100, remaining))
+        return showUsed ? 100 - clamped : clamped
+    }
+}
+
 private struct HistoryView: View {
     let entry: WidgetSnapshot.ProviderEntry
     let isLarge: Bool
@@ -687,22 +701,24 @@ private struct HeaderView: View {
 }
 
 private struct UsageBarRow: View {
+    @Environment(\.widgetUsageShowsUsed) private var showUsed
     let title: String
     let percentLeft: Double?
     let color: Color
 
     var body: some View {
+        let percent = WidgetUsageDisplay.percent(fromRemaining: self.percentLeft, showUsed: self.showUsed)
         VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Text(self.title)
                     .font(.caption)
                 Spacer()
-                Text(WidgetFormat.percent(self.percentLeft))
+                Text(WidgetFormat.percent(percent))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
             GeometryReader { proxy in
-                let width = max(0, min(1, (percentLeft ?? 0) / 100)) * proxy.size.width
+                let width = max(0, min(1, (percent ?? 0) / 100)) * proxy.size.width
                 ZStack(alignment: .leading) {
                     Capsule().fill(Color.primary.opacity(0.08))
                     Capsule().fill(self.color).frame(width: width)

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -5,6 +5,13 @@ import Testing
 
 struct CodexBarWidgetProviderTests {
     @Test
+    func `usage display follows remaining and used preference`() {
+        #expect(WidgetUsageDisplay.percent(fromRemaining: 48, showUsed: false) == 48)
+        #expect(WidgetUsageDisplay.percent(fromRemaining: 48, showUsed: true) == 52)
+        #expect(WidgetUsageDisplay.percent(fromRemaining: nil, showUsed: true) == nil)
+    }
+
+    @Test
     func `small widget limits custom usage rows`() {
         let entry = WidgetSnapshot.ProviderEntry(
             provider: .antigravity,

--- a/Tests/CodexBarTests/StatusMenuUsageDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusMenuUsageDisplayTests.swift
@@ -1,0 +1,31 @@
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+extension StatusMenuTests {
+    @Test
+    func `overview card model follows usage display preference`() throws {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        settings.usageBarsShowUsed = false
+        let remainingMetric = try #require(controller.menuCardModel(for: .codex)?.metrics.first { $0.id == "primary" })
+        #expect(remainingMetric.percent == 78)
+        #expect(remainingMetric.percentStyle.rawValue == "left")
+
+        settings.usageBarsShowUsed = true
+        let usedMetric = try #require(controller.menuCardModel(for: .codex)?.metrics.first { $0.id == "primary" })
+        #expect(usedMetric.percent == 22)
+        #expect(usedMetric.percentStyle.rawValue == "used")
+    }
+}

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -17,6 +17,7 @@ struct UsageStoreWidgetSnapshotTests {
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
         settings.statusChecksEnabled = false
+        settings.usageBarsShowUsed = true
 
         let store = UsageStore(
             fetcher: UsageFetcher(environment: [:]),
@@ -43,6 +44,7 @@ struct UsageStoreWidgetSnapshotTests {
         await store.widgetSnapshotPersistTask?.value
 
         let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .antigravity })
+        #expect(widgetSnapshots.last?.usageBarsShowUsed == true)
         #expect(entry.usageRows?.map(\.id) == ["primary", "secondary"])
         #expect(entry.usageRows?.map(\.title) == ["Gemini Models", "Claude and GPT"])
         #expect(entry.usageRows?.compactMap(\.percentLeft) == [90, 80])

--- a/Tests/CodexBarTests/WidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/WidgetSnapshotTests.swift
@@ -32,6 +32,7 @@ struct WidgetSnapshotTests {
         let snapshot = WidgetSnapshot(
             entries: [entry],
             enabledProviders: [.codex, .claude],
+            usageBarsShowUsed: true,
             generatedAt: Date())
 
         let encoder = JSONEncoder()
@@ -50,6 +51,7 @@ struct WidgetSnapshotTests {
         #expect(decoded.entries.first?.tokenUsage?.last30DaysLabel == "This month")
         #expect(decoded.entries.first?.usageRows?.map(\.id) == ["session", "weekly"])
         #expect(decoded.enabledProviders == [.codex, .claude])
+        #expect(decoded.usageBarsShowUsed)
     }
 
     @Test
@@ -166,6 +168,7 @@ struct WidgetSnapshotTests {
         #expect(decoded.entries.count == 1)
         #expect(decoded.entries.first?.usageRows == nil)
         #expect(decoded.entries.first?.secondary?.usedPercent == 25)
+        #expect(!decoded.usageBarsShowUsed)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- carry the existing used-versus-remaining display preference into the widget snapshot
- apply the preference to Usage and Switcher widget rows while preserving raw remaining percentages
- keep older widget snapshots backward-compatible and add model/state regression coverage

Fixes #1738.

## Validation

- `swift test --filter 'WidgetSnapshotTests|UsageStoreWidgetSnapshotTests|CodexBarWidgetProviderTests|StatusMenuTests'` (187 tests)
- `make test` (44/44 shards)
- `make check`
- AutoReview: clean, no actionable findings
- `./Scripts/package_app.sh`; packaged Overview verified in remaining and used modes, with personal information hidden

The Overview model already honored this preference. This closes the remaining widget inconsistency without changing provider data, scan frequency, or stored raw quota values.
