### PR TITLE
test: stabilize Kiro helper cleanup assertion

### DIFF
--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -503,7 +503,7 @@ struct KiroStatusProbeTests {
     }
 
     @Test
-    func `tty runner cleans a same group helper after normal exit`() throws {
+    func `tty runner cleans a same group helper after normal exit`() async throws {
         let childPIDFile = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-kiro-normal-exit-\(UUID().uuidString).pid")
         let cliURL = try self.makeCLI(
@@ -545,6 +545,11 @@ struct KiroStatusProbeTests {
         let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
         let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
         defer { _ = kill(childPID, SIGKILL) }
+
+        let cleanupDeadline = Date().addingTimeInterval(1)
+        while kill(childPID, 0) == 0, Date() < cleanupDeadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
         #expect(kill(childPID, 0) == -1)
     }
 


### PR DESCRIPTION
## Summary

- wait up to one second for the Kiro same-process-group helper to disappear before asserting cleanup
- poll every 20 ms, matching the adjacent escaped-helper cleanup test
- keep the change test-only; runtime, provider behavior, and changelog remain unchanged

## Root cause

The runner already sends TERM and then KILL correctly. After the helper dies, `kill(pid, 0)` can still observe the orphan while launchd has not yet reaped its zombie entry. The immediate assertion therefore flakes even though runtime cleanup completed.

## Validation

- exact flaky test: 50/50 passed, with exactly one matching test executed per iteration
- `swift test --no-parallel --filter KiroStatusProbeTests`: 43/43 passed
- `make check`: passed; SwiftFormat clean and SwiftLint reported 0 violations
- exact-diff autoreview against `945d4ba1264ca7cc50032dcc88a0643e231c3bc8`: clean, no findings, confidence 0.92
- `make test`: passed through shard 44/44
- `LiveAccountTests`: skipped because `LIVE_TEST` was unset
- `KeychainNoUIQueryTests` and `KeychainPromptSafetyAuditTests`: passed; no interactive Keychain or live-provider probes
