### PR TITLE
Fix Claude same-dir account-switch history mis-attribution (#1886)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Claude CLI: skip the identity probe after terminal usage errors or loading stalls, cutting failed refresh latency and subprocess churn.
 - OpenCode web: search Dia after Chrome for automatic cookie import, with Keychain preflight scoped to the candidate browser (fixes #1822). Thanks @zeajose!
 - Claude: make the "Avoid Keychain prompts" setting use the no-prompt policy instead of the experimental `security` CLI reader. Thanks @gmkbenjamin!
+- Claude: keep per-account plan-utilization history separate after an in-place account switch in the shared `~/.claude` directory, so background polls no longer attribute the new account's usage to the previous account's history (fixes #1886). Thanks @ss251!
 
 ## 0.38.1 — 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@
 - Claude CLI: skip the identity probe after terminal usage errors or loading stalls, cutting failed refresh latency and subprocess churn.
 - OpenCode web: search Dia after Chrome for automatic cookie import, with Keychain preflight scoped to the candidate browser (fixes #1822). Thanks @zeajose!
 - Claude: make the "Avoid Keychain prompts" setting use the no-prompt policy instead of the experimental `security` CLI reader. Thanks @gmkbenjamin!
-- Claude: keep per-account plan-utilization history separate after an in-place account switch in the shared `~/.claude` directory, so background polls no longer attribute the new account's usage to the previous account's history (fixes #1886). Thanks @ss251!
 
 ## 0.38.1 — 2026-07-04
 

--- a/Sources/CodexBar/UsageStore+CodexResetCredits.swift
+++ b/Sources/CodexBar/UsageStore+CodexResetCredits.swift
@@ -119,7 +119,8 @@ extension ProviderFetchOutcome {
                 strategyKind: result.strategyKind,
                 claudeOAuthKeychainPersistentRefHash: result.claudeOAuthKeychainPersistentRefHash,
                 claudeOAuthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier,
-                claudeOAuthKeychainCredentialMismatch: result.claudeOAuthKeychainCredentialMismatch)),
+                claudeOAuthKeychainCredentialMismatch: result.claudeOAuthKeychainCredentialMismatch,
+                claudeOAuthKeychainCredentialUnavailable: result.claudeOAuthKeychainCredentialUnavailable)),
             attempts: self.attempts)
     }
 

--- a/Sources/CodexBar/UsageStore+CodexResetCredits.swift
+++ b/Sources/CodexBar/UsageStore+CodexResetCredits.swift
@@ -120,6 +120,7 @@ extension ProviderFetchOutcome {
                 claudeOAuthKeychainPersistentRefHash: result.claudeOAuthKeychainPersistentRefHash,
                 claudeOAuthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier,
                 claudeOAuthKeychainCredentialMismatch: result.claudeOAuthKeychainCredentialMismatch,
+                claudeOAuthKeychainCredentialAbsent: result.claudeOAuthKeychainCredentialAbsent,
                 claudeOAuthKeychainCredentialUnavailable: result.claudeOAuthKeychainCredentialUnavailable)),
             attempts: self.attempts)
     }

--- a/Sources/CodexBar/UsageStore+CodexResetCredits.swift
+++ b/Sources/CodexBar/UsageStore+CodexResetCredits.swift
@@ -119,7 +119,7 @@ extension ProviderFetchOutcome {
                 strategyKind: result.strategyKind,
                 claudeOAuthKeychainPersistentRefHash: result.claudeOAuthKeychainPersistentRefHash,
                 claudeOAuthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier,
-                claudeOAuthUsesClaudeCLIKeychain: result.claudeOAuthUsesClaudeCLIKeychain)),
+                claudeOAuthKeychainCredentialMismatch: result.claudeOAuthKeychainCredentialMismatch)),
             attempts: self.attempts)
     }
 

--- a/Sources/CodexBar/UsageStore+CodexResetCredits.swift
+++ b/Sources/CodexBar/UsageStore+CodexResetCredits.swift
@@ -118,7 +118,8 @@ extension ProviderFetchOutcome {
                 strategyID: result.strategyID,
                 strategyKind: result.strategyKind,
                 claudeOAuthKeychainPersistentRefHash: result.claudeOAuthKeychainPersistentRefHash,
-                claudeOAuthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier)),
+                claudeOAuthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier,
+                claudeOAuthUsesClaudeCLIKeychain: result.claudeOAuthUsesClaudeCLIKeychain)),
             attempts: self.attempts)
     }
 

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -153,6 +153,7 @@ extension UsageStore {
         account: ProviderTokenAccount? = nil,
         claudeOAuthPersistentRefHash: String? = nil,
         claudeOAuthHistoryOwnerIdentifier: String? = nil,
+        isClaudeCLIKeychainSample: Bool = false,
         isClaudeOAuthSample: Bool = false,
         shouldUpdatePreferredAccountKey: Bool = true,
         shouldAdoptUnscopedHistory: Bool = true,
@@ -161,7 +162,11 @@ extension UsageStore {
     {
         let samples = self.planUtilizationSeriesSamples(provider: provider, snapshot: snapshot, capturedAt: now)
         var effectiveOwner = claudeOAuthHistoryOwnerIdentifier
-        if provider == .claude, isClaudeOAuthSample, let owner = claudeOAuthHistoryOwnerIdentifier {
+        if provider == .claude,
+           isClaudeOAuthSample,
+           isClaudeCLIKeychainSample,
+           let owner = claudeOAuthHistoryOwnerIdentifier
+        {
             let currentAccountIdentity = Self.activeClaudeAccountIdentity()
             var map = Self.loadClaudeOAuthAccountUuidMap(from: self.settings.userDefaults)
             if let mapped = map[owner], let currentAccountIdentity, mapped != currentAccountIdentity {

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -162,27 +162,28 @@ extension UsageStore {
         let samples = self.planUtilizationSeriesSamples(provider: provider, snapshot: snapshot, capturedAt: now)
         var effectiveOwner = claudeOAuthHistoryOwnerIdentifier
         if provider == .claude, isClaudeOAuthSample, let owner = claudeOAuthHistoryOwnerIdentifier {
-            let currentUuid = Self.activeClaudeAccountUuid()
+            let currentAccountIdentity = Self.activeClaudeAccountIdentity()
             var map = Self.loadClaudeOAuthAccountUuidMap(from: self.settings.userDefaults)
-            if let mapped = map[owner], let currentUuid, mapped != currentUuid {
+            if let mapped = map[owner], let currentAccountIdentity, mapped != currentAccountIdentity {
                 // Active Claude account changed (per ~/.claude.json) but a stale credential for a
                 // PREVIOUS account is being served (background cache, keychain gated). Quarantine: do
                 // not attribute B's usage to A's bucket. Recovery happens once a later fetch yields the new
                 // account's credential with exact current-Keychain match evidence.
                 // An existing binding is authoritative, so honor it on ANY interaction (background too).
                 effectiveOwner = nil
-            } else if map[owner] == nil,
-                      let currentUuid,
-                      claudeOAuthPersistentRefHash != nil
-            {
-                // First sighting of this owner: bind it only when the exact credential used for the fetch
-                // matches the current Claude Keychain item. Interaction context is insufficient evidence:
-                // even a user-initiated freshness sync can be unavailable, cancelled, or denied and fall
-                // back to a stale cached credential. Without the match, fail open without persisting a
-                // binding; a later corroborated sample can safely arm the quarantine.
-                // Never OVERWRITE on mismatch (that is the stale case handled above).
-                map[owner] = currentUuid
-                self.persistClaudeOAuthAccountUuidMap(map)
+            } else if map[owner] == nil, let currentAccountIdentity {
+                if claudeOAuthPersistentRefHash != nil {
+                    // First sighting of this owner: bind it only when the exact credential used for the fetch
+                    // matches the current Claude Keychain item. Interaction context is insufficient evidence:
+                    // even a user-initiated freshness sync can be unavailable, cancelled, or denied and fall
+                    // back to a stale cached credential. Never overwrite on mismatch.
+                    map[owner] = currentAccountIdentity
+                    self.persistClaudeOAuthAccountUuidMap(map)
+                } else {
+                    // An empty map is common immediately after upgrading. Without exact credential evidence,
+                    // accepting the sample could contaminate history before the quarantine is armed.
+                    effectiveOwner = nil
+                }
             }
         }
         let detectorAccountKey = if provider == .claude, isClaudeOAuthSample {
@@ -920,7 +921,7 @@ extension UsageStore {
         ClaudeActiveAccountProbe.activeClaudeAccountUuid()
     }
 
-    /// Persisted `historyOwnerIdentifier -> active accountUuid` bindings. Mirrors `loadLimitResetDetectorStates`.
+    /// Persisted `historyOwnerIdentifier -> hashed active account identity` bindings.
     nonisolated static func loadClaudeOAuthAccountUuidMap(from userDefaults: UserDefaults) -> [String: String] {
         guard let data = userDefaults.data(forKey: claudeOAuthAccountUuidMapDefaultsKey) else { return [:] }
         do {
@@ -945,14 +946,27 @@ extension UsageStore {
         }
     }
 
+    private nonisolated static func activeClaudeAccountIdentity() -> String? {
+        self.activeClaudeAccountUuid().map(self.claudeAccountIdentity)
+    }
+
+    private nonisolated static func claudeAccountIdentity(_ uuid: String) -> String {
+        self.sha256Hex(
+            "claude:active-account:v1:\(uuid.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())")
+    }
+
     #if DEBUG
     static func withActiveClaudeAccountUuidForTesting<T>(
         _ uuid: String?,
         _ body: () async throws -> T) async rethrows -> T
     {
         try await ClaudeActiveAccountProbe.$activeClaudeAccountUuidOverrideForTesting.withValue(
-            uuid,
+            .value(uuid),
             operation: body)
+    }
+
+    nonisolated static func _activeClaudeAccountIdentityForTesting(_ uuid: String) -> String {
+        self.claudeAccountIdentity(uuid)
     }
     #endif
 
@@ -1493,7 +1507,11 @@ actor PlanUtilizationHistoryPersistenceCoordinator {
 /// storage must be nonisolated, whereas `UsageStore` is `@MainActor`.
 private enum ClaudeActiveAccountProbe {
     #if DEBUG
-    @TaskLocal static var activeClaudeAccountUuidOverrideForTesting: String?
+    enum Override: Sendable {
+        case value(String?)
+    }
+
+    @TaskLocal static var activeClaudeAccountUuidOverrideForTesting: Override?
     #endif
 
     private struct ClaudeConfigAccount: Decodable {
@@ -1506,8 +1524,8 @@ private enum ClaudeActiveAccountProbe {
 
     static func activeClaudeAccountUuid() -> String? {
         #if DEBUG
-        if let override = self.activeClaudeAccountUuidOverrideForTesting {
-            return override
+        if case let .value(uuid) = self.activeClaudeAccountUuidOverrideForTesting {
+            return uuid
         }
         #endif
         // `~/.claude.json` is a SIBLING of `.claude/`, not inside it. Home resolution mirrors

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -174,18 +174,21 @@ extension UsageStore {
             case let .stable(identity): identity
             case .changed: nil
             }
-            if claudeOAuthKeychainCredentialMismatch || claudeOAuthActiveAccountObservation == .changed {
-                // A proven credential mismatch or an account/credential change while capturing the UUID
-                // cannot safely identify this sample. Never let either case arm or reuse a durable binding.
+            if claudeOAuthActiveAccountObservation == .changed {
+                // An account/credential change while capturing the UUID cannot safely identify this sample.
+                // Never let it arm or reuse a durable binding.
                 effectiveOwner = nil
-            } else if let mapped = map[owner], let currentAccountIdentity, mapped != currentAccountIdentity {
-                // Active Claude account changed (per ~/.claude.json) but a stale credential for a
-                // PREVIOUS account is being served (background cache, keychain gated). Quarantine: do
-                // not attribute B's usage to A's bucket. Recovery happens once a later fetch yields the new
-                // account's credential with exact current-Keychain match evidence.
-                // An existing binding is authoritative, so honor it on ANY interaction (background too).
-                effectiveOwner = nil
-            } else if map[owner] == nil, let currentAccountIdentity {
+            } else if let mapped = map[owner] {
+                if let currentAccountIdentity, mapped != currentAccountIdentity {
+                    // Active Claude account changed (per ~/.claude.json) but a stale credential for a
+                    // PREVIOUS account is being served. An existing binding is authoritative on every poll.
+                    effectiveOwner = nil
+                } else if currentAccountIdentity == nil, claudeOAuthKeychainCredentialMismatch {
+                    // A rotated access token can differ while retaining the same owner. Preserve it only when
+                    // the active account identity still corroborates the established binding.
+                    effectiveOwner = nil
+                }
+            } else if let currentAccountIdentity {
                 if claudeOAuthPersistentRefHash != nil {
                     // First sighting of this owner: bind it only when the exact credential used for the fetch
                     // matches the current Claude Keychain item. Interaction context is insufficient evidence:
@@ -193,7 +196,11 @@ extension UsageStore {
                     // back to a stale cached credential. Never overwrite on mismatch.
                     map[owner] = currentAccountIdentity
                     self.persistClaudeOAuthAccountUuidMap(map)
+                } else if claudeOAuthKeychainCredentialMismatch {
+                    effectiveOwner = nil
                 }
+            } else if claudeOAuthKeychainCredentialMismatch {
+                effectiveOwner = nil
             }
         }
         let detectorAccountKey = if provider == .claude, isClaudeOAuthSample {

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -10,6 +10,11 @@ extension UsageStore {
     private nonisolated static let planUtilizationUnscopedPreferredKey = "__unscoped__"
     private nonisolated static let claudeOAuthPlanUtilizationAccountKeyPrefix = "__claude_oauth__:"
 
+    enum ClaudeOAuthActiveAccountObservation: Equatable, Sendable {
+        case stable(identity: String?)
+        case changed
+    }
+
     struct LimitResetDetectorState: Codable, Equatable {
         let wasAboveThreshold: Bool
         let lastObservedAt: Date
@@ -154,6 +159,7 @@ extension UsageStore {
         claudeOAuthPersistentRefHash: String? = nil,
         claudeOAuthHistoryOwnerIdentifier: String? = nil,
         claudeOAuthKeychainCredentialMismatch: Bool = false,
+        claudeOAuthActiveAccountObservation: ClaudeOAuthActiveAccountObservation = .stable(identity: nil),
         isClaudeOAuthSample: Bool = false,
         shouldUpdatePreferredAccountKey: Bool = true,
         shouldAdoptUnscopedHistory: Bool = true,
@@ -163,9 +169,16 @@ extension UsageStore {
         let samples = self.planUtilizationSeriesSamples(provider: provider, snapshot: snapshot, capturedAt: now)
         var effectiveOwner = claudeOAuthHistoryOwnerIdentifier
         if provider == .claude, isClaudeOAuthSample, let owner = claudeOAuthHistoryOwnerIdentifier {
-            let currentAccountIdentity = Self.activeClaudeAccountIdentity()
             var map = Self.loadClaudeOAuthAccountUuidMap(from: self.settings.userDefaults)
-            if let mapped = map[owner], let currentAccountIdentity, mapped != currentAccountIdentity {
+            let currentAccountIdentity: String? = switch claudeOAuthActiveAccountObservation {
+            case let .stable(identity): identity
+            case .changed: nil
+            }
+            if claudeOAuthKeychainCredentialMismatch || claudeOAuthActiveAccountObservation == .changed {
+                // A proven credential mismatch or an account/credential change while capturing the UUID
+                // cannot safely identify this sample. Never let either case arm or reuse a durable binding.
+                effectiveOwner = nil
+            } else if let mapped = map[owner], let currentAccountIdentity, mapped != currentAccountIdentity {
                 // Active Claude account changed (per ~/.claude.json) but a stale credential for a
                 // PREVIOUS account is being served (background cache, keychain gated). Quarantine: do
                 // not attribute B's usage to A's bucket. Recovery happens once a later fetch yields the new
@@ -180,11 +193,6 @@ extension UsageStore {
                     // back to a stale cached credential. Never overwrite on mismatch.
                     map[owner] = currentAccountIdentity
                     self.persistClaudeOAuthAccountUuidMap(map)
-                } else if claudeOAuthKeychainCredentialMismatch {
-                    // An empty map is common immediately after upgrading. Without exact credential evidence,
-                    // a proven mismatch could contaminate history before the quarantine is armed. An unavailable
-                    // comparison remains compatible with file-backed and Keychain-disabled OAuth routes.
-                    effectiveOwner = nil
                 }
             }
         }
@@ -948,7 +956,7 @@ extension UsageStore {
         }
     }
 
-    private nonisolated static func activeClaudeAccountIdentity() -> String? {
+    nonisolated static func activeClaudeAccountIdentity() -> String? {
         self.activeClaudeAccountUuid().map(self.claudeAccountIdentity)
     }
 

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -153,7 +153,7 @@ extension UsageStore {
         account: ProviderTokenAccount? = nil,
         claudeOAuthPersistentRefHash: String? = nil,
         claudeOAuthHistoryOwnerIdentifier: String? = nil,
-        isClaudeCLIKeychainSample: Bool = false,
+        claudeOAuthKeychainCredentialMismatch: Bool = false,
         isClaudeOAuthSample: Bool = false,
         shouldUpdatePreferredAccountKey: Bool = true,
         shouldAdoptUnscopedHistory: Bool = true,
@@ -162,11 +162,7 @@ extension UsageStore {
     {
         let samples = self.planUtilizationSeriesSamples(provider: provider, snapshot: snapshot, capturedAt: now)
         var effectiveOwner = claudeOAuthHistoryOwnerIdentifier
-        if provider == .claude,
-           isClaudeOAuthSample,
-           isClaudeCLIKeychainSample,
-           let owner = claudeOAuthHistoryOwnerIdentifier
-        {
+        if provider == .claude, isClaudeOAuthSample, let owner = claudeOAuthHistoryOwnerIdentifier {
             let currentAccountIdentity = Self.activeClaudeAccountIdentity()
             var map = Self.loadClaudeOAuthAccountUuidMap(from: self.settings.userDefaults)
             if let mapped = map[owner], let currentAccountIdentity, mapped != currentAccountIdentity {
@@ -184,9 +180,10 @@ extension UsageStore {
                     // back to a stale cached credential. Never overwrite on mismatch.
                     map[owner] = currentAccountIdentity
                     self.persistClaudeOAuthAccountUuidMap(map)
-                } else {
+                } else if claudeOAuthKeychainCredentialMismatch {
                     // An empty map is common immediately after upgrading. Without exact credential evidence,
-                    // accepting the sample could contaminate history before the quarantine is armed.
+                    // a proven mismatch could contaminate history before the quarantine is armed. An unavailable
+                    // comparison remains compatible with file-backed and Keychain-disabled OAuth routes.
                     effectiveOwner = nil
                 }
             }

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -5,6 +5,7 @@ extension UsageStore {
     private nonisolated static let limitResetThreshold = 1.0
     nonisolated static let sessionLimitResetDetectorDefaultsKey = "sessionLimitResetDetectorStates"
     private nonisolated static let weeklyLimitResetDetectorDefaultsKey = "weeklyLimitResetDetectorStates"
+    private nonisolated static let claudeOAuthAccountUuidMapDefaultsKey = "ClaudeOAuthHistoryOwnerAccountUuidMapV1"
     private nonisolated static let weeklyWindowMinutes = 7 * 24 * 60
     private nonisolated static let planUtilizationUnscopedPreferredKey = "__unscoped__"
     private nonisolated static let claudeOAuthPlanUtilizationAccountKeyPrefix = "__claude_oauth__:"
@@ -159,9 +160,26 @@ extension UsageStore {
         async
     {
         let samples = self.planUtilizationSeriesSamples(provider: provider, snapshot: snapshot, capturedAt: now)
+        var effectiveOwner = claudeOAuthHistoryOwnerIdentifier
+        if provider == .claude, isClaudeOAuthSample, let owner = claudeOAuthHistoryOwnerIdentifier {
+            let currentUuid = Self.activeClaudeAccountUuid()
+            var map = Self.loadClaudeOAuthAccountUuidMap(from: self.settings.userDefaults)
+            if let mapped = map[owner], let currentUuid, mapped != currentUuid {
+                // Active Claude account changed (per ~/.claude.json) but a stale credential for a
+                // PREVIOUS account is being served (background cache, keychain gated). Quarantine: do
+                // not attribute B's usage to A's bucket. Recovery happens on the next user-initiated
+                // refresh, when the keychain freshness sync yields the new account's real credential.
+                effectiveOwner = nil
+            } else if map[owner] == nil, let currentUuid {
+                // First sighting of this owner: bind it to the account active right now.
+                // Never OVERWRITE on mismatch (that is the stale case handled above).
+                map[owner] = currentUuid
+                self.persistClaudeOAuthAccountUuidMap(map)
+            }
+        }
         let detectorAccountKey = if provider == .claude, isClaudeOAuthSample {
             Self.claudeOAuthPlanUtilizationAccountKey(
-                historyOwnerIdentifier: claudeOAuthHistoryOwnerIdentifier,
+                historyOwnerIdentifier: effectiveOwner,
                 corroboratingPersistentRefHash: claudeOAuthPersistentRefHash)
         } else {
             self.planUtilizationAccountKey(
@@ -199,7 +217,7 @@ extension UsageStore {
                 snapshot: snapshot,
                 preferredAccount: preferredAccount,
                 claudeOAuthPersistentRefHash: claudeOAuthPersistentRefHash,
-                claudeOAuthHistoryOwnerIdentifier: claudeOAuthHistoryOwnerIdentifier,
+                claudeOAuthHistoryOwnerIdentifier: effectiveOwner,
                 isClaudeOAuthSample: isClaudeOAuthSample,
                 shouldUpdatePreferredAccountKey: shouldUpdatePreferredAccountKey,
                 shouldAdoptUnscopedHistory: shouldAdoptUnscopedHistory,
@@ -884,6 +902,52 @@ extension UsageStore {
         }
     }
 
+    // MARK: - Active Claude account corroboration (~/.claude.json)
+
+    /// The currently-active Claude account UUID, read prompt-free from `~/.claude.json`. This is the only
+    /// always-fresh, never-gated signal of the active account on a background poll: Claude Code's `/login`
+    /// updates the Keychain item in place and leaves `~/.claude/.credentials.json` stale, but immediately
+    /// rewrites `oauthAccount.accountUuid` in this sibling plain file. Returns nil on absence/corruption.
+    nonisolated static func activeClaudeAccountUuid() -> String? {
+        ClaudeActiveAccountProbe.activeClaudeAccountUuid()
+    }
+
+    /// Persisted `historyOwnerIdentifier -> active accountUuid` bindings. Mirrors `loadLimitResetDetectorStates`.
+    nonisolated static func loadClaudeOAuthAccountUuidMap(from userDefaults: UserDefaults) -> [String: String] {
+        guard let data = userDefaults.data(forKey: claudeOAuthAccountUuidMapDefaultsKey) else { return [:] }
+        do {
+            return try JSONDecoder().decode([String: String].self, from: data)
+        } catch {
+            CodexBarLog.logger(LogCategories.confetti).error(
+                "Failed to decode Claude OAuth history owner account UUID map",
+                metadata: ["error": String(describing: error)])
+            return [:]
+        }
+    }
+
+    /// Persist the `historyOwnerIdentifier -> active accountUuid` map. Mirrors `persistLimitResetDetectorStates`.
+    func persistClaudeOAuthAccountUuidMap(_ map: [String: String]) {
+        do {
+            let data = try JSONEncoder().encode(map)
+            self.settings.userDefaults.set(data, forKey: Self.claudeOAuthAccountUuidMapDefaultsKey)
+        } catch {
+            CodexBarLog.logger(LogCategories.confetti).error(
+                "Failed to encode Claude OAuth history owner account UUID map",
+                metadata: ["error": String(describing: error)])
+        }
+    }
+
+    #if DEBUG
+    static func withActiveClaudeAccountUuidForTesting<T>(
+        _ uuid: String?,
+        _ body: () async throws -> T) async rethrows -> T
+    {
+        try await ClaudeActiveAccountProbe.$activeClaudeAccountUuidOverrideForTesting.withValue(
+            uuid,
+            operation: body)
+    }
+    #endif
+
     private func resolvePlanUtilizationAccountKey(
         provider: UsageProvider,
         snapshot: UsageSnapshot?,
@@ -1413,5 +1477,44 @@ actor PlanUtilizationHistoryPersistenceCoordinator {
         await Task.detached(priority: .utility) {
             store.save(snapshot)
         }.value
+    }
+}
+
+/// Prompt-free reader for the active Claude account UUID recorded in `~/.claude.json`. The `@TaskLocal` test
+/// seam lives here (not on `UsageStore`) because Swift forbids stored properties in extensions and task-local
+/// storage must be nonisolated, whereas `UsageStore` is `@MainActor`.
+private enum ClaudeActiveAccountProbe {
+    #if DEBUG
+    @TaskLocal static var activeClaudeAccountUuidOverrideForTesting: String?
+    #endif
+
+    private struct ClaudeConfigAccount: Decodable {
+        struct OAuthAccount: Decodable {
+            let accountUuid: String?
+        }
+
+        let oauthAccount: OAuthAccount?
+    }
+
+    static func activeClaudeAccountUuid() -> String? {
+        #if DEBUG
+        if let override = self.activeClaudeAccountUuidOverrideForTesting {
+            return override
+        }
+        #endif
+        // `~/.claude.json` is a SIBLING of `.claude/`, not inside it. Home resolution mirrors
+        // `ClaudeOAuthCredentials.defaultCredentialsURL()`. This intentionally does NOT honor
+        // CLAUDE_CONFIG_DIR: the credential store that yields `historyOwnerIdentifier` is purely
+        // home-relative, so the accountUuid corroboration must resolve against the same home or the
+        // two signals would point at different accounts.
+        let url = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude.json")
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode(ClaudeConfigAccount.self, from: data),
+              let uuid = decoded.oauthAccount?.accountUuid?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !uuid.isEmpty
+        else {
+            return nil
+        }
+        return uuid
     }
 }

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -1029,11 +1029,10 @@ extension UsageStore {
         }
 
         if evidence.keychainCredentialUnavailable,
-           !evidence.keychainCredentialMismatch,
-           self.settings.claudeOAuthKeychainPromptMode == .never
+           !evidence.keychainCredentialMismatch
         {
-            // With no authoritative binding, `never` mode can safely use the secret-derived file owner.
-            // Existing bindings are checked above so a stale file cannot cross an observed account switch.
+            // With no authoritative binding, the secret-derived file owner is the only safe bootstrap scope.
+            // Existing bindings are checked above, so normal background gating cannot bypass a detected switch.
             return evidence.owner
         }
         if evidence.keychainCredentialAbsent {

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -167,23 +167,19 @@ extension UsageStore {
             if let mapped = map[owner], let currentUuid, mapped != currentUuid {
                 // Active Claude account changed (per ~/.claude.json) but a stale credential for a
                 // PREVIOUS account is being served (background cache, keychain gated). Quarantine: do
-                // not attribute B's usage to A's bucket. Recovery happens on the next user-initiated
-                // refresh, when the keychain freshness sync yields the new account's real credential.
+                // not attribute B's usage to A's bucket. Recovery happens once a later fetch yields the new
+                // account's credential with exact current-Keychain match evidence.
                 // An existing binding is authoritative, so honor it on ANY interaction (background too).
                 effectiveOwner = nil
             } else if map[owner] == nil,
                       let currentUuid,
-                      ProviderInteractionContext.current == .userInitiated
+                      claudeOAuthPersistentRefHash != nil
             {
-                // First sighting of this owner: bind it to the account active right now. Only trustworthy
-                // on a USER-INITIATED refresh, where the Claude keychain freshness sync runs (gate open),
-                // so the served owner reflects the CURRENTLY ACTIVE account (either the cache was already
-                // correct, or the sync corrected it after a switch). On a BACKGROUND poll the sync is gated
-                // and the served owner may be STALE for a previous account: binding it here would POISON the
-                // map (a false owner->uuid binding that later wrongly quarantines legitimate samples). So we
-                // fail-open instead: effectiveOwner stays = owner, the write proceeds, and NO binding is
-                // persisted. The binding still gets created on the next user-initiated use while on this
-                // account, arming the quarantine for a later background switch.
+                // First sighting of this owner: bind it only when the exact credential used for the fetch
+                // matches the current Claude Keychain item. Interaction context is insufficient evidence:
+                // even a user-initiated freshness sync can be unavailable, cancelled, or denied and fall
+                // back to a stale cached credential. Without the match, fail open without persisting a
+                // binding; a later corroborated sample can safely arm the quarantine.
                 // Never OVERWRITE on mismatch (that is the stale case handled above).
                 map[owner] = currentUuid
                 self.persistClaudeOAuthAccountUuidMap(map)

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -169,9 +169,21 @@ extension UsageStore {
                 // PREVIOUS account is being served (background cache, keychain gated). Quarantine: do
                 // not attribute B's usage to A's bucket. Recovery happens on the next user-initiated
                 // refresh, when the keychain freshness sync yields the new account's real credential.
+                // An existing binding is authoritative, so honor it on ANY interaction (background too).
                 effectiveOwner = nil
-            } else if map[owner] == nil, let currentUuid {
-                // First sighting of this owner: bind it to the account active right now.
+            } else if map[owner] == nil,
+                      let currentUuid,
+                      ProviderInteractionContext.current == .userInitiated
+            {
+                // First sighting of this owner: bind it to the account active right now. Only trustworthy
+                // on a USER-INITIATED refresh, where the Claude keychain freshness sync runs (gate open),
+                // so the served owner reflects the CURRENTLY ACTIVE account (either the cache was already
+                // correct, or the sync corrected it after a switch). On a BACKGROUND poll the sync is gated
+                // and the served owner may be STALE for a previous account: binding it here would POISON the
+                // map (a false owner->uuid binding that later wrongly quarantines legitimate samples). So we
+                // fail-open instead: effectiveOwner stays = owner, the write proceeds, and NO binding is
+                // persisted. The binding still gets created on the next user-initiated use while on this
+                // account, arming the quarantine for a later background switch.
                 // Never OVERWRITE on mismatch (that is the stale case handled above).
                 map[owner] = currentUuid
                 self.persistClaudeOAuthAccountUuidMap(map)

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -999,6 +999,11 @@ extension UsageStore {
             // An account/credential change while capturing the UUID cannot safely identify this sample.
             return nil
         }
+        if evidence.keychainCredentialUnavailable, !evidence.keychainCredentialMismatch {
+            // `never` Keychain mode intentionally uses the file credential without corroboration. Its
+            // secret-derived owner remains isolated; only continuity across credential rotation is unavailable.
+            return evidence.owner
+        }
 
         var map = Self.loadClaudeOAuthAccountUuidMap(from: self.settings.userDefaults)
         if let mapped = map[evidence.owner] {

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -999,15 +999,6 @@ extension UsageStore {
             // An account/credential change while capturing the UUID cannot safely identify this sample.
             return nil
         }
-        if evidence.keychainCredentialUnavailable,
-           !evidence.keychainCredentialMismatch,
-           self.settings.claudeOAuthKeychainPromptMode == .never
-        {
-            // `never` Keychain mode intentionally uses the file credential without corroboration. Its
-            // secret-derived owner remains isolated; only continuity across credential rotation is unavailable.
-            return evidence.owner
-        }
-
         var map = Self.loadClaudeOAuthAccountUuidMap(from: self.settings.userDefaults)
         if let mapped = map[evidence.owner] {
             guard let currentAccountIdentity else {
@@ -1030,6 +1021,15 @@ extension UsageStore {
             // Two stable exact-Keychain observations repair a binding poisoned by a non-atomic login.
             map[evidence.owner] = currentAccountIdentity
             self.persistClaudeOAuthAccountUuidMap(map)
+            return evidence.owner
+        }
+
+        if evidence.keychainCredentialUnavailable,
+           !evidence.keychainCredentialMismatch,
+           self.settings.claudeOAuthKeychainPromptMode == .never
+        {
+            // With no authoritative binding, `never` mode can safely use the secret-derived file owner.
+            // Existing bindings are checked above so a stale file cannot cross an observed account switch.
             return evidence.owner
         }
 

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -26,6 +26,7 @@ extension UsageStore {
         let owner: String
         let persistentRefHash: String?
         let keychainCredentialMismatch: Bool
+        let keychainCredentialAbsent: Bool
         let keychainCredentialUnavailable: Bool
         let activeAccountObservation: ClaudeOAuthActiveAccountObservation
         let observedAt: Date
@@ -175,6 +176,7 @@ extension UsageStore {
         claudeOAuthPersistentRefHash: String? = nil,
         claudeOAuthHistoryOwnerIdentifier: String? = nil,
         claudeOAuthKeychainCredentialMismatch: Bool = false,
+        claudeOAuthKeychainCredentialAbsent: Bool = false,
         claudeOAuthKeychainCredentialUnavailable: Bool = false,
         claudeOAuthActiveAccountObservation: ClaudeOAuthActiveAccountObservation = .stable(identity: nil),
         isClaudeOAuthSample: Bool = false,
@@ -190,6 +192,7 @@ extension UsageStore {
                 owner: owner,
                 persistentRefHash: claudeOAuthPersistentRefHash,
                 keychainCredentialMismatch: claudeOAuthKeychainCredentialMismatch,
+                keychainCredentialAbsent: claudeOAuthKeychainCredentialAbsent,
                 keychainCredentialUnavailable: claudeOAuthKeychainCredentialUnavailable,
                 activeAccountObservation: claudeOAuthActiveAccountObservation,
                 observedAt: now))
@@ -990,6 +993,7 @@ extension UsageStore {
     private func resolvedClaudeOAuthHistoryOwner(evidence: ClaudeOAuthHistoryEvidence) -> String? {
         let requiresClaudeCodeCorroboration = evidence.persistentRefHash != nil
             || evidence.keychainCredentialMismatch
+            || evidence.keychainCredentialAbsent
             || evidence.keychainCredentialUnavailable
         guard requiresClaudeCodeCorroboration else {
             // Explicit/environment credentials do not belong to Claude Code's active-account lifecycle.
@@ -1030,6 +1034,11 @@ extension UsageStore {
         {
             // With no authoritative binding, `never` mode can safely use the secret-derived file owner.
             // Existing bindings are checked above so a stale file cannot cross an observed account switch.
+            return evidence.owner
+        }
+        if evidence.keychainCredentialAbsent {
+            // A proven-empty Keychain leaves the file credential as the only owner. Existing bindings were
+            // checked above, so an unbound owner is safe without inventing account continuity.
             return evidence.owner
         }
 

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -6,6 +6,8 @@ extension UsageStore {
     nonisolated static let sessionLimitResetDetectorDefaultsKey = "sessionLimitResetDetectorStates"
     private nonisolated static let weeklyLimitResetDetectorDefaultsKey = "weeklyLimitResetDetectorStates"
     private nonisolated static let claudeOAuthAccountUuidMapDefaultsKey = "ClaudeOAuthHistoryOwnerAccountUuidMapV1"
+    private nonisolated static let claudeOAuthAccountCandidateMapDefaultsKey =
+        "ClaudeOAuthHistoryOwnerAccountCandidateMapV1"
     private nonisolated static let weeklyWindowMinutes = 7 * 24 * 60
     private nonisolated static let planUtilizationUnscopedPreferredKey = "__unscoped__"
     private nonisolated static let claudeOAuthPlanUtilizationAccountKeyPrefix = "__claude_oauth__:"
@@ -13,6 +15,20 @@ extension UsageStore {
     enum ClaudeOAuthActiveAccountObservation: Equatable, Sendable {
         case stable(identity: String?)
         case changed
+    }
+
+    struct ClaudeOAuthAccountBindingCandidate: Codable, Equatable {
+        let identity: String
+        let observedAt: Date
+    }
+
+    private struct ClaudeOAuthHistoryEvidence {
+        let owner: String
+        let persistentRefHash: String?
+        let keychainCredentialMismatch: Bool
+        let keychainCredentialUnavailable: Bool
+        let activeAccountObservation: ClaudeOAuthActiveAccountObservation
+        let observedAt: Date
     }
 
     struct LimitResetDetectorState: Codable, Equatable {
@@ -159,6 +175,7 @@ extension UsageStore {
         claudeOAuthPersistentRefHash: String? = nil,
         claudeOAuthHistoryOwnerIdentifier: String? = nil,
         claudeOAuthKeychainCredentialMismatch: Bool = false,
+        claudeOAuthKeychainCredentialUnavailable: Bool = false,
         claudeOAuthActiveAccountObservation: ClaudeOAuthActiveAccountObservation = .stable(identity: nil),
         isClaudeOAuthSample: Bool = false,
         shouldUpdatePreferredAccountKey: Bool = true,
@@ -169,39 +186,13 @@ extension UsageStore {
         let samples = self.planUtilizationSeriesSamples(provider: provider, snapshot: snapshot, capturedAt: now)
         var effectiveOwner = claudeOAuthHistoryOwnerIdentifier
         if provider == .claude, isClaudeOAuthSample, let owner = claudeOAuthHistoryOwnerIdentifier {
-            var map = Self.loadClaudeOAuthAccountUuidMap(from: self.settings.userDefaults)
-            let currentAccountIdentity: String? = switch claudeOAuthActiveAccountObservation {
-            case let .stable(identity): identity
-            case .changed: nil
-            }
-            if claudeOAuthActiveAccountObservation == .changed {
-                // An account/credential change while capturing the UUID cannot safely identify this sample.
-                // Never let it arm or reuse a durable binding.
-                effectiveOwner = nil
-            } else if let mapped = map[owner] {
-                if let currentAccountIdentity, mapped != currentAccountIdentity {
-                    // Active Claude account changed (per ~/.claude.json) but a stale credential for a
-                    // PREVIOUS account is being served. An existing binding is authoritative on every poll.
-                    effectiveOwner = nil
-                } else if currentAccountIdentity == nil, claudeOAuthKeychainCredentialMismatch {
-                    // A rotated access token can differ while retaining the same owner. Preserve it only when
-                    // the active account identity still corroborates the established binding.
-                    effectiveOwner = nil
-                }
-            } else if let currentAccountIdentity {
-                if claudeOAuthPersistentRefHash != nil {
-                    // First sighting of this owner: bind it only when the exact credential used for the fetch
-                    // matches the current Claude Keychain item. Interaction context is insufficient evidence:
-                    // even a user-initiated freshness sync can be unavailable, cancelled, or denied and fall
-                    // back to a stale cached credential. Never overwrite on mismatch.
-                    map[owner] = currentAccountIdentity
-                    self.persistClaudeOAuthAccountUuidMap(map)
-                } else if claudeOAuthKeychainCredentialMismatch {
-                    effectiveOwner = nil
-                }
-            } else if claudeOAuthKeychainCredentialMismatch {
-                effectiveOwner = nil
-            }
+            effectiveOwner = self.resolvedClaudeOAuthHistoryOwner(evidence: ClaudeOAuthHistoryEvidence(
+                owner: owner,
+                persistentRefHash: claudeOAuthPersistentRefHash,
+                keychainCredentialMismatch: claudeOAuthKeychainCredentialMismatch,
+                keychainCredentialUnavailable: claudeOAuthKeychainCredentialUnavailable,
+                activeAccountObservation: claudeOAuthActiveAccountObservation,
+                observedAt: now))
         }
         let detectorAccountKey = if provider == .claude, isClaudeOAuthSample {
             Self.claudeOAuthPlanUtilizationAccountKey(
@@ -959,6 +950,114 @@ extension UsageStore {
         } catch {
             CodexBarLog.logger(LogCategories.confetti).error(
                 "Failed to encode Claude OAuth history owner account UUID map",
+                metadata: ["error": String(describing: error)])
+        }
+    }
+
+    nonisolated static func loadClaudeOAuthAccountBindingCandidateMap(
+        from userDefaults: UserDefaults) -> [String: ClaudeOAuthAccountBindingCandidate]
+    {
+        guard let data = userDefaults.data(forKey: claudeOAuthAccountCandidateMapDefaultsKey) else { return [:] }
+        do {
+            return try JSONDecoder().decode([String: ClaudeOAuthAccountBindingCandidate].self, from: data)
+        } catch {
+            CodexBarLog.logger(LogCategories.confetti).error(
+                "Failed to decode Claude OAuth account binding candidates",
+                metadata: ["error": String(describing: error)])
+            return [:]
+        }
+    }
+
+    private func confirmClaudeOAuthAccountBindingCandidate(
+        owner: String,
+        identity: String,
+        observedAt: Date) -> Bool
+    {
+        var candidates = Self.loadClaudeOAuthAccountBindingCandidateMap(from: self.settings.userDefaults)
+        if let candidate = candidates[owner],
+           candidate.identity == identity,
+           candidate.observedAt < observedAt
+        {
+            candidates.removeValue(forKey: owner)
+            self.persistClaudeOAuthAccountBindingCandidateMap(candidates)
+            return true
+        }
+        candidates[owner] = ClaudeOAuthAccountBindingCandidate(identity: identity, observedAt: observedAt)
+        self.persistClaudeOAuthAccountBindingCandidateMap(candidates)
+        return false
+    }
+
+    private func resolvedClaudeOAuthHistoryOwner(evidence: ClaudeOAuthHistoryEvidence) -> String? {
+        let requiresClaudeCodeCorroboration = evidence.persistentRefHash != nil
+            || evidence.keychainCredentialMismatch
+            || evidence.keychainCredentialUnavailable
+        guard requiresClaudeCodeCorroboration else {
+            // Explicit/environment credentials do not belong to Claude Code's active-account lifecycle.
+            return evidence.owner
+        }
+        guard case let .stable(currentAccountIdentity) = evidence.activeAccountObservation else {
+            // An account/credential change while capturing the UUID cannot safely identify this sample.
+            return nil
+        }
+
+        var map = Self.loadClaudeOAuthAccountUuidMap(from: self.settings.userDefaults)
+        if let mapped = map[evidence.owner] {
+            guard let currentAccountIdentity else {
+                return evidence.keychainCredentialMismatch || evidence.keychainCredentialUnavailable
+                    ? nil
+                    : evidence.owner
+            }
+            guard mapped != currentAccountIdentity else {
+                self.clearClaudeOAuthAccountBindingCandidate(owner: evidence.owner)
+                return evidence.owner
+            }
+            guard evidence.persistentRefHash != nil,
+                  self.confirmClaudeOAuthAccountBindingCandidate(
+                      owner: evidence.owner,
+                      identity: currentAccountIdentity,
+                      observedAt: evidence.observedAt)
+            else {
+                return nil
+            }
+            // Two stable exact-Keychain observations repair a binding poisoned by a non-atomic login.
+            map[evidence.owner] = currentAccountIdentity
+            self.persistClaudeOAuthAccountUuidMap(map)
+            return evidence.owner
+        }
+
+        guard let currentAccountIdentity else {
+            return evidence.keychainCredentialMismatch || evidence.keychainCredentialUnavailable
+                ? nil
+                : evidence.owner
+        }
+        guard evidence.persistentRefHash != nil else { return nil }
+        // Two stable exact-Keychain observations are required before a first binding becomes authoritative.
+        if self.confirmClaudeOAuthAccountBindingCandidate(
+            owner: evidence.owner,
+            identity: currentAccountIdentity,
+            observedAt: evidence.observedAt)
+        {
+            map[evidence.owner] = currentAccountIdentity
+            self.persistClaudeOAuthAccountUuidMap(map)
+        }
+        return evidence.owner
+    }
+
+    private func clearClaudeOAuthAccountBindingCandidate(owner: String) {
+        var candidates = Self.loadClaudeOAuthAccountBindingCandidateMap(from: self.settings.userDefaults)
+        guard candidates.removeValue(forKey: owner) != nil else { return }
+        self.persistClaudeOAuthAccountBindingCandidateMap(candidates)
+    }
+
+    private func persistClaudeOAuthAccountBindingCandidateMap(
+        _ candidates: [String: ClaudeOAuthAccountBindingCandidate])
+    {
+        do {
+            let data = try JSONEncoder().encode(candidates)
+            self.settings.userDefaults.set(data, forKey: Self.claudeOAuthAccountCandidateMapDefaultsKey)
+        } catch {
+            CodexBarLog.logger(LogCategories.confetti).error(
+                "Failed to encode Claude OAuth account binding candidates",
                 metadata: ["error": String(describing: error)])
         }
     }

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -999,7 +999,10 @@ extension UsageStore {
             // An account/credential change while capturing the UUID cannot safely identify this sample.
             return nil
         }
-        if evidence.keychainCredentialUnavailable, !evidence.keychainCredentialMismatch {
+        if evidence.keychainCredentialUnavailable,
+           !evidence.keychainCredentialMismatch,
+           self.settings.claudeOAuthKeychainPromptMode == .never
+        {
             // `never` Keychain mode intentionally uses the file credential without corroboration. Its
             // secret-derived owner remains isolated; only continuity across credential rotation is unavailable.
             return evidence.owner

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -213,6 +213,9 @@ extension UsageStore {
             afterFetchFingerprintToken: claudeAuthFingerprintAfterFetch,
             afterFetchPersistentRefHash: claudeHistoryAccountState?.keychainPersistentRefHash,
             accountStateWasStable: claudeHistoryAccountState?.wasStable == true)
+        let claudeOAuthActiveAccountObservation = Self.claudeOAuthActiveAccountObservation(
+            beforeFetch: claudeAuthStateBeforeFetch,
+            afterFetch: claudeHistoryAccountState)
         // Credential detection consumes change markers. Clean up before rejecting a superseded generation;
         // replacement refreshes wait for their predecessor, so they cannot race this state reset.
         if claudeCredentialsChanged {
@@ -229,8 +232,7 @@ extension UsageStore {
                 generation: generation,
                 codexExpectedGuard: codexExpectedGuard,
                 claudeOAuthHistoryPersistentRefHash: claudeOAuthHistoryPersistentRefHash,
-                claudeOAuthActiveAccountObservation: claudeHistoryAccountState?.observation
-                    ?? .stable(identity: nil)))
+                claudeOAuthActiveAccountObservation: claudeOAuthActiveAccountObservation))
     }
 
     private func applyProviderRefreshOutcome(
@@ -370,12 +372,14 @@ extension UsageStore {
         let credentialsFileChanged: Bool
         let keychainFingerprintChanged: Bool
         let keychainPersistentRefHash: String?
+        let activeAccountIdentity: String?
+        let accountStateWasStable: Bool
     }
 
     private struct ClaudeHistoryAccountState {
         let fingerprintToken: String
         let keychainPersistentRefHash: String?
-        let observation: ClaudeOAuthActiveAccountObservation
+        let activeAccountIdentity: String?
         let wasStable: Bool
     }
 
@@ -408,19 +412,27 @@ extension UsageStore {
     {
         await withTaskGroup(of: ClaudeRefreshAuthState.self, returning: ClaudeRefreshAuthState.self) { group in
             group.addTask {
-                let fingerprintToken = ClaudeOAuthCredentialsStore.authFingerprintToken()
                 let credentialsFileChanged = invalidateCredentialsFile
                     ? ClaudeOAuthCredentialsStore.invalidateCacheIfCredentialsFileChanged()
                     : false
                 let keychainFingerprintChanged = ClaudeOAuthCredentialsStore
                     .claudeKeychainFingerprintChangedWithoutConsuming()
-                let keychainPersistentRefHash = ClaudeOAuthCredentialsStore
+                let fingerprintBefore = ClaudeOAuthCredentialsStore.authFingerprintToken()
+                let persistentRefBefore = ClaudeOAuthCredentialsStore
                     .claudeKeychainPersistentRefHashWithoutPrompt()
+                let activeAccountIdentity = Self.activeClaudeAccountIdentity()
+                let persistentRefAfter = ClaudeOAuthCredentialsStore
+                    .claudeKeychainPersistentRefHashWithoutPrompt()
+                let fingerprintAfter = ClaudeOAuthCredentialsStore.authFingerprintToken()
+                let accountStateWasStable = fingerprintBefore == fingerprintAfter
+                    && persistentRefBefore == persistentRefAfter
                 return ClaudeRefreshAuthState(
-                    fingerprintToken: fingerprintToken,
+                    fingerprintToken: fingerprintAfter,
                     credentialsFileChanged: credentialsFileChanged,
                     keychainFingerprintChanged: keychainFingerprintChanged,
-                    keychainPersistentRefHash: keychainPersistentRefHash)
+                    keychainPersistentRefHash: persistentRefAfter,
+                    activeAccountIdentity: activeAccountIdentity,
+                    accountStateWasStable: accountStateWasStable)
             }
             return await group.next()!
         }
@@ -440,12 +452,7 @@ extension UsageStore {
                 return ClaudeHistoryAccountState(
                     fingerprintToken: fingerprintAfter,
                     keychainPersistentRefHash: persistentRefAfter,
-                    observation: self.claudeOAuthActiveAccountObservation(
-                        fingerprintBefore: fingerprintBefore,
-                        fingerprintAfter: fingerprintAfter,
-                        persistentRefBefore: persistentRefBefore,
-                        persistentRefAfter: persistentRefAfter,
-                        identity: activeAccountIdentity),
+                    activeAccountIdentity: activeAccountIdentity,
                     wasStable: wasStable)
             }
             return await group.next()!
@@ -453,14 +460,18 @@ extension UsageStore {
     }
 
     private nonisolated static func claudeOAuthActiveAccountObservation(
-        fingerprintBefore: String,
-        fingerprintAfter: String,
-        persistentRefBefore: String?,
-        persistentRefAfter: String?,
-        identity: String?) -> ClaudeOAuthActiveAccountObservation
+        beforeFetch: ClaudeRefreshAuthState?,
+        afterFetch: ClaudeHistoryAccountState?) -> ClaudeOAuthActiveAccountObservation
     {
-        let wasStable = fingerprintBefore == fingerprintAfter && persistentRefBefore == persistentRefAfter
-        return wasStable ? .stable(identity: identity) : .changed
+        guard let beforeFetch,
+              beforeFetch.accountStateWasStable,
+              let afterFetch,
+              afterFetch.wasStable,
+              beforeFetch.activeAccountIdentity == afterFetch.activeAccountIdentity
+        else {
+            return .changed
+        }
+        return .stable(identity: afterFetch.activeAccountIdentity)
     }
 
     private nonisolated static func stableClaudeKeychainPersistentRefHash(
@@ -471,6 +482,7 @@ extension UsageStore {
     {
         guard accountStateWasStable,
               let beforeFetch,
+              beforeFetch.accountStateWasStable,
               beforeFetch.fingerprintToken == afterFetchFingerprintToken,
               let beforeFetchPersistentRefHash = beforeFetch.keychainPersistentRefHash,
               beforeFetchPersistentRefHash == afterFetchPersistentRefHash
@@ -492,25 +504,33 @@ extension UsageStore {
                 fingerprintToken: beforeFetchFingerprintToken,
                 credentialsFileChanged: false,
                 keychainFingerprintChanged: false,
-                keychainPersistentRefHash: beforeFetchPersistentRefHash),
+                keychainPersistentRefHash: beforeFetchPersistentRefHash,
+                activeAccountIdentity: nil,
+                accountStateWasStable: true),
             afterFetchFingerprintToken: afterFetchFingerprintToken,
             afterFetchPersistentRefHash: afterFetchPersistentRefHash,
             accountStateWasStable: true)
     }
 
     nonisolated static func _claudeOAuthActiveAccountObservationForTesting(
-        fingerprintBefore: String,
-        fingerprintAfter: String,
-        persistentRefBefore: String?,
-        persistentRefAfter: String?,
-        identity: String?) -> ClaudeOAuthActiveAccountObservation
+        identityBeforeFetch: String?,
+        identityAfterFetch: String?,
+        beforeFetchWasStable: Bool = true,
+        afterFetchWasStable: Bool = true) -> ClaudeOAuthActiveAccountObservation
     {
         self.claudeOAuthActiveAccountObservation(
-            fingerprintBefore: fingerprintBefore,
-            fingerprintAfter: fingerprintAfter,
-            persistentRefBefore: persistentRefBefore,
-            persistentRefAfter: persistentRefAfter,
-            identity: identity)
+            beforeFetch: ClaudeRefreshAuthState(
+                fingerprintToken: "before",
+                credentialsFileChanged: false,
+                keychainFingerprintChanged: false,
+                keychainPersistentRefHash: "before-ref",
+                activeAccountIdentity: identityBeforeFetch,
+                accountStateWasStable: beforeFetchWasStable),
+            afterFetch: ClaudeHistoryAccountState(
+                fingerprintToken: "after",
+                keychainPersistentRefHash: "after-ref",
+                activeAccountIdentity: identityAfterFetch,
+                wasStable: afterFetchWasStable))
     }
     #endif
 

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -6,6 +6,7 @@ extension UsageStore {
         let generation: UInt64
         let codexExpectedGuard: CodexAccountScopedRefreshGuard?
         let claudeOAuthHistoryPersistentRefHash: String?
+        let claudeOAuthActiveAccountObservation: ClaudeOAuthActiveAccountObservation
     }
 
     static func commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
@@ -192,12 +193,10 @@ extension UsageStore {
             }
             return await group.next()!
         }
-        let claudeAuthFingerprintAfterFetch = provider == .claude
-            ? await Self.captureClaudeAuthFingerprintToken()
+        let claudeHistoryAccountState = provider == .claude
+            ? await Self.captureClaudeHistoryAccountState()
             : nil
-        let claudeKeychainPersistentRefHashAfterFetch = provider == .claude
-            ? await Self.captureClaudeKeychainPersistentRefHash()
-            : nil
+        let claudeAuthFingerprintAfterFetch = claudeHistoryAccountState?.fingerprintToken
         let claudeAuthChangedDuringFetch = Self.claudeAuthChangedDuringFetch(
             provider: provider,
             beforeFetch: claudeAuthStateBeforeFetch,
@@ -212,7 +211,8 @@ extension UsageStore {
         let claudeOAuthHistoryPersistentRefHash = Self.stableClaudeKeychainPersistentRefHash(
             beforeFetch: claudeAuthStateBeforeFetch,
             afterFetchFingerprintToken: claudeAuthFingerprintAfterFetch,
-            afterFetchPersistentRefHash: claudeKeychainPersistentRefHashAfterFetch)
+            afterFetchPersistentRefHash: claudeHistoryAccountState?.keychainPersistentRefHash,
+            accountStateWasStable: claudeHistoryAccountState?.wasStable == true)
         // Credential detection consumes change markers. Clean up before rejecting a superseded generation;
         // replacement refreshes wait for their predecessor, so they cannot race this state reset.
         if claudeCredentialsChanged {
@@ -228,7 +228,9 @@ extension UsageStore {
             context: ProviderRefreshOutcomeContext(
                 generation: generation,
                 codexExpectedGuard: codexExpectedGuard,
-                claudeOAuthHistoryPersistentRefHash: claudeOAuthHistoryPersistentRefHash))
+                claudeOAuthHistoryPersistentRefHash: claudeOAuthHistoryPersistentRefHash,
+                claudeOAuthActiveAccountObservation: claudeHistoryAccountState?.observation
+                    ?? .stable(identity: nil)))
     }
 
     private func applyProviderRefreshOutcome(
@@ -305,6 +307,7 @@ extension UsageStore {
                     : nil,
                 claudeOAuthKeychainCredentialMismatch: isClaudeOAuthSample
                     && result.claudeOAuthKeychainCredentialMismatch,
+                claudeOAuthActiveAccountObservation: context.claudeOAuthActiveAccountObservation,
                 isClaudeOAuthSample: isClaudeOAuthSample)
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             if let runtime = self.providerRuntimes[provider] {
@@ -369,6 +372,13 @@ extension UsageStore {
         let keychainPersistentRefHash: String?
     }
 
+    private struct ClaudeHistoryAccountState {
+        let fingerprintToken: String
+        let keychainPersistentRefHash: String?
+        let observation: ClaudeOAuthActiveAccountObservation
+        let wasStable: Bool
+    }
+
     private nonisolated static func claudeCredentialsChanged(
         beforeFetch: ClaudeRefreshAuthState?,
         changedDuringFetch: Bool) -> Bool
@@ -416,30 +426,51 @@ extension UsageStore {
         }
     }
 
-    private nonisolated static func captureClaudeAuthFingerprintToken() async -> String {
-        await withTaskGroup(of: String.self, returning: String.self) { group in
+    private nonisolated static func captureClaudeHistoryAccountState() async -> ClaudeHistoryAccountState {
+        await withTaskGroup(of: ClaudeHistoryAccountState.self, returning: ClaudeHistoryAccountState.self) { group in
             group.addTask {
-                ClaudeOAuthCredentialsStore.authFingerprintToken()
+                let fingerprintBefore = ClaudeOAuthCredentialsStore.authFingerprintToken()
+                let persistentRefBefore = ClaudeOAuthCredentialsStore
+                    .claudeKeychainPersistentRefHashWithoutPrompt()
+                let activeAccountIdentity = Self.activeClaudeAccountIdentity()
+                let persistentRefAfter = ClaudeOAuthCredentialsStore
+                    .claudeKeychainPersistentRefHashWithoutPrompt()
+                let fingerprintAfter = ClaudeOAuthCredentialsStore.authFingerprintToken()
+                let wasStable = fingerprintBefore == fingerprintAfter && persistentRefBefore == persistentRefAfter
+                return ClaudeHistoryAccountState(
+                    fingerprintToken: fingerprintAfter,
+                    keychainPersistentRefHash: persistentRefAfter,
+                    observation: self.claudeOAuthActiveAccountObservation(
+                        fingerprintBefore: fingerprintBefore,
+                        fingerprintAfter: fingerprintAfter,
+                        persistentRefBefore: persistentRefBefore,
+                        persistentRefAfter: persistentRefAfter,
+                        identity: activeAccountIdentity),
+                    wasStable: wasStable)
             }
             return await group.next()!
         }
     }
 
-    private nonisolated static func captureClaudeKeychainPersistentRefHash() async -> String? {
-        await withTaskGroup(of: String?.self, returning: String?.self) { group in
-            group.addTask {
-                ClaudeOAuthCredentialsStore.claudeKeychainPersistentRefHashWithoutPrompt()
-            }
-            return await group.next()!
-        }
+    private nonisolated static func claudeOAuthActiveAccountObservation(
+        fingerprintBefore: String,
+        fingerprintAfter: String,
+        persistentRefBefore: String?,
+        persistentRefAfter: String?,
+        identity: String?) -> ClaudeOAuthActiveAccountObservation
+    {
+        let wasStable = fingerprintBefore == fingerprintAfter && persistentRefBefore == persistentRefAfter
+        return wasStable ? .stable(identity: identity) : .changed
     }
 
     private nonisolated static func stableClaudeKeychainPersistentRefHash(
         beforeFetch: ClaudeRefreshAuthState?,
         afterFetchFingerprintToken: String?,
-        afterFetchPersistentRefHash: String?) -> String?
+        afterFetchPersistentRefHash: String?,
+        accountStateWasStable: Bool) -> String?
     {
-        guard let beforeFetch,
+        guard accountStateWasStable,
+              let beforeFetch,
               beforeFetch.fingerprintToken == afterFetchFingerprintToken,
               let beforeFetchPersistentRefHash = beforeFetch.keychainPersistentRefHash,
               beforeFetchPersistentRefHash == afterFetchPersistentRefHash
@@ -463,7 +494,23 @@ extension UsageStore {
                 keychainFingerprintChanged: false,
                 keychainPersistentRefHash: beforeFetchPersistentRefHash),
             afterFetchFingerprintToken: afterFetchFingerprintToken,
-            afterFetchPersistentRefHash: afterFetchPersistentRefHash)
+            afterFetchPersistentRefHash: afterFetchPersistentRefHash,
+            accountStateWasStable: true)
+    }
+
+    nonisolated static func _claudeOAuthActiveAccountObservationForTesting(
+        fingerprintBefore: String,
+        fingerprintAfter: String,
+        persistentRefBefore: String?,
+        persistentRefAfter: String?,
+        identity: String?) -> ClaudeOAuthActiveAccountObservation
+    {
+        self.claudeOAuthActiveAccountObservation(
+            fingerprintBefore: fingerprintBefore,
+            fingerprintAfter: fingerprintAfter,
+            persistentRefBefore: persistentRefBefore,
+            persistentRefAfter: persistentRefAfter,
+            identity: identity)
     }
     #endif
 

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -303,7 +303,8 @@ extension UsageStore {
                 claudeOAuthHistoryOwnerIdentifier: isClaudeOAuthSample
                     ? result.claudeOAuthHistoryOwnerIdentifier
                     : nil,
-                isClaudeCLIKeychainSample: isClaudeOAuthSample && result.claudeOAuthUsesClaudeCLIKeychain,
+                claudeOAuthKeychainCredentialMismatch: isClaudeOAuthSample
+                    && result.claudeOAuthKeychainCredentialMismatch,
                 isClaudeOAuthSample: isClaudeOAuthSample)
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             if let runtime = self.providerRuntimes[provider] {

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -309,6 +309,8 @@ extension UsageStore {
                     : nil,
                 claudeOAuthKeychainCredentialMismatch: isClaudeOAuthSample
                     && result.claudeOAuthKeychainCredentialMismatch,
+                claudeOAuthKeychainCredentialAbsent: isClaudeOAuthSample
+                    && result.claudeOAuthKeychainCredentialAbsent,
                 claudeOAuthKeychainCredentialUnavailable: isClaudeOAuthSample
                     && (result.claudeOAuthKeychainCredentialUnavailable
                         || (result.claudeOAuthKeychainPersistentRefHash != nil

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -309,6 +309,10 @@ extension UsageStore {
                     : nil,
                 claudeOAuthKeychainCredentialMismatch: isClaudeOAuthSample
                     && result.claudeOAuthKeychainCredentialMismatch,
+                claudeOAuthKeychainCredentialUnavailable: isClaudeOAuthSample
+                    && (result.claudeOAuthKeychainCredentialUnavailable
+                        || (result.claudeOAuthKeychainPersistentRefHash != nil
+                            && claudeOAuthPersistentRefHash == nil)),
                 claudeOAuthActiveAccountObservation: context.claudeOAuthActiveAccountObservation,
                 isClaudeOAuthSample: isClaudeOAuthSample)
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -303,6 +303,7 @@ extension UsageStore {
                 claudeOAuthHistoryOwnerIdentifier: isClaudeOAuthSample
                     ? result.claudeOAuthHistoryOwnerIdentifier
                     : nil,
+                isClaudeCLIKeychainSample: isClaudeOAuthSample && result.claudeOAuthUsesClaudeCLIKeychain,
                 isClaudeOAuthSample: isClaudeOAuthSample)
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             if let runtime = self.providerRuntimes[provider] {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
@@ -202,6 +202,10 @@ enum ClaudeKeychainCredentialMatch: Equatable, Sendable {
         self == .mismatch
     }
 
+    var isAbsent: Bool {
+        self == .absent
+    }
+
     var isUnavailable: Bool {
         self == .unavailable
     }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
@@ -186,6 +186,22 @@ public enum ClaudeOAuthCredentialSource: String, Sendable {
     case claudeKeychain
 }
 
+enum ClaudeKeychainCredentialMatch: Equatable, Sendable {
+    case notApplicable
+    case unavailable
+    case mismatch
+    case matched(persistentRefHash: String)
+
+    var persistentRefHash: String? {
+        guard case let .matched(persistentRefHash) = self else { return nil }
+        return persistentRefHash
+    }
+
+    var isMismatch: Bool {
+        self == .mismatch
+    }
+}
+
 public struct ClaudeOAuthCredentialRecord: Sendable {
     public let credentials: ClaudeOAuthCredentials
     public let owner: ClaudeOAuthCredentialOwner

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
@@ -188,6 +188,7 @@ public enum ClaudeOAuthCredentialSource: String, Sendable {
 
 enum ClaudeKeychainCredentialMatch: Equatable, Sendable {
     case notApplicable
+    case absent
     case unavailable
     case mismatch
     case matched(persistentRefHash: String)

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
@@ -200,6 +200,10 @@ enum ClaudeKeychainCredentialMatch: Equatable, Sendable {
     var isMismatch: Bool {
         self == .mismatch
     }
+
+    var isUnavailable: Bool {
+        self == .unavailable
+    }
 }
 
 public struct ClaudeOAuthCredentialRecord: Sendable {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1351,10 +1351,20 @@ public enum ClaudeOAuthCredentialsStore {
     public static func matchingClaudeKeychainPersistentRefHashWithoutPrompt(
         for record: ClaudeOAuthCredentialRecord) -> String?
     {
-        guard record.owner == .claudeCLI else { return nil }
-        return self.matchingClaudeKeychainPersistentRefHash(
-            for: record,
-            evidence: self.newestClaudeKeychainCredentialEvidenceWithoutPrompt())
+        self.claudeKeychainCredentialMatchWithoutPrompt(for: record).persistentRefHash
+    }
+
+    static func claudeKeychainCredentialMatchWithoutPrompt(
+        for record: ClaudeOAuthCredentialRecord) -> ClaudeKeychainCredentialMatch
+    {
+        guard record.owner == .claudeCLI else { return .notApplicable }
+        guard let evidence = self.newestClaudeKeychainCredentialEvidenceWithoutPrompt() else {
+            return .unavailable
+        }
+        guard evidence.credentials.accessToken == record.credentials.accessToken else {
+            return .mismatch
+        }
+        return .matched(persistentRefHash: evidence.persistentRefHash)
     }
 
     private static func matchingClaudeKeychainPersistentRefHash(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1358,8 +1358,14 @@ public enum ClaudeOAuthCredentialsStore {
         for record: ClaudeOAuthCredentialRecord) -> ClaudeKeychainCredentialMatch
     {
         guard record.owner == .claudeCLI else { return .notApplicable }
-        guard let evidence = self.newestClaudeKeychainCredentialEvidenceWithoutPrompt() else {
+        let evidence: ClaudeKeychainCredentialEvidence
+        switch self.newestClaudeKeychainCredentialEvidenceWithoutPrompt() {
+        case .unavailable:
             return .unavailable
+        case .value(nil):
+            return .absent
+        case let .value(value?):
+            evidence = value
         }
         guard evidence.credentials.accessToken == record.credentials.accessToken else {
             return .mismatch
@@ -1380,24 +1386,25 @@ public enum ClaudeOAuthCredentialsStore {
     }
 
     private static func newestClaudeKeychainCredentialEvidenceWithoutPrompt()
-        -> ClaudeKeychainCredentialEvidence?
+        -> ClaudeKeychainProbe<ClaudeKeychainCredentialEvidence?>
     {
         #if DEBUG
         if let store = self.taskClaudeKeychainOverrideStore {
+            guard store.data != nil || store.fingerprint != nil else { return .value(nil) }
             return self.makeClaudeKeychainCredentialEvidence(
                 data: store.data,
-                persistentRefHash: store.fingerprint?.persistentRefHash)
+                persistentRefHash: store.fingerprint?.persistentRefHash).map { .value($0) } ?? .unavailable
         }
         let overrideData = self.taskClaudeKeychainDataOverride ?? self.claudeKeychainDataOverride
         let overrideFingerprint = self.taskClaudeKeychainFingerprintOverride ?? self.claudeKeychainFingerprintOverride
         if overrideData != nil || overrideFingerprint != nil {
             return self.makeClaudeKeychainCredentialEvidence(
                 data: overrideData,
-                persistentRefHash: overrideFingerprint?.persistentRefHash)
+                persistentRefHash: overrideFingerprint?.persistentRefHash).map { .value($0) } ?? .unavailable
         }
         if self.taskSecurityCLIReadOverride != nil || self.securityCLIReadOverride != nil {
             // A security(1) result cannot be bound to a persistent reference without an exact candidate read.
-            return nil
+            return .unavailable
         }
         #endif
 
@@ -1406,33 +1413,35 @@ public enum ClaudeOAuthCredentialsStore {
         let newest: ClaudeKeychainCandidate?
         switch self.claudeKeychainCandidatesProbeWithoutPrompt(promptMode: promptMode) {
         case .unavailable:
-            return nil
+            return .unavailable
         case let .value(candidates):
             if let first = candidates.first {
                 newest = first
             } else {
                 switch self.claudeKeychainLegacyCandidateProbeWithoutPrompt(promptMode: promptMode) {
                 case .unavailable:
-                    return nil
+                    return .unavailable
                 case let .value(candidate):
                     newest = candidate
                 }
             }
         }
-        guard let newest,
-              let persistentRefHash = self.sha256Prefix(newest.persistentRef),
+        guard let newest else { return .value(nil) }
+        guard let persistentRefHash = self.sha256Prefix(newest.persistentRef),
               let data = try? self.loadClaudeKeychainData(
                   candidate: newest,
                   allowKeychainPrompt: false,
                   promptMode: promptMode)
         else {
-            return nil
+            return .unavailable
         }
-        return self.makeClaudeKeychainCredentialEvidence(
+        guard let evidence = self.makeClaudeKeychainCredentialEvidence(
             data: data,
             persistentRefHash: persistentRefHash)
+        else { return .unavailable }
+        return .value(evidence)
         #else
-        return nil
+        return .unavailable
         #endif
     }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -382,7 +382,7 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
             strategyKind: self.kind,
             claudeOAuthKeychainPersistentRefHash: usage.oauthKeychainPersistentRefHash,
             claudeOAuthHistoryOwnerIdentifier: usage.oauthHistoryOwnerIdentifier,
-            claudeOAuthUsesClaudeCLIKeychain: usage.oauthUsesClaudeCLIKeychain)
+            claudeOAuthKeychainCredentialMismatch: usage.oauthKeychainCredentialMismatch)
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -381,7 +381,8 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
             strategyID: self.id,
             strategyKind: self.kind,
             claudeOAuthKeychainPersistentRefHash: usage.oauthKeychainPersistentRefHash,
-            claudeOAuthHistoryOwnerIdentifier: usage.oauthHistoryOwnerIdentifier)
+            claudeOAuthHistoryOwnerIdentifier: usage.oauthHistoryOwnerIdentifier,
+            claudeOAuthUsesClaudeCLIKeychain: usage.oauthUsesClaudeCLIKeychain)
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -383,6 +383,7 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
             claudeOAuthKeychainPersistentRefHash: usage.oauthKeychainPersistentRefHash,
             claudeOAuthHistoryOwnerIdentifier: usage.oauthHistoryOwnerIdentifier,
             claudeOAuthKeychainCredentialMismatch: usage.oauthKeychainCredentialMismatch,
+            claudeOAuthKeychainCredentialAbsent: usage.oauthKeychainCredentialAbsent,
             claudeOAuthKeychainCredentialUnavailable: usage.oauthKeychainCredentialUnavailable)
     }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -382,7 +382,8 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
             strategyKind: self.kind,
             claudeOAuthKeychainPersistentRefHash: usage.oauthKeychainPersistentRefHash,
             claudeOAuthHistoryOwnerIdentifier: usage.oauthHistoryOwnerIdentifier,
-            claudeOAuthKeychainCredentialMismatch: usage.oauthKeychainCredentialMismatch)
+            claudeOAuthKeychainCredentialMismatch: usage.oauthKeychainCredentialMismatch,
+            claudeOAuthKeychainCredentialUnavailable: usage.oauthKeychainCredentialUnavailable)
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -29,6 +29,8 @@ public struct ClaudeUsageSnapshot: Sendable {
     public let oauthHistoryOwnerIdentifier: String?
     /// True when a prompt-free comparison proved this credential differs from Claude Code's Keychain entry.
     public let oauthKeychainCredentialMismatch: Bool
+    /// True when a Claude CLI credential won routing but the prompt-free Keychain comparison was unavailable.
+    public let oauthKeychainCredentialUnavailable: Bool
 
     public init(
         primary: RateWindow,
@@ -44,7 +46,8 @@ public struct ClaudeUsageSnapshot: Sendable {
         rawText: String?,
         oauthKeychainPersistentRefHash: String? = nil,
         oauthHistoryOwnerIdentifier: String? = nil,
-        oauthKeychainCredentialMismatch: Bool = false)
+        oauthKeychainCredentialMismatch: Bool = false,
+        oauthKeychainCredentialUnavailable: Bool = false)
     {
         self.primary = primary
         self.primaryWindowKind = primaryWindowKind
@@ -60,6 +63,7 @@ public struct ClaudeUsageSnapshot: Sendable {
         self.oauthKeychainPersistentRefHash = oauthKeychainPersistentRefHash
         self.oauthHistoryOwnerIdentifier = oauthHistoryOwnerIdentifier
         self.oauthKeychainCredentialMismatch = oauthKeychainCredentialMismatch
+        self.oauthKeychainCredentialUnavailable = oauthKeychainCredentialUnavailable
     }
 }
 
@@ -323,7 +327,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     credentials: credentials,
                     oauthKeychainPersistentRefHash: keychainMatch.persistentRefHash,
                     oauthHistoryOwnerIdentifier: credentialRecord.historyOwnerIdentifier,
-                    oauthKeychainCredentialMismatch: keychainMatch.isMismatch)
+                    oauthKeychainCredentialMismatch: keychainMatch.isMismatch,
+                    oauthKeychainCredentialUnavailable: keychainMatch.isUnavailable)
             } catch let error as CancellationError {
                 throw error
             } catch let error as ClaudeUsageError {
@@ -468,7 +473,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     credentials: refreshedCredentials,
                     oauthKeychainPersistentRefHash: keychainMatch.persistentRefHash,
                     oauthHistoryOwnerIdentifier: refreshedRecord.historyOwnerIdentifier,
-                    oauthKeychainCredentialMismatch: keychainMatch.isMismatch)
+                    oauthKeychainCredentialMismatch: keychainMatch.isMismatch,
+                    oauthKeychainCredentialUnavailable: keychainMatch.isUnavailable)
             } catch {
                 ClaudeUsageFetcher.log.debug(
                     "Claude OAuth post-delegation retry failed",
@@ -995,7 +1001,8 @@ extension ClaudeUsageFetcher {
         credentials: ClaudeOAuthCredentials,
         oauthKeychainPersistentRefHash: String? = nil,
         oauthHistoryOwnerIdentifier: String? = nil,
-        oauthKeychainCredentialMismatch: Bool = false) throws -> ClaudeUsageSnapshot
+        oauthKeychainCredentialMismatch: Bool = false,
+        oauthKeychainCredentialUnavailable: Bool = false) throws -> ClaudeUsageSnapshot
     {
         let oauthHistoryOwnerIdentifier = ClaudeOAuthCredentials.normalizedHistoryOwnerIdentifier(
             oauthHistoryOwnerIdentifier) ?? credentials.historyOwnerIdentifier
@@ -1043,7 +1050,8 @@ extension ClaudeUsageFetcher {
                     rawText: nil,
                     oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash,
                     oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier,
-                    oauthKeychainCredentialMismatch: oauthKeychainCredentialMismatch)
+                    oauthKeychainCredentialMismatch: oauthKeychainCredentialMismatch,
+                    oauthKeychainCredentialUnavailable: oauthKeychainCredentialUnavailable)
             }
             throw ClaudeUsageError.parseFailed("missing session data")
         }
@@ -1067,7 +1075,8 @@ extension ClaudeUsageFetcher {
             rawText: nil,
             oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash,
             oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier,
-            oauthKeychainCredentialMismatch: oauthKeychainCredentialMismatch)
+            oauthKeychainCredentialMismatch: oauthKeychainCredentialMismatch,
+            oauthKeychainCredentialUnavailable: oauthKeychainCredentialUnavailable)
     }
 
     private static func oauthExtraUsageCost(
@@ -1375,7 +1384,8 @@ extension ClaudeUsageFetcher {
                     rawText: snapshot.rawText,
                     oauthKeychainPersistentRefHash: snapshot.oauthKeychainPersistentRefHash,
                     oauthHistoryOwnerIdentifier: snapshot.oauthHistoryOwnerIdentifier,
-                    oauthKeychainCredentialMismatch: snapshot.oauthKeychainCredentialMismatch)
+                    oauthKeychainCredentialMismatch: snapshot.oauthKeychainCredentialMismatch,
+                    oauthKeychainCredentialUnavailable: snapshot.oauthKeychainCredentialUnavailable)
             }
         } catch {
             Self.log.debug("Claude web extras fetch failed: \(error.localizedDescription)")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -29,6 +29,8 @@ public struct ClaudeUsageSnapshot: Sendable {
     public let oauthHistoryOwnerIdentifier: String?
     /// True when a prompt-free comparison proved this credential differs from Claude Code's Keychain entry.
     public let oauthKeychainCredentialMismatch: Bool
+    /// True when a prompt-free probe proved Claude Code has no Keychain credential.
+    public let oauthKeychainCredentialAbsent: Bool
     /// True when a Claude CLI credential won routing but the prompt-free Keychain comparison was unavailable.
     public let oauthKeychainCredentialUnavailable: Bool
 
@@ -47,6 +49,7 @@ public struct ClaudeUsageSnapshot: Sendable {
         oauthKeychainPersistentRefHash: String? = nil,
         oauthHistoryOwnerIdentifier: String? = nil,
         oauthKeychainCredentialMismatch: Bool = false,
+        oauthKeychainCredentialAbsent: Bool = false,
         oauthKeychainCredentialUnavailable: Bool = false)
     {
         self.primary = primary
@@ -63,6 +66,7 @@ public struct ClaudeUsageSnapshot: Sendable {
         self.oauthKeychainPersistentRefHash = oauthKeychainPersistentRefHash
         self.oauthHistoryOwnerIdentifier = oauthHistoryOwnerIdentifier
         self.oauthKeychainCredentialMismatch = oauthKeychainCredentialMismatch
+        self.oauthKeychainCredentialAbsent = oauthKeychainCredentialAbsent
         self.oauthKeychainCredentialUnavailable = oauthKeychainCredentialUnavailable
     }
 }
@@ -328,6 +332,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     oauthKeychainPersistentRefHash: keychainMatch.persistentRefHash,
                     oauthHistoryOwnerIdentifier: credentialRecord.historyOwnerIdentifier,
                     oauthKeychainCredentialMismatch: keychainMatch.isMismatch,
+                    oauthKeychainCredentialAbsent: keychainMatch.isAbsent,
                     oauthKeychainCredentialUnavailable: keychainMatch.isUnavailable)
             } catch let error as CancellationError {
                 throw error
@@ -474,6 +479,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     oauthKeychainPersistentRefHash: keychainMatch.persistentRefHash,
                     oauthHistoryOwnerIdentifier: refreshedRecord.historyOwnerIdentifier,
                     oauthKeychainCredentialMismatch: keychainMatch.isMismatch,
+                    oauthKeychainCredentialAbsent: keychainMatch.isAbsent,
                     oauthKeychainCredentialUnavailable: keychainMatch.isUnavailable)
             } catch {
                 ClaudeUsageFetcher.log.debug(
@@ -1002,6 +1008,7 @@ extension ClaudeUsageFetcher {
         oauthKeychainPersistentRefHash: String? = nil,
         oauthHistoryOwnerIdentifier: String? = nil,
         oauthKeychainCredentialMismatch: Bool = false,
+        oauthKeychainCredentialAbsent: Bool = false,
         oauthKeychainCredentialUnavailable: Bool = false) throws -> ClaudeUsageSnapshot
     {
         let oauthHistoryOwnerIdentifier = ClaudeOAuthCredentials.normalizedHistoryOwnerIdentifier(
@@ -1051,6 +1058,7 @@ extension ClaudeUsageFetcher {
                     oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash,
                     oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier,
                     oauthKeychainCredentialMismatch: oauthKeychainCredentialMismatch,
+                    oauthKeychainCredentialAbsent: oauthKeychainCredentialAbsent,
                     oauthKeychainCredentialUnavailable: oauthKeychainCredentialUnavailable)
             }
             throw ClaudeUsageError.parseFailed("missing session data")
@@ -1076,6 +1084,7 @@ extension ClaudeUsageFetcher {
             oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash,
             oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier,
             oauthKeychainCredentialMismatch: oauthKeychainCredentialMismatch,
+            oauthKeychainCredentialAbsent: oauthKeychainCredentialAbsent,
             oauthKeychainCredentialUnavailable: oauthKeychainCredentialUnavailable)
     }
 
@@ -1385,6 +1394,7 @@ extension ClaudeUsageFetcher {
                     oauthKeychainPersistentRefHash: snapshot.oauthKeychainPersistentRefHash,
                     oauthHistoryOwnerIdentifier: snapshot.oauthHistoryOwnerIdentifier,
                     oauthKeychainCredentialMismatch: snapshot.oauthKeychainCredentialMismatch,
+                    oauthKeychainCredentialAbsent: snapshot.oauthKeychainCredentialAbsent,
                     oauthKeychainCredentialUnavailable: snapshot.oauthKeychainCredentialUnavailable)
             }
         } catch {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -27,8 +27,8 @@ public struct ClaudeUsageSnapshot: Sendable {
     public let oauthKeychainPersistentRefHash: String?
     /// One-way, high-entropy ownership evidence derived from the exact credential used for this OAuth fetch.
     public let oauthHistoryOwnerIdentifier: String?
-    /// True when OAuth routing used a credential owned by Claude Code's Keychain entry.
-    public let oauthUsesClaudeCLIKeychain: Bool
+    /// True when a prompt-free comparison proved this credential differs from Claude Code's Keychain entry.
+    public let oauthKeychainCredentialMismatch: Bool
 
     public init(
         primary: RateWindow,
@@ -44,7 +44,7 @@ public struct ClaudeUsageSnapshot: Sendable {
         rawText: String?,
         oauthKeychainPersistentRefHash: String? = nil,
         oauthHistoryOwnerIdentifier: String? = nil,
-        oauthUsesClaudeCLIKeychain: Bool = false)
+        oauthKeychainCredentialMismatch: Bool = false)
     {
         self.primary = primary
         self.primaryWindowKind = primaryWindowKind
@@ -59,7 +59,7 @@ public struct ClaudeUsageSnapshot: Sendable {
         self.rawText = rawText
         self.oauthKeychainPersistentRefHash = oauthKeychainPersistentRefHash
         self.oauthHistoryOwnerIdentifier = oauthHistoryOwnerIdentifier
-        self.oauthUsesClaudeCLIKeychain = oauthUsesClaudeCLIKeychain
+        self.oauthKeychainCredentialMismatch = oauthKeychainCredentialMismatch
     }
 }
 
@@ -316,13 +316,14 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                 let usage = try await ClaudeUsageFetcher.fetchOAuthUsage(
                     accessToken: credentials.accessToken,
                     detectClaudeVersion: self.fetcher.allowsOAuthClaudeVersionDetection)
+                let keychainMatch = ClaudeOAuthCredentialsStore
+                    .claudeKeychainCredentialMatchWithoutPrompt(for: credentialRecord)
                 return try ClaudeUsageFetcher.mapOAuthUsage(
                     usage,
                     credentials: credentials,
-                    oauthKeychainPersistentRefHash: ClaudeOAuthCredentialsStore
-                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: credentialRecord),
+                    oauthKeychainPersistentRefHash: keychainMatch.persistentRefHash,
                     oauthHistoryOwnerIdentifier: credentialRecord.historyOwnerIdentifier,
-                    oauthUsesClaudeCLIKeychain: credentialRecord.owner == .claudeCLI)
+                    oauthKeychainCredentialMismatch: keychainMatch.isMismatch)
             } catch let error as CancellationError {
                 throw error
             } catch let error as ClaudeUsageError {
@@ -460,13 +461,14 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                 let usage = try await ClaudeUsageFetcher.fetchOAuthUsage(
                     accessToken: refreshedCredentials.accessToken,
                     detectClaudeVersion: self.fetcher.allowsOAuthClaudeVersionDetection)
+                let keychainMatch = ClaudeOAuthCredentialsStore
+                    .claudeKeychainCredentialMatchWithoutPrompt(for: refreshedRecord)
                 return try ClaudeUsageFetcher.mapOAuthUsage(
                     usage,
                     credentials: refreshedCredentials,
-                    oauthKeychainPersistentRefHash: ClaudeOAuthCredentialsStore
-                        .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: refreshedRecord),
+                    oauthKeychainPersistentRefHash: keychainMatch.persistentRefHash,
                     oauthHistoryOwnerIdentifier: refreshedRecord.historyOwnerIdentifier,
-                    oauthUsesClaudeCLIKeychain: refreshedRecord.owner == .claudeCLI)
+                    oauthKeychainCredentialMismatch: keychainMatch.isMismatch)
             } catch {
                 ClaudeUsageFetcher.log.debug(
                     "Claude OAuth post-delegation retry failed",
@@ -993,7 +995,7 @@ extension ClaudeUsageFetcher {
         credentials: ClaudeOAuthCredentials,
         oauthKeychainPersistentRefHash: String? = nil,
         oauthHistoryOwnerIdentifier: String? = nil,
-        oauthUsesClaudeCLIKeychain: Bool = false) throws -> ClaudeUsageSnapshot
+        oauthKeychainCredentialMismatch: Bool = false) throws -> ClaudeUsageSnapshot
     {
         let oauthHistoryOwnerIdentifier = ClaudeOAuthCredentials.normalizedHistoryOwnerIdentifier(
             oauthHistoryOwnerIdentifier) ?? credentials.historyOwnerIdentifier
@@ -1041,7 +1043,7 @@ extension ClaudeUsageFetcher {
                     rawText: nil,
                     oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash,
                     oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier,
-                    oauthUsesClaudeCLIKeychain: oauthUsesClaudeCLIKeychain)
+                    oauthKeychainCredentialMismatch: oauthKeychainCredentialMismatch)
             }
             throw ClaudeUsageError.parseFailed("missing session data")
         }
@@ -1065,7 +1067,7 @@ extension ClaudeUsageFetcher {
             rawText: nil,
             oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash,
             oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier,
-            oauthUsesClaudeCLIKeychain: oauthUsesClaudeCLIKeychain)
+            oauthKeychainCredentialMismatch: oauthKeychainCredentialMismatch)
     }
 
     private static func oauthExtraUsageCost(
@@ -1373,7 +1375,7 @@ extension ClaudeUsageFetcher {
                     rawText: snapshot.rawText,
                     oauthKeychainPersistentRefHash: snapshot.oauthKeychainPersistentRefHash,
                     oauthHistoryOwnerIdentifier: snapshot.oauthHistoryOwnerIdentifier,
-                    oauthUsesClaudeCLIKeychain: snapshot.oauthUsesClaudeCLIKeychain)
+                    oauthKeychainCredentialMismatch: snapshot.oauthKeychainCredentialMismatch)
             }
         } catch {
             Self.log.debug("Claude web extras fetch failed: \(error.localizedDescription)")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -27,6 +27,8 @@ public struct ClaudeUsageSnapshot: Sendable {
     public let oauthKeychainPersistentRefHash: String?
     /// One-way, high-entropy ownership evidence derived from the exact credential used for this OAuth fetch.
     public let oauthHistoryOwnerIdentifier: String?
+    /// True when OAuth routing used a credential owned by Claude Code's Keychain entry.
+    public let oauthUsesClaudeCLIKeychain: Bool
 
     public init(
         primary: RateWindow,
@@ -41,7 +43,8 @@ public struct ClaudeUsageSnapshot: Sendable {
         loginMethod: String?,
         rawText: String?,
         oauthKeychainPersistentRefHash: String? = nil,
-        oauthHistoryOwnerIdentifier: String? = nil)
+        oauthHistoryOwnerIdentifier: String? = nil,
+        oauthUsesClaudeCLIKeychain: Bool = false)
     {
         self.primary = primary
         self.primaryWindowKind = primaryWindowKind
@@ -56,6 +59,7 @@ public struct ClaudeUsageSnapshot: Sendable {
         self.rawText = rawText
         self.oauthKeychainPersistentRefHash = oauthKeychainPersistentRefHash
         self.oauthHistoryOwnerIdentifier = oauthHistoryOwnerIdentifier
+        self.oauthUsesClaudeCLIKeychain = oauthUsesClaudeCLIKeychain
     }
 }
 
@@ -317,7 +321,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     credentials: credentials,
                     oauthKeychainPersistentRefHash: ClaudeOAuthCredentialsStore
                         .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: credentialRecord),
-                    oauthHistoryOwnerIdentifier: credentialRecord.historyOwnerIdentifier)
+                    oauthHistoryOwnerIdentifier: credentialRecord.historyOwnerIdentifier,
+                    oauthUsesClaudeCLIKeychain: credentialRecord.owner == .claudeCLI)
             } catch let error as CancellationError {
                 throw error
             } catch let error as ClaudeUsageError {
@@ -460,7 +465,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     credentials: refreshedCredentials,
                     oauthKeychainPersistentRefHash: ClaudeOAuthCredentialsStore
                         .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: refreshedRecord),
-                    oauthHistoryOwnerIdentifier: refreshedRecord.historyOwnerIdentifier)
+                    oauthHistoryOwnerIdentifier: refreshedRecord.historyOwnerIdentifier,
+                    oauthUsesClaudeCLIKeychain: refreshedRecord.owner == .claudeCLI)
             } catch {
                 ClaudeUsageFetcher.log.debug(
                     "Claude OAuth post-delegation retry failed",
@@ -986,7 +992,8 @@ extension ClaudeUsageFetcher {
         _ usage: OAuthUsageResponse,
         credentials: ClaudeOAuthCredentials,
         oauthKeychainPersistentRefHash: String? = nil,
-        oauthHistoryOwnerIdentifier: String? = nil) throws -> ClaudeUsageSnapshot
+        oauthHistoryOwnerIdentifier: String? = nil,
+        oauthUsesClaudeCLIKeychain: Bool = false) throws -> ClaudeUsageSnapshot
     {
         let oauthHistoryOwnerIdentifier = ClaudeOAuthCredentials.normalizedHistoryOwnerIdentifier(
             oauthHistoryOwnerIdentifier) ?? credentials.historyOwnerIdentifier
@@ -1033,7 +1040,8 @@ extension ClaudeUsageFetcher {
                     loginMethod: loginMethod,
                     rawText: nil,
                     oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash,
-                    oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier)
+                    oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier,
+                    oauthUsesClaudeCLIKeychain: oauthUsesClaudeCLIKeychain)
             }
             throw ClaudeUsageError.parseFailed("missing session data")
         }
@@ -1056,7 +1064,8 @@ extension ClaudeUsageFetcher {
             loginMethod: loginMethod,
             rawText: nil,
             oauthKeychainPersistentRefHash: oauthKeychainPersistentRefHash,
-            oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier)
+            oauthHistoryOwnerIdentifier: oauthHistoryOwnerIdentifier,
+            oauthUsesClaudeCLIKeychain: oauthUsesClaudeCLIKeychain)
     }
 
     private static func oauthExtraUsageCost(
@@ -1363,7 +1372,8 @@ extension ClaudeUsageFetcher {
                     loginMethod: snapshot.loginMethod,
                     rawText: snapshot.rawText,
                     oauthKeychainPersistentRefHash: snapshot.oauthKeychainPersistentRefHash,
-                    oauthHistoryOwnerIdentifier: snapshot.oauthHistoryOwnerIdentifier)
+                    oauthHistoryOwnerIdentifier: snapshot.oauthHistoryOwnerIdentifier,
+                    oauthUsesClaudeCLIKeychain: snapshot.oauthUsesClaudeCLIKeychain)
             }
         } catch {
             Self.log.debug("Claude web extras fetch failed: \(error.localizedDescription)")

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -109,6 +109,8 @@ public struct ProviderFetchResult: Sendable {
     public let claudeOAuthHistoryOwnerIdentifier: String?
     /// Whether a prompt-free comparison proved the winning credential differs from Claude Code's Keychain entry.
     public let claudeOAuthKeychainCredentialMismatch: Bool
+    /// Whether a prompt-free probe proved Claude Code has no Keychain credential.
+    public let claudeOAuthKeychainCredentialAbsent: Bool
     /// Whether the winning Claude CLI credential could not be compared with Keychain without prompting.
     public let claudeOAuthKeychainCredentialUnavailable: Bool
 
@@ -122,6 +124,7 @@ public struct ProviderFetchResult: Sendable {
         claudeOAuthKeychainPersistentRefHash: String? = nil,
         claudeOAuthHistoryOwnerIdentifier: String? = nil,
         claudeOAuthKeychainCredentialMismatch: Bool = false,
+        claudeOAuthKeychainCredentialAbsent: Bool = false,
         claudeOAuthKeychainCredentialUnavailable: Bool = false)
     {
         self.usage = usage
@@ -133,6 +136,7 @@ public struct ProviderFetchResult: Sendable {
         self.claudeOAuthKeychainPersistentRefHash = claudeOAuthKeychainPersistentRefHash
         self.claudeOAuthHistoryOwnerIdentifier = claudeOAuthHistoryOwnerIdentifier
         self.claudeOAuthKeychainCredentialMismatch = claudeOAuthKeychainCredentialMismatch
+        self.claudeOAuthKeychainCredentialAbsent = claudeOAuthKeychainCredentialAbsent
         self.claudeOAuthKeychainCredentialUnavailable = claudeOAuthKeychainCredentialUnavailable
     }
 }

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -109,6 +109,8 @@ public struct ProviderFetchResult: Sendable {
     public let claudeOAuthHistoryOwnerIdentifier: String?
     /// Whether a prompt-free comparison proved the winning credential differs from Claude Code's Keychain entry.
     public let claudeOAuthKeychainCredentialMismatch: Bool
+    /// Whether the winning Claude CLI credential could not be compared with Keychain without prompting.
+    public let claudeOAuthKeychainCredentialUnavailable: Bool
 
     public init(
         usage: UsageSnapshot,
@@ -119,7 +121,8 @@ public struct ProviderFetchResult: Sendable {
         strategyKind: ProviderFetchKind,
         claudeOAuthKeychainPersistentRefHash: String? = nil,
         claudeOAuthHistoryOwnerIdentifier: String? = nil,
-        claudeOAuthKeychainCredentialMismatch: Bool = false)
+        claudeOAuthKeychainCredentialMismatch: Bool = false,
+        claudeOAuthKeychainCredentialUnavailable: Bool = false)
     {
         self.usage = usage
         self.credits = credits
@@ -130,6 +133,7 @@ public struct ProviderFetchResult: Sendable {
         self.claudeOAuthKeychainPersistentRefHash = claudeOAuthKeychainPersistentRefHash
         self.claudeOAuthHistoryOwnerIdentifier = claudeOAuthHistoryOwnerIdentifier
         self.claudeOAuthKeychainCredentialMismatch = claudeOAuthKeychainCredentialMismatch
+        self.claudeOAuthKeychainCredentialUnavailable = claudeOAuthKeychainCredentialUnavailable
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -107,8 +107,8 @@ public struct ProviderFetchResult: Sendable {
     /// A one-way discriminator derived from the winning Claude OAuth credential.
     /// Raw access and refresh tokens never enter the fetch result or persisted history.
     public let claudeOAuthHistoryOwnerIdentifier: String?
-    /// Whether the winning Claude OAuth credential belongs to Claude Code's Keychain entry.
-    public let claudeOAuthUsesClaudeCLIKeychain: Bool
+    /// Whether a prompt-free comparison proved the winning credential differs from Claude Code's Keychain entry.
+    public let claudeOAuthKeychainCredentialMismatch: Bool
 
     public init(
         usage: UsageSnapshot,
@@ -119,7 +119,7 @@ public struct ProviderFetchResult: Sendable {
         strategyKind: ProviderFetchKind,
         claudeOAuthKeychainPersistentRefHash: String? = nil,
         claudeOAuthHistoryOwnerIdentifier: String? = nil,
-        claudeOAuthUsesClaudeCLIKeychain: Bool = false)
+        claudeOAuthKeychainCredentialMismatch: Bool = false)
     {
         self.usage = usage
         self.credits = credits
@@ -129,7 +129,7 @@ public struct ProviderFetchResult: Sendable {
         self.strategyKind = strategyKind
         self.claudeOAuthKeychainPersistentRefHash = claudeOAuthKeychainPersistentRefHash
         self.claudeOAuthHistoryOwnerIdentifier = claudeOAuthHistoryOwnerIdentifier
-        self.claudeOAuthUsesClaudeCLIKeychain = claudeOAuthUsesClaudeCLIKeychain
+        self.claudeOAuthKeychainCredentialMismatch = claudeOAuthKeychainCredentialMismatch
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -107,6 +107,8 @@ public struct ProviderFetchResult: Sendable {
     /// A one-way discriminator derived from the winning Claude OAuth credential.
     /// Raw access and refresh tokens never enter the fetch result or persisted history.
     public let claudeOAuthHistoryOwnerIdentifier: String?
+    /// Whether the winning Claude OAuth credential belongs to Claude Code's Keychain entry.
+    public let claudeOAuthUsesClaudeCLIKeychain: Bool
 
     public init(
         usage: UsageSnapshot,
@@ -116,7 +118,8 @@ public struct ProviderFetchResult: Sendable {
         strategyID: String,
         strategyKind: ProviderFetchKind,
         claudeOAuthKeychainPersistentRefHash: String? = nil,
-        claudeOAuthHistoryOwnerIdentifier: String? = nil)
+        claudeOAuthHistoryOwnerIdentifier: String? = nil,
+        claudeOAuthUsesClaudeCLIKeychain: Bool = false)
     {
         self.usage = usage
         self.credits = credits
@@ -126,6 +129,7 @@ public struct ProviderFetchResult: Sendable {
         self.strategyKind = strategyKind
         self.claudeOAuthKeychainPersistentRefHash = claudeOAuthKeychainPersistentRefHash
         self.claudeOAuthHistoryOwnerIdentifier = claudeOAuthHistoryOwnerIdentifier
+        self.claudeOAuthUsesClaudeCLIKeychain = claudeOAuthUsesClaudeCLIKeychain
     }
 }
 

--- a/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
@@ -61,8 +61,11 @@ struct ClaudeOAuthHistoryCredentialRoutingTests {
             data: nil,
             fingerprint: fingerprint)
         {
-            #expect(ClaudeOAuthCredentialsStore
-                .claudeKeychainCredentialMatchWithoutPrompt(for: matchingCLIRecord) == .unavailable)
+            let unavailable = ClaudeOAuthCredentialsStore
+                .claudeKeychainCredentialMatchWithoutPrompt(for: matchingCLIRecord)
+            #expect(unavailable == .unavailable)
+            #expect(unavailable.isUnavailable)
+            #expect(!unavailable.isMismatch)
         }
     }
 

--- a/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
@@ -46,8 +46,23 @@ struct ClaudeOAuthHistoryCredentialRoutingTests {
                         .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: matchingEnvironmentRecord) == nil)
                     #expect(ClaudeOAuthCredentialsStore
                         .matchingClaudeKeychainPersistentRefHashWithoutPrompt(for: matchingCodexBarRecord) == nil)
+                    #expect(ClaudeOAuthCredentialsStore
+                        .claudeKeychainCredentialMatchWithoutPrompt(for: matchingCLIRecord) ==
+                        .matched(persistentRefHash: "opaque-ref"))
+                    #expect(ClaudeOAuthCredentialsStore
+                        .claudeKeychainCredentialMatchWithoutPrompt(for: differentCLIRecord) == .mismatch)
+                    #expect(ClaudeOAuthCredentialsStore
+                        .claudeKeychainCredentialMatchWithoutPrompt(for: matchingEnvironmentRecord) == .notApplicable)
                 }
             }
+        }
+
+        ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+            data: nil,
+            fingerprint: fingerprint)
+        {
+            #expect(ClaudeOAuthCredentialsStore
+                .claudeKeychainCredentialMatchWithoutPrompt(for: matchingCLIRecord) == .unavailable)
         }
     }
 

--- a/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthHistoryCredentialRoutingTests.swift
@@ -67,6 +67,12 @@ struct ClaudeOAuthHistoryCredentialRoutingTests {
             #expect(unavailable.isUnavailable)
             #expect(!unavailable.isMismatch)
         }
+
+        let absentStore = ClaudeOAuthCredentialsStore.ClaudeKeychainOverrideStore()
+        ClaudeOAuthCredentialsStore.withMutableClaudeKeychainOverrideStoreForTesting(absentStore) {
+            #expect(ClaudeOAuthCredentialsStore
+                .claudeKeychainCredentialMatchWithoutPrompt(for: matchingCLIRecord) == .absent)
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -105,7 +105,6 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
     @Test
     func `file backed owner records history when keychain comparison is unavailable`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
-        store.settings.claudeOAuthKeychainPromptMode = .never
         let owner = String(repeating: "e", count: 64)
         let key = try #require(
             UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: owner))

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -103,13 +103,16 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
 
     @MainActor
     @Test
-    func `unavailable keychain comparison cannot arm first Claude CLI owner`() async {
+    func `file backed owner records history when keychain comparison is unavailable`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
+        let owner = String(repeating: "e", count: 64)
+        let key = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: owner))
 
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
             snapshot: self.snapshot(usedPercent: 90),
-            claudeOAuthHistoryOwnerIdentifier: String(repeating: "u", count: 64),
+            claudeOAuthHistoryOwnerIdentifier: owner,
             claudeOAuthKeychainCredentialUnavailable: true,
             claudeOAuthActiveAccountObservation: .stable(
                 identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-current")),
@@ -118,7 +121,9 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
         #expect(UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults).isEmpty)
         #expect(UsageStore.loadClaudeOAuthAccountBindingCandidateMap(
             from: store.settings.userDefaults).isEmpty)
-        #expect(store.planUtilizationHistory[.claude] == nil)
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(findSeries(buckets.accounts[key] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [90])
     }
 
     @MainActor

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -129,6 +129,28 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
 
     @MainActor
     @Test
+    func `never prompt mode still quarantines an owner bound to another account`() async {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        store.settings.claudeOAuthKeychainPromptMode = .never
+        let owner = String(repeating: "f", count: 64)
+        store.persistClaudeOAuthAccountUuidMap([
+            owner: UsageStore._activeClaudeAccountIdentityForTesting("uuid-A"),
+        ])
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.snapshot(usedPercent: 90),
+            claudeOAuthHistoryOwnerIdentifier: owner,
+            claudeOAuthKeychainCredentialUnavailable: true,
+            claudeOAuthActiveAccountObservation: .stable(
+                identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")),
+            isClaudeOAuthSample: true)
+
+        #expect(store.planUtilizationHistory[.claude] == nil)
+    }
+
+    @MainActor
+    @Test
     func `account change during identity capture cannot bind or write history`() async {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let snapshot = UsageSnapshot(

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -6,6 +6,57 @@ import Testing
 struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
     @MainActor
     @Test
+    func `first sighting without keychain match is quarantined`() async {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 90,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: snapshot,
+            claudeOAuthHistoryOwnerIdentifier: String(repeating: "s", count: 64),
+            claudeOAuthKeychainCredentialMismatch: true,
+            claudeOAuthActiveAccountObservation: .stable(
+                identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-current")),
+            isClaudeOAuthSample: true)
+
+        #expect(UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults).isEmpty)
+        #expect(store.planUtilizationHistory[.claude] == nil)
+    }
+
+    @MainActor
+    @Test
+    func `account change during identity capture cannot bind or write history`() async {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 90,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: snapshot,
+            claudeOAuthPersistentRefHash: "account-a-ref",
+            claudeOAuthHistoryOwnerIdentifier: String(repeating: "r", count: 64),
+            claudeOAuthActiveAccountObservation: .changed,
+            isClaudeOAuthSample: true)
+
+        #expect(UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults).isEmpty)
+        #expect(store.planUtilizationHistory[.claude] == nil)
+    }
+
+    @MainActor
+    @Test
     func `missing active account identity preserves owner scoped history`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let owner = String(repeating: "c", count: 64)
@@ -25,6 +76,7 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
                 provider: .claude,
                 snapshot: snapshot,
                 claudeOAuthHistoryOwnerIdentifier: owner,
+                claudeOAuthActiveAccountObservation: .stable(identity: nil),
                 isClaudeOAuthSample: true)
         }
 
@@ -54,6 +106,8 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
                 provider: .claude,
                 snapshot: snapshot,
                 claudeOAuthHistoryOwnerIdentifier: owner,
+                claudeOAuthActiveAccountObservation: .stable(
+                    identity: UsageStore._activeClaudeAccountIdentityForTesting("claude-code-account")),
                 isClaudeOAuthSample: true)
         }
 
@@ -78,5 +132,25 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
 
         #expect(stablePersistentRefHash == "stable-ref")
         #expect(changedFingerprintPersistentRefHash == nil)
+    }
+
+    @Test
+    func `credential change around account read invalidates the observation`() {
+        let identity = UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")
+        let stable = UsageStore._claudeOAuthActiveAccountObservationForTesting(
+            fingerprintBefore: "fingerprint-B",
+            fingerprintAfter: "fingerprint-B",
+            persistentRefBefore: "ref-B",
+            persistentRefAfter: "ref-B",
+            identity: identity)
+        let changed = UsageStore._claudeOAuthActiveAccountObservationForTesting(
+            fingerprintBefore: "fingerprint-A",
+            fingerprintAfter: "fingerprint-B",
+            persistentRefBefore: "ref-A",
+            persistentRefAfter: "ref-B",
+            identity: identity)
+
+        #expect(stable == .stable(identity: identity))
+        #expect(changed == .changed)
     }
 }

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -1,0 +1,52 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
+    @MainActor
+    @Test
+    func `missing active account identity preserves owner scoped history`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let owner = String(repeating: "c", count: 64)
+        let key = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: owner))
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 35,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        await UsageStore.withActiveClaudeAccountUuidForTesting(nil) {
+            await store.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: snapshot,
+                claudeOAuthHistoryOwnerIdentifier: owner,
+                isClaudeOAuthSample: true)
+        }
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(findSeries(buckets.accounts[key] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [35])
+    }
+
+    @Test
+    func `claude oauth history scope requires full auth fingerprint stability`() {
+        let stablePersistentRefHash = UsageStore._stableClaudeKeychainPersistentRefHashForTesting(
+            beforeFetchFingerprintToken: "stable-fingerprint",
+            afterFetchFingerprintToken: "stable-fingerprint",
+            beforeFetchPersistentRefHash: "stable-ref",
+            afterFetchPersistentRefHash: "stable-ref")
+        let changedFingerprintPersistentRefHash = UsageStore._stableClaudeKeychainPersistentRefHashForTesting(
+            beforeFetchFingerprintToken: "before-fingerprint",
+            afterFetchFingerprintToken: "after-fingerprint",
+            beforeFetchPersistentRefHash: "stable-ref",
+            afterFetchPersistentRefHash: "stable-ref")
+
+        #expect(stablePersistentRefHash == "stable-ref")
+        #expect(changedFingerprintPersistentRefHash == nil)
+    }
+}

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -6,6 +6,38 @@ import Testing
 struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
     @MainActor
     @Test
+    func `established account accepts same owner after access token rotation`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let owner = String(repeating: "a", count: 64)
+        let accountIdentity = UsageStore._activeClaudeAccountIdentityForTesting("uuid-A")
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.snapshot(usedPercent: 30),
+            claudeOAuthPersistentRefHash: "account-a-ref",
+            claudeOAuthHistoryOwnerIdentifier: owner,
+            claudeOAuthActiveAccountObservation: .stable(identity: accountIdentity),
+            isClaudeOAuthSample: true,
+            now: start)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.snapshot(usedPercent: 50),
+            claudeOAuthHistoryOwnerIdentifier: owner,
+            claudeOAuthKeychainCredentialMismatch: true,
+            claudeOAuthActiveAccountObservation: .stable(identity: accountIdentity),
+            isClaudeOAuthSample: true,
+            now: start.addingTimeInterval(2 * 60 * 60))
+
+        let key = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: owner))
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(findSeries(buckets.accounts[key] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [30, 50])
+    }
+
+    @MainActor
+    @Test
     func `first sighting without keychain match is quarantined`() async {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let snapshot = UsageSnapshot(
@@ -152,5 +184,16 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
         #expect(stable == .stable(identity: identityB))
         #expect(changed == .changed)
         #expect(unstable == .changed)
+    }
+
+    private func snapshot(usedPercent: Double) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: usedPercent,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
     }
 }

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -136,21 +136,21 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
 
     @Test
     func `credential change around account read invalidates the observation`() {
-        let identity = UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")
+        let identityA = UsageStore._activeClaudeAccountIdentityForTesting("uuid-A")
+        let identityB = UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")
         let stable = UsageStore._claudeOAuthActiveAccountObservationForTesting(
-            fingerprintBefore: "fingerprint-B",
-            fingerprintAfter: "fingerprint-B",
-            persistentRefBefore: "ref-B",
-            persistentRefAfter: "ref-B",
-            identity: identity)
+            identityBeforeFetch: identityB,
+            identityAfterFetch: identityB)
         let changed = UsageStore._claudeOAuthActiveAccountObservationForTesting(
-            fingerprintBefore: "fingerprint-A",
-            fingerprintAfter: "fingerprint-B",
-            persistentRefBefore: "ref-A",
-            persistentRefAfter: "ref-B",
-            identity: identity)
+            identityBeforeFetch: identityA,
+            identityAfterFetch: identityB)
+        let unstable = UsageStore._claudeOAuthActiveAccountObservationForTesting(
+            identityBeforeFetch: identityB,
+            identityAfterFetch: identityB,
+            beforeFetchWasStable: false)
 
-        #expect(stable == .stable(identity: identity))
+        #expect(stable == .stable(identity: identityB))
         #expect(changed == .changed)
+        #expect(unstable == .changed)
     }
 }

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -105,6 +105,7 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
     @Test
     func `file backed owner records history when keychain comparison is unavailable`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
+        store.settings.claudeOAuthKeychainPromptMode = .never
         let owner = String(repeating: "e", count: 64)
         let key = try #require(
             UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: owner))

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -33,6 +33,36 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
             .entries.map(\.usedPercent) == [35])
     }
 
+    @MainActor
+    @Test
+    func `explicit oauth credential ignores Claude Code account identity`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let owner = String(repeating: "d", count: 64)
+        let key = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: owner))
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 45,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        await UsageStore.withActiveClaudeAccountUuidForTesting("claude-code-account") {
+            await store.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: snapshot,
+                claudeOAuthHistoryOwnerIdentifier: owner,
+                isClaudeOAuthSample: true)
+        }
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(findSeries(buckets.accounts[key] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [45])
+        #expect(UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults).isEmpty)
+    }
+
     @Test
     func `claude oauth history scope requires full auth fingerprint stability`() {
         let stablePersistentRefHash = UsageStore._stableClaudeKeychainPersistentRefHashForTesting(

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -129,9 +129,8 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
 
     @MainActor
     @Test
-    func `never prompt mode still quarantines an owner bound to another account`() async {
+    func `absent keychain still quarantines an owner bound to another account`() async {
         let store = UsageStorePlanUtilizationTests.makeStore()
-        store.settings.claudeOAuthKeychainPromptMode = .never
         let owner = String(repeating: "f", count: 64)
         store.persistClaudeOAuthAccountUuidMap([
             owner: UsageStore._activeClaudeAccountIdentityForTesting("uuid-A"),
@@ -141,12 +140,34 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
             provider: .claude,
             snapshot: self.snapshot(usedPercent: 90),
             claudeOAuthHistoryOwnerIdentifier: owner,
-            claudeOAuthKeychainCredentialUnavailable: true,
+            claudeOAuthKeychainCredentialAbsent: true,
             claudeOAuthActiveAccountObservation: .stable(
                 identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")),
             isClaudeOAuthSample: true)
 
         #expect(store.planUtilizationHistory[.claude] == nil)
+    }
+
+    @MainActor
+    @Test
+    func `absent keychain records an unbound file owner`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let owner = String(repeating: "b", count: 64)
+        let key = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: owner))
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.snapshot(usedPercent: 80),
+            claudeOAuthHistoryOwnerIdentifier: owner,
+            claudeOAuthKeychainCredentialAbsent: true,
+            claudeOAuthActiveAccountObservation: .stable(
+                identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-current")),
+            isClaudeOAuthSample: true)
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(findSeries(buckets.accounts[key] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [80])
     }
 
     @MainActor

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityBoundaryTests.swift
@@ -6,6 +6,37 @@ import Testing
 struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
     @MainActor
     @Test
+    func `claude history without identity falls back to last resolved account`() async {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: snapshot,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let identitylessSnapshot = UsageSnapshot(
+            primary: snapshot.primary,
+            secondary: snapshot.secondary,
+            updatedAt: snapshot.updatedAt)
+        store._setSnapshotForTesting(identitylessSnapshot, provider: .claude)
+
+        let history = store.planUtilizationHistory(for: .claude)
+        #expect(findSeries(history, name: .session, windowMinutes: 300)?.entries.last?.usedPercent == 10)
+        #expect(findSeries(history, name: .weekly, windowMinutes: 10080)?.entries.last?.usedPercent == 20)
+    }
+
+    @MainActor
+    @Test
     func `established account accepts same owner after access token rotation`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let owner = String(repeating: "a", count: 64)
@@ -20,6 +51,14 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
             claudeOAuthActiveAccountObservation: .stable(identity: accountIdentity),
             isClaudeOAuthSample: true,
             now: start)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.snapshot(usedPercent: 30),
+            claudeOAuthPersistentRefHash: "account-a-ref",
+            claudeOAuthHistoryOwnerIdentifier: owner,
+            claudeOAuthActiveAccountObservation: .stable(identity: accountIdentity),
+            isClaudeOAuthSample: true,
+            now: start.addingTimeInterval(30 * 60))
         await store.recordPlanUtilizationHistorySample(
             provider: .claude,
             snapshot: self.snapshot(usedPercent: 50),
@@ -59,6 +98,26 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
             isClaudeOAuthSample: true)
 
         #expect(UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults).isEmpty)
+        #expect(store.planUtilizationHistory[.claude] == nil)
+    }
+
+    @MainActor
+    @Test
+    func `unavailable keychain comparison cannot arm first Claude CLI owner`() async {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: self.snapshot(usedPercent: 90),
+            claudeOAuthHistoryOwnerIdentifier: String(repeating: "u", count: 64),
+            claudeOAuthKeychainCredentialUnavailable: true,
+            claudeOAuthActiveAccountObservation: .stable(
+                identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-current")),
+            isClaudeOAuthSample: true)
+
+        #expect(UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults).isEmpty)
+        #expect(UsageStore.loadClaudeOAuthAccountBindingCandidateMap(
+            from: store.settings.userDefaults).isEmpty)
         #expect(store.planUtilizationHistory[.claude] == nil)
     }
 
@@ -138,8 +197,7 @@ struct UsageStorePlanUtilizationClaudeIdentityBoundaryTests {
                 provider: .claude,
                 snapshot: snapshot,
                 claudeOAuthHistoryOwnerIdentifier: owner,
-                claudeOAuthActiveAccountObservation: .stable(
-                    identity: UsageStore._activeClaudeAccountIdentityForTesting("claude-code-account")),
+                claudeOAuthActiveAccountObservation: .changed,
                 isClaudeOAuthSample: true)
         }
 

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -318,6 +318,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
                     claudeOAuthPersistentRefHash: "account-a-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true,
                     now: hourStart)
             }
@@ -341,6 +342,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
                     claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(2 * 60 * 60))
             }
@@ -366,6 +368,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
                     claudeOAuthPersistentRefHash: "account-b-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerB,
+                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(3 * 60 * 60))
             }
@@ -401,6 +404,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
                     claudeOAuthPersistentRefHash: "account-a-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true,
                     now: hourStart)
             }
@@ -422,6 +426,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
                     claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(2 * 60 * 60))
             }
@@ -445,6 +450,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
                     claudeOAuthPersistentRefHash: "account-b-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerB,
+                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(3 * 60 * 60))
             }
@@ -472,6 +478,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
                     claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: staleOwner,
+                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true)
             }
         }

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -318,7 +318,6 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
                     claudeOAuthPersistentRefHash: "account-a-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
-                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true,
                     now: hourStart)
             }
@@ -342,7 +341,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
                     claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
-                    isClaudeCLIKeychainSample: true,
+                    claudeOAuthKeychainCredentialMismatch: true,
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(2 * 60 * 60))
             }
@@ -368,7 +367,6 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
                     claudeOAuthPersistentRefHash: "account-b-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerB,
-                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(3 * 60 * 60))
             }
@@ -404,7 +402,6 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
                     claudeOAuthPersistentRefHash: "account-a-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
-                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true,
                     now: hourStart)
             }
@@ -426,7 +423,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
                     claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
-                    isClaudeCLIKeychainSample: true,
+                    claudeOAuthKeychainCredentialMismatch: true,
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(2 * 60 * 60))
             }
@@ -450,7 +447,6 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
                     claudeOAuthPersistentRefHash: "account-b-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerB,
-                    isClaudeCLIKeychainSample: true,
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(3 * 60 * 60))
             }
@@ -478,7 +474,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
                     claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: staleOwner,
-                    isClaudeCLIKeychainSample: true,
+                    claudeOAuthKeychainCredentialMismatch: true,
                     isClaudeOAuthSample: true)
             }
         }

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -309,15 +309,18 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: ownerB))
         let hourStart = Date(timeIntervalSince1970: 1_700_000_000)
 
-        // 1) Active account A (~/.claude.json = uuid-A): owner_A sample binds to A and writes to key_A.
+        // 1) Active account A (~/.claude.json = uuid-A). A USER-INITIATED refresh ran the keychain freshness
+        //    sync, so the served owner_A is trustworthy: it binds to A and writes to key_A.
         try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-A") {
-            await store.recordPlanUtilizationHistorySample(
-                provider: .claude,
-                snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
-                claudeOAuthPersistentRefHash: "account-a-ref",
-                claudeOAuthHistoryOwnerIdentifier: ownerA,
-                isClaudeOAuthSample: true,
-                now: hourStart)
+            await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                await store.recordPlanUtilizationHistorySample(
+                    provider: .claude,
+                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
+                    claudeOAuthPersistentRefHash: "account-a-ref",
+                    claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    isClaudeOAuthSample: true,
+                    now: hourStart)
+            }
         }
 
         do {
@@ -327,16 +330,20 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             #expect(buckets.unscoped.isEmpty)
         }
 
-        // 2) `/login` switched the active account to B (~/.claude.json = uuid-B), but the gated background
-        //    poll still serves the STALE owner_A credential. This must be quarantined: no new sample lands.
+        // 2) `/login` switched the active account to B (~/.claude.json = uuid-B), but the gated BACKGROUND
+        //    poll still serves the STALE owner_A credential. The existing owner_A -> uuid-A binding (created
+        //    in step 1) is authoritative and detects the mismatch, so this must be quarantined even though it
+        //    is a background poll: no new sample lands.
         try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
-            await store.recordPlanUtilizationHistorySample(
-                provider: .claude,
-                snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
-                claudeOAuthPersistentRefHash: "account-a-ref",
-                claudeOAuthHistoryOwnerIdentifier: ownerA,
-                isClaudeOAuthSample: true,
-                now: hourStart.addingTimeInterval(2 * 60 * 60))
+            await ProviderInteractionContext.$current.withValue(.background) {
+                await store.recordPlanUtilizationHistorySample(
+                    provider: .claude,
+                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
+                    claudeOAuthPersistentRefHash: "account-a-ref",
+                    claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    isClaudeOAuthSample: true,
+                    now: hourStart.addingTimeInterval(2 * 60 * 60))
+            }
         }
 
         do {
@@ -350,16 +357,19 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             #expect(buckets.accounts[keyB] == nil)
         }
 
-        // 3) A user-initiated refresh yields account B's real credential (owner_B). Recovery: writes to key_B,
-        //    key_A stays untouched.
+        // 3) A USER-INITIATED refresh yields account B's real credential (owner_B); the freshness sync makes
+        //    the served owner trustworthy so it binds owner_B -> uuid-B. Recovery: writes to key_B, key_A
+        //    stays untouched.
         try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
-            await store.recordPlanUtilizationHistorySample(
-                provider: .claude,
-                snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
-                claudeOAuthPersistentRefHash: "account-b-ref",
-                claudeOAuthHistoryOwnerIdentifier: ownerB,
-                isClaudeOAuthSample: true,
-                now: hourStart.addingTimeInterval(3 * 60 * 60))
+            await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                await store.recordPlanUtilizationHistorySample(
+                    provider: .claude,
+                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
+                    claudeOAuthPersistentRefHash: "account-b-ref",
+                    claudeOAuthHistoryOwnerIdentifier: ownerB,
+                    isClaudeOAuthSample: true,
+                    now: hourStart.addingTimeInterval(3 * 60 * 60))
+            }
         }
 
         let buckets = try #require(store.planUtilizationHistory[.claude])
@@ -367,6 +377,83 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             .entries.map(\.usedPercent) == [75])
         #expect(findSeries(buckets.accounts[keyA] ?? [], name: .session, windowMinutes: 300)?
             .entries.map(\.usedPercent) == [30])
+        #expect(buckets.unscoped.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func `background first sighting does not poison the account map`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let ownerA = self.oauthOwnerIdentifier("a")
+        let ownerB = self.oauthOwnerIdentifier("b")
+        let keyB = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: ownerB))
+        let hourStart = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // 1) First run after upgrading: the account UUID map is EMPTY. A BACKGROUND poll serves owner_A while
+        //    ~/.claude.json still reports uuid-A. Because the freshness sync is gated on a background poll, the
+        //    served owner is NOT trustworthy for creating a binding: fail-open writes the sample (key_A bucket)
+        //    but must NOT persist any owner_A binding.
+        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-A") {
+            await ProviderInteractionContext.$current.withValue(.background) {
+                await store.recordPlanUtilizationHistorySample(
+                    provider: .claude,
+                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
+                    claudeOAuthPersistentRefHash: "account-a-ref",
+                    claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    isClaudeOAuthSample: true,
+                    now: hourStart)
+            }
+        }
+
+        // 2) `/login` switched to account B (~/.claude.json = uuid-B), but the gated BACKGROUND poll still
+        //    serves the STALE owner_A credential. This is the Codex P2 scenario: with an unmapped owner, the
+        //    naive first-sighting bind would persist owner_A -> uuid-B, POISONING the map. The fix must NOT
+        //    create that (or any) binding for owner_A on a background poll.
+        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
+            await ProviderInteractionContext.$current.withValue(.background) {
+                await store.recordPlanUtilizationHistorySample(
+                    provider: .claude,
+                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
+                    claudeOAuthPersistentRefHash: "account-a-ref",
+                    claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    isClaudeOAuthSample: true,
+                    now: hourStart.addingTimeInterval(2 * 60 * 60))
+            }
+        }
+
+        do {
+            let mapAfterBackground = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
+            // No poison: owner_A was never bound to uuid-B. Stronger: no binding for owner_A exists at all,
+            // because a background poll can never create a first-sighting binding.
+            #expect(mapAfterBackground[ownerA] == nil)
+            #expect(mapAfterBackground["uuid-B"] == nil)
+            let buckets = try #require(store.planUtilizationHistory[.claude])
+            #expect(buckets.unscoped.isEmpty)
+        }
+
+        // 3) A USER-INITIATED refresh yields account B's real credential (owner_B). The freshness sync ran, so
+        //    the served owner is trustworthy: this CREATES the owner_B -> uuid-B binding (arming the quarantine)
+        //    and writes to key_B. This proves the primary #1886 fix still arms via normal user-initiated use.
+        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
+            await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                await store.recordPlanUtilizationHistorySample(
+                    provider: .claude,
+                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
+                    claudeOAuthPersistentRefHash: "account-b-ref",
+                    claudeOAuthHistoryOwnerIdentifier: ownerB,
+                    isClaudeOAuthSample: true,
+                    now: hourStart.addingTimeInterval(3 * 60 * 60))
+            }
+        }
+
+        let mapAfterRecovery = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
+        // User-initiated (not background) is what creates the binding.
+        #expect(mapAfterRecovery[ownerB] == "uuid-B")
+        #expect(mapAfterRecovery[ownerA] == nil)
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(findSeries(buckets.accounts[keyB] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [75])
         #expect(buckets.unscoped.isEmpty)
     }
 

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -299,6 +299,79 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
+    func `same dir account switch quarantines stale background credential`() async throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let ownerA = self.oauthOwnerIdentifier("a")
+        let ownerB = self.oauthOwnerIdentifier("b")
+        let keyA = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: ownerA))
+        let keyB = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: ownerB))
+        let hourStart = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // 1) Active account A (~/.claude.json = uuid-A): owner_A sample binds to A and writes to key_A.
+        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-A") {
+            await store.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
+                claudeOAuthPersistentRefHash: "account-a-ref",
+                claudeOAuthHistoryOwnerIdentifier: ownerA,
+                isClaudeOAuthSample: true,
+                now: hourStart)
+        }
+
+        do {
+            let buckets = try #require(store.planUtilizationHistory[.claude])
+            #expect(findSeries(buckets.accounts[keyA] ?? [], name: .session, windowMinutes: 300)?
+                .entries.map(\.usedPercent) == [30])
+            #expect(buckets.unscoped.isEmpty)
+        }
+
+        // 2) `/login` switched the active account to B (~/.claude.json = uuid-B), but the gated background
+        //    poll still serves the STALE owner_A credential. This must be quarantined: no new sample lands.
+        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
+            await store.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
+                claudeOAuthPersistentRefHash: "account-a-ref",
+                claudeOAuthHistoryOwnerIdentifier: ownerA,
+                isClaudeOAuthSample: true,
+                now: hourStart.addingTimeInterval(2 * 60 * 60))
+        }
+
+        do {
+            let buckets = try #require(store.planUtilizationHistory[.claude])
+            // key_A history is UNCHANGED (the stale sample was dropped, not appended).
+            #expect(findSeries(buckets.accounts[keyA] ?? [], name: .session, windowMinutes: 300)?
+                .entries.map(\.usedPercent) == [30])
+            // Critically, the quarantined sample did NOT leak into the shared unscoped bucket. This is the
+            // assertion that catches the naive-nil bug (nil accountKey writes to `unscoped`, not nowhere).
+            #expect(buckets.unscoped.isEmpty)
+            #expect(buckets.accounts[keyB] == nil)
+        }
+
+        // 3) A user-initiated refresh yields account B's real credential (owner_B). Recovery: writes to key_B,
+        //    key_A stays untouched.
+        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
+            await store.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
+                claudeOAuthPersistentRefHash: "account-b-ref",
+                claudeOAuthHistoryOwnerIdentifier: ownerB,
+                isClaudeOAuthSample: true,
+                now: hourStart.addingTimeInterval(3 * 60 * 60))
+        }
+
+        let buckets = try #require(store.planUtilizationHistory[.claude])
+        #expect(findSeries(buckets.accounts[keyB] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [75])
+        #expect(findSeries(buckets.accounts[keyA] ?? [], name: .session, windowMinutes: 300)?
+            .entries.map(\.usedPercent) == [30])
+        #expect(buckets.unscoped.isEmpty)
+    }
+
+    @MainActor
+    @Test
     func `coalesced claude oauth sample without owner cannot switch preferred account`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let scopedOwner = self.oauthOwnerIdentifier("c")

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -407,7 +407,10 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         }
 
         let mapAfterFirstSample = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
-        #expect(mapAfterFirstSample[ownerA] == "uuid-A")
+        let accountAIdentity = UsageStore._activeClaudeAccountIdentityForTesting("uuid-A")
+        let accountBIdentity = UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")
+        #expect(mapAfterFirstSample[ownerA] == accountAIdentity)
+        #expect(mapAfterFirstSample[ownerA] != "uuid-A")
 
         // 2) `/login` switched to account B (~/.claude.json = uuid-B), but the gated BACKGROUND poll still
         //    serves the stale owner_A credential. It no longer matches the current Keychain item, and the
@@ -426,7 +429,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
         do {
             let mapAfterBackground = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
-            #expect(mapAfterBackground[ownerA] == "uuid-A")
+            #expect(mapAfterBackground[ownerA] == accountAIdentity)
             let buckets = try #require(store.planUtilizationHistory[.claude])
             #expect(findSeries(buckets.accounts[keyA] ?? [], name: .session, windowMinutes: 300)?
                 .entries.map(\.usedPercent) == [30])
@@ -448,8 +451,8 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         }
 
         let mapAfterRecovery = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
-        #expect(mapAfterRecovery[ownerB] == "uuid-B")
-        #expect(mapAfterRecovery[ownerA] == "uuid-A")
+        #expect(mapAfterRecovery[ownerB] == accountBIdentity)
+        #expect(mapAfterRecovery[ownerA] == accountAIdentity)
         let buckets = try #require(store.planUtilizationHistory[.claude])
         #expect(findSeries(buckets.accounts[keyB] ?? [], name: .session, windowMinutes: 300)?
             .entries.map(\.usedPercent) == [75])
@@ -458,7 +461,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
-    func `user initiated first sighting without keychain match does not bind`() async {
+    func `first sighting without keychain match is quarantined`() async {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let staleOwner = self.oauthOwnerIdentifier("s")
 
@@ -475,6 +478,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
         let map = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
         #expect(map[staleOwner] == nil)
+        #expect(store.planUtilizationHistory[.claude] == nil)
     }
 
     @MainActor
@@ -650,18 +654,20 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         let accountBKey = try #require(UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(
             historyOwnerIdentifier: accountBOwner))
 
-        await store.recordPlanUtilizationHistorySample(
-            provider: .claude,
-            snapshot: self.identitylessClaudeSnapshot(usedPercent: 10),
-            claudeOAuthHistoryOwnerIdentifier: accountAOwner,
-            isClaudeOAuthSample: true,
-            now: Date(timeIntervalSince1970: 1_700_000_000))
-        await store.recordPlanUtilizationHistorySample(
-            provider: .claude,
-            snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
-            claudeOAuthHistoryOwnerIdentifier: accountBOwner,
-            isClaudeOAuthSample: true,
-            now: Date(timeIntervalSince1970: 1_700_007_200))
+        await UsageStore.withActiveClaudeAccountUuidForTesting(nil) {
+            await store.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: self.identitylessClaudeSnapshot(usedPercent: 10),
+                claudeOAuthHistoryOwnerIdentifier: accountAOwner,
+                isClaudeOAuthSample: true,
+                now: Date(timeIntervalSince1970: 1_700_000_000))
+            await store.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
+                claudeOAuthHistoryOwnerIdentifier: accountBOwner,
+                isClaudeOAuthSample: true,
+                now: Date(timeIntervalSince1970: 1_700_007_200))
+        }
 
         let buckets = try #require(store.planUtilizationHistory[.claude])
         #expect(buckets.unscoped.isEmpty)
@@ -738,23 +744,6 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         #expect(first != owner)
         #expect(first.hasPrefix("__claude_oauth__:"))
         #expect(first.dropFirst("__claude_oauth__:".count).count == 64)
-    }
-
-    @Test
-    func `claude oauth history scope requires full auth fingerprint stability`() {
-        let stablePersistentRefHash = UsageStore._stableClaudeKeychainPersistentRefHashForTesting(
-            beforeFetchFingerprintToken: "stable-fingerprint",
-            afterFetchFingerprintToken: "stable-fingerprint",
-            beforeFetchPersistentRefHash: "stable-ref",
-            afterFetchPersistentRefHash: "stable-ref")
-        let changedFingerprintPersistentRefHash = UsageStore._stableClaudeKeychainPersistentRefHashForTesting(
-            beforeFetchFingerprintToken: "before-fingerprint",
-            afterFetchFingerprintToken: "after-fingerprint",
-            beforeFetchPersistentRefHash: "stable-ref",
-            afterFetchPersistentRefHash: "stable-ref")
-
-        #expect(stablePersistentRefHash == "stable-ref")
-        #expect(changedFingerprintPersistentRefHash == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -309,9 +309,9 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: ownerB))
         let hourStart = Date(timeIntervalSince1970: 1_700_000_000)
 
-        // 1) Active account A (~/.claude.json = uuid-A). A USER-INITIATED refresh ran the keychain freshness
-        //    sync, so the served owner_A is trustworthy: it binds to A and writes to key_A.
-        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-A") {
+        // 1) Active account A (~/.claude.json = uuid-A). The credential used for this fetch exactly matches
+        //    the current Claude Keychain item, so owner_A is trustworthy: it binds to A and writes to key_A.
+        await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-A") {
             await ProviderInteractionContext.$current.withValue(.userInitiated) {
                 await store.recordPlanUtilizationHistorySample(
                     provider: .claude,
@@ -334,12 +334,12 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         //    poll still serves the STALE owner_A credential. The existing owner_A -> uuid-A binding (created
         //    in step 1) is authoritative and detects the mismatch, so this must be quarantined even though it
         //    is a background poll: no new sample lands.
-        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
+        await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
             await ProviderInteractionContext.$current.withValue(.background) {
                 await store.recordPlanUtilizationHistorySample(
                     provider: .claude,
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
-                    claudeOAuthPersistentRefHash: "account-a-ref",
+                    claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(2 * 60 * 60))
@@ -357,10 +357,9 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             #expect(buckets.accounts[keyB] == nil)
         }
 
-        // 3) A USER-INITIATED refresh yields account B's real credential (owner_B); the freshness sync makes
-        //    the served owner trustworthy so it binds owner_B -> uuid-B. Recovery: writes to key_B, key_A
-        //    stays untouched.
-        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
+        // 3) A USER-INITIATED refresh yields account B's real credential (owner_B), with exact current-Keychain
+        //    match evidence. Recovery: bind owner_B -> uuid-B, write to key_B, and leave key_A untouched.
+        await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
             await ProviderInteractionContext.$current.withValue(.userInitiated) {
                 await store.recordPlanUtilizationHistorySample(
                     provider: .claude,
@@ -382,19 +381,20 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
-    func `background first sighting does not poison the account map`() async throws {
+    func `exact keychain match arms account map on background poll`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let ownerA = self.oauthOwnerIdentifier("a")
         let ownerB = self.oauthOwnerIdentifier("b")
+        let keyA = try #require(
+            UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: ownerA))
         let keyB = try #require(
             UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: ownerB))
         let hourStart = Date(timeIntervalSince1970: 1_700_000_000)
 
-        // 1) First run after upgrading: the account UUID map is EMPTY. A BACKGROUND poll serves owner_A while
-        //    ~/.claude.json still reports uuid-A. Because the freshness sync is gated on a background poll, the
-        //    served owner is NOT trustworthy for creating a binding: fail-open writes the sample (key_A bucket)
-        //    but must NOT persist any owner_A binding.
-        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-A") {
+        // 1) First run after upgrading: the map is empty. A background poll serves owner_A while
+        //    ~/.claude.json reports uuid-A, and exact current-Keychain evidence corroborates the credential.
+        //    This is safe to bind even though the interaction is background.
+        await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-A") {
             await ProviderInteractionContext.$current.withValue(.background) {
                 await store.recordPlanUtilizationHistorySample(
                     provider: .claude,
@@ -406,16 +406,18 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             }
         }
 
+        let mapAfterFirstSample = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
+        #expect(mapAfterFirstSample[ownerA] == "uuid-A")
+
         // 2) `/login` switched to account B (~/.claude.json = uuid-B), but the gated BACKGROUND poll still
-        //    serves the STALE owner_A credential. This is the Codex P2 scenario: with an unmapped owner, the
-        //    naive first-sighting bind would persist owner_A -> uuid-B, POISONING the map. The fix must NOT
-        //    create that (or any) binding for owner_A on a background poll.
-        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
+        //    serves the stale owner_A credential. It no longer matches the current Keychain item, and the
+        //    existing owner_A -> uuid-A binding detects the UUID mismatch, so the sample is quarantined.
+        await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
             await ProviderInteractionContext.$current.withValue(.background) {
                 await store.recordPlanUtilizationHistorySample(
                     provider: .claude,
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
-                    claudeOAuthPersistentRefHash: "account-a-ref",
+                    claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(2 * 60 * 60))
@@ -424,19 +426,17 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
         do {
             let mapAfterBackground = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
-            // No poison: owner_A was never bound to uuid-B. Stronger: no binding for owner_A exists at all,
-            // because a background poll can never create a first-sighting binding.
-            #expect(mapAfterBackground[ownerA] == nil)
-            #expect(mapAfterBackground["uuid-B"] == nil)
+            #expect(mapAfterBackground[ownerA] == "uuid-A")
             let buckets = try #require(store.planUtilizationHistory[.claude])
+            #expect(findSeries(buckets.accounts[keyA] ?? [], name: .session, windowMinutes: 300)?
+                .entries.map(\.usedPercent) == [30])
             #expect(buckets.unscoped.isEmpty)
         }
 
-        // 3) A USER-INITIATED refresh yields account B's real credential (owner_B). The freshness sync ran, so
-        //    the served owner is trustworthy: this CREATES the owner_B -> uuid-B binding (arming the quarantine)
-        //    and writes to key_B. This proves the primary #1886 fix still arms via normal user-initiated use.
-        try await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
-            await ProviderInteractionContext.$current.withValue(.userInitiated) {
+        // 3) A background poll now yields account B's real credential (owner_B) with exact current-Keychain
+        //    match evidence. That evidence, not the interaction label, binds owner_B -> uuid-B and writes key_B.
+        await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
+            await ProviderInteractionContext.$current.withValue(.background) {
                 await store.recordPlanUtilizationHistorySample(
                     provider: .claude,
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
@@ -448,13 +448,33 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         }
 
         let mapAfterRecovery = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
-        // User-initiated (not background) is what creates the binding.
         #expect(mapAfterRecovery[ownerB] == "uuid-B")
-        #expect(mapAfterRecovery[ownerA] == nil)
+        #expect(mapAfterRecovery[ownerA] == "uuid-A")
         let buckets = try #require(store.planUtilizationHistory[.claude])
         #expect(findSeries(buckets.accounts[keyB] ?? [], name: .session, windowMinutes: 300)?
             .entries.map(\.usedPercent) == [75])
         #expect(buckets.unscoped.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func `user initiated first sighting without keychain match does not bind`() async {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let staleOwner = self.oauthOwnerIdentifier("s")
+
+        await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-current") {
+            await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                await store.recordPlanUtilizationHistorySample(
+                    provider: .claude,
+                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
+                    claudeOAuthPersistentRefHash: nil,
+                    claudeOAuthHistoryOwnerIdentifier: staleOwner,
+                    isClaudeOAuthSample: true)
+            }
+        }
+
+        let map = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
+        #expect(map[staleOwner] == nil)
     }
 
     @MainActor

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -311,9 +311,9 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         }
 
         // 2) `/login` switched the active account to B (~/.claude.json = uuid-B), but the gated BACKGROUND
-        //    poll still serves the STALE owner_A credential. The existing owner_A -> uuid-A binding (created
-        //    in step 1) is authoritative and detects the mismatch, so this must be quarantined even though it
-        //    is a background poll: no new sample lands.
+        //    poll still serves the STALE owner_A credential. Prompt-free Keychain comparison is unavailable,
+        //    but the existing owner_A -> uuid-A binding detects the mismatch, so this must be quarantined:
+        //    no new sample lands.
         await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
             await ProviderInteractionContext.$current.withValue(.background) {
                 await store.recordPlanUtilizationHistorySample(
@@ -321,7 +321,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
                     claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
-                    claudeOAuthKeychainCredentialMismatch: true,
+                    claudeOAuthKeychainCredentialUnavailable: true,
                     claudeOAuthActiveAccountObservation: .stable(
                         identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")),
                     isClaudeOAuthSample: true,

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -101,37 +101,6 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
     @MainActor
     @Test
-    func `claude history without identity falls back to last resolved account`() async {
-        let store = UsageStorePlanUtilizationTests.makeStore()
-        let snapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
-            secondary: RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
-            updatedAt: Date(),
-            identity: ProviderIdentitySnapshot(
-                providerID: .claude,
-                accountEmail: "alice@example.com",
-                accountOrganization: nil,
-                loginMethod: "max"))
-        store._setSnapshotForTesting(snapshot, provider: .claude)
-
-        await store.recordPlanUtilizationHistorySample(
-            provider: .claude,
-            snapshot: snapshot,
-            now: Date(timeIntervalSince1970: 1_700_000_000))
-
-        let identitylessSnapshot = UsageSnapshot(
-            primary: snapshot.primary,
-            secondary: snapshot.secondary,
-            updatedAt: snapshot.updatedAt)
-        store._setSnapshotForTesting(identitylessSnapshot, provider: .claude)
-
-        let history = store.planUtilizationHistory(for: .claude)
-        #expect(findSeries(history, name: .session, windowMinutes: 300)?.entries.last?.usedPercent == 10)
-        #expect(findSeries(history, name: .weekly, windowMinutes: 10080)?.entries.last?.usedPercent == 20)
-    }
-
-    @MainActor
-    @Test
     func `claude oauth credential owner separates switched account history`() async throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let accountBOwner = self.oauthOwnerIdentifier("b")
@@ -309,8 +278,8 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             UsageStore._claudeOAuthPlanUtilizationAccountKeyForTesting(historyOwnerIdentifier: ownerB))
         let hourStart = Date(timeIntervalSince1970: 1_700_000_000)
 
-        // 1) Active account A (~/.claude.json = uuid-A). The credential used for this fetch exactly matches
-        //    the current Claude Keychain item, so owner_A is trustworthy: it binds to A and writes to key_A.
+        // 1) Active account A (~/.claude.json = uuid-A). Two stable exact-Keychain observations bind owner_A
+        //    to A; the short confirmation interval does not add a second history point.
         await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-A") {
             await ProviderInteractionContext.$current.withValue(.userInitiated) {
                 await store.recordPlanUtilizationHistorySample(
@@ -322,6 +291,15 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                         identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-A")),
                     isClaudeOAuthSample: true,
                     now: hourStart)
+                await store.recordPlanUtilizationHistorySample(
+                    provider: .claude,
+                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
+                    claudeOAuthPersistentRefHash: "account-a-ref",
+                    claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    claudeOAuthActiveAccountObservation: .stable(
+                        identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-A")),
+                    isClaudeOAuthSample: true,
+                    now: hourStart.addingTimeInterval(30 * 60))
             }
         }
 
@@ -400,7 +378,7 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
 
         // 1) First run after upgrading: the map is empty. A background poll serves owner_A while
         //    ~/.claude.json reports uuid-A, and exact current-Keychain evidence corroborates the credential.
-        //    This is safe to bind even though the interaction is background.
+        //    The first observation stages a candidate; a later identical observation confirms the binding.
         await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-A") {
             await ProviderInteractionContext.$current.withValue(.background) {
                 await store.recordPlanUtilizationHistorySample(
@@ -415,11 +393,26 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             }
         }
 
-        let mapAfterFirstSample = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
         let accountAIdentity = UsageStore._activeClaudeAccountIdentityForTesting("uuid-A")
         let accountBIdentity = UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")
-        #expect(mapAfterFirstSample[ownerA] == accountAIdentity)
-        #expect(mapAfterFirstSample[ownerA] != "uuid-A")
+        #expect(UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)[ownerA] == nil)
+        #expect(UsageStore.loadClaudeOAuthAccountBindingCandidateMap(
+            from: store.settings.userDefaults)[ownerA]?.identity == accountAIdentity)
+
+        await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-A") {
+            await ProviderInteractionContext.$current.withValue(.background) {
+                await store.recordPlanUtilizationHistorySample(
+                    provider: .claude,
+                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
+                    claudeOAuthPersistentRefHash: "account-a-ref",
+                    claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    claudeOAuthActiveAccountObservation: .stable(identity: accountAIdentity),
+                    isClaudeOAuthSample: true,
+                    now: hourStart.addingTimeInterval(30 * 60))
+            }
+        }
+        #expect(UsageStore.loadClaudeOAuthAccountUuidMap(
+            from: store.settings.userDefaults)[ownerA] == accountAIdentity)
 
         // 2) `/login` switched to account B (~/.claude.json = uuid-B), but the gated BACKGROUND poll still
         //    serves the stale owner_A credential. It no longer matches the current Keychain item, and the
@@ -461,6 +454,20 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                         identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")),
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(3 * 60 * 60))
+            }
+        }
+
+        #expect(UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)[ownerB] == nil)
+        await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-B") {
+            await ProviderInteractionContext.$current.withValue(.background) {
+                await store.recordPlanUtilizationHistorySample(
+                    provider: .claude,
+                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
+                    claudeOAuthPersistentRefHash: "account-b-ref",
+                    claudeOAuthHistoryOwnerIdentifier: ownerB,
+                    claudeOAuthActiveAccountObservation: .stable(identity: accountBIdentity),
+                    isClaudeOAuthSample: true,
+                    now: hourStart.addingTimeInterval(3 * 60 * 60 + 30 * 60))
             }
         }
 

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -318,6 +318,8 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
                     claudeOAuthPersistentRefHash: "account-a-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    claudeOAuthActiveAccountObservation: .stable(
+                        identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-A")),
                     isClaudeOAuthSample: true,
                     now: hourStart)
             }
@@ -342,6 +344,8 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
                     claudeOAuthKeychainCredentialMismatch: true,
+                    claudeOAuthActiveAccountObservation: .stable(
+                        identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")),
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(2 * 60 * 60))
             }
@@ -367,6 +371,8 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
                     claudeOAuthPersistentRefHash: "account-b-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerB,
+                    claudeOAuthActiveAccountObservation: .stable(
+                        identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")),
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(3 * 60 * 60))
             }
@@ -402,6 +408,8 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 30),
                     claudeOAuthPersistentRefHash: "account-a-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
+                    claudeOAuthActiveAccountObservation: .stable(
+                        identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-A")),
                     isClaudeOAuthSample: true,
                     now: hourStart)
             }
@@ -424,6 +432,8 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     claudeOAuthPersistentRefHash: nil,
                     claudeOAuthHistoryOwnerIdentifier: ownerA,
                     claudeOAuthKeychainCredentialMismatch: true,
+                    claudeOAuthActiveAccountObservation: .stable(
+                        identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")),
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(2 * 60 * 60))
             }
@@ -447,6 +457,8 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
                     snapshot: self.identitylessClaudeSnapshot(usedPercent: 75),
                     claudeOAuthPersistentRefHash: "account-b-ref",
                     claudeOAuthHistoryOwnerIdentifier: ownerB,
+                    claudeOAuthActiveAccountObservation: .stable(
+                        identity: UsageStore._activeClaudeAccountIdentityForTesting("uuid-B")),
                     isClaudeOAuthSample: true,
                     now: hourStart.addingTimeInterval(3 * 60 * 60))
             }
@@ -459,29 +471,6 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
         #expect(findSeries(buckets.accounts[keyB] ?? [], name: .session, windowMinutes: 300)?
             .entries.map(\.usedPercent) == [75])
         #expect(buckets.unscoped.isEmpty)
-    }
-
-    @MainActor
-    @Test
-    func `first sighting without keychain match is quarantined`() async {
-        let store = UsageStorePlanUtilizationTests.makeStore()
-        let staleOwner = self.oauthOwnerIdentifier("s")
-
-        await UsageStore.withActiveClaudeAccountUuidForTesting("uuid-current") {
-            await ProviderInteractionContext.$current.withValue(.userInitiated) {
-                await store.recordPlanUtilizationHistorySample(
-                    provider: .claude,
-                    snapshot: self.identitylessClaudeSnapshot(usedPercent: 90),
-                    claudeOAuthPersistentRefHash: nil,
-                    claudeOAuthHistoryOwnerIdentifier: staleOwner,
-                    claudeOAuthKeychainCredentialMismatch: true,
-                    isClaudeOAuthSample: true)
-            }
-        }
-
-        let map = UsageStore.loadClaudeOAuthAccountUuidMap(from: store.settings.userDefaults)
-        #expect(map[staleOwner] == nil)
-        #expect(store.planUtilizationHistory[.claude] == nil)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Addresses the history-isolation portion of #1886.

Claude Code can update the shared Keychain item and `~/.claude.json` during `/login` while `~/.claude/.credentials.json` remains stale. A background refresh could then attribute a successful OAuth sample to the wrong account-history lifecycle.

## Final design

- Derives an opaque history owner from the exact OAuth credential used for the successful fetch; raw tokens are never persisted.
- Brackets the fetch with prompt-free credential/account observations and rejects evidence that changes mid-fetch.
- Distinguishes exact Keychain match, mismatch, proven absence, and unavailable comparison.
- Confirms new owner-to-account bindings with two stable exact-match observations; existing bindings quarantine stale samples after an observed account switch.
- Keeps supported file-only and default background refreshes recording into their credential-owned bucket when no authoritative binding exists.
- Preserves explicit/environment credentials and proven refresh-token rotation lineage.
- Stores only hashed account identities and opaque credential-owner identifiers.

This intentionally does not change visible menu snapshot selection. #1886 should remain open for that remaining behavior.

## Proof

- `swift test --filter 'ClaudeOAuthHistoryCredentialRoutingTests|UsageStorePlanUtilizationClaudeIdentity'` — 37 tests passed across 3 suites.
- `make check` — clean; SwiftFormat and strict SwiftLint passed.
- `make test` — all 47 shards passed.
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.

Exact reviewed head: `bfe9ccda2ba7c07db6648ba246e1a63eed2cfe99`

## Notes

- No UI change; no screenshots required.
- No dependency or Keychain-prompt policy change.
- Contributor live reproduction established the original same-directory `/login` behavior; maintainer hardening and isolated regression tests cover the final evidence boundary.
