### PR TITLE
Guard Mistral billing costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 - Tests: block real Keychain and `security` CLI access by default so test runs cannot display password prompts.
+- Mistral: discard non-finite and overflowing billing costs so malformed price data cannot poison spend totals or charts. Thanks @joeVenner!
 - Claude: notify on model-scoped weekly and Daily Routines quota thresholds using independent warning state. Thanks @cleanerzkp!
 - OpenCode web: search Dia after Chrome for automatic cookie import, with Keychain preflight scoped to the candidate browser (fixes #1822). Thanks @zeajose!
 - Claude: make the "Avoid Keychain prompts" setting use the no-prompt policy instead of the experimental `security` CLI reader. Thanks @gmkbenjamin!

--- a/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
@@ -220,7 +220,7 @@ public enum MistralUsageFetcher {
                 totalInput += input
                 totalOutput += output
                 totalCached += cached
-                totalCost += cost
+                Self.accumulateFiniteCost(cost, into: &totalCost)
                 Self.addDailyEntries(
                     modelName: modelName,
                     data: modelData,
@@ -235,7 +235,7 @@ public enum MistralUsageFetcher {
             if let models = category?.models {
                 for (modelName, modelData) in models {
                     let (_, _, _, cost) = Self.aggregateModel(modelData, prices: prices)
-                    totalCost += cost
+                    Self.accumulateFiniteCost(cost, into: &totalCost)
                     Self.addDailyEntries(
                         modelName: modelName,
                         data: modelData,
@@ -250,7 +250,7 @@ public enum MistralUsageFetcher {
         if let models = billing.librariesApi?.pages?.models {
             for (modelName, modelData) in models {
                 let (_, _, _, cost) = Self.aggregateModel(modelData, prices: prices)
-                totalCost += cost
+                Self.accumulateFiniteCost(cost, into: &totalCost)
                 Self.addDailyEntries(
                     modelName: modelName,
                     data: modelData,
@@ -262,7 +262,7 @@ public enum MistralUsageFetcher {
         if let models = billing.librariesApi?.tokens?.models {
             for (modelName, modelData) in models {
                 let (_, _, _, cost) = Self.aggregateModel(modelData, prices: prices)
-                totalCost += cost
+                Self.accumulateFiniteCost(cost, into: &totalCost)
                 Self.addDailyEntries(
                     modelName: modelName,
                     data: modelData,
@@ -277,7 +277,7 @@ public enum MistralUsageFetcher {
             if let models {
                 for (modelName, modelData) in models {
                     let (_, _, _, cost) = Self.aggregateModel(modelData, prices: prices)
-                    totalCost += cost
+                    Self.accumulateFiniteCost(cost, into: &totalCost)
                     Self.addDailyEntries(
                         modelName: modelName,
                         data: modelData,
@@ -316,7 +316,8 @@ public enum MistralUsageFetcher {
             guard let metric = price.billingMetric,
                   let group = price.billingGroup,
                   let priceStr = price.price,
-                  let value = Double(priceStr)
+                  let value = Double(priceStr),
+                  value.isFinite
             else { continue }
             let key = "\(metric)::\(group)"
             index[key] = value
@@ -336,28 +337,19 @@ public enum MistralUsageFetcher {
         for entry in data.input ?? [] {
             let tokens = entry.valuePaid ?? entry.value ?? 0
             totalInput += tokens
-            if let metric = entry.billingMetric, let group = entry.billingGroup {
-                let pricePerToken = prices["\(metric)::\(group)"] ?? 0
-                totalCost += Double(tokens) * pricePerToken
-            }
+            Self.accumulateFiniteCost(Self.cost(for: entry, units: tokens, prices: prices), into: &totalCost)
         }
 
         for entry in data.output ?? [] {
             let tokens = entry.valuePaid ?? entry.value ?? 0
             totalOutput += tokens
-            if let metric = entry.billingMetric, let group = entry.billingGroup {
-                let pricePerToken = prices["\(metric)::\(group)"] ?? 0
-                totalCost += Double(tokens) * pricePerToken
-            }
+            Self.accumulateFiniteCost(Self.cost(for: entry, units: tokens, prices: prices), into: &totalCost)
         }
 
         for entry in data.cached ?? [] {
             let tokens = entry.valuePaid ?? entry.value ?? 0
             totalCached += tokens
-            if let metric = entry.billingMetric, let group = entry.billingGroup {
-                let pricePerToken = prices["\(metric)::\(group)"] ?? 0
-                totalCost += Double(tokens) * pricePerToken
-            }
+            Self.accumulateFiniteCost(Self.cost(for: entry, units: tokens, prices: prices), into: &totalCost)
         }
 
         return (totalInput, totalOutput, totalCached, totalCost)
@@ -424,7 +416,15 @@ public enum MistralUsageFetcher {
 
     private static func cost(for entry: MistralUsageEntry, units: Int, prices: [String: Double]) -> Double {
         guard let metric = entry.billingMetric, let group = entry.billingGroup else { return 0 }
-        return Double(units) * (prices["\(metric)::\(group)"] ?? 0)
+        let cost = Double(units) * (prices["\(metric)::\(group)"] ?? 0)
+        return cost.isFinite ? cost : 0
+    }
+
+    fileprivate static func accumulateFiniteCost(_ cost: Double, into total: inout Double) {
+        guard cost.isFinite else { return }
+        let updatedTotal = total + cost
+        guard updatedTotal.isFinite else { return }
+        total = updatedTotal
     }
 
     private static func displayModelName(_ raw: String, entry: MistralUsageEntry) -> String {
@@ -477,9 +477,9 @@ private struct DailyAccumulator {
         cost: Double,
         countsTokens: Bool)
     {
-        self.cost += cost
+        MistralUsageFetcher.accumulateFiniteCost(cost, into: &self.cost)
         var model = self.models[modelName] ?? ModelAccumulator(name: modelName)
-        model.cost += cost
+        MistralUsageFetcher.accumulateFiniteCost(cost, into: &model.cost)
         guard countsTokens else {
             self.models[modelName] = model
             return

--- a/Tests/CodexBarTests/MistralUsageParserTests.swift
+++ b/Tests/CodexBarTests/MistralUsageParserTests.swift
@@ -47,6 +47,101 @@ struct MistralUsageParserTests {
         #expect(snapshot.totalCost > 0)
     }
 
+    @Test(arguments: ["NaN", "Infinity", "1e308"])
+    func `ignores prices that produce nonfinite costs`(price: String) async throws {
+        let json = """
+        {
+          "completion": {
+            "models": {
+              "mistral-small": {
+                "input": [{
+                  "billing_metric": "tokens",
+                  "billing_group": "input",
+                  "timestamp": "2026-07-04",
+                  "value": 2
+                }]
+              }
+            }
+          },
+          "prices": [{
+            "billing_metric": "tokens",
+            "billing_group": "input",
+            "price": "\(price)"
+          }]
+        }
+        """
+        let transport = ProviderHTTPTransportHandler { request in
+            #expect(request.url?.path == "/api/billing/v2/usage")
+            #expect(request.value(forHTTPHeaderField: "Cookie") == "ory_session_test=abc")
+            let requestURL = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: requestURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil))
+            return (Data(json.utf8), response)
+        }
+
+        let snapshot = try await MistralUsageFetcher.fetchUsage(
+            cookieHeader: "ory_session_test=abc",
+            csrfToken: nil,
+            transport: transport)
+
+        #expect(snapshot.totalCost == 0)
+        #expect(snapshot.totalCost.isFinite)
+        #expect(snapshot.daily.first?.cost == 0)
+        #expect(snapshot.daily.first?.models.first?.cost == 0)
+    }
+
+    @Test
+    func `keeps cost totals finite when individually valid costs overflow their sum`() throws {
+        let json = """
+        {
+          "completion": {
+            "models": {
+              "mistral-small": {
+                "input": [
+                  {
+                    "billing_metric": "tokens",
+                    "billing_group": "input",
+                    "timestamp": "2026-07-04",
+                    "value": 1
+                  },
+                  {
+                    "billing_metric": "tokens",
+                    "billing_group": "input",
+                    "timestamp": "2026-07-04",
+                    "value": 1
+                  }
+                ]
+              },
+              "mistral-large": {
+                "input": [{
+                  "billing_metric": "tokens",
+                  "billing_group": "input",
+                  "timestamp": "2026-07-04",
+                  "value": 1
+                }]
+              }
+            }
+          },
+          "prices": [{
+            "billing_metric": "tokens",
+            "billing_group": "input",
+            "price": "1e308"
+          }]
+        }
+        """
+
+        let snapshot = try MistralUsageFetcher.parseResponse(data: Data(json.utf8), updatedAt: Date())
+
+        #expect(snapshot.totalCost == 1e308)
+        #expect(snapshot.totalCost.isFinite)
+        #expect(snapshot.daily.first?.cost == 1e308)
+        #expect(snapshot.daily.first?.models.count == 2)
+        #expect(snapshot.daily.first?.models.allSatisfy { $0.cost == 1e308 } == true)
+    }
+
     @Test
     func `parses empty response with no usage`() throws {
         let data = try #require(Self.emptyResponseJSON.data(using: .utf8))


### PR DESCRIPTION
## Summary

- ignore non-finite Mistral billing prices before building the price index
- discard finite prices whose multiplication overflows instead of propagating infinity
- reuse the guarded cost path for monthly totals and daily model breakdowns
- add regression coverage for `NaN`, `Infinity`, and finite overflow input

## Production-path proof

A temporary standalone executable linked against `CodexBarCore` called the public `MistralUsageFetcher.fetchUsage` with in-memory HTTP fixtures. The temporary target was removed after the run.

```text
$ swift run --disable-sandbox --scratch-path .build MistralPriceProof
Build of product MistralPriceProof complete!
price=NaN cost=0.0 finite=true
price=Infinity cost=0.0 finite=true
price=1e308 cost=0.0 finite=true
```

This exercises the shipping fetch/decode/aggregation path without accessing browser cookies or a live account.

## Testing

- `swift test --disable-sandbox --filter MistralUsageParserTests` (21 tests passed across matched Mistral suites)
- `make check` (SwiftFormat clean; SwiftLint 0 violations; later host plist write failed because the sandbox cannot write the system cache directory)
- `git diff --check`