### PR TITLE
fix: keep Alibaba Safe Storage keychain read non-interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Repository: reject oversized tracked blobs and generated release/build artifacts during checks. Thanks @joeVenner!
 
 ### Fixed
+- Alibaba: keep the browser Safe Storage keychain read non-interactive and honor the "Disable Keychain access" setting, so cookie import can never trigger a Keychain prompt.
 - Tests: block real Keychain and `security` CLI access by default so test runs cannot display password prompts.
 - Claude: notify on model-scoped weekly and Daily Routines quota thresholds using independent warning state. Thanks @cleanerzkp!
 - Claude CLI: skip the identity probe after terminal usage errors or loading stalls, cutting failed refresh latency and subprocess churn.

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanCookieImporter.swift
@@ -364,13 +364,18 @@ enum AlibabaChromiumCookieFallbackImporter {
     }
 
     private static func safeStoragePassword(service: String, account: String) -> String? {
-        let query: [String: Any] = [
+        // The preflight classifies prompt-requiring items as .interactionRequired, but its
+        // .notFound (gate disabled) and .failure outcomes still reach this read. Honor the
+        // access gate and keep the read strictly non-interactive so it can never prompt.
+        guard !KeychainAccessGate.isDisabled else { return nil }
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
+        KeychainNoUIQuery.apply(to: &query)
 
         var result: AnyObject?
         let status = KeychainSecurity.copyMatching(query as CFDictionary, &result)


### PR DESCRIPTION
## Summary

Follow-up to #1897 closing the last keychain-prompt hole this investigation found: the Alibaba browser Safe Storage read.

`AlibabaChromiumCookieFallbackImporter.safeStoragePassword` issued a raw secret read (`kSecReturnData`) with no access-gate check and no non-interactive policy. The preflight above it classifies prompt-requiring items as `.interactionRequired`, but its `.notFound` (returned when the keychain gate is disabled) and `.failure` outcomes still fall through to this read. `KeychainSecurity` (#1897) blocks it under tests, but in production the read could still trigger a Keychain prompt and it ignored the user's "Disable Keychain access" setting.

## Changes

- Honor `KeychainAccessGate.isDisabled` before reading browser Safe Storage keys.
- Apply `KeychainNoUIQuery` so the read is strictly non-interactive (any prompt-requiring case was already filtered out by the preflight).

## Context

This branch originally carried the broader tests-off-the-real-keychain hardening, but #1897 and #1899 landed equivalent fixes first (fail-closed `KeychainSecurity` gateway, `security` CLI guard, timezone-stable cost test). The leaked `com.steipete.codexbar.cache.tests.*` items that caused the login-keychain password prompts have been deleted from the affected machine.

## Testing

- `swift test --filter 'AlibabaCodingPlanCookieImporterTests|KeychainPromptSafetyAuditTests|KeychainCacheStoreTests'` green.
- Full build green.
