### PR TITLE
Settings window layout

### DIFF
--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -100,7 +100,7 @@ struct CodexBarApp: App {
                 })
         }
         .defaultSize(width: SettingsPane.windowWidth, height: SettingsPane.windowHeight)
-        .windowResizability(.contentSize)
+        .windowResizability(.contentMinSize)
     }
 
     private func openSettings(pane: SettingsPane) {

--- a/Sources/CodexBar/PreferencesAboutPane.swift
+++ b/Sources/CodexBar/PreferencesAboutPane.swift
@@ -80,6 +80,7 @@ struct AboutPane: View {
         }
         .formStyle(.grouped)
         .toggleStyle(.switch)
+        .scrollContentBackground(.hidden)
         .onAppear {
             guard !self.didLoadUpdaterState else { return }
             // Align Sparkle's flag with the persisted preference on first load.

--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -65,6 +65,7 @@ struct AdvancedPane: View {
         }
         .formStyle(.grouped)
         .toggleStyle(.switch)
+        .scrollContentBackground(.hidden)
     }
 }
 

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -102,6 +102,7 @@ struct DisplayPane: View {
         }
         .formStyle(.grouped)
         .toggleStyle(.switch)
+        .scrollContentBackground(.hidden)
         .onAppear {
             self.reconcileOverviewSelection()
         }

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -151,5 +151,6 @@ struct GeneralPane: View {
         }
         .formStyle(.grouped)
         .toggleStyle(.switch)
+        .scrollContentBackground(.hidden)
     }
 }

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -183,6 +183,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
             }
         }
         .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
     }
 }
 

--- a/Sources/CodexBar/PreferencesSidebar.swift
+++ b/Sources/CodexBar/PreferencesSidebar.swift
@@ -16,9 +16,9 @@ struct SettingsSidebarView: View {
                 SettingsSidebarSearchField(searchText: self.$searchText)
                 SettingsSidebarSortToggle(isOn: self.sortAlphabeticallyBinding)
             }
-            .padding(.horizontal, 10)
-            .padding(.top, 10)
-            .padding(.bottom, 4)
+            .padding(.horizontal, 8)
+            .padding(.top, 16)
+            .padding(.bottom, 8)
 
             List(selection: self.selectionBinding) {
                 self.appPanesSection
@@ -27,6 +27,7 @@ struct SettingsSidebarView: View {
             .listStyle(.sidebar)
             .scrollContentBackground(.hidden)
         }
+        .padding(.horizontal, 8)
     }
 
     private var appPanesSection: some View {

--- a/Sources/CodexBar/PreferencesSidebar.swift
+++ b/Sources/CodexBar/PreferencesSidebar.swift
@@ -25,6 +25,7 @@ struct SettingsSidebarView: View {
                 self.providersSection
             }
             .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
         }
     }
 

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -15,7 +15,8 @@ enum SettingsPane: Hashable {
     static let windowHeight: CGFloat = 640
     static let windowMinWidth: CGFloat = 780
     static let windowMinHeight: CGFloat = 520
-    static let sidebarWidth: CGFloat = 224
+    static let sidebarWidth: CGFloat = 276
+    static let detailMaxWidth: CGFloat = 780
 
     var title: String {
         switch self {
@@ -252,3 +253,5 @@ private struct SettingsSidebarMaterial: NSViewRepresentable {
         view.state = .followsWindowActiveState
     }
 }
+
+

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -16,7 +16,6 @@ enum SettingsPane: Hashable {
     static let windowMinWidth: CGFloat = 780
     static let windowMinHeight: CGFloat = 520
     static let sidebarWidth: CGFloat = 224
-    static let sidebarMinWidth: CGFloat = 224
 
     var title: String {
         switch self {
@@ -41,7 +40,6 @@ struct PreferencesView: View {
     let codexAccountPromotionCoordinator: CodexAccountPromotionCoordinator
     let runProviderLoginFlow: @MainActor (UsageProvider) async -> Void
     @Environment(\.colorScheme) private var colorScheme
-    @State private var columnVisibility: NavigationSplitViewVisibility = .doubleColumn
 
     init(
         settings: SettingsStore,
@@ -66,20 +64,19 @@ struct PreferencesView: View {
     }
 
     var body: some View {
-        NavigationSplitView(columnVisibility: self.columnVisibilityBinding) {
-            SettingsSidebarView(settings: self.settings, store: self.store, selection: self.$selection.pane)
-                .frame(
-                    minWidth: SettingsPane.sidebarMinWidth,
-                    idealWidth: SettingsPane.sidebarWidth,
-                    maxWidth: SettingsPane.sidebarWidth)
-                .navigationSplitViewColumnWidth(
-                    min: SettingsPane.sidebarMinWidth,
-                    ideal: SettingsPane.sidebarWidth,
-                    max: SettingsPane.sidebarWidth)
-                .toolbar(removing: .sidebarToggle)
-        } detail: {
+        HStack(spacing: 0) {
+            ZStack {
+                SettingsSidebarMaterial()
+                SettingsSidebarView(settings: self.settings, store: self.store, selection: self.$selection.pane)
+            }
+            .frame(width: SettingsPane.sidebarWidth)
+            .frame(maxHeight: .infinity)
+            .clipped()
+
+            Divider()
+
             self.detailView
-                .navigationTitle(self.selection.pane.title)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .frame(
             minWidth: SettingsPane.windowMinWidth,
@@ -90,12 +87,11 @@ struct PreferencesView: View {
             maxHeight: .infinity)
         .id(self.settings.appLanguage)
         .background {
-            SettingsWindowAppearanceBridge(colorScheme: self.colorScheme)
+            SettingsWindowAppearanceBridge(colorScheme: self.colorScheme, windowTitle: self.selection.pane.title)
                 .allowsHitTesting(false)
         }
         .onAppear {
             self.ensureValidSelection()
-            self.columnVisibility = .doubleColumn
         }
         .onChange(of: self.settings.debugMenuEnabled) { _, _ in
             self.ensureValidSelection()
@@ -127,16 +123,6 @@ struct PreferencesView: View {
         }
     }
 
-    private var columnVisibilityBinding: Binding<NavigationSplitViewVisibility> {
-        Binding(
-            get: { self.columnVisibility },
-            set: { self.columnVisibility = Self.visibleColumnVisibility(for: $0) })
-    }
-
-    static func visibleColumnVisibility(for _: NavigationSplitViewVisibility) -> NavigationSplitViewVisibility {
-        .doubleColumn
-    }
-
     private func ensureValidSelection() {
         if !self.settings.debugMenuEnabled, self.selection.pane == .debug {
             self.selection.pane = .general
@@ -162,24 +148,6 @@ enum SettingsWindowSizing {
             frame.size = repairedSize
             window.setFrame(frame, display: true)
         }
-
-        self.enforceSidebarWidth(in: window)
-    }
-
-    private static func enforceSidebarWidth(in window: NSWindow) {
-        // SwiftUI's split-view identifier is private and has changed across macOS releases.
-        // The Settings navigation split is the widest vertical two-pane split in this window.
-        guard let splitView = window.contentView?.descendantSplitViews
-            .filter({ $0.isVertical && $0.subviews.count == 2 })
-            .max(by: { $0.bounds.width < $1.bounds.width })
-        else {
-            return
-        }
-
-        let sidebar = splitView.subviews[0]
-        guard sidebar.frame.width < SettingsPane.sidebarWidth else { return }
-        splitView.setPosition(SettingsPane.sidebarWidth, ofDividerAt: 0)
-        splitView.adjustSubviews()
     }
 }
 
@@ -215,23 +183,17 @@ enum SettingsWindowAppearance {
     }
 }
 
-extension NSView {
-    fileprivate var descendantSplitViews: [NSSplitView] {
-        let current = (self as? NSSplitView).map { [$0] } ?? []
-        return current + self.subviews.flatMap(\.descendantSplitViews)
-    }
-}
-
 @MainActor
 struct SettingsWindowAppearanceBridge: NSViewRepresentable {
     let colorScheme: ColorScheme
+    let windowTitle: String
 
     func makeNSView(context: Context) -> SettingsWindowAppearanceView {
         SettingsWindowAppearanceView()
     }
 
     func updateNSView(_ nsView: SettingsWindowAppearanceView, context: Context) {
-        nsView.refreshWindowAppearance(for: self.colorScheme)
+        nsView.refreshWindowAppearance(for: self.colorScheme, windowTitle: self.windowTitle)
     }
 }
 
@@ -239,6 +201,7 @@ struct SettingsWindowAppearanceBridge: NSViewRepresentable {
 final class SettingsWindowAppearanceView: NSView {
     private let scheduleReset: SettingsWindowAppearance.ResetScheduler
     private var colorScheme: ColorScheme?
+    private var windowTitle: String?
 
     init(scheduleReset: @escaping SettingsWindowAppearance.ResetScheduler = SettingsWindowAppearance.scheduleReset) {
         self.scheduleReset = scheduleReset
@@ -255,14 +218,37 @@ final class SettingsWindowAppearanceView: NSView {
         self.refreshWindowAppearance()
     }
 
-    func refreshWindowAppearance(for colorScheme: ColorScheme) {
-        guard self.colorScheme != colorScheme else { return }
+    func refreshWindowAppearance(for colorScheme: ColorScheme, windowTitle: String? = nil) {
+        guard self.colorScheme != colorScheme || self.windowTitle != windowTitle else { return }
         self.colorScheme = colorScheme
+        self.windowTitle = windowTitle
         self.refreshWindowAppearance()
     }
 
     private func refreshWindowAppearance() {
         guard let window else { return }
+        if let windowTitle {
+            window.title = windowTitle
+        }
         SettingsWindowAppearance.refresh(window, scheduleReset: self.scheduleReset)
+    }
+}
+
+@MainActor
+private struct SettingsSidebarMaterial: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        self.configure(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        self.configure(nsView)
+    }
+
+    private func configure(_ view: NSVisualEffectView) {
+        view.material = .sidebar
+        view.blendingMode = .behindWindow
+        view.state = .followsWindowActiveState
     }
 }

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -11,11 +11,11 @@ enum SettingsPane: Hashable {
     case debug
     case provider(UsageProvider)
 
-    static let windowWidth: CGFloat = 920
-    static let windowHeight: CGFloat = 640
-    static let windowMinWidth: CGFloat = 780
-    static let windowMinHeight: CGFloat = 520
-    static let sidebarWidth: CGFloat = 276
+    static let windowWidth: CGFloat = 880
+    static let windowHeight: CGFloat = 620
+    static let windowMinWidth: CGFloat = 800
+    static let windowMinHeight: CGFloat = 540
+    static let sidebarWidth: CGFloat = 260
     static let detailMaxWidth: CGFloat = 780
 
     var title: String {
@@ -68,13 +68,27 @@ struct PreferencesView: View {
         HStack(spacing: 0) {
             ZStack {
                 SettingsSidebarMaterial()
+                    .blur(radius: 20)
+                self.sidebarWashColor
+
                 SettingsSidebarView(settings: self.settings, store: self.store, selection: self.$selection.pane)
             }
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .shadow(color: Color.black.opacity(0.08), radius: 3, x: 0, y: 1)
+            .shadow(color: Color.black.opacity(0.22), radius: 20, x: 0, y: 6)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.22), lineWidth: 0.75))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(
+                        Color(self.colorScheme == .dark ? Color.white.opacity(0.27) : Color.white.opacity(0.72)),
+                        lineWidth: 0.85))
             .frame(width: SettingsPane.sidebarWidth)
-            .frame(maxHeight: .infinity)
-            .clipped()
-
-            Divider()
+            .padding(.leading, 12)
+            .padding(.top, 0)
+            .padding(.bottom, 12)
+            .padding(.trailing, 4)
 
             self.detailView
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -122,6 +136,12 @@ struct PreferencesView: View {
                 runProviderLoginFlow: self.runProviderLoginFlow)
                 .id(provider)
         }
+    }
+
+    private var sidebarWashColor: Color {
+        self.colorScheme == .dark
+            ? Color.black.opacity(0.60)
+            : Color.white.opacity(0.60)
     }
 
     private func ensureValidSelection() {
@@ -214,24 +234,76 @@ final class SettingsWindowAppearanceView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        NotificationCenter.default.removeObserver(self, name: NSWindow.didUpdateNotification, object: nil)
+        if let window {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(self.windowDidUpdate(_:)),
+                name: NSWindow.didUpdateNotification,
+                object: window)
+        }
+        self.configureWindowStyle()
         self.refreshWindowAppearance()
     }
 
+    @objc private func windowDidUpdate(_ notification: Notification) {
+        self.configureWindowStyle()
+    }
+
     func refreshWindowAppearance(for colorScheme: ColorScheme, windowTitle: String? = nil) {
-        guard self.colorScheme != colorScheme || self.windowTitle != windowTitle else { return }
+        let colorSchemeChanged = self.colorScheme != colorScheme
+        let windowTitleChanged = self.windowTitle != windowTitle
+        guard colorSchemeChanged || windowTitleChanged else { return }
         self.colorScheme = colorScheme
         self.windowTitle = windowTitle
-        self.refreshWindowAppearance()
+
+        guard let window else { return }
+        self.configureWindowStyle()
+        if windowTitleChanged, let windowTitle {
+            window.title = windowTitle
+        }
+        if colorSchemeChanged {
+            SettingsWindowAppearance.refresh(window, scheduleReset: self.scheduleReset)
+        }
     }
 
     private func refreshWindowAppearance() {
         guard let window else { return }
+        self.configureWindowStyle()
         if let windowTitle {
             window.title = windowTitle
         }
         SettingsWindowAppearance.refresh(window, scheduleReset: self.scheduleReset)
+    }
+
+    override func layout() {
+        super.layout()
+        self.configureWindowStyle()
+    }
+
+    private func configureWindowStyle() {
+        guard let window else { return }
+        if !window.titlebarAppearsTransparent {
+            window.titlebarAppearsTransparent = true
+        }
+        if window.titleVisibility != .visible {
+            window.titleVisibility = .visible
+        }
+        if window.titlebarSeparatorStyle != .none {
+            window.titlebarSeparatorStyle = .none
+        }
+        if window.toolbar != nil {
+            window.toolbar = nil
+        }
+        if window.styleMask.contains(.fullSizeContentView) {
+            window.styleMask.remove(.fullSizeContentView)
+        }
     }
 }
 
@@ -253,5 +325,3 @@ private struct SettingsSidebarMaterial: NSViewRepresentable {
         view.state = .followsWindowActiveState
     }
 }
-
-

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -293,6 +293,9 @@ final class SettingsWindowAppearanceView: NSView {
 
     private func configureWindowStyle() {
         guard let window else { return }
+        if !window.styleMask.contains(.resizable) {
+            window.styleMask.insert(.resizable)
+        }
         if !window.titlebarAppearsTransparent {
             window.titlebarAppearsTransparent = true
         }

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -82,7 +82,7 @@ struct PreferencesView: View {
             .overlay(
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .stroke(
-                        Color(self.colorScheme == .dark ? Color.white.opacity(0.27) : Color.white.opacity(0.72)),
+                        self.colorScheme == .dark ? Color.white.opacity(0.27) : Color.white.opacity(0.72),
                         lineWidth: 0.85))
             .frame(width: SettingsPane.sidebarWidth)
             .padding(.leading, 12)
@@ -91,6 +91,10 @@ struct PreferencesView: View {
             .padding(.trailing, 4)
 
             self.detailView
+                .frame(
+                    maxWidth: SettingsPane.detailMaxWidth,
+                    maxHeight: .infinity,
+                    alignment: .topLeading)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .frame(

--- a/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
+++ b/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
@@ -121,6 +121,20 @@ struct SettingsWindowAppearanceTests {
     }
 
     @Test
+    func `settings window style remains resizable`() {
+        let bridge = SettingsWindowAppearanceView()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+
+        window.contentView = bridge
+
+        #expect(window.styleMask.contains(.resizable))
+    }
+
+    @Test
     func `repeated theme updates cannot leave an explicit appearance`() {
         let resetCapture = ResetCapture()
         let bridge = SettingsWindowAppearanceView { resetCapture.actions.append($0) }

--- a/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
+++ b/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
@@ -7,7 +7,7 @@ import Testing
 struct SettingsWindowAppearanceTests {
     @Test
     func `settings sidebar uses a fixed noncollapsible width`() {
-        #expect(SettingsPane.sidebarWidth == 276)
+        #expect(SettingsPane.sidebarWidth == 260)
         #expect(SettingsPane.windowMinWidth > SettingsPane.sidebarWidth)
         #expect(SettingsPane.detailMaxWidth > SettingsPane.windowMinWidth - SettingsPane.sidebarWidth)
     }

--- a/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
+++ b/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
@@ -7,8 +7,9 @@ import Testing
 struct SettingsWindowAppearanceTests {
     @Test
     func `settings sidebar uses a fixed noncollapsible width`() {
-        #expect(SettingsPane.sidebarWidth == 224)
+        #expect(SettingsPane.sidebarWidth == 276)
         #expect(SettingsPane.windowMinWidth > SettingsPane.sidebarWidth)
+        #expect(SettingsPane.detailMaxWidth > SettingsPane.windowMinWidth - SettingsPane.sidebarWidth)
     }
 
     @Test
@@ -99,7 +100,7 @@ struct SettingsWindowAppearanceTests {
     }
 
     @Test
-    func `bridge updates window title when selected pane changes`() {
+    func `bridge updates window title without pulsing appearance on pane changes`() {
         let resetCapture = ResetCapture()
         let bridge = SettingsWindowAppearanceView { resetCapture.actions.append($0) }
         let window = NSWindow(
@@ -111,10 +112,12 @@ struct SettingsWindowAppearanceTests {
         resetCapture.actions.removeAll()
 
         bridge.refreshWindowAppearance(for: .light, windowTitle: "Display")
+        #expect(resetCapture.actions.count == 1)
+
         bridge.refreshWindowAppearance(for: .light, windowTitle: "General")
 
         #expect(window.title == "General")
-        #expect(resetCapture.actions.count == 2)
+        #expect(resetCapture.actions.count == 1)
     }
 
     @Test

--- a/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
+++ b/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
@@ -6,10 +6,9 @@ import Testing
 @MainActor
 struct SettingsWindowAppearanceTests {
     @Test
-    func `settings always keeps both navigation columns visible`() {
-        #expect(PreferencesView.visibleColumnVisibility(for: .detailOnly) == .doubleColumn)
-        #expect(PreferencesView.visibleColumnVisibility(for: .automatic) == .doubleColumn)
-        #expect(PreferencesView.visibleColumnVisibility(for: .doubleColumn) == .doubleColumn)
+    func `settings sidebar uses a fixed noncollapsible width`() {
+        #expect(SettingsPane.sidebarWidth == 224)
+        #expect(SettingsPane.windowMinWidth > SettingsPane.sidebarWidth)
     }
 
     @Test
@@ -47,7 +46,7 @@ struct SettingsWindowAppearanceTests {
     }
 
     @Test
-    func `settings window sizing restores a collapsed sidebar without private identifiers`() {
+    func `settings window sizing does not mutate content split views`() {
         let window = NSWindow(
             contentRect: NSRect(x: 120, y: 160, width: 180, height: 140),
             styleMask: [.titled],
@@ -66,34 +65,7 @@ struct SettingsWindowAppearanceTests {
         SettingsWindowSizing.enforceMinimumSize(window)
 
         #expect(window.frame.width >= window.minSize.width)
-        #expect(sidebar.frame.width >= SettingsPane.sidebarWidth)
-    }
-
-    @Test
-    func `settings window sizing repairs the outer navigation split`() {
-        let window = NSWindow(
-            contentRect: NSRect(x: 120, y: 160, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false)
-        let outerSplit = NSSplitView(
-            frame: NSRect(x: 0, y: 0, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight))
-        outerSplit.isVertical = true
-        let sidebar = NSView(frame: NSRect(x: 0, y: 0, width: 0, height: SettingsPane.windowHeight))
-        let detail = NSView(
-            frame: NSRect(x: 0, y: 0, width: SettingsPane.windowWidth, height: SettingsPane.windowHeight))
-        let nestedSplit = NSSplitView(frame: NSRect(x: 0, y: 0, width: 300, height: 300))
-        nestedSplit.isVertical = true
-        nestedSplit.addSubview(NSView(frame: .zero))
-        nestedSplit.addSubview(NSView(frame: .zero))
-        detail.addSubview(nestedSplit)
-        outerSplit.addSubview(sidebar)
-        outerSplit.addSubview(detail)
-        window.contentView = outerSplit
-
-        SettingsWindowSizing.enforceMinimumSize(window)
-
-        #expect(sidebar.frame.width >= SettingsPane.sidebarWidth)
+        #expect(sidebar.frame.width == 0)
     }
 
     @Test
@@ -124,6 +96,25 @@ struct SettingsWindowAppearanceTests {
 
         #expect(window.appearance == nil)
         #expect(window.viewsNeedDisplay)
+    }
+
+    @Test
+    func `bridge updates window title when selected pane changes`() {
+        let resetCapture = ResetCapture()
+        let bridge = SettingsWindowAppearanceView { resetCapture.actions.append($0) }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        window.contentView = bridge
+        resetCapture.actions.removeAll()
+
+        bridge.refreshWindowAppearance(for: .light, windowTitle: "Display")
+        bridge.refreshWindowAppearance(for: .light, windowTitle: "General")
+
+        #expect(window.title == "General")
+        #expect(resetCapture.actions.count == 2)
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR improves the Settings window layout and sidebar behavior.

- Replaces the unstable resizable `NavigationSplitView` sidebar with a fixed-width custom layout.
- Keeps the sidebar visible and non-draggable, so it can no longer collapse, disappear, or become extremely wide.
- Polishes the sidebar visual treatment with a rounded translucent panel, lighter/darker wash for light and dark mode, and adjusted spacing.
- Keeps the detail content constrained so settings rows do not stretch awkwardly across the full window.
- Preserves normal window resizing: an 800-point minimum, the 880-point default, and wider layouts all keep the sidebar stable while the detail column stays readable.
- Reduces unnecessary window appearance refresh work when only the selected pane title changes.

## Why

The previous Settings window used SwiftUI `NavigationSplitView`, but the underlying split divider was still draggable. That caused two bad states:

- dragging left could collapse the sidebar until it disappeared
- dragging right could make the sidebar much wider than intended

Trying to repair this from AppKit was fragile because SwiftUI still owned the split layout. A fixed custom layout better matches the intended behavior: a stable System Settings-style sidebar that is always visible and not user-resizable.

The visual updates make the sidebar feel closer to macOS Settings while keeping the existing app structure and behavior.

## Validation

Ran:

- `swift test --filter SettingsWindowAppearanceTests`
- `make check`
- `git diff --check`
- exact release bundle: resized live to 800×572, 880×652, and 1500×900; verified the sidebar remains fixed, the detail column remains capped, and the minimum layout scrolls instead of clipping controls

## Screenshots
### Before

| Issue | Screenshot |
|---|---|
| Dragging left could collapse the sidebar until it disappeared. | <img width="1500" alt="Screenshot 2026-07-03 at 21 56 27" src="https://github.com/user-attachments/assets/17819406-b4aa-4501-ab0c-639fe6eba62b" /> |
| Dragging right could make the sidebar much wider than intended. | <img width="1500" alt="Screenshot 2026-07-03 at 21 56 13" src="https://github.com/user-attachments/assets/7f72dfe5-a3a5-467a-bead-ae0f00948e27" /> |

### after
<img width="700" alt="Screenshot 2026-07-04 at 13 59 17" src="https://github.com/user-attachments/assets/0c16ec63-1b5c-45aa-aa39-f6bb35a1812c" />
