### PR TITLE
Guard Mistral credit balances

### DIFF
--- a/Sources/CodexBarCore/Providers/Mistral/MistralModels.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralModels.swift
@@ -287,7 +287,8 @@ public struct MistralCreditsSnapshot: Codable, Equatable, Sendable {
     }
 
     public var availableAmount: Double {
-        max(0, self.walletAmount + self.creditNotesAmount - self.ongoingUsageBalance)
+        let amount = self.walletAmount + self.creditNotesAmount - self.ongoingUsageBalance
+        return amount.isFinite ? max(0, amount) : 0
     }
 
     public var formattedAvailableAmount: String {

--- a/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
@@ -154,11 +154,17 @@ public enum MistralUsageFetcher {
             throw MistralUsageError.parseFailed(error.localizedDescription)
         }
 
-        return MistralCreditsSnapshot(
+        let snapshot = MistralCreditsSnapshot(
             walletAmount: response.walletAmount,
             creditNotesAmount: response.creditNotesAmount ?? 0,
             ongoingUsageBalance: response.ongoingUsageBalance ?? 0,
             currency: response.currency)
+        let amounts = [snapshot.walletAmount, snapshot.creditNotesAmount, snapshot.ongoingUsageBalance]
+        let available = snapshot.walletAmount + snapshot.creditNotesAmount - snapshot.ongoingUsageBalance
+        guard amounts.allSatisfy(\.isFinite), available.isFinite else {
+            throw MistralUsageError.parseFailed("Invalid credit amount")
+        }
+        return snapshot
     }
 
     static func vibeCookieHeader(csrfToken: String) throws -> String {

--- a/Tests/CodexBarTests/MistralUsageParserTests.swift
+++ b/Tests/CodexBarTests/MistralUsageParserTests.swift
@@ -95,6 +95,30 @@ struct MistralUsageParserTests {
     }
 
     @Test
+    func `rejects credit amounts whose sum overflows`() throws {
+        let json = """
+        {
+          "wallet_amount": 1e308,
+          "credit_notes_amount": 1e308,
+          "ongoing_usage_balance": 0,
+          "currency": "USD"
+        }
+        """
+
+        #expect(throws: MistralUsageError.self) {
+            try MistralUsageFetcher.parseCredits(data: Data(json.utf8))
+        }
+
+        let credits = MistralCreditsSnapshot(
+            walletAmount: 1e308,
+            creditNotesAmount: 1e308,
+            ongoingUsageBalance: 0,
+            currency: "USD")
+        #expect(credits.availableAmount == 0)
+        #expect(credits.formattedAvailableAmount == "$0.00")
+    }
+
+    @Test
     func `fetches credits from dashboard endpoint with existing web session`() async throws {
         let json = """
         {


### PR DESCRIPTION
## Summary

- reject Mistral credit responses whose components or computed available balance are non-finite
- prevent public credit snapshots from formatting an infinite balance
- preserve the existing zero floor for negative available balances
- add regression coverage for finite inputs whose sum overflows

## Production-path proof

A temporary standalone executable linked against `CodexBarCore` called the public `MistralUsageFetcher.fetchCredits` with an in-memory HTTP fixture. The temporary target was removed after the run.

```text
$ swift run --disable-sandbox --scratch-path .build MistralCreditProof
Build of product MistralCreditProof complete!
overflowing-credit-fixture=rejected reason=Invalid credit amount
```

This exercises the shipping credit fetch/decode path without accessing browser cookies or a live account.

## Testing

- `swift test --disable-sandbox --filter MistralUsageParserTests` (21 tests passed across matched Mistral suites)
- `make check` (SwiftFormat clean; SwiftLint 0 violations; later host plist write failed because the sandbox cannot write the system cache directory)
- `git diff --check`