### PR TITLE
Fix slow Claude CLI failure refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 - Tests: block real Keychain and `security` CLI access by default so test runs cannot display password prompts.
 - Claude: notify on model-scoped weekly and Daily Routines quota thresholds using independent warning state. Thanks @cleanerzkp!
+- Claude CLI: skip the identity probe after terminal usage errors or loading stalls, cutting failed refresh latency and subprocess churn.
 - OpenCode web: search Dia after Chrome for automatic cookie import, with Keychain preflight scoped to the candidate browser (fixes #1822). Thanks @zeajose!
 - Claude: make the "Avoid Keychain prompts" setting use the no-prompt policy instead of the experimental `security` CLI reader. Thanks @gmkbenjamin!
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -107,6 +107,9 @@ public struct ClaudeStatusProbe: Sendable {
                 Self.log.debug("Claude CLI /usage looked like startup output; retrying once")
                 usage = try await Self.capture(subcommand: "/usage", binary: resolved, timeout: max(timeout, 14))
             }
+            // `/status` only enriches a valid usage snapshot with identity. Terminal usage errors and loading stalls
+            // cannot be repaired by it, so fail now instead of paying for another interactive CLI round trip.
+            try Self.validateUsageBeforeStatusProbe(usage)
             let status = try? await Self.capture(subcommand: "/status", binary: resolved, timeout: min(timeout, 12))
             let snap = try Self.parse(text: usage, statusText: status)
 
@@ -329,6 +332,18 @@ public struct ClaudeStatusProbe: Sendable {
             || normalized.contains("loadingusage")
             || normalized.contains("failedtoloadusagedata")
             || self.usageCaptureHasSubscriptionNotice(normalized)
+    }
+
+    private static func validateUsageBeforeStatusProbe(_ text: String) throws {
+        let clean = TextParsing.stripANSICodes(text)
+        if let usageError = self.extractUsageError(text: clean) {
+            throw ClaudeStatusProbeError.parseFailed(usageError)
+        }
+
+        let latestUsagePanel = self.trimToLatestUsagePanel(clean)
+        if self.isUsageStillLoading(text: latestUsagePanel ?? clean) {
+            throw ClaudeStatusProbeError.parseFailed("Claude CLI /usage is still loading usage data.")
+        }
     }
 
     private static func extractPercent(labelSubstrings: [String], context: LabelSearchContext) -> Int? {

--- a/Tests/CodexBarTests/MenuCardCostComparisonTests.swift
+++ b/Tests/CodexBarTests/MenuCardCostComparisonTests.swift
@@ -17,7 +17,7 @@ struct MenuCardCostComparisonTests {
                 Self.entry(day: "2026-06-25", cost: 2, tokens: 200),
                 Self.entry(day: "2026-07-01", cost: 4, tokens: 400),
             ],
-            updatedAt: Date(timeIntervalSince1970: 1_782_864_000))
+            updatedAt: Self.localNoon(year: 2026, month: 7, day: 1))
 
         let section = try #require(UsageMenuCardView.Model.tokenUsageSection(
             provider: .claude,
@@ -105,5 +105,9 @@ struct MenuCardCostComparisonTests {
             costUSD: cost,
             modelsUsed: nil,
             modelBreakdowns: nil)
+    }
+
+    private static func localNoon(year: Int, month: Int, day: Int) -> Date {
+        Calendar.current.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
     }
 }

--- a/Tests/CodexBarTests/TTYIntegrationTests.swift
+++ b/Tests/CodexBarTests/TTYIntegrationTests.swift
@@ -74,8 +74,13 @@ struct TTYIntegrationTests {
 
     @Test
     func `claude pty usage stops on subscription notice`() async throws {
-        let cli = try Self.makeSubscriptionNoticeClaudeCLI()
-        defer { Task { await ClaudeCLISession.shared.reset() } }
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarTTYTests-\(UUID().uuidString).log")
+        let cli = try Self.makeSubscriptionNoticeClaudeCLI(logURL: logURL)
+        defer {
+            try? FileManager.default.removeItem(at: logURL)
+            Task { await ClaudeCLISession.shared.reset() }
+        }
 
         do {
             try await ClaudeCLISession.withIsolatedSessionForTesting {
@@ -87,6 +92,10 @@ struct TTYIntegrationTests {
         } catch {
             #expect(Bool(false), "Unexpected error: \(error)")
         }
+
+        let commands = try String(contentsOf: logURL, encoding: .utf8)
+        #expect(commands.contains("/usage"))
+        #expect(!commands.contains("/status"))
     }
 
     private static func makeSlowUsageClaudeCLI() throws -> URL {
@@ -117,7 +126,7 @@ struct TTYIntegrationTests {
         return url
     }
 
-    private static func makeSubscriptionNoticeClaudeCLI() throws -> URL {
+    private static func makeSubscriptionNoticeClaudeCLI(logURL: URL) throws -> URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("CodexBarTTYTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -125,6 +134,7 @@ struct TTYIntegrationTests {
         let script = """
         #!/bin/sh
         while IFS= read -r line; do
+          printf '%s\\n' "$line" >> '\(logURL.path)'
           case "$line" in
             *"/usage"*)
               printf '%s\\n' 'You are currently using your subscription to power your Claude Code usage'


### PR DESCRIPTION
## Summary

- stop the Claude CLI probe before `/status` when `/usage` already returned a terminal error or loading stall
- preserve `/status` identity enrichment for successful usage snapshots
- stabilize the new cost-window test around local calendar days
- document the Claude refresh improvement in the changelog

## Proof

- `swift test --filter TTYIntegrationTests`
- `swift test --filter MenuCardCostComparisonTests`
- `swift test --filter StatusProbeTests`
- `swift test --filter ClaudeCLITimeoutRetryTests`
- `make check`
- `make test` — 47/47 shards passed
- autoreview — no actionable findings

Live Claude CLI failure timings improved from `19.22s / 7.68s / 19.43s` to `7.77s / 7.33s / 8.04s`, removing the redundant interactive identity round trip. The freshly packaged app also completed authenticated Claude Web fetches successfully and rendered session, weekly, daily, and extra-usage windows in the menu.
