### PR TITLE
Fix settings sidebar recovery

### DIFF
--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -16,6 +16,7 @@ enum SettingsPane: Hashable {
     static let windowMinWidth: CGFloat = 780
     static let windowMinHeight: CGFloat = 520
     static let sidebarWidth: CGFloat = 224
+    static let sidebarMinWidth: CGFloat = 224
 
     var title: String {
         switch self {
@@ -40,6 +41,7 @@ struct PreferencesView: View {
     let codexAccountPromotionCoordinator: CodexAccountPromotionCoordinator
     let runProviderLoginFlow: @MainActor (UsageProvider) async -> Void
     @Environment(\.colorScheme) private var colorScheme
+    @State private var columnVisibility: NavigationSplitViewVisibility = .doubleColumn
 
     init(
         settings: SettingsStore,
@@ -64,9 +66,16 @@ struct PreferencesView: View {
     }
 
     var body: some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: self.columnVisibilityBinding) {
             SettingsSidebarView(settings: self.settings, store: self.store, selection: self.$selection.pane)
-                .navigationSplitViewColumnWidth(SettingsPane.sidebarWidth)
+                .frame(
+                    minWidth: SettingsPane.sidebarMinWidth,
+                    idealWidth: SettingsPane.sidebarWidth,
+                    maxWidth: SettingsPane.sidebarWidth)
+                .navigationSplitViewColumnWidth(
+                    min: SettingsPane.sidebarMinWidth,
+                    ideal: SettingsPane.sidebarWidth,
+                    max: SettingsPane.sidebarWidth)
                 .toolbar(removing: .sidebarToggle)
         } detail: {
             self.detailView
@@ -86,6 +95,7 @@ struct PreferencesView: View {
         }
         .onAppear {
             self.ensureValidSelection()
+            self.columnVisibility = .doubleColumn
         }
         .onChange(of: self.settings.debugMenuEnabled) { _, _ in
             self.ensureValidSelection()
@@ -117,10 +127,66 @@ struct PreferencesView: View {
         }
     }
 
+    private var columnVisibilityBinding: Binding<NavigationSplitViewVisibility> {
+        Binding(
+            get: { self.columnVisibility },
+            set: { self.columnVisibility = Self.visibleColumnVisibility(for: $0) })
+    }
+
+    private static func visibleColumnVisibility(for proposedVisibility: NavigationSplitViewVisibility)
+        -> NavigationSplitViewVisibility
+    {
+        switch proposedVisibility {
+        case .detailOnly:
+            .doubleColumn
+        default:
+            proposedVisibility
+        }
+    }
+
     private func ensureValidSelection() {
         if !self.settings.debugMenuEnabled, self.selection.pane == .debug {
             self.selection.pane = .general
         }
+    }
+}
+
+@MainActor
+enum SettingsWindowSizing {
+    private static let sidebarSplitViewIdentifier = "SidebarNavigationSplitView"
+
+    static func enforceMinimumSize(_ window: NSWindow) {
+        let toolbarHeight = max(0, window.frame.height - window.contentLayoutRect.height)
+        let minimumSize = NSSize(
+            width: SettingsPane.windowMinWidth,
+            height: SettingsPane.windowMinHeight + toolbarHeight)
+        window.minSize = minimumSize
+        self.enforceSidebarWidth(in: window)
+
+        guard window.frame.width < minimumSize.width || window.frame.height < minimumSize.height else {
+            return
+        }
+
+        var frame = window.frame
+        let repairedSize = NSSize(
+            width: max(frame.width, minimumSize.width),
+            height: max(frame.height, minimumSize.height))
+        frame.origin.y += frame.height - repairedSize.height
+        frame.size = repairedSize
+        window.setFrame(frame, display: true)
+    }
+
+    private static func enforceSidebarWidth(in window: NSWindow) {
+        guard let splitView = window.contentView?.firstDescendantSplitView(matching: {
+            $0.identifier?.rawValue.contains(self.sidebarSplitViewIdentifier) == true
+        }), splitView.subviews.indices.contains(0) else {
+            return
+        }
+
+        let sidebar = splitView.subviews[0]
+        guard sidebar.frame.width < SettingsPane.sidebarWidth else { return }
+        splitView.setPosition(SettingsPane.sidebarWidth, ofDividerAt: 0)
+        splitView.adjustSubviews()
     }
 }
 
@@ -134,11 +200,15 @@ enum SettingsWindowAppearance {
         application: NSApplication = NSApp,
         scheduleReset: ResetScheduler = Self.scheduleReset)
     {
+        SettingsWindowSizing.enforceMinimumSize(window)
         window.appearanceSource = application
         // Pulse the exact effective appearance so the native toolbar redraws without
         // dropping inherited accessibility attributes, then restore KVO inheritance.
         window.appearance = application.effectiveAppearance
         scheduleReset { [weak window] in
+            if let window {
+                SettingsWindowSizing.enforceMinimumSize(window)
+            }
             window?.appearance = nil
             window?.viewsNeedDisplay = true
         }
@@ -149,6 +219,20 @@ enum SettingsWindowAppearance {
             await Task.yield()
             action()
         }
+    }
+}
+
+extension NSView {
+    fileprivate func firstDescendantSplitView(matching predicate: (NSSplitView) -> Bool) -> NSSplitView? {
+        if let splitView = self as? NSSplitView, predicate(splitView) {
+            return splitView
+        }
+        for subview in self.subviews {
+            if let splitView = subview.firstDescendantSplitView(matching: predicate) {
+                return splitView
+            }
+        }
+        return nil
     }
 }
 

--- a/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
+++ b/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
@@ -6,6 +6,64 @@ import Testing
 @MainActor
 struct SettingsWindowAppearanceTests {
     @Test
+    func `settings window sizing repairs collapsed saved frames`() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 120, y: 160, width: 180, height: 140),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        let originalMaxY = window.frame.maxY
+
+        SettingsWindowSizing.enforceMinimumSize(window)
+
+        #expect(window.minSize.width == SettingsPane.windowMinWidth)
+        #expect(window.minSize.height >= SettingsPane.windowMinHeight)
+        #expect(window.frame.width >= window.minSize.width)
+        #expect(window.frame.height >= window.minSize.height)
+        #expect(abs(window.frame.maxY - originalMaxY) < 1)
+    }
+
+    @Test
+    func `settings window sizing leaves valid frames alone`() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 120, y: 160, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        let originalFrame = window.frame
+
+        SettingsWindowSizing.enforceMinimumSize(window)
+
+        #expect(window.frame == originalFrame)
+        #expect(window.minSize.width == SettingsPane.windowMinWidth)
+        #expect(window.minSize.height >= SettingsPane.windowMinHeight)
+    }
+
+    @Test
+    func `settings window sizing restores a collapsed sidebar split view`() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 120, y: 160, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        let splitView = NSSplitView(
+            frame: NSRect(x: 0, y: 0, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight))
+        splitView
+            .identifier = NSUserInterfaceItemIdentifier("com_apple_SwiftUI_Settings_window, SidebarNavigationSplitView")
+        splitView.isVertical = true
+        let sidebar = NSView(frame: NSRect(x: 0, y: 0, width: 0, height: SettingsPane.windowHeight))
+        let detail = NSView(
+            frame: NSRect(x: 0, y: 0, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight))
+        splitView.addSubview(sidebar)
+        splitView.addSubview(detail)
+        window.contentView = splitView
+
+        SettingsWindowSizing.enforceMinimumSize(window)
+
+        #expect(sidebar.frame.width >= SettingsPane.sidebarWidth)
+    }
+
+    @Test
     func `bridge pulses exact effective appearance then restores inheritance`() {
         let application = NSApplication.shared
         let effectiveAppearance = application.effectiveAppearance


### PR DESCRIPTION
## Summary
- Keep the Settings sidebar visible by binding `NavigationSplitView` to the two-column state and clamping the sidebar column to 224 pt.
- Repair undersized saved Settings window frames on open.
- Repair collapsed saved `SidebarNavigationSplitView` frames so the sidebar comes back usable after a bad persisted width.

## Root Cause
The 0.38 Settings redesign moved to a System Settings-style `NavigationSplitView`. SwiftUI/AppKit persisted the split-view subview frames, so a sidebar dragged down to zero or a very narrow width could be restored on the next open with no visible recovery affordance.

## Live Proof
Fresh packaged build: `/Users/alec/Dev/apps/CodexBar/CodexBar.app`, version `0.38.1 (95)`, built July 3, 2026 at 13:32.

Injected persisted bad state before launching:
- `NSSplitView Subview Frames com_apple_SwiftUI_Settings_window, SidebarNavigationSplitView`: first pane width `0.000000`
- `NSWindow Frame com_apple_SwiftUI_Settings_window`: `180x140`

Opened Settings from the app menu. Result:
- accessibility tree reported `splitter ... value 224`
- saved split defaults after open: first pane `224.000000`, detail pane `695.000000`
- window-only screenshot captured locally at `/tmp/codexbar-settings-sidebar-proof.png`

## Validation
- `swift test --filter SettingsWindowAppearanceTests` — 5 tests passed
- `./Scripts/package_app.sh` — packaged `CodexBar.app`
- `./Scripts/lint.sh lint-macos` — passed
- `.build/lint-tools/bin/swiftlint --strict` — passed, 0 violations
- `make check` — attempted; portable checks ran through docs/site locale checks, then failed on the existing `node --check docs/site.js` ESM/CommonJS issue with local Node `25.9.0` and `24.15.0`
