### PR TITLE
Show OpenCode Go monthly pace

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -411,12 +411,12 @@ extension UsageMenuCardView.Model {
         return pace.expectedUsedPercent >= 3 || pace.etaSeconds == 0 ? pace : nil
     }
 
-    static func cursorBillingCyclePaceDetail(
+    static func billingCyclePaceDetail(
         window: RateWindow,
         input: Input,
         pace: UsagePace? = nil) -> PaceDetail?
     {
-        guard input.provider == .cursor,
+        guard input.provider == .cursor || input.provider == .opencodego,
               window.windowMinutes != nil,
               window.remainingPercent > 0
         else { return nil }

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1166,7 +1166,7 @@ extension UsageMenuCardView.Model {
             let opusResetText: String? = input.provider == .perplexity
                 ? opus.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
                 : Self.resetText(for: opus, style: input.resetTimeDisplayStyle, now: input.now)
-            let tertiaryPaceDetail = Self.cursorBillingCyclePaceDetail(window: opus, input: input)
+            let tertiaryPaceDetail = Self.billingCyclePaceDetail(window: opus, input: input)
             metrics.append(Metric(
                 id: "tertiary",
                 title: labels.tertiary,
@@ -1318,7 +1318,9 @@ extension UsageMenuCardView.Model {
                 }
             }
         }
-        if let paceDetail = Self.cursorBillingCyclePaceDetail(window: primary, input: input) {
+        if input.provider == .cursor,
+           let paceDetail = Self.billingCyclePaceDetail(window: primary, input: input)
+        {
             primaryDetailLeft = paceDetail.leftLabel
             primaryDetailRight = paceDetail.rightLabel
             primaryPacePercent = paceDetail.pacePercent
@@ -1434,10 +1436,11 @@ extension UsageMenuCardView.Model {
         {
             paceDetail = PaceDetail(leftLabel: detail, rightLabel: nil, pacePercent: nil, paceOnTop: true)
         }
-        if let cursorPaceDetail = Self.cursorBillingCyclePaceDetail(
-            window: weekly,
-            input: input,
-            pace: input.weeklyPace)
+        if input.provider == .cursor,
+           let cursorPaceDetail = Self.billingCyclePaceDetail(
+               window: weekly,
+               input: input,
+               pace: input.weeklyPace)
         {
             paceDetail = cursorPaceDetail
         }

--- a/Tests/CodexBarTests/OpenCodeGoMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoMenuCardModelTests.swift
@@ -5,6 +5,49 @@ import Testing
 
 struct OpenCodeGoMenuCardModelTests {
     @Test
+    func `monthly usage shows pace details`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 40, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            tertiary: RateWindow(
+                usedPercent: 75,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: now.addingTimeInterval(15 * 24 * 3600),
+                resetDescription: nil),
+            updatedAt: now,
+            identity: nil)
+        let metadata = try #require(ProviderDefaults.metadata[.opencodego])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .opencodego,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        let monthly = try #require(model.metrics.first { $0.id == "tertiary" })
+        #expect(monthly.title == "Monthly")
+        #expect(monthly.detailLeftText == "25% in deficit")
+        #expect(monthly.detailRightText == "Runs out in 5d")
+        #expect(monthly.pacePercent == 50)
+        #expect(monthly.paceOnTop == false)
+    }
+
+    @Test
     func `zen balance renders as optional balance`() throws {
         let now = Date()
         let snapshot = UsageSnapshot(


### PR DESCRIPTION
## Summary

- show pace status and projected run-out details on the OpenCode Go monthly row
- reuse the existing billing-cycle pace calculation shared with Cursor
- keep OpenCode Go's 5-hour row unchanged, limiting the fix to the reported monthly gap
- add deterministic menu-card model coverage

Fixes #1863.

## After-fix visual proof

This image is rendered from the production `UsageMenuCardView` on this branch with a deterministic OpenCode Go fixture. It shows the unchanged 5-hour/Weekly rows and the new Monthly pace detail:

![OpenCode Go monthly pace after fix](https://raw.githubusercontent.com/joeVenner/CodexBar/proof-assets/proof/opencodego-monthly-pace-pr1867.png)

The Monthly row now shows `25% in deficit`, `Runs out in 5d`, and the expected pace marker. The capture path does not read browser cookies, Keychain data, or a live provider account.

## Testing

- `swift test --disable-sandbox --filter OpenCodeGoMenuCardModelTests` (4 passed)
- `swift test --disable-sandbox --filter UsagePaceTextTests` (21 passed)
- `swift test --disable-sandbox --filter MenuBarPaceTextTests` (2 passed)
- production SwiftUI proof render passed (`OpenCodeGoProofCaptureTests`, temporary uncommitted capture harness)
- `make check` (0 formatting or lint violations)
- `make test` (sandbox module-cache failure during test discovery in the isolated checkout; all focused changed-area suites pass)
