### PR TITLE
Add Mistral widget support

### DIFF
--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -16,6 +16,7 @@ enum ProviderChoice: String, AppEnum {
     case kilo
     case opencode
     case opencodego
+    case mistral
 
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Provider")
 
@@ -32,6 +33,7 @@ enum ProviderChoice: String, AppEnum {
         .kilo: DisplayRepresentation(title: "Kilo"),
         .opencode: DisplayRepresentation(title: "OpenCode"),
         .opencodego: DisplayRepresentation(title: "OpenCode Go"),
+        .mistral: DisplayRepresentation(title: "Mistral"),
     ]
 
     var provider: UsageProvider {
@@ -48,6 +50,7 @@ enum ProviderChoice: String, AppEnum {
         case .kilo: .kilo
         case .opencode: .opencode
         case .opencodego: .opencodego
+        case .mistral: .mistral
         }
     }
 
@@ -94,7 +97,7 @@ enum ProviderChoice: String, AppEnum {
         case .doubao: return nil // Doubao not yet supported in widgets
         case .sakana: return nil // Sakana AI not yet supported in widgets
         case .abacus: return nil // Abacus AI not yet supported in widgets
-        case .mistral: return nil // Mistral not yet supported in widgets
+        case .mistral: self = .mistral
         case .deepseek: return nil // DeepSeek not yet supported in widgets
         case .codebuff: return nil // Codebuff not yet supported in widgets
         case .crof: return nil // Crof not yet supported in widgets

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -260,6 +260,12 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `provider choice supports Mistral`() {
+        #expect(ProviderChoice(provider: .mistral) == .mistral)
+        #expect(ProviderChoice.mistral.provider == .mistral)
+    }
+
+    @Test
     func `provider choice excludes unsupported Chutes widgets`() {
         #expect(ProviderChoice(provider: .chutes) == nil)
     }
@@ -305,6 +311,24 @@ struct CodexBarWidgetProviderTests {
         let snapshot = WidgetSnapshot(entries: [entry], enabledProviders: [.alibabatokenplan], generatedAt: now)
 
         #expect(CodexBarSwitcherTimelineProvider.supportedProviders(from: snapshot) == [.alibabatokenplan])
+    }
+
+    @Test
+    func `supported providers keep Mistral when it is the only enabled provider`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .mistral,
+            updatedAt: now,
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+        let snapshot = WidgetSnapshot(entries: [entry], enabledProviders: [.mistral], generatedAt: now)
+
+        #expect(CodexBarSwitcherTimelineProvider.supportedProviders(from: snapshot) == [.mistral])
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add Mistral to the widget provider intent and switcher choices
- allow enabled Mistral snapshots to remain in the supported widget provider list
- reuse the existing generic quota and token-cost widget rendering
- add focused mapping and provider-filter regression coverage

## Screenshot

This is a real SwiftUI render of `CodexBarSwitcherWidgetView` using a Mistral widget snapshot:

![Mistral selected in the CodexBar widget](https://raw.githubusercontent.com/joeVenner/CodexBar/proof-assets/proof/mistral-widget-support.png)

The selected Mistral chip and its latest billing-day cost/token summary are visible. The temporary screenshot test was removed after capture.

## Testing

- `swift test --disable-sandbox --filter CodexBarWidgetProviderTests` (33 tests passed)
- temporary SwiftUI render test (1 test passed)
- `make check` (SwiftFormat clean; SwiftLint 0 violations; later host plist write failed because the sandbox cannot write the system cache directory)
- `git diff --check`