### PR TITLE
Fix Claude keychain prompt safety tests

### DIFF
--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -144,7 +144,9 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
             _ = await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
                 .withValue(recordWithoutRequiredScope) {
                     await ProviderInteractionContext.$current.withValue(.userInitiated) {
-                        await strategy.isAvailable(context)
+                        await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                            await strategy.isAvailable(context)
+                        }
                     }
                 }
 
@@ -181,9 +183,11 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                     await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
                         await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
                             await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
-                                await ProviderRefreshContext.$current.withValue(.startup) {
-                                    await ProviderInteractionContext.$current.withValue(.background) {
-                                        await strategy.isAvailable(context)
+                                await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                                    await ProviderRefreshContext.$current.withValue(.startup) {
+                                        await ProviderInteractionContext.$current.withValue(.background) {
+                                            await strategy.isAvailable(context)
+                                        }
                                     }
                                 }
                             }
@@ -246,9 +250,11 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                     await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
                         await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
                             await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.nonZeroExit) {
-                                await ProviderRefreshContext.$current.withValue(.startup) {
-                                    await ProviderInteractionContext.$current.withValue(.background) {
-                                        await strategy.isAvailable(context)
+                                await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                                    await ProviderRefreshContext.$current.withValue(.startup) {
+                                        await ProviderInteractionContext.$current.withValue(.background) {
+                                            await strategy.isAvailable(context)
+                                        }
                                     }
                                 }
                             }

--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -144,7 +144,7 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
             _ = await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
                 .withValue(recordWithoutRequiredScope) {
                     await ProviderInteractionContext.$current.withValue(.userInitiated) {
-                        await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                        await self.withAvailabilityKeychainDoubles {
                             await strategy.isAvailable(context)
                         }
                     }
@@ -183,7 +183,7 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                     await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
                         await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
                             await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
-                                await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                                await self.withAvailabilityKeychainDoubles {
                                     await ProviderRefreshContext.$current.withValue(.startup) {
                                         await ProviderInteractionContext.$current.withValue(.background) {
                                             await strategy.isAvailable(context)
@@ -250,7 +250,7 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                     await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
                         await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
                             await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.nonZeroExit) {
-                                await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                                await self.withAvailabilityKeychainDoubles {
                                     await ProviderRefreshContext.$current.withValue(.startup) {
                                         await ProviderInteractionContext.$current.withValue(.background) {
                                             await strategy.isAvailable(context)
@@ -370,6 +370,16 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
         }
 
         #expect(available == false)
+    }
+
+    private func withAvailabilityKeychainDoubles<T>(
+        operation: () async throws -> T) async rethrows -> T
+    {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        return try await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(
+            true,
+            operation: operation)
     }
 }
 #endif

--- a/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
@@ -42,6 +42,32 @@ struct KeychainPromptSafetyAuditTests {
     }
 
     @Test
+    func `claude availability tests with keychain enabled use test doubles`() throws {
+        let file = Self.repoRoot().appendingPathComponent(
+            "Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift")
+        let lines = try Self.lines(in: file)
+        let callSites = lines.enumerated().compactMap { lineNumber, line -> PromptCallSite? in
+            guard line.contains("strategy.isAvailable(context)") else { return nil }
+            let oneBasedLineNumber = lineNumber + 1
+            guard Self.hasOpenScope(
+                containing: "KeychainAccessGate.withTaskOverrideForTesting(false)",
+                lines: lines,
+                before: oneBasedLineNumber)
+            else {
+                return nil
+            }
+            return PromptCallSite(file: file, lineNumber: oneBasedLineNumber)
+        }
+
+        #expect(callSites.isEmpty == false)
+        for callSite in callSites {
+            let failureMessage = "\(callSite.file.path):\(callSite.lineNumber) calls strategy.isAvailable(context) "
+                + "with test keychain access enabled and no scoped keychain double"
+            #expect(Self.hasOpenKeychainTestDouble(lines: lines, before: callSite.lineNumber), "\(failureMessage)")
+        }
+    }
+
+    @Test
     func `tests do not call SecItemCopyMatching except no UI query coverage`() throws {
         let offenders = try Self.swiftTestFiles().filter { file in
             let text = try Self.readFile(file)
@@ -96,13 +122,24 @@ struct KeychainPromptSafetyAuditTests {
     private static func hasOpenKeychainTestDouble(lines: [Substring], before oneBasedLineNumber: Int) -> Bool {
         let helperNames = [
             "withClaudeKeychainOverridesForTesting",
+            "withKeychainAccessOverrideForTesting(true)",
             "withSecurityCLIReadOverrideForTesting",
             "KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting",
         ]
+        return helperNames.contains { helperName in
+            self.hasOpenScope(containing: helperName, lines: lines, before: oneBasedLineNumber)
+        }
+    }
+
+    private static func hasOpenScope(
+        containing needle: String,
+        lines: [Substring],
+        before oneBasedLineNumber: Int) -> Bool
+    {
         let targetIndex = oneBasedLineNumber - 1
         let lineRange = lines.indices.prefix(through: targetIndex)
         return lineRange.contains { index in
-            helperNames.contains { lines[index].contains($0) }
+            lines[index].contains(needle)
                 && self.hasOpenBraceScope(lines: lines, from: index, through: targetIndex)
         }
     }
@@ -110,7 +147,8 @@ struct KeychainPromptSafetyAuditTests {
     private static func hasOpenBraceScope(lines: [Substring], from startIndex: Int, through endIndex: Int) -> Bool {
         var balance = 0
         var sawOpeningBrace = false
-        for line in lines[startIndex...endIndex] {
+        for index in startIndex...endIndex {
+            let line = lines[index]
             for character in line {
                 switch character {
                 case "{":
@@ -121,6 +159,9 @@ struct KeychainPromptSafetyAuditTests {
                 default:
                     continue
                 }
+            }
+            if index < endIndex, sawOpeningBrace, balance <= 0 {
+                return false
             }
         }
         return sawOpeningBrace && balance > 0

--- a/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
@@ -62,9 +62,37 @@ struct KeychainPromptSafetyAuditTests {
         #expect(callSites.isEmpty == false)
         for callSite in callSites {
             let failureMessage = "\(callSite.file.path):\(callSite.lineNumber) calls strategy.isAvailable(context) "
-                + "with test keychain access enabled and no scoped keychain double"
-            #expect(Self.hasOpenKeychainTestDouble(lines: lines, before: callSite.lineNumber), "\(failureMessage)")
+                + "with test keychain access enabled and incomplete scoped keychain isolation"
+            #expect(
+                Self.hasOpenAvailabilityKeychainIsolation(lines: lines, before: callSite.lineNumber),
+                "\(failureMessage)")
         }
+    }
+
+    @Test
+    func `availability audit rejects a Claude-only keychain override`() {
+        let lines: [Substring] = [
+            "KeychainAccessGate.withTaskOverrideForTesting(false) {",
+            "ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {",
+            "strategy.isAvailable(context)",
+            "}",
+            "}",
+        ]
+
+        #expect(Self.hasOpenAvailabilityKeychainIsolation(lines: lines, before: 3) == false)
+    }
+
+    @Test
+    func `availability audit accepts combined cache and Claude keychain doubles`() {
+        let lines: [Substring] = [
+            "KeychainAccessGate.withTaskOverrideForTesting(false) {",
+            "self.withAvailabilityKeychainDoubles {",
+            "strategy.isAvailable(context)",
+            "}",
+            "}",
+        ]
+
+        #expect(Self.hasOpenAvailabilityKeychainIsolation(lines: lines, before: 3))
     }
 
     @Test
@@ -129,6 +157,26 @@ struct KeychainPromptSafetyAuditTests {
         return helperNames.contains { helperName in
             self.hasOpenScope(containing: helperName, lines: lines, before: oneBasedLineNumber)
         }
+    }
+
+    private static func hasOpenAvailabilityKeychainIsolation(
+        lines: [Substring],
+        before oneBasedLineNumber: Int) -> Bool
+    {
+        if self.hasOpenScope(
+            containing: "withAvailabilityKeychainDoubles",
+            lines: lines,
+            before: oneBasedLineNumber)
+        {
+            return true
+        }
+
+        let bypassesCacheKeychain = self.hasOpenScope(
+            containing: "nonInteractiveCredentialRecordOverride",
+            lines: lines,
+            before: oneBasedLineNumber)
+        return bypassesCacheKeychain
+            && self.hasOpenKeychainTestDouble(lines: lines, before: oneBasedLineNumber)
     }
 
     private static func hasOpenScope(


### PR DESCRIPTION
## Summary

- replace #1881 because the contributor fork does not allow maintainer edits
- preserve @gmkbenjamin's regression coverage for Claude availability checks with keychain access enabled
- isolate both `KeychainCacheStore` and `ClaudeOAuthCredentialsStore`, so the test cannot reach either real SecItem path
- harden the source audit to reject the incomplete Claude-only override and accept only complete availability isolation

Fixes #1880.

## Proof

- `swift test --filter 'ClaudeOAuthFetchStrategyAvailabilityTests|KeychainPromptSafetyAuditTests'` — 19/19 passed on the final head
- `make check` — passed; 0 SwiftFormat changes, 0 SwiftLint violations
- `make test` — all 46 groups passed before the clean current-main merge
- autoreview — clean, 0.86
- live prompt observation — repeated Peekaboo app-list checks before, during, and after the full suite showed no SecurityAgent process or keychain prompt window

The final branch merges current `origin/main`; the only post-suite main change is the independently green Gemini timeout fix from #1873.
