### PR TITLE
fix: handle Claude Education quota gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Quota warnings: add an optional centered on-screen text alert that stays click-through and does not steal focus. Thanks @SAASEmpiree!
 
 ### Fixed
+- Claude Education: treat subscription-only CLI responses as unavailable quotas, keep local cost data in menus and widgets, and suppress expected refresh cancellations (#1808).
 - Claude web usage: bound stale requests so Auto can reach CLI fallback instead of hanging indefinitely.
 - Claude history: keep OAuth utilization separate across account switches while preserving continuity through token refreshes.
 - Linux CLI: keep Claude OAuth usage subprocess-free, skip version probes, and let Auto bypass unsupported web sources. Thanks @derekszen!

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -329,7 +329,8 @@ extension UsageMenuCardView.Model {
         let currentError = lastError ?? input.lastError
         if let currentError = currentError?.trimmingCharacters(in: .whitespacesAndNewlines),
            !currentError.isEmpty,
-           !UsageError.isNoRateLimitsFoundDescription(currentError)
+           !UsageError.isNoRateLimitsFoundDescription(currentError),
+           !ClaudeStatusProbe.isSubscriptionQuotaUnavailableDescription(currentError)
         {
             return false
         }

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -334,6 +334,9 @@ extension UsageMenuCardView.Model {
         {
             return false
         }
+        if input.limitsAvailability?.isUnavailable == true {
+            return true
+        }
         return self.rateLimitsUnavailable(input: input, lastError: currentError)
     }
 

--- a/Sources/CodexBar/MenuCardView+ModelInput.swift
+++ b/Sources/CodexBar/MenuCardView+ModelInput.swift
@@ -16,6 +16,7 @@ extension UsageMenuCardView.Model {
         let account: AccountInfo
         let isRefreshing: Bool
         let lastError: String?
+        let limitsAvailability: UsageLimitsAvailability?
         let usageBarsShowUsed: Bool
         let resetTimeDisplayStyle: ResetTimeDisplayStyle
         let tokenCostUsageEnabled: Bool
@@ -46,6 +47,7 @@ extension UsageMenuCardView.Model {
             account: AccountInfo,
             isRefreshing: Bool,
             lastError: String?,
+            limitsAvailability: UsageLimitsAvailability? = nil,
             usageBarsShowUsed: Bool,
             resetTimeDisplayStyle: ResetTimeDisplayStyle,
             tokenCostUsageEnabled: Bool,
@@ -75,6 +77,7 @@ extension UsageMenuCardView.Model {
             self.account = account
             self.isRefreshing = isRefreshing
             self.lastError = lastError
+            self.limitsAvailability = limitsAvailability
             self.usageBarsShowUsed = usageBarsShowUsed
             self.resetTimeDisplayStyle = resetTimeDisplayStyle
             self.tokenCostUsageEnabled = tokenCostUsageEnabled

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -242,6 +242,10 @@ struct MenuDescriptor {
             if snap.rateLimitsUnavailable(for: provider) {
                 entries.append(.text(L("Limits not available"), .secondary))
             }
+        } else if !store.isStale(provider: provider),
+                  store.knownLimitsAvailability(for: provider)?.isUnavailable == true
+        {
+            entries.append(.text(L("Limits not available"), .secondary))
         } else {
             entries.append(.text(L("No usage yet"), .secondary))
         }

--- a/Sources/CodexBar/PreferencesProvidersPane+Testing.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane+Testing.swift
@@ -11,6 +11,10 @@ extension ProvidersPane {
         self.providerSubtitle(provider)
     }
 
+    func _test_providerSidebarSubtitle(_ provider: UsageProvider) -> String {
+        self.providerSidebarSubtitle(provider)
+    }
+
     func _test_moveProviders(fromOffsets: IndexSet, toOffset: Int) {
         self.moveProviders(fromOffsets: fromOffsets, toOffset: toOffset)
     }

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -226,11 +226,13 @@ struct ProvidersPane: View {
     func providerSubtitle(_ provider: UsageProvider) -> String {
         let meta = self.store.metadata(for: provider)
         let usageText: String
-        if let snapshot = self.store.snapshot(for: provider) {
+        if self.store.isStale(provider: provider) {
+            usageText = L("last_fetch_failed")
+        } else if self.store.knownLimitsAvailability(for: provider)?.isUnavailable == true {
+            usageText = L("Limits not available")
+        } else if let snapshot = self.store.snapshot(for: provider) {
             let relative = snapshot.updatedAt.relativeDescription()
             usageText = relative
-        } else if self.store.isStale(provider: provider) {
-            usageText = L("last_fetch_failed")
         } else {
             usageText = L("usage_not_fetched_yet")
         }
@@ -250,10 +252,12 @@ struct ProvidersPane: View {
 
     func providerSidebarSubtitle(_ provider: UsageProvider) -> String {
         let meta = self.store.metadata(for: provider)
-        let usageText: String = if let snapshot = self.store.snapshot(for: provider) {
-            snapshot.updatedAt.relativeDescription()
-        } else if self.store.isStale(provider: provider) {
+        let usageText: String = if self.store.isStale(provider: provider) {
             L("last_fetch_failed")
+        } else if self.store.knownLimitsAvailability(for: provider)?.isUnavailable == true {
+            L("Limits not available")
+        } else if let snapshot = self.store.snapshot(for: provider) {
+            snapshot.updatedAt.relativeDescription()
         } else {
             L("usage_not_fetched_yet")
         }
@@ -742,6 +746,7 @@ struct ProvidersPane: View {
             account: self.store.accountInfo(for: provider),
             isRefreshing: self.store.refreshingProviders.contains(provider),
             lastError: codexProjection?.userFacingErrors.usage ?? self.store.userFacingError(for: provider),
+            limitsAvailability: self.store.knownLimitsAvailability(for: provider),
             usageBarsShowUsed: self.settings.usageBarsShowUsed,
             resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
             tokenCostUsageEnabled: self.settings.isCostUsageEffectivelyEnabled(for: provider),

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -1186,11 +1186,11 @@ extension StatusItemController {
         if isFallbackOnly { return false }
 
         let isStale = self.store.isStale(provider: provider)
-        let hasData = self.store.snapshot(for: provider) != nil
-        if provider == .warp, !hasData, self.store.refreshingProviders.contains(provider) {
+        let hasSatisfiedUsageFetch = self.store.hasSatisfiedUsageFetch(for: provider)
+        if provider == .warp, !hasSatisfiedUsageFetch, self.store.refreshingProviders.contains(provider) {
             return true
         }
-        return !hasData && !isStale
+        return !hasSatisfiedUsageFetch && !isStale
     }
 
     func updateAnimationState() {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1116,7 +1116,7 @@ extension StatusItemController {
         // open regardless of freshness — still after the delay below, and still via the light usage-only
         // primitive so the OpenAI dashboard scrape stays deferred until the menu closes.
         let providersNeedingRetryAtOpen = self.delayedRefreshRetryProviders(for: menu).filter {
-            self.store.isStale(provider: $0) || self.store.snapshot(for: $0) == nil
+            self.store.needsUsageRefreshRetry(for: $0)
         }
         if !providersNeedingRetryAtOpen.isEmpty {
             self.deferMenuInteractionRefreshIfNeeded(providers: providersNeedingRetryAtOpen)
@@ -1141,7 +1141,7 @@ extension StatusItemController {
                 visibleProviders: visibleProviders,
                 refreshingProviders: self.store.refreshingProviders,
                 staleProviders: Set(visibleProviders.filter { self.store.isStale(provider: $0) }),
-                missingProviders: Set(visibleProviders.filter { self.store.snapshot(for: $0) == nil })))
+                missingProviders: Set(visibleProviders.filter { !self.store.hasSatisfiedUsageFetch(for: $0) })))
             if plan.refreshCodexDashboard { self.deferOpenAIDashboardRefreshUntilMenuCloses(reason: "refresh all") }
             let retryProviders = plan.providers
             guard !retryProviders.isEmpty else {
@@ -1178,7 +1178,7 @@ extension StatusItemController {
                 }
             }
             let stillNeedsRetry = retryProviders.contains {
-                self.store.isStale(provider: $0) || self.store.snapshot(for: $0) == nil
+                self.store.needsUsageRefreshRetry(for: $0)
             }
             if !stillNeedsRetry {
                 self.clearSatisfiedDeferredMenuInteractionRefreshes(for: retryProviders)
@@ -1196,7 +1196,7 @@ extension StatusItemController {
         let providersToCheck = self.delayedRefreshRetryProviders(for: menu)
         guard !providersToCheck.isEmpty else { return false }
         return providersToCheck.contains { provider in
-            self.store.isStale(provider: provider) || self.store.snapshot(for: provider) == nil
+            self.store.needsUsageRefreshRetry(for: provider)
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -105,6 +105,7 @@ extension StatusItemController {
             lastError: errorOverride
                 ?? codexProjection?.userFacingErrors.usage
                 ?? self.store.userFacingError(for: target),
+            limitsAvailability: self.store.knownLimitsAvailability(for: target),
             usageBarsShowUsed: self.settings.usageBarsShowUsed,
             resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
             tokenCostUsageEnabled: self.settings.isCostUsageEffectivelyEnabled(for: target),

--- a/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
@@ -89,7 +89,7 @@ extension StatusItemController {
 
     func clearSatisfiedDeferredMenuInteractionRefreshes(for providers: [UsageProvider]) {
         for provider in providers
-            where !self.store.isStale(provider: provider) && self.store.snapshot(for: provider) != nil
+            where !self.store.needsUsageRefreshRetry(for: provider)
         {
             self.deferredMenuInteractionRefreshProviders.remove(provider)
         }

--- a/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
+++ b/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
@@ -7,6 +7,7 @@ extension UsageStore {
         self.refreshingProviders.remove(provider)
         self.snapshots.removeValue(forKey: provider)
         self.errors[provider] = nil
+        self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
         self.lastSourceLabels.removeValue(forKey: provider)
         self.lastFetchAttempts.removeValue(forKey: provider)
         self.accountSnapshots.removeValue(forKey: provider)

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -307,6 +307,8 @@ extension UsageStore {
                 self.recordCodexHistoricalSampleIfNeeded(snapshot: backfilled)
             }
         case let .failure(error):
+            // Superseded or explicitly cancelled refreshes are control flow, not provider failures.
+            guard !Self.errorIsCancellation(error) else { return }
             if provider == .codex,
                let codexExpectedGuard = context.codexExpectedGuard,
                !self.shouldApplyCodexScopedFailure(expectedGuard: codexExpectedGuard)

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -516,6 +516,21 @@ extension UsageStore {
         let shouldNotifyPermissionPrompt = Self.isPermissionPromptWaiting(error)
         await MainActor.run {
             guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
+            if provider == .claude,
+               ClaudeStatusProbe.isSubscriptionQuotaUnavailableDescription(error.localizedDescription)
+            {
+                // This is a successful answer about quota availability, not a transient probe failure.
+                // Drop prior limits immediately so an Education subscription notice cannot leave stale bars visible.
+                self.snapshots.removeValue(forKey: provider)
+                self.lastKnownResetSnapshots.removeValue(forKey: provider)
+                self.lastKnownSessionRemaining.removeValue(forKey: provider)
+                self.lastKnownSessionWindowSource.removeValue(forKey: provider)
+                self.quotaWarningState = self.quotaWarningState.filter { $0.key.provider != provider }
+                self.lastSourceLabels.removeValue(forKey: provider)
+                self.errors[provider] = error.localizedDescription
+                self.failureGates[provider]?.reset()
+                return
+            }
             let hadPriorData = self.snapshots[provider] != nil
             let preservesPriorData = Self.shouldPreservePriorSnapshot(
                 after: error,

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -5,8 +5,6 @@ extension UsageStore {
     private struct ProviderRefreshOutcomeContext {
         let generation: UInt64
         let codexExpectedGuard: CodexAccountScopedRefreshGuard?
-        let claudeCredentialsChanged: Bool
-        let shouldConsumeClaudeKeychainFingerprint: Bool
         let claudeOAuthHistoryPersistentRefHash: String?
     }
 
@@ -188,7 +186,6 @@ extension UsageStore {
             }
             return await group.next()!
         }
-        guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
         let claudeAuthFingerprintAfterFetch = provider == .claude
             ? await Self.captureClaudeAuthFingerprintToken()
             : nil
@@ -210,6 +207,14 @@ extension UsageStore {
             beforeFetch: claudeAuthStateBeforeFetch,
             afterFetchFingerprintToken: claudeAuthFingerprintAfterFetch,
             afterFetchPersistentRefHash: claudeKeychainPersistentRefHashAfterFetch)
+        // Credential detection consumes change markers. Clean up before rejecting a superseded generation;
+        // replacement refreshes wait for their predecessor, so they cannot race this state reset.
+        if claudeCredentialsChanged {
+            await self.clearClaudeCredentialDerivedStateForCredentialSwap()
+        }
+        if shouldConsumeClaudeKeychainFingerprint {
+            _ = await Self.consumeClaudeKeychainFingerprintChangeWithoutPrompt()
+        }
         guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
         await self.applyProviderRefreshOutcome(
             provider: provider,
@@ -217,8 +222,6 @@ extension UsageStore {
             context: ProviderRefreshOutcomeContext(
                 generation: generation,
                 codexExpectedGuard: codexExpectedGuard,
-                claudeCredentialsChanged: claudeCredentialsChanged,
-                shouldConsumeClaudeKeychainFingerprint: shouldConsumeClaudeKeychainFingerprint,
                 claudeOAuthHistoryPersistentRefHash: claudeOAuthHistoryPersistentRefHash))
     }
 
@@ -243,9 +246,6 @@ extension UsageStore {
             let backfilled = await MainActor.run { () -> UsageSnapshot? in
                 guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else {
                     return nil
-                }
-                if context.claudeCredentialsChanged {
-                    self.clearClaudeCredentialDerivedStateForCredentialSwapNow()
                 }
                 let resetBackfillSource = provider == .codex
                     ? self.codexLastKnownResetSnapshot(matching: context.codexExpectedGuard)
@@ -276,9 +276,6 @@ extension UsageStore {
                 return backfilled
             }
             guard let backfilled else { return }
-            if context.shouldConsumeClaudeKeychainFingerprint {
-                _ = await Self.consumeClaudeKeychainFingerprintChangeWithoutPrompt()
-            }
             let isClaudeOAuthSample = provider == .claude
                 && result.strategyKind == .oauth
             let claudeOAuthPersistentRefHash: String? = if isClaudeOAuthSample,
@@ -307,7 +304,7 @@ extension UsageStore {
                 self.recordCodexHistoricalSampleIfNeeded(snapshot: backfilled)
             }
         case let .failure(error):
-            // Superseded or explicitly cancelled refreshes are control flow, not provider failures.
+            // Credential-change cleanup already ran above; cancellation is now safe to suppress.
             guard !Self.errorIsCancellation(error) else { return }
             if provider == .codex,
                let codexExpectedGuard = context.codexExpectedGuard,
@@ -317,12 +314,6 @@ extension UsageStore {
             }
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             self.recordStartupConnectivityRetryableFailure(error)
-            if context.claudeCredentialsChanged {
-                await self.clearClaudeCredentialDerivedStateForCredentialSwap()
-            }
-            if context.shouldConsumeClaudeKeychainFingerprint {
-                _ = await Self.consumeClaudeKeychainFingerprintChangeWithoutPrompt()
-            }
             await self.handleProviderFetchFailure(
                 provider: provider,
                 error: error,

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -268,6 +268,7 @@ extension UsageStore {
                 }
                 self.lastSourceLabels[provider] = result.sourceLabel
                 self.errors[provider] = nil
+                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
                 self.failureGates[provider]?.recordSuccess()
                 if provider == .codex {
                     self.rememberLiveSystemCodexEmailIfNeeded(scoped.accountEmail(for: .codex))
@@ -327,6 +328,7 @@ extension UsageStore {
             self.snapshots.removeValue(forKey: provider)
             self.lastKnownResetSnapshots.removeValue(forKey: provider)
             self.errors[provider] = nil
+            self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
             self.lastSourceLabels.removeValue(forKey: provider)
             self.lastFetchAttempts.removeValue(forKey: provider)
             self.accountSnapshots.removeValue(forKey: provider)
@@ -487,6 +489,7 @@ extension UsageStore {
         self.snapshots.removeValue(forKey: .claude)
         self.lastKnownResetSnapshots.removeValue(forKey: .claude)
         self.errors[.claude] = nil
+        self.knownLimitsAvailabilityByProvider.removeValue(forKey: .claude)
         self.lastSourceLabels.removeValue(forKey: .claude)
         self.accountSnapshots.removeValue(forKey: .claude)
         self.tokenSnapshots.removeValue(forKey: .claude)
@@ -507,6 +510,8 @@ extension UsageStore {
         let shouldNotifyPermissionPrompt = Self.isPermissionPromptWaiting(error)
         await MainActor.run {
             guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
+            let hadKnownUnavailableLimits = self.knownLimitsAvailabilityByProvider[provider]?.isUnavailable == true
+            self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
             if provider == .claude,
                ClaudeStatusProbe.isSubscriptionQuotaUnavailableDescription(error.localizedDescription)
             {
@@ -518,8 +523,18 @@ extension UsageStore {
                 self.lastKnownSessionWindowSource.removeValue(forKey: provider)
                 self.quotaWarningState = self.quotaWarningState.filter { $0.key.provider != provider }
                 self.lastSourceLabels.removeValue(forKey: provider)
-                self.errors[provider] = error.localizedDescription
+                self.errors[provider] = nil
+                self.knownLimitsAvailabilityByProvider[provider] = .unavailable
                 self.failureGates[provider]?.reset()
+                return
+            }
+            if provider == .claude,
+               hadKnownUnavailableLimits,
+               Self.shouldPreservePriorSnapshot(after: error, hadPriorData: true) ||
+               Self.isClaudeCLIRateLimitFailure(error)
+            {
+                self.errors[provider] = nil
+                self.knownLimitsAvailabilityByProvider[provider] = .unavailable
                 return
             }
             let hadPriorData = self.snapshots[provider] != nil

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -504,7 +504,7 @@ extension UsageStore {
         return false
     }
 
-    private static func errorIsCancellation(_ error: any Error) -> Bool {
+    nonisolated static func errorIsCancellation(_ error: any Error) -> Bool {
         if error is CancellationError {
             return true
         }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -35,6 +35,7 @@ struct CodexAccountUsageSnapshot: Identifiable {
 
 extension UsageStore {
     func activateCachedTokenAccountSnapshot(provider: UsageProvider, accountID: UUID) {
+        self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
         guard let cached = self.accountSnapshots[provider]?.first(where: { $0.account.id == accountID }) else {
             self.snapshots.removeValue(forKey: provider)
             self.errors.removeValue(forKey: provider)
@@ -1248,6 +1249,7 @@ extension UsageStore {
                 self.snapshots[provider] = backfilled
                 self.lastSourceLabels[provider] = result.sourceLabel
                 self.errors[provider] = nil
+                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
                 self.failureGates[provider]?.recordSuccess()
                 return backfilled
             }
@@ -1258,6 +1260,7 @@ extension UsageStore {
                 account: account)
         case let .failure(error):
             await MainActor.run {
+                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
                 guard let message = self.tokenAccountErrorMessage(error) else {
                     self.errors[provider] = nil
                     return

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -38,7 +38,9 @@ extension UsageStore {
     }
 
     private func makeWidgetEntry(for provider: UsageProvider) -> WidgetSnapshot.ProviderEntry? {
-        guard let snapshot = self.snapshots[provider] else { return nil }
+        let snapshot = self.snapshots[provider]
+        let storedTokenSnapshot = self.tokenSnapshots[provider]
+        guard snapshot != nil || (provider == .claude && storedTokenSnapshot != nil) else { return nil }
 
         let tokenSnapshot = self.tokenSnapshot(fromProviderSnapshot: snapshot, provider: provider) ?? self
             .tokenSnapshots[provider]
@@ -50,11 +52,11 @@ extension UsageStore {
         } ?? []
 
         let tokenUsage = Self.widgetTokenUsageSummary(from: tokenSnapshot, provider: provider)
-        let usageRows = self.widgetUsageRows(provider: provider, snapshot: snapshot)
+        let usageRows = snapshot.map { self.widgetUsageRows(provider: provider, snapshot: $0) } ?? []
 
         let creditsRemaining: Double?
         let codeReviewRemaining: Double?
-        if provider == .codex {
+        if provider == .codex, let snapshot {
             let projection = self.codexConsumerProjection(
                 surface: .widget,
                 snapshotOverride: snapshot,
@@ -69,10 +71,10 @@ extension UsageStore {
 
         return WidgetSnapshot.ProviderEntry(
             provider: provider,
-            updatedAt: snapshot.updatedAt,
-            primary: snapshot.primary,
-            secondary: snapshot.secondary,
-            tertiary: snapshot.tertiary,
+            updatedAt: snapshot?.updatedAt ?? tokenSnapshot?.updatedAt ?? Date(),
+            primary: snapshot?.primary,
+            secondary: snapshot?.secondary,
+            tertiary: snapshot?.tertiary,
             usageRows: usageRows,
             creditsRemaining: creditsRemaining,
             codeReviewRemainingPercent: codeReviewRemaining,

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -11,6 +11,7 @@ extension UsageStore {
     var menuObservationToken: Int {
         _ = self.snapshots
         _ = self.errors
+        _ = self.knownLimitsAvailabilityByProvider
         _ = self.lastSourceLabels
         _ = self.lastFetchAttempts
         _ = self.accountSnapshots
@@ -40,6 +41,7 @@ extension UsageStore {
     var iconObservationToken: Int {
         _ = self.snapshots
         _ = self.errors
+        _ = self.knownLimitsAvailabilityByProvider
         _ = self.credits
         _ = self.lastCreditsError
         _ = self.openAIDashboard
@@ -133,6 +135,7 @@ final class UsageStore {
 
     var snapshots: [UsageProvider: UsageSnapshot] = [:]
     var errors: [UsageProvider: String] = [:]
+    var knownLimitsAvailabilityByProvider: [UsageProvider: UsageLimitsAvailability] = [:]
     var lastSourceLabels: [UsageProvider: String] = [:]
     var lastFetchAttempts: [UsageProvider: [ProviderFetchAttempt]] = [:]
     var accountSnapshots: [UsageProvider: [TokenAccountUsageSnapshot]] = [:]
@@ -484,6 +487,18 @@ final class UsageStore {
 
     func isStale(provider: UsageProvider) -> Bool {
         self.errors[provider] != nil
+    }
+
+    func knownLimitsAvailability(for provider: UsageProvider) -> UsageLimitsAvailability? {
+        self.knownLimitsAvailabilityByProvider[provider]
+    }
+
+    func hasSatisfiedUsageFetch(for provider: UsageProvider) -> Bool {
+        self.snapshot(for: provider) != nil || self.knownLimitsAvailability(for: provider)?.isUnavailable == true
+    }
+
+    func needsUsageRefreshRetry(for provider: UsageProvider) -> Bool {
+        self.isStale(provider: provider) || !self.hasSatisfiedUsageFetch(for: provider)
     }
 
     func isEnabled(_ provider: UsageProvider) -> Bool {
@@ -933,6 +948,7 @@ extension UsageStore {
         try? output.write(to: url, atomically: true, encoding: .utf8)
         await MainActor.run {
             let snippet = String(output.prefix(180)).replacingOccurrences(of: "\n", with: " ")
+            self.knownLimitsAvailabilityByProvider.removeValue(forKey: .claude)
             self.errors[.claude] = "[Claude] \(snippet) (saved: \(url.path))"
             NSWorkspace.shared.open(url)
         }
@@ -948,6 +964,7 @@ extension UsageStore {
             return url
         } catch {
             await MainActor.run {
+                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
                 self.errors[provider] = "Failed to save log: \(error.localizedDescription)"
             }
             return nil

--- a/Sources/CodexBar/UsageStoreSupport.swift
+++ b/Sources/CodexBar/UsageStoreSupport.swift
@@ -117,6 +117,13 @@ extension UsageStore {
         self.errors[provider] = error
     }
 
+    func _setKnownLimitsAvailabilityForTesting(
+        _ availability: UsageLimitsAvailability?,
+        provider: UsageProvider)
+    {
+        self.knownLimitsAvailabilityByProvider[provider] = availability
+    }
+
     func _setCodexHistoricalDatasetForTesting(_ dataset: CodexHistoricalDataset?, accountKey: String? = nil) {
         self.codexHistoricalDataset = dataset
         self.codexHistoricalDatasetAccountKey = accountKey

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -655,8 +655,11 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
             sourceLabel: "claude")
     }
 
-    func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
+    func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
         guard context.runtime == .app, context.sourceMode == .auto else { return false }
+        guard !ClaudeStatusProbe.isSubscriptionQuotaUnavailableDescription(error.localizedDescription) else {
+            return false
+        }
         // Reuse the bounded planning result instead of repeating browser/Keychain work after CLI failure.
         return self.hasWebFallback
     }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -44,6 +44,10 @@ public enum ClaudeStatusProbeError: LocalizedError, Sendable {
 
 /// Runs `claude` inside a PTY, sends `/usage`, and parses the rendered text panel.
 public struct ClaudeStatusProbe: Sendable {
+    public static let subscriptionQuotaUnavailableDescription =
+        "Claude CLI /usage returned a subscription notice without session quota data. " +
+        "Local cost and token history remain available."
+
     public var claudeBinary: String = "claude"
     public var timeout: TimeInterval = 20.0
     public var keepCLISessionsAlive: Bool = false
@@ -462,7 +466,7 @@ public struct ClaudeStatusProbe: Sendable {
             return "Claude CLI usage endpoint is rate limited right now. Please try again later."
         }
         if self.isSubscriptionNoticeOnly(text: text) {
-            return "Claude CLI /usage returned a subscription notice without session quota data."
+            return self.subscriptionQuotaUnavailableDescription
         }
         if lower.contains("failed to load usage data") {
             return "Claude CLI could not load usage data. Open the CLI and retry `/usage`."
@@ -495,6 +499,10 @@ public struct ClaudeStatusProbe: Sendable {
             || normalized.contains("%used") || normalized.contains("%left") || normalized.contains("%remaining")
             || normalized.contains("%available")
         return !hasQuotaData
+    }
+
+    public static func isSubscriptionQuotaUnavailableDescription(_ text: String?) -> Bool {
+        text?.localizedCaseInsensitiveContains("subscription notice without session quota data") == true
     }
 
     /// Collect remaining percentages in the order they appear; used as a backup when labels move/rename.

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -629,6 +629,13 @@ public enum UsageLimitsAvailability: Equatable, Sendable {
         account: AccountInfo? = nil,
         lastErrorDescription: String? = nil) -> Self
     {
+        if provider == .claude {
+            guard snapshot == nil else { return .available }
+            return ClaudeStatusProbe.isSubscriptionQuotaUnavailableDescription(lastErrorDescription)
+                ? .unavailable
+                : .available
+        }
+
         if provider == .doubao || provider == .antigravity {
             guard let snapshot,
                   snapshot.identity(for: provider) != nil

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -347,6 +347,14 @@ private struct SwitcherSmallUsageView: View {
                     percentLeft: codeReview,
                     color: WidgetColors.color(for: self.entry.provider))
             }
+            if let token = WidgetUsageRow.compactTokenUsage(for: self.entry) {
+                ValueLine(
+                    title: token.sessionLabel,
+                    value: WidgetFormat.costAndTokens(
+                        cost: token.sessionCostUSD,
+                        tokens: token.sessionTokens,
+                        currencyCode: token.currencyCode))
+            }
         }
     }
 }
@@ -442,6 +450,14 @@ private struct SmallUsageView: View {
                     title: "Code review",
                     percentLeft: codeReview,
                     color: WidgetColors.color(for: self.entry.provider))
+            }
+            if let token = WidgetUsageRow.compactTokenUsage(for: self.entry) {
+                ValueLine(
+                    title: token.sessionLabel,
+                    value: WidgetFormat.costAndTokens(
+                        cost: token.sessionCostUSD,
+                        tokens: token.sessionTokens,
+                        currencyCode: token.currencyCode))
             }
         }
         .padding(12)
@@ -611,6 +627,17 @@ struct WidgetUsageRow: Identifiable, Equatable {
             return selected
         }
         return Array(rows.prefix(max(0, limit)))
+    }
+
+    static func compactTokenUsage(
+        for entry: WidgetSnapshot.ProviderEntry) -> WidgetSnapshot.TokenUsageSummary?
+    {
+        guard self.rows(for: entry).isEmpty,
+              entry.codeReviewRemainingPercent == nil
+        else {
+            return nil
+        }
+        return entry.tokenUsage
     }
 
     private static func antigravityQuotaFamily(for row: WidgetUsageRow) -> AntigravityQuotaFamily? {

--- a/Tests/CodexBarTests/ClaudeEducationAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeEducationAvailabilityTests.swift
@@ -5,6 +5,33 @@ import Testing
 
 struct ClaudeEducationAvailabilityTests {
     @Test
+    func `auto CLI subscription notice is terminal before web fallback`() {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        let strategy = ClaudeCLIFetchStrategy(
+            useWebExtras: false,
+            manualCookieHeader: "sessionKey=test-session",
+            browserDetection: browserDetection,
+            hasWebFallback: true)
+        let context = ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .auto,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: nil,
+            fetcher: UsageFetcher(environment: [:]),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+
+        let unavailable = ClaudeStatusProbeError.parseFailed(
+            ClaudeStatusProbe.subscriptionQuotaUnavailableDescription)
+        #expect(!strategy.shouldFallback(on: unavailable, context: context))
+        #expect(strategy.shouldFallback(on: ClaudeStatusProbeError.timedOut, context: context))
+    }
+
+    @Test
     func `subscription-only response is informational across Claude surfaces`() async throws {
         try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
             let tempDir = FileManager.default.temporaryDirectory

--- a/Tests/CodexBarTests/ClaudeEducationAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeEducationAvailabilityTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+struct ClaudeEducationAvailabilityTests {
+    @Test
+    func `subscription-only response is informational across Claude surfaces`() async throws {
+        try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("missing-credentials.json")
+
+            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                let (store, tokenSnapshot) = try await MainActor.run {
+                    let settings = testSettingsStore(suiteName: "ClaudeEducationAvailabilityTests")
+                    settings.refreshFrequency = .manual
+                    settings.statusChecksEnabled = false
+                    settings.claudeUsageDataSource = .cli
+                    settings.claudeOAuthKeychainPromptMode = .never
+                    settings.providerDetectionCompleted = true
+
+                    let metadata = ProviderRegistry.shared.metadata
+                    for provider in UsageProvider.allCases {
+                        try settings.setProviderEnabled(
+                            provider: provider,
+                            metadata: #require(metadata[provider]),
+                            enabled: provider == .claude)
+                    }
+
+                    let store = UsageStore(
+                        fetcher: UsageFetcher(environment: [:]),
+                        browserDetection: BrowserDetection(cacheTTL: 0),
+                        settings: settings,
+                        startupBehavior: .testing,
+                        environmentBase: [:])
+                    store._setSnapshotForTesting(
+                        UsageSnapshot(
+                            primary: RateWindow(
+                                usedPercent: 12,
+                                windowMinutes: 300,
+                                resetsAt: nil,
+                                resetDescription: nil),
+                            secondary: RateWindow(
+                                usedPercent: 34,
+                                windowMinutes: 10080,
+                                resetsAt: nil,
+                                resetDescription: nil),
+                            updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+                            identity: ProviderIdentitySnapshot(
+                                providerID: .claude,
+                                accountEmail: "claude@example.com",
+                                accountOrganization: nil,
+                                loginMethod: "Education")),
+                        provider: .claude)
+                    let tokenSnapshot = CostUsageTokenSnapshot(
+                        sessionTokens: 4200,
+                        sessionCostUSD: 1.25,
+                        last30DaysTokens: 42000,
+                        last30DaysCostUSD: 12.50,
+                        daily: [],
+                        updatedAt: Date(timeIntervalSince1970: 1_800_000_001))
+                    store._setTokenSnapshotForTesting(tokenSnapshot, provider: .claude)
+                    try Self.installStrategy(ClaudeSubscriptionOnlyFetchStrategy(), in: store)
+                    return (store, tokenSnapshot)
+                }
+
+                await store.refreshProvider(.claude)
+                await MainActor.run {
+                    let pane = ProvidersPane(settings: store.settings, store: store)
+                    let menuModel = pane._test_menuCardModel(for: .claude)
+                    let descriptor = MenuDescriptor.build(
+                        provider: .claude,
+                        store: store,
+                        settings: store.settings,
+                        account: AccountInfo(email: nil, plan: nil),
+                        updateReady: false,
+                        includeContextualActions: false)
+                    let descriptorLines = descriptor.sections
+                        .flatMap(\.entries)
+                        .compactMap { entry -> String? in
+                            guard case let .text(text, _) = entry else { return nil }
+                            return text
+                        }
+
+                    #expect(store.snapshot(for: .claude) == nil)
+                    #expect(store.error(for: .claude) == nil)
+                    #expect(store.knownLimitsAvailability(for: .claude) == .unavailable)
+                    #expect(!store.isStale(provider: .claude))
+                    #expect(store.hasSatisfiedUsageFetch(for: .claude))
+                    #expect(!store.needsUsageRefreshRetry(for: .claude))
+                    #expect(store.tokenSnapshot(for: .claude) == tokenSnapshot)
+                    #expect(pane._test_providerErrorDisplay(for: .claude) == nil)
+                    #expect(pane._test_providerSidebarSubtitle(.claude).hasSuffix("\nLimits not available"))
+                    #expect(menuModel.placeholder == "Limits not available")
+                    #expect(descriptorLines.contains("Limits not available"))
+                    #expect(!descriptorLines.contains("No usage yet"))
+                }
+
+                try await MainActor.run {
+                    try Self.installStrategy(ClaudeAvailabilityTimeoutFetchStrategy(), in: store)
+                }
+                await store.refreshProvider(.claude)
+
+                await MainActor.run {
+                    #expect(store.error(for: .claude) == nil)
+                    #expect(store.knownLimitsAvailability(for: .claude) == .unavailable)
+                    #expect(!store.isStale(provider: .claude))
+                    #expect(store.hasSatisfiedUsageFetch(for: .claude))
+                    #expect(!store.needsUsageRefreshRetry(for: .claude))
+                    #expect(store.tokenSnapshot(for: .claude) == tokenSnapshot)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private static func installStrategy(
+        _ strategy: some ProviderFetchStrategy,
+        in store: UsageStore) throws
+    {
+        let currentSpec = try #require(store.providerSpecs[.claude])
+        let currentDescriptor = currentSpec.descriptor
+        store.providerSpecs[.claude] = ProviderSpec(
+            style: currentSpec.style,
+            isEnabled: currentSpec.isEnabled,
+            descriptor: ProviderDescriptor(
+                id: .claude,
+                metadata: currentDescriptor.metadata,
+                branding: currentDescriptor.branding,
+                tokenCost: currentDescriptor.tokenCost,
+                fetchPlan: ProviderFetchPlan(
+                    sourceModes: [.cli],
+                    pipeline: ProviderFetchPipeline { _ in [strategy] }),
+                cli: currentDescriptor.cli),
+            makeFetchContext: currentSpec.makeFetchContext)
+    }
+}
+
+private struct ClaudeAvailabilityTimeoutFetchStrategy: ProviderFetchStrategy {
+    let id = "test.claude-availability-timeout"
+    let kind: ProviderFetchKind = .cli
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        throw ClaudeStatusProbeError.timedOut
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}
+
+private struct ClaudeSubscriptionOnlyFetchStrategy: ProviderFetchStrategy {
+    let id = "test.claude-subscription-only"
+    let kind: ProviderFetchKind = .cli
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        throw ClaudeStatusProbeError.parseFailed(ClaudeStatusProbe.subscriptionQuotaUnavailableDescription)
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}

--- a/Tests/CodexBarTests/ClaudeResilienceTests.swift
+++ b/Tests/CodexBarTests/ClaudeResilienceTests.swift
@@ -5,6 +5,67 @@ import Testing
 
 struct ClaudeResilienceTests {
     @Test
+    func `cancelled Claude refresh never publishes an error`() async throws {
+        try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("missing-credentials.json")
+
+            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                let store = try await MainActor.run {
+                    let settings = Self.makeSettingsStore(suite: "ClaudeResilienceTests-cancellation")
+                    settings.refreshFrequency = .manual
+                    settings.statusChecksEnabled = false
+                    settings.claudeUsageDataSource = .cli
+                    settings.claudeOAuthKeychainPromptMode = .never
+
+                    let metadata = ProviderRegistry.shared.metadata
+                    for provider in UsageProvider.allCases {
+                        try settings.setProviderEnabled(
+                            provider: provider,
+                            metadata: #require(metadata[provider]),
+                            enabled: provider == .claude)
+                    }
+
+                    let store = UsageStore(
+                        fetcher: UsageFetcher(environment: [:]),
+                        browserDetection: BrowserDetection(cacheTTL: 0),
+                        settings: settings,
+                        startupBehavior: .testing,
+                        environmentBase: [:])
+                    let baseSpec = try #require(store.providerSpecs[.claude])
+                    let descriptor = ProviderDescriptor(
+                        id: .claude,
+                        metadata: baseSpec.descriptor.metadata,
+                        branding: baseSpec.descriptor.branding,
+                        tokenCost: baseSpec.descriptor.tokenCost,
+                        fetchPlan: ProviderFetchPlan(
+                            sourceModes: [.cli],
+                            pipeline: ProviderFetchPipeline { _ in [CancellationFetchStrategy()] }),
+                        cli: baseSpec.descriptor.cli)
+                    store.providerSpecs[.claude] = ProviderSpec(
+                        style: baseSpec.style,
+                        isEnabled: baseSpec.isEnabled,
+                        descriptor: descriptor,
+                        makeFetchContext: baseSpec.makeFetchContext)
+                    return store
+                }
+
+                await store.refreshProvider(.claude)
+                let result = await MainActor.run {
+                    (
+                        hasSnapshot: store.snapshot(for: .claude) != nil,
+                        error: store.error(for: .claude))
+                }
+
+                #expect(!result.hasSnapshot)
+                #expect(result.error == nil)
+            }
+        }
+    }
+
+    @Test
     func `suppresses single flake when prior data exists`() {
         var gate = ConsecutiveFailureGate()
         let firstFailure = gate.shouldSurfaceError(onFailureWithPriorData: true)
@@ -1028,6 +1089,23 @@ private struct TimeoutFetchStrategy: ProviderFetchStrategy {
 
     func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
         throw ClaudeStatusProbeError.timedOut
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}
+
+private struct CancellationFetchStrategy: ProviderFetchStrategy {
+    let id = "test.cancellation"
+    let kind: ProviderFetchKind = .cli
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        throw CancellationError()
     }
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {

--- a/Tests/CodexBarTests/ClaudeResilienceTests.swift
+++ b/Tests/CodexBarTests/ClaudeResilienceTests.swift
@@ -5,6 +5,97 @@ import Testing
 
 struct ClaudeResilienceTests {
     @Test
+    func `subscription-only response replaces stale quotas but preserves local cost`() async throws {
+        try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("missing-credentials.json")
+
+            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                let (store, tokenSnapshot) = try await MainActor.run {
+                    let settings = Self.makeSettingsStore(suite: "ClaudeResilienceTests-subscription-only")
+                    settings.refreshFrequency = .manual
+                    settings.statusChecksEnabled = false
+                    settings.claudeUsageDataSource = .cli
+                    settings.claudeOAuthKeychainPromptMode = .never
+
+                    let metadata = ProviderRegistry.shared.metadata
+                    for provider in UsageProvider.allCases {
+                        try settings.setProviderEnabled(
+                            provider: provider,
+                            metadata: #require(metadata[provider]),
+                            enabled: provider == .claude)
+                    }
+
+                    let store = UsageStore(
+                        fetcher: UsageFetcher(environment: [:]),
+                        browserDetection: BrowserDetection(cacheTTL: 0),
+                        settings: settings,
+                        startupBehavior: .testing,
+                        environmentBase: [:])
+                    store._setSnapshotForTesting(
+                        UsageSnapshot(
+                            primary: RateWindow(
+                                usedPercent: 12,
+                                windowMinutes: 300,
+                                resetsAt: nil,
+                                resetDescription: nil),
+                            secondary: RateWindow(
+                                usedPercent: 34,
+                                windowMinutes: 10080,
+                                resetsAt: nil,
+                                resetDescription: nil),
+                            updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+                            identity: ProviderIdentitySnapshot(
+                                providerID: .claude,
+                                accountEmail: "claude@example.com",
+                                accountOrganization: nil,
+                                loginMethod: "Education")),
+                        provider: .claude)
+                    let tokenSnapshot = CostUsageTokenSnapshot(
+                        sessionTokens: 4200,
+                        sessionCostUSD: 1.25,
+                        last30DaysTokens: 42000,
+                        last30DaysCostUSD: 12.50,
+                        daily: [],
+                        updatedAt: Date(timeIntervalSince1970: 1_800_000_001))
+                    store._setTokenSnapshotForTesting(tokenSnapshot, provider: .claude)
+
+                    let baseSpec = try #require(store.providerSpecs[.claude])
+                    let descriptor = ProviderDescriptor(
+                        id: .claude,
+                        metadata: baseSpec.descriptor.metadata,
+                        branding: baseSpec.descriptor.branding,
+                        tokenCost: baseSpec.descriptor.tokenCost,
+                        fetchPlan: ProviderFetchPlan(
+                            sourceModes: [.cli],
+                            pipeline: ProviderFetchPipeline { _ in [SubscriptionOnlyFetchStrategy()] }),
+                        cli: baseSpec.descriptor.cli)
+                    store.providerSpecs[.claude] = ProviderSpec(
+                        style: baseSpec.style,
+                        isEnabled: baseSpec.isEnabled,
+                        descriptor: descriptor,
+                        makeFetchContext: baseSpec.makeFetchContext)
+                    return (store, tokenSnapshot)
+                }
+
+                await store.refreshProvider(.claude)
+                let result = await MainActor.run {
+                    (
+                        hasSnapshot: store.snapshot(for: .claude) != nil,
+                        error: store.error(for: .claude),
+                        tokenSnapshot: store.tokenSnapshot(for: .claude))
+                }
+
+                #expect(!result.hasSnapshot)
+                #expect(ClaudeStatusProbe.isSubscriptionQuotaUnavailableDescription(result.error))
+                #expect(result.tokenSnapshot == tokenSnapshot)
+            }
+        }
+    }
+
+    @Test
     func `cancelled Claude refresh never publishes an error`() async throws {
         try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
             let tempDir = FileManager.default.temporaryDirectory
@@ -1106,6 +1197,23 @@ private struct CancellationFetchStrategy: ProviderFetchStrategy {
 
     func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
         throw CancellationError()
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}
+
+private struct SubscriptionOnlyFetchStrategy: ProviderFetchStrategy {
+    let id = "test.subscription-only"
+    let kind: ProviderFetchKind = .cli
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        throw ClaudeStatusProbeError.parseFailed(ClaudeStatusProbe.subscriptionQuotaUnavailableDescription)
     }
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {

--- a/Tests/CodexBarTests/ClaudeResilienceTests.swift
+++ b/Tests/CodexBarTests/ClaudeResilienceTests.swift
@@ -157,6 +157,113 @@ struct ClaudeResilienceTests {
     }
 
     @Test
+    func `superseded credential change clears prior Claude state after cancellation`() async throws {
+        try await KeychainCacheStore.withServiceOverrideForTesting("com.steipete.codexbar.cache.tests.\(UUID())") {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+            try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+                let tempDir = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(UUID().uuidString, isDirectory: true)
+                try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+                let fileURL = tempDir.appendingPathComponent("credentials.json")
+                try Data("{}".utf8).write(to: fileURL)
+
+                try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                    #expect(ClaudeOAuthCredentialsStore.invalidateCacheIfCredentialsFileChanged())
+                    let cancellations = CredentialSwapCancellationSequence(credentialsFileURL: fileURL)
+
+                    let store = try await MainActor.run {
+                        let settings = Self.makeSettingsStore(suite: "ClaudeResilienceTests-cancelled-auth-change")
+                        settings.refreshFrequency = .manual
+                        settings.statusChecksEnabled = false
+                        settings.claudeUsageDataSource = .cli
+                        settings.claudeOAuthKeychainPromptMode = .never
+
+                        let metadata = ProviderRegistry.shared.metadata
+                        for provider in UsageProvider.allCases {
+                            try settings.setProviderEnabled(
+                                provider: provider,
+                                metadata: #require(metadata[provider]),
+                                enabled: provider == .claude)
+                        }
+
+                        let store = UsageStore(
+                            fetcher: UsageFetcher(environment: [:]),
+                            browserDetection: BrowserDetection(cacheTTL: 0),
+                            settings: settings,
+                            startupBehavior: .testing,
+                            environmentBase: [:])
+                        store._setSnapshotForTesting(
+                            UsageSnapshot(
+                                primary: RateWindow(
+                                    usedPercent: 12,
+                                    windowMinutes: 300,
+                                    resetsAt: nil,
+                                    resetDescription: nil),
+                                secondary: nil,
+                                updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+                                identity: ProviderIdentitySnapshot(
+                                    providerID: .claude,
+                                    accountEmail: "old@example.com",
+                                    accountOrganization: nil,
+                                    loginMethod: "Pro")),
+                            provider: .claude)
+                        store._setTokenSnapshotForTesting(
+                            CostUsageTokenSnapshot(
+                                sessionTokens: 4200,
+                                sessionCostUSD: 1.25,
+                                last30DaysTokens: 42000,
+                                last30DaysCostUSD: 12.50,
+                                daily: [],
+                                updatedAt: Date(timeIntervalSince1970: 1_800_000_001)),
+                            provider: .claude)
+
+                        let baseSpec = try #require(store.providerSpecs[.claude])
+                        let descriptor = ProviderDescriptor(
+                            id: .claude,
+                            metadata: baseSpec.descriptor.metadata,
+                            branding: baseSpec.descriptor.branding,
+                            tokenCost: baseSpec.descriptor.tokenCost,
+                            fetchPlan: ProviderFetchPlan(
+                                sourceModes: [.cli],
+                                pipeline: ProviderFetchPipeline { _ in
+                                    [CancellationAfterCredentialSwapFetchStrategy(cancellations: cancellations)]
+                                }),
+                            cli: baseSpec.descriptor.cli)
+                        store.providerSpecs[.claude] = ProviderSpec(
+                            style: baseSpec.style,
+                            isEnabled: baseSpec.isEnabled,
+                            descriptor: descriptor,
+                            makeFetchContext: baseSpec.makeFetchContext)
+                        return store
+                    }
+
+                    let olderRefresh = Task {
+                        await store.refreshProvider(.claude)
+                    }
+                    await cancellations.waitUntilStarted(count: 1)
+                    let newerRefresh = Task {
+                        await store.refreshProvider(.claude)
+                    }
+                    await newerRefresh.value
+                    await olderRefresh.value
+                    let result = await MainActor.run {
+                        (
+                            hasSnapshot: store.snapshot(for: .claude) != nil,
+                            hasTokenSnapshot: store.tokenSnapshot(for: .claude) != nil,
+                            error: store.error(for: .claude))
+                    }
+
+                    #expect(!result.hasSnapshot)
+                    #expect(!result.hasTokenSnapshot)
+                    #expect(result.error == nil)
+                }
+            }
+        }
+    }
+
+    @Test
     func `suppresses single flake when prior data exists`() {
         var gate = ConsecutiveFailureGate()
         let firstFailure = gate.shouldSurfaceError(onFailureWithPriorData: true)
@@ -1218,6 +1325,63 @@ private struct SubscriptionOnlyFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
         false
+    }
+}
+
+private struct CancellationAfterCredentialSwapFetchStrategy: ProviderFetchStrategy {
+    let id = "test.cancelled-credential-swap"
+    let kind: ProviderFetchKind = .cli
+    let cancellations: CredentialSwapCancellationSequence
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        try await self.cancellations.fetch()
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}
+
+private actor CredentialSwapCancellationSequence {
+    private struct StartWaiter {
+        let count: Int
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private let credentialsFileURL: URL
+    private var starts = 0
+    private var startWaiters: [StartWaiter] = []
+
+    init(credentialsFileURL: URL) {
+        self.credentialsFileURL = credentialsFileURL
+    }
+
+    func fetch() async throws -> ProviderFetchResult {
+        self.starts += 1
+        let call = self.starts
+        self.resumeReadyStartWaiters()
+        if call == 1 {
+            try Data("{\"updated\":true}".utf8).write(to: self.credentialsFileURL)
+            try await Task.sleep(for: .seconds(60))
+        }
+        throw CancellationError()
+    }
+
+    func waitUntilStarted(count: Int) async {
+        guard self.starts < count else { return }
+        await withCheckedContinuation { continuation in
+            self.startWaiters.append(StartWaiter(count: count, continuation: continuation))
+        }
+    }
+
+    private func resumeReadyStartWaiters() {
+        let ready = self.startWaiters.filter { $0.count <= self.starts }
+        self.startWaiters.removeAll { $0.count <= self.starts }
+        ready.forEach { $0.continuation.resume() }
     }
 }
 

--- a/Tests/CodexBarTests/ClaudeResilienceTests.swift
+++ b/Tests/CodexBarTests/ClaudeResilienceTests.swift
@@ -5,97 +5,6 @@ import Testing
 
 struct ClaudeResilienceTests {
     @Test
-    func `subscription-only response replaces stale quotas but preserves local cost`() async throws {
-        try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
-            let tempDir = FileManager.default.temporaryDirectory
-                .appendingPathComponent(UUID().uuidString, isDirectory: true)
-            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-            let fileURL = tempDir.appendingPathComponent("missing-credentials.json")
-
-            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
-                let (store, tokenSnapshot) = try await MainActor.run {
-                    let settings = Self.makeSettingsStore(suite: "ClaudeResilienceTests-subscription-only")
-                    settings.refreshFrequency = .manual
-                    settings.statusChecksEnabled = false
-                    settings.claudeUsageDataSource = .cli
-                    settings.claudeOAuthKeychainPromptMode = .never
-
-                    let metadata = ProviderRegistry.shared.metadata
-                    for provider in UsageProvider.allCases {
-                        try settings.setProviderEnabled(
-                            provider: provider,
-                            metadata: #require(metadata[provider]),
-                            enabled: provider == .claude)
-                    }
-
-                    let store = UsageStore(
-                        fetcher: UsageFetcher(environment: [:]),
-                        browserDetection: BrowserDetection(cacheTTL: 0),
-                        settings: settings,
-                        startupBehavior: .testing,
-                        environmentBase: [:])
-                    store._setSnapshotForTesting(
-                        UsageSnapshot(
-                            primary: RateWindow(
-                                usedPercent: 12,
-                                windowMinutes: 300,
-                                resetsAt: nil,
-                                resetDescription: nil),
-                            secondary: RateWindow(
-                                usedPercent: 34,
-                                windowMinutes: 10080,
-                                resetsAt: nil,
-                                resetDescription: nil),
-                            updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
-                            identity: ProviderIdentitySnapshot(
-                                providerID: .claude,
-                                accountEmail: "claude@example.com",
-                                accountOrganization: nil,
-                                loginMethod: "Education")),
-                        provider: .claude)
-                    let tokenSnapshot = CostUsageTokenSnapshot(
-                        sessionTokens: 4200,
-                        sessionCostUSD: 1.25,
-                        last30DaysTokens: 42000,
-                        last30DaysCostUSD: 12.50,
-                        daily: [],
-                        updatedAt: Date(timeIntervalSince1970: 1_800_000_001))
-                    store._setTokenSnapshotForTesting(tokenSnapshot, provider: .claude)
-
-                    let baseSpec = try #require(store.providerSpecs[.claude])
-                    let descriptor = ProviderDescriptor(
-                        id: .claude,
-                        metadata: baseSpec.descriptor.metadata,
-                        branding: baseSpec.descriptor.branding,
-                        tokenCost: baseSpec.descriptor.tokenCost,
-                        fetchPlan: ProviderFetchPlan(
-                            sourceModes: [.cli],
-                            pipeline: ProviderFetchPipeline { _ in [SubscriptionOnlyFetchStrategy()] }),
-                        cli: baseSpec.descriptor.cli)
-                    store.providerSpecs[.claude] = ProviderSpec(
-                        style: baseSpec.style,
-                        isEnabled: baseSpec.isEnabled,
-                        descriptor: descriptor,
-                        makeFetchContext: baseSpec.makeFetchContext)
-                    return (store, tokenSnapshot)
-                }
-
-                await store.refreshProvider(.claude)
-                let result = await MainActor.run {
-                    (
-                        hasSnapshot: store.snapshot(for: .claude) != nil,
-                        error: store.error(for: .claude),
-                        tokenSnapshot: store.tokenSnapshot(for: .claude))
-                }
-
-                #expect(!result.hasSnapshot)
-                #expect(ClaudeStatusProbe.isSubscriptionQuotaUnavailableDescription(result.error))
-                #expect(result.tokenSnapshot == tokenSnapshot)
-            }
-        }
-    }
-
-    @Test
     func `cancelled Claude refresh never publishes an error`() async throws {
         try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
             let tempDir = FileManager.default.temporaryDirectory
@@ -1304,23 +1213,6 @@ private struct CancellationFetchStrategy: ProviderFetchStrategy {
 
     func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
         throw CancellationError()
-    }
-
-    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
-        false
-    }
-}
-
-private struct SubscriptionOnlyFetchStrategy: ProviderFetchStrategy {
-    let id = "test.subscription-only"
-    let kind: ProviderFetchKind = .cli
-
-    func isAvailable(_: ProviderFetchContext) async -> Bool {
-        true
-    }
-
-    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
-        throw ClaudeStatusProbeError.parseFailed(ClaudeStatusProbe.subscriptionQuotaUnavailableDescription)
     }
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -12,6 +12,43 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `small widget falls back to local cost when quota rows are unavailable`() {
+        let tokenUsage = WidgetSnapshot.TokenUsageSummary(
+            sessionCostUSD: 1.25,
+            sessionTokens: 4200,
+            last30DaysCostUSD: 12.50,
+            last30DaysTokens: 42000,
+            currencyCode: "USD",
+            sessionLabel: "Today",
+            last30DaysLabel: "30d")
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .claude,
+            updatedAt: Date(),
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            usageRows: [],
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: tokenUsage,
+            dailyUsage: [])
+        let windowedEntry = WidgetSnapshot.ProviderEntry(
+            provider: .claude,
+            updatedAt: Date(),
+            primary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            usageRows: nil,
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: tokenUsage,
+            dailyUsage: [])
+
+        #expect(WidgetUsageRow.compactTokenUsage(for: entry)?.sessionTokens == 4200)
+        #expect(WidgetUsageRow.compactTokenUsage(for: windowedEntry) == nil)
+    }
+
+    @Test
     func `small widget limits custom usage rows`() {
         let entry = WidgetSnapshot.ProviderEntry(
             provider: .antigravity,

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -57,6 +57,47 @@ struct OverviewMenuCardVisibilityTests {
         #expect(model.placeholder == "Limits not available")
         #expect(!model.isOverviewErrorOnly)
     }
+
+    @Test
+    func `claude subscription-only quota keeps local cost content`() throws {
+        let metadata = try #require(ProviderDefaults.metadata[.claude])
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let tokenSnapshot = CostUsageTokenSnapshot(
+            sessionTokens: 4200,
+            sessionCostUSD: 1.25,
+            last30DaysTokens: 42000,
+            last30DaysCostUSD: 12.50,
+            daily: [],
+            updatedAt: now)
+        let quotaError = ClaudeStatusProbeError.parseFailed(
+            ClaudeStatusProbe.subscriptionQuotaUnavailableDescription).localizedDescription
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .claude,
+            metadata: metadata,
+            snapshot: nil,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: tokenSnapshot,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: quotaError,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: true,
+            tokenCostMenuSectionEnabled: true,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.placeholder == "Limits not available")
+        #expect(model.subtitleStyle == .info)
+        #expect(model.tokenUsage != nil)
+        #expect(model.metrics.isEmpty)
+        #expect(!model.isOverviewErrorOnly)
+    }
 }
 
 struct ProviderInlineDashboardModelTests {

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -27,6 +27,40 @@ struct StatusItemAnimationTests {
     }
 
     @Test
+    func `known unavailable limits stop loading animation`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-known-unavailable"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        store._setSnapshotForTesting(nil, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+        #expect(controller.shouldAnimate(provider: .claude))
+
+        store._setKnownLimitsAvailabilityForTesting(.unavailable, provider: .claude)
+        #expect(!controller.shouldAnimate(provider: .claude))
+    }
+
+    @Test
     func `merged icon loading animation tracks selected provider only`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "StatusItemAnimationTests-merged"),

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -564,6 +564,13 @@ struct StatusProbeTests {
             let lower = message.lowercased()
             #expect(lower.contains("subscription"))
             #expect(!lower.contains("still loading"))
+            #expect(ClaudeStatusProbe.isSubscriptionQuotaUnavailableDescription(message))
+
+            let errorDescription = ClaudeStatusProbeError.parseFailed(message).localizedDescription
+            #expect(UsageLimitsAvailability.resolve(
+                provider: .claude,
+                snapshot: nil,
+                lastErrorDescription: errorDescription) == .unavailable)
         } catch {
             #expect(Bool(false), "Unexpected error: \(error)")
         }

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -197,4 +197,59 @@ struct UsageStoreWidgetSnapshotTests {
         #expect(entry.secondary == nil)
         #expect(entry.usageRows?.isEmpty == true)
     }
+
+    @Test
+    func `widget snapshot keeps Claude local cost without quota data`() async throws {
+        let suite = "UsageStoreWidgetSnapshotTests-claude-local-cost-only"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let updatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        store._setTokenSnapshotForTesting(
+            CostUsageTokenSnapshot(
+                sessionTokens: 4200,
+                sessionCostUSD: 1.25,
+                last30DaysTokens: 42000,
+                last30DaysCostUSD: 12.50,
+                daily: [],
+                updatedAt: updatedAt),
+            provider: .claude)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 30, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: updatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: nil,
+                    accountOrganization: nil,
+                    loginMethod: nil)),
+            provider: .codex)
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        store.persistWidgetSnapshot(reason: "claude-local-cost-only-test")
+        await store.widgetSnapshotPersistTask?.value
+
+        let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .claude })
+        #expect(entry.updatedAt == updatedAt)
+        #expect(entry.primary == nil)
+        #expect(entry.secondary == nil)
+        #expect(entry.usageRows?.isEmpty == true)
+        #expect(entry.tokenUsage?.sessionTokens == 4200)
+        #expect(entry.tokenUsage?.last30DaysTokens == 42000)
+    }
 }

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -128,6 +128,9 @@ Admin API key setup:
   - Extracts percent left/used and reset text near those headers.
   - Parses `Account:` and `Org:` lines when present.
   - Surfaces CLI errors (e.g. token expired) directly.
+  - Some Education and organization-managed subscriptions return only a subscription notice, with no numeric
+    session or weekly quota fields. CodexBar reports those limits as unavailable, keeps local cost/token history
+    visible, and never derives quota percentages from spend or token totals.
 
 ## Cost usage (local log scan)
 - Source roots:

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -12,6 +12,8 @@ read_when:
 - `WidgetSnapshotStore` writes compact JSON snapshots to the app-group container.
 - Widgets read the snapshot and render usage/credits/history states.
 - The app writes snapshots after the main refresh pipeline and token-usage refreshes; narrow single-provider refresh paths may wait for the next snapshot write.
+- Claude local cost/token history remains eligible for widget snapshots when its account does not expose numeric
+  session or weekly quota data.
 - If no snapshot is available, widgets fall back to preview/empty data.
 
 ## Extension


### PR DESCRIPTION
## Summary

- treat Claude subscription notices without numeric session quota fields as an unavailable quota contract, not a red provider failure
- suppress refresh cancellation as control flow and preserve valid provider state
- stop auto mode before web fallback once the CLI has established that subscription limits are unavailable
- clear stale Claude quota state at credential/account lifecycle boundaries while preserving Claude-local cost/token history
- keep menus, widgets, preferences, sidebar status, and the menu bar icon consistent with the known-unavailable state
- document the Education/organization-managed subscription boundary without deriving quota percentages from spend or tokens

The Claude CLI subscription notice does not provide numeric session or weekly quota fields, so CodexBar cannot truthfully manufacture quota percentages. This change keeps useful local history visible and reports quota as unavailable instead.

## Proof

- focused Education, Claude resilience, credential/account swap, menu, widget, and status/icon suites green; final animation-focused run: 53 tests across 3 suites
- `make check`: SwiftFormat 0/1211 and SwiftLint 0/1210
- `make test`: 44/44 shards green on exact head without a retry
- `./Scripts/package_app.sh`; strict deep code-signature verification passed
- packaged/launched exact binary SHA-256: `fd7aee73f22f585136c7a10688a41d4d9a3b3682aae58440a6386bd6108b797d`
- exact packaged commit: `0720f0447495f8d2c0e389033cb7363ffd8b6193`
- fresh exact-bundle launch verified by process path and matching binary hash
- Peekaboo 3.5.2 verified the visible `codexbar-codex` status item and an in-bounds menu interaction at `(1115,15)` on the 2056x1212 display; local-only visual inspection confirmed the menu opened
- two independent full-branch autoreview passes clean after accepted fallback and icon-animation findings were fixed
- exact-head CI run [28539755548](https://github.com/steipete/CodexBar/actions/runs/28539755548): all 10 status contexts passed, including the aggregate gate and GitGuardian

Fixes #1808
