### PR TITLE
Improve long reset countdown precision

### DIFF
--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -111,7 +111,6 @@ public enum UsageFormatter {
         let minutes = totalMinutes % 60
 
         if days > 0 {
-            if hours > 0, minutes > 0 { return "in \(days)d \(hours)h \(minutes)m" }
             if hours > 0 { return "in \(days)d \(hours)h" }
             if minutes > 0 { return "in \(days)d \(minutes)m" }
             return "in \(days)d"

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -111,7 +111,9 @@ public enum UsageFormatter {
         let minutes = totalMinutes % 60
 
         if days > 0 {
+            if hours > 0, minutes > 0 { return "in \(days)d \(hours)h \(minutes)m" }
             if hours > 0 { return "in \(days)d \(hours)h" }
+            if minutes > 0 { return "in \(days)d \(minutes)m" }
             return "in \(days)d"
         }
         if hours > 0 {

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -223,7 +223,7 @@ struct UsageFormatterTests {
     @Test
     func `reset countdown days and exact hours`() {
         let now = Date(timeIntervalSince1970: 1_000_000)
-        let reset = now.addingTimeInterval((26 * 3600))
+        let reset = now.addingTimeInterval(26 * 3600)
         #expect(UsageFormatter.resetCountdownDescription(from: reset, now: now) == "in 1d 2h")
     }
 

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -214,10 +214,31 @@ struct UsageFormatterTests {
     }
 
     @Test
-    func `reset countdown days and hours`() {
+    func `reset countdown days hours and minutes`() {
         let now = Date(timeIntervalSince1970: 1_000_000)
-        let reset = now.addingTimeInterval((26 * 3600) + 10)
+        let reset = now.addingTimeInterval((26 * 3600) + (1 * 60))
+        #expect(UsageFormatter.resetCountdownDescription(from: reset, now: now) == "in 1d 2h 1m")
+    }
+
+    @Test
+    func `reset countdown days and exact hours`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let reset = now.addingTimeInterval((26 * 3600))
         #expect(UsageFormatter.resetCountdownDescription(from: reset, now: now) == "in 1d 2h")
+    }
+
+    @Test
+    func `reset countdown days and minutes without whole hours`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let reset = now.addingTimeInterval((24 * 3600) + (5 * 60))
+        #expect(UsageFormatter.resetCountdownDescription(from: reset, now: now) == "in 1d 5m")
+    }
+
+    @Test
+    func `reset countdown exact days`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let reset = now.addingTimeInterval(2 * 24 * 3600)
+        #expect(UsageFormatter.resetCountdownDescription(from: reset, now: now) == "in 2d")
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -214,10 +214,10 @@ struct UsageFormatterTests {
     }
 
     @Test
-    func `reset countdown days hours and minutes`() {
+    func `reset countdown caps days with hours at two units`() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let reset = now.addingTimeInterval((26 * 3600) + (1 * 60))
-        #expect(UsageFormatter.resetCountdownDescription(from: reset, now: now) == "in 1d 2h 1m")
+        #expect(UsageFormatter.resetCountdownDescription(from: reset, now: now) == "in 1d 2h")
     }
 
     @Test
@@ -239,6 +239,13 @@ struct UsageFormatterTests {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let reset = now.addingTimeInterval(2 * 24 * 3600)
         #expect(UsageFormatter.resetCountdownDescription(from: reset, now: now) == "in 2d")
+    }
+
+    @Test
+    func `reset countdown rounds the last minute into a day`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let reset = now.addingTimeInterval((24 * 3600) - 59)
+        #expect(UsageFormatter.resetCountdownDescription(from: reset, now: now) == "in 1d")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Long reset countdowns remain compact to at most two units, but day-scale values previously dropped meaningful minutes whenever there were zero whole hours. This change preserves those minutes without making ordinary day-and-hour countdowns noisier.

- Exactly 5 days → `in 5d`
- 5 days and 12 hours → `in 5d 12h`
- 5 days, 12 hours, and 34 minutes → `in 5d 12h`, preserving the intentional two-unit cap
- 5 days and 37 minutes → `in 5d 37m`, preserving minutes when there are no whole hours
- 23 hours, 59 minutes, and 31 seconds → `in 1d`, correctly rounding into the next day

The shared formatter feeds menu, CLI, and widget reset labels.

## Validation

- [x] `swift test --filter UsageFormatterTests` — 41/41 passed
- [x] Added readable regression coverage for day/minute fallback, compact two-unit output, and the near-day rounding boundary
- [x] `make check`
- [x] Autoreview clean
- [x] Exact-head CI green
