### PR TITLE
Fix monthly reset-window pace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Xiaomi MiMo: require authoritative cadence evidence before showing reserve or deficit projections, avoiding guesses from plan dates or names.
 
 ### Fixed
+- Monthly quota pace: show reserve, deficit, and run-out estimates for OpenCode Go, Doubao, and Alibaba monthly reset windows using their calendar-cycle length. Thanks @Zihao-Qi and @joeVenner!
 - Claude: block background delegated CLI OAuth refresh when the keychain holds MCP-only state (`mcpOAuth` without `claudeAiOauth`) while preserving explicit Refresh recovery (#1844). Thanks @Yuxin-Qiao!
 
 ## 0.38.0 — 2026-07-03

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -434,20 +434,21 @@ extension UsageMenuCardView.Model {
             showUsed: input.usageBarsShowUsed)
     }
 
-    private static let monthlyResetWindowMinutes = 30 * 24 * 60
+    private static let monthlyWindowSentinelMinutes = 30 * 24 * 60
 
     private static func supportsResetWindowPace(provider: UsageProvider, window: RateWindow) -> Bool {
         switch provider {
         case .cursor:
             window.windowMinutes != nil
         case .alibaba, .alibabatokenplan, .doubao, .opencodego:
-            window.windowMinutes == self.monthlyResetWindowMinutes
+            window.windowMinutes == self.monthlyWindowSentinelMinutes
         default:
             false
         }
     }
 
     private static func resetWindowForPace(provider: UsageProvider, window: RateWindow) -> RateWindow {
+        // Provider snapshots use 30 days as a monthly sentinel; use the reset date for the real calendar-cycle length.
         guard self.usesInferredMonthlyDuration(provider: provider, window: window),
               let resetsAt = window.resetsAt,
               let minutes = self.inferredMonthlyWindowMinutes(endingAt: resetsAt)
@@ -462,7 +463,7 @@ extension UsageMenuCardView.Model {
     }
 
     private static func usesInferredMonthlyDuration(provider: UsageProvider, window: RateWindow) -> Bool {
-        guard window.windowMinutes == self.monthlyResetWindowMinutes else { return false }
+        guard window.windowMinutes == self.monthlyWindowSentinelMinutes else { return false }
         switch provider {
         case .alibaba, .alibabatokenplan, .doubao, .opencodego:
             return true

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -411,27 +411,73 @@ extension UsageMenuCardView.Model {
         return pace.expectedUsedPercent >= 3 || pace.etaSeconds == 0 ? pace : nil
     }
 
-    static func cursorBillingCyclePaceDetail(
+    static func resetWindowPaceDetail(
         window: RateWindow,
         input: Input,
         pace: UsagePace? = nil) -> PaceDetail?
     {
-        guard input.provider == .cursor,
-              window.windowMinutes != nil,
+        guard self.supportsResetWindowPace(provider: input.provider, window: window),
               window.remainingPercent > 0
         else { return nil }
+        let paceWindow = Self.resetWindowForPace(provider: input.provider, window: window)
         let resolved = pace ?? UsagePace.weekly(
-            window: window,
+            window: paceWindow,
             now: input.now,
             defaultWindowMinutes: 10080,
             workDays: input.workDaysPerWeek)
         guard let resolved = Self.displayableWeeklyPace(resolved) else { return nil }
         return Self.weeklyPaceDetail(
             provider: input.provider,
-            window: window,
+            window: paceWindow,
             now: input.now,
             pace: resolved,
             showUsed: input.usageBarsShowUsed)
+    }
+
+    private static let monthlyResetWindowMinutes = 30 * 24 * 60
+
+    private static func supportsResetWindowPace(provider: UsageProvider, window: RateWindow) -> Bool {
+        switch provider {
+        case .cursor:
+            window.windowMinutes != nil
+        case .alibaba, .alibabatokenplan, .doubao, .opencodego:
+            window.windowMinutes == self.monthlyResetWindowMinutes
+        default:
+            false
+        }
+    }
+
+    private static func resetWindowForPace(provider: UsageProvider, window: RateWindow) -> RateWindow {
+        guard self.usesInferredMonthlyDuration(provider: provider, window: window),
+              let resetsAt = window.resetsAt,
+              let minutes = self.inferredMonthlyWindowMinutes(endingAt: resetsAt)
+        else { return window }
+        return RateWindow(
+            usedPercent: window.usedPercent,
+            windowMinutes: minutes,
+            resetsAt: window.resetsAt,
+            resetDescription: window.resetDescription,
+            nextRegenPercent: window.nextRegenPercent,
+            isSyntheticPlaceholder: window.isSyntheticPlaceholder)
+    }
+
+    private static func usesInferredMonthlyDuration(provider: UsageProvider, window: RateWindow) -> Bool {
+        guard window.windowMinutes == self.monthlyResetWindowMinutes else { return false }
+        switch provider {
+        case .alibaba, .alibabatokenplan, .doubao, .opencodego:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func inferredMonthlyWindowMinutes(endingAt resetsAt: Date) -> Int? {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? calendar.timeZone
+        guard let startsAt = calendar.date(byAdding: .month, value: -1, to: resetsAt) else { return nil }
+        let minutes = resetsAt.timeIntervalSince(startsAt) / 60
+        guard minutes.isFinite, minutes > 0 else { return nil }
+        return Int(minutes.rounded())
     }
 
     static func antigravityMetrics(input: Input, snapshot: UsageSnapshot) -> [Metric] {

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1166,7 +1166,7 @@ extension UsageMenuCardView.Model {
             let opusResetText: String? = input.provider == .perplexity
                 ? opus.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
                 : Self.resetText(for: opus, style: input.resetTimeDisplayStyle, now: input.now)
-            let tertiaryPaceDetail = Self.cursorBillingCyclePaceDetail(window: opus, input: input)
+            let tertiaryPaceDetail = Self.resetWindowPaceDetail(window: opus, input: input)
             metrics.append(Metric(
                 id: "tertiary",
                 title: labels.tertiary,
@@ -1317,8 +1317,7 @@ extension UsageMenuCardView.Model {
                     primaryPaceOnTop = paceDetail.paceOnTop
                 }
             }
-        }
-        if let paceDetail = Self.cursorBillingCyclePaceDetail(window: primary, input: input) {
+        } else if let paceDetail = Self.resetWindowPaceDetail(window: primary, input: input) {
             primaryDetailLeft = paceDetail.leftLabel
             primaryDetailRight = paceDetail.rightLabel
             primaryPacePercent = paceDetail.pacePercent
@@ -1434,7 +1433,7 @@ extension UsageMenuCardView.Model {
         {
             paceDetail = PaceDetail(leftLabel: detail, rightLabel: nil, pacePercent: nil, paceOnTop: true)
         }
-        if let cursorPaceDetail = Self.cursorBillingCyclePaceDetail(
+        if let cursorPaceDetail = Self.resetWindowPaceDetail(
             window: weekly,
             input: input,
             pace: input.weeklyPace)

--- a/Tests/CodexBarTests/AlibabaCodingPlanMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/AlibabaCodingPlanMenuCardModelTests.swift
@@ -3,9 +3,9 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-struct DoubaoMenuCardModelTests {
+struct AlibabaCodingPlanMenuCardModelTests {
     @Test
-    func `coding plan monthly quota shows deficit and run out details`() throws {
+    func `monthly quota shows deficit and run out details`() throws {
         let now = Date(timeIntervalSince1970: 10_368_000) // 1970-05-01T00:00:00Z
         let reset = now.addingTimeInterval(6 * 24 * 3600)
         let snapshot = UsageSnapshot(
@@ -13,23 +13,23 @@ struct DoubaoMenuCardModelTests {
                 usedPercent: 25,
                 windowMinutes: 5 * 60,
                 resetsAt: now.addingTimeInterval(2 * 3600),
-                resetDescription: nil),
+                resetDescription: "250 / 1000 used"),
             secondary: RateWindow(
                 usedPercent: 40,
                 windowMinutes: 7 * 24 * 60,
                 resetsAt: now.addingTimeInterval(4 * 24 * 3600),
-                resetDescription: nil),
+                resetDescription: "400 / 1000 used"),
             tertiary: RateWindow(
                 usedPercent: 90,
                 windowMinutes: 30 * 24 * 60,
                 resetsAt: reset,
-                resetDescription: nil),
+                resetDescription: "900 / 1000 used"),
             updatedAt: now,
             identity: nil)
-        let metadata = try #require(ProviderDefaults.metadata[.doubao])
+        let metadata = try #require(ProviderDefaults.metadata[.alibaba])
 
         let model = UsageMenuCardView.Model.make(.init(
-            provider: .doubao,
+            provider: .alibaba,
             metadata: metadata,
             snapshot: snapshot,
             credits: nil,
@@ -51,6 +51,7 @@ struct DoubaoMenuCardModelTests {
         #expect(model.metrics.map(\.title) == ["5-hour", "Weekly", "Monthly"])
         let monthly = try #require(model.metrics.first { $0.id == "tertiary" })
         #expect(monthly.percentLabel == "10% left")
+        #expect(monthly.detailText == "900 / 1000 used")
         #expect(monthly.detailLeftText == "10% in deficit")
         #expect(monthly.detailRightText == "Runs out in 2d 16h")
         #expect(monthly.pacePercent == 20)
@@ -58,20 +59,50 @@ struct DoubaoMenuCardModelTests {
     }
 
     @Test
-    func `unknown request limit renders unavailable instead of full quota`() throws {
-        let now = Date(timeIntervalSince1970: 1_742_771_200)
-        let metadata = try #require(ProviderDefaults.metadata[.doubao])
-        let snapshot = DoubaoUsageSnapshot(
-            remainingRequests: 0,
-            limitRequests: 1000,
-            resetTime: nil,
-            updatedAt: now,
-            apiKeyValid: true,
-            requestLimitsReliable: false)
-            .toUsageSnapshot()
+    func `monthly pace uses thirty one day reset window`() throws {
+        let now = try Self.date("2026-07-01T23:00:00Z")
+        let reset = try Self.date("2026-08-01T00:00:00Z")
+        let model = try Self.model(
+            now: now,
+            monthly: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: reset,
+                resetDescription: nil))
 
-        let model = UsageMenuCardView.Model.make(.init(
-            provider: .doubao,
+        let monthly = try #require(model.metrics.first { $0.id == "tertiary" })
+        #expect(monthly.detailLeftText == "7% in deficit")
+        #expect(monthly.detailRightText == "Runs out in 8d 15h")
+    }
+
+    @Test
+    func `monthly pace uses twenty eight day reset window`() throws {
+        let now = try Self.date("2026-02-02T00:00:00Z")
+        let reset = try Self.date("2026-03-01T00:00:00Z")
+        let model = try Self.model(
+            now: now,
+            monthly: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: reset,
+                resetDescription: nil))
+
+        let monthly = try #require(model.metrics.first { $0.id == "tertiary" })
+        #expect(monthly.detailLeftText == "4% in reserve")
+        #expect(monthly.detailRightText == "Lasts until reset")
+    }
+
+    private static func model(now: Date, monthly: RateWindow) throws -> UsageMenuCardView.Model {
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: monthly,
+            updatedAt: now,
+            identity: nil)
+        let metadata = try #require(ProviderDefaults.metadata[.alibaba])
+
+        return UsageMenuCardView.Model.make(.init(
+            provider: .alibaba,
             metadata: metadata,
             snapshot: snapshot,
             credits: nil,
@@ -89,9 +120,9 @@ struct DoubaoMenuCardModelTests {
             showOptionalCreditsAndExtraUsage: true,
             hidePersonalInfo: false,
             now: now))
+    }
 
-        #expect(model.metrics.isEmpty)
-        #expect(model.placeholder == "Limits not available")
-        #expect(model.subtitleStyle == .info)
+    private static func date(_ value: String) throws -> Date {
+        try #require(ISO8601DateFormatter().date(from: value))
     }
 }

--- a/Tests/CodexBarTests/AlibabaTokenPlanMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanMenuCardModelTests.swift
@@ -1,0 +1,49 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct AlibabaTokenPlanMenuCardModelTests {
+    @Test
+    func `monthly quota shows deficit and run out details`() throws {
+        let now = Date(timeIntervalSince1970: 10_368_000) // 1970-05-01T00:00:00Z
+        let snapshot = AlibabaTokenPlanUsageSnapshot(
+            planName: "TOKEN PLAN",
+            usedQuota: 900,
+            totalQuota: 1000,
+            remainingQuota: nil,
+            resetsAt: now.addingTimeInterval(6 * 24 * 3600),
+            updatedAt: now)
+            .toUsageSnapshot()
+        let metadata = try #require(ProviderDefaults.metadata[.alibabatokenplan])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .alibabatokenplan,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.map(\.title) == ["Credits"])
+        let monthly = try #require(model.metrics.first { $0.id == "primary" })
+        #expect(monthly.percentLabel == "10% left")
+        #expect(monthly.detailText == "900 / 1,000 credits used")
+        #expect(monthly.detailLeftText == "10% in deficit")
+        #expect(monthly.detailRightText == "Runs out in 2d 16h")
+        #expect(monthly.pacePercent == 20)
+        #expect(monthly.paceOnTop == false)
+    }
+}

--- a/Tests/CodexBarTests/OpenCodeGoMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoMenuCardModelTests.swift
@@ -5,6 +5,60 @@ import Testing
 
 struct OpenCodeGoMenuCardModelTests {
     @Test
+    func `monthly quota shows deficit and run out details`() throws {
+        let now = Date(timeIntervalSince1970: 10_368_000) // 1970-05-01T00:00:00Z
+        let reset = now.addingTimeInterval(6 * 24 * 3600)
+        let monthlyMinutes = 30 * 24 * 60
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 25,
+                windowMinutes: 5 * 60,
+                resetsAt: now.addingTimeInterval(2 * 3600),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 40,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(4 * 24 * 3600),
+                resetDescription: nil),
+            tertiary: RateWindow(
+                usedPercent: 90,
+                windowMinutes: monthlyMinutes,
+                resetsAt: reset,
+                resetDescription: nil),
+            updatedAt: now,
+            identity: nil)
+        let metadata = try #require(ProviderDefaults.metadata[.opencodego])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .opencodego,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.map(\.title) == ["5-hour", "Weekly", "Monthly"])
+        let monthly = try #require(model.metrics.first { $0.id == "tertiary" })
+        #expect(monthly.percentLabel == "10% left")
+        #expect(monthly.detailLeftText == "10% in deficit")
+        #expect(monthly.detailRightText == "Runs out in 2d 16h")
+        #expect(monthly.pacePercent == 20)
+        #expect(monthly.paceOnTop == false)
+    }
+
+    @Test
     func `zen balance renders as optional balance`() throws {
         let now = Date()
         let snapshot = UsageSnapshot(


### PR DESCRIPTION
## Summary

Fix monthly reset-window pace details for OpenCode Go and related providers.

- Generalize the old Cursor-only billing-cycle pace helper into an explicit reset-window pace helper.
- Enable monthly pace details for OpenCode Go, Doubao, Alibaba Coding Plan, and Alibaba Token Plan.
- Infer actual monthly duration from `resetsAt` so 28/29/31-day cycles do not blank or skew pace.
- Keep the helper provider/window allowlisted to avoid affecting unrelated tertiary rows.
- Add focused menu-model tests for the supported providers and month-length edge cases.

## Why

OpenCode Go exposes a monthly quota window, but the menu only showed pace details for Cursor billing-cycle windows. The same monthly reset-window shape also exists for Doubao and Alibaba plans, so keeping the logic Cursor-specific would miss equivalent provider behavior.

The fix keeps the behavior narrow: only known monthly reset-window providers opt in, and unrelated daily, credit-balance, or arbitrary tertiary rows continue using existing rendering.

This overlaps with #1867, but covers the broader monthly reset-window family and adds 28/31-day month coverage.

Fixes #1863.

## Validation

- `swift test --filter 'OpenCodeGoMenuCardModelTests|DoubaoMenuCardModelTests|AlibabaCodingPlanMenuCardModelTests|AlibabaTokenPlanMenuCardModelTests|CursorMenuCardModelTests'`
- `make check`
- `git diff --check`