### PR TITLE
Fix Settings sidebar recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 - Localization: translate the Default Terminal setting across every supported app language. Thanks @Zihao-Qi!
+- Settings: recover collapsed sidebars and undersized saved window frames when reopening Settings. Thanks @ProspectOre!
 - Claude: block background delegated CLI OAuth refresh when the keychain holds MCP-only state (`mcpOAuth` without `claudeAiOauth`) while preserving explicit Refresh recovery (#1844). Thanks @Yuxin-Qiao!
 
 ## 0.38.0 — 2026-07-03

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -16,6 +16,7 @@ enum SettingsPane: Hashable {
     static let windowMinWidth: CGFloat = 780
     static let windowMinHeight: CGFloat = 520
     static let sidebarWidth: CGFloat = 224
+    static let sidebarMinWidth: CGFloat = 224
 
     var title: String {
         switch self {
@@ -40,6 +41,7 @@ struct PreferencesView: View {
     let codexAccountPromotionCoordinator: CodexAccountPromotionCoordinator
     let runProviderLoginFlow: @MainActor (UsageProvider) async -> Void
     @Environment(\.colorScheme) private var colorScheme
+    @State private var columnVisibility: NavigationSplitViewVisibility = .doubleColumn
 
     init(
         settings: SettingsStore,
@@ -64,9 +66,16 @@ struct PreferencesView: View {
     }
 
     var body: some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: self.columnVisibilityBinding) {
             SettingsSidebarView(settings: self.settings, store: self.store, selection: self.$selection.pane)
-                .navigationSplitViewColumnWidth(SettingsPane.sidebarWidth)
+                .frame(
+                    minWidth: SettingsPane.sidebarMinWidth,
+                    idealWidth: SettingsPane.sidebarWidth,
+                    maxWidth: SettingsPane.sidebarWidth)
+                .navigationSplitViewColumnWidth(
+                    min: SettingsPane.sidebarMinWidth,
+                    ideal: SettingsPane.sidebarWidth,
+                    max: SettingsPane.sidebarWidth)
                 .toolbar(removing: .sidebarToggle)
         } detail: {
             self.detailView
@@ -86,6 +95,7 @@ struct PreferencesView: View {
         }
         .onAppear {
             self.ensureValidSelection()
+            self.columnVisibility = .doubleColumn
         }
         .onChange(of: self.settings.debugMenuEnabled) { _, _ in
             self.ensureValidSelection()
@@ -117,10 +127,59 @@ struct PreferencesView: View {
         }
     }
 
+    private var columnVisibilityBinding: Binding<NavigationSplitViewVisibility> {
+        Binding(
+            get: { self.columnVisibility },
+            set: { self.columnVisibility = Self.visibleColumnVisibility(for: $0) })
+    }
+
+    static func visibleColumnVisibility(for _: NavigationSplitViewVisibility) -> NavigationSplitViewVisibility {
+        .doubleColumn
+    }
+
     private func ensureValidSelection() {
         if !self.settings.debugMenuEnabled, self.selection.pane == .debug {
             self.selection.pane = .general
         }
+    }
+}
+
+@MainActor
+enum SettingsWindowSizing {
+    static func enforceMinimumSize(_ window: NSWindow) {
+        let toolbarHeight = max(0, window.frame.height - window.contentLayoutRect.height)
+        let minimumSize = NSSize(
+            width: SettingsPane.windowMinWidth,
+            height: SettingsPane.windowMinHeight + toolbarHeight)
+        window.minSize = minimumSize
+
+        if window.frame.width < minimumSize.width || window.frame.height < minimumSize.height {
+            var frame = window.frame
+            let repairedSize = NSSize(
+                width: max(frame.width, minimumSize.width),
+                height: max(frame.height, minimumSize.height))
+            frame.origin.y += frame.height - repairedSize.height
+            frame.size = repairedSize
+            window.setFrame(frame, display: true)
+        }
+
+        self.enforceSidebarWidth(in: window)
+    }
+
+    private static func enforceSidebarWidth(in window: NSWindow) {
+        // SwiftUI's split-view identifier is private and has changed across macOS releases.
+        // The Settings navigation split is the widest vertical two-pane split in this window.
+        guard let splitView = window.contentView?.descendantSplitViews
+            .filter({ $0.isVertical && $0.subviews.count == 2 })
+            .max(by: { $0.bounds.width < $1.bounds.width })
+        else {
+            return
+        }
+
+        let sidebar = splitView.subviews[0]
+        guard sidebar.frame.width < SettingsPane.sidebarWidth else { return }
+        splitView.setPosition(SettingsPane.sidebarWidth, ofDividerAt: 0)
+        splitView.adjustSubviews()
     }
 }
 
@@ -134,11 +193,15 @@ enum SettingsWindowAppearance {
         application: NSApplication = NSApp,
         scheduleReset: ResetScheduler = Self.scheduleReset)
     {
+        SettingsWindowSizing.enforceMinimumSize(window)
         window.appearanceSource = application
         // Pulse the exact effective appearance so the native toolbar redraws without
         // dropping inherited accessibility attributes, then restore KVO inheritance.
         window.appearance = application.effectiveAppearance
         scheduleReset { [weak window] in
+            if let window {
+                SettingsWindowSizing.enforceMinimumSize(window)
+            }
             window?.appearance = nil
             window?.viewsNeedDisplay = true
         }
@@ -149,6 +212,13 @@ enum SettingsWindowAppearance {
             await Task.yield()
             action()
         }
+    }
+}
+
+extension NSView {
+    fileprivate var descendantSplitViews: [NSSplitView] {
+        let current = (self as? NSSplitView).map { [$0] } ?? []
+        return current + self.subviews.flatMap(\.descendantSplitViews)
     }
 }
 

--- a/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
+++ b/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
@@ -6,6 +6,97 @@ import Testing
 @MainActor
 struct SettingsWindowAppearanceTests {
     @Test
+    func `settings always keeps both navigation columns visible`() {
+        #expect(PreferencesView.visibleColumnVisibility(for: .detailOnly) == .doubleColumn)
+        #expect(PreferencesView.visibleColumnVisibility(for: .automatic) == .doubleColumn)
+        #expect(PreferencesView.visibleColumnVisibility(for: .doubleColumn) == .doubleColumn)
+    }
+
+    @Test
+    func `settings window sizing repairs collapsed saved frames`() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 120, y: 160, width: 180, height: 140),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        let originalMaxY = window.frame.maxY
+
+        SettingsWindowSizing.enforceMinimumSize(window)
+
+        #expect(window.minSize.width == SettingsPane.windowMinWidth)
+        #expect(window.minSize.height >= SettingsPane.windowMinHeight)
+        #expect(window.frame.width >= window.minSize.width)
+        #expect(window.frame.height >= window.minSize.height)
+        #expect(abs(window.frame.maxY - originalMaxY) < 1)
+    }
+
+    @Test
+    func `settings window sizing leaves valid frames alone`() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 120, y: 160, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        let originalFrame = window.frame
+
+        SettingsWindowSizing.enforceMinimumSize(window)
+
+        #expect(window.frame == originalFrame)
+        #expect(window.minSize.width == SettingsPane.windowMinWidth)
+        #expect(window.minSize.height >= SettingsPane.windowMinHeight)
+    }
+
+    @Test
+    func `settings window sizing restores a collapsed sidebar without private identifiers`() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 120, y: 160, width: 180, height: 140),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        let splitView = NSSplitView(
+            frame: NSRect(x: 0, y: 0, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight))
+        splitView.isVertical = true
+        let sidebar = NSView(frame: NSRect(x: 0, y: 0, width: 0, height: SettingsPane.windowHeight))
+        let detail = NSView(
+            frame: NSRect(x: 0, y: 0, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight))
+        splitView.addSubview(sidebar)
+        splitView.addSubview(detail)
+        window.contentView = splitView
+
+        SettingsWindowSizing.enforceMinimumSize(window)
+
+        #expect(window.frame.width >= window.minSize.width)
+        #expect(sidebar.frame.width >= SettingsPane.sidebarWidth)
+    }
+
+    @Test
+    func `settings window sizing repairs the outer navigation split`() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 120, y: 160, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        let outerSplit = NSSplitView(
+            frame: NSRect(x: 0, y: 0, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight))
+        outerSplit.isVertical = true
+        let sidebar = NSView(frame: NSRect(x: 0, y: 0, width: 0, height: SettingsPane.windowHeight))
+        let detail = NSView(
+            frame: NSRect(x: 0, y: 0, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight))
+        let nestedSplit = NSSplitView(frame: NSRect(x: 0, y: 0, width: 300, height: 300))
+        nestedSplit.isVertical = true
+        nestedSplit.addSubview(NSView(frame: .zero))
+        nestedSplit.addSubview(NSView(frame: .zero))
+        detail.addSubview(nestedSplit)
+        outerSplit.addSubview(sidebar)
+        outerSplit.addSubview(detail)
+        window.contentView = outerSplit
+
+        SettingsWindowSizing.enforceMinimumSize(window)
+
+        #expect(sidebar.frame.width >= SettingsPane.sidebarWidth)
+    }
+
+    @Test
     func `bridge pulses exact effective appearance then restores inheritance`() {
         let application = NSApplication.shared
         let effectiveAppearance = application.effectiveAppearance


### PR DESCRIPTION
## Summary

- Keep the Settings navigation sidebar visible and fixed at its intended width.
- Repair undersized persisted Settings window frames and collapsed sidebar frames on reopen.
- Avoid SwiftUI's private split-view identifier by selecting the outer navigation split structurally.
- Add focused regression coverage and a changelog entry crediting @ProspectOre.

Supersedes #1865 because the contributor fork was archived and rejects maintainer fixup pushes.

## Live proof

Built and launched a fresh signed app after injecting a 180×140 saved Settings frame and a zero-width saved sidebar. Opening Settings recovered to 920×640; the accessibility tree reported a 224-point sidebar with the full navigation visible. The original user defaults were restored after the test.

## Validation

- `swift test --filter SettingsWindowAppearanceTests` — 7 passed
- `make check` — passed
- fresh `./Scripts/compile_and_run.sh` bundle — stayed running
- local screenshot inspection — recovered full sidebar and Settings content
- `autoreview --mode branch --base origin/main` — no actionable findings

Co-authored-by: pickaxe <54486432+ProspectOre@users.noreply.github.com>
