### PR TITLE
[codex] Improve General settings layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Quota warnings: add an optional centered on-screen text alert that stays click-through and does not steal focus. Thanks @SAASEmpiree!
 
 ### Fixed
+- Settings: align General-pane controls, show installed terminal app icons, and enlarge the window to fit more options.
 - Sakana AI: parse server-rendered quota reset timestamps as UTC instead of device-local time (#1826). Thanks @ss251!
 - Cursor: hide misleading pace and run-out details once a billing-cycle quota is fully depleted. Thanks @Yuxin-Qiao!
 - Claude Education: treat subscription-only CLI responses as unavailable quotas, keep local cost data in menus and widgets, and suppress expected refresh cancellations (#1808).

--- a/Sources/CodexBar/PreferencesComponents.swift
+++ b/Sources/CodexBar/PreferencesComponents.swift
@@ -1,6 +1,45 @@
 import AppKit
 import SwiftUI
 
+enum PreferenceControlLayout {
+    static let width: CGFloat = 210
+}
+
+@MainActor
+struct PreferenceControlRow<Control: View>: View {
+    let title: String
+    let subtitle: String?
+    private let control: Control
+
+    init(
+        title: String,
+        subtitle: String? = nil,
+        @ViewBuilder control: () -> Control)
+    {
+        self.title = title
+        self.subtitle = subtitle
+        self.control = control()
+    }
+
+    var body: some View {
+        HStack(alignment: self.subtitle == nil ? .center : .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(self.title)
+                    .font(.body)
+                if let subtitle, !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(.footnote)
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer(minLength: 16)
+            self.control
+                .frame(width: PreferenceControlLayout.width, alignment: .trailing)
+        }
+    }
+}
+
 @MainActor
 struct PreferenceToggleRow: View {
     let title: String

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -72,46 +72,39 @@ struct GeneralPane: View {
                         .foregroundStyle(.secondary)
                         .textCase(.uppercase)
 
-                    VStack(alignment: .leading, spacing: 6) {
-                        HStack(alignment: .top, spacing: 12) {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(L("language_title"))
-                                    .font(.body)
-                                Text(L("language_subtitle"))
-                                    .font(.footnote)
-                                    .foregroundStyle(.tertiary)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-                            Spacer()
-                            Picker(L("language_title"), selection: self.$settings.appLanguage) {
-                                ForEach(AppLanguage.allCases) { option in
-                                    Text(option.label).tag(option.rawValue)
-                                }
-                            }
-                            .labelsHidden()
-                            .pickerStyle(.menu)
-                            .frame(maxWidth: 200)
-                        }
-                    }
-
-                    HStack(alignment: .top, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(L("terminal_app_title"))
-                                .font(.body)
-                            Text(L("terminal_app_subtitle"))
-                                .font(.footnote)
-                                .foregroundStyle(.tertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        Spacer()
-                        Picker(L("terminal_app_title"), selection: self.$settings.terminalApp) {
-                            ForEach(TerminalApp.allCases) { option in
-                                Text(option.label).tag(option)
+                    PreferenceControlRow(
+                        title: L("language_title"),
+                        subtitle: L("language_subtitle"))
+                    {
+                        Picker(L("language_title"), selection: self.$settings.appLanguage) {
+                            ForEach(AppLanguage.allCases) { option in
+                                Text(option.label).tag(option.rawValue)
                             }
                         }
                         .labelsHidden()
                         .pickerStyle(.menu)
-                        .frame(maxWidth: 200)
+                    }
+
+                    PreferenceControlRow(
+                        title: L("terminal_app_title"),
+                        subtitle: L("terminal_app_subtitle"))
+                    {
+                        Picker(L("terminal_app_title"), selection: self.$settings.terminalApp) {
+                            ForEach(TerminalApp.pickerOptions(selected: self.settings.terminalApp)) { option in
+                                HStack(spacing: 6) {
+                                    if let icon = option.appIcon {
+                                        Image(nsImage: icon)
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fit)
+                                            .frame(width: 16, height: 16)
+                                    }
+                                    Text(option.label)
+                                }
+                                .tag(option)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
                     }
 
                     PreferenceToggleRow(
@@ -143,28 +136,20 @@ struct GeneralPane: View {
 
                             if self.settings.costUsageEnabled {
                                 VStack(alignment: .leading, spacing: 12) {
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        HStack(alignment: .center, spacing: 12) {
-                                            Text(L("cost_summary_style_title"))
-                                                .font(.body)
-                                            Spacer(minLength: 16)
-                                            Picker(
-                                                L("cost_summary_style_title"),
-                                                selection: self.$settings.costSummaryDisplayStyle)
-                                            {
-                                                ForEach(CostSummaryDisplayStyle.allCases) { style in
-                                                    Text(style.label).tag(style)
-                                                }
+                                    PreferenceControlRow(
+                                        title: L("cost_summary_style_title"),
+                                        subtitle: self.settings.costSummaryDisplayStyle.helpText)
+                                    {
+                                        Picker(
+                                            L("cost_summary_style_title"),
+                                            selection: self.$settings.costSummaryDisplayStyle)
+                                        {
+                                            ForEach(CostSummaryDisplayStyle.allCases) { style in
+                                                Text(style.label).tag(style)
                                             }
-                                            .labelsHidden()
-                                            .pickerStyle(.menu)
-                                            .frame(width: CostSummarySettingsLayout.controlWidth)
                                         }
-
-                                        Text(self.settings.costSummaryDisplayStyle.helpText)
-                                            .font(.footnote)
-                                            .foregroundStyle(.tertiary)
-                                            .fixedSize(horizontal: false, vertical: true)
+                                        .labelsHidden()
+                                        .pickerStyle(.menu)
                                     }
                                     .padding(.top, 4)
 
@@ -191,15 +176,10 @@ struct GeneralPane: View {
                         .foregroundStyle(.secondary)
                         .textCase(.uppercase)
                     VStack(alignment: .leading, spacing: 6) {
-                        HStack(alignment: .top, spacing: 12) {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(L("refresh_cadence_title"))
-                                    .font(.body)
-                                Text(L("refresh_cadence_subtitle"))
-                                    .font(.footnote)
-                                    .foregroundStyle(.tertiary)
-                            }
-                            Spacer()
+                        PreferenceControlRow(
+                            title: L("refresh_cadence_title"),
+                            subtitle: L("refresh_cadence_subtitle"))
+                        {
                             Picker(L("Refresh cadence"), selection: self.$settings.refreshFrequency) {
                                 ForEach(RefreshFrequency.allCases) { option in
                                     Text(option.label).tag(option)
@@ -207,7 +187,6 @@ struct GeneralPane: View {
                             }
                             .labelsHidden()
                             .pickerStyle(.menu)
-                            .frame(maxWidth: 200)
                         }
                         if self.settings.refreshFrequency == .manual {
                             Text(L("manual_refresh_hint"))
@@ -305,10 +284,6 @@ struct GeneralPane: View {
     }
 }
 
-private enum CostSummarySettingsLayout {
-    static let controlWidth: CGFloat = 210
-}
-
 @MainActor
 struct CostHistoryDaysEditor: View {
     @Bindable var settings: SettingsStore
@@ -320,25 +295,24 @@ struct CostHistoryDaysEditor: View {
     var body: some View {
         let title = Self.title(days: self.settings.costUsageHistoryDays)
 
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Stepper(
-                value: self.$settings.costUsageHistoryDays,
-                in: 1...365,
-                step: 1)
-            {
-                Text(title)
-                    .font(.footnote)
-            }
+        PreferenceControlRow(title: title) {
+            HStack(spacing: 8) {
+                TextField(
+                    title,
+                    value: self.$settings.costUsageHistoryDays,
+                    format: .number)
+                    .labelsHidden()
+                    .textFieldStyle(.roundedBorder)
+                    .font(.body)
+                    .monospacedDigit()
+                    .frame(width: 72)
 
-            TextField(
-                title,
-                value: self.$settings.costUsageHistoryDays,
-                format: .number)
+                Stepper(value: self.$settings.costUsageHistoryDays, in: 1...365, step: 1) {
+                    EmptyView()
+                }
                 .labelsHidden()
-                .textFieldStyle(.roundedBorder)
-                .font(.footnote)
-                .monospacedDigit()
-                .frame(width: 64)
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
         }
     }
 }

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -12,7 +12,7 @@ enum PreferencesTab: String, CaseIterable, Hashable {
 
     static let defaultWidth: CGFloat = 546
     static let providersWidth: CGFloat = 792
-    static let windowHeight: CGFloat = 662
+    static let windowHeight: CGFloat = 794
 
     var title: String {
         switch self {

--- a/Sources/CodexBar/TerminalApp.swift
+++ b/Sources/CodexBar/TerminalApp.swift
@@ -23,7 +23,34 @@ enum TerminalApp: String, CaseIterable, Identifiable {
     }
 
     var isInstalled: Bool {
-        NSWorkspace.shared.urlForApplication(withBundleIdentifier: self.bundleIdentifier) != nil
+        self.isInstalled { NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0) }
+    }
+
+    func isInstalled(applicationURL: (String) -> URL?) -> Bool {
+        self == .terminal || applicationURL(self.bundleIdentifier) != nil
+    }
+
+    var appIcon: NSImage? {
+        guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: self.bundleIdentifier) else {
+            return nil
+        }
+        return NSWorkspace.shared.icon(forFile: appURL.path)
+    }
+
+    static var installed: [Self] {
+        self.installed { NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0) }
+    }
+
+    static func installed(applicationURL: (String) -> URL?) -> [Self] {
+        self.allCases.filter { $0.isInstalled(applicationURL: applicationURL) }
+    }
+
+    static func pickerOptions(selected: Self) -> [Self] {
+        self.pickerOptions(selected: selected) { NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0) }
+    }
+
+    static func pickerOptions(selected: Self, applicationURL: (String) -> URL?) -> [Self] {
+        self.allCases.filter { $0 == selected || $0.isInstalled(applicationURL: applicationURL) }
     }
 
     func appleScript(command: String) -> String {

--- a/Tests/CodexBarTests/PreferencesTabLayoutCoordinatorTests.swift
+++ b/Tests/CodexBarTests/PreferencesTabLayoutCoordinatorTests.swift
@@ -3,6 +3,12 @@ import Testing
 
 struct PreferencesTabLayoutCoordinatorTests {
     @Test
+    func `settings window is twenty percent taller`() {
+        #expect(PreferencesTab.windowHeight == 794)
+        #expect(PreferencesTab.windowHeight >= 662 * 1.19)
+    }
+
+    @Test
     func `binding selection defers one layout and suppresses observed duplicate`() {
         var coordinator = PreferencesTabLayoutCoordinator()
 

--- a/Tests/CodexBarTests/TerminalAppTests.swift
+++ b/Tests/CodexBarTests/TerminalAppTests.swift
@@ -54,6 +54,23 @@ struct TerminalAppTests {
     }
 
     @Test
+    func `installed terminals always include Terminal and detected alternatives`() {
+        let iTermURL = URL(fileURLWithPath: "/Applications/iTerm.app")
+        let installed = TerminalApp.installed { bundleIdentifier in
+            bundleIdentifier == TerminalApp.iTerm.bundleIdentifier ? iTermURL : nil
+        }
+
+        #expect(installed == [.terminal, .iTerm])
+        #expect(TerminalApp.installed { _ in nil } == [.terminal])
+    }
+
+    @Test
+    func `picker options preserve an unavailable persisted selection`() {
+        #expect(TerminalApp.pickerOptions(selected: .terminal) { _ in nil } == [.terminal])
+        #expect(TerminalApp.pickerOptions(selected: .iTerm) { _ in nil } == [.terminal, .iTerm])
+    }
+
+    @Test
     func `all cases have unique bundle identifiers`() {
         let ids = TerminalApp.allCases.map(\.bundleIdentifier)
         #expect(Set(ids).count == TerminalApp.allCases.count)


### PR DESCRIPTION
## Summary

- align General-pane selectors and numeric controls to one trailing column
- show native app icons for installed Terminal choices, while preserving a saved unavailable choice
- increase the settings window height by roughly 20% so more options fit without scrolling

## Validation

- `swift test --filter 'TerminalAppTests|PreferencesTabLayoutCoordinatorTests|PreferencesPaneSmokeTests'` (24 tests passed)
- `make check`
- `make test` (45 shards passed)
- autoreview clean after fixing the persisted-terminal edge case
- fresh debug bundle launched with `./Scripts/compile_and_run.sh --debug-lldb`; verified aligned controls and Terminal/iTerm icons in the open picker
