### PR TITLE
Group menu usage rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 - Settings: complete redesign as a System Settings-style window — a sidebar lists app panes plus every provider (search, drag reorder, status dots, enable via context menu), panes use native grouped forms, the window keeps one size instead of resizing per tab, and the last selected pane is remembered across launches.
+- Menu: group Plan Usage, Cost, and Storage rows so related account usage is easier to scan. Thanks @Zihao-Qi!
 
 ### Fixed
 - Usage refresh: refresh provider data shortly after known quota reset boundaries instead of leaving expired reset times visible until the next normal poll. Thanks @pavbar!

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -236,6 +236,7 @@
 "Picker subtitle" = "عنوان فرعي لاختيار";
 "Placeholder" = "العنصر المؤقت";
 "Plan" = "الخطة";
+"Plan Usage" = "استخدام الخطة";
 "Play full-screen confetti when weekly usage resets." = "شغل ورق الورق الورقية بملء الشاشة عند إعادة ضبط الاستخدام الأسبوعي.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "استطلاعات OpenAI/Claude صفحات الحالة ومساحة العمل Google ل  ";
 "Prevents any Keychain access while enabled." = "يمنع أي وصول Keychain أثناء التفعيل.";
@@ -304,7 +305,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "مخزن في ~/.codexbar/config.json. الصق مفتاح MiniMax API الخاص بك.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "مخزنة في ~/.codexbar/config.json. يمكنك أيضا توفير KILO_API_KEY or ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "يخزن تاريخ استخدام Codex محليا (8 أسابيع) لتخصيص توقعات Pac.";
-"Subscription Utilization" = "استخدام الاشتراكات";
 "Surprise me" = "فاجئني";
 "Switcher shows icons" = "المحول يعرض الأيقونات";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Symlink CodexBarCLI إلى /usr/local/bin و /opt/homebrew/bin ك codexbar.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 "Picker subtitle" = "Subtítol del selector";
 "Placeholder" = "Text de marcador";
 "Plan" = "Pla";
+"Plan Usage" = "Ús del pla";
 "Play full-screen confetti when weekly usage resets." = "Mostreu confeti a pantalla completa quan es reinicia l'ús setmanal.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Consulta les pàgines d'estat d'OpenAI/Claude i Google Workspace per a ";
 "Prevents any Keychain access while enabled." = "Impedeix qualsevol accés al Clauer mentre estigui activat.";
@@ -302,7 +303,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Desat a ~/.codexbar/config.json. Enganxeu la vostra clau d'API de MiniMax.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Desat a ~/.codexbar/config.json. També podeu proporcionar KILO_API_KEY o ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Desa l'historial d'ús local de Codex (8 setmanes) per personalitzar les prediccions de Ritme.";
-"Subscription Utilization" = "Ús de la subscripció";
 "Surprise me" = "Sorprèn-me";
 "Switcher shows icons" = "El selector mostra icones";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Creeu un enllaç simbòlic de CodexBarCLI a /usr/local/bin i /opt/homebrew/bin com a codexbar.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -232,6 +232,7 @@
 "Picker subtitle" = "Picker-Untertitel";
 "Placeholder" = "Platzhalter";
 "Plan" = "Planen";
+"Plan Usage" = "Plannutzung";
 "Play full-screen confetti when weekly usage resets." = "Spielen Sie Konfetti im Vollbildmodus ab, wenn die wöchentliche Nutzung zurückgesetzt wird.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Fragt OpenAI/Claude-Statusseiten und Google Workspace ab";
 "Prevents any Keychain access while enabled." = "Verhindert jeglichen Zugriff auf den Schlüsselbund, solange diese Option aktiviert ist.";
@@ -299,7 +300,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Gespeichert in ~/.codexbar/config.json. Fügen Sie Ihren MiniMax-API-Schlüssel ein.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Gespeichert in ~/.codexbar/config.json. Sie können auch KILO_API_KEY oder angeben";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Speichert den lokalen Codex-Nutzungsverlauf (8 Wochen), um Pace-Vorhersagen zu personalisieren.";
-"Subscription Utilization" = "Abonnementnutzung";
 "Surprise me" = "Überrasche mich";
 "Switcher shows icons" = "Switcher zeigt Symbole an";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Verknüpfen Sie CodexBarCLI mit /usr/local/bin und /opt/homebrew/bin als Codexbar.";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -236,6 +236,7 @@
 "Picker subtitle" = "Picker subtitle";
 "Placeholder" = "Placeholder";
 "Plan" = "Plan";
+"Plan Usage" = "Plan Usage";
 "Play full-screen confetti when weekly usage resets." = "Play full-screen confetti when weekly usage resets.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Polls OpenAI/Claude status pages and Google Workspace for ";
 "Prevents any Keychain access while enabled." = "Prevents any Keychain access while enabled.";
@@ -304,7 +305,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Stored in ~/.codexbar/config.json. Paste your MiniMax API key.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Stores local Codex usage history (8 weeks) to personalize Pace predictions.";
-"Subscription Utilization" = "Subscription Utilization";
 "Surprise me" = "Surprise me";
 "Switcher shows icons" = "Switcher shows icons";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 "Picker subtitle" = "Subtítulo del selector";
 "Placeholder" = "Marcador de posición";
 "Plan" = "Plan";
+"Plan Usage" = "Uso del plan";
 "Play full-screen confetti when weekly usage resets." = "Mostrar confeti a pantalla completa cuando se reinicia el uso semanal.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Consulta las páginas de estado de OpenAI/Claude y Google Workspace para ";
 "Prevents any Keychain access while enabled." = "Impide cualquier acceso al Llavero mientras esté activado.";
@@ -302,7 +303,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Almacenado en ~/.codexbar/config.json. Pega tu clave de API de MiniMax.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Almacenado en ~/.codexbar/config.json. También puedes proporcionar KILO_API_KEY o ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Almacena el historial de uso local de Codex (8 semanas) para personalizar las predicciones de Ritmo.";
-"Subscription Utilization" = "Uso de la suscripción";
 "Surprise me" = "Sorpréndeme";
 "Switcher shows icons" = "El selector muestra iconos";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Crear un enlace simbólico de CodexBarCLI en /usr/local/bin y /opt/homebrew/bin como codexbar.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -236,6 +236,7 @@
 "Picker subtitle" = "زیرعنوان پیکر";
 "Placeholder" = "جایگزین جایگزین";
 "Plan" = "طرح";
+"Plan Usage" = "استفاده از طرح";
 "Play full-screen confetti when weekly usage resets." = "وقتی استفاده هفتگی ریست می شود، کنفتی تمام صفحه را پخش کنید.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "نظرسنجی ها OpenAI/Claude صفحات وضعیت و Google Workspace for ";
 "Prevents any Keychain access while enabled." = "در حالت فعال بودن از هرگونه دسترسی Keychain جلوگیری می کند.";
@@ -304,7 +305,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "ذخیره شده در ~/.codexbar/config.json. کلید MiniMax API خود را بچسبانید.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "ذخیره شده در ~/.codexbar/config.json. همچنین می توانید KILO_API_KEY or  ارائه دهید";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "تاریخچه استفاده Codex محلی (۸ هفته) را برای شخصی سازی پیش بینی های سرعت ذخیره می کند.";
-"Subscription Utilization" = "استفاده از اشتراک";
 "Surprise me" = "سورپرایزم کن";
 "Switcher shows icons" = "سوئیچر آیکون ها را نشان می دهد";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Symlink CodexBarCLI به /usr/local/bin و /opt/homebrew/bin به عنوان codexbar.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 "Picker subtitle" = "Sous-titre du sélecteur";
 "Placeholder" = "Espace réservé";
 "Plan" = "Forfait";
+"Plan Usage" = "Utilisation du forfait";
 "Play full-screen confetti when weekly usage resets." = "Jouez des confettis en plein écran lorsque l'utilisation hebdomadaire est réinitialisée.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Sonde les pages d'état OpenAI/Claude et Google Workspace pour";
 "Prevents any Keychain access while enabled." = "Empêche tout accès au Trousseau lorsqu'il est activé.";
@@ -301,7 +302,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Stocké dans ~/.codexbar/config.json. Collez votre clé API MiniMax.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Stocké dans ~/.codexbar/config.json. Vous pouvez également fournir KILO_API_KEY ou";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Stocke l’historique d’utilisation local du Codex (8 semaines) pour personnaliser les prédictions Pace.";
-"Subscription Utilization" = "Utilisation de l'abonnement";
 "Surprise me" = "Surprenez-moi";
 "Switcher shows icons" = "Le commutateur affiche des icônes";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Lien symbolique CodexBarCLI vers /usr/local/bin et /opt/homebrew/bin en tant que codexbar.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -236,6 +236,7 @@
 "Picker subtitle" = "Subjudul pemilih";
 "Placeholder" = "Placeholder";
 "Plan" = "Paket";
+"Plan Usage" = "Penggunaan Paket";
 "Play full-screen confetti when weekly usage resets." = "Mainkan confetti layar penuh saat penggunaan mingguan direset.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Memeriksa halaman status OpenAI/Claude dan Google Workspace untuk ";
 "Prevents any Keychain access while enabled." = "Mencegah semua akses Keychain saat diaktifkan.";
@@ -304,7 +305,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Disimpan di ~/.codexbar/config.json. Tempel kunci API MiniMax Anda.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Disimpan di ~/.codexbar/config.json. Anda juga dapat menyediakan KILO_API_KEY atau ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Menyimpan riwayat penggunaan Codex lokal (8 minggu) untuk personalisasi prediksi Pace.";
-"Subscription Utilization" = "Pemanfaatan Langganan";
 "Surprise me" = "Kejutkan saya";
 "Switcher shows icons" = "Pengalih tampilkan ikon";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Symlink CodexBarCLI ke /usr/local/bin dan /opt/homebrew/bin sebagai codexbar.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -236,6 +236,7 @@
 "Picker subtitle" = "Sottotitolo selettore";
 "Placeholder" = "Segnaposto";
 "Plan" = "Piano";
+"Plan Usage" = "Utilizzo piano";
 "Play full-screen confetti when weekly usage resets." = "Mostra coriandoli a schermo intero quando l'utilizzo settimanale si resetta.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Interroga le pagine di stato di OpenAI/Claude e Google Workspace per ";
 "Prevents any Keychain access while enabled." = "Impedisce qualsiasi accesso al portachiavi quando è attivo.";
@@ -304,7 +305,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Memorizzato in ~/.codexbar/config.json. Incolla la tua chiave API MiniMax.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Memorizzato in ~/.codexbar/config.json. Puoi anche fornire KILO_API_KEY o ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Memorizza la cronologia di utilizzo locale di Codex (8 settimane) per personalizzare le previsioni di andamento.";
-"Subscription Utilization" = "Utilizzo abbonamento";
 "Surprise me" = "Sorprendimi";
 "Switcher shows icons" = "Il selettore mostra icone";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Crea il symlink di CodexBarCLI in /usr/local/bin e /opt/homebrew/bin come codexbar.";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 "Picker subtitle" = "ピッカーのサブタイトル";
 "Placeholder" = "プレースホルダ";
 "Plan" = "プラン";
+"Plan Usage" = "プラン使用状況";
 "Play full-screen confetti when weekly usage resets." = "週間使用量がリセットされたときに全画面の紙吹雪を表示します。";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "OpenAI/Claude のステータスページと Google Workspace をポーリングして、";
 "Prevents any Keychain access while enabled." = "有効にすると、キーチェーンへのアクセスをすべて防ぎます。";
@@ -301,7 +302,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "~/.codexbar/config.json に保存されます。MiniMax API キーを貼り付けてください。";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "~/.codexbar/config.json に保存されます。KILO_API_KEY を指定することもできます。または ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "ローカルの Codex 使用履歴（8 週間分）を保存して、ペース予測をパーソナライズします。";
-"Subscription Utilization" = "サブスクリプション利用率";
 "Surprise me" = "サプライズ";
 "Switcher shows icons" = "切替バーにアイコンを表示";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "CodexBarCLI を codexbar として /usr/local/bin と /opt/homebrew/bin にシンボリックリンクします。";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 "Picker subtitle" = "선택기 부제목";
 "Placeholder" = "플레이스홀더";
 "Plan" = "요금제";
+"Plan Usage" = "요금제 사용량";
 "Play full-screen confetti when weekly usage resets." = "주간 사용량이 재설정되면 전체 화면 색종이를 재생합니다.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "OpenAI/Claude 상태 페이지와 Google Workspace를 폴링하여 ";
 "Prevents any Keychain access while enabled." = "사용 중에는 모든 키체인 접근을 차단합니다.";
@@ -301,7 +302,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "~/.codexbar/config.json에 저장됩니다. MiniMax API 키를 붙여넣으세요.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "~/.codexbar/config.json에 저장됩니다. KILO_API_KEY를 제공할 수도 있습니다. ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "사용 속도 예측을 개인화하기 위해 로컬 Codex 사용 기록(8주)을 저장합니다.";
-"Subscription Utilization" = "구독 사용률";
 "Surprise me" = "랜덤으로 선택";
 "Switcher shows icons" = "전환기에 아이콘 표시";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "CodexBarCLI를 codexbar로 /usr/local/bin 및 /opt/homebrew/bin에 심볼릭 링크합니다.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 "Picker subtitle" = "Ondertitel kiezen";
 "Placeholder" = "Tijdelijke aanduiding";
 "Plan" = "Plan";
+"Plan Usage" = "Plangebruik";
 "Play full-screen confetti when weekly usage resets." = "Speel confetti op volledig scherm af wanneer het wekelijkse gebruik wordt gereset.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Polls OpenAI/Claude-statuspagina's en Google Workspace voor";
 "Prevents any Keychain access while enabled." = "Voorkomt elke sleutelhangertoegang indien ingeschakeld.";
@@ -301,7 +302,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Opgeslagen in ~/.codexbar/config.json. Plak uw MiniMax API-sleutel.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Opgeslagen in ~/.codexbar/config.json. U kunt ook KILO_API_KEY of";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Slaat de lokale Codex-gebruiksgeschiedenis op (8 weken) om tempo-voorspellingen te personaliseren.";
-"Subscription Utilization" = "Abonnementsgebruik";
 "Surprise me" = "Verras mij";
 "Switcher shows icons" = "Switcher toont pictogrammen";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Symlink CodexBarCLI naar /usr/local/bin en /opt/homebrew/bin als codexbar.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -236,6 +236,7 @@
 "Picker subtitle" = "Podtytuł selektora";
 "Placeholder" = "Tekst zastępczy";
 "Plan" = "Plan";
+"Plan Usage" = "Wykorzystanie planu";
 "Play full-screen confetti when weekly usage resets." = "Odtwórz pełnoekranowe konfetti, gdy tygodniowe użycie się resetuje.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Sprawdza strony statusu OpenAI/Claude oraz Google Workspace dla ";
 "Prevents any Keychain access while enabled." = "Blokuje wszelki dostęp do pęku kluczy, gdy opcja jest włączona.";
@@ -304,7 +305,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Przechowywane w ~/.codexbar/config.json. Wklej swój klucz API MiniMax.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Przechowywane w ~/.codexbar/config.json. Możesz też podać KILO_API_KEY lub ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Przechowuje lokalną historię użycia Codex (8 tygodni), aby personalizować prognozy Tempo.";
-"Subscription Utilization" = "Wykorzystanie subskrypcji";
 "Surprise me" = "Zaskocz mnie";
 "Switcher shows icons" = "Przełącznik pokazuje ikony";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Dowiąż symbolicznie CodexBarCLI do /usr/local/bin i /opt/homebrew/bin jako codexbar.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 "Picker subtitle" = "Subtítulo do seletor";
 "Placeholder" = "Texto de exemplo";
 "Plan" = "Plano";
+"Plan Usage" = "Uso do plano";
 "Play full-screen confetti when weekly usage resets." = "Mostra confete em tela cheia quando o uso semanal for renovado.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Consulta as páginas de status da OpenAI/Claude e o Google Workspace para ";
 "Prevents any Keychain access while enabled." = "Impede qualquer acesso ao Keychain quando ativado.";
@@ -301,7 +302,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Armazenado em ~/.codexbar/config.json. Cole sua chave de API do MiniMax.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Armazenado em ~/.codexbar/config.json. Você também pode informar KILO_API_KEY ou ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Armazena histórico local de uso do Codex (8 semanas) para personalizar previsões de Ritmo.";
-"Subscription Utilization" = "Uso da assinatura";
 "Surprise me" = "Surpreenda-me";
 "Switcher shows icons" = "Alternador mostra ícones";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Cria symlink de CodexBarCLI em /usr/local/bin e /opt/homebrew/bin como codexbar.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -235,6 +235,7 @@
 "Picker subtitle" = "Väljarunderrubrik";
 "Placeholder" = "Platshållare";
 "Plan" = "Plan";
+"Plan Usage" = "Plananvändning";
 "Play full-screen confetti when weekly usage resets." = "Spela konfetti i helskärm när veckoförbrukningen återställs.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Kontrollerar OpenAI/Claude-statussidor och Google Workspace för ";
 "Prevents any Keychain access while enabled." = "Förhindrar all åtkomst till Nyckelring när det är aktiverat.";
@@ -302,7 +303,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Sparas i ~/.codexbar/config.json. Klistra in din MiniMax-API-nyckel.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Sparas i ~/.codexbar/config.json. Du kan också ange KILO_API_KEY eller ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Sparar lokal Codex-användningshistorik (8 veckor) för att anpassa taktprognoser.";
-"Subscription Utilization" = "Abonnemangsutnyttjande";
 "Surprise me" = "Överraska mig";
 "Switcher shows icons" = "Växlaren visar ikoner";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Symlänka CodexBarCLI till /usr/local/bin och /opt/homebrew/bin som codexbar.";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -236,6 +236,7 @@
 "Picker subtitle" = "คําบรรยาย Picker";
 "Placeholder" = "ตัวยึดตําแหน่ง";
 "Plan" = "วางแผน";
+"Plan Usage" = "การใช้งานแผน";
 "Play full-screen confetti when weekly usage resets." = "เล่นลูกปาแบบเต็มหน้าจอเมื่อรีเซ็ตการใช้งานรายสัปดาห์";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "โพล OpenAI/Claude หน้าสถานะและพื้นที่ทํางาน Google สําหรับ  ";
 "Prevents any Keychain access while enabled." = "ป้องกันการเข้าถึง Keychain ใดๆ ขณะเปิดใช้งาน";
@@ -304,7 +305,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "เก็บไว้ใน ~/.codexbar/config.json. วางคีย์ MiniMax API ของคุณ";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "เก็บไว้ใน ~/.codexbar/config.json. คุณยังสามารถระบุ KILO_API_KEY or ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "จัดเก็บประวัติการใช้งาน Codex ในพื้นที่ (8 สัปดาห์) เพื่อปรับแต่งการคาดการณ์ Pace ในแบบของคุณ";
-"Subscription Utilization" = "การใช้การสมัครสมาชิก";
 "Surprise me" = "ทําให้ฉันประหลาดใจ";
 "Switcher shows icons" = "ตัวสลับแสดงไอคอน";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Symlink CodexBarCLI เป็น /usr/local/bin และ /opt/homebrew/bin เป็น codexbar";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -236,6 +236,7 @@
 "Picker subtitle" = "Seçici alt başlığı";
 "Placeholder" = "Yer tutucu";
 "Plan" = "Plan";
+"Plan Usage" = "Plan Kullanımı";
 "Play full-screen confetti when weekly usage resets." = "Haftalık kullanım sıfırlandığında tam ekran konfeti oynat.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "OpenAI/Claude durum sayfalarını ve Google Workspace'i ";
 "Prevents any Keychain access while enabled." = "Etkinleştirildiğinde tüm Anahtarlık erişimini engeller.";
@@ -304,7 +305,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "~/.codexbar/config.json dosyasında depolandı. MiniMax API anahtarınızı yapıştırın.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "~/.codexbar/config.json dosyasında depolandı. Ayrıca KILO_API_KEY sağlayabilirsiniz veya ";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Hız tahminlerini kişiselleştirmek için yerel Codex kullanım geçmişini (8 hafta) depolar.";
-"Subscription Utilization" = "Abonelik Kullanımı";
 "Surprise me" = "Beni şaşırt";
 "Switcher shows icons" = "Değiştirici simgeleri gösterir";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "CodexBarCLI'yi codexbar olarak /usr/local/bin ve /opt/homebrew/bin dizinlerine sembolik bağlayın.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 "Picker subtitle" = "Підзаголовок засобу вибору";
 "Placeholder" = "Заповнювач";
 "Plan" = "План";
+"Plan Usage" = "Використання плану";
 "Play full-screen confetti when weekly usage resets." = "Відтворення конфетті на весь екран, коли тижневе використання скидається.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Опитує сторінки статусу OpenAI/Claude і Google Workspace для";
 "Prevents any Keychain access while enabled." = "Запобігає будь-якому доступу Keychain, коли ввімкнено.";
@@ -301,7 +302,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Зберігається в ~/.codexbar/config.json. Вставте ключ MiniMax API.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Зберігається в ~/.codexbar/config.json. Ви також можете надати KILO_API_KEY або";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Зберігає локальну історію використання Codex (8 тижнів) для персоналізації прогнозів Pace.";
-"Subscription Utilization" = "Використання підписки";
 "Surprise me" = "Здивуйте мене";
 "Switcher shows icons" = "Перемикач показує значки";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Символьне посилання CodexBarCLI на /usr/local/bin і /opt/homebrew/bin як codexbar.";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 "Picker subtitle" = "Tiêu đề phụ của bộ chọn";
 "Placeholder" = "Trình giữ chỗ";
 "Plan" = "Kế hoạch";
+"Plan Usage" = "Mức sử dụng gói";
 "Play full-screen confetti when weekly usage resets." = "Phát hoa giấy toàn màn hình khi đặt lại Mức sử dụng hàng tuần.";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "Cuộc thăm dò ý kiến ​​OpenAI / Claude trang trạng thái và Google Không gian làm việc dành cho";
 "Prevents any Keychain access while enabled." = "Ngăn chặn mọi quyền truy cập Keychain khi được bật.";
@@ -301,7 +302,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "Được lưu trữ trong ~/.codexbar/config.json. Dán khóa MiniMax API của bạn.";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "Được lưu trữ trong ~/.codexbar/config.json. Bạn cũng có thể cung cấp lịch sử KILO_API_KEY hoặc";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "Stores Codex cục bộ Mức sử dụng (8 tuần) để cá nhân hóa dự đoán Pace.";
-"Subscription Utilization" = "Gói đăng ký Mức sử dụng";
 "Surprise me" = "Làm tôi ngạc nhiên";
 "Switcher shows icons" = "Trình chuyển đổi hiển thị các biểu tượng";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Symlink CodexBarCLI tới /usr/local/bin và /opt/homebrew/bin dưới dạng codexbar.";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -239,6 +239,7 @@
 "Picker subtitle" = "选择器副标题";
 "Placeholder" = "占位符";
 "Plan" = "套餐";
+"Plan Usage" = "套餐用量";
 "Play full-screen confetti when weekly usage resets." = "当每周用量重置时播放全屏彩纸。";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "轮询 OpenAI/Claude 状态页面和 Google Workspace，以检查";
 "Prevents any Keychain access while enabled." = "启用时阻止任何钥匙串访问。";
@@ -310,7 +311,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "存储在 ~/.codexbar/config.json 中。请粘贴你的 MiniMax API 密钥。";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "存储在 ~/.codexbar/config.json 中。你也可以提供 KILO_API_KEY 或";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "存储本地 Codex 用量历史（8 周），用于个性化进度预测。";
-"Subscription Utilization" = "订阅使用率";
 "Surprise me" = "给我惊喜";
 "Switcher shows icons" = "切换器显示图标";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "将 CodexBarCLI 作为 codexbar 符号链接到 /usr/local/bin 和 /opt/homebrew/bin。";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -241,6 +241,7 @@
 "Picker subtitle" = "選擇器副標題";
 "Placeholder" = "預留位置";
 "Plan" = "方案";
+"Plan Usage" = "方案用量";
 "Play full-screen confetti when weekly usage resets." = "每週使用量重置時播放全螢幕慶祝動畫。";
 "Polls OpenAI/Claude status pages and Google Workspace for " = "輪詢 OpenAI/Claude 狀態頁面和 Google Workspace，以檢查";
 "Prevents any Keychain access while enabled." = "啟用時封鎖任何鑰匙圈存取。";
@@ -313,7 +314,6 @@
 "Stored in ~/.codexbar/config.json. Paste your MiniMax API key." = "儲存在 ~/.codexbar/config.json 中。請貼上你的 MiniMax API 金鑰。";
 "Stored in ~/.codexbar/config.json. You can also provide KILO_API_KEY or " = "儲存在 ~/.codexbar/config.json 中。你也可以提供 KILO_API_KEY 或";
 "Stores local Codex usage history (8 weeks) to personalize Pace predictions." = "儲存本機 Codex 使用量歷史（8 週），用於個人化進度預測。";
-"Subscription Utilization" = "訂閱使用率";
 "Surprise me" = "給我驚喜";
 "Switcher shows icons" = "切換器顯示圖示";
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "將 CodexBarCLI 作為 codexbar 符號連結到 /usr/local/bin 和 /opt/homebrew/bin。";

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -753,13 +753,7 @@ extension StatusItemController {
                 currentProvider: context.currentProvider,
                 context: context.openAIContext,
                 addedOpenAIWebItems: addedOpenAIWebItems)
-            if self.addUsageHistoryMenuItemIfNeeded(
-                to: menu,
-                provider: context.currentProvider,
-                width: context.menuWidth)
-            {
-                menu.addItem(.separator())
-            }
+            self.addUsageHistoryClusterIfNeeded(to: menu, context: context)
             if self.addZaiHourlyUsageMenuItemIfNeeded(
                 to: menu,
                 provider: context.currentProvider,
@@ -1344,24 +1338,6 @@ extension StatusItemController {
                 submenu: costSubmenu,
                 width: width))
         }
-    }
-
-    @discardableResult
-    func addStorageMenuCardSection(to menu: NSMenu, provider: UsageProvider, width: CGFloat) -> Bool {
-        guard let storageText = self.store.storageFootprintText(for: provider) else { return false }
-        let storageSubmenu = self.makeStorageBreakdownSubmenu(provider: provider, width: width)
-        let menuFont = NSFont.menuFont(ofSize: 0)
-        let title = NSMutableAttributedString(string: L("Storage"), attributes: [.font: menuFont])
-        title.append(NSAttributedString(
-            string: "  \(storageText)",
-            attributes: [.font: menuFont, .foregroundColor: NSColor.secondaryLabelColor]))
-        let item = NSMenuItem(title: L("Storage"), action: nil, keyEquivalent: "")
-        item.attributedTitle = title
-        item.isEnabled = storageSubmenu != nil
-        item.representedObject = "menuCardStorage"
-        item.submenu = storageSubmenu
-        menu.addItem(item)
-        return true
     }
 
     private func switcherIcon(for provider: UsageProvider) -> NSImage {

--- a/Sources/CodexBar/StatusItemController+MenuRowReordering.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRowReordering.swift
@@ -1,0 +1,47 @@
+import AppKit
+
+extension StatusItemController {
+    func addUsageHistoryClusterIfNeeded(to menu: NSMenu, context: MenuCardContext) {
+        if self.addUsageHistoryMenuItemIfNeeded(
+            to: menu,
+            provider: context.currentProvider,
+            width: context.menuWidth)
+        {
+            self.moveCostAndStorageRowsUnderUsageHistory(in: menu)
+            menu.addItem(.separator())
+        }
+    }
+
+    func moveCostAndStorageRowsUnderUsageHistory(in menu: NSMenu) {
+        guard let usageHistoryItem = menu.items.first(where: {
+            ($0.representedObject as? String) == "usageHistorySubmenu"
+        }) else { return }
+
+        let rowIDs = ["menuCardCost", "menuCardStorage"]
+        let rowsToMove = rowIDs.compactMap { rowID in
+            menu.items.first { ($0.representedObject as? String) == rowID }
+        }
+        guard !rowsToMove.isEmpty else { return }
+
+        for item in rowsToMove {
+            menu.removeItem(item)
+        }
+
+        guard let usageHistoryIndex = menu.items.firstIndex(where: { $0 === usageHistoryItem }) else { return }
+        for (offset, item) in rowsToMove.enumerated() {
+            menu.insertItem(item, at: min(usageHistoryIndex + 1 + offset, menu.items.count))
+        }
+        self.collapseAdjacentSeparators(in: menu)
+    }
+
+    private func collapseAdjacentSeparators(in menu: NSMenu) {
+        var index = 1
+        while index < menu.items.count {
+            if menu.items[index - 1].isSeparatorItem, menu.items[index].isSeparatorItem {
+                menu.removeItem(at: index)
+            } else {
+                index += 1
+            }
+        }
+    }
+}

--- a/Sources/CodexBar/StatusItemController+StorageMenuCard.swift
+++ b/Sources/CodexBar/StatusItemController+StorageMenuCard.swift
@@ -1,0 +1,26 @@
+import AppKit
+import CodexBarCore
+
+extension StatusItemController {
+    @discardableResult
+    func addStorageMenuCardSection(to menu: NSMenu, provider: UsageProvider, width: CGFloat) -> Bool {
+        guard let storageText = self.store.storageFootprintText(for: provider) else { return false }
+        let storageSubmenu = self.makeStorageBreakdownSubmenu(provider: provider, width: width)
+        menu.addItem(Self.makeNativeStorageMenuCardItem(storageText: storageText, submenu: storageSubmenu))
+        return true
+    }
+
+    private static func makeNativeStorageMenuCardItem(storageText: String, submenu: NSMenu?) -> NSMenuItem {
+        let menuFont = NSFont.menuFont(ofSize: 0)
+        let title = NSMutableAttributedString(string: L("Storage"), attributes: [.font: menuFont])
+        title.append(NSAttributedString(
+            string: "  \(storageText)",
+            attributes: [.font: menuFont, .foregroundColor: NSColor.secondaryLabelColor]))
+        let item = NSMenuItem(title: L("Storage"), action: nil, keyEquivalent: "")
+        item.attributedTitle = title
+        item.isEnabled = submenu != nil
+        item.representedObject = "menuCardStorage"
+        item.submenu = submenu
+        return item
+    }
+}

--- a/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
+++ b/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
@@ -12,7 +12,7 @@ extension StatusItemController {
     @discardableResult
     func addUsageHistoryMenuItemIfNeeded(to menu: NSMenu, provider: UsageProvider, width: CGFloat) -> Bool {
         guard let submenu = self.makeUsageHistorySubmenu(provider: provider, width: width) else { return false }
-        let item = NSMenuItem(title: L("Subscription Utilization"), action: nil, keyEquivalent: "")
+        let item = NSMenuItem(title: L("Plan Usage"), action: nil, keyEquivalent: "")
         item.isEnabled = true
         item.representedObject = "usageHistorySubmenu"
         item.submenu = submenu

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -139,7 +139,7 @@ extension StatusMenuTests {
 
         let menu = NSMenu()
         let usageHistoryItem = controller.makeMenuCardItem(
-            Text("Subscription Utilization"),
+            Text("Plan Usage"),
             id: "usageHistorySubmenu",
             width: StatusItemController.menuCardBaseWidth)
         menu.addItem(usageHistoryItem)

--- a/Tests/CodexBarTests/StatusMenuNativeSectionSpacingTests.swift
+++ b/Tests/CodexBarTests/StatusMenuNativeSectionSpacingTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuNativeSectionSpacingTests {
     @Test
-    func `storage credits and cost never create adjacent separators`() throws {
+    func `usage history cost and storage stay together without adjacent separators`() throws {
         let previousRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = true
         defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
@@ -72,6 +72,9 @@ struct StatusMenuNativeSectionSpacingTests {
 
         let menu = controller.makeMenu(for: .codex)
         controller.menuWillOpen(menu)
+        let usageHistoryIndex = try #require(menu.items.firstIndex {
+            ($0.representedObject as? String) == "usageHistorySubmenu"
+        })
         let storageIndex = try #require(menu.items.firstIndex {
             ($0.representedObject as? String) == "menuCardStorage"
         })
@@ -81,9 +84,14 @@ struct StatusMenuNativeSectionSpacingTests {
         let costIndex = try #require(menu.items.firstIndex {
             ($0.representedObject as? String) == "menuCardCost"
         })
-        #expect(storageIndex < creditsIndex)
-        #expect(creditsIndex < costIndex)
-        #expect(menu.items[costIndex + 1].isSeparatorItem)
+        #expect(creditsIndex < usageHistoryIndex)
+        #expect(usageHistoryIndex < costIndex)
+        #expect(costIndex < storageIndex)
+        #expect(menu.items[usageHistoryIndex].title == "Plan Usage")
+        #expect(menu.items[storageIndex].view == nil)
+        #expect(menu.items[storageIndex].title.hasPrefix("Storage"))
+        #expect(menu.items[storageIndex].title.contains("1 KB"))
+        #expect(menu.items[storageIndex + 1].isSeparatorItem)
         #expect(!zip(menu.items, menu.items.dropFirst()).contains { first, second in
             first.isSeparatorItem && second.isSeparatorItem
         })

--- a/Tests/CodexBarTests/UserFacingLocalizationCoverageTests.swift
+++ b/Tests/CodexBarTests/UserFacingLocalizationCoverageTests.swift
@@ -86,9 +86,6 @@ struct UserFacingLocalizationCoverageTests {
                 "\"Disabled —",
                 ".accessibilityLabel(\"Sort",
             ],
-            "Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift": [
-                "Text(\"Subscription Utilization\")",
-            ],
             "Sources/CodexBar/StatusItemController+CostMenuCard.swift": [
                 "static let costMenuTitle",
             ],


### PR DESCRIPTION
## Summary
- Group `Plan Usage`, `Cost`, and `Storage` together.
- Rename `Subscription Utilization` to `Plan Usage` so the grouped rows scan better.

## Why
`Plan Usage`, `Cost`, and `Storage` all describe selected plan/account usage, so grouping them makes the menu structure clearer and easier to scan.  

The rename supports that grouping: `Plan Usage` is shorter and visually balances better with compact rows like `Cost` and `Storage`.

## Validation
- `swift test --filter UserFacingLocalizationCoverageTests`
- `swift test --filter StatusMenuNativeSectionSpacingTests`
- `make check`

## Screenshot


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img height="450" alt="Before: Subscription Utilization, Cost, and Storage separated in the menu" src="https://github.com/user-attachments/assets/e6997fca-69f7-48e4-9e47-61d3ad01375f" />
    </td>
    <td>
      <img height="450" alt="After: Plan Usage, Cost, and Storage grouped together" src="https://github.com/user-attachments/assets/e2d9ab62-5e67-4487-9858-1c5c998902d6" />
    </td>
  </tr>
</table>

## Follow-up
If PR #1690 is merged, consider whether `Reset credits` should also move into this block.