### PR TITLE
Fix oversized terminal picker icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Quota warnings: add an optional centered on-screen text alert that stays click-through and does not steal focus. Thanks @SAASEmpiree!
 
 ### Fixed
-- Settings: align General-pane controls, show installed terminal app icons, and enlarge the window to fit more options.
+- Settings: align General-pane controls, show compact installed terminal app icons, and enlarge the window to fit more options.
 - Sakana AI: parse server-rendered quota reset timestamps as UTC instead of device-local time (#1826). Thanks @ss251!
 - Cursor: hide misleading pace and run-out details once a billing-cycle quota is fully depleted. Thanks @Yuxin-Qiao!
 - Claude Education: treat subscription-only CLI responses as unavailable quotas, keep local cost data in menus and widgets, and suppress expected refresh cancellations (#1808).

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -92,11 +92,8 @@ struct GeneralPane: View {
                         Picker(L("terminal_app_title"), selection: self.$settings.terminalApp) {
                             ForEach(TerminalApp.pickerOptions(selected: self.settings.terminalApp)) { option in
                                 HStack(spacing: 6) {
-                                    if let icon = option.appIcon {
+                                    if let icon = option.pickerIcon {
                                         Image(nsImage: icon)
-                                            .resizable()
-                                            .aspectRatio(contentMode: .fit)
-                                            .frame(width: 16, height: 16)
                                     }
                                     Text(option.label)
                                 }

--- a/Sources/CodexBar/TerminalApp.swift
+++ b/Sources/CodexBar/TerminalApp.swift
@@ -1,6 +1,8 @@
 import AppKit
 
 enum TerminalApp: String, CaseIterable, Identifiable {
+    static let pickerIconSize = NSSize(width: 16, height: 16)
+
     case terminal
     case iTerm
 
@@ -35,6 +37,43 @@ enum TerminalApp: String, CaseIterable, Identifiable {
             return nil
         }
         return NSWorkspace.shared.icon(forFile: appURL.path)
+    }
+
+    var pickerIcon: NSImage? {
+        self.appIcon.map(Self.pickerIcon(from:))
+    }
+
+    static func pickerIcon(from icon: NSImage) -> NSImage {
+        let sourceSize = icon.size
+        let targetSize = self.pickerIconSize
+
+        guard sourceSize.width.isFinite, sourceSize.width > 0,
+              sourceSize.height.isFinite, sourceSize.height > 0
+        else {
+            let empty = NSImage(size: targetSize)
+            empty.isTemplate = icon.isTemplate
+            return empty
+        }
+
+        // MenuPickerStyle sizes selected images from their intrinsic NSImage dimensions.
+        let resized = NSImage(size: targetSize, flipped: false) { _ in
+            let scale = min(targetSize.width / sourceSize.width, targetSize.height / sourceSize.height)
+            let scaledSize = NSSize(width: sourceSize.width * scale, height: sourceSize.height * scale)
+            let drawingRect = NSRect(
+                x: (targetSize.width - scaledSize.width) / 2,
+                y: (targetSize.height - scaledSize.height) / 2,
+                width: scaledSize.width,
+                height: scaledSize.height)
+            NSGraphicsContext.current?.imageInterpolation = .high
+            icon.draw(
+                in: drawingRect,
+                from: NSRect(origin: .zero, size: sourceSize),
+                operation: .copy,
+                fraction: 1)
+            return true
+        }
+        resized.isTemplate = icon.isTemplate
+        return resized
     }
 
     static var installed: [Self] {

--- a/Tests/CodexBarTests/TerminalAppTests.swift
+++ b/Tests/CodexBarTests/TerminalAppTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 @testable import CodexBar
@@ -68,6 +69,24 @@ struct TerminalAppTests {
     func `picker options preserve an unavailable persisted selection`() {
         #expect(TerminalApp.pickerOptions(selected: .terminal) { _ in nil } == [.terminal])
         #expect(TerminalApp.pickerOptions(selected: .iTerm) { _ in nil } == [.terminal, .iTerm])
+    }
+
+    @Test
+    @MainActor
+    func `picker icon has compact intrinsic size`() {
+        let source = NSImage(size: NSSize(width: 128, height: 64))
+
+        let icon = TerminalApp.pickerIcon(from: source)
+
+        #expect(icon.size == NSSize(width: 16, height: 16))
+    }
+
+    @Test
+    @MainActor
+    func `zero size picker icon remains compact`() {
+        let icon = TerminalApp.pickerIcon(from: NSImage(size: .zero))
+
+        #expect(icon.size == NSSize(width: 16, height: 16))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- pre-resize terminal app icons to an intrinsic 16-point image before SwiftUI's menu picker renders them
- preserve aspect ratio and template metadata, with a safe zero/non-finite-size fallback
- cover normal and zero-size icon inputs and clarify the unreleased changelog entry

## Validation

- `swift test --filter TerminalAppTests` (13 tests)
- `make check`
- `make test` (45/45 shards)
- `./Scripts/compile_and_run.sh`
- live Peekaboo inspection of the freshly packaged General settings pane; the closed picker icon now renders at text height inside the 24-point control

## Context

Follow-up to #1849. `MenuPickerStyle` uses the native `NSImage` dimensions for selected content, so SwiftUI-only resizing still let the application icon render oversized.
