### PR TITLE
Prototype portable UI preferences contract

### DIFF
--- a/Sources/CodexBarCore/Config/CodexBarPortablePreferences.swift
+++ b/Sources/CodexBarCore/Config/CodexBarPortablePreferences.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+public struct CodexBarPortablePreferences: Codable, Equatable, Sendable {
+    public static let currentVersion = 1
+
+    public var version: Int?
+    public var refreshFrequency: String?
+    public var usageBarsShowUsed: Bool?
+    public var resetTimesShowAbsolute: Bool?
+    public var providerChangelogLinksEnabled: Bool?
+    public var menuBarDisplayMode: String?
+    public var menuBarShowsBrandIconWithPercent: Bool?
+    public var menuBarHidesCritters: Bool?
+    public var menuBarShowsHighestUsage: Bool?
+    public var mergeIcons: Bool?
+    public var switcherShowsIcons: Bool?
+    public var mergedOverviewSelectedProviders: [String]?
+    public var providersSortedAlphabetically: Bool?
+    public var appLanguage: String?
+    public var randomBlinkEnabled: Bool?
+    public var confettiOnWeeklyLimitResetsEnabled: Bool?
+
+    public init(
+        version: Int = Self.currentVersion,
+        refreshFrequency: String? = nil,
+        usageBarsShowUsed: Bool? = nil,
+        resetTimesShowAbsolute: Bool? = nil,
+        providerChangelogLinksEnabled: Bool? = nil,
+        menuBarDisplayMode: String? = nil,
+        menuBarShowsBrandIconWithPercent: Bool? = nil,
+        menuBarHidesCritters: Bool? = nil,
+        menuBarShowsHighestUsage: Bool? = nil,
+        mergeIcons: Bool? = nil,
+        switcherShowsIcons: Bool? = nil,
+        mergedOverviewSelectedProviders: [String]? = nil,
+        providersSortedAlphabetically: Bool? = nil,
+        appLanguage: String? = nil,
+        randomBlinkEnabled: Bool? = nil,
+        confettiOnWeeklyLimitResetsEnabled: Bool? = nil)
+    {
+        self.version = version
+        self.refreshFrequency = refreshFrequency
+        self.usageBarsShowUsed = usageBarsShowUsed
+        self.resetTimesShowAbsolute = resetTimesShowAbsolute
+        self.providerChangelogLinksEnabled = providerChangelogLinksEnabled
+        self.menuBarDisplayMode = menuBarDisplayMode
+        self.menuBarShowsBrandIconWithPercent = menuBarShowsBrandIconWithPercent
+        self.menuBarHidesCritters = menuBarHidesCritters
+        self.menuBarShowsHighestUsage = menuBarShowsHighestUsage
+        self.mergeIcons = mergeIcons
+        self.switcherShowsIcons = switcherShowsIcons
+        self.mergedOverviewSelectedProviders = mergedOverviewSelectedProviders
+        self.providersSortedAlphabetically = providersSortedAlphabetically
+        self.appLanguage = appLanguage
+        self.randomBlinkEnabled = randomBlinkEnabled
+        self.confettiOnWeeklyLimitResetsEnabled = confettiOnWeeklyLimitResetsEnabled
+    }
+
+    /// Explicit portable values win; omitted keys preserve the device's existing defaults state.
+    public func resolved(over fallback: Self) -> Self {
+        let portable = self.normalized()
+        return Self(
+            refreshFrequency: portable.refreshFrequency ?? fallback.refreshFrequency,
+            usageBarsShowUsed: portable.usageBarsShowUsed ?? fallback.usageBarsShowUsed,
+            resetTimesShowAbsolute: portable.resetTimesShowAbsolute ?? fallback.resetTimesShowAbsolute,
+            providerChangelogLinksEnabled: portable.providerChangelogLinksEnabled ?? fallback
+                .providerChangelogLinksEnabled,
+            menuBarDisplayMode: portable.menuBarDisplayMode ?? fallback.menuBarDisplayMode,
+            menuBarShowsBrandIconWithPercent: portable.menuBarShowsBrandIconWithPercent ?? fallback
+                .menuBarShowsBrandIconWithPercent,
+            menuBarHidesCritters: portable.menuBarHidesCritters ?? fallback.menuBarHidesCritters,
+            menuBarShowsHighestUsage: portable.menuBarShowsHighestUsage ?? fallback.menuBarShowsHighestUsage,
+            mergeIcons: portable.mergeIcons ?? fallback.mergeIcons,
+            switcherShowsIcons: portable.switcherShowsIcons ?? fallback.switcherShowsIcons,
+            mergedOverviewSelectedProviders: portable.mergedOverviewSelectedProviders ?? fallback
+                .mergedOverviewSelectedProviders,
+            providersSortedAlphabetically: portable.providersSortedAlphabetically ?? fallback
+                .providersSortedAlphabetically,
+            appLanguage: portable.appLanguage ?? fallback.appLanguage,
+            randomBlinkEnabled: portable.randomBlinkEnabled ?? fallback.randomBlinkEnabled,
+            confettiOnWeeklyLimitResetsEnabled: portable.confettiOnWeeklyLimitResetsEnabled ?? fallback
+                .confettiOnWeeklyLimitResetsEnabled)
+    }
+
+    public func normalized() -> Self {
+        var normalized = self
+        normalized.version = Self.currentVersion
+        normalized.refreshFrequency = Self.allowed(
+            self.refreshFrequency,
+            values: ["manual", "oneMinute", "twoMinutes", "fiveMinutes", "fifteenMinutes", "thirtyMinutes"])
+        normalized.menuBarDisplayMode = Self.allowed(
+            self.menuBarDisplayMode,
+            values: ["percent", "pace", "both", "resetTime"])
+        normalized.appLanguage = Self.normalizedLanguage(self.appLanguage)
+        normalized.mergedOverviewSelectedProviders = self.mergedOverviewSelectedProviders.map { providers in
+            var seen: Set<String> = []
+            return providers.compactMap { raw -> String? in
+                guard let value = Self.nonempty(raw), seen.insert(value).inserted else { return nil }
+                return value
+            }
+        }
+        return normalized
+    }
+
+    private static func nonempty(_ raw: String?) -> String? {
+        guard let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func allowed(_ raw: String?, values: Set<String>) -> String? {
+        guard let value = nonempty(raw), values.contains(value) else { return nil }
+        return value
+    }
+
+    private static func normalizedLanguage(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        if raw.isEmpty { return "" }
+        return Self.allowed(raw, values: [
+            "ar", "ca", "de", "en", "es", "fa", "fr", "id", "it", "ja", "ko", "nl", "pl", "pt-BR", "sv",
+            "th", "tr", "uk", "vi", "zh-Hans", "zh-Hant",
+        ])
+    }
+}
+
+public enum CodexBarPortablePreferencesStoreError: LocalizedError {
+    case decodeFailed(String)
+    case encodeFailed(String)
+    case unsupportedVersion(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .decodeFailed(details):
+            "Failed to decode CodexBar portable preferences: \(details)"
+        case let .encodeFailed(details):
+            "Failed to encode CodexBar portable preferences: \(details)"
+        case let .unsupportedVersion(version):
+            "CodexBar portable preferences version \(version) is newer than this app supports."
+        }
+    }
+}
+
+public struct CodexBarPortablePreferencesStore: @unchecked Sendable {
+    public static let pathEnvironmentKey = "CODEXBAR_PREFERENCES"
+
+    public let fileURL: URL
+    private let fileManager: FileManager
+
+    public init(fileURL: URL = Self.defaultURL(), fileManager: FileManager = .default) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    public func load() throws -> CodexBarPortablePreferences? {
+        guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return nil }
+        let data = try Data(contentsOf: self.fileURL)
+        do {
+            let decoded = try JSONDecoder().decode(CodexBarPortablePreferences.self, from: data)
+            if let version = decoded.version, version > CodexBarPortablePreferences.currentVersion {
+                throw CodexBarPortablePreferencesStoreError.unsupportedVersion(version)
+            }
+            return decoded.normalized()
+        } catch let error as CodexBarPortablePreferencesStoreError {
+            throw error
+        } catch {
+            throw CodexBarPortablePreferencesStoreError.decodeFailed(error.localizedDescription)
+        }
+    }
+
+    public func save(_ preferences: CodexBarPortablePreferences) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data: Data
+        do {
+            data = try encoder.encode(preferences.normalized())
+        } catch {
+            throw CodexBarPortablePreferencesStoreError.encodeFailed(error.localizedDescription)
+        }
+
+        let directory = self.fileURL.deletingLastPathComponent()
+        if !self.fileManager.fileExists(atPath: directory.path) {
+            try self.fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        try data.write(to: self.fileURL, options: [.atomic])
+        #if os(macOS) || os(Linux)
+        try self.fileManager.setAttributes([
+            .posixPermissions: NSNumber(value: Int16(0o600)),
+        ], ofItemAtPath: self.fileURL.path)
+        #endif
+    }
+
+    public static func defaultURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        configURL: URL? = nil) -> URL
+    {
+        if let override = environment[self.pathEnvironmentKey]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !override.isEmpty
+        {
+            return URL(fileURLWithPath: (override as NSString).expandingTildeInPath)
+        }
+
+        let configURL = configURL ?? CodexBarConfigStore.defaultURL(environment: environment)
+        return configURL.deletingLastPathComponent().appendingPathComponent("preferences.json")
+    }
+}

--- a/Tests/CodexBarTests/CodexBarPortablePreferencesTests.swift
+++ b/Tests/CodexBarTests/CodexBarPortablePreferencesTests.swift
@@ -1,0 +1,145 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CodexBarPortablePreferencesTests {
+    @Test
+    func `explicit portable keys override defaults while omissions preserve them`() {
+        let defaults = CodexBarPortablePreferences(
+            refreshFrequency: "fiveMinutes",
+            usageBarsShowUsed: false,
+            mergeIcons: false,
+            switcherShowsIcons: true,
+            appLanguage: "en")
+        let portable = CodexBarPortablePreferences(
+            refreshFrequency: "manual",
+            usageBarsShowUsed: true,
+            mergeIcons: true)
+
+        let resolved = portable.resolved(over: defaults)
+
+        #expect(resolved.refreshFrequency == "manual")
+        #expect(resolved.usageBarsShowUsed == true)
+        #expect(resolved.mergeIcons == true)
+        #expect(resolved.switcherShowsIcons == true)
+        #expect(resolved.appLanguage == "en")
+    }
+
+    @Test
+    func `invalid enum values fall back per key`() {
+        let defaults = CodexBarPortablePreferences(
+            refreshFrequency: "fiveMinutes",
+            menuBarDisplayMode: "percent",
+            appLanguage: "en")
+        let portable = CodexBarPortablePreferences(
+            refreshFrequency: "sometimes",
+            menuBarDisplayMode: "huge",
+            appLanguage: "klingon")
+
+        let resolved = portable.resolved(over: defaults)
+
+        #expect(resolved.refreshFrequency == "fiveMinutes")
+        #expect(resolved.menuBarDisplayMode == "percent")
+        #expect(resolved.appLanguage == "en")
+    }
+
+    @Test
+    func `normalization keeps forward compatible provider ids and removes duplicates`() {
+        let preferences = CodexBarPortablePreferences(
+            refreshFrequency: "  fiveMinutes ",
+            menuBarDisplayMode: " both ",
+            mergedOverviewSelectedProviders: ["codex", "", "future-provider", "codex"],
+            appLanguage: " en ")
+
+        let normalized = preferences.normalized()
+
+        #expect(normalized.version == CodexBarPortablePreferences.currentVersion)
+        #expect(normalized.refreshFrequency == "fiveMinutes")
+        #expect(normalized.menuBarDisplayMode == "both")
+        #expect(normalized.mergedOverviewSelectedProviders == ["codex", "future-provider"])
+        #expect(normalized.appLanguage == "en")
+    }
+
+    @Test
+    func `encoded schema excludes secrets privacy controls and device local state`() throws {
+        let data = try JSONEncoder().encode(CodexBarPortablePreferences(
+            refreshFrequency: "fiveMinutes",
+            usageBarsShowUsed: true,
+            mergedOverviewSelectedProviders: ["codex", "claude"]))
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        for excludedKey in [
+            "apiKey",
+            "cookieHeader",
+            "hidePersonalInfo",
+            "launchAtLogin",
+            "selectedMenuProvider",
+            "terminalApp",
+            "tokenCostUsageEnabled",
+        ] {
+            #expect(!json.contains(excludedKey))
+        }
+    }
+
+    @Test
+    func `store stays opt in and round trips a sparse document`() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarPortablePreferencesTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileURL = directory.appendingPathComponent("preferences.json")
+        let store = CodexBarPortablePreferencesStore(fileURL: fileURL)
+
+        #expect(try store.load() == nil)
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+
+        let preferences = CodexBarPortablePreferences(
+            usageBarsShowUsed: true,
+            mergedOverviewSelectedProviders: ["codex", "claude"])
+        try store.save(preferences)
+
+        #expect(try store.load() == preferences)
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+        #expect(permissions.intValue == 0o600)
+    }
+
+    @Test
+    func `empty document loads as no overrides`() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarPortablePreferencesTests-empty-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("preferences.json")
+        try Data("{}".utf8).write(to: fileURL)
+        let store = CodexBarPortablePreferencesStore(fileURL: fileURL)
+
+        #expect(try store.load() == CodexBarPortablePreferences())
+    }
+
+    @Test
+    func `store refuses a future schema version`() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarPortablePreferencesTests-future-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("preferences.json")
+        try Data("{\"version\": 99}".utf8).write(to: fileURL)
+        let store = CodexBarPortablePreferencesStore(fileURL: fileURL)
+
+        #expect(throws: CodexBarPortablePreferencesStoreError.self) {
+            try store.load()
+        }
+    }
+
+    @Test
+    func `default path sits beside config and supports an explicit override`() {
+        let configURL = URL(fileURLWithPath: "/tmp/codexbar/config.json")
+        #expect(CodexBarPortablePreferencesStore.defaultURL(
+            environment: [:],
+            configURL: configURL).path == "/tmp/codexbar/preferences.json")
+
+        #expect(CodexBarPortablePreferencesStore.defaultURL(
+            environment: ["CODEXBAR_PREFERENCES": "/tmp/shared-codexbar.json"],
+            configURL: configURL).path == "/tmp/shared-codexbar.json")
+    }
+}

--- a/docs/portable-preferences.md
+++ b/docs/portable-preferences.md
@@ -1,0 +1,59 @@
+# Portable UI preferences decision
+
+Issue: [#1282](https://github.com/steipete/CodexBar/issues/1282)
+
+## Recommendation
+
+Use a separate `preferences.json` beside CodexBar's resolved `config.json`, with `CODEXBAR_PREFERENCES` as an explicit path override. Do not place UI preferences inside `config.json`: provider configuration can contain API keys, cookie headers, and other credentials, so encouraging users to commit that file to dotfiles would create an avoidable secret-disclosure trap.
+
+Portable preferences should be opt-in by file presence. CodexBar must not create or populate the file during an upgrade. This keeps existing installs on UserDefaults and avoids silently exporting a user's device state.
+
+## Proposed precedence and writes
+
+1. An explicit, valid key in `preferences.json` wins.
+2. An omitted key preserves the existing UserDefaults value.
+3. If neither exists, the current code default applies.
+
+An empty document therefore changes nothing. Invalid values should be logged and ignored per key rather than rejecting every preference.
+
+Recommended UI-write behavior: when the portable file exists, changing a portable setting writes the file and mirrors UserDefaults as a local fallback. External file changes should update only the in-memory portable subset. Both behaviors need owner approval before runtime wiring because they establish a new synchronization and conflict contract.
+
+## Phase-one portable whitelist
+
+- refresh cadence;
+- usage bars as used or remaining;
+- reset-time presentation and provider changelog links;
+- menu bar display mode, branding, critter visibility, and highest-usage choice;
+- merged-menu and switcher presentation;
+- Overview provider selection;
+- provider-list sort presentation;
+- app language;
+- blink and weekly-limit confetti presentation.
+
+The prototype schema is sparse and versioned. Unknown provider IDs survive normalization so a newer machine does not erase a synced selection merely because an older CodexBar build cannot render that provider yet.
+
+## Explicit exclusions
+
+- `launchAtLogin`: OS registration, not a portable preference;
+- terminal app, window frames, last-selected provider/menu, and provider-detection completion: device/session state;
+- debug, logging, browser, keychain, and authentication controls: security or diagnostics state;
+- `hidePersonalInfo`: syncing an explicit `false` could unexpectedly reveal identity on another screen;
+- historical tracking, cost scanning, notifications, and storage-footprint collection: performance, retention, or permission choices;
+- provider credentials, cookies, account routing, and token accounts: remain in the existing protected provider config path.
+
+## Migration and failure behavior
+
+- no automatic migration or file creation;
+- malformed JSON leaves UserDefaults active and surfaces one actionable diagnostic;
+- missing/invalid individual values fall back without rewriting the source file;
+- future schema versions must preserve unknown keys or refuse writes rather than destructively downgrading;
+- deletion disables portable overrides immediately and returns to UserDefaults;
+- documentation must warn that `config.json` is secret-bearing and should not be committed wholesale.
+
+## Maintainer choice
+
+1. **Recommended:** separate, file-presence opt-in `preferences.json`; explicit keys override UserDefaults; UI changes dual-write while active.
+2. Put a `preferences` block in `config.json`. Fewer files, but materially easier to leak provider secrets through dotfiles.
+3. Export/import only. No live synchronization conflicts, but edits on one Mac do not declaratively update another.
+
+This branch supplies the versioned schema, normalization, resolver, path contract, and state tests. It intentionally does not connect the store to `SettingsStore` until the storage, precedence, and write-back choices above are approved.


### PR DESCRIPTION
## Summary

- prototype a sparse, versioned portable UI-preference schema and file store
- keep portable preferences in a separate `preferences.json` beside the resolved config, with a `CODEXBAR_PREFERENCES` override
- document explicit-key precedence plus portable, device-local, privacy, and security boundaries
- intentionally leave `SettingsStore` runtime wiring out until the product choice is approved

## Product decision

Recommended contract:

- separate preference file rather than the existing provider config
- opt in by creating the file; no automatic creation or migration
- explicit valid file key > local `UserDefaults` value > code default
- once enabled, UI changes dual-write the preference file and `UserDefaults`

The existing config can contain API keys, cookie headers, and other credentials. Putting UI preferences there would encourage users to sync or commit a secret-bearing file. The alternatives are a preference block inside that config (simpler, unsafe sharing affordance) or export/import only (safer, but not continuous sync).

## Scope

The prototype includes presentation and behavior preferences that can safely follow a user between Macs. It excludes credentials, account routing, login items, terminal paths, window state, discovery/debug state, privacy toggles, histories, notifications, and storage policy.

## Proof

- `swift test --filter CodexBarPortablePreferencesTests` (8 tests)
- `make check`
- `make test` (44 shards)
- `./Scripts/package_app.sh`
- autoreview clean after fixing sparse-version and invalid-language handling

No screenshot: this decision branch deliberately adds no live UI or runtime behavior.

Refs #1282
