### PR TITLE
ci: modernize build toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,20 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SWIFT_VERSION: 6.2.1
+  SWIFT_VERSION: 6.3.3
+  SWIFTLY_VERSION: 1.1.3
+  SWIFTLY_SIGNING_FINGERPRINT: E813C892820A6FA13755B268F167DF1ACF9CE069
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       macos-tests: ${{ steps.macos-tests.outputs.macos-tests }}
       macos-tests-reason: ${{ steps.macos-tests.outputs.macos-tests-reason }}
       changed-path-count: ${{ steps.macos-tests.outputs.changed-path-count }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -72,10 +74,10 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install lint tools
         run: ./Scripts/install_lint_tools.sh swiftlint
@@ -86,7 +88,7 @@ jobs:
   swift-test-macos:
     needs: changes
     if: ${{ needs.changes.outputs.macos-tests == 'true' }}
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -94,12 +96,12 @@ jobs:
         shard-index: [0, 1, 2, 3]
         shard-count: [4]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Select Xcode 26.1.1 (if present) or fallback to default
+      - name: Select Xcode 26.6 (if present) or fallback to default
         run: |
           set -euo pipefail
-          for candidate in /Applications/Xcode_26.1.1.app /Applications/Xcode_26.1.app /Applications/Xcode.app; do
+          for candidate in /Applications/Xcode_26.6.app /Applications/Xcode_26.5.app /Applications/Xcode.app; do
             if [[ -d "$candidate" ]]; then
               sudo xcode-select -s "${candidate}/Contents/Developer"
               echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
@@ -149,7 +151,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   lint-build-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs:
       - changes
@@ -157,7 +159,7 @@ jobs:
       - swift-test-macos
     if: ${{ always() && !cancelled() }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Verify lint and macOS test jobs
         run: |
@@ -203,7 +205,7 @@ jobs:
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Runner info
         run: |
@@ -213,10 +215,10 @@ jobs:
 
       - name: Restore Swift toolchain cache
         id: swift-toolchain-cache
-        uses: actions/cache@v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.local/share/swiftly
-          key: swift-${{ runner.os }}-${{ runner.arch }}-${{ env.SWIFT_VERSION }}-v2
+          key: swift-${{ runner.os }}-${{ runner.arch }}-${{ env.SWIFT_VERSION }}-swiftly-${{ env.SWIFTLY_VERSION }}
 
       - name: Install Swift ${{ env.SWIFT_VERSION }} via swiftly
         shell: bash
@@ -235,14 +237,26 @@ jobs:
           fi
 
           SWIFTLY_ARCH="$(uname -m)"
+          SWIFTLY_ARCHIVE="$RUNNER_TEMP/swiftly-${SWIFTLY_VERSION}-${SWIFTLY_ARCH}.tar.gz"
+          SWIFTLY_SIGNATURE="${SWIFTLY_ARCHIVE}.sig"
           SWIFTLY_HOME_DIR="$HOME/.local/share/swiftly"
           SWIFTLY_BIN_DIR="$HOME/.local/bin"
+          SWIFT_GNUPGHOME="$(mktemp -d)"
+          SWIFT_KEYS="$RUNNER_TEMP/swift-signing-keys.asc"
           POST_INSTALL_SCRIPT="$(mktemp)"
 
           mkdir -p "$SWIFTLY_BIN_DIR"
+          chmod 700 "$SWIFT_GNUPGHOME"
           echo "Swift toolchain cache hit: ${{ steps.swift-toolchain-cache.outputs.cache-hit }}"
-          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${SWIFTLY_ARCH}.tar.gz" -o /tmp/swiftly.tar.gz
-          tar -xzf /tmp/swiftly.tar.gz -C /tmp
+          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${SWIFTLY_VERSION}-${SWIFTLY_ARCH}.tar.gz" -o "$SWIFTLY_ARCHIVE"
+          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${SWIFTLY_VERSION}-${SWIFTLY_ARCH}.tar.gz.sig" -o "$SWIFTLY_SIGNATURE"
+          curl -fsSL --compressed "https://www.swift.org/keys/all-keys.asc" -o "$SWIFT_KEYS"
+          GNUPGHOME="$SWIFT_GNUPGHOME" gpg --batch --import "$SWIFT_KEYS"
+          SIGNATURE_STATUS="$(GNUPGHOME="$SWIFT_GNUPGHOME" gpg --batch --status-fd=1 \
+            --verify "$SWIFTLY_SIGNATURE" "$SWIFTLY_ARCHIVE" 2>&1)"
+          printf '%s\n' "$SIGNATURE_STATUS"
+          grep -Fq "[GNUPG:] VALIDSIG ${SWIFTLY_SIGNING_FINGERPRINT} " <<< "$SIGNATURE_STATUS"
+          tar -xzf "$SWIFTLY_ARCHIVE" -C /tmp
           /tmp/swiftly init --assume-yes --skip-install
 
           . "$SWIFTLY_HOME_DIR/env.sh"
@@ -250,7 +264,7 @@ jobs:
           echo "SWIFTLY_HOME_DIR=$SWIFTLY_HOME_DIR" >> "$GITHUB_ENV"
           echo "SWIFTLY_BIN_DIR=$SWIFTLY_BIN_DIR" >> "$GITHUB_ENV"
 
-          swiftly install "$SWIFT_VERSION" --use --assume-yes --post-install-file "$POST_INSTALL_SCRIPT"
+          swiftly install "$SWIFT_VERSION" --use --assume-yes --verify --post-install-file "$POST_INSTALL_SCRIPT"
           if [[ -s "$POST_INSTALL_SCRIPT" ]]; then
             sudo apt-get update
             sudo bash "$POST_INSTALL_SCRIPT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   swift-test-macos:
     needs: changes
     if: ${{ needs.changes.outputs.macos-tests == 'true' }}
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -98,16 +98,18 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Select Xcode 26.6 (if present) or fallback to default
+      - name: Select Xcode 26.3 or 26.2
         run: |
           set -euo pipefail
-          for candidate in /Applications/Xcode_26.6.app /Applications/Xcode_26.5.app /Applications/Xcode.app; do
+          # Both versions are part of the official macOS 15 runner image.
+          for candidate in /Applications/Xcode_26.3.app /Applications/Xcode_26.2.app; do
             if [[ -d "$candidate" ]]; then
               sudo xcode-select -s "${candidate}/Contents/Developer"
               echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
               break
             fi
           done
+          [[ "$(/usr/bin/xcodebuild -version)" == Xcode\ 26.* ]]
           /usr/bin/xcodebuild -version
 
       - name: Swift toolchain version

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -64,7 +64,7 @@ jobs:
             swift-sdk-arch: aarch64
             file-arch-pattern: aarch64
           - name: macos-arm64
-            runs-on: macos-26
+            runs-on: macos-15
             platform: macos
             asset-platform: macos
             asset-arch: arm64
@@ -75,7 +75,7 @@ jobs:
             swift-sdk-arch: ""
             file-arch-pattern: ""
           - name: macos-x86_64
-            runs-on: macos-26-intel
+            runs-on: macos-15-intel
             platform: macos
             asset-platform: macos
             asset-arch: x86_64
@@ -98,17 +98,19 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Select Xcode 26.6 (if present) or fallback to default
+      - name: Select Xcode 26.3 or 26.2
         if: matrix.platform == 'macos'
         run: |
           set -euo pipefail
-          for candidate in /Applications/Xcode_26.6.app /Applications/Xcode_26.5.app /Applications/Xcode.app; do
+          # Both versions are part of the official macOS 15 runner image.
+          for candidate in /Applications/Xcode_26.3.app /Applications/Xcode_26.2.app; do
             if [[ -d "$candidate" ]]; then
               sudo xcode-select -s "${candidate}/Contents/Developer"
               echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
               break
             fi
           done
+          [[ "$(/usr/bin/xcodebuild -version)" == Xcode\ 26.* ]]
           /usr/bin/xcodebuild -version
 
       - name: Runner info

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -64,7 +64,7 @@ jobs:
             swift-sdk-arch: aarch64
             file-arch-pattern: aarch64
           - name: macos-arm64
-            runs-on: macos-15
+            runs-on: macos-26
             platform: macos
             asset-platform: macos
             asset-arch: arm64
@@ -75,7 +75,7 @@ jobs:
             swift-sdk-arch: ""
             file-arch-pattern: ""
           - name: macos-x86_64
-            runs-on: macos-15-intel
+            runs-on: macos-26-intel
             platform: macos
             asset-platform: macos
             asset-arch: x86_64
@@ -88,18 +88,21 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+      SWIFT_VERSION: 6.2.1
+      SWIFTLY_VERSION: 1.1.3
+      SWIFTLY_SIGNING_FINGERPRINT: E813C892820A6FA13755B268F167DF1ACF9CE069
       SWIFT_STATIC_LINUX_SDK_URL: https://download.swift.org/swift-6.2.1-release/static-sdk/swift-6.2.1-RELEASE/swift-6.2.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz
       SWIFT_STATIC_LINUX_SDK_CHECKSUM: 08e1939a504e499ec871b36826569173103e4562769e12b9b8c2a50f098374ad
-      SQLITE_AMALGAMATION_VERSION: "3530200"
-      SQLITE_AMALGAMATION_SHA3_256: 81142986038e18f96c4a54e1a72562ae17e502a916f2a7701eff43388cbf1a40
+      SQLITE_AMALGAMATION_VERSION: "3530300"
+      SQLITE_AMALGAMATION_SHA3_256: d45c688a8cb23f68611a894a756a12d7eb6ab6e9e2468ca70adbeab3808b5ab9
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Select Xcode 26.1.1 (if present) or fallback to default
+      - name: Select Xcode 26.6 (if present) or fallback to default
         if: matrix.platform == 'macos'
         run: |
           set -euo pipefail
-          for candidate in /Applications/Xcode_26.1.1.app /Applications/Xcode_26.1.app /Applications/Xcode.app; do
+          for candidate in /Applications/Xcode_26.6.app /Applications/Xcode_26.5.app /Applications/Xcode.app; do
             if [[ -d "$candidate" ]]; then
               sudo xcode-select -s "${candidate}/Contents/Developer"
               echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
@@ -129,7 +132,7 @@ jobs:
             exit 1
           fi
 
-      - name: Install Swift 6.2.1 via swiftly
+      - name: Install Swift ${{ env.SWIFT_VERSION }} via swiftly
         if: matrix.platform == 'linux'
         shell: bash
         run: |
@@ -141,13 +144,25 @@ jobs:
           fi
 
           SWIFTLY_ARCH="$(uname -m)"
+          SWIFTLY_ARCHIVE="$RUNNER_TEMP/swiftly-${SWIFTLY_VERSION}-${SWIFTLY_ARCH}.tar.gz"
+          SWIFTLY_SIGNATURE="${SWIFTLY_ARCHIVE}.sig"
           SWIFTLY_HOME_DIR="$HOME/.local/share/swiftly"
           SWIFTLY_BIN_DIR="$HOME/.local/bin"
+          SWIFT_GNUPGHOME="$(mktemp -d)"
+          SWIFT_KEYS="$RUNNER_TEMP/swift-signing-keys.asc"
           POST_INSTALL_SCRIPT="$(mktemp)"
 
           mkdir -p "$SWIFTLY_BIN_DIR"
-          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${SWIFTLY_ARCH}.tar.gz" -o /tmp/swiftly.tar.gz
-          tar -xzf /tmp/swiftly.tar.gz -C /tmp
+          chmod 700 "$SWIFT_GNUPGHOME"
+          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${SWIFTLY_VERSION}-${SWIFTLY_ARCH}.tar.gz" -o "$SWIFTLY_ARCHIVE"
+          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${SWIFTLY_VERSION}-${SWIFTLY_ARCH}.tar.gz.sig" -o "$SWIFTLY_SIGNATURE"
+          curl -fsSL --compressed "https://www.swift.org/keys/all-keys.asc" -o "$SWIFT_KEYS"
+          GNUPGHOME="$SWIFT_GNUPGHOME" gpg --batch --import "$SWIFT_KEYS"
+          SIGNATURE_STATUS="$(GNUPGHOME="$SWIFT_GNUPGHOME" gpg --batch --status-fd=1 \
+            --verify "$SWIFTLY_SIGNATURE" "$SWIFTLY_ARCHIVE" 2>&1)"
+          printf '%s\n' "$SIGNATURE_STATUS"
+          grep -Fq "[GNUPG:] VALIDSIG ${SWIFTLY_SIGNING_FINGERPRINT} " <<< "$SIGNATURE_STATUS"
+          tar -xzf "$SWIFTLY_ARCHIVE" -C /tmp
           /tmp/swiftly init --assume-yes --skip-install
 
           . "$SWIFTLY_HOME_DIR/env.sh"
@@ -155,7 +170,7 @@ jobs:
           echo "SWIFTLY_HOME_DIR=$SWIFTLY_HOME_DIR" >> "$GITHUB_ENV"
           echo "SWIFTLY_BIN_DIR=$SWIFTLY_BIN_DIR" >> "$GITHUB_ENV"
 
-          swiftly install 6.2.1 --use --assume-yes --post-install-file "$POST_INSTALL_SCRIPT"
+          swiftly install "$SWIFT_VERSION" --use --assume-yes --verify --post-install-file "$POST_INSTALL_SCRIPT"
           if [[ -s "$POST_INSTALL_SCRIPT" ]]; then
             sudo apt-get update
             sudo bash "$POST_INSTALL_SCRIPT"
@@ -393,7 +408,7 @@ jobs:
 
       - name: Upload workflow artifact (manual runs)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codexbar-cli-${{ matrix.name }}
           path: |
@@ -401,7 +416,7 @@ jobs:
             ${{ steps.pkg.outputs.out_dir }}/${{ steps.pkg.outputs.asset }}.sha256
 
   update-homebrew-tap:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build-cli
     if: github.event_name == 'release'
     steps:

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -18,14 +18,14 @@ on:
 
 jobs:
   check-upstreams:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       contents: read
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       
@@ -91,7 +91,7 @@ jobs:
       
       - name: Create or update issue
         if: steps.check.outputs.upstream_commits > 0 || steps.check.outputs.quotio_commits > 0
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const upstreamCommits = '${{ steps.check.outputs.upstream_commits }}';

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,4 +1,4 @@
-# SwiftFormat configuration for Peekaboo project
+# SwiftFormat configuration for CodexBar
 # Compatible with Swift 6 strict concurrency mode
 
 # IMPORTANT: Don't remove self where it's required for Swift 6 concurrency
@@ -39,7 +39,8 @@
 --enumthreshold 0
 
 # Swift 6 specific
---swiftversion 6.2
+--swiftversion 6.3
+--disable redundantSendable # Keep explicit concurrency contracts visible
 
 # Other
 --stripunusedargs closure-only

--- a/Scripts/install_lint_tools.sh
+++ b/Scripts/install_lint_tools.sh
@@ -6,13 +6,15 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TOOLS_DIR="${ROOT_DIR}/.build/lint-tools"
 BIN_DIR="${TOOLS_DIR}/bin"
 
-SWIFTFORMAT_VERSION="0.59.1"
-SWIFTLINT_VERSION="0.63.2"
+SWIFTFORMAT_VERSION="0.61.1"
+SWIFTLINT_VERSION="0.65.0"
 
-SWIFTFORMAT_SHA256_DARWIN="8b6289b608a44e73cd3851c3589dbd7c553f32cc805aa54b3a496ce2b90febe7"
-SWIFTLINT_SHA256_DARWIN="c59a405c85f95b92ced677a500804e081596a4cae4a6a485af76065557d6ed29"
-SWIFTFORMAT_SHA256_LINUX_X86_64="150d9693570cf234ec91d8a03ba7165bd36a78335c5e40ed91e4c013a492eb54"
-SWIFTLINT_SHA256_LINUX_X86_64="dd1017cfd20a1457f264590bcb5875a6ee06cd75b9a9d4f77cd43a552499143b"
+SWIFTFORMAT_SHA256_DARWIN="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"
+SWIFTLINT_SHA256_DARWIN="d6cb0aa7a2f5f1ef306fc9e37bcb54dc9a26facc8f7784ac0c3dd3eccf5c6ba6"
+SWIFTFORMAT_SHA256_LINUX_X86_64="7bc8706e3fd51963f1f29eb99098ebdf482f3497fa527c68e6cf75cbee29c77a"
+SWIFTLINT_SHA256_LINUX_X86_64="79306a34e5c7cc55a220cd108cbb861dcad5f10138dcdf261e2624ae8b0a486b"
+SWIFTFORMAT_SHA256_LINUX_ARM64="42a35b557a6d56975fba3a48e78d39ab5388c8faac65d4819f25d3e20c7504c0"
+SWIFTLINT_SHA256_LINUX_ARM64="12d3b84bc5b69ae13a99a5a5c79904f9ce25867f099f6368d0037854f9ee6c26"
 
 log() { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -145,14 +147,16 @@ case "$OS" in
       x86_64)
         SWIFTFORMAT_URL="https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat_linux.zip"
         SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/swiftlint_linux_amd64.zip"
+        SWIFTFORMAT_BINARY="swiftformat_linux"
         SWIFTFORMAT_SHA256="$SWIFTFORMAT_SHA256_LINUX_X86_64"
         SWIFTLINT_SHA256="$SWIFTLINT_SHA256_LINUX_X86_64"
         ;;
       aarch64|arm64)
         SWIFTFORMAT_URL="https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat_linux_aarch64.zip"
         SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/swiftlint_linux_arm64.zip"
-        SWIFTFORMAT_SHA256=""
-        SWIFTLINT_SHA256=""
+        SWIFTFORMAT_BINARY="swiftformat_linux_aarch64"
+        SWIFTFORMAT_SHA256="$SWIFTFORMAT_SHA256_LINUX_ARM64"
+        SWIFTLINT_SHA256="$SWIFTLINT_SHA256_LINUX_ARM64"
         ;;
       *)
         fail "Unsupported Linux arch: ${ARCH}"
@@ -165,7 +169,7 @@ case "$OS" in
       log "WARN: Linux SHA256 verification not configured for ${ARCH}; installing anyway."
     fi
     if [[ "$INSTALL_SWIFTFORMAT" == true ]] && ! swiftformat_installed; then
-      install_zip_binary "SwiftFormat ${SWIFTFORMAT_VERSION}" "$SWIFTFORMAT_URL" "$SWIFTFORMAT_SHA256" "swiftformat_linux" "swiftformat"
+      install_zip_binary "SwiftFormat ${SWIFTFORMAT_VERSION}" "$SWIFTFORMAT_URL" "$SWIFTFORMAT_SHA256" "$SWIFTFORMAT_BINARY" "swiftformat"
     fi
     if [[ "$INSTALL_SWIFTLINT" == true ]] && ! swiftlint_installed; then
       install_zip_binary "SwiftLint ${SWIFTLINT_VERSION}" "$SWIFTLINT_URL" "$SWIFTLINT_SHA256" "swiftlint"


### PR DESCRIPTION
## Summary

- move ordinary Linux CI to Swift 6.3.3 and Ubuntu 24.04
- move macOS jobs to macOS 26 and prefer Xcode 26.6
- pin third-party actions to immutable release commits
- verify Swiftly 1.1.3 signatures before execution
- update SwiftFormat to 0.61.1, SwiftLint to 0.65.0, and add verified Linux ARM64 artifacts
- update the static CLI SQLite amalgamation to 3.53.3

The static Linux release compiler and SDK deliberately remain paired at Swift 6.2.1. A local rehearsal of Swift 6.3.3 exposed a `swift-crypto` musl/C++ link incompatibility with the Ubuntu host toolchain; mixing compiler and SDK versions is unsupported.

## Validation

- `make check`
- `make test` (47 shards)
- Linux ARM64 Swift 6.3.3: 56 tests in 14 suites
- native ARM64 release CLI build, help, and config-validation smoke
- Swiftly signature verification on Linux AMD64 and ARM64
- lint-tool installer on Linux AMD64 and ARM64
- `actionlint -color -ignore 'SC2016|SC2086'`
- workflow YAML parse and `git diff --check`
- AutoReview: no accepted or actionable findings

No changelog entry: CI/tooling-only change.
