### PR TITLE
docs: define provider notification identity

### DIFF
--- a/docs/screenshots/provider-notification-identity-options.svg
+++ b/docs/screenshots/provider-notification-identity-options.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="620" viewBox="0 0 1240 620" role="img" aria-labelledby="title desc">
+  <title id="title">Provider notification identity options</title>
+  <desc id="desc">Conceptual comparison of current provider-first text and a supplementary provider attachment. Both retain the CodexBar sender icon.</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-20%" width="120%" height="150%">
+      <feDropShadow dx="0" dy="10" stdDeviation="18" flood-color="#07111f" flood-opacity="0.16"/>
+    </filter>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#eef5ff"/>
+      <stop offset="1" stop-color="#f8f4ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="1240" height="620" fill="url(#bg)"/>
+  <text x="70" y="72" fill="#172033" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="34" font-weight="700">Provider identity in macOS notifications</text>
+  <text x="70" y="108" fill="#566078" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="18">Conceptual mock — exact media placement remains system controlled</text>
+
+  <g transform="translate(70 155)">
+    <text x="0" y="0" fill="#23704f" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="17" font-weight="700">RECOMMENDED · CURRENT CONTRACT</text>
+    <rect x="0" y="25" width="520" height="235" rx="26" fill="#ffffff" filter="url(#shadow)"/>
+    <rect x="26" y="52" width="58" height="58" rx="15" fill="#171b25"/>
+    <path d="M42 72h26M42 82h19M42 92h24" stroke="#fff" stroke-width="5" stroke-linecap="round"/>
+    <text x="105" y="67" fill="#687289" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="15" font-weight="600">CODEXBAR</text>
+    <text x="105" y="98" fill="#172033" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="21" font-weight="700">Synthetic session depleted</text>
+    <text x="105" y="128" fill="#566078" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="17">0% left. Will notify when available again.</text>
+    <rect x="26" y="170" width="468" height="1" fill="#e6e9ef"/>
+    <circle cx="43" cy="203" r="8" fill="#36a269"/>
+    <text x="61" y="210" fill="#2b354b" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="16">Provider name remains authoritative and localized</text>
+  </g>
+
+  <g transform="translate(650 155)">
+    <text x="0" y="0" fill="#9b6314" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="17" font-weight="700">OPTION · SUPPLEMENTARY ATTACHMENT</text>
+    <rect x="0" y="25" width="520" height="235" rx="26" fill="#ffffff" filter="url(#shadow)"/>
+    <rect x="26" y="52" width="58" height="58" rx="15" fill="#171b25"/>
+    <path d="M42 72h26M42 82h19M42 92h24" stroke="#fff" stroke-width="5" stroke-linecap="round"/>
+    <text x="105" y="67" fill="#687289" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="15" font-weight="600">CODEXBAR</text>
+    <text x="105" y="98" fill="#172033" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="21" font-weight="700">Synthetic session depleted</text>
+    <text x="105" y="128" fill="#566078" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="17">0% left. Will notify when available again.</text>
+    <rect x="424" y="58" width="68" height="68" rx="17" fill="#edf0f7" stroke="#cfd5e1"/>
+    <path d="M458 75l17 17-17 17-17-17z" fill="#6a5ce7"/>
+    <text x="458" y="151" text-anchor="middle" fill="#7b8499" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="11">MEDIA?</text>
+    <rect x="26" y="170" width="468" height="1" fill="#e6e9ef"/>
+    <circle cx="43" cy="203" r="8" fill="#e1a536"/>
+    <text x="61" y="210" fill="#2b354b" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="16">Still shows app icon; placement and size can vary</text>
+  </g>
+
+  <g transform="translate(70 475)">
+    <rect width="1100" height="92" rx="22" fill="#172033"/>
+    <text x="28" y="38" fill="#ffffff" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="18" font-weight="700">Public API boundary</text>
+    <text x="28" y="66" fill="#c8d2e7" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="16">No per-notification sender-icon property. Attachments are media alongside content, not icon replacement.</text>
+  </g>
+</svg>

--- a/docs/superpowers/specs/2026-07-01-provider-notification-identity-design.md
+++ b/docs/superpowers/specs/2026-07-01-provider-notification-identity-design.md
@@ -1,0 +1,94 @@
+---
+summary: "Decision proposal for provider identity in macOS notifications."
+read_when:
+  - Reviewing or implementing provider-specific notification visuals
+  - Changing the shared macOS notification delivery path
+---
+
+# Provider Identity in Notifications — Decision Proposal
+
+**Status:** proposed; maintainer sign-off required
+**Date:** 2026-07-01
+**Issue:** #1828
+**Related:** #1299, PR #1818
+
+## Decision requested
+
+Should CodexBar keep provider identity in the notification title, or add each provider mark as a media attachment even though macOS continues to show the CodexBar app icon as the notification's sender?
+
+## Recommendation
+
+Keep the current provider-first titles and do not add an attachment by default. The public macOS User Notifications API does not expose a per-notification sender-icon override. A provider image can only be supplementary media, so it cannot deliver the requested icon replacement and may enlarge or otherwise change the system-controlled notification layout.
+
+Keep #1828 open only if a supplementary attachment is an acceptable interpretation. If the requested outcome specifically requires replacing the CodexBar sender icon, evidence-close it as unsupported by the public API. Do not model quota alerts as communication notifications merely to obtain avatar-like presentation.
+
+## Current behavior already carries provider identity
+
+Every current provider-related notification puts the localized provider display name in its title:
+
+| Path | English title shape |
+| --- | --- |
+| Session depleted | `<Provider> session depleted` |
+| Session restored | `<Provider> session restored` |
+| Quota warning | `<Provider> <window> quota low` |
+| Login success | `<Provider> login successful` |
+| Permission prompt | `<Provider> is waiting for permission` |
+
+This is semantic identity, localized with the rest of the notification, and remains available when images fail to load or are hidden. It satisfies clarity, but not the issue's separate request for glanceable visual branding.
+
+## Platform boundary
+
+Apple's [`UNMutableNotificationContent`](https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent) surface includes title, subtitle, body, attachments, badge, sound, grouping, and delivery metadata. It has no notification-icon property.
+
+Apple describes [`attachments`](https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/attachments) as visual or audio content displayed alongside the main content. Attachments must exist locally before scheduling. [`UNNotificationAttachment`](https://developer.apple.com/documentation/usernotifications/unnotificationattachment) also documents that invalid or unsupported local media prevents the request from being scheduled.
+
+`UNNotificationActionIcon` customizes an action button, not the notification sender. Apple's [notification design guidance](https://developer.apple.com/design/human-interface-guidelines/notifications) reserves prominent avatar presentation for direct communication such as calls and messages; provider quota and login status are noncommunication notifications.
+
+## Options
+
+| Option | Result | Cost / risk | Disposition |
+| --- | --- | --- | --- |
+| Keep provider-first title | CodexBar sender icon plus explicit provider name | No new runtime or failure path; not pictorial | Recommended |
+| Add provider media attachment | CodexBar sender icon plus a system-placed provider image | Does not replace sender icon; layout varies; rasterization, local-file lifecycle, contrast, and fallback work | Prototype only after approval |
+| Add an action icon | Provider image appears on an action button | Requires an otherwise-unneeded action and does not identify the notification itself | Reject |
+| Pretend alerts are direct communication | Potential avatar-like system presentation | Semantically false; incorrect system integration | Reject |
+
+The conceptual comparison is in [provider-notification-identity-options.svg](../../screenshots/provider-notification-identity-options.svg). It intentionally does not claim exact system placement for attachment media.
+
+## Attachment implementation seam after approval
+
+If the supplementary-media interpretation is approved:
+
+1. Keep provider name in the title as the authoritative identity.
+2. Resolve the icon through `ProviderDescriptorRegistry`; do not add provider-specific switches.
+3. Rasterize the bundled template SVG to a notification-safe PNG on a neutral backing. The current shared UI image is a 16-point template image, not a ready notification attachment.
+4. Store generated files in an app-owned cache with bounded cleanup. Do not include account, workspace, plan, usage, or other private values in filenames or attachment metadata.
+5. If resolution, rendering, file creation, or attachment construction fails, post the text-only notification. Visual identity must never suppress a quota or permission alert.
+6. Keep `AppNotifications` generic: accept an optional prepared attachment rather than coupling the delivery layer to provider descriptors.
+
+## Required tests after approval
+
+- All registered providers resolve through the shared descriptor/icon path.
+- Attachment construction produces supported local media without account-derived filenames or metadata.
+- Missing, corrupt, or unwritable media falls back to the existing text-only request.
+- Existing title/body, localization, badge, and sound behavior stays unchanged.
+- #1299/PR #1818 predictive warnings, if approved, use the same centralized identity policy.
+- Headless tests never access `UNUserNotificationCenter`.
+
+## Tahoe proof gate after approval
+
+Use a packaged build and synthetic provider label only. Capture both the transient banner and Notification Center on the supported Tahoe baseline, in light and dark appearances. The proof must show:
+
+- the CodexBar sender icon remains present;
+- whether and where the provider attachment appears in compact and expanded states;
+- readable provider identity without the attachment;
+- no account, workspace, plan, quota amount, or other private data;
+- text-only delivery still succeeds when attachment creation is intentionally failed.
+
+Do not land an attachment implementation based only on source tests or the conceptual mock.
+
+## Overlap
+
+Issue #1299 and PR #1818 propose additional predictive pace notifications through the same delivery path. PR #1818 is documentation-only and does not edit runtime notification or icon files, so there is no current code conflict. The identity decision should nevertheless apply centrally before that proposal is implemented; otherwise each notification family could acquire different visual behavior and fallback semantics.
+
+No other active PR changes `AppNotifications.swift`, `SessionQuotaNotifications.swift`, `ProviderBrandIcon.swift`, or provider icon resources as of this proposal.


### PR DESCRIPTION
## Summary

- document that current provider notifications already identify the provider in localized, provider-first titles
- record the public macOS limitation: `UNMutableNotificationContent` has no per-notification sender-icon override
- compare the existing text-only contract with a possible supplementary attachment experiment
- define privacy-safe implementation, test, and Tahoe proof gates if attachments are approved later
- include a conceptual synthetic SVG that does not claim exact system rendering

## Decision and scope

Decision-only draft. This does not ship notification behavior, change the app icon, add attachments, or close #1828. Keep #1828 open for maintainer choice on whether supplementary media is an acceptable interpretation.

Recommendation: retain provider-first titles and the CodexBar sender icon. If the requested result specifically requires replacing the sender icon, close the issue as unsupported by the public macOS API. Do not model quota alerts as direct communication to obtain avatar-style presentation.

## Evidence

- Current `main` at `c3d33308ac0624424bd8c089d9eff59f3701aefa`: session depleted/restored, quota warning, login success, and permission notifications put the provider display name in the title.
- Apple User Notifications exposes title, subtitle, body, attachments, badge, sound, grouping, and delivery metadata, but no sender-icon field. Attachments are content alongside the alert and can prevent scheduling if the media is invalid.
- Active PR audit: #1818 is documentation-only; no open PR changes the notification runtime or provider icon resources.
- Packaged baseline: `./Scripts/package_app.sh` built successfully from `c3d33308` (runtime-identical to this docs-only head) on macOS 26.5.2 (25F84). An isolated synthetic bundle was launched and inspected with Peekaboo CLI 3.5.2 / GUI bridge 3.5.3. The macOS notification permission card displayed the CodexBar app icon, confirming the system sender identity.
- Bounded live retry limitation: after permission was enabled in System Settings and only the isolated app was restarted, its packaged Debug action logged `enqueuing (prefix=session-codex-depleted)` twice, but macOS left the authorization session unresolved. No live synthetic alert appeared, so this draft does not claim banner or Notification Center rendering proof. The isolated process was stopped; another running CodexBar was not touched.
- `xmllint --noout docs/screenshots/provider-notification-identity-options.svg`
- `make docs-list`
- `make check` — 0 SwiftFormat files changed; 0 SwiftLint violations
- `make test` — all 44 shards passed
- `./Scripts/package_app.sh`
- autoreview — clean; no accepted/actionable findings

No screenshot is uploaded: captures were local-only and the conceptual SVG is the sole visual artifact in this branch.

## Overlap

#1299 and #1818 propose predictive notifications through the same delivery path. This decision should apply centrally before that feature is implemented; this draft does not alter #1818.

Refs #1828.
