### PR TITLE
fix: include Dia for OpenCode cookie import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Repository: reject oversized tracked blobs and generated release/build artifacts during checks. Thanks @joeVenner!
 
 ### Fixed
+- OpenCode web: search Dia after Chrome for automatic cookie import, with Keychain preflight scoped to the candidate browser (fixes #1822). Thanks @zeajose!
 - Claude: make the "Avoid Keychain prompts" setting use the no-prompt policy instead of the experimental `security` CLI reader. Thanks @gmkbenjamin!
 
 ## 0.38.1 — 2026-07-04

--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -63,7 +63,7 @@ public enum BrowserCookieAccessGate {
         }
         guard shouldCheckKeychain else { return false }
 
-        let requiresInteraction = self.chromiumKeychainRequiresInteraction()
+        let requiresInteraction = self.chromiumKeychainRequiresInteraction(for: browser)
         return self.lock.withLock { state in
             self.loadIfNeeded(&state)
             if requiresInteraction {
@@ -110,8 +110,9 @@ public enum BrowserCookieAccessGate {
         }
     }
 
-    private static func chromiumKeychainRequiresInteraction() -> Bool {
-        for label in self.safeStorageLabels {
+    private static func chromiumKeychainRequiresInteraction(for browser: Browser) -> Bool {
+        let labels = browser.safeStorageLabels.isEmpty ? self.safeStorageLabels : browser.safeStorageLabels
+        for label in labels {
             switch KeychainAccessPreflight.checkGenericPassword(service: label.service, account: label.account) {
             case .allowed:
                 return false

--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
@@ -20,7 +20,7 @@ public enum OpenCodeProviderDescriptor {
                 defaultEnabled: false,
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
-                browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
+                browserCookieOrder: ProviderBrowserCookieDefaults.opencodeCookieImportOrder,
                 dashboardURL: "https://opencode.ai",
                 statusPageURL: nil),
             branding: ProviderBranding(

--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeWebCookieSupport.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeWebCookieSupport.swift
@@ -51,12 +51,7 @@ enum OpenCodeWebCookieSupport {
 
     #if os(macOS)
     static func automaticImportOrder(provider: UsageProvider) -> BrowserCookieImportOrder {
-        if provider == .opencodego,
-           let order = ProviderDefaults.metadata[provider]?.browserCookieOrder
-        {
-            return order
-        }
-        return [.chrome]
+        ProviderDefaults.metadata[provider]?.browserCookieOrder ?? [.chrome]
     }
     #endif
 }

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -229,6 +229,16 @@ public enum ProviderBrowserCookieDefaults {
         #endif
     }
 
+    /// OpenCode web Auto stays Chrome-only by default, with Dia as the one bounded provider exception
+    /// because Dia has a confirmed reporter need. Other browsers stay on Manual until users can choose them.
+    public static var opencodeCookieImportOrder: BrowserCookieImportOrder? {
+        #if os(macOS)
+        [.chrome, .dia]
+        #else
+        nil
+        #endif
+    }
+
     /// Grok is normally signed in through Chrome; keep this narrow so CLI/live probes do not touch
     /// unrelated browser keychains.
     public static var grokCookieImportOrder: BrowserCookieImportOrder? {

--- a/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
@@ -49,8 +49,25 @@ struct BrowserCookieOrderStatusStringTests {
     }
 
     @Test
-    func `opencode automatic cookies keep chrome only default`() {
-        #expect(OpenCodeWebCookieSupport.automaticImportOrder(provider: .opencode) == [.chrome])
+    func `opencode automatic cookies only use chrome and dia`() {
+        let order = OpenCodeWebCookieSupport.automaticImportOrder(provider: .opencode)
+        #expect(order == ProviderDefaults.metadata[.opencode]?.browserCookieOrder)
+        #expect(order == ProviderBrowserCookieDefaults.opencodeCookieImportOrder)
+        #expect(order == [.chrome, .dia])
+    }
+
+    @Test
+    func `opencode automatic cookies bound keychain prompt labels to chrome and dia`() {
+        let order = OpenCodeWebCookieSupport.automaticImportOrder(provider: .opencode)
+        let labels = order.flatMap(\.safeStorageLabels).map(\.service)
+
+        #expect(labels == ["Chrome Safe Storage", "Dia Safe Storage"])
+        #expect(!order.contains(.safari))
+        #expect(!order.contains(.firefox))
+        #expect(!order.contains(.edge))
+        #expect(!order.contains(.brave))
+        #expect(!order.contains(.arc))
+        #expect(!order.contains(.chromium))
     }
 
     @Test

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -30,6 +30,14 @@ struct BrowserDetectionTests {
             profileAccessIssue: { _ in nil })
     }
 
+    private static func labelIDs(for browser: Browser) -> [String] {
+        browser.safeStorageLabels.map { self.labelID(service: $0.service, account: $0.account) }
+    }
+
+    private static func labelID(service: String, account: String?) -> String {
+        "\(service)|\(account ?? "")"
+    }
+
     @Test(.disabled(
         if: ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] == "1",
         "Default-home cookie access is explicitly enabled for this test run."))
@@ -279,6 +287,84 @@ struct BrowserDetectionTests {
         }
 
         #expect(preflightCount == 1)
+    }
+
+    @Test
+    func `chrome keychain preflight queries only chrome labels`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        let chromeLabels = Self.labelIDs(for: .chrome)
+        let chromeLabelSet = Set(chromeLabels)
+        var queriedLabels: [String] = []
+
+        KeychainAccessGate.withTaskOverrideForTesting(false) {
+            KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { service, account in
+                let label = Self.labelID(service: service, account: account)
+                queriedLabels.append(label)
+                return .notFound
+            } operation: {
+                #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == true)
+            }
+        }
+
+        #expect(queriedLabels == chromeLabels)
+        #expect(queriedLabels.allSatisfy { chromeLabelSet.contains($0) })
+    }
+
+    @Test
+    func `dia keychain preflight queries only dia labels`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        let diaLabels = Self.labelIDs(for: .dia)
+        let diaLabelSet = Set(diaLabels)
+        var queriedLabels: [String] = []
+
+        KeychainAccessGate.withTaskOverrideForTesting(false) {
+            KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { service, account in
+                let label = Self.labelID(service: service, account: account)
+                queriedLabels.append(label)
+                return .notFound
+            } operation: {
+                #expect(BrowserCookieAccessGate.shouldAttempt(.dia) == true)
+            }
+        }
+
+        #expect(queriedLabels == diaLabels)
+        #expect(queriedLabels.allSatisfy { diaLabelSet.contains($0) })
+    }
+
+    @Test
+    func `browser keychain interaction suppresses only that browser`() throws {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        let start = Date(timeIntervalSince1970: 2000)
+        let chromeLabels = Self.labelIDs(for: .chrome)
+        let diaLabels = Self.labelIDs(for: .dia)
+        let firstChromeLabel = try #require(chromeLabels.first)
+        let firstDiaLabel = try #require(diaLabels.first)
+        let allowedLabels = Set(chromeLabels + diaLabels)
+        var queriedLabels: [String] = []
+
+        KeychainAccessGate.withTaskOverrideForTesting(false) {
+            KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { service, account in
+                let label = Self.labelID(service: service, account: account)
+                queriedLabels.append(label)
+                if label == firstChromeLabel { return .allowed }
+                if label == firstDiaLabel { return .interactionRequired }
+                return .notFound
+            } operation: {
+                #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start) == true)
+                #expect(BrowserCookieAccessGate.shouldAttempt(.dia, now: start.addingTimeInterval(1)) == false)
+                #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(60)) == true)
+                #expect(BrowserCookieAccessGate.shouldAttempt(.dia, now: start.addingTimeInterval(60)) == false)
+            }
+        }
+
+        #expect(queriedLabels == [firstChromeLabel, firstDiaLabel, firstChromeLabel])
+        #expect(queriedLabels.allSatisfy { allowedLabels.contains($0) })
     }
 
     @Test

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -22,7 +22,9 @@ read_when:
 ## Notes
 - Responses are `text/javascript` with serialized objects; parse via regex.
 - Missing workspace ID or rolling usage fields should raise parse errors; omitted weekly usage stays absent.
-- Cookie import defaults to Chrome-only to avoid extra browser prompts; pass a browser list to override.
+- OpenCode web Auto imports Chrome first, then Dia when their cookie stores exist; Keychain preflight stays scoped
+  to each candidate browser. Other browsers stay on Manual Cookie import until CodexBar has an explicit browser
+  selector.
 - Set `CODEXBAR_OPENCODE_WORKSPACE_ID` to skip workspace lookup and force a specific workspace.
 - Workspace override accepts a raw `wrk_…` ID or a full `https://opencode.ai/workspace/...` URL.
 - Cached cookies: Keychain cache `com.steipete.codexbar.cache` (account `cookie.opencode`, source + timestamp). Browser


### PR DESCRIPTION
## Summary

- make OpenCode web Auto try Chrome first, then Dia, while keeping every other browser manual-only
- scope Chromium Keychain preflight to the current candidate browser's own Safe Storage labels
- retain the legacy global-label fallback only for browser definitions without browser-specific labels
- document the bounded default and add regression coverage for order, labels, and per-browser suppression

## Maintainer decision

Accept the bounded Chrome then Dia automatic-import default. This solves the reported Dia case without broad browser enumeration; users may still choose Manual Cookie, and all other Chromium browser families remain excluded from OpenCode Auto.

Closes #1822.

## Validation

- `swift test --filter 'BrowserDetectionTests|BrowserCookieOrderStatusStringTests|OpenCodeWebCookieSupportTests'` (36 tests, 3 suites)
- `make check`
- `make test` (46 shards)
- autoreview: clean, 0.86 confidence
- `CODEXBAR_DISABLE_KEYCHAIN_ACCESS=1 ./Scripts/compile_and_run.sh`; production bundle signed, launched, and stayed running; SecurityAgent absent

No live browser store or real Keychain item was read during validation. The tests use isolated homes and injected preflight results to prove the exact browser-label boundary.

## Risk

When Chrome is unavailable or unusable and Dia is installed, Auto may reach Dia's own Safe Storage preflight. Interaction-required results suppress Dia alone for the existing cooldown; they do not authorize or suppress Chrome.
