### PR TITLE
Distinguish quota warnings from workday markers

### DIFF
--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -89,7 +89,8 @@ extension UsageMenuCardView.Model.Metric {
             self.pacePercent == nil ? "pace=0" : "pace=1",
             self.paceOnTop ? "paceTop=1" : "paceTop=0",
             self.cardStyle ? "card=1" : "card=0",
-            "markers=\(self.warningMarkerPercents.count)",
+            "warningMarkers=\(self.warningMarkerPercents.count)",
+            "workdayMarkers=\(self.workdayMarkerPercents.count)",
         ])
     }
 }

--- a/Sources/CodexBar/MenuCardQuotaWarningMarkers.swift
+++ b/Sources/CodexBar/MenuCardQuotaWarningMarkers.swift
@@ -18,56 +18,6 @@ extension UsageMenuCardView.Model {
             .map { showUsed ? 100 - Double($0) : Double($0) }
             .filter { $0 > 0 && $0 < 100 }
     }
-
-    /// Merges quota warning markers with optional work-day boundary markers.
-    /// Preserves original warning-marker ordering when workdayMarkers is empty,
-    /// sorts the combined set when workday markers are present.
-    static func mergedMarkerPercents(
-        warningMarkers: [Double],
-        workdayMarkers: [Double]) -> [Double]
-    {
-        let combined = warningMarkers + workdayMarkers
-        return workdayMarkers.isEmpty ? combined : combined.sorted()
-    }
-
-    /// Combines quota warning markers with optional work-day boundary markers
-    /// into a single sorted array. Workday markers are only applied when
-    /// includeWorkdayMarkers is true and windowMinutes == 10080.
-    static func markerPercents(
-        thresholds: [Int]?,
-        showUsed: Bool,
-        workDays: Int?,
-        windowMinutes: Int?,
-        includeWorkdayMarkers: Bool) -> [Double]
-    {
-        let warningMarkers = Self.warningMarkerPercents(thresholds: thresholds, showUsed: showUsed)
-        let workdayMarkers = includeWorkdayMarkers
-            ? workDayMarkerPercents(workDays: workDays, windowMinutes: windowMinutes)
-            : []
-        return Self.mergedMarkerPercents(warningMarkers: warningMarkers, workdayMarkers: workdayMarkers)
-    }
-
-    static func weeklyMarkerPercents(input: Input, windowMinutes: Int?) -> [Double] {
-        UsageMenuCardView.Model.markerPercents(
-            thresholds: input.quotaWarningThresholds[.weekly],
-            showUsed: input.usageBarsShowUsed,
-            workDays: input.workDaysPerWeek,
-            windowMinutes: windowMinutes,
-            includeWorkdayMarkers: true)
-    }
-
-    static func codexLaneMarkerPercents(
-        input: Input,
-        lane: CodexConsumerProjection.RateLane,
-        windowMinutes: Int?) -> [Double]
-    {
-        UsageMenuCardView.Model.markerPercents(
-            thresholds: input.quotaWarningThresholds[lane.quotaWarningWindow],
-            showUsed: input.usageBarsShowUsed,
-            workDays: input.workDaysPerWeek,
-            windowMinutes: windowMinutes,
-            includeWorkdayMarkers: lane == .weekly)
-    }
 }
 
 /// Returns boundary percentages for work day markers on a weekly progress bar.

--- a/Sources/CodexBar/MenuCardView+MiniMax.swift
+++ b/Sources/CodexBar/MenuCardView+MiniMax.swift
@@ -39,6 +39,9 @@ extension UsageMenuCardView.Model {
                 warningMarkerPercents: service.isUnlimited
                     ? []
                     : Self.miniMaxWarningMarkerPercents(service: service, input: input),
+                workdayMarkerPercents: service.isUnlimited
+                    ? []
+                    : Self.miniMaxWorkdayMarkerPercents(service: service, input: input),
                 cardStyle: false)
         }
     }
@@ -50,13 +53,17 @@ extension UsageMenuCardView.Model {
                 thresholds: input.quotaWarningThresholds[.session],
                 showUsed: true)
         case .weekly:
-            markerPercents(
+            warningMarkerPercents(
                 thresholds: input.quotaWarningThresholds[.weekly],
-                showUsed: true,
-                workDays: input.workDaysPerWeek,
-                windowMinutes: self.miniMaxWindowMinutes(for: service.windowType),
-                includeWorkdayMarkers: true)
+                showUsed: true)
         }
+    }
+
+    private static func miniMaxWorkdayMarkerPercents(service: MiniMaxServiceUsage, input: Input) -> [Double] {
+        guard self.miniMaxQuotaWarningWindow(for: service) == .weekly else { return [] }
+        return workDayMarkerPercents(
+            workDays: input.workDaysPerWeek,
+            windowMinutes: self.miniMaxWindowMinutes(for: service.windowType))
     }
 
     private static func miniMaxQuotaWarningWindow(for service: MiniMaxServiceUsage) -> QuotaWarningWindow {

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -44,6 +44,7 @@ extension UsageMenuCardView.Model {
                 pacePercent: metric.pacePercent,
                 paceOnTop: metric.paceOnTop,
                 warningMarkerPercents: metric.warningMarkerPercents,
+                workdayMarkerPercents: metric.workdayMarkerPercents,
                 cardStyle: metric.cardStyle)
         }
     }

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -37,6 +37,7 @@ struct UsageMenuCardView: View {
             let pacePercent: Double?
             let paceOnTop: Bool
             let warningMarkerPercents: [Double]
+            let workdayMarkerPercents: [Double]
             let cardStyle: Bool
 
             init(
@@ -52,6 +53,7 @@ struct UsageMenuCardView: View {
                 pacePercent: Double?,
                 paceOnTop: Bool,
                 warningMarkerPercents: [Double] = [],
+                workdayMarkerPercents: [Double] = [],
                 cardStyle: Bool = false)
             {
                 self.id = id
@@ -66,6 +68,7 @@ struct UsageMenuCardView: View {
                 self.pacePercent = pacePercent
                 self.paceOnTop = paceOnTop
                 self.warningMarkerPercents = warningMarkerPercents
+                self.workdayMarkerPercents = workdayMarkerPercents
                 self.cardStyle = cardStyle
             }
 
@@ -462,7 +465,8 @@ private struct MetricRow: View {
                     accessibilityLabel: self.metric.percentStyle.accessibilityLabel,
                     pacePercent: self.metric.pacePercent,
                     paceOnTop: self.metric.paceOnTop,
-                    warningMarkerPercents: self.metric.warningMarkerPercents)
+                    warningMarkerPercents: self.metric.warningMarkerPercents,
+                    workdayMarkerPercents: self.metric.workdayMarkerPercents)
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(alignment: .firstTextBaseline) {
                         Text(self.metric.percentLabel)
@@ -1514,7 +1518,12 @@ extension UsageMenuCardView.Model {
             detailRightText: paceDetail?.rightLabel,
             pacePercent: paceDetail?.pacePercent,
             paceOnTop: paceDetail?.paceOnTop ?? true,
-            warningMarkerPercents: Self.weeklyMarkerPercents(input: input, windowMinutes: weekly.windowMinutes))
+            warningMarkerPercents: Self.warningMarkerPercents(
+                thresholds: input.quotaWarningThresholds[.weekly],
+                showUsed: input.usageBarsShowUsed),
+            workdayMarkerPercents: workDayMarkerPercents(
+                workDays: input.workDaysPerWeek,
+                windowMinutes: weekly.windowMinutes))
     }
 
     private static func codexRateMetrics(
@@ -1559,10 +1568,14 @@ extension UsageMenuCardView.Model {
                 detailRightText: paceDetail?.rightLabel,
                 pacePercent: paceDetail?.pacePercent,
                 paceOnTop: paceDetail?.paceOnTop ?? true,
-                warningMarkerPercents: Self.codexLaneMarkerPercents(
-                    input: input,
-                    lane: lane,
-                    windowMinutes: window.windowMinutes))
+                warningMarkerPercents: Self.warningMarkerPercents(
+                    thresholds: input.quotaWarningThresholds[lane.quotaWarningWindow],
+                    showUsed: input.usageBarsShowUsed),
+                workdayMarkerPercents: lane == .weekly
+                    ? workDayMarkerPercents(
+                        workDays: input.workDaysPerWeek,
+                        windowMinutes: window.windowMinutes)
+                    : [])
         }
     }
 }

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -425,7 +425,8 @@ private struct ProviderMetricInlineRow: View {
                     accessibilityLabel: self.metric.percentStyle.accessibilityLabel,
                     pacePercent: self.metric.pacePercent,
                     paceOnTop: self.metric.paceOnTop,
-                    warningMarkerPercents: self.metric.warningMarkerPercents)
+                    warningMarkerPercents: self.metric.warningMarkerPercents,
+                    workdayMarkerPercents: self.metric.workdayMarkerPercents)
                     .frame(maxWidth: .infinity)
 
                 let hasLeftDetail = self.metric.detailLeftText?.isEmpty == false

--- a/Sources/CodexBar/UsageProgressBar.swift
+++ b/Sources/CodexBar/UsageProgressBar.swift
@@ -2,6 +2,16 @@ import SwiftUI
 
 /// Static progress fill with no implicit animations, used inside the menu card.
 struct UsageProgressBar: View {
+    enum MarkerKind: Equatable {
+        case quotaWarning
+        case workdayBoundary
+    }
+
+    struct Marker: Equatable {
+        let percent: Double
+        let kind: MarkerKind
+    }
+
     private static let paceStripeCount = 3
     private static let stripePunchOpacity = 0.9
 
@@ -28,6 +38,7 @@ struct UsageProgressBar: View {
     let pacePercent: Double?
     let paceOnTop: Bool
     let warningMarkerPercents: [Double]
+    let workdayMarkerPercents: [Double]
     @Environment(\.menuItemHighlighted) private var isHighlighted
     @Environment(\.displayScale) private var displayScale
 
@@ -37,7 +48,8 @@ struct UsageProgressBar: View {
         accessibilityLabel: String,
         pacePercent: Double? = nil,
         paceOnTop: Bool = true,
-        warningMarkerPercents: [Double] = [])
+        warningMarkerPercents: [Double] = [],
+        workdayMarkerPercents: [Double] = [])
     {
         self.percent = percent
         self.tint = tint
@@ -45,6 +57,7 @@ struct UsageProgressBar: View {
         self.pacePercent = pacePercent
         self.paceOnTop = paceOnTop
         self.warningMarkerPercents = warningMarkerPercents
+        self.workdayMarkerPercents = workdayMarkerPercents
     }
 
     private var clamped: Double {
@@ -65,9 +78,9 @@ struct UsageProgressBar: View {
             let stripeInset = 1 / scale
             let tipOffset = paceWidth - tipWidth + (Self.paceStripeSpan(for: scale) / 2) + stripeInset
             let showTip = self.pacePercent != nil && tipWidth > 0.5
-            let markerPercents = self.warningMarkerPercents
-                .map(Self.clampedPercent)
-                .filter { $0 > 0 && $0 < 100 }
+            let markers = Self.resolvedMarkers(
+                warningPercents: self.warningMarkerPercents,
+                workdayPercents: self.workdayMarkerPercents)
 
             let cornerRadius = size.height / 2
             let cornerSize = CGSize(width: cornerRadius, height: cornerRadius)
@@ -88,10 +101,10 @@ struct UsageProgressBar: View {
                     with: .color(MenuHighlightStyle.progressTint(self.isHighlighted, fallback: self.tint)))
             }
 
-            if !markerPercents.isEmpty {
-                let markerStripeColor = Self.warningMarkerColor(isHighlighted: self.isHighlighted)
-                for markerPercent in markerPercents {
-                    let x = size.width * markerPercent / 100
+            for marker in markers {
+                let x = size.width * marker.percent / 100
+                switch marker.kind {
+                case .quotaWarning:
                     let markerRect = Self.warningMarkerRect(x: x, size: size, scale: scale)
                     let markerStripeRect = Self.warningMarkerStripeRect(markerRect, scale: scale)
                     let markerPunchPath = Path { p in
@@ -105,7 +118,14 @@ struct UsageProgressBar: View {
                     context.blendMode = .destinationOut
                     context.fill(markerPunchPath, with: .color(.white.opacity(Self.stripePunchOpacity)))
                     context.blendMode = .normal
-                    context.fill(markerStripePath, with: .color(markerStripeColor))
+                    context.fill(
+                        markerStripePath,
+                        with: .color(Self.warningMarkerColor(isHighlighted: self.isHighlighted)))
+                case .workdayBoundary:
+                    let markerRect = Self.workdayMarkerRect(x: x, size: size, scale: scale)
+                    context.fill(
+                        Path(markerRect),
+                        with: .color(Self.workdayMarkerColor(isHighlighted: self.isHighlighted)))
                 }
             }
 
@@ -136,7 +156,51 @@ struct UsageProgressBar: View {
         }
         .frame(height: 6)
         .accessibilityLabel(self.accessibilityLabel)
-        .accessibilityValue(L("%d percent", Self.displayPercent(self.clamped)))
+        .accessibilityValue(self.markerAccessibilityValue)
+    }
+
+    private var markerAccessibilityValue: String {
+        var parts = [L("%d percent", Self.displayPercent(self.clamped))]
+        let markers = Self.resolvedMarkers(
+            warningPercents: self.warningMarkerPercents,
+            workdayPercents: self.workdayMarkerPercents)
+        let warnings = markers.filter { $0.kind == .quotaWarning }.map(Self.markerPercentText)
+        let workdays = markers.filter { $0.kind == .workdayBoundary }.map(Self.markerPercentText)
+        if !warnings.isEmpty {
+            parts.append("\(L("quota_warnings_title")): \(warnings.joined(separator: ", "))")
+        }
+        if !workdays.isEmpty {
+            parts.append("\(L("weekly_progress_work_days_title")): \(workdays.joined(separator: ", "))")
+        }
+        return parts.joined(separator: ". ")
+    }
+
+    nonisolated static func resolvedMarkers(
+        warningPercents: [Double],
+        workdayPercents: [Double]) -> [Marker]
+    {
+        let warnings = Self.normalizedMarkerPercents(warningPercents)
+        let workdays = Self.normalizedMarkerPercents(workdayPercents)
+            .filter { workday in !warnings.contains { abs($0 - workday) < 0.001 } }
+        return (
+            warnings.map { Marker(percent: $0, kind: .quotaWarning) } +
+                workdays.map { Marker(percent: $0, kind: .workdayBoundary) })
+            .sorted { lhs, rhs in lhs.percent < rhs.percent }
+    }
+
+    private nonisolated static func normalizedMarkerPercents(_ values: [Double]) -> [Double] {
+        values
+            .map(self.clampedPercent)
+            .filter { $0 > 0 && $0 < 100 }
+            .reduce(into: [Double]()) { result, value in
+                if !result.contains(where: { abs($0 - value) < 0.001 }) {
+                    result.append(value)
+                }
+            }
+    }
+
+    private nonisolated static func markerPercentText(_ marker: Marker) -> String {
+        "\(Int(marker.percent.rounded()))%"
     }
 
     /// Aligns edge rendering with the rounded percent label: sub-0.5% is empty and 99.5%+ is full.
@@ -224,13 +288,31 @@ struct UsageProgressBar: View {
             height: markerRect.height)
     }
 
+    nonisolated static func workdayMarkerRect(x: CGFloat, size: CGSize, scale rawScale: CGFloat) -> CGRect {
+        let scale = max(rawScale, 1)
+        let width = 1 / scale
+        let height = max(1 / scale, size.height * 0.5)
+        let align: (CGFloat) -> CGFloat = { value in
+            (value * scale).rounded() / scale
+        }
+        return CGRect(
+            x: align(x - width / 2),
+            y: align(size.height - height),
+            width: width,
+            height: align(height))
+    }
+
     private nonisolated static func extendedMarkerRect(_ rect: CGRect, size: CGSize) -> CGRect {
         let extend = size.height * 2
         return rect.insetBy(dx: 0, dy: -extend)
     }
 
     nonisolated static func warningMarkerColor(isHighlighted: Bool) -> Color {
-        isHighlighted ? .white.opacity(0.96) : .white.opacity(0.88)
+        isHighlighted ? .white.opacity(0.96) : .primary.opacity(0.68)
+    }
+
+    nonisolated static func workdayMarkerColor(isHighlighted: Bool) -> Color {
+        isHighlighted ? .white.opacity(0.55) : .primary.opacity(0.30)
     }
 
     private nonisolated static func displayPercent(_ percent: Double) -> Int {

--- a/Sources/CodexBar/UsageProgressBar.swift
+++ b/Sources/CodexBar/UsageProgressBar.swift
@@ -3,6 +3,16 @@ import SwiftUI
 /// Static progress fill with no implicit animations, used inside the menu card.
 struct UsageProgressBar: View {
     private static let paceStripeCount = 3
+    private static let stripePunchOpacity = 0.9
+
+    private nonisolated static var warningMarkerPunchWidth: CGFloat {
+        5
+    }
+
+    private nonisolated static var warningMarkerStripeWidth: CGFloat {
+        1
+    }
+
     private static func paceStripeWidth(for scale: CGFloat) -> CGFloat {
         2
     }
@@ -79,16 +89,23 @@ struct UsageProgressBar: View {
             }
 
             if !markerPercents.isEmpty {
-                let markerColor = Self.warningMarkerColor(isHighlighted: self.isHighlighted)
+                let markerStripeColor = Self.warningMarkerColor(isHighlighted: self.isHighlighted)
                 for markerPercent in markerPercents {
                     let x = size.width * markerPercent / 100
                     let markerRect = Self.warningMarkerRect(x: x, size: size, scale: scale)
-                    let markerPath = Path { p in
-                        p.addRoundedRect(
-                            in: markerRect,
-                            cornerSize: CGSize(width: markerRect.width / 2, height: markerRect.width / 2))
+                    let markerStripeRect = Self.warningMarkerStripeRect(markerRect, scale: scale)
+                    let markerPunchPath = Path { p in
+                        p.addRect(Self.extendedMarkerRect(markerRect, size: size))
                     }
-                    context.fill(markerPath, with: .color(markerColor))
+                    let markerStripePath = Path { p in
+                        p.addRect(Self.extendedMarkerRect(markerStripeRect, size: size))
+                    }
+
+                    // Match the pace stripe treatment: punch through the bar, then draw a slimmer neutral stripe.
+                    context.blendMode = .destinationOut
+                    context.fill(markerPunchPath, with: .color(.white.opacity(Self.stripePunchOpacity)))
+                    context.blendMode = .normal
+                    context.fill(markerStripePath, with: .color(markerStripeColor))
                 }
             }
 
@@ -111,7 +128,7 @@ struct UsageProgressBar: View {
 
                 // Punch out of the accumulated track+fill pixels.
                 context.blendMode = .destinationOut
-                context.fill(stripes.punched.applying(shift), with: .color(.white.opacity(0.9)))
+                context.fill(stripes.punched.applying(shift), with: .color(.white.opacity(Self.stripePunchOpacity)))
                 context.blendMode = .normal
 
                 context.fill(stripes.center.applying(shift), with: .color(stripeColor))
@@ -181,21 +198,39 @@ struct UsageProgressBar: View {
 
     nonisolated static func warningMarkerRect(x: CGFloat, size: CGSize, scale rawScale: CGFloat) -> CGRect {
         let scale = max(rawScale, 1)
-        let width = max(1 / scale, 1)
-        let height = min(size.height, max(1 / scale, size.height * 0.55))
+        let width = Self.warningMarkerPunchWidth
         let align: (CGFloat) -> CGFloat = { value in
             (value * scale).rounded() / scale
         }
 
         return CGRect(
             x: align(x - width / 2),
-            y: align((size.height - height) / 2),
+            y: 0,
             width: width,
-            height: align(height))
+            height: align(size.height))
+    }
+
+    nonisolated static func warningMarkerStripeRect(_ markerRect: CGRect, scale rawScale: CGFloat) -> CGRect {
+        let scale = max(rawScale, 1)
+        let width = min(markerRect.width, max(1 / scale, Self.warningMarkerStripeWidth))
+        let align: (CGFloat) -> CGFloat = { value in
+            (value * scale).rounded() / scale
+        }
+
+        return CGRect(
+            x: align(markerRect.midX - width / 2),
+            y: markerRect.minY,
+            width: width,
+            height: markerRect.height)
+    }
+
+    private nonisolated static func extendedMarkerRect(_ rect: CGRect, size: CGSize) -> CGRect {
+        let extend = size.height * 2
+        return rect.insetBy(dx: 0, dy: -extend)
     }
 
     nonisolated static func warningMarkerColor(isHighlighted: Bool) -> Color {
-        isHighlighted ? .white.opacity(0.72) : .primary.opacity(0.32)
+        isHighlighted ? .white.opacity(0.96) : .white.opacity(0.88)
     }
 
     private nonisolated static func displayPercent(_ percent: Double) -> Int {

--- a/Tests/CodexBarTests/MenuCardModelCodexProjectionTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelCodexProjectionTests.swift
@@ -127,14 +127,15 @@ struct MenuCardModelCodexProjectionTests {
             now: now))
 
         let weekly = try #require(model.metrics.first { $0.id == "secondary" })
-        #expect(weekly.warningMarkerPercents == [20.0, 40.0, 60.0, 80.0])
+        #expect(weekly.warningMarkerPercents.isEmpty)
+        #expect(weekly.workdayMarkerPercents == [20.0, 40.0, 60.0, 80.0])
 
         let session = try #require(model.metrics.first { $0.id == "primary" })
         #expect(session.warningMarkerPercents.isEmpty)
     }
 
     @Test
-    func `codex weekly lane workday markers merge with quota warning markers`() throws {
+    func `codex weekly lane keeps workday and quota warning markers separate`() throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let metadata = try #require(ProviderDefaults.metadata[.codex])
         let identity = ProviderIdentitySnapshot(
@@ -193,7 +194,8 @@ struct MenuCardModelCodexProjectionTests {
             now: now))
 
         let weekly = try #require(model.metrics.first { $0.id == "secondary" })
-        #expect(weekly.warningMarkerPercents == [20.0, 40.0, 50.0, 60.0, 80.0])
+        #expect(weekly.warningMarkerPercents == [50.0])
+        #expect(weekly.workdayMarkerPercents == [20.0, 40.0, 60.0, 80.0])
     }
 
     @Test
@@ -256,7 +258,8 @@ struct MenuCardModelCodexProjectionTests {
             now: now))
 
         let weekly = try #require(model.metrics.first { $0.id == "secondary" })
-        #expect(weekly.warningMarkerPercents == [20.0, 40.0, 60.0, 80.0])
+        #expect(weekly.warningMarkerPercents.isEmpty)
+        #expect(weekly.workdayMarkerPercents == [20.0, 40.0, 60.0, 80.0])
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuCardQuotaWarningMarkerTests.swift
+++ b/Tests/CodexBarTests/MenuCardQuotaWarningMarkerTests.swift
@@ -59,6 +59,45 @@ struct MenuCardQuotaWarningMarkerTests {
     }
 
     @Test
+    func `workday boundary is a subtle lower tick`() {
+        let rect = UsageProgressBar.workdayMarkerRect(
+            x: 50,
+            size: CGSize(width: 100, height: 6),
+            scale: 2)
+
+        #expect(rect.width == 0.5)
+        #expect(rect.height == 3)
+        #expect(rect.minY == 3)
+        #expect(abs(rect.midX - 50) <= 0.5)
+    }
+
+    @Test
+    func `quota warning wins when marker kinds overlap`() {
+        let markers = UsageProgressBar.resolvedMarkers(
+            warningPercents: [50, 80],
+            workdayPercents: [20, 50, 60])
+
+        #expect(markers == [
+            .init(percent: 20, kind: .workdayBoundary),
+            .init(percent: 50, kind: .quotaWarning),
+            .init(percent: 60, kind: .workdayBoundary),
+            .init(percent: 80, kind: .quotaWarning),
+        ])
+    }
+
+    @Test
+    func `marker resolver removes edges duplicates and invalid values`() {
+        let markers = UsageProgressBar.resolvedMarkers(
+            warningPercents: [-10, 0, 50, 50, 100, 120],
+            workdayPercents: [Double.nan, 25, 25])
+
+        #expect(markers == [
+            .init(percent: 25, kind: .workdayBoundary),
+            .init(percent: 50, kind: .quotaWarning),
+        ])
+    }
+
+    @Test
     func `omits quota warning markers for disabled windows`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.codex])

--- a/Tests/CodexBarTests/MenuCardQuotaWarningMarkerTests.swift
+++ b/Tests/CodexBarTests/MenuCardQuotaWarningMarkerTests.swift
@@ -13,16 +13,49 @@ struct MenuCardQuotaWarningMarkerTests {
     }
 
     @Test
-    func `quota warning marker geometry is inset and hairline`() {
+    func `quota warning marker geometry matches pace stripe edges`() {
         let rect = UsageProgressBar.warningMarkerRect(
             x: 50,
             size: CGSize(width: 100, height: 6),
             scale: 2)
+        let stripe = UsageProgressBar.warningMarkerStripeRect(
+            rect,
+            scale: 2)
 
-        #expect(rect.width == 1)
-        #expect(rect.height < 6)
-        #expect(rect.minY > 0)
+        #expect(rect.width == 5)
+        #expect(rect.height == 6)
+        #expect(rect.minY == 0)
+        #expect(rect.maxY == 6)
         #expect(abs(rect.midX - 50) <= 0.5)
+        #expect(stripe.width == 1)
+        #expect(stripe.height == rect.height)
+        #expect(abs(stripe.midX - rect.midX) <= 0.001)
+        #expect(stripe.minX > rect.minX)
+        #expect(stripe.maxX < rect.maxX)
+    }
+
+    @Test
+    func `quota warning marker geometry stays centered across display scales`() {
+        let scales: [CGFloat] = [1, 2, 3]
+
+        for scale in scales {
+            let rect = UsageProgressBar.warningMarkerRect(
+                x: 33,
+                size: CGSize(width: 100, height: 6),
+                scale: scale)
+            let stripe = UsageProgressBar.warningMarkerStripeRect(
+                rect,
+                scale: scale)
+
+            #expect(rect.minY == 0)
+            #expect(rect.height == 6)
+            #expect(rect.width == 5)
+            #expect(stripe.width == 1)
+            #expect(stripe.height == rect.height)
+            #expect(abs(stripe.midX - rect.midX) <= 1 / scale)
+            #expect(stripe.minX > rect.minX)
+            #expect(stripe.maxX < rect.maxX)
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/MiniMaxMenuCardModelPlanTests.swift
+++ b/Tests/CodexBarTests/MiniMaxMenuCardModelPlanTests.swift
@@ -151,9 +151,11 @@ struct MiniMaxMenuCardModelPlanTests {
             showOptionalCreditsAndExtraUsage: true,
             hidePersonalInfo: false,
             quotaWarningThresholds: [.session: [50, 20], .weekly: [50, 20]],
+            workDaysPerWeek: 5,
             now: now))
 
         #expect(model.metrics.map(\.warningMarkerPercents) == [[50, 80], [50, 80]])
+        #expect(model.metrics.map(\.workdayMarkerPercents) == [[], [20, 40, 60, 80]])
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Make quota warning thresholds unmistakable with a full-height punch-out and adaptive neutral stripe.
- Keep workday boundaries as a separate, subtle lower tick instead of flattening both concepts into one marker style.
- Give quota warnings precedence when a threshold and workday boundary overlap.
- Expose both marker classes in the progress bar accessibility value.

## Why

The previous inset warning hairline could disappear into the fill. The original version of this PR improved visibility, but it treated warning thresholds and workday boundaries as the same dominant marker and used a hard-coded white stripe that could disappear in light mode.

The revised model carries warning and workday percentages independently from projection through rendering. Warning thresholds use the strong punch-out treatment; workday boundaries remain lightweight orientation marks. Colors use adaptive primary/selected-row styling.

## Maintainer improvements

- Merged current `main` before validation.
- Removed the old merged marker-array path instead of keeping a compatibility shim.
- Added deterministic normalization, deduplication, edge filtering, and overlap precedence.
- Forwarded typed marker data through menu cards, provider details, redaction copies, MiniMax, Codex projections, and height fingerprints.
- Added readable regression tests for geometry, semantics, overlap, invalid values, Codex lanes, and MiniMax weekly rows.

## Validation

- `swift test --filter 'MenuCardQuotaWarningMarkerTests|MenuCardModelCodexProjectionTests|MiniMaxMenuCardModelPlanTests'` — 33 tests passed.
- `make check` — 0 format/lint violations.
- `make test` — all 47 shards passed.
- Autoreview — no actionable findings.
- Fresh ad-hoc debug app launched and remained running on exact head.
- Deterministic production-view render matrix passed for light/dark × normal/highlighted using identical data:
  - warning thresholds at 20% and 50%,
  - workday boundaries at 20%, 40%, 60%, and 80%,
  - the overlapping 20% marker rendered once as a warning,
  - adaptive contrast remained visible in every state.

## Original before/after proof

Before: softened warning marker.

![Before: softened quota warning marker](https://raw.githubusercontent.com/Alekstodo/CodexBar/proof/quota-warning-markers-updated-ui/proof/quota-warning-markers/before-1px-weekly-crop.png)

After baseline from the contributor branch; the maintainer revision further separates workday ticks and adapts light/dark color.

![After: full-height quota warning marker](https://raw.githubusercontent.com/Alekstodo/CodexBar/proof/quota-warning-markers-updated-ui/proof/quota-warning-markers/after-punchout-weekly-crop.png)
