### PR TITLE
Prevent Keychain password prompts during tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Repository: reject oversized tracked blobs and generated release/build artifacts during checks. Thanks @joeVenner!
 
 ### Fixed
+- Tests: block real Keychain and `security` CLI access by default so test runs cannot display password prompts.
 - Claude: notify on model-scoped weekly and Daily Routines quota thresholds using independent warning state. Thanks @cleanerzkp!
 - OpenCode web: search Dia after Chrome for automatic cookie import, with Keychain preflight scoped to the candidate browser (fixes #1822). Thanks @zeajose!
 - Claude: make the "Avoid Keychain prompts" setting use the no-prompt policy instead of the experimental `security` CLI reader. Thanks @gmkbenjamin!

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -7,6 +7,13 @@ GROUP_SIZE="${CODEXBAR_TEST_GROUP_SIZE:-12}"
 SUITE_TIMEOUT="${CODEXBAR_TEST_SUITE_TIMEOUT:-180}"
 
 cd "${ROOT_DIR}"
+
+# Defense in depth: test processes also self-detect, but keep this explicit so runner changes cannot
+# expose the user's login Keychain. Deliberate isolated Keychain tests must opt in by setting the allow flag.
+if [[ "${CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS:-}" != "1" ]]; then
+  export CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1
+fi
+
 ARGS=(
   --group-size "${GROUP_SIZE}"
   --timeout "${SUITE_TIMEOUT}"

--- a/Sources/CodexBar/CookieHeaderStore.swift
+++ b/Sources/CodexBar/CookieHeaderStore.swift
@@ -78,7 +78,7 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
                 account: self.account))
         }
 
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
             // Cache the nil result
             Self.cacheLock.lock()
@@ -140,7 +140,7 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
 
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        let updateStatus = KeychainSecurity.update(query as CFDictionary, attributes as CFDictionary)
         if updateStatus == errSecSuccess {
             // Update cache
             Self.cacheLock.lock()
@@ -157,7 +157,7 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
         for (key, value) in attributes {
             addQuery[key] = value
         }
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = KeychainSecurity.add(addQuery as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
             Self.log.error("Keychain add failed: \(addStatus)")
             throw CookieHeaderStoreError.keychainStatus(addStatus)
@@ -176,7 +176,7 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
-        let status = SecItemDelete(query as CFDictionary)
+        let status = KeychainSecurity.delete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             // Invalidate cache
             Self.cacheLock.lock()

--- a/Sources/CodexBar/CopilotTokenStore.swift
+++ b/Sources/CodexBar/CopilotTokenStore.swift
@@ -50,7 +50,7 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
                 account: self.account))
         }
 
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
             return nil
         }
@@ -91,7 +91,7 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
 
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        let updateStatus = KeychainSecurity.update(query as CFDictionary, attributes as CFDictionary)
         if updateStatus == errSecSuccess {
             return
         }
@@ -104,7 +104,7 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
         for (key, value) in attributes {
             addQuery[key] = value
         }
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = KeychainSecurity.add(addQuery as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
             Self.log.error("Keychain add failed: \(addStatus)")
             throw CopilotTokenStoreError.keychainStatus(addStatus)
@@ -118,7 +118,7 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
-        let status = SecItemDelete(query as CFDictionary)
+        let status = KeychainSecurity.delete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return
         }

--- a/Sources/CodexBar/KeychainMigration.swift
+++ b/Sources/CodexBar/KeychainMigration.swift
@@ -82,7 +82,7 @@ enum KeychainMigration {
             query[kSecAttrAccount as String] = account
         }
 
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
 
         if status == errSecItemNotFound {
             // Item doesn't exist, nothing to migrate
@@ -115,7 +115,7 @@ enum KeychainMigration {
             deleteQuery[kSecAttrAccount as String] = account
         }
 
-        let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
+        let deleteStatus = KeychainSecurity.delete(deleteQuery as CFDictionary)
         guard deleteStatus == errSecSuccess else {
             throw KeychainMigrationError.deleteFailed(deleteStatus)
         }
@@ -131,7 +131,7 @@ enum KeychainMigration {
             addQuery[kSecAttrAccount as String] = account
         }
 
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = KeychainSecurity.add(addQuery as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
             throw KeychainMigrationError.addFailed(addStatus)
         }

--- a/Sources/CodexBar/KimiK2TokenStore.swift
+++ b/Sources/CodexBar/KimiK2TokenStore.swift
@@ -50,7 +50,7 @@ struct KeychainKimiK2TokenStore: KimiK2TokenStoring {
                 account: self.account))
         }
 
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
             return nil
         }
@@ -91,7 +91,7 @@ struct KeychainKimiK2TokenStore: KimiK2TokenStoring {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
 
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        let updateStatus = KeychainSecurity.update(query as CFDictionary, attributes as CFDictionary)
         if updateStatus == errSecSuccess {
             return
         }
@@ -104,7 +104,7 @@ struct KeychainKimiK2TokenStore: KimiK2TokenStoring {
         for (key, value) in attributes {
             addQuery[key] = value
         }
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = KeychainSecurity.add(addQuery as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
             Self.log.error("Keychain add failed: \(addStatus)")
             throw KimiK2TokenStoreError.keychainStatus(addStatus)
@@ -118,7 +118,7 @@ struct KeychainKimiK2TokenStore: KimiK2TokenStoring {
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
-        let status = SecItemDelete(query as CFDictionary)
+        let status = KeychainSecurity.delete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return
         }

--- a/Sources/CodexBar/KimiTokenStore.swift
+++ b/Sources/CodexBar/KimiTokenStore.swift
@@ -50,7 +50,7 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
                 account: self.account))
         }
 
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
             return nil
         }
@@ -91,7 +91,7 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
 
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        let updateStatus = KeychainSecurity.update(query as CFDictionary, attributes as CFDictionary)
         if updateStatus == errSecSuccess {
             return
         }
@@ -104,7 +104,7 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
         for (key, value) in attributes {
             addQuery[key] = value
         }
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = KeychainSecurity.add(addQuery as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
             Self.log.error("Keychain add failed: \(addStatus)")
             throw KimiTokenStoreError.keychainStatus(addStatus)
@@ -118,7 +118,7 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
-        let status = SecItemDelete(query as CFDictionary)
+        let status = KeychainSecurity.delete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return
         }

--- a/Sources/CodexBar/MiniMaxAPITokenStore.swift
+++ b/Sources/CodexBar/MiniMaxAPITokenStore.swift
@@ -50,7 +50,7 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
                 account: self.account))
         }
 
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
             return nil
         }
@@ -91,7 +91,7 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
 
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        let updateStatus = KeychainSecurity.update(query as CFDictionary, attributes as CFDictionary)
         if updateStatus == errSecSuccess {
             return
         }
@@ -104,7 +104,7 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
         for (key, value) in attributes {
             addQuery[key] = value
         }
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = KeychainSecurity.add(addQuery as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
             Self.log.error("Keychain add failed: \(addStatus)")
             throw MiniMaxAPITokenStoreError.keychainStatus(addStatus)
@@ -118,7 +118,7 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
-        let status = SecItemDelete(query as CFDictionary)
+        let status = KeychainSecurity.delete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return
         }

--- a/Sources/CodexBar/MiniMaxCookieStore.swift
+++ b/Sources/CodexBar/MiniMaxCookieStore.swift
@@ -50,7 +50,7 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
                 account: self.account))
         }
 
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
             return nil
         }
@@ -96,7 +96,7 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
 
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        let updateStatus = KeychainSecurity.update(query as CFDictionary, attributes as CFDictionary)
         if updateStatus == errSecSuccess {
             return
         }
@@ -109,7 +109,7 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
         for (key, value) in attributes {
             addQuery[key] = value
         }
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = KeychainSecurity.add(addQuery as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
             Self.log.error("Keychain add failed: \(addStatus)")
             throw MiniMaxCookieStoreError.keychainStatus(addStatus)
@@ -123,7 +123,7 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
-        let status = SecItemDelete(query as CFDictionary)
+        let status = KeychainSecurity.delete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return
         }

--- a/Sources/CodexBar/SyntheticTokenStore.swift
+++ b/Sources/CodexBar/SyntheticTokenStore.swift
@@ -50,7 +50,7 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
                 account: self.account))
         }
 
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
             return nil
         }
@@ -91,7 +91,7 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
 
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        let updateStatus = KeychainSecurity.update(query as CFDictionary, attributes as CFDictionary)
         if updateStatus == errSecSuccess {
             return
         }
@@ -104,7 +104,7 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
         for (key, value) in attributes {
             addQuery[key] = value
         }
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = KeychainSecurity.add(addQuery as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
             Self.log.error("Keychain add failed: \(addStatus)")
             throw SyntheticTokenStoreError.keychainStatus(addStatus)
@@ -118,7 +118,7 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
-        let status = SecItemDelete(query as CFDictionary)
+        let status = KeychainSecurity.delete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return
         }

--- a/Sources/CodexBar/ZaiTokenStore.swift
+++ b/Sources/CodexBar/ZaiTokenStore.swift
@@ -67,7 +67,7 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
                 account: self.account))
         }
 
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
             // Cache the nil result
             Self.cacheLock.lock()
@@ -123,7 +123,7 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
 
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        let updateStatus = KeychainSecurity.update(query as CFDictionary, attributes as CFDictionary)
         if updateStatus == errSecSuccess {
             // Update cache
             Self.cacheLock.lock()
@@ -141,7 +141,7 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
         for (key, value) in attributes {
             addQuery[key] = value
         }
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = KeychainSecurity.add(addQuery as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
             Self.log.error("Keychain add failed: \(addStatus)")
             throw ZaiTokenStoreError.keychainStatus(addStatus)
@@ -161,7 +161,7 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
-        let status = SecItemDelete(query as CFDictionary)
+        let status = KeychainSecurity.delete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             // Invalidate cache
             Self.cacheLock.lock()

--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -33,7 +33,7 @@ public enum BrowserCookieAccessGate {
         processName: String = ProcessInfo.processInfo.processName,
         environment: [String: String] = ProcessInfo.processInfo.environment) -> BrowserCookieStoreAccessDecision
     {
-        guard self.isRunningUnderTests(processName: processName, environment: environment),
+        guard KeychainTestSafety.isRunningUnderTests(processName: processName, environment: environment),
               environment[self.allowTestCookieAccessEnvironmentKey] != "1"
         else {
             return .allowed
@@ -126,16 +126,6 @@ public enum BrowserCookieAccessGate {
     }
 
     private static let safeStorageLabels: [(service: String, account: String)] = Browser.safeStorageLabels
-
-    private static func isRunningUnderTests(
-        processName: String,
-        environment: [String: String]) -> Bool
-    {
-        processName == "swiftpm-testing-helper"
-            || processName.hasSuffix("PackageTests")
-            || environment["XCTestConfigurationFilePath"] != nil
-            || environment["SWIFT_TESTING"] != nil
-    }
 
     private static func normalizedPath(_ url: URL) -> String {
         url.standardizedFileURL.resolvingSymlinksInPath().path

--- a/Sources/CodexBarCore/KeychainAccessGate.swift
+++ b/Sources/CodexBarCore/KeychainAccessGate.swift
@@ -59,15 +59,7 @@ public enum KeychainAccessGate {
 
     #if DEBUG
     private nonisolated(unsafe) static var forcesDisabledUnderTests: Bool {
-        self.isRunningUnderTests
-            && ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1"
-    }
-
-    private nonisolated(unsafe) static var isRunningUnderTests: Bool {
-        let processName = ProcessInfo.processInfo.processName
-        return processName == "swiftpm-testing-helper"
-            || processName.hasSuffix("PackageTests")
-            || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+        KeychainTestSafety.shouldBlockRealKeychainAccess()
     }
     #endif
 

--- a/Sources/CodexBarCore/KeychainAccessPreflight.swift
+++ b/Sources/CodexBarCore/KeychainAccessPreflight.swift
@@ -100,6 +100,10 @@ public enum KeychainAccessPreflight {
         self.checkGenericPasswordOverride = override
     }
 
+    static var hasCheckGenericPasswordOverrideForTesting: Bool {
+        self.taskCheckGenericPasswordOverrideStore != nil || self.checkGenericPasswordOverride != nil
+    }
+
     static func withCheckGenericPasswordOverrideForTesting<T>(
         _ override: ((String, String?) -> Outcome)?,
         operation: () throws -> T) rethrows -> T
@@ -137,7 +141,7 @@ public enum KeychainAccessPreflight {
         let query = self.makeGenericPasswordPreflightQuery(service: service, account: account)
 
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         switch status {
         case errSecSuccess:
             self.log.debug("Keychain preflight allowed", metadata: ["service": service])

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -83,7 +83,7 @@ public enum KeychainCacheStore {
         KeychainNoUIQuery.apply(to: &query)
 
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         switch status {
         case errSecSuccess:
             guard let data = result as? Data, !data.isEmpty else {
@@ -134,7 +134,7 @@ public enum KeychainCacheStore {
         ]
         KeychainNoUIQuery.apply(to: &query)
 
-        let updateStatus = SecItemUpdate(
+        let updateStatus = KeychainSecurity.update(
             query as CFDictionary,
             [kSecValueData as String: data] as CFDictionary)
         if updateStatus == errSecSuccess {
@@ -153,7 +153,7 @@ public enum KeychainCacheStore {
             addQuery[kSecAttrAccess as String] = access
         }
 
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = KeychainSecurity.add(addQuery as CFDictionary, nil)
         if addStatus != errSecSuccess {
             self.log.error("Keychain cache add failed (\(key.account)): \(addStatus)")
         }
@@ -185,7 +185,7 @@ public enum KeychainCacheStore {
             kSecAttrAccount as String: key.account,
         ]
         KeychainNoUIQuery.apply(to: &query)
-        return self.clearResultForKeychainDeleteStatus(SecItemDelete(query as CFDictionary), key: key)
+        return self.clearResultForKeychainDeleteStatus(KeychainSecurity.delete(query as CFDictionary), key: key)
         #else
         return .failed
         #endif
@@ -220,7 +220,7 @@ public enum KeychainCacheStore {
         KeychainNoUIQuery.apply(to: &query)
 
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         return self.keysResultForKeychainStatus(status, category: category, result: result)
         #else
         return .failed
@@ -343,14 +343,9 @@ public enum KeychainCacheStore {
 
     #if DEBUG
     private static var shouldUseImplicitTestStore: Bool {
-        self.isRunningUnderTests && !self.canUseRealKeychain
-    }
-
-    private static var isRunningUnderTests: Bool {
-        let processName = ProcessInfo.processInfo.processName
-        return processName == "swiftpm-testing-helper"
-            || processName.hasSuffix("PackageTests")
-            || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+        KeychainTestSafety.isRunningUnderTests(
+            processName: ProcessInfo.processInfo.processName,
+            environment: ProcessInfo.processInfo.environment) && !self.canUseRealKeychain
     }
     #else
     private static var shouldUseImplicitTestStore: Bool {

--- a/Sources/CodexBarCore/KeychainSecurity.swift
+++ b/Sources/CodexBarCore/KeychainSecurity.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+enum KeychainTestSafety {
+    static let suppressAccessEnvironmentKey = "CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"
+    static let allowAccessEnvironmentKey = "CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"
+
+    static func shouldBlockRealKeychainAccess(
+        processName: String = ProcessInfo.processInfo.processName,
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool
+    {
+        if environment[self.allowAccessEnvironmentKey] == "1" { return false }
+        if environment[self.suppressAccessEnvironmentKey] == "1" { return true }
+        if environment[KeychainAccessGate.disableAccessEnvironmentKey] == "1" { return true }
+        return self.isRunningUnderTests(processName: processName, environment: environment)
+    }
+
+    static func isRunningUnderTests(
+        processName: String,
+        environment: [String: String]) -> Bool
+    {
+        processName == "swiftpm-testing-helper"
+            || processName.hasSuffix("PackageTests")
+            || processName.hasSuffix(".xctest")
+            || environment["XCTestConfigurationFilePath"] != nil
+            || environment["XCTestBundlePath"] != nil
+            || environment["XCTestSessionIdentifier"] != nil
+            || environment["TESTING_LIBRARY_VERSION"] != nil
+            || environment["SWIFT_TESTING"] != nil
+            || environment["SWIFT_TESTING_ENABLED"] != nil
+    }
+}
+
+#if os(macOS)
+import Security
+
+/// The only first-party entry point for Security.framework item operations.
+/// Test processes fail closed before touching the user's Keychain, even when a test enables
+/// higher-level Keychain logic with `KeychainAccessGate.withTaskOverrideForTesting(false)`.
+public enum KeychainSecurity {
+    public static func copyMatching(
+        _ query: CFDictionary,
+        _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+    {
+        guard !KeychainTestSafety.shouldBlockRealKeychainAccess() else {
+            return errSecInteractionNotAllowed
+        }
+        return SecItemCopyMatching(query, result)
+    }
+
+    public static func update(_ query: CFDictionary, _ attributesToUpdate: CFDictionary) -> OSStatus {
+        guard !KeychainTestSafety.shouldBlockRealKeychainAccess() else {
+            return errSecInteractionNotAllowed
+        }
+        return SecItemUpdate(query, attributesToUpdate)
+    }
+
+    public static func add(
+        _ attributes: CFDictionary,
+        _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+    {
+        guard !KeychainTestSafety.shouldBlockRealKeychainAccess() else {
+            return errSecInteractionNotAllowed
+        }
+        return SecItemAdd(attributes, result)
+    }
+
+    public static func delete(_ query: CFDictionary) -> OSStatus {
+        guard !KeychainTestSafety.shouldBlockRealKeychainAccess() else {
+            return errSecInteractionNotAllowed
+        }
+        return SecItemDelete(query)
+    }
+}
+#endif

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanCookieImporter.swift
@@ -373,7 +373,7 @@ enum AlibabaChromiumCookieFallbackImporter {
         ]
 
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         guard status == errSecSuccess, let data = result as? Data else { return nil }
         return String(data: data, encoding: .utf8)
     }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
@@ -272,6 +272,13 @@ extension ClaudeOAuthCredentialsStore {
         account: String?,
         environment: [String: String]) -> [String]?
     {
+        let isolatedKeychainPath = self.isolatedSecurityCLIKeychainPath(environment: environment)
+        if KeychainTestSafety.shouldBlockRealKeychainAccess(environment: environment),
+           isolatedKeychainPath == nil
+        {
+            return nil
+        }
+
         var arguments = [
             "find-generic-password",
             "-s",
@@ -285,10 +292,10 @@ extension ClaudeOAuthCredentialsStore {
         let rawIsolatedPath = environment[self.isolatedSecurityCLIKeychainEnvironmentKey]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if rawIsolatedPath != nil || KeychainAccessGate.isDisabledByEnvironment(environment) {
-            guard let isolatedPath = self.isolatedSecurityCLIKeychainPath(environment: environment) else {
+            guard let isolatedKeychainPath else {
                 return nil
             }
-            arguments.append(isolatedPath)
+            arguments.append(isolatedKeychainPath)
         }
         return arguments
     }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1961,7 +1961,7 @@ public enum ClaudeOAuthCredentialsStore {
 
         var result: AnyObject?
         let startedAtNs = DispatchTime.now().uptimeNanoseconds
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         let durationMs = Double(DispatchTime.now().uptimeNanoseconds - startedAtNs) / 1_000_000.0
         self.log.debug(
             "Claude keychain data read result",
@@ -2023,7 +2023,7 @@ public enum ClaudeOAuthCredentialsStore {
 
         var result: AnyObject?
         let startedAtNs = DispatchTime.now().uptimeNanoseconds
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         let durationMs = Double(DispatchTime.now().uptimeNanoseconds - startedAtNs) / 1_000_000.0
         self.log.debug(
             "Claude keychain legacy data read result",
@@ -2300,6 +2300,15 @@ extension ClaudeOAuthCredentialsStore {
     }
 
     private static func shouldShowClaudeKeychainPreAlert() -> Bool {
+        #if DEBUG
+        // Synthetic Claude Keychain fixtures must not fall through to the real preflight. Tests that explicitly
+        // override the preflight still exercise its prompt-policy branches.
+        if self.hasTaskKeychainTestingOverride,
+           !KeychainAccessPreflight.hasCheckGenericPasswordOverrideForTesting
+        {
+            return false
+        }
+        #endif
         let mode = ClaudeOAuthKeychainPromptPreference.current()
         guard self.shouldAllowClaudeCodeKeychainAccess(mode: mode) else { return false }
         return switch KeychainAccessPreflight.checkGenericPassword(service: self.claudeKeychainService, account: nil) {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainQueryTiming.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainQueryTiming.swift
@@ -8,7 +8,7 @@ enum ClaudeOAuthKeychainQueryTiming {
     static func copyMatching(_ query: [String: Any]) -> (status: OSStatus, result: AnyObject?, durationMs: Double) {
         var result: AnyObject?
         let startedAtNs = DispatchTime.now().uptimeNanoseconds
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         let durationMs = Double(DispatchTime.now().uptimeNanoseconds - startedAtNs) / 1_000_000.0
         return (status, result, durationMs)
     }

--- a/Sources/CodexBarCore/Providers/Zed/ZedStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Zed/ZedStatusProbe.swift
@@ -276,7 +276,7 @@ public struct ZedKeychainCredentialsReader: ZedCredentialsReading, Sendable {
 
     private func credentials(from query: [String: Any]) throws -> ZedCredentials? {
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)
         switch status {
         case errSecSuccess:
             break

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests.swift
@@ -6,6 +6,28 @@ import Testing
 @Suite(.serialized)
 struct ClaudeOAuthCredentialsStoreIsolatedSecurityCLITests {
     @Test
+    func `safety blocks security CLI access to the login keychain`() {
+        let blockedEnvironment = [KeychainTestSafety.suppressAccessEnvironmentKey: "1"]
+        #expect(ClaudeOAuthCredentialsStore.securityCLIReadArguments(
+            account: nil,
+            environment: blockedEnvironment) == nil)
+
+        let explicitOptIn = [
+            KeychainTestSafety.suppressAccessEnvironmentKey: "1",
+            KeychainTestSafety.allowAccessEnvironmentKey: "1",
+        ]
+        let expectedArguments = [
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+        ]
+        #expect(ClaudeOAuthCredentialsStore.securityCLIReadArguments(
+            account: nil,
+            environment: explicitOptIn) == expectedArguments)
+    }
+
+    @Test
     func `isolated security CLI keychain requires global keychain disable`() {
         let keychainPath = "/tmp/codexbar-fixtures/verify.keychain-db"
         let isolatedEnvironment = [

--- a/Tests/CodexBarTests/KeychainNoUIQueryTests.swift
+++ b/Tests/CodexBarTests/KeychainNoUIQueryTests.swift
@@ -58,5 +58,40 @@ struct KeychainNoUIQueryTests {
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         #expect(status == errSecItemNotFound || status == errSecInteractionNotAllowed)
     }
+
+    @Test
+    func `processes block every Security item operation before system access`() {
+        guard ProcessInfo.processInfo.environment[KeychainTestSafety.allowAccessEnvironmentKey] != "1" else {
+            return
+        }
+
+        #expect(KeychainTestSafety.shouldBlockRealKeychainAccess())
+
+        let empty = [:] as CFDictionary
+        var result: CFTypeRef?
+        #expect(KeychainSecurity.copyMatching(empty, &result) == errSecInteractionNotAllowed)
+        #expect(KeychainSecurity.update(empty, empty) == errSecInteractionNotAllowed)
+        #expect(KeychainSecurity.add(empty, nil) == errSecInteractionNotAllowed)
+        #expect(KeychainSecurity.delete(empty) == errSecInteractionNotAllowed)
+    }
+
+    @Test
+    func `safety recognizes runner variants and explicit controls`() {
+        #expect(KeychainTestSafety.shouldBlockRealKeychainAccess(
+            processName: "swiftpm-testing-helper",
+            environment: [:]))
+        #expect(KeychainTestSafety.shouldBlockRealKeychainAccess(
+            processName: "CodexBarPackageTests.xctest",
+            environment: [:]))
+        #expect(KeychainTestSafety.shouldBlockRealKeychainAccess(
+            processName: "future-test-runner",
+            environment: [KeychainTestSafety.suppressAccessEnvironmentKey: "1"]))
+        #expect(KeychainTestSafety.shouldBlockRealKeychainAccess(
+            processName: "CodexBar",
+            environment: [:]) == false)
+        #expect(KeychainTestSafety.shouldBlockRealKeychainAccess(
+            processName: "swiftpm-testing-helper",
+            environment: [KeychainTestSafety.allowAccessEnvironmentKey: "1"]) == false)
+    }
 }
 #endif

--- a/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
@@ -11,6 +11,14 @@ struct KeychainPromptSafetyAuditTests {
     }
 
     @Test
+    func `default test runner explicitly suppresses real keychain access`() throws {
+        let script = try Self.readRepoFile("Scripts/test.sh")
+
+        #expect(script.contains("CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"))
+        #expect(script.contains("export CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1"))
+    }
+
+    @Test
     func `live TTY integration tests are opt in`() throws {
         let ttyTests = try Self.readRepoFile("Tests/CodexBarTests/TTYIntegrationTests.swift")
 
@@ -96,15 +104,30 @@ struct KeychainPromptSafetyAuditTests {
     }
 
     @Test
-    func `tests do not call SecItemCopyMatching except no UI query coverage`() throws {
+    func `tests do not call Security item APIs except no UI query coverage`() throws {
+        let securityItemCalls = ["SecItemCopyMatching", "SecItemUpdate", "SecItemAdd", "SecItemDelete"]
         let offenders = try Self.swiftTestFiles().filter { file in
             let text = try Self.readFile(file)
-            return text.contains("SecItemCopyMatching")
+            return securityItemCalls.contains(where: text.contains)
                 && !file.path.hasSuffix("Tests/CodexBarTests/KeychainNoUIQueryTests.swift")
                 && !file.path.hasSuffix("Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift")
         }
 
-        #expect(offenders.isEmpty, "Unexpected direct SecItemCopyMatching in tests: \(offenders.map(\.path))")
+        #expect(offenders.isEmpty, "Unexpected direct Security item access in tests: \(offenders.map(\.path))")
+    }
+
+    @Test
+    func `production source routes Security item APIs through the test safety gateway`() throws {
+        let securityItemCalls = ["SecItemCopyMatching", "SecItemUpdate", "SecItemAdd", "SecItemDelete"]
+        let offenders = try Self.swiftFiles(
+            under: Self.repoRoot().appendingPathComponent("Sources", isDirectory: true))
+            .filter { file in
+                guard !file.path.hasSuffix("Sources/CodexBarCore/KeychainSecurity.swift") else { return false }
+                let text = try Self.readFile(file)
+                return securityItemCalls.contains(where: text.contains)
+            }
+
+        #expect(offenders.isEmpty, "Security item access bypasses KeychainSecurity: \(offenders.map(\.path))")
     }
 
     private static func repoRoot() -> URL {
@@ -128,8 +151,14 @@ struct KeychainPromptSafetyAuditTests {
 
     private static func swiftTestFiles(excludingSelf: Bool = false) throws -> [URL] {
         let testsRoot = self.repoRoot().appendingPathComponent("Tests/CodexBarTests", isDirectory: true)
+        return try self.swiftFiles(under: testsRoot).filter { file in
+            !(excludingSelf && file.path.hasSuffix("Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift"))
+        }
+    }
+
+    private static func swiftFiles(under root: URL) throws -> [URL] {
         guard let enumerator = FileManager.default.enumerator(
-            at: testsRoot,
+            at: root,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles])
         else { return [] }
@@ -138,9 +167,6 @@ struct KeychainPromptSafetyAuditTests {
         for case let file as URL in enumerator where file.pathExtension == "swift" {
             let values = try file.resourceValues(forKeys: [.isRegularFileKey])
             if values.isRegularFile == true {
-                if excludingSelf, file.path.hasSuffix("Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift") {
-                    continue
-                }
                 files.append(file)
             }
         }


### PR DESCRIPTION
## Summary

- route every first-party Security.framework item operation through a test-aware fail-closed gateway
- make the default test runner explicitly suppress login-Keychain access, including Claude's experimental `security` CLI reader
- preserve synthetic and explicitly isolated Keychain fixtures while adding source audits that reject future bypasses

Follow-up to #1880 and #1882.

## Proof

- `make check`
- `make test` twice: 47/47 shards, 555 selections, zero failures
- 100 ms `SecurityAgent` monitoring during both full runs: zero observations
- targeted unified-log audits across both full test windows: zero SwiftPM/CodexBar test-runner Keychain events
- focused Claude security-CLI, prompt-policy, Keychain gateway, and source-audit suites passed
- autoreview: no accepted/actionable findings
