### PR TITLE
fix: refresh usage after quota reset boundaries

### DIFF
--- a/Sources/CodexBar/UsageStore+ResetBoundaryRefresh.swift
+++ b/Sources/CodexBar/UsageStore+ResetBoundaryRefresh.swift
@@ -1,0 +1,123 @@
+import CodexBarCore
+import Foundation
+
+extension UsageStore {
+    private struct ResetBoundaryRefreshCandidate {
+        var refreshAt: Date
+        var boundaryRefreshAt: Date
+    }
+
+    func scheduleResetBoundaryRefreshIfNeeded(
+        normalRefreshInterval: TimeInterval?,
+        now: Date = Date())
+    {
+        guard let candidate = Self.nextResetBoundaryRefreshCandidate(
+            snapshots: self.snapshots,
+            normalRefreshInterval: normalRefreshInterval,
+            attemptedBoundaryRefreshes: self.attemptedResetBoundaryRefreshes,
+            now: now)
+        else {
+            self.cancelResetBoundaryRefresh()
+            return
+        }
+
+        let refreshAt = candidate.refreshAt
+        if let scheduledResetBoundaryRefreshAt,
+           abs(scheduledResetBoundaryRefreshAt.timeIntervalSince(refreshAt)) < 1
+        {
+            return
+        }
+
+        self.cancelResetBoundaryRefresh()
+        self.scheduledResetBoundaryRefreshAt = refreshAt
+        self.resetBoundaryRefreshTask = Task.detached(priority: .utility) { [weak self] in
+            let delay = max(0, refreshAt.timeIntervalSince(Date()))
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            await self?.runResetBoundaryRefresh(boundaryRefreshAt: candidate.boundaryRefreshAt)
+        }
+    }
+
+    private func runResetBoundaryRefresh(boundaryRefreshAt: Date) async {
+        self.recordAttemptedResetBoundaryRefresh(boundaryRefreshAt)
+        await self.refresh()
+    }
+
+    private func recordAttemptedResetBoundaryRefresh(_ refreshAt: Date) {
+        self.attemptedResetBoundaryRefreshes.insert(refreshAt)
+        if self.attemptedResetBoundaryRefreshes.count > 64,
+           let oldest = self.attemptedResetBoundaryRefreshes.min()
+        {
+            self.attemptedResetBoundaryRefreshes.remove(oldest)
+        }
+    }
+
+    func cancelResetBoundaryRefresh() {
+        self.resetBoundaryRefreshTask?.cancel()
+        self.resetBoundaryRefreshTask = nil
+        self.scheduledResetBoundaryRefreshAt = nil
+    }
+
+    nonisolated static func nextResetBoundaryRefreshDate(
+        snapshots: [UsageProvider: UsageSnapshot],
+        normalRefreshInterval: TimeInterval?,
+        attemptedBoundaryRefreshes: Set<Date> = [],
+        now: Date)
+        -> Date?
+    {
+        self.nextResetBoundaryRefreshCandidate(
+            snapshots: snapshots,
+            normalRefreshInterval: normalRefreshInterval,
+            attemptedBoundaryRefreshes: attemptedBoundaryRefreshes,
+            now: now)?
+            .refreshAt
+    }
+
+    private nonisolated static func nextResetBoundaryRefreshCandidate(
+        snapshots: [UsageProvider: UsageSnapshot],
+        normalRefreshInterval: TimeInterval?,
+        attemptedBoundaryRefreshes: Set<Date> = [],
+        now: Date)
+        -> ResetBoundaryRefreshCandidate?
+    {
+        guard let normalRefreshInterval else { return nil }
+        let normalRefreshDate = now.addingTimeInterval(normalRefreshInterval)
+        return snapshots.values
+            .flatMap { snapshot in
+                Self.resetBoundaryRefreshCandidates(
+                    snapshot: snapshot,
+                    now: now,
+                    normalRefreshDate: normalRefreshDate,
+                    attemptedBoundaryRefreshes: attemptedBoundaryRefreshes)
+            }
+            .min { $0.refreshAt < $1.refreshAt }
+    }
+
+    private nonisolated static func resetBoundaryRefreshCandidates(
+        snapshot: UsageSnapshot,
+        now: Date,
+        normalRefreshDate: Date,
+        attemptedBoundaryRefreshes: Set<Date>)
+        -> [ResetBoundaryRefreshCandidate]
+    {
+        snapshot.allRateWindows().compactMap { window in
+            guard let resetsAt = window.resetsAt else { return nil }
+            let boundaryRefreshAt = resetsAt.addingTimeInterval(Self.resetBoundaryRefreshGraceSeconds)
+            guard !attemptedBoundaryRefreshes.contains(boundaryRefreshAt) else { return nil }
+            guard boundaryRefreshAt <= normalRefreshDate else { return nil }
+            guard snapshot.updatedAt < boundaryRefreshAt else { return nil }
+            return ResetBoundaryRefreshCandidate(
+                refreshAt: max(
+                    boundaryRefreshAt,
+                    now.addingTimeInterval(Self.resetBoundaryRefreshMinimumDelaySeconds)),
+                boundaryRefreshAt: boundaryRefreshAt)
+        }
+    }
+}
+
+extension UsageSnapshot {
+    fileprivate func allRateWindows() -> [RateWindow] {
+        [self.primary, self.secondary, self.tertiary].compactMap(\.self) +
+            (self.extraRateWindows?.map(\.window) ?? [])
+    }
+}

--- a/Sources/CodexBar/UsageStore+ResetBoundaryRefresh.swift
+++ b/Sources/CodexBar/UsageStore+ResetBoundaryRefresh.swift
@@ -38,7 +38,9 @@ extension UsageStore {
         }
     }
 
-    private func runResetBoundaryRefresh(boundaryRefreshAt: Date) async {
+    func runResetBoundaryRefresh(boundaryRefreshAt: Date) async {
+        self.resetBoundaryRefreshTask = nil
+        self.scheduledResetBoundaryRefreshAt = nil
         guard Self.shouldRecordResetBoundaryAttempt(isRefreshing: self.isRefreshing) else { return }
         self.recordAttemptedResetBoundaryRefresh(boundaryRefreshAt)
         await self.refresh()

--- a/Sources/CodexBar/UsageStore+ResetBoundaryRefresh.swift
+++ b/Sources/CodexBar/UsageStore+ResetBoundaryRefresh.swift
@@ -39,6 +39,7 @@ extension UsageStore {
     }
 
     private func runResetBoundaryRefresh(boundaryRefreshAt: Date) async {
+        guard Self.shouldRecordResetBoundaryAttempt(isRefreshing: self.isRefreshing) else { return }
         self.recordAttemptedResetBoundaryRefresh(boundaryRefreshAt)
         await self.refresh()
     }
@@ -71,6 +72,10 @@ extension UsageStore {
             attemptedBoundaryRefreshes: attemptedBoundaryRefreshes,
             now: now)?
             .refreshAt
+    }
+
+    nonisolated static func shouldRecordResetBoundaryAttempt(isRefreshing: Bool) -> Bool {
+        !isRefreshing
     }
 
     private nonisolated static func nextResetBoundaryRefreshCandidate(

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -255,8 +255,9 @@ final class UsageStore {
     @ObservationIgnored var lastStorageRefreshAt: Date?
     @ObservationIgnored var managedCodexAccountsForStorageOverride: [ManagedCodexAccount]?
     @ObservationIgnored private var pathDebugRefreshTask: Task<Void, Never>?
-    @ObservationIgnored private var resetBoundaryRefreshTask: Task<Void, Never>?
-    @ObservationIgnored private var scheduledResetBoundaryRefreshAt: Date?
+    @ObservationIgnored var resetBoundaryRefreshTask: Task<Void, Never>?
+    @ObservationIgnored var scheduledResetBoundaryRefreshAt: Date?
+    @ObservationIgnored var attemptedResetBoundaryRefreshes: Set<Date> = []
     @ObservationIgnored var codexPlanHistoryBackfillTask: Task<Void, Never>?
     @ObservationIgnored let historicalUsageHistoryStore: HistoricalUsageHistoryStore
     @ObservationIgnored let planUtilizationHistoryStore: PlanUtilizationHistoryStore
@@ -723,74 +724,6 @@ final class UsageStore {
         }
     }
 
-    func scheduleResetBoundaryRefreshIfNeeded(
-        normalRefreshInterval: TimeInterval?,
-        now: Date = Date())
-    {
-        guard let refreshAt = Self.nextResetBoundaryRefreshDate(
-            snapshots: self.snapshots,
-            normalRefreshInterval: normalRefreshInterval,
-            now: now)
-        else {
-            self.cancelResetBoundaryRefresh()
-            return
-        }
-
-        if let scheduledResetBoundaryRefreshAt,
-           abs(scheduledResetBoundaryRefreshAt.timeIntervalSince(refreshAt)) < 1
-        {
-            return
-        }
-
-        self.cancelResetBoundaryRefresh()
-        self.scheduledResetBoundaryRefreshAt = refreshAt
-        self.resetBoundaryRefreshTask = Task.detached(priority: .utility) { [weak self] in
-            let delay = max(0, refreshAt.timeIntervalSince(Date()))
-            try? await Task.sleep(for: .seconds(delay))
-            guard !Task.isCancelled else { return }
-            await self?.refresh()
-        }
-    }
-
-    private func cancelResetBoundaryRefresh() {
-        self.resetBoundaryRefreshTask?.cancel()
-        self.resetBoundaryRefreshTask = nil
-        self.scheduledResetBoundaryRefreshAt = nil
-    }
-
-    nonisolated static func nextResetBoundaryRefreshDate(
-        snapshots: [UsageProvider: UsageSnapshot],
-        normalRefreshInterval: TimeInterval?,
-        now: Date)
-        -> Date?
-    {
-        guard let normalRefreshInterval else { return nil }
-        let normalRefreshDate = now.addingTimeInterval(normalRefreshInterval)
-        return snapshots.values
-            .flatMap { snapshot in
-                Self.resetBoundaryRefreshCandidates(
-                    snapshot: snapshot,
-                    now: now,
-                    normalRefreshDate: normalRefreshDate)
-            }
-            .min()
-    }
-
-    private nonisolated static func resetBoundaryRefreshCandidates(
-        snapshot: UsageSnapshot,
-        now: Date,
-        normalRefreshDate: Date)
-        -> [Date]
-    {
-        snapshot.allRateWindows().compactMap { window in
-            guard let resetsAt = window.resetsAt else { return nil }
-            let refreshAt = resetsAt.addingTimeInterval(Self.resetBoundaryRefreshGraceSeconds)
-            guard refreshAt <= normalRefreshDate else { return nil }
-            guard snapshot.updatedAt < refreshAt else { return nil }
-            return max(refreshAt, now.addingTimeInterval(Self.resetBoundaryRefreshMinimumDelaySeconds))
-        }
-    }
-
     private func startTokenTimer() {
         self.tokenTimerTask?.cancel()
         let wait = self.tokenFetchTTL
@@ -1013,13 +946,6 @@ final class UsageStore {
                 }
             }
         }
-    }
-}
-
-extension UsageSnapshot {
-    fileprivate func allRateWindows() -> [RateWindow] {
-        [self.primary, self.secondary, self.tertiary].compactMap(\.self) +
-            (self.extraRateWindows?.map(\.window) ?? [])
     }
 }
 

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -107,6 +107,9 @@ extension UsageStore {
 @MainActor
 @Observable
 final class UsageStore {
+    nonisolated static let resetBoundaryRefreshGraceSeconds: TimeInterval = 30
+    nonisolated static let resetBoundaryRefreshMinimumDelaySeconds: TimeInterval = 5
+
     private struct ProviderAvailabilityCacheEntry {
         let available: Bool
         let configRevision: Int
@@ -252,6 +255,8 @@ final class UsageStore {
     @ObservationIgnored var lastStorageRefreshAt: Date?
     @ObservationIgnored var managedCodexAccountsForStorageOverride: [ManagedCodexAccount]?
     @ObservationIgnored private var pathDebugRefreshTask: Task<Void, Never>?
+    @ObservationIgnored private var resetBoundaryRefreshTask: Task<Void, Never>?
+    @ObservationIgnored private var scheduledResetBoundaryRefreshAt: Date?
     @ObservationIgnored var codexPlanHistoryBackfillTask: Task<Void, Never>?
     @ObservationIgnored let historicalUsageHistoryStore: HistoricalUsageHistoryStore
     @ObservationIgnored let planUtilizationHistoryStore: PlanUtilizationHistoryStore
@@ -673,6 +678,9 @@ final class UsageStore {
             self.persistWidgetSnapshot(reason: "refresh")
         }
 
+        self.scheduleResetBoundaryRefreshIfNeeded(
+            normalRefreshInterval: self.settings.refreshFrequency.seconds)
+
         if allowsStartupConnectivityRetry {
             self.completeStartupConnectivityRetryPass(currentAttempt: startupConnectivityRetryAttempt ?? 0)
         }
@@ -703,6 +711,7 @@ final class UsageStore {
 
     private func startTimer() {
         self.timerTask?.cancel()
+        self.cancelResetBoundaryRefresh()
         guard let wait = self.settings.refreshFrequency.seconds else { return }
 
         // Background poller so the menu stays responsive; canceled when settings change or store deallocates.
@@ -711,6 +720,74 @@ final class UsageStore {
                 try? await Task.sleep(for: .seconds(wait))
                 await self?.refresh()
             }
+        }
+    }
+
+    func scheduleResetBoundaryRefreshIfNeeded(
+        normalRefreshInterval: TimeInterval?,
+        now: Date = Date())
+    {
+        guard let refreshAt = Self.nextResetBoundaryRefreshDate(
+            snapshots: self.snapshots,
+            normalRefreshInterval: normalRefreshInterval,
+            now: now)
+        else {
+            self.cancelResetBoundaryRefresh()
+            return
+        }
+
+        if let scheduledResetBoundaryRefreshAt,
+           abs(scheduledResetBoundaryRefreshAt.timeIntervalSince(refreshAt)) < 1
+        {
+            return
+        }
+
+        self.cancelResetBoundaryRefresh()
+        self.scheduledResetBoundaryRefreshAt = refreshAt
+        self.resetBoundaryRefreshTask = Task.detached(priority: .utility) { [weak self] in
+            let delay = max(0, refreshAt.timeIntervalSince(Date()))
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            await self?.refresh()
+        }
+    }
+
+    private func cancelResetBoundaryRefresh() {
+        self.resetBoundaryRefreshTask?.cancel()
+        self.resetBoundaryRefreshTask = nil
+        self.scheduledResetBoundaryRefreshAt = nil
+    }
+
+    nonisolated static func nextResetBoundaryRefreshDate(
+        snapshots: [UsageProvider: UsageSnapshot],
+        normalRefreshInterval: TimeInterval?,
+        now: Date)
+        -> Date?
+    {
+        guard let normalRefreshInterval else { return nil }
+        let normalRefreshDate = now.addingTimeInterval(normalRefreshInterval)
+        return snapshots.values
+            .flatMap { snapshot in
+                Self.resetBoundaryRefreshCandidates(
+                    snapshot: snapshot,
+                    now: now,
+                    normalRefreshDate: normalRefreshDate)
+            }
+            .min()
+    }
+
+    private nonisolated static func resetBoundaryRefreshCandidates(
+        snapshot: UsageSnapshot,
+        now: Date,
+        normalRefreshDate: Date)
+        -> [Date]
+    {
+        snapshot.allRateWindows().compactMap { window in
+            guard let resetsAt = window.resetsAt else { return nil }
+            let refreshAt = resetsAt.addingTimeInterval(Self.resetBoundaryRefreshGraceSeconds)
+            guard refreshAt <= normalRefreshDate else { return nil }
+            guard snapshot.updatedAt < refreshAt else { return nil }
+            return max(refreshAt, now.addingTimeInterval(Self.resetBoundaryRefreshMinimumDelaySeconds))
         }
     }
 
@@ -782,6 +859,7 @@ final class UsageStore {
         self.startupConnectivityRetryTask?.cancel()
         self.storageRefreshTask?.cancel()
         self.codexPlanHistoryBackfillTask?.cancel()
+        self.resetBoundaryRefreshTask?.cancel()
     }
 
     enum SessionQuotaWindowSource: String {
@@ -935,6 +1013,13 @@ final class UsageStore {
                 }
             }
         }
+    }
+}
+
+extension UsageSnapshot {
+    fileprivate func allRateWindows() -> [RateWindow] {
+        [self.primary, self.secondary, self.tertiary].compactMap(\.self) +
+            (self.extraRateWindows?.map(\.window) ?? [])
     }
 }
 

--- a/Tests/CodexBarTests/UsageStoreResetBoundaryRefreshTests.swift
+++ b/Tests/CodexBarTests/UsageStoreResetBoundaryRefreshTests.swift
@@ -1,0 +1,128 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct UsageStoreResetBoundaryRefreshTests {
+    @Test
+    func schedulesRefreshAtResetBoundaryBeforeNormalPoll() {
+        let now = Date(timeIntervalSince1970: 1000)
+        let resetsAt = now.addingTimeInterval(10 * 60)
+        let snapshot = Self.snapshot(updatedAt: now, primaryResetsAt: resetsAt)
+
+        let refreshAt = UsageStore.nextResetBoundaryRefreshDate(
+            snapshots: [.codex: snapshot],
+            normalRefreshInterval: 30 * 60,
+            now: now)
+
+        #expect(refreshAt == resetsAt.addingTimeInterval(UsageStore.resetBoundaryRefreshGraceSeconds))
+    }
+
+    @Test
+    func schedulesPromptRefreshWhenResetBoundaryAlreadyPassed() {
+        let now = Date(timeIntervalSince1970: 2000)
+        let resetsAt = now.addingTimeInterval(-3 * 60)
+        let snapshot = Self.snapshot(
+            updatedAt: resetsAt.addingTimeInterval(-60),
+            primaryResetsAt: resetsAt)
+
+        let refreshAt = UsageStore.nextResetBoundaryRefreshDate(
+            snapshots: [.codex: snapshot],
+            normalRefreshInterval: 30 * 60,
+            now: now)
+
+        #expect(refreshAt == now.addingTimeInterval(UsageStore.resetBoundaryRefreshMinimumDelaySeconds))
+    }
+
+    @Test
+    func ignoresResetBoundaryAfterNormalPoll() {
+        let now = Date(timeIntervalSince1970: 3000)
+        let resetsAt = now.addingTimeInterval(40 * 60)
+        let snapshot = Self.snapshot(updatedAt: now, primaryResetsAt: resetsAt)
+
+        let refreshAt = UsageStore.nextResetBoundaryRefreshDate(
+            snapshots: [.codex: snapshot],
+            normalRefreshInterval: 30 * 60,
+            now: now)
+
+        #expect(refreshAt == nil)
+    }
+
+    @Test
+    func ignoresAlreadyRefreshedResetBoundary() {
+        let now = Date(timeIntervalSince1970: 4000)
+        let resetsAt = now.addingTimeInterval(-3 * 60)
+        let snapshot = Self.snapshot(updatedAt: now, primaryResetsAt: resetsAt)
+
+        let refreshAt = UsageStore.nextResetBoundaryRefreshDate(
+            snapshots: [.codex: snapshot],
+            normalRefreshInterval: 30 * 60,
+            now: now)
+
+        #expect(refreshAt == nil)
+    }
+
+    @Test
+    func usesEarliestBoundaryAcrossSecondaryAndExtraWindows() {
+        let now = Date(timeIntervalSince1970: 5000)
+        let secondaryResetsAt = now.addingTimeInterval(8 * 60)
+        let extraResetsAt = now.addingTimeInterval(4 * 60)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(20 * 60),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 80,
+                windowMinutes: 10080,
+                resetsAt: secondaryResetsAt,
+                resetDescription: nil),
+            tertiary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "extra",
+                    title: "Extra",
+                    window: RateWindow(
+                        usedPercent: 50,
+                        windowMinutes: 60,
+                        resetsAt: extraResetsAt,
+                        resetDescription: nil)),
+            ],
+            updatedAt: now)
+
+        let refreshAt = UsageStore.nextResetBoundaryRefreshDate(
+            snapshots: [.codex: snapshot],
+            normalRefreshInterval: 30 * 60,
+            now: now)
+
+        #expect(refreshAt == extraResetsAt.addingTimeInterval(UsageStore.resetBoundaryRefreshGraceSeconds))
+    }
+
+    @Test
+    func manualRefreshCadenceDoesNotScheduleBoundaryRefresh() {
+        let now = Date(timeIntervalSince1970: 6000)
+        let snapshot = Self.snapshot(
+            updatedAt: now,
+            primaryResetsAt: now.addingTimeInterval(10 * 60))
+
+        let refreshAt = UsageStore.nextResetBoundaryRefreshDate(
+            snapshots: [.codex: snapshot],
+            normalRefreshInterval: nil,
+            now: now)
+
+        #expect(refreshAt == nil)
+    }
+
+    private static func snapshot(updatedAt: Date, primaryResetsAt: Date) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: 300,
+                resetsAt: primaryResetsAt,
+                resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: updatedAt)
+    }
+}

--- a/Tests/CodexBarTests/UsageStoreResetBoundaryRefreshTests.swift
+++ b/Tests/CodexBarTests/UsageStoreResetBoundaryRefreshTests.swift
@@ -35,6 +35,24 @@ struct UsageStoreResetBoundaryRefreshTests {
     }
 
     @Test
+    func suppressesRepeatedPromptRefreshAfterAttemptedBoundary() {
+        let now = Date(timeIntervalSince1970: 2500)
+        let resetsAt = now.addingTimeInterval(-3 * 60)
+        let boundaryRefreshAt = resetsAt.addingTimeInterval(UsageStore.resetBoundaryRefreshGraceSeconds)
+        let snapshot = Self.snapshot(
+            updatedAt: resetsAt.addingTimeInterval(-60),
+            primaryResetsAt: resetsAt)
+
+        let refreshAt = UsageStore.nextResetBoundaryRefreshDate(
+            snapshots: [.codex: snapshot],
+            normalRefreshInterval: 30 * 60,
+            attemptedBoundaryRefreshes: [boundaryRefreshAt],
+            now: now)
+
+        #expect(refreshAt == nil)
+    }
+
+    @Test
     func ignoresResetBoundaryAfterNormalPoll() {
         let now = Date(timeIntervalSince1970: 3000)
         let resetsAt = now.addingTimeInterval(40 * 60)

--- a/Tests/CodexBarTests/UsageStoreResetBoundaryRefreshTests.swift
+++ b/Tests/CodexBarTests/UsageStoreResetBoundaryRefreshTests.swift
@@ -82,6 +82,38 @@ struct UsageStoreResetBoundaryRefreshTests {
     }
 
     @Test
+    @MainActor
+    func inFlightBoundaryRefreshClearsFiredScheduleMarker() async {
+        let now = Date(timeIntervalSince1970: 2800)
+        let resetsAt = now.addingTimeInterval(-3 * 60)
+        let boundaryRefreshAt = resetsAt.addingTimeInterval(UsageStore.resetBoundaryRefreshGraceSeconds)
+        let retryAt = now.addingTimeInterval(UsageStore.resetBoundaryRefreshMinimumDelaySeconds)
+        let snapshot = Self.snapshot(
+            updatedAt: resetsAt.addingTimeInterval(-60),
+            primaryResetsAt: resetsAt)
+        let settings = testSettingsStore(suiteName: "UsageStoreResetBoundaryRefreshTests-inflight-marker")
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+        store.snapshots[.codex] = snapshot
+        store.isRefreshing = true
+        store.scheduledResetBoundaryRefreshAt = retryAt
+
+        await store.runResetBoundaryRefresh(boundaryRefreshAt: boundaryRefreshAt)
+
+        #expect(store.scheduledResetBoundaryRefreshAt == nil)
+        #expect(store.attemptedResetBoundaryRefreshes.isEmpty)
+
+        store.isRefreshing = false
+        store.scheduleResetBoundaryRefreshIfNeeded(normalRefreshInterval: 30 * 60, now: now)
+        defer { store.cancelResetBoundaryRefresh() }
+
+        #expect(store.scheduledResetBoundaryRefreshAt == retryAt)
+    }
+
+    @Test
     func ignoresResetBoundaryAfterNormalPoll() {
         let now = Date(timeIntervalSince1970: 3000)
         let resetsAt = now.addingTimeInterval(40 * 60)

--- a/Tests/CodexBarTests/UsageStoreResetBoundaryRefreshTests.swift
+++ b/Tests/CodexBarTests/UsageStoreResetBoundaryRefreshTests.swift
@@ -53,6 +53,35 @@ struct UsageStoreResetBoundaryRefreshTests {
     }
 
     @Test
+    func inFlightBoundaryRefreshRemainsRetryable() {
+        let now = Date(timeIntervalSince1970: 2750)
+        let resetsAt = now.addingTimeInterval(-3 * 60)
+        let boundaryRefreshAt = resetsAt.addingTimeInterval(UsageStore.resetBoundaryRefreshGraceSeconds)
+        let snapshot = Self.snapshot(
+            updatedAt: resetsAt.addingTimeInterval(-60),
+            primaryResetsAt: resetsAt)
+
+        #expect(UsageStore.shouldRecordResetBoundaryAttempt(isRefreshing: true) == false)
+        #expect(UsageStore.shouldRecordResetBoundaryAttempt(isRefreshing: false) == true)
+
+        let refreshAt = UsageStore.nextResetBoundaryRefreshDate(
+            snapshots: [.codex: snapshot],
+            normalRefreshInterval: 30 * 60,
+            attemptedBoundaryRefreshes: [],
+            now: now)
+
+        #expect(refreshAt == now.addingTimeInterval(UsageStore.resetBoundaryRefreshMinimumDelaySeconds))
+
+        let suppressedAfterRecordedAttempt = UsageStore.nextResetBoundaryRefreshDate(
+            snapshots: [.codex: snapshot],
+            normalRefreshInterval: 30 * 60,
+            attemptedBoundaryRefreshes: [boundaryRefreshAt],
+            now: now)
+
+        #expect(suppressedAfterRecordedAttempt == nil)
+    }
+
+    @Test
     func ignoresResetBoundaryAfterNormalPoll() {
         let now = Date(timeIntervalSince1970: 3000)
         let resetsAt = now.addingTimeInterval(40 * 60)


### PR DESCRIPTION
## Summary
- refresh usage shortly after known quota reset boundaries when the boundary is earlier than the configured polling cadence
- suppress repeated prompt retries when provider failures preserve stale data after a boundary refresh attempt
- cover primary, secondary, and extra rate windows with focused scheduler tests

## Review Follow-up
- Boundary-triggered refreshes now record the attempted boundary refresh time when the one-shot fires.
- The scheduler excludes already-attempted boundary refreshes, so preserved stale snapshots fall back to normal polling instead of scheduling another prompt retry.
- Regression proof: `suppressesRepeatedPromptRefreshAfterAttemptedBoundary` models a preserved stale snapshot after an attempted boundary refresh and verifies no prompt retry is scheduled.
- No live provider or Keychain probe was run, per repository guidance to avoid live provider probes and keychain-prompting checks.

## Validation
- `git diff --check`
- `swift test --filter UsageStoreResetBoundaryRefreshTests`
- `make check`
- `swift test --no-parallel --filter '(^CodexBarTests\.CostUsageScannerBreakdownTests/)'`
- `/usr/bin/env CODEXBAR_TEST_SUITE_TIMEOUT=420 make test`

Note: default `make test` uses a 180 second per-suite timeout on this machine. The existing `CostUsageScannerBreakdownTests` suite passed but takes about 321-323 seconds locally, so the full suite was run with the repo-supported `CODEXBAR_TEST_SUITE_TIMEOUT=420` override.
