### PR TITLE
Compact reset credit expiries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Mistral: show available credit balance from the authenticated billing session while preserving API spend and Monthly Plan usage. Thanks @Zihao-Qi!
 
 ### Changed
+- Codex: compact reset-credit expiry inventory into a single scannable timeline instead of one row per credit.
 - Repository: reject oversized tracked blobs and generated release/build artifacts during checks. Thanks @joeVenner!
 
 ### Fixed

--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -123,10 +123,7 @@ extension CodexResetCreditsPresentation {
     fileprivate var heightFingerprint: String {
         MenuCardHeightFingerprint.join([
             MenuCardHeightFingerprint.field("text", self.text),
-            MenuCardHeightFingerprint.field("detail", self.detailText),
-            MenuCardHeightFingerprint.join(self.items.map {
-                MenuCardHeightFingerprint.field("expiry", $0.expiryText)
-            }),
+            MenuCardHeightFingerprint.field("expirySummary", self.expirySummaryText),
         ])
     }
 }

--- a/Sources/CodexBar/MenuCardView+CodexResetCredits.swift
+++ b/Sources/CodexBar/MenuCardView+CodexResetCredits.swift
@@ -3,12 +3,19 @@ import SwiftUI
 
 struct CodexResetCreditPresentationItem: Equatable {
     let expiryText: String
+    let compactExpiryText: String
 }
 
 struct CodexResetCreditsPresentation: Equatable {
     let text: String
-    let detailText: String?
     let items: [CodexResetCreditPresentationItem]
+
+    var expirySummaryText: String {
+        let visibleItems = self.items.prefix(4).map(\.compactExpiryText)
+        let hiddenCount = self.items.count - visibleItems.count
+        let suffix = hiddenCount > 0 ? ["+\(hiddenCount)"] : []
+        return (visibleItems + suffix).joined(separator: " · ")
+    }
 
     var helpText: String {
         self.items.enumerated().map { index, item in
@@ -30,19 +37,10 @@ struct CodexResetCreditsPresentation: Equatable {
         let inventory = snapshot.availableInventory(at: now)
         guard !inventory.credits.isEmpty else { return nil }
         let items = inventory.credits.map { credit in
-            CodexResetCreditPresentationItem(
-                expiryText: Self.expiryText(for: credit, resetStyle: resetStyle, now: now))
+            Self.presentationItem(for: credit, resetStyle: resetStyle, now: now)
         }
-        let detailText = inventory.nextExpiringCredit.flatMap { credit in
-            credit.expiresAt.map { expiresAt in
-                String(
-                    format: L("Next expires %@"),
-                    Self.formattedTime(expiresAt, resetStyle: resetStyle, now: now))
-            }
-        } ?? (inventory.credits.allSatisfy { $0.expiresAt == nil } ? L("No expiry") : nil)
         return CodexResetCreditsPresentation(
             text: Self.availableText(count: inventory.count),
-            detailText: detailText,
             items: items)
     }
 
@@ -50,15 +48,21 @@ struct CodexResetCreditsPresentation: Equatable {
         count == 1 ? L("1 available") : String(format: L("%d available"), count)
     }
 
-    private static func expiryText(
+    private static func presentationItem(
         for credit: CodexRateLimitResetCredit,
         resetStyle: ResetTimeDisplayStyle,
-        now: Date) -> String
+        now: Date) -> CodexResetCreditPresentationItem
     {
-        guard let expiresAt = credit.expiresAt else { return L("No expiry") }
-        return String(
-            format: L("Expires %@"),
-            Self.formattedTime(expiresAt, resetStyle: resetStyle, now: now))
+        guard let expiresAt = credit.expiresAt else {
+            return CodexResetCreditPresentationItem(expiryText: L("No expiry"), compactExpiryText: L("No expiry"))
+        }
+        let formattedTime = Self.formattedTime(expiresAt, resetStyle: resetStyle, now: now)
+        let compactExpiryText = resetStyle == .countdown && formattedTime.hasPrefix("in ")
+            ? String(formattedTime.dropFirst(3))
+            : formattedTime
+        return CodexResetCreditPresentationItem(
+            expiryText: String(format: L("Expires %@"), formattedTime),
+            compactExpiryText: compactExpiryText)
     }
 
     private static func formattedTime(
@@ -80,36 +84,30 @@ struct CodexResetCreditsContent: View {
     let presentation: CodexResetCreditsPresentation
     @Environment(\.menuItemHighlighted) private var isHighlighted
 
-    nonisolated static func expiryRows(_ presentation: CodexResetCreditsPresentation) -> [String] {
-        presentation.items.map(\.expiryText)
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(L("Limit Reset Credits"))
                 .font(.body)
                 .fontWeight(.medium)
                 .lineLimit(1)
-            HStack(alignment: .firstTextBaseline) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(self.presentation.text)
                     .font(.footnote.weight(.semibold))
                     .foregroundStyle(MenuHighlightStyle.primary(self.isHighlighted))
                     .lineLimit(1)
                     .layoutPriority(1)
-                Spacer()
-                if let detailText = self.presentation.detailText, !detailText.isEmpty {
-                    Text(detailText)
-                        .font(.footnote)
+                Spacer(minLength: 8)
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Image(systemName: "clock")
+                        .font(.caption2)
+                    Text(self.presentation.expirySummaryText)
+                        .font(.caption)
                         .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
                         .lineLimit(1)
+                        .minimumScaleFactor(0.8)
                 }
-            }
-            ForEach(Array(Self.expiryRows(self.presentation).enumerated()), id: \.offset) { index, expiryText in
-                Text("\(index + 1). \(expiryText)")
-                    .font(.caption)
-                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                    .lineLimit(1)
-                    .frame(maxWidth: .infinity, alignment: .trailing)
+                .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                .accessibilityHidden(true)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -481,12 +481,17 @@ private struct ProviderCodexResetCreditsInlineRow: View {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
-            ForEach(Array(self.presentation.items.enumerated()), id: \.offset) { _, item in
-                Text(item.expiryText)
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Image(systemName: "clock")
+                    .font(.caption2)
+                Text(self.presentation.expirySummaryText)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
-                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .accessibilityHidden(true)
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)

--- a/Tests/CodexBarTests/CodexResetCreditsMenuCardTests.swift
+++ b/Tests/CodexBarTests/CodexResetCreditsMenuCardTests.swift
@@ -22,13 +22,8 @@ struct CodexResetCreditsMenuCardTests {
         let presentation = try #require(model.codexResetCredits)
 
         #expect(presentation.text == "3 available")
-        #expect(presentation.detailText == "Next expires in 1d")
         #expect(presentation.items.map(\.expiryText) == ["Expires in 1d", "Expires in 2d", "No expiry"])
-        #expect(CodexResetCreditsContent.expiryRows(presentation) == [
-            "Expires in 1d",
-            "Expires in 2d",
-            "No expiry",
-        ])
+        #expect(presentation.expirySummaryText == "1d · 2d · No expiry")
         #expect(presentation.helpText == "1. Expires in 1d\n2. Expires in 2d\n3. No expiry")
         #expect(presentation.accessibilityLabel.contains(presentation.helpText))
     }
@@ -44,8 +39,8 @@ struct CodexResetCreditsMenuCardTests {
         let presentation = try #require(model.codexResetCredits)
 
         #expect(presentation.text == "1 available")
-        #expect(presentation.detailText == "No expiry")
         #expect(presentation.items.map(\.expiryText) == ["No expiry"])
+        #expect(presentation.expirySummaryText == "No expiry")
         #expect(model.hasUsageContent)
     }
 
@@ -62,8 +57,8 @@ struct CodexResetCreditsMenuCardTests {
         let presentation = try #require(model.codexResetCredits)
         let formatted = UsageFormatter.resetDescription(from: expiresAt, now: now)
 
-        #expect(presentation.detailText == "Next expires \(formatted)")
         #expect(presentation.items.map(\.expiryText) == ["Expires \(formatted)"])
+        #expect(presentation.expirySummaryText == formatted)
     }
 
     @Test
@@ -77,7 +72,20 @@ struct CodexResetCreditsMenuCardTests {
             now: now)
 
         #expect(model.codexResetCredits?.text == "1 available")
-        #expect(model.codexResetCredits?.detailText == "Next expires in 1d")
+        #expect(model.codexResetCredits?.expirySummaryText == "1d")
+    }
+
+    @Test
+    func `compact expiry summary caps visible dates`() throws {
+        let now = Date(timeIntervalSince1970: 1_781_726_400)
+        let credits = (1...6).map { day in
+            Self.credit(id: "day-\(day)", status: .available, now: now, expiresIn: Double(day * 86400))
+        }
+        let model = try Self.model(snapshot: Self.snapshot(now: now, credits: credits), now: now)
+
+        let presentation = try #require(model.codexResetCredits)
+        #expect(presentation.expirySummaryText == "1d · 2d · 3d · 4d · +2")
+        #expect(presentation.helpText.split(separator: "\n").count == 6)
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
+++ b/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
@@ -37,12 +37,13 @@ struct MenuCardHeightFingerprintTests {
     func `height fingerprint tracks reset-credit inventory shape`() {
         let one = Self.model(resetCredits: CodexResetCreditsPresentation(
             text: "1 available",
-            detailText: "Next expires in 1d",
-            items: [.init(expiryText: "Expires in 1d")]))
+            items: [.init(expiryText: "Expires in 1d", compactExpiryText: "1d")]))
         let two = Self.model(resetCredits: CodexResetCreditsPresentation(
             text: "2 available",
-            detailText: "Next expires in 1d",
-            items: [.init(expiryText: "Expires in 1d"), .init(expiryText: "No expiry")]))
+            items: [
+                .init(expiryText: "Expires in 1d", compactExpiryText: "1d"),
+                .init(expiryText: "No expiry", compactExpiryText: "No expiry"),
+            ]))
 
         #expect(one.heightFingerprint(section: "card") != two.heightFingerprint(section: "card"))
     }


### PR DESCRIPTION
## Summary

- replace one reset-credit expiry row per credit with a single clock-prefixed timeline
- keep full numbered expiry details in the tooltip and accessibility label
- mirror the compact treatment in provider settings and collapse long inventories with `+N`

## Before / after

### Before

<img width="592" alt="Reset-credit expiries before: one numbered row per credit" src="https://github.com/user-attachments/assets/561e3b08-4c06-49a6-9a96-bc3e321ba856" />

### After

<img width="700" alt="Reset-credit expiries after: one compact clock-prefixed timeline" src="https://github.com/user-attachments/assets/0706f08a-dece-4373-a3db-ce28e0cd90cb" />

## Proof

- `swift test --filter CodexResetCreditsMenuCardTests`
- `swift test --filter MenuCardHeightFingerprintTests`
- `make check`
- `make test` — 47/47 shards passed
- `./Scripts/compile_and_run.sh` — packaged app launched and remained running
- source-blind behavior validation — 5/5 clauses passed, including menu close/reopen
- autoreview — clean; no accepted/actionable findings
