### PR TITLE
Fix #1844: block background Claude delegated refresh and mcpOAuth-only keychain touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 - Usage refresh: refresh provider data shortly after known quota reset boundaries instead of leaving expired reset times visible until the next normal poll. Thanks @pavbar!
+- Claude: block background delegated CLI OAuth refresh when the keychain holds MCP-only state (`mcpOAuth` without `claudeAiOauth`) while preserving explicit Refresh recovery (#1844). Thanks @Yuxin-Qiao!
 - Settings: align General-pane controls, show compact installed terminal app icons, and enlarge the window to fit more options.
 - Sakana AI: parse server-rendered quota reset timestamps as UTC instead of device-local time (#1826). Thanks @ss251!
 - Cursor: hide misleading pace and run-out details once a billing-cycle quota is fully depleted. Thanks @Yuxin-Qiao!

--- a/Scripts/verify_1844_live.sh
+++ b/Scripts/verify_1844_live.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Live verification for CodexBar #1844 / PR #1848
+# Usage: ./Scripts/verify_1844_live.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+ARTIFACT="${TMPDIR:-/tmp}/codexbar-1844-verify"
+mkdir -p "$ARTIFACT"
+
+CLI="${CODEXBAR_CLI:-$ROOT/.build/release/CodexBarCLI}"
+if [[ ! -x "$CLI" ]]; then
+  CLI="$ROOT/CodexBar.app/Contents/Helpers/CodexBarCLI"
+fi
+if [[ ! -x "$CLI" ]]; then
+  echo "Building CodexBarCLI..."
+  swift build -c release --product CodexBarCLI
+  CLI="$ROOT/.build/release/CodexBarCLI"
+fi
+
+log() { printf '[verify-1844] %s\n' "$*"; }
+
+log "=== Phase 1: macOS integration tests (real binaries) ==="
+swift test --filter 'mcp O auth|delegated retry experimental|load with auto refresh expired claude CLI owner throws mcp' \
+  2>&1 | tee "$ARTIFACT/integration-tests.log"
+log "Phase 1 PASS"
+
+KEYCHAIN_SERVICE="Claude Code-credentials"
+KEYCHAIN_ACCOUNT="codexbar-verify-1844"
+CREDS_REAL="$HOME/.claude/.credentials.json"
+CREDS_BACKUP="$ARTIFACT/credentials.json.backup"
+CONFIG="$ARTIFACT/config.json"
+MCP_PAYLOAD='{"mcpOAuth":{"plugin:slack:slack":{"accessToken":""},"craft":{"accessToken":""}}}'
+EXPIRED_PAYLOAD='{"claudeAiOauth":{"accessToken":"verify-expired-redacted","expiresAt":1000,"scopes":["user:profile"],"refreshToken":"verify-refresh-redacted"}}'
+
+HAD_CREDS=0
+[[ -f "$CREDS_REAL" ]] && HAD_CREDS=1 && cp -p "$CREDS_REAL" "$CREDS_BACKUP"
+
+cleanup() {
+  security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" >/dev/null 2>&1 || true
+  if [[ "$HAD_CREDS" -eq 1 && -f "$CREDS_BACKUP" ]]; then
+    mv -f "$CREDS_BACKUP" "$CREDS_REAL"
+  else
+    rm -f "$CREDS_REAL"
+  fi
+}
+trap cleanup EXIT
+
+log "=== Phase 2: optional Keychain fixture E2E ==="
+log "If macOS prompts for Keychain access, click Allow (needed once to install test fixture)."
+
+security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" >/dev/null 2>&1 || true
+if ! security add-generic-password \
+  -a "$KEYCHAIN_ACCOUNT" \
+  -s "$KEYCHAIN_SERVICE" \
+  -w "$MCP_PAYLOAD" \
+  -T "$CLI" \
+  -U 2>"$ARTIFACT/keychain-install.err"; then
+  log "Phase 2 SKIPPED: Keychain fixture install failed (see $ARTIFACT/keychain-install.err)"
+  log "Phase 1 integration proof is still valid for merge review."
+  exit 0
+fi
+
+mkdir -p "$HOME/.claude"
+printf '%s\n' "$EXPIRED_PAYLOAD" >"$CREDS_REAL"
+chmod 600 "$CREDS_REAL"
+printf '%s\n' '{"version":1,"providers":[{"id":"claude","enabled":true}]}' >"$CONFIG"
+
+PROC_LOG="$ARTIFACT/e2e-proc.log"
+: >"$PROC_LOG"
+log "Running background Claude OAuth CLI probe..."
+(
+  CODEXBAR_CONFIG="$CONFIG" CODEXBAR_DEBUG_CLAUDE_OAUTH_FLOW=1 \
+    "$CLI" usage --provider claude --source oauth --format json --json-output --log-level debug \
+      >"$ARTIFACT/e2e-stdout.json" 2>"$ARTIFACT/e2e-stderr.jsonl"
+) &
+PID=$!
+while kill -0 "$PID" 2>/dev/null; do
+  { date -u +%H:%M:%S; pgrep -P "$PID" -l 2>/dev/null || true
+    pgrep -fl '/usr/bin/open|firefox|claude' 2>/dev/null | rg -v 'CodexBarCLI|verify_1844' || true
+  } >>"$PROC_LOG"
+  sleep 0.05
+done
+wait "$PID" || true
+
+{
+  echo "# CodexBar #1844 E2E verification"
+  echo "date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "claude: $(claude --version 2>/dev/null || echo n/a)"
+  echo
+  echo "## stdout"
+  cat "$ARTIFACT/e2e-stdout.json"
+  echo
+  echo "## stderr (filtered)"
+  rg -i 'mcp|delegated|expired|oauth|touch|open|only prompt' "$ARTIFACT/e2e-stderr.jsonl" || true
+  echo
+  echo "## child processes"
+  cat "$PROC_LOG"
+} | tee "$ARTIFACT/E2E-REPORT.md"
+
+if rg -q '/usr/bin/open|firefox' "$PROC_LOG" 2>/dev/null; then
+  log "FAIL: browser/open detected"
+  exit 1
+fi
+if rg -q 'delegated refresh touch' "$ARTIFACT/e2e-stderr.jsonl" 2>/dev/null; then
+  log "FAIL: delegated CLI touch ran"
+  exit 1
+fi
+if ! rg -qi 'mcp oauth|MCP OAuth state only|only prompt on user action' \
+  "$ARTIFACT/e2e-stderr.jsonl" "$ARTIFACT/e2e-stdout.json" 2>/dev/null; then
+  log "FAIL: missing fail-closed messaging"
+  exit 1
+fi
+
+log "Phase 2 PASS: E2E background probe failed closed without open/delegated touch"
+log "Report: $ARTIFACT/E2E-REPORT.md"

--- a/Scripts/verify_1844_live.sh
+++ b/Scripts/verify_1844_live.sh
@@ -1,121 +1,205 @@
 #!/usr/bin/env bash
-# Live verification for CodexBar #1844 / PR #1848
-# Usage: ./Scripts/verify_1844_live.sh
+# Isolated live verification for CodexBar #1844 / PR #1848.
+# Uses only synthetic credentials under a disposable HOME and keychain.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-ARTIFACT="${TMPDIR:-/tmp}/codexbar-1844-verify"
-mkdir -p "$ARTIFACT"
-
-CLI="${CODEXBAR_CLI:-$ROOT/.build/release/CodexBarCLI}"
-if [[ ! -x "$CLI" ]]; then
-  CLI="$ROOT/CodexBar.app/Contents/Helpers/CodexBarCLI"
-fi
-if [[ ! -x "$CLI" ]]; then
-  echo "Building CodexBarCLI..."
-  swift build -c release --product CodexBarCLI
-  CLI="$ROOT/.build/release/CodexBarCLI"
-fi
-
 log() { printf '[verify-1844] %s\n' "$*"; }
 
-log "Phase 1: macOS integration tests"
+ARTIFACT="$(mktemp -d "${TMPDIR:-/tmp}/codexbar-1844-verify.XXXXXX")"
+chmod 700 "$ARTIFACT"
+HOME_FIXTURE="$ARTIFACT/home"
+KEYCHAIN="$ARTIFACT/claude-fixture.keychain-db"
+KEYCHAIN_PASSWORD="codexbar-1844-synthetic-fixture"
+CONFIG="$ARTIFACT/config.json"
+CLI="${CODEXBAR_CLI:-$ROOT/CodexBar.app/Contents/Helpers/CodexBarCLI}"
+APP="${CODEXBAR_APP_BINARY:-$ROOT/CodexBar.app/Contents/MacOS/CodexBar}"
+MCP_PAYLOAD='{"mcpOAuth":{"plugin:synthetic":{"accessToken":"synthetic-mcp-token"}}}'
+EXPIRED_PAYLOAD='{"claudeAiOauth":{"accessToken":"synthetic-expired-token","expiresAt":1000,"scopes":["user:profile"],"refreshToken":"synthetic-refresh-token"}}'
+
+if [[ ! -x "$CLI" ]]; then
+  log "Missing packaged CLI: $CLI"
+  log "Run ./Scripts/package_app.sh, then retry."
+  exit 2
+fi
+if [[ ! -x "$APP" ]]; then
+  log "Missing packaged app binary: $APP"
+  exit 2
+fi
+
+cleanup() {
+  /usr/bin/security delete-keychain "$KEYCHAIN" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+log "Artifacts: $ARTIFACT"
+log "Phase 1: focused integration tests"
 {
   swift test --filter ClaudeOAuthTests
   swift test --filter ClaudeUsageTests
   swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
   swift test --filter 'expired claude CLI owner blocks background'
+  swift test --filter ClaudeOAuthCredentialsStoreSecurityCLITests
+  swift test --filter ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests
 } 2>&1 | tee "$ARTIFACT/integration-tests.log"
 log "Phase 1 passed"
 
-KEYCHAIN_SERVICE="Claude Code-credentials"
-KEYCHAIN_ACCOUNT="codexbar-verify-1844"
-CREDS_REAL="$HOME/.claude/.credentials.json"
-CREDS_BACKUP="$ARTIFACT/credentials.json.backup"
-CONFIG="$ARTIFACT/config.json"
-MCP_PAYLOAD='{"mcpOAuth":{"plugin:slack:slack":{"accessToken":""},"craft":{"accessToken":""}}}'
-EXPIRED_PAYLOAD='{"claudeAiOauth":{"accessToken":"verify-expired-redacted","expiresAt":1000,"scopes":["user:profile"],"refreshToken":"verify-refresh-redacted"}}'
+log "Phase 2: disposable HOME, keychain, credentials, config, and Claude CLI canary"
+mkdir -p "$HOME_FIXTURE/.claude" "$HOME_FIXTURE/Library/Preferences" "$ARTIFACT/bin"
+chmod 700 "$HOME_FIXTURE" "$HOME_FIXTURE/.claude" "$HOME_FIXTURE/Library" \
+  "$HOME_FIXTURE/Library/Preferences" "$ARTIFACT/bin"
+printf '%s\n' "$EXPIRED_PAYLOAD" >"$HOME_FIXTURE/.claude/.credentials.json"
+chmod 600 "$HOME_FIXTURE/.claude/.credentials.json"
+printf '%s\n' '{"version":1,"providers":[{"id":"claude","enabled":true,"source":"oauth"}]}' >"$CONFIG"
+chmod 600 "$CONFIG"
+printf '%s\n' '#!/usr/bin/env bash' 'printf touched >"$CODEXBAR_CLAUDE_TOUCH_CANARY"' 'exit 99' \
+  >"$ARTIFACT/bin/claude"
+chmod 700 "$ARTIFACT/bin/claude"
 
-HAD_CREDS=0
-[[ -f "$CREDS_REAL" ]] && HAD_CREDS=1 && cp -p "$CREDS_REAL" "$CREDS_BACKUP"
-
-cleanup() {
-  security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" >/dev/null 2>&1 || true
-  if [[ "$HAD_CREDS" -eq 1 && -f "$CREDS_BACKUP" ]]; then
-    mv -f "$CREDS_BACKUP" "$CREDS_REAL"
-  else
-    rm -f "$CREDS_REAL"
-  fi
-}
-trap cleanup EXIT
-
-log "Phase 2: optional Keychain fixture E2E"
-log "Approve the macOS Keychain prompt if shown (required once to install the test fixture)."
-
-security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" >/dev/null 2>&1 || true
-if ! security add-generic-password \
-  -a "$KEYCHAIN_ACCOUNT" \
-  -s "$KEYCHAIN_SERVICE" \
+/usr/bin/security list-keychains -d user >"$ARTIFACT/keychains-before.txt"
+/usr/bin/security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+/usr/bin/security set-keychain-settings -t 3600 "$KEYCHAIN"
+/usr/bin/security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+/usr/bin/security add-generic-password \
+  -a codexbar-verify-1844 \
+  -s 'Claude Code-credentials' \
   -w "$MCP_PAYLOAD" \
-  -T "$CLI" \
-  -U 2>"$ARTIFACT/keychain-install.err"; then
-  log "Phase 2 skipped: could not install Keychain fixture (see $ARTIFACT/keychain-install.err)"
-  log "Phase 1 integration results remain valid for review."
-  exit 0
+  -A \
+  "$KEYCHAIN"
+/usr/bin/security list-keychains -d user >"$ARTIFACT/keychains-after.txt"
+if ! cmp -s "$ARTIFACT/keychains-before.txt" "$ARTIFACT/keychains-after.txt"; then
+  log "Phase 2 failed: creating the disposable keychain changed the user search list"
+  exit 1
 fi
+/usr/bin/security find-generic-password \
+  -s 'Claude Code-credentials' \
+  -w \
+  "$KEYCHAIN" >"$ARTIFACT/keychain-fixture.json"
+cmp -s "$ARTIFACT/keychain-fixture.json" <(printf '%s\n' "$MCP_PAYLOAD")
 
-mkdir -p "$HOME/.claude"
-printf '%s\n' "$EXPIRED_PAYLOAD" >"$CREDS_REAL"
-chmod 600 "$CREDS_REAL"
-printf '%s\n' '{"version":1,"providers":[{"id":"claude","enabled":true}]}' >"$CONFIG"
-
-PROC_LOG="$ARTIFACT/e2e-proc.log"
+PROC_LOG="$ARTIFACT/e2e-processes.log"
+STDOUT="$ARTIFACT/e2e-stdout.json"
+STDERR="$ARTIFACT/e2e-stderr.jsonl"
+CANARY="$ARTIFACT/claude-touch-canary"
 : >"$PROC_LOG"
-log "Running background Claude OAuth CLI probe"
+
+set +e
 (
-  CODEXBAR_CONFIG="$CONFIG" CODEXBAR_DEBUG_CLAUDE_OAUTH_FLOW=1 \
-    "$CLI" usage --provider claude --source oauth --format json --json-output --log-level debug \
-      >"$ARTIFACT/e2e-stdout.json" 2>"$ARTIFACT/e2e-stderr.jsonl"
+  env \
+    HOME="$HOME_FIXTURE" \
+    CFFIXED_USER_HOME="$HOME_FIXTURE" \
+    CODEXBAR_CONFIG="$CONFIG" \
+    CODEXBAR_DISABLE_KEYCHAIN_ACCESS=1 \
+    CODEXBAR_CLAUDE_SECURITY_CLI_KEYCHAIN="$KEYCHAIN" \
+    CODEXBAR_CLAUDE_TOUCH_CANARY="$CANARY" \
+    CODEXBAR_DEBUG_CLAUDE_OAUTH_FLOW=1 \
+    PATH="$ARTIFACT/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    "$CLI" usage --provider claude --source oauth --format json --pretty --log-level debug \
+      >"$STDOUT" 2>"$STDERR"
 ) &
 PID=$!
 while kill -0 "$PID" 2>/dev/null; do
-  { date -u +%H:%M:%S; pgrep -P "$PID" -l 2>/dev/null || true
-    pgrep -fl '/usr/bin/open|firefox|claude' 2>/dev/null | rg -v 'CodexBarCLI|verify_1844' || true
+  {
+    date -u +%H:%M:%S
+    pgrep -P "$PID" -l 2>/dev/null || true
   } >>"$PROC_LOG"
-  sleep 0.05
+  sleep 0.02
 done
-wait "$PID" || true
+wait "$PID"
+CLI_STATUS=$?
+set -e
 
 {
-  echo "# CodexBar #1844 E2E verification"
+  echo "# CodexBar #1844 isolated E2E verification"
   echo "date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  echo "claude: $(claude --version 2>/dev/null || echo n/a)"
+  echo "candidate: $(git rev-parse HEAD)"
+  echo "packaged-cli: $CLI"
+  echo "cli-exit: $CLI_STATUS"
+  echo "default-keychain-search-list-unchanged: yes"
+  echo "real-home-referenced: no"
+  echo "claude-touch-canary: $([[ -e "$CANARY" ]] && echo touched || echo untouched)"
   echo
   echo "## stdout"
-  cat "$ARTIFACT/e2e-stdout.json"
+  cat "$STDOUT"
   echo
   echo "## stderr (filtered)"
-  rg -i 'mcp|delegated|expired|oauth|touch|open|only prompt' "$ARTIFACT/e2e-stderr.jsonl" || true
+  rg -i 'mcp|delegated|expired|oauth|touch|open|only prompt|user action' "$STDERR" || true
   echo
   echo "## child processes"
   cat "$PROC_LOG"
 } | tee "$ARTIFACT/E2E-REPORT.md"
 
-if rg -q '/usr/bin/open|firefox' "$PROC_LOG" 2>/dev/null; then
-  log "Phase 2 failed: browser or open helper launched"
+if [[ "$CLI_STATUS" -eq 0 ]]; then
+  log "Phase 2 failed: the MCP-only fixture unexpectedly produced successful OAuth usage"
   exit 1
 fi
-if rg -q 'delegated refresh touch' "$ARTIFACT/e2e-stderr.jsonl" 2>/dev/null; then
-  log "Phase 2 failed: delegated CLI touch ran"
+if [[ -e "$CANARY" ]]; then
+  log "Phase 2 failed: delegated Claude CLI touch ran"
   exit 1
 fi
-if ! rg -qi 'mcp oauth|MCP OAuth state only|only prompt on user action' \
-  "$ARTIFACT/e2e-stderr.jsonl" "$ARTIFACT/e2e-stdout.json" 2>/dev/null; then
-  log "Phase 2 failed: expected fail-closed OAuth messaging not found"
+if rg -q '/usr/bin/open|(^|/)open$|firefox|Google Chrome|Safari' "$PROC_LOG" 2>/dev/null; then
+  log "Phase 2 failed: an open helper or browser was a probe child"
+  exit 1
+fi
+if ! rg -qi 'MCP OAuth state only|mcpOAuthOnlyKeychain|MCP OAuth' "$STDERR" "$STDOUT"; then
+  log "Phase 2 failed: expected MCP-only fail-closed message not found"
   exit 1
 fi
 
-log "Phase 2 passed: background probe failed closed without open or delegated CLI touch"
+log "Phase 2 passed: exact packaged CLI failed closed without delegated touch or browser child"
+
+log "Phase 3: isolated packaged app runtime smoke"
+APP_PROC_LOG="$ARTIFACT/app-processes.log"
+APP_STDOUT="$ARTIFACT/app-stdout.log"
+APP_STDERR="$ARTIFACT/app-stderr.log"
+: >"$APP_PROC_LOG"
+(
+  env \
+    HOME="$HOME_FIXTURE" \
+    CFFIXED_USER_HOME="$HOME_FIXTURE" \
+    CODEXBAR_CONFIG="$CONFIG" \
+    CODEXBAR_DISABLE_KEYCHAIN_ACCESS=1 \
+    CODEXBAR_CLAUDE_SECURITY_CLI_KEYCHAIN="$KEYCHAIN" \
+    CODEXBAR_CLAUDE_TOUCH_CANARY="$CANARY" \
+    CODEXBAR_DEBUG_CLAUDE_OAUTH_FLOW=1 \
+    PATH="$ARTIFACT/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    "$APP" >"$APP_STDOUT" 2>"$APP_STDERR"
+) &
+APP_PID=$!
+for _ in $(seq 1 250); do
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
+    log "Phase 3 failed: packaged app exited before the 5-second isolation smoke completed"
+    wait "$APP_PID" || true
+    exit 1
+  fi
+  {
+    date -u +%H:%M:%S
+    pgrep -P "$APP_PID" -l 2>/dev/null || true
+  } >>"$APP_PROC_LOG"
+  sleep 0.02
+done
+kill "$APP_PID"
+wait "$APP_PID" 2>/dev/null || true
+
+if [[ -e "$CANARY" ]]; then
+  log "Phase 3 failed: packaged app invoked delegated Claude CLI touch"
+  exit 1
+fi
+if rg -q '/usr/bin/open|(^|/)open$|firefox|Google Chrome|Safari' "$APP_PROC_LOG" 2>/dev/null; then
+  log "Phase 3 failed: an open helper or browser was an app child"
+  exit 1
+fi
+{
+  echo
+  echo "## packaged app runtime"
+  echo "app-binary: $APP"
+  echo "isolated-runtime-seconds: 5"
+  echo "app-stayed-running: yes"
+  echo "claude-touch-canary: untouched"
+  echo "browser-child: none"
+} | tee -a "$ARTIFACT/E2E-REPORT.md"
+
+log "Phase 3 passed: packaged app stayed running in isolation without delegated touch or browser child"
 log "Report: $ARTIFACT/E2E-REPORT.md"

--- a/Scripts/verify_1844_live.sh
+++ b/Scripts/verify_1844_live.sh
@@ -22,8 +22,12 @@ fi
 log() { printf '[verify-1844] %s\n' "$*"; }
 
 log "Phase 1: macOS integration tests"
-swift test --filter 'mcp O auth|delegated retry experimental|load with auto refresh expired claude CLI owner throws mcp' \
-  2>&1 | tee "$ARTIFACT/integration-tests.log"
+{
+  swift test --filter ClaudeOAuthTests
+  swift test --filter ClaudeUsageTests
+  swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
+  swift test --filter 'expired claude CLI owner blocks background'
+} 2>&1 | tee "$ARTIFACT/integration-tests.log"
 log "Phase 1 passed"
 
 KEYCHAIN_SERVICE="Claude Code-credentials"

--- a/Scripts/verify_1844_live.sh
+++ b/Scripts/verify_1844_live.sh
@@ -55,9 +55,25 @@ printf '%s\n' "$EXPIRED_PAYLOAD" >"$HOME_FIXTURE/.claude/.credentials.json"
 chmod 600 "$HOME_FIXTURE/.claude/.credentials.json"
 printf '%s\n' '{"version":1,"providers":[{"id":"claude","enabled":true,"source":"oauth"}]}' >"$CONFIG"
 chmod 600 "$CONFIG"
-printf '%s\n' '#!/usr/bin/env bash' 'printf touched >"$CODEXBAR_CLAUDE_TOUCH_CANARY"' 'exit 99' \
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "args:" >>"$CODEXBAR_CLAUDE_INVOCATIONS"' \
+  'printf " %q" "$@" >>"$CODEXBAR_CLAUDE_INVOCATIONS"' \
+  'printf "\\n" >>"$CODEXBAR_CLAUDE_INVOCATIONS"' \
+  'if [[ "$*" == "auth status --json" ]]; then printf "{\"loggedIn\":true}\\n"; exit 0; fi' \
+  'if [[ "$*" == "--version" ]]; then printf "2.1.0\\n"; exit 0; fi' \
+  'if IFS= read -r line; then' \
+  '  printf "stdin:%s\\n" "$line" >>"$CODEXBAR_CLAUDE_INVOCATIONS"' \
+  '  if [[ "$line" == *"/status"* ]]; then printf touched >"$CODEXBAR_CLAUDE_TOUCH_CANARY"; fi' \
+  'fi' \
+  'exit 99' \
   >"$ARTIFACT/bin/claude"
-chmod 700 "$ARTIFACT/bin/claude"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf touched >"$CODEXBAR_OPEN_TOUCH_CANARY"' \
+  'exit 99' \
+  >"$ARTIFACT/bin/open"
+chmod 700 "$ARTIFACT/bin/claude" "$ARTIFACT/bin/open"
 
 /usr/bin/security list-keychains -d user >"$ARTIFACT/keychains-before.txt"
 /usr/bin/security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
@@ -83,8 +99,11 @@ cmp -s "$ARTIFACT/keychain-fixture.json" <(printf '%s\n' "$MCP_PAYLOAD")
 PROC_LOG="$ARTIFACT/e2e-processes.log"
 STDOUT="$ARTIFACT/e2e-stdout.json"
 STDERR="$ARTIFACT/e2e-stderr.jsonl"
-CANARY="$ARTIFACT/claude-touch-canary"
+CANARY="$ARTIFACT/claude-status-canary"
+INVOCATIONS="$ARTIFACT/claude-invocations.log"
+OPEN_CANARY="$ARTIFACT/open-touch-canary"
 : >"$PROC_LOG"
+: >"$INVOCATIONS"
 
 set +e
 (
@@ -95,7 +114,10 @@ set +e
     CODEXBAR_DISABLE_KEYCHAIN_ACCESS=1 \
     CODEXBAR_CLAUDE_SECURITY_CLI_KEYCHAIN="$KEYCHAIN" \
     CODEXBAR_CLAUDE_TOUCH_CANARY="$CANARY" \
+    CODEXBAR_CLAUDE_INVOCATIONS="$INVOCATIONS" \
+    CODEXBAR_OPEN_TOUCH_CANARY="$OPEN_CANARY" \
     CODEXBAR_DEBUG_CLAUDE_OAUTH_FLOW=1 \
+    CLAUDE_CLI_PATH="$ARTIFACT/bin/claude" \
     PATH="$ARTIFACT/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
     "$CLI" usage --provider claude --source oauth --format json --pretty --log-level debug \
       >"$STDOUT" 2>"$STDERR"
@@ -120,13 +142,17 @@ set -e
   echo "cli-exit: $CLI_STATUS"
   echo "default-keychain-search-list-unchanged: yes"
   echo "real-home-referenced: no"
-  echo "claude-touch-canary: $([[ -e "$CANARY" ]] && echo touched || echo untouched)"
+  echo "claude-status-canary: $([[ -e "$CANARY" ]] && echo touched || echo untouched)"
+  echo "open-touch-canary: $([[ -e "$OPEN_CANARY" ]] && echo touched || echo untouched)"
   echo
   echo "## stdout"
   cat "$STDOUT"
   echo
   echo "## stderr (filtered)"
   rg -i 'mcp|delegated|expired|oauth|touch|open|only prompt|user action' "$STDERR" || true
+  echo
+  echo "## Claude CLI invocations"
+  cat "$INVOCATIONS"
   echo
   echo "## child processes"
   cat "$PROC_LOG"
@@ -137,7 +163,11 @@ if [[ "$CLI_STATUS" -eq 0 ]]; then
   exit 1
 fi
 if [[ -e "$CANARY" ]]; then
-  log "Phase 2 failed: delegated Claude CLI touch ran"
+  log "Phase 2 failed: delegated Claude CLI /status touch ran"
+  exit 1
+fi
+if [[ -e "$OPEN_CANARY" ]]; then
+  log "Phase 2 failed: browser/open helper ran"
   exit 1
 fi
 if rg -q '/usr/bin/open|(^|/)open$|firefox|Google Chrome|Safari' "$PROC_LOG" 2>/dev/null; then
@@ -149,13 +179,14 @@ if ! rg -qi 'MCP OAuth state only|mcpOAuthOnlyKeychain|MCP OAuth' "$STDERR" "$ST
   exit 1
 fi
 
-log "Phase 2 passed: exact packaged CLI failed closed without delegated touch or browser child"
+log "Phase 2 passed: exact packaged CLI failed closed without delegated /status touch or browser child"
 
 log "Phase 3: isolated packaged app runtime smoke"
 APP_PROC_LOG="$ARTIFACT/app-processes.log"
 APP_STDOUT="$ARTIFACT/app-stdout.log"
 APP_STDERR="$ARTIFACT/app-stderr.log"
 : >"$APP_PROC_LOG"
+: >"$INVOCATIONS"
 (
   env \
     HOME="$HOME_FIXTURE" \
@@ -164,14 +195,19 @@ APP_STDERR="$ARTIFACT/app-stderr.log"
     CODEXBAR_DISABLE_KEYCHAIN_ACCESS=1 \
     CODEXBAR_CLAUDE_SECURITY_CLI_KEYCHAIN="$KEYCHAIN" \
     CODEXBAR_CLAUDE_TOUCH_CANARY="$CANARY" \
+    CODEXBAR_CLAUDE_INVOCATIONS="$INVOCATIONS" \
+    CODEXBAR_OPEN_TOUCH_CANARY="$OPEN_CANARY" \
     CODEXBAR_DEBUG_CLAUDE_OAUTH_FLOW=1 \
+    CLAUDE_CLI_PATH="$ARTIFACT/bin/claude" \
     PATH="$ARTIFACT/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
     "$APP" >"$APP_STDOUT" 2>"$APP_STDERR"
 ) &
 APP_PID=$!
-for _ in $(seq 1 250); do
+APP_OBSERVED_CLI=0
+POST_DISCOVERY_TICKS=0
+for _ in $(seq 1 1000); do
   if ! kill -0 "$APP_PID" 2>/dev/null; then
-    log "Phase 3 failed: packaged app exited before the 5-second isolation smoke completed"
+    log "Phase 3 failed: packaged app exited before the isolated startup smoke completed"
     wait "$APP_PID" || true
     exit 1
   fi
@@ -179,13 +215,28 @@ for _ in $(seq 1 250); do
     date -u +%H:%M:%S
     pgrep -P "$APP_PID" -l 2>/dev/null || true
   } >>"$APP_PROC_LOG"
+  if rg -q '^args: --version$' "$INVOCATIONS"; then
+    APP_OBSERVED_CLI=1
+    POST_DISCOVERY_TICKS=$((POST_DISCOVERY_TICKS + 1))
+    if [[ "$POST_DISCOVERY_TICKS" -ge 250 ]]; then
+      break
+    fi
+  fi
   sleep 0.02
 done
 kill "$APP_PID"
 wait "$APP_PID" 2>/dev/null || true
 
+if [[ "$APP_OBSERVED_CLI" -ne 1 ]]; then
+  log "Phase 3 failed: packaged app never exercised the isolated Claude CLI fixture"
+  exit 1
+fi
 if [[ -e "$CANARY" ]]; then
-  log "Phase 3 failed: packaged app invoked delegated Claude CLI touch"
+  log "Phase 3 failed: packaged app invoked delegated Claude CLI /status touch"
+  exit 1
+fi
+if [[ -e "$OPEN_CANARY" ]]; then
+  log "Phase 3 failed: packaged app invoked browser/open helper"
   exit 1
 fi
 if rg -q '/usr/bin/open|(^|/)open$|firefox|Google Chrome|Safari' "$APP_PROC_LOG" 2>/dev/null; then
@@ -196,11 +247,16 @@ fi
   echo
   echo "## packaged app runtime"
   echo "app-binary: $APP"
-  echo "isolated-runtime-seconds: 5"
+  echo "isolated-claude-cli-discovery-observed: yes"
+  echo "post-discovery-observation-seconds: 5"
   echo "app-stayed-running: yes"
-  echo "claude-touch-canary: untouched"
+  echo "claude-status-canary: untouched"
+  echo "open-touch-canary: untouched"
   echo "browser-child: none"
+  echo
+  echo "## packaged app Claude CLI invocations"
+  cat "$INVOCATIONS"
 } | tee -a "$ARTIFACT/E2E-REPORT.md"
 
-log "Phase 3 passed: packaged app stayed running in isolation without delegated touch or browser child"
+log "Phase 3 passed: packaged app exercised CLI discovery without delegated /status touch or browser child"
 log "Report: $ARTIFACT/E2E-REPORT.md"

--- a/Scripts/verify_1844_live.sh
+++ b/Scripts/verify_1844_live.sh
@@ -21,10 +21,10 @@ fi
 
 log() { printf '[verify-1844] %s\n' "$*"; }
 
-log "=== Phase 1: macOS integration tests (real binaries) ==="
+log "Phase 1: macOS integration tests"
 swift test --filter 'mcp O auth|delegated retry experimental|load with auto refresh expired claude CLI owner throws mcp' \
   2>&1 | tee "$ARTIFACT/integration-tests.log"
-log "Phase 1 PASS"
+log "Phase 1 passed"
 
 KEYCHAIN_SERVICE="Claude Code-credentials"
 KEYCHAIN_ACCOUNT="codexbar-verify-1844"
@@ -47,8 +47,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-log "=== Phase 2: optional Keychain fixture E2E ==="
-log "If macOS prompts for Keychain access, click Allow (needed once to install test fixture)."
+log "Phase 2: optional Keychain fixture E2E"
+log "Approve the macOS Keychain prompt if shown (required once to install the test fixture)."
 
 security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" >/dev/null 2>&1 || true
 if ! security add-generic-password \
@@ -57,8 +57,8 @@ if ! security add-generic-password \
   -w "$MCP_PAYLOAD" \
   -T "$CLI" \
   -U 2>"$ARTIFACT/keychain-install.err"; then
-  log "Phase 2 SKIPPED: Keychain fixture install failed (see $ARTIFACT/keychain-install.err)"
-  log "Phase 1 integration proof is still valid for merge review."
+  log "Phase 2 skipped: could not install Keychain fixture (see $ARTIFACT/keychain-install.err)"
+  log "Phase 1 integration results remain valid for review."
   exit 0
 fi
 
@@ -69,7 +69,7 @@ printf '%s\n' '{"version":1,"providers":[{"id":"claude","enabled":true}]}' >"$CO
 
 PROC_LOG="$ARTIFACT/e2e-proc.log"
 : >"$PROC_LOG"
-log "Running background Claude OAuth CLI probe..."
+log "Running background Claude OAuth CLI probe"
 (
   CODEXBAR_CONFIG="$CONFIG" CODEXBAR_DEBUG_CLAUDE_OAUTH_FLOW=1 \
     "$CLI" usage --provider claude --source oauth --format json --json-output --log-level debug \
@@ -100,18 +100,18 @@ wait "$PID" || true
 } | tee "$ARTIFACT/E2E-REPORT.md"
 
 if rg -q '/usr/bin/open|firefox' "$PROC_LOG" 2>/dev/null; then
-  log "FAIL: browser/open detected"
+  log "Phase 2 failed: browser or open helper launched"
   exit 1
 fi
 if rg -q 'delegated refresh touch' "$ARTIFACT/e2e-stderr.jsonl" 2>/dev/null; then
-  log "FAIL: delegated CLI touch ran"
+  log "Phase 2 failed: delegated CLI touch ran"
   exit 1
 fi
 if ! rg -qi 'mcp oauth|MCP OAuth state only|only prompt on user action' \
   "$ARTIFACT/e2e-stderr.jsonl" "$ARTIFACT/e2e-stdout.json" 2>/dev/null; then
-  log "FAIL: missing fail-closed messaging"
+  log "Phase 2 failed: expected fail-closed OAuth messaging not found"
   exit 1
 fi
 
-log "Phase 2 PASS: E2E background probe failed closed without open/delegated touch"
+log "Phase 2 passed: background probe failed closed without open or delegated CLI touch"
 log "Report: $ARTIFACT/E2E-REPORT.md"

--- a/Scripts/verify_1844_live.sh
+++ b/Scripts/verify_1844_live.sh
@@ -43,6 +43,7 @@ log "Phase 1: focused integration tests"
   swift test --filter 'expired claude CLI owner blocks background'
   swift test --filter ClaudeOAuthCredentialsStoreSecurityCLITests
   swift test --filter ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests
+  swift test --filter ClaudeOAuthCredentialsStoreMCPOnlyGuardTests
 } 2>&1 | tee "$ARTIFACT/integration-tests.log"
 log "Phase 1 passed"
 

--- a/Sources/CodexBarCore/KeychainAccessGate.swift
+++ b/Sources/CodexBarCore/KeychainAccessGate.swift
@@ -5,6 +5,7 @@ import SweetCookieKit
 
 public enum KeychainAccessGate {
     private static let flagKey = "debugDisableKeychainAccess"
+    static let disableAccessEnvironmentKey = "CODEXBAR_DISABLE_KEYCHAIN_ACCESS"
     @TaskLocal private static var taskOverrideValue: Bool?
     private nonisolated(unsafe) static var overrideValue: Bool?
     private static let processForceDisabledLock = NSLock()
@@ -13,6 +14,7 @@ public enum KeychainAccessGate {
     public nonisolated(unsafe) static var isDisabled: Bool {
         get {
             if let taskOverrideValue { return taskOverrideValue }
+            if self.isDisabledByEnvironment() { return true }
             #if DEBUG
             if Self.forcesDisabledUnderTests {
                 return true
@@ -32,6 +34,12 @@ public enum KeychainAccessGate {
             BrowserCookieKeychainAccessGate.isDisabled = self.isDisabled
             #endif
         }
+    }
+
+    static func isDisabledByEnvironment(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool
+    {
+        environment[self.disableAccessEnvironmentKey] == "1"
     }
 
     public static func forceDisabledForProcess(reason: String) {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
@@ -87,7 +87,18 @@ public struct ClaudeOAuthCredentials: Sendable {
         return normalized
     }
 
+    public static func isMcpOAuthOnlyPayload(data: Data) -> Bool {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return false
+        }
+        return json["claudeAiOauth"] == nil && json["mcpOAuth"] != nil
+    }
+
     public static func parse(data: Data) throws -> ClaudeOAuthCredentials {
+        if ClaudeOAuthCredentials.isMcpOAuthOnlyPayload(data: data) {
+            throw ClaudeOAuthCredentialsError.mcpOAuthOnlyKeychain
+        }
+
         let decoder = JSONDecoder()
         guard let root = try? decoder.decode(Root.self, from: data) else {
             throw ClaudeOAuthCredentialsError.decodeFailed
@@ -215,6 +226,7 @@ public struct ClaudeOAuthCredentialRecord: Sendable {
 public enum ClaudeOAuthCredentialsError: LocalizedError, Sendable {
     case decodeFailed
     case missingOAuth
+    case mcpOAuthOnlyKeychain
     case missingAccessToken
     case notFound
     case keychainError(Int)
@@ -229,6 +241,11 @@ public enum ClaudeOAuthCredentialsError: LocalizedError, Sendable {
             return "Claude OAuth credentials are invalid."
         case .missingOAuth:
             return "Claude OAuth credentials missing. Run `claude` to authenticate."
+        case .mcpOAuthOnlyKeychain:
+            return "Claude keychain contains MCP OAuth state only (no claudeAiOauth). "
+                + "Claude Code may store subscription OAuth elsewhere now. "
+                + "Open the CodexBar menu and click Refresh to re-authenticate, "
+                + "or switch Claude Usage source to Web/CLI."
         case .missingAccessToken:
             return "Claude OAuth access token missing. Run `claude` to authenticate."
         case .notFound:

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
@@ -350,14 +350,16 @@ extension ClaudeOAuthCredentialsStore {
         guard !keychainAccessDisabled || self.isolatedSecurityCLIKeychainPath(environment: environment) != nil else {
             return false
         }
-        guard readStrategy == .securityCLIExperimental else { return false }
-        guard let payload = self.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
-            interaction: interaction,
-            readStrategy: readStrategy,
-            environment: environment)
-        else {
-            return false
+        let payload: Data? = switch readStrategy {
+        case .securityFramework:
+            self.readRawClaudeKeychainPayloadViaSecurityFrameworkWithoutPrompt()
+        case .securityCLIExperimental:
+            self.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
+                interaction: interaction,
+                readStrategy: readStrategy,
+                environment: environment)
         }
+        guard let payload else { return false }
         return ClaudeOAuthCredentials.isMcpOAuthOnlyPayload(data: payload)
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
@@ -12,6 +12,7 @@ import Musl
 extension ClaudeOAuthCredentialsStore {
     private static let securityBinaryPath = "/usr/bin/security"
     private static let securityCLIReadTimeout: TimeInterval = 1.5
+    static let isolatedSecurityCLIKeychainEnvironmentKey = "CODEXBAR_CLAUDE_SECURITY_CLI_KEYCHAIN"
 
     struct SecurityCLIReadRequest {
         let account: String?
@@ -27,6 +28,7 @@ extension ClaudeOAuthCredentialsStore {
     #if os(macOS)
     private enum SecurityCLIReadError: Error {
         case binaryUnavailable
+        case isolatedKeychainUnavailable
         case launchFailed
         case timedOut
         case nonZeroExit(status: Int32, stderrLength: Int)
@@ -85,7 +87,8 @@ extension ClaudeOAuthCredentialsStore {
 
     static func readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
         interaction: ProviderInteraction,
-        readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current())
+        readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current(),
+        environment: [String: String] = ProcessInfo.processInfo.environment)
         -> Data?
     {
         guard self.shouldPreferSecurityCLIKeychainRead(readStrategy: readStrategy) else { return nil }
@@ -119,7 +122,8 @@ extension ClaudeOAuthCredentialsStore {
             } else {
                 let result = try self.runClaudeSecurityCLIRead(
                     timeout: self.securityCLIReadTimeout,
-                    account: preferredAccount)
+                    account: preferredAccount,
+                    environment: environment)
                 output = result.stdout
                 status = result.status
                 stderrLength = result.stderrLength
@@ -128,7 +132,8 @@ extension ClaudeOAuthCredentialsStore {
             #else
             let result = try self.runClaudeSecurityCLIRead(
                 timeout: self.securityCLIReadTimeout,
-                account: preferredAccount)
+                account: preferredAccount,
+                environment: environment)
             output = result.stdout
             status = result.status
             stderrLength = result.stderrLength
@@ -170,6 +175,8 @@ extension ClaudeOAuthCredentialsStore {
             switch error {
             case .binaryUnavailable:
                 metadata["reason"] = "binaryUnavailable"
+            case .isolatedKeychainUnavailable:
+                metadata["reason"] = "isolatedKeychainUnavailable"
             case .launchFailed:
                 metadata["reason"] = "launchFailed"
             case .timedOut:
@@ -203,21 +210,15 @@ extension ClaudeOAuthCredentialsStore {
 
     private static func runClaudeSecurityCLIRead(
         timeout: TimeInterval,
-        account: String?) throws -> SecurityCLIReadCommandResult
+        account: String?,
+        environment: [String: String]) throws -> SecurityCLIReadCommandResult
     {
         guard FileManager.default.isExecutableFile(atPath: self.securityBinaryPath) else {
             throw SecurityCLIReadError.binaryUnavailable
         }
-
-        var arguments = [
-            "find-generic-password",
-            "-s",
-            self.claudeKeychainService,
-        ]
-        if let account, !account.isEmpty {
-            arguments.append(contentsOf: ["-a", account])
+        guard let arguments = self.securityCLIReadArguments(account: account, environment: environment) else {
+            throw SecurityCLIReadError.isolatedKeychainUnavailable
         }
-        arguments.append("-w")
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: self.securityBinaryPath)
@@ -267,6 +268,31 @@ extension ClaudeOAuthCredentialsStore {
             durationMs: durationMs)
     }
 
+    static func securityCLIReadArguments(
+        account: String?,
+        environment: [String: String]) -> [String]?
+    {
+        var arguments = [
+            "find-generic-password",
+            "-s",
+            self.claudeKeychainService,
+        ]
+        if let account, !account.isEmpty {
+            arguments.append(contentsOf: ["-a", account])
+        }
+        arguments.append("-w")
+
+        let rawIsolatedPath = environment[self.isolatedSecurityCLIKeychainEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if rawIsolatedPath != nil || KeychainAccessGate.isDisabledByEnvironment(environment) {
+            guard let isolatedPath = self.isolatedSecurityCLIKeychainPath(environment: environment) else {
+                return nil
+            }
+            arguments.append(isolatedPath)
+        }
+        return arguments
+    }
+
     private static func terminate(process: Process, processGroup: pid_t?) {
         guard process.isRunning else { return }
         process.terminate()
@@ -295,23 +321,40 @@ extension ClaudeOAuthCredentialsStore {
 
     static func readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
         interaction _: ProviderInteraction,
-        readStrategy _: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current())
+        readStrategy _: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current(),
+        environment _: [String: String] = ProcessInfo.processInfo.environment)
         -> Data?
     {
         nil
     }
     #endif
 
+    private static func isolatedSecurityCLIKeychainPath(environment: [String: String]) -> String? {
+        guard KeychainAccessGate.isDisabledByEnvironment(environment) else { return nil }
+        guard let rawPath = environment[self.isolatedSecurityCLIKeychainEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawPath.isEmpty,
+            (rawPath as NSString).isAbsolutePath
+        else {
+            return nil
+        }
+        return URL(fileURLWithPath: rawPath).standardizedFileURL.path
+    }
+
     static func isMcpOAuthOnlyClaudeKeychainPayloadPresent(
         interaction: ProviderInteraction,
         readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current(),
-        keychainAccessDisabled: Bool = KeychainAccessGate.isDisabled) -> Bool
+        keychainAccessDisabled: Bool = KeychainAccessGate.isDisabled,
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool
     {
-        guard !keychainAccessDisabled else { return false }
+        guard !keychainAccessDisabled || self.isolatedSecurityCLIKeychainPath(environment: environment) != nil else {
+            return false
+        }
         guard readStrategy == .securityCLIExperimental else { return false }
         guard let payload = self.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
             interaction: interaction,
-            readStrategy: readStrategy)
+            readStrategy: readStrategy,
+            environment: environment)
         else {
             return false
         }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
@@ -83,6 +83,22 @@ extension ClaudeOAuthCredentialsStore {
         return sanitized
     }
 
+    static func isMcpOAuthOnlyClaudeKeychainPayloadPresent(
+        interaction: ProviderInteraction,
+        readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current(),
+        keychainAccessDisabled: Bool = KeychainAccessGate.isDisabled) -> Bool
+    {
+        guard !keychainAccessDisabled else { return false }
+        guard readStrategy == .securityCLIExperimental else { return false }
+        guard let payload = self.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
+            interaction: interaction,
+            readStrategy: readStrategy)
+        else {
+            return false
+        }
+        return ClaudeOAuthCredentials.isMcpOAuthOnlyPayload(data: payload)
+    }
+
     static func readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
         interaction: ProviderInteraction,
         readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current())

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
@@ -83,22 +83,6 @@ extension ClaudeOAuthCredentialsStore {
         return sanitized
     }
 
-    static func isMcpOAuthOnlyClaudeKeychainPayloadPresent(
-        interaction: ProviderInteraction,
-        readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current(),
-        keychainAccessDisabled: Bool = KeychainAccessGate.isDisabled) -> Bool
-    {
-        guard !keychainAccessDisabled else { return false }
-        guard readStrategy == .securityCLIExperimental else { return false }
-        guard let payload = self.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
-            interaction: interaction,
-            readStrategy: readStrategy)
-        else {
-            return false
-        }
-        return ClaudeOAuthCredentials.isMcpOAuthOnlyPayload(data: payload)
-    }
-
     static func readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
         interaction: ProviderInteraction,
         readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current())
@@ -317,4 +301,20 @@ extension ClaudeOAuthCredentialsStore {
         nil
     }
     #endif
+
+    static func isMcpOAuthOnlyClaudeKeychainPayloadPresent(
+        interaction: ProviderInteraction,
+        readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current(),
+        keychainAccessDisabled: Bool = KeychainAccessGate.isDisabled) -> Bool
+    {
+        guard !keychainAccessDisabled else { return false }
+        guard readStrategy == .securityCLIExperimental else { return false }
+        guard let payload = self.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
+            interaction: interaction,
+            readStrategy: readStrategy)
+        else {
+            return false
+        }
+        return ClaudeOAuthCredentials.isMcpOAuthOnlyPayload(data: payload)
+    }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
@@ -46,6 +46,48 @@ extension ClaudeOAuthCredentialsStore {
         readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current())
         -> Data?
     {
+        guard let sanitized = self.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
+            interaction: interaction,
+            readStrategy: readStrategy)
+        else {
+            return nil
+        }
+
+        let interactionMetadata = interaction == .userInitiated ? "user" : "background"
+        let parsedCredentials: ClaudeOAuthCredentials
+        do {
+            parsedCredentials = try ClaudeOAuthCredentials.parse(data: sanitized)
+        } catch {
+            self.log.warning(
+                "Claude keychain security CLI output invalid; falling back",
+                metadata: [
+                    "reader": "securityCLI",
+                    "callerInteraction": interactionMetadata,
+                    "payload_bytes": "\(sanitized.count)",
+                    "parse_error_type": String(describing: type(of: error)),
+                ])
+            return nil
+        }
+
+        var metadata: [String: String] = [
+            "reader": "securityCLI",
+            "callerInteraction": interactionMetadata,
+            "payload_bytes": "\(sanitized.count)",
+        ]
+        for (key, value) in parsedCredentials.diagnosticsMetadata(now: Date()) {
+            metadata[key] = value
+        }
+        self.log.debug(
+            "Claude keychain security CLI read succeeded",
+            metadata: metadata)
+        return sanitized
+    }
+
+    static func readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
+        interaction: ProviderInteraction,
+        readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current())
+        -> Data?
+    {
         guard self.shouldPreferSecurityCLIKeychainRead(readStrategy: readStrategy) else { return nil }
         let interactionMetadata = interaction == .userInitiated ? "user" : "background"
 
@@ -95,12 +137,9 @@ extension ClaudeOAuthCredentialsStore {
 
             let sanitized = self.sanitizeSecurityCLIOutput(output)
             guard !sanitized.isEmpty else { return nil }
-            let parsedCredentials: ClaudeOAuthCredentials
-            do {
-                parsedCredentials = try ClaudeOAuthCredentials.parse(data: sanitized)
-            } catch {
+            if ClaudeOAuthCredentials.isMcpOAuthOnlyPayload(data: sanitized) {
                 self.log.warning(
-                    "Claude keychain security CLI output invalid; falling back",
+                    "Claude keychain security CLI output is MCP OAuth only; falling back",
                     metadata: [
                         "reader": "securityCLI",
                         "callerInteraction": interactionMetadata,
@@ -108,26 +147,19 @@ extension ClaudeOAuthCredentialsStore {
                         "duration_ms": String(format: "%.2f", durationMs),
                         "stderr_length": "\(stderrLength)",
                         "payload_bytes": "\(sanitized.count)",
-                        "parse_error_type": String(describing: type(of: error)),
                     ])
-                return nil
+            } else {
+                self.log.debug(
+                    "Claude keychain security CLI raw read succeeded",
+                    metadata: [
+                        "reader": "securityCLI",
+                        "callerInteraction": interactionMetadata,
+                        "status": "\(status)",
+                        "duration_ms": String(format: "%.2f", durationMs),
+                        "stderr_length": "\(stderrLength)",
+                        "payload_bytes": "\(sanitized.count)",
+                    ])
             }
-
-            var metadata: [String: String] = [
-                "reader": "securityCLI",
-                "callerInteraction": interactionMetadata,
-                "status": "\(status)",
-                "duration_ms": String(format: "%.2f", durationMs),
-                "stderr_length": "\(stderrLength)",
-                "payload_bytes": "\(sanitized.count)",
-                "accountPinned": preferredAccount == nil ? "0" : "1",
-            ]
-            for (key, value) in parsedCredentials.diagnosticsMetadata(now: Date()) {
-                metadata[key] = value
-            }
-            self.log.debug(
-                "Claude keychain security CLI read succeeded",
-                metadata: metadata)
             return sanitized
         } catch let error as SecurityCLIReadError {
             var metadata: [String: String] = [
@@ -254,6 +286,14 @@ extension ClaudeOAuthCredentialsStore {
     }
     #else
     static func loadFromClaudeKeychainViaSecurityCLIIfEnabled(
+        interaction _: ProviderInteraction,
+        readStrategy _: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current())
+        -> Data?
+    {
+        nil
+    }
+
+    static func readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
         interaction _: ProviderInteraction,
         readStrategy _: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current())
         -> Data?

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1174,6 +1174,14 @@ public enum ClaudeOAuthCredentialsStore {
 
         switch record.owner {
         case .claudeCLI:
+            if ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
+                interaction: ProviderInteractionContext.current)
+            {
+                self.log.warning(
+                    "Claude OAuth credentials expired; Claude keychain has MCP OAuth state only",
+                    metadata: expiryMetadata)
+                throw ClaudeOAuthCredentialsError.mcpOAuthOnlyKeychain
+            }
             self.log.info(
                 "Claude OAuth credentials expired; delegating refresh to Claude CLI",
                 metadata: expiryMetadata)

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1174,8 +1174,9 @@ public enum ClaudeOAuthCredentialsStore {
 
         switch record.owner {
         case .claudeCLI:
-            if ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
-                interaction: ProviderInteractionContext.current)
+            if ProviderInteractionContext.current != .userInitiated,
+               ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
+                   interaction: ProviderInteractionContext.current)
             {
                 self.log.warning(
                     "Claude OAuth credentials expired; Claude keychain has MCP OAuth state only",

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1176,7 +1176,8 @@ public enum ClaudeOAuthCredentialsStore {
         case .claudeCLI:
             if ProviderInteractionContext.current != .userInitiated,
                ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
-                   interaction: ProviderInteractionContext.current)
+                   interaction: ProviderInteractionContext.current,
+                   environment: environment)
             {
                 self.log.warning(
                     "Claude OAuth credentials expired; Claude keychain has MCP OAuth state only",

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1635,11 +1635,16 @@ public enum ClaudeOAuthCredentialsStore {
         return "\(modifiedAt):\(fingerprint.size)"
     }
 
-    private static func loadFromClaudeKeychainNonInteractive() throws -> Data? {
+    private static func loadFromClaudeKeychainNonInteractive(
+        readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current())
+        throws -> Data?
+    {
         #if os(macOS)
-        let fallbackPromptMode = ClaudeOAuthKeychainPromptPreference.securityFrameworkFallbackMode()
+        let fallbackPromptMode = ClaudeOAuthKeychainPromptPreference.securityFrameworkFallbackMode(
+            readStrategy: readStrategy)
         if let data = self.loadFromClaudeKeychainViaSecurityCLIIfEnabled(
-            interaction: ProviderInteractionContext.current)
+            interaction: ProviderInteractionContext.current,
+            readStrategy: readStrategy)
         {
             return data
         }
@@ -1669,6 +1674,38 @@ public enum ClaudeOAuthCredentialsStore {
             promptMode: fallbackPromptMode)
         if let legacyData, !legacyData.isEmpty { return legacyData }
         return nil
+        #else
+        return nil
+        #endif
+    }
+
+    static func readRawClaudeKeychainPayloadViaSecurityFrameworkWithoutPrompt() -> Data? {
+        #if os(macOS)
+        guard self.keychainAccessAllowed else { return nil }
+        #if DEBUG
+        if let store = self.taskClaudeKeychainOverrideStore { return store.data }
+        if let override = self.taskClaudeKeychainDataOverride ?? self.claudeKeychainDataOverride { return override }
+        #endif
+
+        // This probe must work under the default `onlyOnUserAction` policy, but must never show Keychain UI.
+        // The candidate and data queries both use KeychainNoUIQuery; `.always` only bypasses the prompt-policy gate.
+        switch self.claudeKeychainCandidatesProbeWithoutPrompt(
+            promptMode: .always,
+            enforcePromptPolicy: false)
+        {
+        case .unavailable:
+            return nil
+        case let .value(candidates):
+            if let newest = candidates.first {
+                return try? self.loadClaudeKeychainData(
+                    candidate: newest,
+                    allowKeychainPrompt: false,
+                    promptMode: .always)
+            }
+        }
+        return try? self.loadClaudeKeychainLegacyData(
+            allowKeychainPrompt: false,
+            promptMode: .always)
         #else
         return nil
         #endif

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -8,6 +8,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         var lastAttemptAt: Date?
         var lastCooldownInterval: TimeInterval?
         var inFlightAttemptID: UInt64?
+        var inFlightInteraction: ProviderInteraction?
         var inFlightTask: Task<Outcome, Never>?
         var nextAttemptID: UInt64 = 0
 
@@ -40,9 +41,29 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             return .attemptedFailed("Cancelled.")
         }
 
-        switch self.inFlightDecision(now: now, timeout: timeout, environment: environment) {
+        let decision = self.inFlightDecision(
+            now: now,
+            timeout: timeout,
+            environment: environment,
+            interaction: ProviderInteractionContext.current)
+        #if DEBUG
+        if case .joinThenRetry = decision {
+            self.userInitiatedBackgroundJoinObserverForTesting?()
+        }
+        #endif
+
+        switch decision {
         case let .join(task):
             return await task.value
+        case let .joinThenRetry(id, task, state):
+            let outcome = await task.value
+            self.clearInFlightTaskIfStillCurrent(id: id, state: state)
+            switch outcome {
+            case .attemptedFailed, .skippedByCooldown, .cliUnavailable:
+                return await self.attempt(now: now, timeout: timeout, environment: environment)
+            case .attemptedSucceeded:
+                return outcome
+            }
         case let .start(id, task, state):
             let outcome = await task.value
             self.clearInFlightTaskIfStillCurrent(id: id, state: state)
@@ -52,11 +73,13 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
 
     private enum InFlightDecision {
         case join(Task<Outcome, Never>)
+        case joinThenRetry(UInt64, Task<Outcome, Never>, AttemptStateStorage)
         case start(UInt64, Task<Outcome, Never>, AttemptStateStorage)
     }
 
     private struct AttemptConfiguration {
         let environment: [String: String]
+        let interaction: ProviderInteraction
         let readStrategy: ClaudeOAuthKeychainReadStrategy
         let keychainAccessDisabled: Bool
         #if DEBUG
@@ -69,13 +92,20 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
     private static func inFlightDecision(
         now: Date,
         timeout: TimeInterval,
-        environment: [String: String]) -> InFlightDecision
+        environment: [String: String],
+        interaction: ProviderInteraction) -> InFlightDecision
     {
         let state = self.currentStateStorage
         state.lock.lock()
         defer { state.lock.unlock() }
 
         if let existing = state.inFlightTask {
+            if interaction == .userInitiated,
+               state.inFlightInteraction != .userInitiated,
+               let existingID = state.inFlightAttemptID
+            {
+                return .joinThenRetry(existingID, existing, state)
+            }
             return .join(existing)
         }
 
@@ -85,6 +115,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         #if DEBUG
         let configuration = AttemptConfiguration(
             environment: environment,
+            interaction: interaction,
             readStrategy: ClaudeOAuthKeychainReadStrategyPreference.current(),
             keychainAccessDisabled: KeychainAccessGate.isDisabled,
             cliAvailableOverride: self.cliAvailableOverrideForTesting,
@@ -94,6 +125,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         #else
         let configuration = AttemptConfiguration(
             environment: environment,
+            interaction: interaction,
             readStrategy: ClaudeOAuthKeychainReadStrategyPreference.current(),
             keychainAccessDisabled: KeychainAccessGate.isDisabled)
         #endif
@@ -115,6 +147,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             #endif
         }
         state.inFlightAttemptID = attemptID
+        state.inFlightInteraction = interaction
         state.inFlightTask = task
         return .start(attemptID, task, state)
     }
@@ -132,12 +165,17 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
 
         // Atomically reserve an attempt under the lock so concurrent callers don't race past isInCooldown() and start
         // multiple touches/poll loops.
-        guard self.reserveAttemptIfNotInCooldown(now: now, state: state) else {
+        guard self.reserveAttemptIfNotInCooldown(
+            now: now,
+            bypassCooldown: configuration.interaction == .userInitiated,
+            state: state)
+        else {
             self.log.debug("Claude OAuth delegated refresh skipped by cooldown")
             return .skippedByCooldown
         }
 
         if let mcpOAuthOnlyFailure = self.mcpOAuthOnlyKeychainFailureIfPresent(
+            interaction: configuration.interaction,
             readStrategy: configuration.readStrategy,
             keychainAccessDisabled: configuration.keychainAccessDisabled)
         {
@@ -375,11 +413,13 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
     }
 
     private static func mcpOAuthOnlyKeychainFailureIfPresent(
+        interaction: ProviderInteraction,
         readStrategy: ClaudeOAuthKeychainReadStrategy,
         keychainAccessDisabled: Bool) -> String?
     {
+        guard interaction != .userInitiated else { return nil }
         guard ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
-            interaction: .background,
+            interaction: interaction,
             readStrategy: readStrategy,
             keychainAccessDisabled: keychainAccessDisabled)
         else {
@@ -393,6 +433,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         state.lock.lock()
         if state.inFlightAttemptID == id {
             state.inFlightAttemptID = nil
+            state.inFlightInteraction = nil
             state.inFlightTask = nil
         }
         state.lock.unlock()
@@ -409,13 +450,20 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         UserDefaults.standard.set(cooldown, forKey: self.cooldownIntervalDefaultsKey)
     }
 
-    private static func reserveAttemptIfNotInCooldown(now: Date, state: AttemptStateStorage) -> Bool {
+    private static func reserveAttemptIfNotInCooldown(
+        now: Date,
+        bypassCooldown: Bool,
+        state: AttemptStateStorage) -> Bool
+    {
         state.lock.lock()
         defer { state.lock.unlock() }
         self.loadStateIfNeededLocked(state: state)
 
         let cooldown = state.lastCooldownInterval ?? self.defaultCooldownInterval
-        if let lastAttemptAt = state.lastAttemptAt, now.timeIntervalSince(lastAttemptAt) < cooldown {
+        if !bypassCooldown,
+           let lastAttemptAt = state.lastAttemptAt,
+           now.timeIntervalSince(lastAttemptAt) < cooldown
+        {
             return false
         }
 
@@ -457,6 +505,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         [String: String]) async throws -> Void)?
     @TaskLocal static var keychainFingerprintOverrideForTesting: (@Sendable () -> ClaudeOAuthCredentialsStore
         .ClaudeKeychainFingerprint?)?
+    @TaskLocal static var userInitiatedBackgroundJoinObserverForTesting: (@Sendable () -> Void)?
 
     static func withCLIAvailableOverrideForTesting<T>(
         _ override: Bool?,
@@ -485,6 +534,15 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         }
     }
 
+    static func withUserInitiatedBackgroundJoinObserverForTesting<T>(
+        _ observer: (@Sendable () -> Void)?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$userInitiatedBackgroundJoinObserverForTesting.withValue(observer) {
+            try await operation()
+        }
+    }
+
     static func withIsolatedStateForTesting<T>(operation: () async throws -> T) async rethrows -> T {
         let state = AttemptStateStorage(persistsCooldown: false)
         return try await self.$stateStorageForTesting.withValue(state) {
@@ -499,6 +557,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         state.lastAttemptAt = nil
         state.lastCooldownInterval = nil
         state.inFlightAttemptID = nil
+        state.inFlightInteraction = nil
         state.inFlightTask = nil
         state.nextAttemptID = 0
         state.lock.unlock()

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -137,6 +137,17 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             return .skippedByCooldown
         }
 
+        if let mcpOAuthOnlyFailure = self.mcpOAuthOnlyKeychainFailureIfPresent(
+            readStrategy: configuration.readStrategy,
+            keychainAccessDisabled: configuration.keychainAccessDisabled)
+        {
+            self.recordAttempt(now: now, cooldown: self.defaultCooldownInterval, state: state)
+            self.log.warning(
+                "Claude OAuth delegated refresh skipped: Claude keychain has MCP OAuth state only",
+                metadata: ["readStrategy": configuration.readStrategy.rawValue])
+            return .attemptedFailed(mcpOAuthOnlyFailure)
+        }
+
         let baseline = self.currentKeychainChangeObservationBaseline(
             readStrategy: configuration.readStrategy,
             keychainAccessDisabled: configuration.keychainAccessDisabled,
@@ -358,9 +369,26 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         interaction: ProviderInteraction) -> Data?
     {
         guard !keychainAccessDisabled else { return nil }
-        return ClaudeOAuthCredentialsStore.loadFromClaudeKeychainViaSecurityCLIIfEnabled(
+        return ClaudeOAuthCredentialsStore.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
             interaction: interaction,
             readStrategy: readStrategy)
+    }
+
+    private static func mcpOAuthOnlyKeychainFailureIfPresent(
+        readStrategy: ClaudeOAuthKeychainReadStrategy,
+        keychainAccessDisabled: Bool) -> String?
+    {
+        guard !keychainAccessDisabled else { return nil }
+        guard readStrategy == .securityCLIExperimental else { return nil }
+        guard let payload = ClaudeOAuthCredentialsStore.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
+            interaction: .background,
+            readStrategy: readStrategy),
+            ClaudeOAuthCredentials.isMcpOAuthOnlyPayload(data: payload)
+        else {
+            return nil
+        }
+        return ClaudeOAuthCredentialsError.mcpOAuthOnlyKeychain.errorDescription
+            ?? "Claude keychain contains MCP OAuth state only."
     }
 
     private static func clearInFlightTaskIfStillCurrent(id: UInt64, state: AttemptStateStorage) {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -177,7 +177,8 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         if let mcpOAuthOnlyFailure = self.mcpOAuthOnlyKeychainFailureIfPresent(
             interaction: configuration.interaction,
             readStrategy: configuration.readStrategy,
-            keychainAccessDisabled: configuration.keychainAccessDisabled)
+            keychainAccessDisabled: configuration.keychainAccessDisabled,
+            environment: configuration.environment)
         {
             self.recordAttempt(now: now, cooldown: self.defaultCooldownInterval, state: state)
             self.log.warning(
@@ -415,13 +416,15 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
     private static func mcpOAuthOnlyKeychainFailureIfPresent(
         interaction: ProviderInteraction,
         readStrategy: ClaudeOAuthKeychainReadStrategy,
-        keychainAccessDisabled: Bool) -> String?
+        keychainAccessDisabled: Bool,
+        environment: [String: String]) -> String?
     {
         guard interaction != .userInitiated else { return nil }
         guard ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
             interaction: interaction,
             readStrategy: readStrategy,
-            keychainAccessDisabled: keychainAccessDisabled)
+            keychainAccessDisabled: keychainAccessDisabled,
+            environment: environment)
         else {
             return nil
         }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -378,12 +378,10 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         readStrategy: ClaudeOAuthKeychainReadStrategy,
         keychainAccessDisabled: Bool) -> String?
     {
-        guard !keychainAccessDisabled else { return nil }
-        guard readStrategy == .securityCLIExperimental else { return nil }
-        guard let payload = ClaudeOAuthCredentialsStore.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
+        guard ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
             interaction: .background,
-            readStrategy: readStrategy),
-            ClaudeOAuthCredentials.isMcpOAuthOnlyPayload(data: payload)
+            readStrategy: readStrategy,
+            keychainAccessDisabled: keychainAccessDisabled)
         else {
             return nil
         }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -198,9 +198,11 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
     }
 
     private static func currentClaudeOAuthDelegatedRefreshPolicy() -> ClaudeOAuthKeychainPromptPolicy {
+        // Delegated refresh must honor the stored prompt mode for every keychain read strategy.
+        // securityCLIExperimental is not "prompt policy N/A" for CLI touch repair.
         ClaudeOAuthKeychainPromptPolicy(
-            mode: ClaudeOAuthKeychainPromptPreference.current(),
-            isApplicable: ClaudeOAuthKeychainPromptPreference.isApplicable(),
+            mode: ClaudeOAuthKeychainPromptPreference.storedMode(),
+            isApplicable: true,
             interaction: ProviderInteractionContext.current)
     }
 
@@ -208,7 +210,6 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         policy: ClaudeOAuthKeychainPromptPolicy,
         allowBackgroundDelegatedRefresh: Bool) throws
     {
-        guard policy.isApplicable else { return }
         if policy.mode == .never {
             throw ClaudeUsageError.oauthFailed("Delegated refresh is disabled by 'never' keychain policy.")
         }
@@ -1396,6 +1397,8 @@ extension ClaudeUsageFetcher {
             "decodeFailed"
         case .missingOAuth:
             "missingOAuth"
+        case .mcpOAuthOnlyKeychain:
+            "mcpOAuthOnlyKeychain"
         case .missingAccessToken:
             "missingAccessToken"
         case .notFound:

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
@@ -499,6 +499,73 @@ struct ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests {
             }
         }
     }
+
+    @Test
+    func `load with auto refresh expired claude CLI owner throws mcp O auth only keychain`() async throws {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        let mcpOAuthOnly = Data("""
+        {
+          "mcpOAuth": {
+            "plugin:slack:slack": { "accessToken": "" }
+          }
+        }
+        """.utf8)
+
+        try await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+            ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
+            defer { ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting() }
+
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("credentials.json")
+
+            await KeychainAccessGate.withTaskOverrideForTesting(false) {
+                await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(
+                    .securityCLIExperimental,
+                    operation: {
+                        await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                            await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(
+                                .data(mcpOAuthOnly))
+                            {
+                                ClaudeOAuthCredentialsStore.invalidateCache()
+                                let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+                                defer { KeychainCacheStore.clear(key: cacheKey) }
+
+                                let expiredData = self.makeCredentialsData(
+                                    accessToken: "expired-claude-cli-owner",
+                                    expiresAt: Date(timeIntervalSinceNow: -3600),
+                                    refreshToken: "refresh-token")
+                                KeychainCacheStore.store(
+                                    key: cacheKey,
+                                    entry: ClaudeOAuthCredentialsStore.CacheEntry(
+                                        data: expiredData,
+                                        storedAt: Date(),
+                                        owner: .claudeCLI))
+
+                                do {
+                                    _ = try await ClaudeOAuthCredentialsStore.loadWithAutoRefresh(
+                                        environment: [:],
+                                        allowKeychainPrompt: false,
+                                        respectKeychainPromptCooldown: true)
+                                    Issue.record("Expected mcpOAuth-only keychain error")
+                                } catch let error as ClaudeOAuthCredentialsError {
+                                    guard case .mcpOAuthOnlyKeychain = error else {
+                                        Issue.record("Expected .mcpOAuthOnlyKeychain, got \(error)")
+                                        return
+                                    }
+                                } catch {
+                                    Issue.record("Expected ClaudeOAuthCredentialsError, got \(error)")
+                                }
+                            }
+                        }
+                    })
+            }
+        }
+    }
 }
 
 private final class ClaudeOAuthTokenRefreshStubURLProtocol: URLProtocol {

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
@@ -501,7 +501,7 @@ struct ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests {
     }
 
     @Test
-    func `load with auto refresh expired claude CLI owner throws mcp O auth only keychain`() async throws {
+    func `expired claude CLI owner blocks background mcp O auth but lets user action delegate`() async throws {
         let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
         let mcpOAuthOnly = Data("""
         {
@@ -555,6 +555,23 @@ struct ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests {
                                 } catch let error as ClaudeOAuthCredentialsError {
                                     guard case .mcpOAuthOnlyKeychain = error else {
                                         Issue.record("Expected .mcpOAuthOnlyKeychain, got \(error)")
+                                        return
+                                    }
+                                } catch {
+                                    Issue.record("Expected ClaudeOAuthCredentialsError, got \(error)")
+                                }
+
+                                do {
+                                    _ = try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                                        try await ClaudeOAuthCredentialsStore.loadWithAutoRefresh(
+                                            environment: [:],
+                                            allowKeychainPrompt: false,
+                                            respectKeychainPromptCooldown: true)
+                                    }
+                                    Issue.record("Expected delegated refresh on explicit user action")
+                                } catch let error as ClaudeOAuthCredentialsError {
+                                    guard case .refreshDelegatedToClaudeCLI = error else {
+                                        Issue.record("Expected .refreshDelegatedToClaudeCLI, got \(error)")
                                         return
                                     }
                                 } catch {

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if os(macOS)
+@Suite(.serialized)
+struct ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests {
+    @Test
+    func `isolated security CLI keychain requires global keychain disable`() {
+        let keychainPath = "/tmp/codexbar-fixtures/verify.keychain-db"
+        let isolatedEnvironment = [
+            KeychainAccessGate.disableAccessEnvironmentKey: "1",
+            ClaudeOAuthCredentialsStore.isolatedSecurityCLIKeychainEnvironmentKey: keychainPath,
+        ]
+        let expectedArguments = [
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+            keychainPath,
+        ]
+
+        #expect(KeychainAccessGate.isDisabledByEnvironment(isolatedEnvironment))
+        #expect(ClaudeOAuthCredentialsStore.securityCLIReadArguments(
+            account: nil,
+            environment: isolatedEnvironment) == expectedArguments)
+        #expect(ClaudeOAuthCredentialsStore.securityCLIReadArguments(
+            account: nil,
+            environment: [
+                ClaudeOAuthCredentialsStore.isolatedSecurityCLIKeychainEnvironmentKey: keychainPath,
+            ]) == nil)
+        #expect(ClaudeOAuthCredentialsStore.securityCLIReadArguments(
+            account: nil,
+            environment: [KeychainAccessGate.disableAccessEnvironmentKey: "1"]) == nil)
+        #expect(ClaudeOAuthCredentialsStore.securityCLIReadArguments(
+            account: nil,
+            environment: [
+                KeychainAccessGate.disableAccessEnvironmentKey: "1",
+                ClaudeOAuthCredentialsStore.isolatedSecurityCLIKeychainEnvironmentKey: "relative.keychain-db",
+            ]) == nil)
+    }
+
+    @Test
+    func `isolated security CLI keychain remains readable while other keychain access is disabled`() {
+        let mcpOnlyPayload = Data(#"{"mcpOAuth":{"plugin:test":{"accessToken":"synthetic"}}}"#.utf8)
+        let environment = [
+            KeychainAccessGate.disableAccessEnvironmentKey: "1",
+            ClaudeOAuthCredentialsStore.isolatedSecurityCLIKeychainEnvironmentKey: "/tmp/verify.keychain-db",
+        ]
+
+        let isMcpOnly = ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.data(mcpOnlyPayload)) {
+            ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
+                interaction: .background,
+                readStrategy: .securityCLIExperimental,
+                keychainAccessDisabled: true,
+                environment: environment)
+        }
+        #expect(isMcpOnly)
+
+        let blockedWithoutIsolatedKeychain = ClaudeOAuthCredentialsStore
+            .withSecurityCLIReadOverrideForTesting(.data(mcpOnlyPayload)) {
+                ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
+                    interaction: .background,
+                    readStrategy: .securityCLIExperimental,
+                    keychainAccessDisabled: true,
+                    environment: [KeychainAccessGate.disableAccessEnvironmentKey: "1"])
+            }
+        #expect(blockedWithoutIsolatedKeychain == false)
+    }
+}
+#endif

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreMCPOnlyGuardTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreMCPOnlyGuardTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if os(macOS)
+@Suite(.serialized)
+struct ClaudeOAuthCredentialsStoreMCPOnlyGuardTests {
+    @Test
+    func `standard reader blocks expired CLI owner in background but preserves user refresh`() async throws {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        let mcpOAuthOnly = Data(#"{"mcpOAuth":{"plugin:test":{"accessToken":"synthetic"}}}"#.utf8)
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let credentialsURL = tempDir.appendingPathComponent("credentials.json")
+
+        await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+            ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
+            defer { ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting() }
+
+            await KeychainAccessGate.withTaskOverrideForTesting(false) {
+                await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
+                    await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
+                        await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(credentialsURL) {
+                            await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+                                data: mcpOAuthOnly,
+                                fingerprint: nil)
+                            {
+                                let isMcpOnly = ProviderInteractionContext.$current.withValue(.background) {
+                                    ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
+                                        interaction: .background,
+                                        readStrategy: .securityFramework,
+                                        keychainAccessDisabled: false,
+                                        environment: [:])
+                                }
+                                #expect(isMcpOnly)
+
+                                ClaudeOAuthCredentialsStore.invalidateCache()
+                                let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+                                defer { KeychainCacheStore.clear(key: cacheKey) }
+                                KeychainCacheStore.store(
+                                    key: cacheKey,
+                                    entry: ClaudeOAuthCredentialsStore.CacheEntry(
+                                        data: self.expiredCredentialsData,
+                                        storedAt: Date(),
+                                        owner: .claudeCLI))
+
+                                do {
+                                    _ = try await ClaudeOAuthCredentialsStore.loadWithAutoRefresh(
+                                        environment: [:],
+                                        allowKeychainPrompt: false,
+                                        respectKeychainPromptCooldown: true)
+                                    Issue.record("Expected MCP-only keychain failure")
+                                } catch let error as ClaudeOAuthCredentialsError {
+                                    guard case .mcpOAuthOnlyKeychain = error else {
+                                        Issue.record("Expected .mcpOAuthOnlyKeychain, got \(error)")
+                                        return
+                                    }
+                                } catch {
+                                    Issue.record("Expected ClaudeOAuthCredentialsError, got \(error)")
+                                }
+
+                                do {
+                                    _ = try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                                        try await ClaudeOAuthCredentialsStore.loadWithAutoRefresh(
+                                            environment: [:],
+                                            allowKeychainPrompt: false,
+                                            respectKeychainPromptCooldown: true)
+                                    }
+                                    Issue.record("Expected explicit user Refresh to delegate")
+                                } catch let error as ClaudeOAuthCredentialsError {
+                                    guard case .refreshDelegatedToClaudeCLI = error else {
+                                        Issue.record("Expected .refreshDelegatedToClaudeCLI, got \(error)")
+                                        return
+                                    }
+                                } catch {
+                                    Issue.record("Expected ClaudeOAuthCredentialsError, got \(error)")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var expiredCredentialsData: Data {
+        let json = #"""
+        {
+          "claudeAiOauth": {
+            "accessToken": "expired",
+            "refreshToken": "refresh",
+            "expiresAt": 1000,
+            "scopes": ["user:profile"]
+          }
+        }
+        """#
+        return Data(json.utf8)
+    }
+}
+#endif

--- a/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
@@ -570,4 +570,51 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
             #expect(securityReadCounter.count < 1)
         }
     }
+
+    @Test
+    func `experimental strategy skips delegated touch for mcp O auth only keychain`() async {
+        ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting()
+        defer { ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting() }
+        await KeychainAccessGate.withTaskOverrideForTesting(false) {
+            await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(
+                .securityCLIExperimental)
+            {
+                final class CounterBox: @unchecked Sendable {
+                    private let lock = NSLock()
+                    private(set) var count: Int = 0
+                    func increment() {
+                        self.lock.lock()
+                        self.count += 1
+                        self.lock.unlock()
+                    }
+                }
+
+                let touchCounter = CounterBox()
+                let mcpOAuthOnly = Data("""
+                {
+                  "mcpOAuth": {
+                    "plugin:slack:slack": { "accessToken": "" }
+                  }
+                }
+                """.utf8)
+                let outcome = await self.withCoordinatorOverrides(
+                    cliAvailable: true,
+                    touchAuthPath: { _, _ in touchCounter.increment() },
+                    operation: {
+                        await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.data(mcpOAuthOnly)) {
+                            await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                                now: Date(timeIntervalSince1970: 63000),
+                                timeout: 0.1)
+                        }
+                    })
+
+                guard case let .attemptedFailed(message) = outcome else {
+                    Issue.record("Expected .attemptedFailed outcome")
+                    return
+                }
+                #expect(message.contains("MCP OAuth"))
+                #expect(touchCounter.count < 1)
+            }
+        }
+    }
 }

--- a/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
@@ -335,6 +335,136 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
     }
 
     @Test
+    func `user action retries after joining failed background attempt`() async throws {
+        ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting()
+        defer { ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting() }
+
+        actor Gate {
+            private var releaseContinuation: CheckedContinuation<Void, Never>?
+            private var startedContinuation: CheckedContinuation<Void, Never>?
+            private var joinedContinuation: CheckedContinuation<Void, Never>?
+            private var hasStarted = false
+            private var isReleased = false
+            private var hasJoined = false
+
+            func markStarted() {
+                self.hasStarted = true
+                self.startedContinuation?.resume()
+                self.startedContinuation = nil
+            }
+
+            func waitStarted() async {
+                if self.hasStarted { return }
+                await withCheckedContinuation { self.startedContinuation = $0 }
+            }
+
+            func release() {
+                self.isReleased = true
+                self.releaseContinuation?.resume()
+                self.releaseContinuation = nil
+            }
+
+            func waitRelease() async {
+                if self.isReleased { return }
+                await withCheckedContinuation { self.releaseContinuation = $0 }
+            }
+
+            func markJoined() {
+                self.hasJoined = true
+                self.joinedContinuation?.resume()
+                self.joinedContinuation = nil
+            }
+
+            func waitJoined() async {
+                if self.hasJoined { return }
+                await withCheckedContinuation { self.joinedContinuation = $0 }
+            }
+        }
+
+        final class StateBox: @unchecked Sendable {
+            private let lock = NSLock()
+            private var touchCount = 0
+            private var fingerprint = ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint(
+                modifiedAt: 1,
+                createdAt: 1,
+                persistentRefHash: "before")
+
+            func beginTouch() -> Int {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                self.touchCount += 1
+                return self.touchCount
+            }
+
+            func markChanged() {
+                self.lock.lock()
+                self.fingerprint = ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint(
+                    modifiedAt: 2,
+                    createdAt: 2,
+                    persistentRefHash: "after")
+                self.lock.unlock()
+            }
+
+            func snapshot() -> (Int, ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint) {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                return (self.touchCount, self.fingerprint)
+            }
+        }
+
+        let gate = Gate()
+        let state = StateBox()
+        let outcomes = try await KeychainAccessGate.withTaskOverrideForTesting(false) {
+            try await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
+                try await self.withCoordinatorOverrides(
+                    isolateState: false,
+                    cliAvailable: true,
+                    touchAuthPath: { _, _ in
+                        if state.beginTouch() == 1 {
+                            await gate.markStarted()
+                            await gate.waitRelease()
+                            throw StubError.failed
+                        }
+                        state.markChanged()
+                    },
+                    keychainFingerprint: { state.snapshot().1 },
+                    operation: {
+                        await ClaudeOAuthDelegatedRefreshCoordinator
+                            .withUserInitiatedBackgroundJoinObserverForTesting {
+                                Task { await gate.markJoined() }
+                            } operation: {
+                                let background = Task {
+                                    await ProviderInteractionContext.$current.withValue(.background) {
+                                        await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                                            now: Date(timeIntervalSince1970: 51000),
+                                            timeout: 2)
+                                    }
+                                }
+                                await gate.waitStarted()
+                                let userInitiated = Task {
+                                    await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                                        await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                                            now: Date(timeIntervalSince1970: 51001),
+                                            timeout: 2)
+                                    }
+                                }
+                                await gate.waitJoined()
+                                await gate.release()
+                                return await (background.value, userInitiated.value)
+                            }
+                    })
+            }
+        }
+
+        guard case .attemptedFailed = outcomes.0 else {
+            Issue.record("Expected the background attempt to fail")
+            return
+        }
+        #expect(outcomes.1 == .attemptedSucceeded)
+        #expect(state.snapshot().0 == 2)
+    }
+
+    @Test
     func `experimental strategy does not use security framework fingerprint observation`() async {
         ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting()
         defer { ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting() }
@@ -572,24 +702,31 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
     }
 
     @Test
-    func `experimental strategy skips delegated touch for mcp O auth only keychain`() async {
+    func `experimental strategy blocks background mcp O auth but lets user action retry`() async {
         ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting()
         defer { ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting() }
         await KeychainAccessGate.withTaskOverrideForTesting(false) {
             await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(
                 .securityCLIExperimental)
             {
-                final class CounterBox: @unchecked Sendable {
+                final class StateBox: @unchecked Sendable {
                     private let lock = NSLock()
-                    private(set) var count: Int = 0
-                    func increment() {
+                    private var touchCount = 0
+
+                    func touch() {
                         self.lock.lock()
-                        self.count += 1
+                        self.touchCount += 1
                         self.lock.unlock()
+                    }
+
+                    func count() -> Int {
+                        self.lock.lock()
+                        defer { self.lock.unlock() }
+                        return self.touchCount
                     }
                 }
 
-                let touchCounter = CounterBox()
+                let state = StateBox()
                 let mcpOAuthOnly = Data("""
                 {
                   "mcpOAuth": {
@@ -597,23 +734,39 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
                   }
                 }
                 """.utf8)
-                let outcome = await self.withCoordinatorOverrides(
+                let refreshedCredentials = self.makeCredentialsData(
+                    accessToken: "refreshed-after-user-action",
+                    expiresAt: Date(timeIntervalSinceNow: 3600))
+                let outcomes = await self.withCoordinatorOverrides(
                     cliAvailable: true,
-                    touchAuthPath: { _, _ in touchCounter.increment() },
+                    touchAuthPath: { _, _ in state.touch() },
                     operation: {
-                        await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.data(mcpOAuthOnly)) {
-                            await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
-                                now: Date(timeIntervalSince1970: 63000),
-                                timeout: 0.1)
+                        await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.dynamic { _ in
+                            state.count() > 0 ? refreshedCredentials : mcpOAuthOnly
+                        }) {
+                            let background = await ProviderInteractionContext.$current.withValue(.background) {
+                                await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                                    now: Date(timeIntervalSince1970: 63000),
+                                    timeout: 0.1)
+                            }
+                            let backgroundTouchCount = state.count()
+                            let userInitiated = await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                                await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                                    now: Date(timeIntervalSince1970: 63001),
+                                    timeout: 0.1)
+                            }
+                            return (background, backgroundTouchCount, userInitiated)
                         }
                     })
 
-                guard case let .attemptedFailed(message) = outcome else {
-                    Issue.record("Expected .attemptedFailed outcome")
+                guard case let .attemptedFailed(message) = outcomes.0 else {
+                    Issue.record("Expected background .attemptedFailed outcome")
                     return
                 }
                 #expect(message.contains("MCP OAuth"))
-                #expect(touchCounter.count < 1)
+                #expect(outcomes.1 == 0)
+                #expect(outcomes.2 == .attemptedSucceeded)
+                #expect(state.count() == 1)
             }
         }
     }

--- a/Tests/CodexBarTests/ClaudeOAuthTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthTests.swift
@@ -53,6 +53,35 @@ struct ClaudeOAuthTests {
     }
 
     @Test
+    func `mcp O auth only keychain payload throws`() {
+        let json = """
+        {
+          "mcpOAuth": {
+            "plugin:slack:slack": {
+              "accessToken": ""
+            }
+          }
+        }
+        """
+        #expect(throws: ClaudeOAuthCredentialsError.self) {
+            _ = try ClaudeOAuthCredentials.parse(data: Data(json.utf8))
+        }
+    }
+
+    @Test
+    func `detects mcp O auth only keychain payload shape`() {
+        let json = """
+        {
+          "mcpOAuth": {
+            "craft": { "accessToken": "" }
+          }
+        }
+        """
+        let data = Data(json.utf8)
+        #expect(ClaudeOAuthCredentials.isMcpOAuthOnlyPayload(data: data))
+    }
+
+    @Test
     func `treats missing expiry as expired`() {
         let creds = ClaudeOAuthCredentials(
             accessToken: "token",

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -1407,7 +1407,7 @@ extension ClaudeUsageTests {
     }
 
     @Test
-    func `oauth delegated retry experimental background ignores only on user action suppression`() async throws {
+    func `oauth delegated retry experimental background respects only on user action suppression`() async throws {
         let loadCounter = AsyncCounter()
         let delegatedCounter = AsyncCounter()
         let usageResponse = try Self.makeOAuthUsageResponse()
@@ -1431,43 +1431,36 @@ extension ClaudeUsageTests {
             [String: String],
             Bool,
             Bool) async throws -> ClaudeOAuthCredentials)? = { _, _, _ in
-            let call = await loadCounter.increment()
-            if call == 1 {
-                throw ClaudeOAuthCredentialsError.refreshDelegatedToClaudeCLI
-            }
-            return ClaudeOAuthCredentials(
-                accessToken: "fresh-token",
-                refreshToken: "refresh-token",
-                expiresAt: Date(timeIntervalSinceNow: 3600),
-                scopes: ["user:profile"],
-                rateLimitTier: nil)
+            _ = await loadCounter.increment()
+            throw ClaudeOAuthCredentialsError.refreshDelegatedToClaudeCLI
         }
 
-        let snapshot = try await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(
-            .securityCLIExperimental,
-            operation: {
-                try await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
-                    try await ProviderInteractionContext.$current.withValue(.background) {
-                        try await ClaudeUsageFetcher.$hasCachedCredentialsOverride.withValue(true) {
-                            try await ClaudeUsageFetcher.$fetchOAuthUsageOverride.withValue(fetchOverride) {
-                                try await ClaudeUsageFetcher.$delegatedRefreshAttemptOverride.withValue(
-                                    delegatedOverride)
-                                {
-                                    try await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(
-                                        loadCredsOverride)
+        await #expect(throws: ClaudeUsageError.self) {
+            try await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(
+                .securityCLIExperimental,
+                operation: {
+                    try await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
+                        try await ProviderInteractionContext.$current.withValue(.background) {
+                            try await ClaudeUsageFetcher.$hasCachedCredentialsOverride.withValue(true) {
+                                try await ClaudeUsageFetcher.$fetchOAuthUsageOverride.withValue(fetchOverride) {
+                                    try await ClaudeUsageFetcher.$delegatedRefreshAttemptOverride.withValue(
+                                        delegatedOverride)
                                     {
-                                        try await fetcher.loadLatestUsage(model: "sonnet")
+                                        try await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(
+                                            loadCredsOverride)
+                                        {
+                                            try await fetcher.loadLatestUsage(model: "sonnet")
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
-            })
+                })
+        }
 
-        #expect(await loadCounter.current() == 2)
-        #expect(await delegatedCounter.current() == 1)
-        #expect(snapshot.primary.usedPercent == 7)
+        #expect(await loadCounter.current() == 1)
+        #expect(await delegatedCounter.current() == 0)
     }
 
     @Test

--- a/TestsLinux/ClaudeOAuthDelegatedRefreshLinuxTests.swift
+++ b/TestsLinux/ClaudeOAuthDelegatedRefreshLinuxTests.swift
@@ -63,13 +63,8 @@ struct ClaudeOAuthDelegatedRefreshLinuxTests {
             interaction: .background,
             promptMode: .onlyOnUserAction)
 
-        #if os(Linux)
-        #expect(result.attempts == 1)
-        #expect(result.message.contains("still unavailable after delegated Claude CLI refresh"))
-        #else
         #expect(result.attempts == 0)
         #expect(result.message.contains("background repair is suppressed"))
-        #endif
     }
 
     private func runDelegatedRefresh(

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -65,6 +65,7 @@ Admin API key setup:
   - CodexBar OAuth cache when available.
   - File fallback: `~/.claude/.credentials.json`.
   - Claude CLI Keychain bootstrap/repair fallback: `Claude Code-credentials`.
+- On Claude Code 2.1.x, `Claude Code-credentials` may contain only MCP server OAuth state (`mcpOAuth`) with no `claudeAiOauth`. CodexBar treats that as an OAuth configuration error, does not run background delegated `claude /status` refresh, and surfaces re-auth guidance. Use Web or CLI usage source, or restore a valid Claude OAuth keychain entry. See #1844.
 - Requires `user:profile` scope (CLI tokens with only `user:inference` cannot call usage).
 - Endpoint:
   - `GET https://api.anthropic.com/api/oauth/usage`

--- a/docs/pr-1848-body.md
+++ b/docs/pr-1848-body.md
@@ -1,0 +1,47 @@
+## Summary
+
+Partial fix for #1844: when Claude Code stores only MCP OAuth state in `Claude Code-credentials` (no `claudeAiOauth`), CodexBar no longer runs background delegated `claude /status` refresh—which can launch the default browser via `/usr/bin/open`.
+
+**Scope:** Phase 1 guard only. Does not discover Claude Code 2.1.x's primary OAuth storage location.
+
+## Problem
+
+On Claude Code 2.1.x, the `Claude Code-credentials` keychain item may contain only `mcpOAuth`. CodexBar then fails to parse Claude OAuth credentials, treats the session as expired, and may periodically attempt delegated CLI refresh. That path can open the user's default browser from the background.
+
+Contributing issues on `main`:
+
+1. Delegated refresh used `ClaudeOAuthKeychainPromptPreference.current()`, which becomes `.always` when the experimental security CLI reader is active—so `onlyOnUserAction` did not suppress background repair.
+2. Delegated refresh could still invoke `claude /status` even when the keychain shape could not succeed.
+
+## Changes
+
+1. **Honor stored keychain prompt mode for delegated refresh** across all keychain read strategies (including `securityCLIExperimental`). Background refresh with `onlyOnUserAction` fails closed with existing user-action guidance instead of calling `claude /status`.
+2. **Detect MCP-only keychain payloads** via `ClaudeOAuthCredentialsError.mcpOAuthOnlyKeychain`, skip delegated CLI touch, and fail fast during expired Claude CLI credential load.
+3. **Split security CLI read paths**: `readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled` vs parsed credential load.
+4. **Verification helper**: `Scripts/verify_1844_live.sh` and `docs/verify-1844-proof.md`.
+
+## Tests
+
+- Updated: background delegated-refresh suppression with experimental reader
+- Added: MCP-only parse/shape detection
+- Added: coordinator test—no delegated touch for MCP-only keychain
+- Added: store test—expired CLI owner fails fast before delegation
+
+## Verification
+
+- [x] Focused macOS integration tests (2026-07-03) — details in `docs/verify-1844-proof.md` and PR comment
+- [x] `make check` on contributor machine
+- [ ] Optional: Keychain fixture E2E via `./Scripts/verify_1844_live.sh` (one Keychain Allow)
+- [ ] Optional: Menu Refresh screenshot on a host with the reporter's keychain shape
+
+### Commands
+
+```bash
+make check
+swift test --filter ClaudeOAuthTests
+swift test --filter 'ClaudeUsageTests.oauth delegated'
+swift test --filter 'ClaudeOAuthDelegatedRefreshCoordinatorTests.experimental strategy skips'
+./Scripts/verify_1844_live.sh
+```
+
+Fixes #1844 (partial)

--- a/docs/pr-1848-body.md
+++ b/docs/pr-1848-body.md
@@ -1,6 +1,6 @@
 ## Summary
 
-Partial fix for #1844: when Claude Code stores only MCP OAuth state in `Claude Code-credentials` (no `claudeAiOauth`), CodexBar no longer runs background delegated `claude /status` refresh—which can launch the default browser via `/usr/bin/open`.
+Partial fix related to https://github.com/steipete/CodexBar/issues/1844: when Claude Code stores only MCP OAuth state in `Claude Code-credentials` (no `claudeAiOauth`), CodexBar no longer runs background delegated `claude /status` refresh—which can launch the default browser via `/usr/bin/open`.
 
 **Scope:** Phase 1 guard only. Does not discover Claude Code 2.1.x's primary OAuth storage location.
 
@@ -18,7 +18,7 @@ Contributing issues on `main`:
 1. **Honor stored keychain prompt mode for delegated refresh** across all keychain read strategies (including `securityCLIExperimental`). Background refresh with `onlyOnUserAction` fails closed with existing user-action guidance instead of calling `claude /status`.
 2. **Detect MCP-only keychain payloads** via `ClaudeOAuthCredentialsError.mcpOAuthOnlyKeychain`, skip delegated CLI touch, and fail fast during expired Claude CLI credential load.
 3. **Split security CLI read paths**: `readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled` vs parsed credential load.
-4. **Verification helper**: `Scripts/verify_1844_live.sh` and `docs/verify-1844-proof.md`.
+4. **Isolated verification helper**: the production `/usr/bin/security` reader can target a disposable keychain only while all general keychain access is disabled. `Scripts/verify_1844_live.sh` combines that keychain with disposable `HOME`, `CFFIXED_USER_HOME`, credentials, config, and a synthetic `claude` touch canary.
 
 ## Tests
 
@@ -26,12 +26,13 @@ Contributing issues on `main`:
 - Added: MCP-only parse/shape detection
 - Added: coordinator test—background MCP-only guard plus explicit Refresh recovery
 - Added: store test—expired CLI owner fails closed in background and delegates on explicit Refresh
+- Added: fail-closed tests for the isolated-keychain argument seam
 
 ## Verification
 
-- [x] Focused macOS integration tests (2026-07-03) — details in `docs/verify-1844-proof.md` and PR comment
-- [x] `make check` on contributor machine
-- [ ] Optional: Keychain fixture E2E via `./Scripts/verify_1844_live.sh` (one Keychain Allow)
+- [x] Focused macOS integration tests (2026-07-03) — details in `docs/verify-1844-proof.md`
+- [x] Release-built `CodexBar.app` and packaged `CodexBarCLI` isolated live proof
+- [ ] Final `make check`, sharded `make test`, and autoreview on the local port
 - [ ] Optional: Menu Refresh screenshot on a host with the reporter's keychain shape
 
 ### Commands
@@ -45,4 +46,4 @@ swift test --filter 'expired claude CLI owner blocks background'
 ./Scripts/verify_1844_live.sh
 ```
 
-Fixes #1844 (partial)
+Related: https://github.com/steipete/CodexBar/issues/1844 (Phase 1 only; the issue must remain open for primary OAuth storage discovery and reporter-environment confirmation.)

--- a/docs/pr-1848-body.md
+++ b/docs/pr-1848-body.md
@@ -32,7 +32,7 @@ Contributing issues on `main`:
 
 - [x] Focused macOS integration tests (2026-07-03) — details in `docs/verify-1844-proof.md`
 - [x] Release-built `CodexBar.app` and packaged `CodexBarCLI` isolated live proof
-- [ ] Final `make check`, sharded `make test`, and autoreview on the local port
+- [x] Final `make check`, 45-shard `make test`, and autoreview on the local port
 - [ ] Optional: Menu Refresh screenshot on a host with the reporter's keychain shape
 
 ### Commands

--- a/docs/pr-1848-body.md
+++ b/docs/pr-1848-body.md
@@ -1,8 +1,8 @@
 ## Summary
 
-Partial fix related to https://github.com/steipete/CodexBar/issues/1844: when Claude Code stores only MCP OAuth state in `Claude Code-credentials` (no `claudeAiOauth`), CodexBar no longer runs background delegated `claude /status` refresh—which can launch the default browser via `/usr/bin/open`.
+Fixes the background browser-launch regression in https://github.com/steipete/CodexBar/issues/1844: when Claude Code stores only MCP OAuth state in `Claude Code-credentials` (no `claudeAiOauth`), CodexBar no longer runs background delegated `claude /status` refresh—which can launch the default browser via `/usr/bin/open`.
 
-**Scope:** Phase 1 guard only. Does not discover Claude Code 2.1.x's primary OAuth storage location.
+**Scope:** fail-closed safety guard for both keychain readers. Discovery of Claude Code 2.1.x's primary OAuth storage location remains tracked by https://github.com/steipete/CodexBar/issues/1823.
 
 ## Problem
 
@@ -16,7 +16,7 @@ Contributing issues on `main`:
 ## Changes
 
 1. **Honor stored keychain prompt mode for delegated refresh** across all keychain read strategies (including `securityCLIExperimental`). Background refresh with `onlyOnUserAction` fails closed with existing user-action guidance instead of calling `claude /status`.
-2. **Detect MCP-only keychain payloads** via `ClaudeOAuthCredentialsError.mcpOAuthOnlyKeychain`, skip delegated CLI touch, and fail fast during expired Claude CLI credential load.
+2. **Detect MCP-only keychain payloads through both keychain readers** via `ClaudeOAuthCredentialsError.mcpOAuthOnlyKeychain`, skip delegated CLI touch, and fail fast during expired Claude CLI credential load.
 3. **Split security CLI read paths**: `readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled` vs parsed credential load.
 4. **Isolated verification helper**: the production `/usr/bin/security` reader can target a disposable keychain only while all general keychain access is disabled. `Scripts/verify_1844_live.sh` combines that keychain with disposable `HOME`, `CFFIXED_USER_HOME`, credentials, config, and a synthetic `claude` touch canary.
 
@@ -27,6 +27,7 @@ Contributing issues on `main`:
 - Added: coordinator test—background MCP-only guard plus explicit Refresh recovery
 - Added: store test—expired CLI owner fails closed in background and delegates on explicit Refresh
 - Added: fail-closed tests for the isolated-keychain argument seam
+- Added: standard Security.framework reader regression—background fails closed while explicit Refresh delegates
 
 ## Verification
 
@@ -43,7 +44,8 @@ swift test --filter ClaudeOAuthTests
 swift test --filter ClaudeUsageTests
 swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
 swift test --filter 'expired claude CLI owner blocks background'
+swift test --filter ClaudeOAuthCredentialsStoreMCPOnlyGuardTests
 ./Scripts/verify_1844_live.sh
 ```
 
-Related: https://github.com/steipete/CodexBar/issues/1844 (Phase 1 only; the issue must remain open for primary OAuth storage discovery and reporter-environment confirmation.)
+Fixes https://github.com/steipete/CodexBar/issues/1844. Primary OAuth storage discovery remains tracked by https://github.com/steipete/CodexBar/issues/1823.

--- a/docs/pr-1848-body.md
+++ b/docs/pr-1848-body.md
@@ -18,7 +18,7 @@ Contributing issues on `main`:
 1. **Honor stored keychain prompt mode for delegated refresh** across all keychain read strategies (including `securityCLIExperimental`). Background refresh with `onlyOnUserAction` fails closed with existing user-action guidance instead of calling `claude /status`.
 2. **Detect MCP-only keychain payloads through both keychain readers** via `ClaudeOAuthCredentialsError.mcpOAuthOnlyKeychain`, skip delegated CLI touch, and fail fast during expired Claude CLI credential load.
 3. **Split security CLI read paths**: `readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled` vs parsed credential load.
-4. **Isolated verification helper**: the production `/usr/bin/security` reader can target a disposable keychain only while all general keychain access is disabled. `Scripts/verify_1844_live.sh` combines that keychain with disposable `HOME`, `CFFIXED_USER_HOME`, credentials, config, and a synthetic `claude` touch canary.
+4. **Isolated verification helper**: the production `/usr/bin/security` reader can target a disposable keychain only while all general keychain access is disabled. `Scripts/verify_1844_live.sh` combines that keychain with disposable `HOME`, `CFFIXED_USER_HOME`, credentials, config, and a synthetic `claude` fixture that distinguishes benign CLI discovery from `/status` touch.
 
 ## Tests
 
@@ -33,8 +33,8 @@ Contributing issues on `main`:
 
 - [x] Focused macOS integration tests (2026-07-03) — details in `docs/verify-1844-proof.md`
 - [x] Release-built `CodexBar.app` and packaged `CodexBarCLI` isolated live proof
+- [x] Real Claude-tab Refresh click against the isolated built app
 - [x] Final `make check`, 45-shard `make test`, and autoreview on the local port
-- [ ] Optional: Menu Refresh screenshot on a host with the reporter's keychain shape
 
 ### Commands
 

--- a/docs/pr-1848-body.md
+++ b/docs/pr-1848-body.md
@@ -24,8 +24,8 @@ Contributing issues on `main`:
 
 - Updated: background delegated-refresh suppression with experimental reader
 - Added: MCP-only parse/shape detection
-- Added: coordinator test—no delegated touch for MCP-only keychain
-- Added: store test—expired CLI owner fails fast before delegation
+- Added: coordinator test—background MCP-only guard plus explicit Refresh recovery
+- Added: store test—expired CLI owner fails closed in background and delegates on explicit Refresh
 
 ## Verification
 
@@ -39,8 +39,9 @@ Contributing issues on `main`:
 ```bash
 make check
 swift test --filter ClaudeOAuthTests
-swift test --filter 'ClaudeUsageTests.oauth delegated'
-swift test --filter 'ClaudeOAuthDelegatedRefreshCoordinatorTests.experimental strategy skips'
+swift test --filter ClaudeUsageTests
+swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
+swift test --filter 'expired claude CLI owner blocks background'
 ./Scripts/verify_1844_live.sh
 ```
 

--- a/docs/pr-1848-verification-comment.md
+++ b/docs/pr-1848-verification-comment.md
@@ -7,16 +7,21 @@ Contributor verification for the Phase 1 guard in this PR. Full write-up: [`docs
 ### Integration tests
 
 ```bash
-swift test --filter 'mcp O auth|delegated retry experimental|load with auto refresh expired claude CLI owner throws mcp'
+swift test --filter ClaudeOAuthTests
+swift test --filter ClaudeUsageTests
+swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
+swift test --filter 'expired claude CLI owner blocks background'
 ```
 
-**Result:** 5/5 passed on macOS release-linked binaries.
+**Result:** all selected suites and the targeted storage-owner regression passed on macOS release-linked binaries.
 
 | Behavior | Result |
 |----------|--------|
 | Background `onlyOnUserAction` suppresses delegated refresh (`securityCLIExperimental`) | Pass |
-| Coordinator skips `claude /status` when keychain is MCP-only | Pass |
-| Expired Claude CLI owner fails fast with `mcpOAuthOnlyKeychain` | Pass |
+| Coordinator skips background `claude /status` when keychain is MCP-only | Pass |
+| Explicit user Refresh bypasses the MCP-only guard and delegated-refresh cooldown | Pass |
+| Explicit user Refresh retries after an in-flight background failure | Pass |
+| Expired Claude CLI owner fails fast with `mcpOAuthOnlyKeychain` in background | Pass |
 
 Representative logs:
 

--- a/docs/pr-1848-verification-comment.md
+++ b/docs/pr-1848-verification-comment.md
@@ -1,0 +1,42 @@
+## macOS verification (2026-07-03)
+
+Contributor verification for the Phase 1 guard in this PR. Full write-up: [`docs/verify-1844-proof.md`](https://github.com/Yuxin-Qiao/CodexBar/blob/cursor/fix-claude-oauth-background-refresh-1114/docs/verify-1844-proof.md) on the PR branch.
+
+**Environment:** macOS arm64, Claude Code 2.1.193, branch `cursor/fix-claude-oauth-background-refresh-1114` @ `7befb637`
+
+### Integration tests
+
+```bash
+swift test --filter 'mcp O auth|delegated retry experimental|load with auto refresh expired claude CLI owner throws mcp'
+```
+
+**Result:** 5/5 passed on macOS release-linked binaries.
+
+| Behavior | Result |
+|----------|--------|
+| Background `onlyOnUserAction` suppresses delegated refresh (`securityCLIExperimental`) | Pass |
+| Coordinator skips `claude /status` when keychain is MCP-only | Pass |
+| Expired Claude CLI owner fails fast with `mcpOAuthOnlyKeychain` | Pass |
+
+Representative logs:
+
+```text
+Claude OAuth delegated refresh skipped: Claude keychain has MCP OAuth state only
+Claude OAuth credentials expired; Claude keychain has MCP OAuth state only
+```
+
+No delegated CLI touch or `/usr/bin/open` activity is exercised in these tests.
+
+### Keychain fixture E2E
+
+Not completed in unattended automation (macOS Keychain write requires interactive approval). Optional follow-up on a machine with the reporter's keychain shape, or locally via:
+
+```bash
+./Scripts/verify_1844_live.sh
+```
+
+### Conclusion
+
+Phase 1 code paths are covered by macOS integration tests and demonstrate fail-closed behavior for MCP-only keychain payloads without background delegated CLI refresh.
+
+@clawsweeper re-review

--- a/docs/pr-1848-verification-comment.md
+++ b/docs/pr-1848-verification-comment.md
@@ -1,6 +1,6 @@
 ## Maintainer verification (2026-07-03)
 
-Local current-main port of https://github.com/steipete/CodexBar/pull/1848. This is a Phase 1 guard related to https://github.com/steipete/CodexBar/issues/1844; it intentionally does not close the issue.
+Local current-main port of https://github.com/steipete/CodexBar/pull/1848. This fixes the background browser-launch regression in https://github.com/steipete/CodexBar/issues/1844; primary OAuth storage discovery remains tracked by https://github.com/steipete/CodexBar/issues/1823.
 
 ### Focused regression proof
 
@@ -11,9 +11,10 @@ swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
 swift test --filter 'expired claude CLI owner blocks background'
 swift test --filter ClaudeOAuthCredentialsStoreSecurityCLITests
 swift test --filter ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests
+swift test --filter ClaudeOAuthCredentialsStoreMCPOnlyGuardTests
 ```
 
-Result: **104 tests passed** (33 + 39 + 12 + 1 + 17 + 2).
+Result: **105 tests passed** (33 + 39 + 12 + 1 + 17 + 2 + 1).
 
 | Behavior | Result |
 |----------|--------|
@@ -23,6 +24,7 @@ Result: **104 tests passed** (33 + 39 + 12 + 1 + 17 + 2).
 | Explicit user Refresh retries after an in-flight background failure | Pass |
 | Expired Claude CLI-owned credentials fail closed with `mcpOAuthOnlyKeychain` | Pass |
 | Isolated keychain path is accepted only with general keychain access disabled | Pass |
+| Standard Security.framework reader fails closed in background while explicit Refresh delegates | Pass |
 
 ### Isolated built-bundle proof
 
@@ -41,4 +43,4 @@ The verifier used only synthetic data under a unique temporary directory:
 
 The packaged `CodexBarCLI` exited 3 with the MCP-only guidance, the canary stayed untouched, no browser/open child appeared, and the user keychain search list was unchanged. The packaged `CodexBar.app` binary then stayed running for a five-second isolated smoke with the same untouched canary and no browser/open child.
 
-Final local gates passed: `make check`, all 45 `make test` shards, and autoreview with no accepted/actionable findings. No public PR/issue mutation was performed.
+Final local gates passed: `make check`, all 45 `make test` shards, exact-SHA autoreview, and source-blind behavior validation.

--- a/docs/pr-1848-verification-comment.md
+++ b/docs/pr-1848-verification-comment.md
@@ -1,47 +1,44 @@
-## macOS verification (2026-07-03)
+## Maintainer verification (2026-07-03)
 
-Contributor verification for the Phase 1 guard in this PR. Full write-up: [`docs/verify-1844-proof.md`](https://github.com/Yuxin-Qiao/CodexBar/blob/cursor/fix-claude-oauth-background-refresh-1114/docs/verify-1844-proof.md) on the PR branch.
+Local current-main port of https://github.com/steipete/CodexBar/pull/1848. This is a Phase 1 guard related to https://github.com/steipete/CodexBar/issues/1844; it intentionally does not close the issue.
 
-**Environment:** macOS arm64, Claude Code 2.1.193, branch `cursor/fix-claude-oauth-background-refresh-1114` @ `7befb637`
-
-### Integration tests
+### Focused regression proof
 
 ```bash
 swift test --filter ClaudeOAuthTests
 swift test --filter ClaudeUsageTests
 swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
 swift test --filter 'expired claude CLI owner blocks background'
+swift test --filter ClaudeOAuthCredentialsStoreSecurityCLITests
+swift test --filter ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests
 ```
 
-**Result:** all selected suites and the targeted storage-owner regression passed on macOS release-linked binaries.
+Result: **104 tests passed** (33 + 39 + 12 + 1 + 17 + 2).
 
 | Behavior | Result |
 |----------|--------|
-| Background `onlyOnUserAction` suppresses delegated refresh (`securityCLIExperimental`) | Pass |
-| Coordinator skips background `claude /status` when keychain is MCP-only | Pass |
-| Explicit user Refresh bypasses the MCP-only guard and delegated-refresh cooldown | Pass |
+| Background `onlyOnUserAction` suppresses delegated refresh with `securityCLIExperimental` | Pass |
+| MCP-only background guard prevents `claude /status` touch | Pass |
+| Explicit user Refresh bypasses the MCP-only guard and cooldown | Pass |
 | Explicit user Refresh retries after an in-flight background failure | Pass |
-| Expired Claude CLI owner fails fast with `mcpOAuthOnlyKeychain` in background | Pass |
+| Expired Claude CLI-owned credentials fail closed with `mcpOAuthOnlyKeychain` | Pass |
+| Isolated keychain path is accepted only with general keychain access disabled | Pass |
 
-Representative logs:
-
-```text
-Claude OAuth delegated refresh skipped: Claude keychain has MCP OAuth state only
-Claude OAuth credentials expired; Claude keychain has MCP OAuth state only
-```
-
-No delegated CLI touch or `/usr/bin/open` activity is exercised in these tests.
-
-### Keychain fixture E2E
-
-Not completed in unattended automation (macOS Keychain write requires interactive approval). Optional follow-up on a machine with the reporter's keychain shape, or locally via:
+### Isolated built-bundle proof
 
 ```bash
+./Scripts/package_app.sh
 ./Scripts/verify_1844_live.sh
 ```
 
-### Conclusion
+The verifier used only synthetic data under a unique temporary directory:
 
-Phase 1 code paths are covered by macOS integration tests and demonstrate fail-closed behavior for MCP-only keychain payloads without background delegated CLI refresh.
+- disposable `HOME` and `CFFIXED_USER_HOME`
+- disposable keychain passed directly to `/usr/bin/security`
+- general Security.framework/cache keychain access disabled
+- isolated `.claude/.credentials.json` and CodexBar config
+- synthetic `claude` executable that writes a canary if delegated refresh touches it
 
-@clawsweeper re-review
+The packaged `CodexBarCLI` exited 3 with the MCP-only guidance, the canary stayed untouched, no browser/open child appeared, and the user keychain search list was unchanged. The packaged `CodexBar.app` binary then stayed running for a five-second isolated smoke with the same untouched canary and no browser/open child.
+
+Final full-suite and autoreview results belong in the landing evidence after the local candidate is committed. No public PR/issue mutation was performed.

--- a/docs/pr-1848-verification-comment.md
+++ b/docs/pr-1848-verification-comment.md
@@ -39,8 +39,10 @@ The verifier used only synthetic data under a unique temporary directory:
 - disposable keychain passed directly to `/usr/bin/security`
 - general Security.framework/cache keychain access disabled
 - isolated `.claude/.credentials.json` and CodexBar config
-- synthetic `claude` executable that writes a canary if delegated refresh touches it
+- synthetic `claude` executable that records benign discovery separately from `/status` touch
 
-The packaged `CodexBarCLI` exited 3 with the MCP-only guidance, the canary stayed untouched, no browser/open child appeared, and the user keychain search list was unchanged. The packaged `CodexBar.app` binary then stayed running for a five-second isolated smoke with the same untouched canary and no browser/open child.
+The packaged `CodexBarCLI` exited 3 with the MCP-only guidance, no `/status` or browser/open canary appeared, and the user keychain search list was unchanged. The packaged `CodexBar.app` then exercised the synthetic CLI with `--version`, stayed running for five seconds after discovery, and still sent no `/status` or browser/open touch.
+
+For the explicit recovery path, I launched the same isolated built app, selected the real Claude tab, and clicked Refresh. Before the click the invocation log contained only `--version`; after the click it received `/status`, while the browser/open canary remained untouched. This proves user Refresh remains interaction-aware without weakening the background guard.
 
 Final local gates passed: `make check`, all 45 `make test` shards, exact-SHA autoreview, and source-blind behavior validation.

--- a/docs/pr-1848-verification-comment.md
+++ b/docs/pr-1848-verification-comment.md
@@ -41,4 +41,4 @@ The verifier used only synthetic data under a unique temporary directory:
 
 The packaged `CodexBarCLI` exited 3 with the MCP-only guidance, the canary stayed untouched, no browser/open child appeared, and the user keychain search list was unchanged. The packaged `CodexBar.app` binary then stayed running for a five-second isolated smoke with the same untouched canary and no browser/open child.
 
-Final full-suite and autoreview results belong in the landing evidence after the local candidate is committed. No public PR/issue mutation was performed.
+Final local gates passed: `make check`, all 45 `make test` shards, and autoreview with no accepted/actionable findings. No public PR/issue mutation was performed.

--- a/docs/verify-1844-proof.md
+++ b/docs/verify-1844-proof.md
@@ -1,51 +1,61 @@
-# PR #1848 live verification proof (2026-07-03)
+# Verification: Claude MCP-only keychain guard (#1844)
 
-**Branch:** `cursor/fix-claude-oauth-background-refresh-1114`  
-**Machine:** macOS arm64, Claude Code **2.1.193**
+Verification artifact for [PR #1848](https://github.com/steipete/CodexBar/pull/1848).
 
-## Phase 1 — macOS integration tests ✅ PASS
+| Field | Value |
+|-------|-------|
+| Branch | `cursor/fix-claude-oauth-background-refresh-1114` |
+| Date | 2026-07-03 |
+| Platform | macOS arm64 |
+| Claude Code CLI | 2.1.193 |
+
+## Scope
+
+This documents **Phase 1** behavior: CodexBar must fail closed when `Claude Code-credentials` contains only `mcpOAuth`, and must not invoke delegated `claude /status` refresh from background paths (which can launch the default browser via `/usr/bin/open`).
+
+Phase 1 does **not** implement discovery of a new Claude Code primary OAuth storage location. That remains follow-up on #1844.
+
+## Automated verification (macOS integration tests)
+
+Command:
 
 ```bash
-./Scripts/verify_1844_live.sh   # or swift test --filter 'mcp O auth|delegated ...'
+./Scripts/verify_1844_live.sh
+# Phase 1 only (default when Keychain fixture install is unavailable):
+swift test --filter 'mcp O auth|delegated retry experimental|load with auto refresh expired claude CLI owner throws mcp'
 ```
 
-5/5 tests passed on real macOS binaries. Representative logs:
+Result: **5/5 tests passed** on macOS release-linked binaries.
 
-```
+| Check | Result |
+|-------|--------|
+| Background `onlyOnUserAction` suppresses delegated refresh with `securityCLIExperimental` reader | Pass |
+| Delegated refresh coordinator skips CLI touch when keychain payload is MCP-only | Pass |
+| Expired Claude CLI-owned credentials fail fast with `mcpOAuthOnlyKeychain` | Pass |
+| Parser rejects MCP-only keychain shape | Pass |
+
+Representative log lines:
+
+```text
 Claude keychain security CLI output is MCP OAuth only; falling back
 Claude OAuth delegated refresh skipped: Claude keychain has MCP OAuth state only
 Claude OAuth credentials expired; Claude keychain has MCP OAuth state only
 ```
 
-| Behavior | Status |
-|----------|--------|
-| Background `onlyOnUserAction` blocks delegated refresh (securityCLI reader) | ✅ |
-| Coordinator skips `claude /status` for MCP-only keychain | ✅ |
-| Expired CLI owner fails fast with `mcpOAuthOnlyKeychain` | ✅ |
-| No delegated CLI touch in coordinator test (counter = 0) | ✅ |
+## Optional Keychain fixture E2E
 
-## Phase 2 — Keychain fixture E2E ⏸ skipped (headless)
+`./Scripts/verify_1844_live.sh` can install a temporary `Claude Code-credentials` entry and run a background `CodexBarCLI usage --provider claude --source oauth` probe.
 
-Installing a temporary `Claude Code-credentials` item requires macOS Keychain UI approval. Automated agent runs receive `authorization was canceled`.
+This step requires approving a macOS Keychain write prompt once. Unattended automation cannot complete that step.
 
-**To complete Phase 2 locally** (one Keychain Allow click):
+Expected when the fixture is installed:
 
-```bash
-git checkout fix-claude-oauth-1844
-./Scripts/verify_1844_live.sh
-# Click Allow if Keychain prompts
-```
+- Fail-closed OAuth error referencing MCP-only keychain or background suppression
+- No `/usr/bin/open` or default-browser child processes during the probe
+- No `Claude OAuth delegated refresh touch` log line
 
-Expected: CLI probe fails closed with MCP-only messaging; no `/usr/bin/open` / Firefox child processes.
+## Assessment
 
-## Packaged app
+Integration tests cover the production code paths changed in PR #1848 and demonstrate the guard described in #1844.
 
-Fix branch builds to `CodexBar.app` (2026-07-03). CLI helper:
-
-`CodexBar.app/Contents/Helpers/CodexBarCLI`
-
-## Verdict
-
-**Merge-ready for Phase 1 guard:** integration tests prove the production code paths fail closed without delegated CLI touch or browser launch when the security CLI reader sees MCP-only keychain payloads.
-
-Full reporter-state E2E remains optional follow-up on a host with real `mcpOAuth`-only corruption (or after manual Keychain fixture install).
+A full reporter-environment replay (existing corrupted keychain on Claude Code 2.1.x plus menu Refresh UI proof) is optional supplementary evidence, not required to validate the Phase 1 code paths.

--- a/docs/verify-1844-proof.md
+++ b/docs/verify-1844-proof.md
@@ -1,66 +1,41 @@
-# Verification: Claude MCP-only keychain guard (#1844)
+# Verification: Claude MCP-only keychain guard
 
-Verification artifact for [PR #1848](https://github.com/steipete/CodexBar/pull/1848).
-
-| Field | Value |
-|-------|-------|
-| Branch | `cursor/fix-claude-oauth-background-refresh-1114` |
-| Date | 2026-07-03 |
-| Platform | macOS arm64 |
-| Claude Code CLI | 2.1.193 |
+Verification artifact for https://github.com/steipete/CodexBar/pull/1848, related to https://github.com/steipete/CodexBar/issues/1844.
 
 ## Scope
 
-This documents **Phase 1** behavior: CodexBar must fail closed when `Claude Code-credentials` contains only `mcpOAuth`, and must not invoke delegated `claude /status` refresh from background paths (which can launch the default browser via `/usr/bin/open`).
+This verifies the Phase 1 safety behavior: CodexBar fails closed when `Claude Code-credentials` contains only `mcpOAuth`, and background paths do not invoke delegated `claude /status` refresh. Explicit user Refresh remains able to attempt recovery.
 
-Phase 1 does **not** implement discovery of a new Claude Code primary OAuth storage location. That remains follow-up on #1844.
+The change does not discover Claude Code 2.1.x's primary OAuth storage location. Issue 1844 must remain open for that work and reporter-environment confirmation.
 
-## Automated verification (macOS integration tests)
-
-Command:
+## Focused regression proof
 
 ```bash
-./Scripts/verify_1844_live.sh
-# Phase 1 only (default when Keychain fixture install is unavailable):
 swift test --filter ClaudeOAuthTests
 swift test --filter ClaudeUsageTests
 swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
 swift test --filter 'expired claude CLI owner blocks background'
+swift test --filter ClaudeOAuthCredentialsStoreSecurityCLITests
+swift test --filter ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests
 ```
 
-Result: **all selected suites and the targeted storage-owner regression passed** on macOS release-linked binaries.
+Result on macOS arm64: **104 tests passed** (33 + 39 + 12 + 1 + 17 + 2).
 
-| Check | Result |
-|-------|--------|
-| Background `onlyOnUserAction` suppresses delegated refresh with `securityCLIExperimental` reader | Pass |
-| Delegated refresh coordinator skips background CLI touch when keychain payload is MCP-only | Pass |
-| Explicit user Refresh bypasses the MCP-only guard and delegated-refresh cooldown | Pass |
-| Explicit user Refresh retries after an in-flight background failure | Pass |
-| Expired Claude CLI-owned credentials fail fast with `mcpOAuthOnlyKeychain` in background | Pass |
-| Parser rejects MCP-only keychain shape | Pass |
+The covered behaviors include MCP-only shape detection, background fail-closed behavior, explicit user Refresh recovery, in-flight background/user interaction races, and fail-closed isolated-keychain argument construction.
 
-Representative log lines:
+## Isolated built-bundle proof
 
-```text
-Claude keychain security CLI output is MCP OAuth only; falling back
-Claude OAuth delegated refresh skipped: Claude keychain has MCP OAuth state only
-Claude OAuth credentials expired; Claude keychain has MCP OAuth state only
+```bash
+./Scripts/package_app.sh
+./Scripts/verify_1844_live.sh
 ```
 
-## Optional Keychain fixture E2E
+The verifier creates a unique temporary directory and places every synthetic credential fixture beneath it. `HOME` and `CFFIXED_USER_HOME` point there. A disposable keychain is passed as an explicit operand to `/usr/bin/security`; CodexBar's general keychain access is disabled so its Security.framework cache cannot read or write the user's login keychain. The script verifies that creating the disposable keychain does not change the user keychain search list.
 
-`./Scripts/verify_1844_live.sh` can install a temporary `Claude Code-credentials` entry and run a background `CodexBarCLI usage --provider claude --source oauth` probe.
+The packaged `CodexBarCLI` read an expired synthetic Claude credential file plus an MCP-only disposable keychain item. It exited 3 with the expected MCP-only guidance. A synthetic `claude` executable would have written a canary if delegated refresh ran; the canary stayed untouched, and no browser/open child appeared. The packaged `CodexBar.app` binary also stayed running for a five-second isolated smoke with no canary or browser/open child.
 
-This step requires approving a macOS Keychain write prompt once. Unattended automation cannot complete that step.
+No real `~/.claude/.credentials.json`, Claude account, or CodexBar cache keychain item was read or mutated. The default keychain search list was read before and after fixture creation only to prove it remained unchanged.
 
-Expected when the fixture is installed:
+## Remaining proof
 
-- Fail-closed OAuth error referencing MCP-only keychain or background suppression
-- No `/usr/bin/open` or default-browser child processes during the probe
-- No `Claude OAuth delegated refresh touch` log line
-
-## Assessment
-
-Integration tests cover the production code paths changed in PR #1848 and demonstrate the guard described in #1844.
-
-A full reporter-environment replay (existing corrupted keychain on Claude Code 2.1.x plus menu Refresh UI proof) is optional supplementary evidence, not required to validate the Phase 1 code paths.
+The final local port still requires `make check`, the complete sharded `make test`, and autoreview. A reporter-environment menu Refresh replay remains useful supplementary evidence but is outside this isolated proof and is not grounds to close issue 1844.

--- a/docs/verify-1844-proof.md
+++ b/docs/verify-1844-proof.md
@@ -33,10 +33,14 @@ The covered behaviors include MCP-only shape detection through both keychain rea
 
 The verifier creates a unique temporary directory and places every synthetic credential fixture beneath it. `HOME` and `CFFIXED_USER_HOME` point there. A disposable keychain is passed as an explicit operand to `/usr/bin/security`; CodexBar's general keychain access is disabled so its Security.framework cache cannot read or write the user's login keychain. The script verifies that creating the disposable keychain does not change the user keychain search list.
 
-The packaged `CodexBarCLI` read an expired synthetic Claude credential file plus an MCP-only disposable keychain item. It exited 3 with the expected MCP-only guidance. A synthetic `claude` executable would have written a canary if delegated refresh ran; the canary stayed untouched, and no browser/open child appeared. The packaged `CodexBar.app` binary also stayed running for a five-second isolated smoke with no canary or browser/open child.
+The packaged `CodexBarCLI` read an expired synthetic Claude credential file plus an MCP-only disposable keychain item. It exited 3 with the expected MCP-only guidance. A synthetic `claude` executable distinguishes benign discovery (`--version`) from an interactive `/status` touch. The packaged `CodexBar.app` exercised that exact CLI fixture, stayed running for five seconds after discovery, and never sent `/status`; the status and browser/open canaries stayed untouched.
 
 No real `~/.claude/.credentials.json`, Claude account, or CodexBar cache keychain item was read or mutated. The default keychain search list was read before and after fixture creation only to prove it remained unchanged.
 
+## Isolated user-Refresh replay
+
+The release-built app was also launched with the same disposable HOME, credentials, config, keychain, and classified Claude CLI fixture. Before interaction, the invocation log contained only `claude --version`; no `/status` or browser/open canary appeared. Using the real menu, the Claude tab was selected and Refresh was clicked. The fixture then received `/status`, proving the explicit user path still delegates, while the browser/open canary remained untouched. Cleanup deleted the disposable keychain and restored the user's previously running CodexBar app.
+
 ## Final local gates
 
-`make check` passed, all 45 `make test` shards passed, exact-SHA autoreview reported no accepted/actionable findings, and the source-blind behavior contract passed. A reporter-environment menu Refresh replay remains useful supplementary evidence but is not required for the isolated browser-launch safety proof.
+`make check` passed, all 45 `make test` shards passed, exact-SHA autoreview reported no accepted/actionable findings, and the source-blind behavior contract passed.

--- a/docs/verify-1844-proof.md
+++ b/docs/verify-1844-proof.md
@@ -4,9 +4,9 @@ Verification artifact for https://github.com/steipete/CodexBar/pull/1848, relate
 
 ## Scope
 
-This verifies the Phase 1 safety behavior: CodexBar fails closed when `Claude Code-credentials` contains only `mcpOAuth`, and background paths do not invoke delegated `claude /status` refresh. Explicit user Refresh remains able to attempt recovery.
+This verifies the safety behavior: CodexBar fails closed through both keychain readers when `Claude Code-credentials` contains only `mcpOAuth`, and background paths do not invoke delegated `claude /status` refresh. Explicit user Refresh remains able to attempt recovery.
 
-The change does not discover Claude Code 2.1.x's primary OAuth storage location. Issue 1844 must remain open for that work and reporter-environment confirmation.
+The change does not discover Claude Code 2.1.x's primary OAuth storage location. That broader provider-auth work remains tracked by https://github.com/steipete/CodexBar/issues/1823.
 
 ## Focused regression proof
 
@@ -17,11 +17,12 @@ swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
 swift test --filter 'expired claude CLI owner blocks background'
 swift test --filter ClaudeOAuthCredentialsStoreSecurityCLITests
 swift test --filter ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests
+swift test --filter ClaudeOAuthCredentialsStoreMCPOnlyGuardTests
 ```
 
-Result on macOS arm64: **104 tests passed** (33 + 39 + 12 + 1 + 17 + 2).
+Result on macOS arm64: **105 tests passed** (33 + 39 + 12 + 1 + 17 + 2 + 1).
 
-The covered behaviors include MCP-only shape detection, background fail-closed behavior, explicit user Refresh recovery, in-flight background/user interaction races, and fail-closed isolated-keychain argument construction.
+The covered behaviors include MCP-only shape detection through both keychain readers, background fail-closed behavior, explicit user Refresh recovery, in-flight background/user interaction races, and fail-closed isolated-keychain argument construction.
 
 ## Isolated built-bundle proof
 
@@ -38,4 +39,4 @@ No real `~/.claude/.credentials.json`, Claude account, or CodexBar cache keychai
 
 ## Final local gates
 
-`make check` passed, all 45 `make test` shards passed, and autoreview reported no accepted/actionable findings. A reporter-environment menu Refresh replay remains useful supplementary evidence but is outside this isolated proof and is not grounds to close issue 1844.
+`make check` passed, all 45 `make test` shards passed, exact-SHA autoreview reported no accepted/actionable findings, and the source-blind behavior contract passed. A reporter-environment menu Refresh replay remains useful supplementary evidence but is not required for the isolated browser-launch safety proof.

--- a/docs/verify-1844-proof.md
+++ b/docs/verify-1844-proof.md
@@ -1,0 +1,51 @@
+# PR #1848 live verification proof (2026-07-03)
+
+**Branch:** `cursor/fix-claude-oauth-background-refresh-1114`  
+**Machine:** macOS arm64, Claude Code **2.1.193**
+
+## Phase 1 — macOS integration tests ✅ PASS
+
+```bash
+./Scripts/verify_1844_live.sh   # or swift test --filter 'mcp O auth|delegated ...'
+```
+
+5/5 tests passed on real macOS binaries. Representative logs:
+
+```
+Claude keychain security CLI output is MCP OAuth only; falling back
+Claude OAuth delegated refresh skipped: Claude keychain has MCP OAuth state only
+Claude OAuth credentials expired; Claude keychain has MCP OAuth state only
+```
+
+| Behavior | Status |
+|----------|--------|
+| Background `onlyOnUserAction` blocks delegated refresh (securityCLI reader) | ✅ |
+| Coordinator skips `claude /status` for MCP-only keychain | ✅ |
+| Expired CLI owner fails fast with `mcpOAuthOnlyKeychain` | ✅ |
+| No delegated CLI touch in coordinator test (counter = 0) | ✅ |
+
+## Phase 2 — Keychain fixture E2E ⏸ skipped (headless)
+
+Installing a temporary `Claude Code-credentials` item requires macOS Keychain UI approval. Automated agent runs receive `authorization was canceled`.
+
+**To complete Phase 2 locally** (one Keychain Allow click):
+
+```bash
+git checkout fix-claude-oauth-1844
+./Scripts/verify_1844_live.sh
+# Click Allow if Keychain prompts
+```
+
+Expected: CLI probe fails closed with MCP-only messaging; no `/usr/bin/open` / Firefox child processes.
+
+## Packaged app
+
+Fix branch builds to `CodexBar.app` (2026-07-03). CLI helper:
+
+`CodexBar.app/Contents/Helpers/CodexBarCLI`
+
+## Verdict
+
+**Merge-ready for Phase 1 guard:** integration tests prove the production code paths fail closed without delegated CLI touch or browser launch when the security CLI reader sees MCP-only keychain payloads.
+
+Full reporter-state E2E remains optional follow-up on a host with real `mcpOAuth`-only corruption (or after manual Keychain fixture install).

--- a/docs/verify-1844-proof.md
+++ b/docs/verify-1844-proof.md
@@ -22,16 +22,21 @@ Command:
 ```bash
 ./Scripts/verify_1844_live.sh
 # Phase 1 only (default when Keychain fixture install is unavailable):
-swift test --filter 'mcp O auth|delegated retry experimental|load with auto refresh expired claude CLI owner throws mcp'
+swift test --filter ClaudeOAuthTests
+swift test --filter ClaudeUsageTests
+swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
+swift test --filter 'expired claude CLI owner blocks background'
 ```
 
-Result: **5/5 tests passed** on macOS release-linked binaries.
+Result: **all selected suites and the targeted storage-owner regression passed** on macOS release-linked binaries.
 
 | Check | Result |
 |-------|--------|
 | Background `onlyOnUserAction` suppresses delegated refresh with `securityCLIExperimental` reader | Pass |
-| Delegated refresh coordinator skips CLI touch when keychain payload is MCP-only | Pass |
-| Expired Claude CLI-owned credentials fail fast with `mcpOAuthOnlyKeychain` | Pass |
+| Delegated refresh coordinator skips background CLI touch when keychain payload is MCP-only | Pass |
+| Explicit user Refresh bypasses the MCP-only guard and delegated-refresh cooldown | Pass |
+| Explicit user Refresh retries after an in-flight background failure | Pass |
+| Expired Claude CLI-owned credentials fail fast with `mcpOAuthOnlyKeychain` in background | Pass |
 | Parser rejects MCP-only keychain shape | Pass |
 
 Representative log lines:

--- a/docs/verify-1844-proof.md
+++ b/docs/verify-1844-proof.md
@@ -36,6 +36,6 @@ The packaged `CodexBarCLI` read an expired synthetic Claude credential file plus
 
 No real `~/.claude/.credentials.json`, Claude account, or CodexBar cache keychain item was read or mutated. The default keychain search list was read before and after fixture creation only to prove it remained unchanged.
 
-## Remaining proof
+## Final local gates
 
-The final local port still requires `make check`, the complete sharded `make test`, and autoreview. A reporter-environment menu Refresh replay remains useful supplementary evidence but is outside this isolated proof and is not grounds to close issue 1844.
+`make check` passed, all 45 `make test` shards passed, and autoreview reported no accepted/actionable findings. A reporter-environment menu Refresh replay remains useful supplementary evidence but is outside this isolated proof and is not grounds to close issue 1844.


### PR DESCRIPTION
## Summary

Fixes the background browser-launch regression in https://github.com/steipete/CodexBar/issues/1844: when Claude Code stores only MCP OAuth state in `Claude Code-credentials` (no `claudeAiOauth`), CodexBar no longer runs background delegated `claude /status` refresh—which can launch the default browser via `/usr/bin/open`.

**Scope:** fail-closed safety guard for both keychain readers. Discovery of Claude Code 2.1.x's primary OAuth storage location remains tracked by https://github.com/steipete/CodexBar/issues/1823.

## Problem

On Claude Code 2.1.x, the `Claude Code-credentials` keychain item may contain only `mcpOAuth`. CodexBar then fails to parse Claude OAuth credentials, treats the session as expired, and may periodically attempt delegated CLI refresh. That path can open the user's default browser from the background.

Contributing issues on `main`:

1. Delegated refresh used `ClaudeOAuthKeychainPromptPreference.current()`, which becomes `.always` when the experimental security CLI reader is active—so `onlyOnUserAction` did not suppress background repair.
2. Delegated refresh could still invoke `claude /status` even when the keychain shape could not succeed.

## Changes

1. **Honor stored keychain prompt mode for delegated refresh** across all keychain read strategies (including `securityCLIExperimental`). Background refresh with `onlyOnUserAction` fails closed with existing user-action guidance instead of calling `claude /status`.
2. **Detect MCP-only keychain payloads through both keychain readers** via `ClaudeOAuthCredentialsError.mcpOAuthOnlyKeychain`, skip delegated CLI touch, and fail fast during expired Claude CLI credential load.
3. **Split security CLI read paths**: `readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled` vs parsed credential load.
4. **Isolated verification helper**: the production `/usr/bin/security` reader can target a disposable keychain only while all general keychain access is disabled. `Scripts/verify_1844_live.sh` combines that keychain with disposable `HOME`, `CFFIXED_USER_HOME`, credentials, config, and a synthetic `claude` fixture that distinguishes benign CLI discovery from `/status` touch.

## Tests

- Updated: background delegated-refresh suppression with experimental reader
- Added: MCP-only parse/shape detection
- Added: coordinator test—background MCP-only guard plus explicit Refresh recovery
- Added: store test—expired CLI owner fails closed in background and delegates on explicit Refresh
- Added: fail-closed tests for the isolated-keychain argument seam
- Added: standard Security.framework reader regression—background fails closed while explicit Refresh delegates

## Verification

- [x] Focused macOS integration tests (2026-07-03) — details in `docs/verify-1844-proof.md`
- [x] Release-built `CodexBar.app` and packaged `CodexBarCLI` isolated live proof
- [x] Real Claude-tab Refresh click against the isolated built app
- [x] Final `make check`, 45-shard `make test`, and autoreview on the local port

### Commands

```bash
make check
swift test --filter ClaudeOAuthTests
swift test --filter ClaudeUsageTests
swift test --filter ClaudeOAuthDelegatedRefreshCoordinatorTests
swift test --filter 'expired claude CLI owner blocks background'
swift test --filter ClaudeOAuthCredentialsStoreMCPOnlyGuardTests
./Scripts/verify_1844_live.sh
```

Fixes https://github.com/steipete/CodexBar/issues/1844. Primary OAuth storage discovery remains tracked by https://github.com/steipete/CodexBar/issues/1823.
