### PR TITLE
feat(claude): surface scoped weekly limits[] (Fable promo) as extra rate windows

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
@@ -156,6 +156,7 @@ struct OAuthUsageResponse: Decodable {
     let sevenDayRoutinesSourceKey: String?
     let iguanaNecktie: OAuthUsageWindow?
     let extraUsage: OAuthExtraUsage?
+    let limits: [OAuthUsageLimit]
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DynamicCodingKey.self)
@@ -177,6 +178,7 @@ struct OAuthUsageResponse: Decodable {
         self.sevenDayRoutinesSourceKey = routines.sourceKey
         self.iguanaNecktie = Self.decodeWindow(in: container, keys: ["iguana_necktie"])
         self.extraUsage = Self.decodeValue(in: container, keys: ["extra_usage"])
+        self.limits = Self.decodeValue(in: container, keys: ["limits"]) ?? []
     }
 
     private static func decodeWindow(
@@ -239,6 +241,36 @@ struct OAuthUsageWindow: Decodable {
     enum CodingKeys: String, CodingKey {
         case utilization
         case resetsAt = "resets_at"
+    }
+}
+
+struct OAuthUsageLimit: Decodable {
+    let kind: String?
+    let percent: Double?
+    let resetsAt: String?
+    let isActive: Bool?
+    let scope: Scope?
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case percent
+        case resetsAt = "resets_at"
+        case isActive = "is_active"
+        case scope
+    }
+
+    struct Scope: Decodable {
+        let model: Model?
+
+        struct Model: Decodable {
+            let id: String?
+            let displayName: String?
+
+            enum CodingKeys: String, CodingKey {
+                case id
+                case displayName = "display_name"
+            }
+        }
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeScopedWeeklyLimitWindows.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeScopedWeeklyLimitWindows.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Maps `limits[]` entries with `kind == "weekly_scoped"` from the Claude usage APIs into extra
+/// rate windows (for example the "Fable" scoped weekly promo quota).
+///
+/// Both the claude.ai web usage API and the OAuth usage API return the `limits[]` array alongside
+/// the legacy top-level window fields. Only scoped weekly entries are surfaced here; the legacy
+/// fields stay authoritative for the session/weekly/model windows, so `session` and `weekly_all`
+/// kinds are intentionally ignored to avoid duplicating those lanes.
+enum ClaudeScopedWeeklyLimitWindows {
+    struct Entry {
+        let kind: String?
+        let percent: Double?
+        let resetsAt: Date?
+        let modelDisplayName: String?
+    }
+
+    private static let scopedWeeklyKind = "weekly_scoped"
+    private static let weeklyWindowMinutes = 7 * 24 * 60
+
+    /// Builds extra rate windows from parsed `limits[]` entries.
+    ///
+    /// Entries are included whenever `percent` is present, regardless of `is_active`, so a scoped
+    /// quota that has not been touched yet still renders as a visible 0%/n% bar.
+    static func windows(
+        from entries: [Entry],
+        formatReset: ((Date) -> String)? = nil) -> [NamedRateWindow]
+    {
+        var windows: [NamedRateWindow] = []
+        var usedIDs: Set<String> = []
+        for entry in entries {
+            guard entry.kind == Self.scopedWeeklyKind, let percent = entry.percent else { continue }
+            let trimmedName = entry.modelDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let displayName = (trimmedName?.isEmpty ?? true) ? nil : trimmedName
+            let title = displayName.map { "\($0) weekly" } ?? "Scoped weekly"
+            let baseID = "claude-scoped-\(Self.slug(displayName ?? "weekly"))"
+            var id = baseID
+            var suffix = 2
+            while usedIDs.contains(id) {
+                id = "\(baseID)-\(suffix)"
+                suffix += 1
+            }
+            usedIDs.insert(id)
+            windows.append(NamedRateWindow(
+                id: id,
+                title: title,
+                window: RateWindow(
+                    usedPercent: percent,
+                    windowMinutes: Self.weeklyWindowMinutes,
+                    resetsAt: entry.resetsAt,
+                    resetDescription: entry.resetsAt.flatMap { formatReset?($0) })))
+        }
+        return windows
+    }
+
+    /// Parses the `JSONSerialization` form of `limits[]` used by the web usage path.
+    static func entries(fromJSONValue value: Any?) -> [Entry] {
+        guard let items = value as? [[String: Any]] else { return [] }
+        return items.map { item in
+            let scope = item["scope"] as? [String: Any]
+            let model = scope?["model"] as? [String: Any]
+            return Entry(
+                kind: item["kind"] as? String,
+                percent: Self.percentValue(from: item["percent"]),
+                resetsAt: (item["resets_at"] as? String).flatMap(Self.parseISO8601Date),
+                modelDisplayName: model?["display_name"] as? String)
+        }
+    }
+
+    private static func slug(_ name: String) -> String {
+        let lowered = name.lowercased()
+        let mapped = lowered.map { char -> Character in
+            char.isLetter || char.isNumber ? char : "-"
+        }
+        return String(mapped)
+    }
+
+    private static func percentValue(from value: Any?) -> Double? {
+        if let intValue = value as? Int {
+            return Double(intValue)
+        }
+        if let doubleValue = value as? Double {
+            return doubleValue
+        }
+        return nil
+    }
+
+    private static func parseISO8601Date(_ string: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: string) {
+            return date
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: string)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -1126,7 +1126,18 @@ extension ClaudeUsageFetcher {
         if let routinesKey = usage.sevenDayRoutinesSourceKey {
             Self.log.debug("Claude OAuth extra usage key matched: routines=\(routinesKey)")
         }
-        return definitions.compactMap { definition in
+        // Scoped weekly promo limits (e.g. "Fable") arrive in the `limits[]` array; legacy top-level
+        // fields remain authoritative for the session/weekly/model windows.
+        let scopedWeeklyWindows = ClaudeScopedWeeklyLimitWindows.windows(
+            from: usage.limits.map { limit in
+                ClaudeScopedWeeklyLimitWindows.Entry(
+                    kind: limit.kind,
+                    percent: limit.percent,
+                    resetsAt: ClaudeOAuthUsageFetcher.parseISO8601Date(limit.resetsAt),
+                    modelDisplayName: limit.scope?.model?.displayName)
+            },
+            formatReset: Self.formatResetDate)
+        let definedWindows: [NamedRateWindow] = definitions.compactMap { definition in
             let utilization: Double
             let resetDate: Date?
             if let window = definition.window, let parsedUtilization = window.utilization {
@@ -1149,6 +1160,7 @@ extension ClaudeUsageFetcher {
                     resetsAt: resetDate,
                     resetDescription: resetDescription))
         }
+        return definedWindows + scopedWeeklyWindows
     }
 
     // MARK: - Web API path (uses browser cookies)

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -650,6 +650,13 @@ public enum ClaudeWebAPIFetcher {
         if let sourceKey = extraRateParse.sourceKeys["claude-routines"] {
             logger?("Usage API extra window key matched: routines=\(sourceKey)")
         }
+        // Scoped weekly promo limits (e.g. "Fable") arrive in the `limits[]` array; legacy top-level
+        // fields above remain authoritative for the session/weekly/model windows.
+        let scopedWeeklyWindows = ClaudeScopedWeeklyLimitWindows.windows(
+            from: ClaudeScopedWeeklyLimitWindows.entries(fromJSONValue: json["limits"]))
+        if !scopedWeeklyWindows.isEmpty {
+            logger?("Usage API scoped weekly limits matched: \(scopedWeeklyWindows.map(\.id).joined(separator: ","))")
+        }
         let extraUsageCost = ClaudeWebExtraUsageCost.parse(from: json["extra_usage"])
 
         return WebUsageData(
@@ -658,7 +665,7 @@ public enum ClaudeWebAPIFetcher {
             weeklyPercentUsed: weeklyPercent,
             weeklyResetsAt: weeklyResets,
             opusPercentUsed: opusPercent,
-            extraRateWindows: extraRateParse.windows,
+            extraRateWindows: extraRateParse.windows + scopedWeeklyWindows,
             extraUsageCost: extraUsageCost,
             accountOrganization: nil,
             accountEmail: nil,

--- a/Tests/CodexBarTests/ClaudeScopedWeeklyLimitTests.swift
+++ b/Tests/CodexBarTests/ClaudeScopedWeeklyLimitTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeScopedWeeklyLimitWebTests {
+    @Test
+    func `parses active scoped weekly limit as extra rate window`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 9, "resets_at": "2026-07-02T16:00:00.000Z" },
+          "seven_day": { "utilization": 34, "resets_at": "2026-07-08T06:00:00.000Z" },
+          "limits": [
+            { "kind": "session", "group": "session", "percent": 9, "severity": "normal",
+              "resets_at": "2026-07-02T16:00:00+00:00", "scope": null, "is_active": true },
+            { "kind": "weekly_all", "group": "weekly", "percent": 34, "severity": "normal",
+              "resets_at": "2026-07-08T06:00:00+00:00", "scope": null, "is_active": true },
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 70, "severity": "normal",
+              "resets_at": "2026-07-08T06:00:00+00:00",
+              "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+              "is_active": true }
+          ]
+        }
+        """
+        let parsed = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(Data(json.utf8))
+
+        let fable = try #require(parsed.extraRateWindows.first { $0.id == "claude-scoped-fable" })
+        #expect(fable.title == "Fable weekly")
+        #expect(fable.window.usedPercent == 70)
+        #expect(fable.window.windowMinutes == 7 * 24 * 60)
+        #expect(fable.window.resetsAt != nil)
+        // Legacy fields stay authoritative; session/weekly limits[] kinds are not duplicated.
+        #expect(parsed.extraRateWindows.count == 1)
+        #expect(parsed.sessionPercentUsed == 9)
+        #expect(parsed.weeklyPercentUsed == 34)
+    }
+
+    @Test
+    func `includes inactive scoped weekly limit when percent is present`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 9, "resets_at": "2026-07-02T16:00:00.000Z" },
+          "limits": [
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 0, "severity": "normal",
+              "resets_at": "2026-07-08T06:00:00+00:00",
+              "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+              "is_active": false }
+          ]
+        }
+        """
+        let parsed = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(Data(json.utf8))
+
+        let fable = try #require(parsed.extraRateWindows.first { $0.id == "claude-scoped-fable" })
+        #expect(fable.window.usedPercent == 0)
+    }
+
+    @Test
+    func `skips scoped weekly limit without percent`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 9, "resets_at": "2026-07-02T16:00:00.000Z" },
+          "limits": [
+            { "kind": "weekly_scoped", "group": "weekly", "percent": null, "severity": "normal",
+              "resets_at": "2026-07-08T06:00:00+00:00",
+              "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+              "is_active": true }
+          ]
+        }
+        """
+        let parsed = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(Data(json.utf8))
+
+        #expect(parsed.extraRateWindows.isEmpty)
+    }
+
+    @Test
+    func `legacy payload without limits array is unchanged`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 9, "resets_at": "2026-07-02T16:00:00.000Z" },
+          "seven_day": { "utilization": 34, "resets_at": "2026-07-08T06:00:00.000Z" },
+          "seven_day_cowork": { "utilization": 11, "resets_at": "2026-07-08T06:00:00.000Z" }
+        }
+        """
+        let parsed = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(Data(json.utf8))
+
+        #expect(parsed.sessionPercentUsed == 9)
+        #expect(parsed.weeklyPercentUsed == 34)
+        #expect(parsed.extraRateWindows.count == 1)
+        #expect(parsed.extraRateWindows.first?.id == "claude-routines")
+    }
+}
+
+struct ClaudeScopedWeeklyLimitOAuthTests {
+    @Test
+    func `maps active scoped weekly limit as extra rate window`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 12.5, "resets_at": "2026-07-02T16:00:00.000Z" },
+          "seven_day": { "utilization": 34, "resets_at": "2026-07-08T06:00:00.000Z" },
+          "limits": [
+            { "kind": "session", "group": "session", "percent": 12, "severity": "normal",
+              "resets_at": "2026-07-02T16:00:00+00:00", "scope": null, "is_active": true },
+            { "kind": "weekly_all", "group": "weekly", "percent": 34, "severity": "normal",
+              "resets_at": "2026-07-08T06:00:00+00:00", "scope": null, "is_active": true },
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 70, "severity": "normal",
+              "resets_at": "2026-07-08T06:00:00+00:00",
+              "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+              "is_active": true }
+          ]
+        }
+        """
+        let snap = try ClaudeUsageFetcher._mapOAuthUsageForTesting(Data(json.utf8))
+
+        let fable = try #require(snap.extraRateWindows.first { $0.id == "claude-scoped-fable" })
+        #expect(fable.title == "Fable weekly")
+        #expect(fable.window.usedPercent == 70)
+        #expect(fable.window.windowMinutes == 7 * 24 * 60)
+        #expect(fable.window.resetsAt != nil)
+        // Legacy fields stay authoritative; session/weekly limits[] kinds are not duplicated.
+        #expect(snap.extraRateWindows.count == 1)
+        #expect(snap.primary.usedPercent == 12.5)
+        #expect(snap.secondary?.usedPercent == 34)
+    }
+
+    @Test
+    func `maps inactive scoped weekly limit when percent is present`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 12.5, "resets_at": "2026-07-02T16:00:00.000Z" },
+          "limits": [
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 5, "severity": "normal",
+              "resets_at": "2026-07-08T06:00:00+00:00",
+              "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+              "is_active": false }
+          ]
+        }
+        """
+        let snap = try ClaudeUsageFetcher._mapOAuthUsageForTesting(Data(json.utf8))
+
+        let fable = try #require(snap.extraRateWindows.first { $0.id == "claude-scoped-fable" })
+        #expect(fable.window.usedPercent == 5)
+    }
+
+    @Test
+    func `legacy payload without limits array is unchanged`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 12.5, "resets_at": "2026-07-02T16:00:00.000Z" },
+          "seven_day": { "utilization": 34, "resets_at": "2026-07-08T06:00:00.000Z" },
+          "seven_day_routines": { "utilization": 18, "resets_at": "2026-07-08T06:00:00.000Z" }
+        }
+        """
+        let snap = try ClaudeUsageFetcher._mapOAuthUsageForTesting(Data(json.utf8))
+
+        #expect(snap.primary.usedPercent == 12.5)
+        #expect(snap.secondary?.usedPercent == 34)
+        #expect(snap.extraRateWindows.count == 1)
+        #expect(snap.extraRateWindows.first?.id == "claude-routines")
+    }
+}


### PR DESCRIPTION
## What

Anthropic's usage APIs now return a `limits[]` array alongside the legacy window fields — on both the claude.ai web API (`GET /api/organizations/{orgId}/usage`) and the OAuth API (`GET /api/oauth/usage`). Entries with `kind == "weekly_scoped"` carry per-model promo quotas, currently the **"Fable 5" promo** (≤50%-weekly-usage users get scoped Fable access through Jul 7 2026):

```json
{"kind":"weekly_scoped","group":"weekly","percent":70,"severity":"normal",
 "resets_at":"2026-07-08T06:00:00+00:00",
 "scope":{"model":{"id":null,"display_name":"Fable"},"surface":null},"is_active":true}
```

CodexBar ignored `limits[]` entirely, so this quota was invisible. This PR surfaces scoped weekly limits as extra rate windows (same mechanism as "Daily Routines"), so they render in the menu dropdown and CLI JSON with no UI changes.

## Mapping contract

- Shared mapper: `ClaudeScopedWeeklyLimitWindows`, used by both the web parser and the OAuth path.
- Only `kind == "weekly_scoped"` is mapped. `session` / `weekly_all` kinds are ignored — the legacy top-level fields stay authoritative for those lanes, so nothing gets duplicated.
- Title from `scope.model.display_name` → "Fable weekly" (fallback "Scoped weekly"); id `claude-scoped-<slug>`.
- `percent` → `usedPercent`, `resets_at` → `resetsAt`, `windowMinutes` = 10080.
- Included regardless of `is_active` when `percent` is non-null (an untouched scoped quota still shows a bar); entries with null `percent` are skipped.
- Payloads without `limits[]` are byte-for-byte unchanged in behavior.

## Tests

`Tests/CodexBarTests/ClaudeScopedWeeklyLimitTests.swift` — 7 tests across both paths:

- web: active Fable entry mapped (title/percent/window/reset), inactive entry still included, null-percent skipped, legacy payload without `limits[]` unchanged (routines window untouched)
- OAuth: active entry mapped + legacy session/weekly stay authoritative, inactive entry included, legacy payload unchanged

`swift build` and `make check` (swiftformat + swiftlint, 0 violations) pass. `swift test`: all 7 new tests plus the Claude suites pass; the only local failures are pre-existing timing/environment flakes (fnm/login-runner/memory-pressure/codex-home hydration) that fail identically on `main` (verified on 450ca4d9).
