### PR TITLE
Fix Claude keychain prompt toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 - Branding: replace the malformed Poe icon and use Poe's official purple consistently across the app, widget, and website. Thanks @garethpaul!
+- Claude: make the "Avoid Keychain prompts" setting use the no-prompt policy instead of the experimental `security` CLI reader. Thanks @gmkbenjamin!
 - Monthly quota pace: show reserve, deficit, and run-out estimates for OpenCode Go, Doubao, and Alibaba monthly reset windows using their calendar-cycle length. Thanks @Zihao-Qi and @joeVenner!
 - Localization: translate the Default Terminal setting across every supported app language. Thanks @Zihao-Qi!
 - Settings: recover collapsed sidebars and undersized saved window frames when reopening Settings. Thanks @ProspectOre!

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -67,7 +67,7 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         let subtitle = if context.settings.debugDisableKeychainAccess {
             "Inactive while \"Disable Keychain access\" is enabled in Advanced."
         } else {
-            "Use /usr/bin/security to read Claude credentials and avoid CodexBar keychain prompts."
+            "Never allow Claude OAuth credential reads to show macOS Keychain prompts."
         }
 
         let promptFreeBinding = Binding(
@@ -141,8 +141,7 @@ struct ClaudeProviderImplementation: ProviderImplementation {
             if context.settings.debugDisableKeychainAccess {
                 return "Global Keychain access is disabled in Advanced, so this setting is currently inactive."
             }
-            return "Controls Claude OAuth Keychain prompts when the standard reader is active. Choosing " +
-                "\"Never prompt\" can make OAuth unavailable; use Web/CLI when needed."
+            return "Choosing \"Never prompt\" can make OAuth unavailable; use Web/CLI when needed."
         }
 
         return [
@@ -162,11 +161,11 @@ struct ClaudeProviderImplementation: ProviderImplementation {
             ProviderSettingsPickerDescriptor(
                 id: "claude-keychain-prompt-policy",
                 title: "Keychain prompt policy",
-                subtitle: "Applies only to the Security.framework OAuth keychain reader.",
+                subtitle: "Controls when Claude OAuth may ask macOS for Keychain access.",
                 dynamicSubtitle: keychainPromptPolicySubtitle,
                 binding: keychainPromptPolicyBinding,
                 options: keychainPromptPolicyOptions,
-                isVisible: { context.settings.claudeOAuthKeychainReadStrategy == .securityFramework },
+                isVisible: nil,
                 isEnabled: { !context.settings.debugDisableKeychainAccess },
                 onChange: nil),
             ProviderSettingsPickerDescriptor(

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -406,9 +406,10 @@ extension SettingsStore {
     var claudeOAuthKeychainReadStrategy: ClaudeOAuthKeychainReadStrategy {
         get {
             guard let raw = self.defaultsState.claudeOAuthKeychainReadStrategyRaw else {
-                return .securityCLIExperimental
+                return .securityFramework
             }
-            return ClaudeOAuthKeychainReadStrategy(rawValue: raw) ?? .securityFramework
+            let strategy = ClaudeOAuthKeychainReadStrategy(rawValue: raw) ?? .securityFramework
+            return strategy == .securityCLIExperimental ? .securityFramework : strategy
         }
         set {
             self.defaultsState.claudeOAuthKeychainReadStrategyRaw = newValue.rawValue
@@ -417,11 +418,14 @@ extension SettingsStore {
     }
 
     var claudeOAuthPromptFreeCredentialsEnabled: Bool {
-        get { self.claudeOAuthKeychainReadStrategy == .securityCLIExperimental }
+        get { self.claudeOAuthKeychainPromptMode == .never }
         set {
-            self.claudeOAuthKeychainReadStrategy = newValue
-                ? .securityCLIExperimental
-                : .securityFramework
+            self.claudeOAuthKeychainReadStrategy = .securityFramework
+            if newValue {
+                self.claudeOAuthKeychainPromptMode = .never
+            } else if self.claudeOAuthKeychainPromptMode == .never {
+                self.claudeOAuthKeychainPromptMode = .onlyOnUserAction
+            }
         }
     }
 

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -423,8 +423,8 @@ extension SettingsStore {
         let randomBlinkEnabled = userDefaults.object(forKey: "randomBlinkEnabled") as? Bool ?? false
         let confettiOnReset = Self.loadConfettiOnResetDefaults(userDefaults: userDefaults)
         let menuBarShowsHighestUsage = userDefaults.object(forKey: "menuBarShowsHighestUsage") as? Bool ?? false
+        let claudeOAuthKeychainReadStrategyRaw = Self.loadClaudeOAuthKeychainReadStrategyRaw(userDefaults: userDefaults)
         let claudeOAuthKeychainPromptModeRaw = userDefaults.string(forKey: "claudeOAuthKeychainPromptMode")
-        let claudeOAuthKeychainReadStrategyRaw = userDefaults.string(forKey: "claudeOAuthKeychainReadStrategy")
         let claudeWebExtrasEnabledRaw = userDefaults.object(forKey: "claudeWebExtrasEnabled") as? Bool ?? false
         let creditsExtrasDefault = userDefaults.object(forKey: "showOptionalCreditsAndExtraUsage") as? Bool
         let showOptionalCreditsAndExtraUsage = creditsExtrasDefault ?? true
@@ -533,6 +533,21 @@ extension SettingsStore {
             userDefaults.set(migratedStyle, forKey: "costSummaryDisplayStyle")
         }
         return migratedStyle
+    }
+
+    private static func loadClaudeOAuthKeychainReadStrategyRaw(userDefaults: UserDefaults) -> String? {
+        let key = "claudeOAuthKeychainReadStrategy"
+        guard let raw = userDefaults.string(forKey: key) else { return nil }
+        guard let strategy = ClaudeOAuthKeychainReadStrategy(rawValue: raw) else { return raw }
+        guard strategy == .securityCLIExperimental else { return raw }
+
+        let migrated = ClaudeOAuthKeychainReadStrategy.securityFramework.rawValue
+        userDefaults.set(migrated, forKey: key)
+        let promptModeKey = "claudeOAuthKeychainPromptMode"
+        if userDefaults.string(forKey: promptModeKey) == nil {
+            userDefaults.set(ClaudeOAuthKeychainPromptMode.never.rawValue, forKey: promptModeKey)
+        }
+        return migrated
     }
 
     private static func loadConfettiOnResetDefaults(userDefaults: UserDefaults) -> (session: Bool, weekly: Bool) {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainReadStrategy.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainReadStrategy.swift
@@ -17,26 +17,13 @@ public enum ClaudeOAuthKeychainReadStrategyPreference {
         if let taskOverride { return taskOverride }
         #endif
         if let raw = userDefaults.string(forKey: self.userDefaultsKey) {
-            return ClaudeOAuthKeychainReadStrategy(rawValue: raw) ?? .securityFramework
+            let strategy = ClaudeOAuthKeychainReadStrategy(rawValue: raw) ?? .securityFramework
+            return strategy == .securityCLIExperimental ? .securityFramework : strategy
         }
-        #if DEBUG
-        if self.isRunningUnderTests,
-           ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1"
-        {
-            return .securityFramework
-        }
-        #endif
-        return .securityCLIExperimental
+        return .securityFramework
     }
 
     #if DEBUG
-    private static var isRunningUnderTests: Bool {
-        let processName = ProcessInfo.processInfo.processName
-        return processName == "swiftpm-testing-helper"
-            || processName.hasSuffix("PackageTests")
-            || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-    }
-
     public static func withTaskOverrideForTesting<T>(
         _ strategy: ClaudeOAuthKeychainReadStrategy?,
         operation: () throws -> T) rethrows -> T

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -114,16 +114,17 @@ struct ProviderSettingsDescriptorTests {
     }
 
     @Test
-    func `claude prompt policy picker hidden when experimental reader selected`() throws {
+    func `claude prompt policy picker remains visible for prompt free toggle`() throws {
         let fixture = try self.makeSettingsFixture(
-            suite: "ProviderSettingsDescriptorTests-claude-prompt-hidden-experimental")
+            suite: "ProviderSettingsDescriptorTests-claude-prompt-visible-prompt-free")
         fixture.settings.debugDisableKeychainAccess = false
-        fixture.settings.claudeOAuthKeychainReadStrategy = .securityCLIExperimental
+        fixture.settings.claudeOAuthPromptFreeCredentialsEnabled = true
         let context = fixture.settingsContext(provider: .claude)
 
         let pickers = ClaudeProviderImplementation().settingsPickers(context: context)
         let keychainPicker = try #require(pickers.first(where: { $0.id == "claude-keychain-prompt-policy" }))
-        #expect(keychainPicker.isVisible?() == false)
+        #expect(keychainPicker.isVisible?() ?? true)
+        #expect(keychainPicker.binding.wrappedValue == ClaudeOAuthKeychainPromptMode.never.rawValue)
     }
 
     @Test

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -471,9 +471,9 @@ struct SettingsStoreCoverageTests {
     }
 
     @Test
-    func `claude keychain read strategy defaults to security CLI experimental`() {
+    func `claude keychain read strategy defaults to security framework`() {
         let settings = Self.makeSettingsStore()
-        #expect(settings.claudeOAuthKeychainReadStrategy == .securityCLIExperimental)
+        #expect(settings.claudeOAuthKeychainReadStrategy == .securityFramework)
     }
 
     @Test
@@ -484,13 +484,56 @@ struct SettingsStoreCoverageTests {
         let configStore = testConfigStore(suiteName: suite)
 
         let first = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
-        first.claudeOAuthKeychainReadStrategy = .securityCLIExperimental
+        first.claudeOAuthKeychainReadStrategy = .securityFramework
         #expect(
             defaults.string(forKey: "claudeOAuthKeychainReadStrategy")
-                == ClaudeOAuthKeychainReadStrategy.securityCLIExperimental.rawValue)
+                == ClaudeOAuthKeychainReadStrategy.securityFramework.rawValue)
 
         let second = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
-        #expect(second.claudeOAuthKeychainReadStrategy == .securityCLIExperimental)
+        #expect(second.claudeOAuthKeychainReadStrategy == .securityFramework)
+    }
+
+    @Test
+    func `claude legacy security CLI read strategy preserves no prompt intent`() throws {
+        let suite = "SettingsStoreCoverageTests-claude-keychain-read-strategy-migration"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(
+            ClaudeOAuthKeychainReadStrategy.securityCLIExperimental.rawValue,
+            forKey: "claudeOAuthKeychainReadStrategy")
+        let configStore = testConfigStore(suiteName: suite)
+
+        let settings = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+
+        #expect(settings.claudeOAuthKeychainReadStrategy == .securityFramework)
+        #expect(settings.claudeOAuthKeychainPromptMode == .never)
+        #expect(settings.claudeOAuthPromptFreeCredentialsEnabled)
+        #expect(
+            defaults.string(forKey: "claudeOAuthKeychainReadStrategy")
+                == ClaudeOAuthKeychainReadStrategy.securityFramework.rawValue)
+        #expect(
+            defaults.string(forKey: "claudeOAuthKeychainPromptMode")
+                == ClaudeOAuthKeychainPromptMode.never.rawValue)
+    }
+
+    @Test
+    func `claude legacy security CLI migration preserves explicit prompt policy`() throws {
+        let suite = "SettingsStoreCoverageTests-claude-keychain-explicit-prompt-migration"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(
+            ClaudeOAuthKeychainReadStrategy.securityCLIExperimental.rawValue,
+            forKey: "claudeOAuthKeychainReadStrategy")
+        defaults.set(
+            ClaudeOAuthKeychainPromptMode.always.rawValue,
+            forKey: "claudeOAuthKeychainPromptMode")
+        let configStore = testConfigStore(suiteName: suite)
+
+        let settings = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+
+        #expect(settings.claudeOAuthKeychainReadStrategy == .securityFramework)
+        #expect(settings.claudeOAuthKeychainPromptMode == .always)
+        #expect(!settings.claudeOAuthPromptFreeCredentialsEnabled)
     }
 
     @Test
@@ -506,15 +549,17 @@ struct SettingsStoreCoverageTests {
     }
 
     @Test
-    func `claude prompt free credentials toggle maps to read strategy`() {
+    func `claude prompt free credentials toggle maps to never prompt policy`() {
         let settings = Self.makeSettingsStore()
-        #expect(settings.claudeOAuthPromptFreeCredentialsEnabled == true)
+        #expect(settings.claudeOAuthPromptFreeCredentialsEnabled == false)
+
+        settings.claudeOAuthPromptFreeCredentialsEnabled = true
+        #expect(settings.claudeOAuthKeychainReadStrategy == .securityFramework)
+        #expect(settings.claudeOAuthKeychainPromptMode == .never)
 
         settings.claudeOAuthPromptFreeCredentialsEnabled = false
         #expect(settings.claudeOAuthKeychainReadStrategy == .securityFramework)
-
-        settings.claudeOAuthPromptFreeCredentialsEnabled = true
-        #expect(settings.claudeOAuthKeychainReadStrategy == .securityCLIExperimental)
+        #expect(settings.claudeOAuthKeychainPromptMode == .onlyOnUserAction)
     }
 
     @Test

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -56,8 +56,8 @@ window has elapsed.
   reports sizes and cleanup ideas, it does not delete files.
 - Display: “Overview tab providers” controls which providers appear in Merge Icons → Overview (up to 3).
 - If no providers are selected for Overview, the Overview tab is hidden.
-- Providers → Claude: “Avoid Keychain prompts” uses the prompt-free Security CLI reader when available.
-- The lower-level “Keychain prompt policy” picker only appears when the Security.framework reader is active.
+- Providers → Claude: “Avoid Keychain prompts” selects the Security.framework reader's `Never prompt` policy.
+- The lower-level “Keychain prompt policy” picker remains visible as the source of truth for Claude OAuth prompts.
 
 ## Widgets (high level)
 - Widgets render shared usage snapshots for the supported widget families and


### PR DESCRIPTION
## Summary

- Replace Claude's experimental `/usr/bin/security` toggle path with the Security.framework `Never prompt` policy.
- Preserve no-prompt intent when migrating legacy `securityCLIExperimental` preferences, while retaining an explicitly selected prompt policy.
- Keep the prompt-policy picker visible as the source of truth; update copy, docs, changelog, and regression coverage.

Maintainer replacement for https://github.com/steipete/CodexBar/pull/1878 because its fork does not allow maintainer edits. Based on @gmkbenjamin's implementation and preserves contributor credit.

Fixes #1877.

## Root cause

The **Avoid Keychain prompts** toggle selected `/usr/bin/security find-generic-password -w`, which can itself display macOS Keychain prompts. The standard Security.framework reader already supports a non-interactive policy, so the toggle now selects that reader with `Never prompt`.

## Validation

- `swift test --filter '(SettingsStoreCoverageTests|ProviderSettingsDescriptorTests|ClaudeOAuthCredentialsStorePromptPolicyTests)'` — 69 tests passed.
- `make check` — SwiftFormat, SwiftLint, repository checks passed.
- `make test` — full 46-group local suite passed.
- `autoreview --mode local` — clean, 0.84 confidence.
- Built-app proof from this exact candidate: launched with `CODEXBAR_DISABLE_KEYCHAIN_ACCESS=1`, seeded the legacy `securityCLIExperimental` preference with no explicit prompt mode, and verified runtime migration to `securityFramework` + `never`; Accessibility inspection showed **Never prompt**, the **Avoid Keychain prompts** toggle on, and the prompt-policy picker visible. The prior debug preferences were exported before the run and restored afterward.

## Risk

Low and contained to Claude OAuth preference migration and settings presentation. An explicit existing prompt policy wins during migration; only legacy CLI-reader preferences without an explicit policy gain `Never prompt`.
