### PR TITLE
Fix Claude Code sign-in flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 - Keychain prompts: explain that macOS handles password entry, surface the existing opt-out path, and link to troubleshooting before access begins (fixes #1681). Thanks @someshfengde and @Yuxin-Qiao!
+- Claude: use the dedicated Claude Code authentication command for sign-in, report its real exit status, and stop treating a browser URL as completed login (fixes #1715).
 - OpenAI API: explain that project service-account keys cannot read organization usage instead of surfacing a generic credit-balance HTTP 401 error (fixes #1792). Thanks @dhruv-anand-aintech!
 - Overview: render row selection on the GPU to keep trackpad scrolling smooth. Thanks @hhh2210!
 - Codex cost history: count cache reads separately, deduplicate active and archived sessions at row level, and preserve cached days across narrow refreshes. Thanks @kiranmagic7!

--- a/Sources/CodexBar/ClaudeLoginRunner.swift
+++ b/Sources/CodexBar/ClaudeLoginRunner.swift
@@ -85,6 +85,7 @@ struct ClaudeLoginRunner {
         options.baseEnvironment = environment
         options.stopOnURL = false // keep running until CLI confirms
         options.stopOnSubstrings = self.successMarkers
+        options.sendOnSubstrings = ["press ENTER to open in browser": "\r"]
         options.settleAfterStop = 0.35
         options.returnOnEmptyProcessExit = true
         do {

--- a/Sources/CodexBar/ClaudeLoginRunner.swift
+++ b/Sources/CodexBar/ClaudeLoginRunner.swift
@@ -3,6 +3,9 @@ import Darwin
 import Foundation
 
 struct ClaudeLoginRunner {
+    static let loginArguments = ["auth", "login", "--claudeai"]
+    private static let successMarkers = ["Successfully logged in", "Login successful", "Logged in successfully"]
+
     enum Phase {
         case requesting
         case waitingBrowser
@@ -22,22 +25,35 @@ struct ClaudeLoginRunner {
         let authLink: String?
     }
 
-    static func run(timeout: TimeInterval = 120, onPhaseChange: @escaping @Sendable (Phase) -> Void) async -> Result {
+    static func run(
+        timeout: TimeInterval = 120,
+        binary: String = "claude",
+        environment: [String: String]? = nil,
+        onPhaseChange: @escaping @Sendable (Phase) -> Void) async -> Result
+    {
         await Task(priority: .userInitiated) {
             onPhaseChange(.requesting)
             do {
-                let runResult = try self.runPTY(timeout: timeout, onPhaseChange: onPhaseChange)
+                let runResult = try self.runPTY(
+                    timeout: timeout,
+                    binary: binary,
+                    environment: environment,
+                    onPhaseChange: onPhaseChange)
                 let link = self.firstLink(in: runResult.output)
-                if let link {
+                switch runResult.completion {
+                case .processExited(status: 0):
                     return Result(outcome: .success, output: runResult.output, authLink: link)
+                case let .processExited(status):
+                    return Result(outcome: .failed(status: status), output: runResult.output, authLink: link)
+                case .outputCondition where self.successMarkers.contains(where: runResult.output.contains):
+                    return Result(outcome: .success, output: runResult.output, authLink: link)
+                case .outputCondition, .idleTimeout, .deadlineExceeded:
+                    return Result(outcome: .timedOut, output: runResult.output, authLink: link)
                 }
-                return Result(outcome: .timedOut, output: runResult.output, authLink: nil)
             } catch LoginError.binaryNotFound {
                 return Result(outcome: .missingBinary, output: "", authLink: nil)
             } catch let LoginError.timedOut(text) {
                 return Result(outcome: .timedOut, output: text, authLink: self.firstLink(in: text))
-            } catch let LoginError.failed(status, text) {
-                return Result(outcome: .failed(status: status), output: text, authLink: self.firstLink(in: text))
             } catch {
                 return Result(outcome: .launchFailed(error.localizedDescription), output: "", authLink: nil)
             }
@@ -49,32 +65,35 @@ struct ClaudeLoginRunner {
     private enum LoginError: Error {
         case binaryNotFound
         case timedOut(text: String)
-        case failed(status: Int32, text: String)
         case launchFailed(String)
     }
 
     private struct PTYRunResult {
         let output: String
+        let completion: TTYCommandRunner.Result.Completion
     }
 
     private static func runPTY(
         timeout: TimeInterval,
+        binary: String,
+        environment: [String: String]?,
         onPhaseChange: @escaping @Sendable (Phase) -> Void) throws -> PTYRunResult
     {
         let runner = TTYCommandRunner()
         var options = TTYCommandRunner.Options(rows: 50, cols: 160, timeout: timeout)
-        options.extraArgs = ["/login"]
+        options.extraArgs = self.loginArguments
+        options.baseEnvironment = environment
         options.stopOnURL = false // keep running until CLI confirms
-        options.stopOnSubstrings = ["Successfully logged in", "Login successful", "Logged in successfully"]
-        options.sendEnterEvery = 1.0
+        options.stopOnSubstrings = self.successMarkers
         options.settleAfterStop = 0.35
+        options.returnOnEmptyProcessExit = true
         do {
             let result = try runner.run(
-                binary: "claude",
+                binary: binary,
                 send: "",
                 options: options,
                 onURLDetected: { onPhaseChange(.waitingBrowser) })
-            return PTYRunResult(output: result.text)
+            return PTYRunResult(output: result.text, completion: result.completion)
         } catch TTYCommandRunner.Error.binaryNotFound {
             throw LoginError.binaryNotFound
         } catch TTYCommandRunner.Error.timedOut {

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -230,8 +230,10 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         if self.shouldOpenBrowserForWebSessionError(context: context) {
             return ("Re-login at claude.ai", .loginToProvider(url: "https://claude.ai/"))
         }
-        guard self.shouldOpenTerminalForOAuthError(store: context.store) else { return nil }
-        return ("Open Terminal", .openTerminal(command: "claude"))
+        if self.shouldOpenTerminalForOAuthError(store: context.store) {
+            return ("Open Terminal", .openTerminal(command: "claude"))
+        }
+        return ("Sign in with Claude Code...", .switchAccount(.claude))
     }
 
     @MainActor

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -626,13 +626,13 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
                 title: L("Claude CLI not found"),
                 message: L("Install the Claude CLI (npm i -g @anthropic-ai/claude-code) and try again."))
         case let .launchFailed(message):
-            self.presentLoginAlert(title: L("Could not start claude /login"), message: message)
+            self.presentLoginAlert(title: L("Could not start Claude Code login"), message: message)
         case .timedOut:
             self.presentLoginAlert(
                 title: L("Claude login timed out"),
                 message: self.trimmedLoginOutput(result.output))
         case let .failed(status):
-            let statusLine = String(format: L("claude /login exited with status %d."), status)
+            let statusLine = String(format: L("claude auth login exited with status %d."), status)
             let message = self.trimmedLoginOutput(result.output.isEmpty ? statusLine : result.output)
             self.presentLoginAlert(title: L("Claude login failed"), message: message)
         }

--- a/Tests/CodexBarTests/ClaudeLoginRunnerTests.swift
+++ b/Tests/CodexBarTests/ClaudeLoginRunnerTests.swift
@@ -5,10 +5,12 @@ import Testing
 @Suite(.serialized)
 struct ClaudeLoginRunnerTests {
     @Test
-    func `dedicated auth command completes successfully`() async throws {
+    func `dedicated auth command opens browser prompt and completes successfully`() async throws {
         let fixture = try self.makeFixture(script: """
         #!/bin/sh
         printf 'args:%s\\n' "$*"
+        printf 'Authenticate your account at (press ENTER to open in browser): '
+        IFS= read -r _
         printf 'https://claude.ai/oauth/authorize?test=1\\n'
         printf 'Successfully logged in\\n'
         """)

--- a/Tests/CodexBarTests/ClaudeLoginRunnerTests.swift
+++ b/Tests/CodexBarTests/ClaudeLoginRunnerTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite(.serialized)
+struct ClaudeLoginRunnerTests {
+    @Test
+    func `dedicated auth command completes successfully`() async throws {
+        let fixture = try self.makeFixture(script: """
+        #!/bin/sh
+        printf 'args:%s\\n' "$*"
+        printf 'https://claude.ai/oauth/authorize?test=1\\n'
+        printf 'Successfully logged in\\n'
+        """)
+        defer { fixture.remove() }
+
+        let result = await ClaudeLoginRunner.run(
+            timeout: 2,
+            binary: fixture.executable.path,
+            environment: fixture.environment,
+            onPhaseChange: { _ in })
+
+        guard case .success = result.outcome else {
+            Issue.record("Expected success, got \(String(describing: result.outcome))")
+            return
+        }
+        #expect(result.output.contains("args:auth login --claudeai"))
+        #expect(result.authLink == "https://claude.ai/oauth/authorize?test=1")
+    }
+
+    @Test
+    func `authorization URL alone is not treated as success`() async throws {
+        let fixture = try self.makeFixture(script: """
+        #!/bin/sh
+        printf 'https://claude.ai/oauth/authorize?test=1\\n'
+        /bin/sleep 5
+        """)
+        defer { fixture.remove() }
+
+        let result = await ClaudeLoginRunner.run(
+            timeout: 1,
+            binary: fixture.executable.path,
+            environment: fixture.environment,
+            onPhaseChange: { _ in })
+
+        guard case .timedOut = result.outcome else {
+            Issue.record("Expected timeout, got \(String(describing: result.outcome))")
+            return
+        }
+        #expect(result.authLink == "https://claude.ai/oauth/authorize?test=1")
+    }
+
+    @Test
+    func `dedicated auth command preserves failure status`() async throws {
+        let fixture = try self.makeFixture(script: """
+        #!/bin/sh
+        printf 'login failed\\n'
+        exit 7
+        """)
+        defer { fixture.remove() }
+
+        let result = await ClaudeLoginRunner.run(
+            timeout: 2,
+            binary: fixture.executable.path,
+            environment: fixture.environment,
+            onPhaseChange: { _ in })
+
+        guard case .failed(status: 7) = result.outcome else {
+            Issue.record("Expected status 7, got \(String(describing: result.outcome))")
+            return
+        }
+        #expect(result.output.contains("login failed"))
+    }
+
+    private func makeFixture(script: String) throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-claude-login-\(UUID().uuidString)", isDirectory: true)
+        let binDirectory = root.appendingPathComponent("bin", isDirectory: true)
+        let homeDirectory = root.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+
+        let executable = binDirectory.appendingPathComponent("claude")
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        return Fixture(
+            root: root,
+            executable: executable,
+            environment: [
+                "HOME": homeDirectory.path,
+                "PATH": binDirectory.path,
+            ])
+    }
+
+    private struct Fixture {
+        let root: URL
+        let executable: URL
+        let environment: [String: String]
+
+        func remove() {
+            try? FileManager.default.removeItem(at: self.root)
+        }
+    }
+}

--- a/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
@@ -25,7 +25,7 @@ struct ClaudeWebRecoveryMenuTests {
     }
 
     private func actions(
-        error: String,
+        error: String? = nil,
         source: ClaudeUsageDataSource,
         cookieSource: ProviderCookieSource = .auto,
         selectedSessionKey: Bool = false,
@@ -57,6 +57,16 @@ struct ClaudeWebRecoveryMenuTests {
                 guard case let .action(label, action) = entry else { return nil }
                 return (label, action)
             }
+    }
+
+    @Test
+    func `default account action describes ambient Claude Code sign in`() {
+        let actions = self.actions(source: .auto)
+
+        #expect(actions.contains {
+            $0.0 == "Sign in with Claude Code..." && $0.1 == .switchAccount(.claude)
+        })
+        #expect(!actions.contains { $0.0 == "Add Account..." })
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace the misleading Claude `Add Account...` action with `Sign in with Claude Code...`
- run the dedicated `claude auth login --claudeai` flow and answer only its browser-open prompt
- require a success marker or zero process exit; an OAuth URL alone no longer reports success
- preserve nonzero exit status and surface the current command in failure guidance

Closes #1715.

This intentionally fixes ambient Claude Code sign-in only. It does not claim to store or display multiple Claude subscriptions; #1756 and #1268 need a separate product/auth decision.

## Validation

- `swift test --filter ClaudeLoginRunnerTests`
- `swift test --filter ClaudeWebRecoveryMenuTests`
- `make check`
- `make test` (44/44 shards)
- `./Scripts/package_app.sh`
- `codesign --verify --deep --strict CodexBar.app`
- autoreview: clean after addressing the browser-open prompt finding

Packaged live proof used an isolated home/config, disabled Keychain access, and a synthetic Claude executable. The menu rendered `Sign in with Claude Code...`; activating it recorded `auth login --claudeai`; the synthetic URL-only process remained running instead of being reported as successful. No real credentials or provider requests were used.

## Overlap audit

- #1800 and #1776 are merged into the base and touch the OAuth credential/history stack, not this login runner.
- open #1771 and #1742 do not touch the changed login/action files.
