### PR TITLE
[codex] Fix Claude keychain prompt test

### DIFF
--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -144,7 +144,9 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
             _ = await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
                 .withValue(recordWithoutRequiredScope) {
                     await ProviderInteractionContext.$current.withValue(.userInitiated) {
-                        await strategy.isAvailable(context)
+                        await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                            await strategy.isAvailable(context)
+                        }
                     }
                 }
 
@@ -181,9 +183,11 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                     await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
                         await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
                             await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
-                                await ProviderRefreshContext.$current.withValue(.startup) {
-                                    await ProviderInteractionContext.$current.withValue(.background) {
-                                        await strategy.isAvailable(context)
+                                await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                                    await ProviderRefreshContext.$current.withValue(.startup) {
+                                        await ProviderInteractionContext.$current.withValue(.background) {
+                                            await strategy.isAvailable(context)
+                                        }
                                     }
                                 }
                             }
@@ -246,9 +250,11 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                     await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
                         await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
                             await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.nonZeroExit) {
-                                await ProviderRefreshContext.$current.withValue(.startup) {
-                                    await ProviderInteractionContext.$current.withValue(.background) {
-                                        await strategy.isAvailable(context)
+                                await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                                    await ProviderRefreshContext.$current.withValue(.startup) {
+                                        await ProviderInteractionContext.$current.withValue(.background) {
+                                            await strategy.isAvailable(context)
+                                        }
                                     }
                                 }
                             }

--- a/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
@@ -42,6 +42,32 @@ struct KeychainPromptSafetyAuditTests {
     }
 
     @Test
+    func `claude availability tests with keychain enabled use test doubles`() throws {
+        let file = Self.repoRoot().appendingPathComponent(
+            "Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift")
+        let lines = try Self.lines(in: file)
+        let callSites = lines.enumerated().compactMap { lineNumber, line -> PromptCallSite? in
+            guard line.contains("strategy.isAvailable(context)") else { return nil }
+            let oneBasedLineNumber = lineNumber + 1
+            guard Self.hasOpenScope(
+                containing: "KeychainAccessGate.withTaskOverrideForTesting(false)",
+                lines: lines,
+                before: oneBasedLineNumber)
+            else {
+                return nil
+            }
+            return PromptCallSite(file: file, lineNumber: oneBasedLineNumber)
+        }
+
+        #expect(callSites.isEmpty == false)
+        for callSite in callSites {
+            let failureMessage = "\(callSite.file.path):\(callSite.lineNumber) calls strategy.isAvailable(context) "
+                + "with test keychain access enabled and no scoped keychain double"
+            #expect(Self.hasOpenKeychainTestDouble(lines: lines, before: callSite.lineNumber), "\(failureMessage)")
+        }
+    }
+
+    @Test
     func `tests do not call SecItemCopyMatching except no UI query coverage`() throws {
         let offenders = try Self.swiftTestFiles().filter { file in
             let text = try Self.readFile(file)
@@ -96,13 +122,24 @@ struct KeychainPromptSafetyAuditTests {
     private static func hasOpenKeychainTestDouble(lines: [Substring], before oneBasedLineNumber: Int) -> Bool {
         let helperNames = [
             "withClaudeKeychainOverridesForTesting",
+            "withKeychainAccessOverrideForTesting(true)",
             "withSecurityCLIReadOverrideForTesting",
             "KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting",
         ]
+        return helperNames.contains { helperName in
+            self.hasOpenScope(containing: helperName, lines: lines, before: oneBasedLineNumber)
+        }
+    }
+
+    private static func hasOpenScope(
+        containing needle: String,
+        lines: [Substring],
+        before oneBasedLineNumber: Int) -> Bool
+    {
         let targetIndex = oneBasedLineNumber - 1
         let lineRange = lines.indices.prefix(through: targetIndex)
         return lineRange.contains { index in
-            helperNames.contains { lines[index].contains($0) }
+            lines[index].contains(needle)
                 && self.hasOpenBraceScope(lines: lines, from: index, through: targetIndex)
         }
     }
@@ -110,7 +147,8 @@ struct KeychainPromptSafetyAuditTests {
     private static func hasOpenBraceScope(lines: [Substring], from startIndex: Int, through endIndex: Int) -> Bool {
         var balance = 0
         var sawOpeningBrace = false
-        for line in lines[startIndex...endIndex] {
+        for index in startIndex...endIndex {
+            let line = lines[index]
             for character in line {
                 switch character {
                 case "{":
@@ -121,6 +159,9 @@ struct KeychainPromptSafetyAuditTests {
                 default:
                     continue
                 }
+            }
+            if index < endIndex, sawOpeningBrace, balance <= 0 {
+                return false
             }
         }
         return sawOpeningBrace && balance > 0


### PR DESCRIPTION
## Summary

- Replace the accidental real Claude Keychain availability path in `ClaudeOAuthFetchStrategyAvailabilityTests` with scoped test keychain doubles.
- Extend `KeychainPromptSafetyAuditTests` so availability tests that explicitly enable Keychain access must also keep a scoped Keychain/CLI double open.
- Tighten the audit scope helper so a helper scope only counts while its brace scope is actually open.

## Root Cause

`auto mode user initiated clears keychain cooldown gate` enabled real test Keychain access with `KeychainAccessGate.withTaskOverrideForTesting(false)` and then called `strategy.isAvailable(context)` without a Claude credential/keychain double. The non-interactive credential fixture lacked the required `user:profile` scope, so availability fell through to `ClaudeOAuthCredentialsStore.hasClaudeKeychainCredentialsWithoutPrompt()`, which can invoke a real `SecItemCopyMatching` lookup for `Claude Code-credentials` during `make test`.

## Validation

- `swift test --filter ClaudeOAuthFetchStrategyAvailabilityTests`
- `swift test --filter KeychainPromptSafetyAuditTests`
- `git diff --check`
- `make check`

I intentionally did not rerun full `make test` because the existing issue is that the full suite can display a macOS Keychain prompt before this PR lands.

Fixes #1880