### PR TITLE
Opt-in expiry runway for Codex reset credits (addresses #1758)

### DIFF
--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -121,7 +121,15 @@ extension UsageMenuCardView.Model.TokenUsageSection {
 
 extension CodexResetCreditsPresentation {
     fileprivate var heightFingerprint: String {
-        MenuCardHeightFingerprint.join([
+        // The runway is a fixed-height component (track + axis) distinct from the single-line list,
+        // so the style choice is the only height-relevant contributor once runway is active.
+        if self.showsRunway {
+            return MenuCardHeightFingerprint.join([
+                MenuCardHeightFingerprint.field("text", self.text),
+                MenuCardHeightFingerprint.field("expiry", "runway"),
+            ])
+        }
+        return MenuCardHeightFingerprint.join([
             MenuCardHeightFingerprint.field("text", self.text),
             MenuCardHeightFingerprint.field("expirySummary", self.expirySummaryText),
         ])

--- a/Sources/CodexBar/MenuCardView+CodexResetCreditRunway.swift
+++ b/Sources/CodexBar/MenuCardView+CodexResetCreditRunway.swift
@@ -1,0 +1,158 @@
+import CodexBarCore
+import SwiftUI
+
+/// One expiring reset credit placed on the runway timeline.
+struct CodexResetCreditRunwayMarker: Equatable, Identifiable {
+    let id: String
+    /// 0…1 along the horizon: 0 = now, 1 = a freshly granted credit at the far edge.
+    let position: Double
+    let isNearest: Bool
+    /// Nearest credit expiring within 48h.
+    let isUrgent: Bool
+    /// Resting label shown above the track for the nearest credit only.
+    let restingLabel: String?
+    /// Exact values revealed on hover for every credit (countdown · absolute date).
+    let hoverText: String
+}
+
+extension CodexResetCreditsPresentation {
+    private static let runwayUrgencyWindow: TimeInterval = 48 * 3600
+
+    /// Places each dated, still-valid credit on a data-derived horizon (the longest credit
+    /// lifetime in the inventory), so a credit's position drifts left predictably as it ages.
+    /// Credits with no expiry stay in the count and tooltip but off the track.
+    static func runwayMarkers(
+        credits: [CodexRateLimitResetCredit],
+        resetStyle: ResetTimeDisplayStyle,
+        now: Date) -> [CodexResetCreditRunwayMarker]
+    {
+        let dated = credits
+            .compactMap { credit -> (expiresAt: Date, lifetime: TimeInterval)? in
+                guard let expiresAt = credit.expiresAt, expiresAt > now else { return nil }
+                return (expiresAt, expiresAt.timeIntervalSince(credit.grantedAt))
+            }
+            .sorted { $0.expiresAt < $1.expiresAt }
+        guard let horizon = dated.map(\.lifetime).max(), horizon > 0 else { return [] }
+
+        return dated.enumerated().map { index, entry in
+            let remaining = entry.expiresAt.timeIntervalSince(now)
+            let isNearest = index == 0
+            return CodexResetCreditRunwayMarker(
+                id: "codex-reset-runway-\(index)",
+                position: min(1, max(0, remaining / horizon)),
+                isNearest: isNearest,
+                isUrgent: isNearest && remaining < Self.runwayUrgencyWindow,
+                restingLabel: isNearest
+                    ? Self.compactExpiryText(for: entry.expiresAt, resetStyle: resetStyle, now: now)
+                    : nil,
+                hoverText: Self.runwayHoverText(for: entry.expiresAt, now: now))
+        }
+    }
+
+    /// Label for the far end of the axis (the longest lifetime), reusing the countdown formatter.
+    static func runwayHorizonLabel(credits: [CodexRateLimitResetCredit], now: Date) -> String? {
+        let horizon = credits
+            .compactMap { credit -> TimeInterval? in
+                guard let expiresAt = credit.expiresAt, expiresAt > now else { return nil }
+                return expiresAt.timeIntervalSince(credit.grantedAt)
+            }
+            .max()
+        guard let horizon, horizon > 0 else { return nil }
+        let countdown = UsageFormatter.resetCountdownDescription(from: now.addingTimeInterval(horizon), now: now)
+        return countdown.hasPrefix("in ") ? String(countdown.dropFirst(3)) : countdown
+    }
+
+    private static func runwayHoverText(for expiresAt: Date, now: Date) -> String {
+        let countdown = UsageFormatter.resetCountdownDescription(from: expiresAt, now: now)
+        let compact = countdown.hasPrefix("in ") ? String(countdown.dropFirst(3)) : countdown
+        let absolute = UsageFormatter.resetDescription(from: expiresAt, now: now)
+        return compact == absolute ? compact : "\(compact) · \(absolute)"
+    }
+}
+
+/// Horizontal timeline of reset-credit expiries — an opt-in alternative to the compact text list.
+/// Colors resolve through `MenuHighlightStyle` so the runway stays legible on the highlighted row.
+struct CodexResetCreditRunway: View {
+    let markers: [CodexResetCreditRunwayMarker]
+    let horizonLabel: String
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var hoveredMarkerID: String?
+
+    private var activeLabel: (text: String, position: Double, urgent: Bool)? {
+        if let hovered = self.markers.first(where: { $0.id == self.hoveredMarkerID }) {
+            return (hovered.hoverText, hovered.position, hovered.isUrgent)
+        }
+        guard let nearest = self.markers.first(where: \.isNearest), let label = nearest.restingLabel else {
+            return nil
+        }
+        return (label, nearest.position, nearest.isUrgent)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            GeometryReader { geo in
+                ZStack(alignment: .topLeading) {
+                    if let label = self.activeLabel {
+                        Text(label.text)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(label.urgent
+                                ? MenuHighlightStyle.error(self.isHighlighted)
+                                : MenuHighlightStyle.primary(self.isHighlighted))
+                            .fixedSize()
+                            .frame(width: geo.size.width, alignment: .leading)
+                            .offset(x: self.clampedLabelX(label.position, width: geo.size.width), y: 0)
+                    }
+                    Capsule()
+                        .fill(MenuHighlightStyle.progressTrack(self.isHighlighted))
+                        .frame(height: 4)
+                        .offset(y: 20)
+                    ForEach(self.markers) { marker in
+                        self.dot(for: marker)
+                            .position(x: geo.size.width * marker.position, y: 22)
+                    }
+                }
+                .animation(self.reduceMotion ? nil : .easeInOut(duration: 0.12), value: self.hoveredMarkerID)
+            }
+            .frame(height: 28)
+            HStack {
+                Text(L("now"))
+                Spacer(minLength: 8)
+                Text(self.horizonLabel)
+            }
+            .font(.caption2)
+            .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+            .accessibilityHidden(true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func dot(for marker: CodexResetCreditRunwayMarker) -> some View {
+        let hovered = self.hoveredMarkerID == marker.id
+        let color = marker.isUrgent
+            ? MenuHighlightStyle.error(self.isHighlighted)
+            : MenuHighlightStyle.progressTint(self.isHighlighted, fallback: Color(nsColor: .controlAccentColor))
+        let diameter: CGFloat = marker.isNearest ? 11 : 8
+        return Circle()
+            .fill(color)
+            .opacity(marker.isNearest || hovered ? 1 : 0.55)
+            .frame(width: diameter, height: diameter)
+            .scaleEffect(hovered && !self.reduceMotion ? 1.25 : 1)
+            .frame(width: 20, height: 20)
+            .contentShape(Rectangle())
+            .onHover { hovering in
+                if hovering {
+                    self.hoveredMarkerID = marker.id
+                } else if self.hoveredMarkerID == marker.id {
+                    self.hoveredMarkerID = nil
+                }
+            }
+    }
+
+    private func clampedLabelX(_ position: Double, width: CGFloat) -> CGFloat {
+        // Center the label over its dot, but keep it inside the track bounds.
+        let estimatedHalf: CGFloat = 34
+        let target = width * position
+        return min(max(target - estimatedHalf, 0), max(width - estimatedHalf * 2, 0))
+    }
+}

--- a/Sources/CodexBar/MenuCardView+CodexResetCredits.swift
+++ b/Sources/CodexBar/MenuCardView+CodexResetCredits.swift
@@ -9,12 +9,34 @@ struct CodexResetCreditPresentationItem: Equatable {
 struct CodexResetCreditsPresentation: Equatable {
     let text: String
     let items: [CodexResetCreditPresentationItem]
+    let expiryStyle: CreditExpiryDisplayStyle
+    let markers: [CodexResetCreditRunwayMarker]
+    let horizonLabel: String?
+
+    init(
+        text: String,
+        items: [CodexResetCreditPresentationItem],
+        expiryStyle: CreditExpiryDisplayStyle = .list,
+        markers: [CodexResetCreditRunwayMarker] = [],
+        horizonLabel: String? = nil)
+    {
+        self.text = text
+        self.items = items
+        self.expiryStyle = expiryStyle
+        self.markers = markers
+        self.horizonLabel = horizonLabel
+    }
 
     var expirySummaryText: String {
         let visibleItems = self.items.prefix(4).map(\.compactExpiryText)
         let hiddenCount = self.items.count - visibleItems.count
         let suffix = hiddenCount > 0 ? ["+\(hiddenCount)"] : []
         return (visibleItems + suffix).joined(separator: " · ")
+    }
+
+    /// The runway only renders when the user opted in and there is at least one dated credit to place.
+    var showsRunway: Bool {
+        self.expiryStyle == .runway && !self.markers.isEmpty && self.horizonLabel != nil
     }
 
     var helpText: String {
@@ -32,6 +54,7 @@ struct CodexResetCreditsPresentation: Equatable {
     static func make(
         snapshot: CodexRateLimitResetCreditsSnapshot,
         resetStyle: ResetTimeDisplayStyle,
+        expiryStyle: CreditExpiryDisplayStyle = .list,
         now: Date) -> CodexResetCreditsPresentation?
     {
         let inventory = snapshot.availableInventory(at: now)
@@ -39,9 +62,18 @@ struct CodexResetCreditsPresentation: Equatable {
         let items = inventory.credits.map { credit in
             Self.presentationItem(for: credit, resetStyle: resetStyle, now: now)
         }
+        let markers = expiryStyle == .runway
+            ? Self.runwayMarkers(credits: inventory.credits, resetStyle: resetStyle, now: now)
+            : []
+        let horizonLabel = expiryStyle == .runway
+            ? Self.runwayHorizonLabel(credits: inventory.credits, now: now)
+            : nil
         return CodexResetCreditsPresentation(
             text: Self.availableText(count: inventory.count),
-            items: items)
+            items: items,
+            expiryStyle: expiryStyle,
+            markers: markers,
+            horizonLabel: horizonLabel)
     }
 
     private static func availableText(count: Int) -> String {
@@ -57,12 +89,20 @@ struct CodexResetCreditsPresentation: Equatable {
             return CodexResetCreditPresentationItem(expiryText: L("No expiry"), compactExpiryText: L("No expiry"))
         }
         let formattedTime = Self.formattedTime(expiresAt, resetStyle: resetStyle, now: now)
-        let compactExpiryText = resetStyle == .countdown && formattedTime.hasPrefix("in ")
-            ? String(formattedTime.dropFirst(3))
-            : formattedTime
         return CodexResetCreditPresentationItem(
             expiryText: String(format: L("Expires %@"), formattedTime),
-            compactExpiryText: compactExpiryText)
+            compactExpiryText: Self.compactExpiryText(for: expiresAt, resetStyle: resetStyle, now: now))
+    }
+
+    static func compactExpiryText(
+        for expiresAt: Date,
+        resetStyle: ResetTimeDisplayStyle,
+        now: Date) -> String
+    {
+        let formattedTime = Self.formattedTime(expiresAt, resetStyle: resetStyle, now: now)
+        return resetStyle == .countdown && formattedTime.hasPrefix("in ")
+            ? String(formattedTime.dropFirst(3))
+            : formattedTime
     }
 
     private static func formattedTime(
@@ -90,24 +130,32 @@ struct CodexResetCreditsContent: View {
                 .font(.body)
                 .fontWeight(.medium)
                 .lineLimit(1)
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
+            if self.presentation.showsRunway, let horizonLabel = self.presentation.horizonLabel {
                 Text(self.presentation.text)
                     .font(.footnote.weight(.semibold))
                     .foregroundStyle(MenuHighlightStyle.primary(self.isHighlighted))
                     .lineLimit(1)
-                    .layoutPriority(1)
-                Spacer(minLength: 8)
-                HStack(alignment: .firstTextBaseline, spacing: 4) {
-                    Image(systemName: "clock")
-                        .font(.caption2)
-                    Text(self.presentation.expirySummaryText)
-                        .font(.caption)
-                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                CodexResetCreditRunway(markers: self.presentation.markers, horizonLabel: horizonLabel)
+            } else {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(self.presentation.text)
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(MenuHighlightStyle.primary(self.isHighlighted))
                         .lineLimit(1)
-                        .minimumScaleFactor(0.8)
+                        .layoutPriority(1)
+                    Spacer(minLength: 8)
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Image(systemName: "clock")
+                            .font(.caption2)
+                        Text(self.presentation.expirySummaryText)
+                            .font(.caption)
+                            .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+                    }
+                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    .accessibilityHidden(true)
                 }
-                .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                .accessibilityHidden(true)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -127,6 +175,7 @@ extension UsageMenuCardView.Model {
         return CodexResetCreditsPresentation.make(
             snapshot: resetCredits,
             resetStyle: input.resetTimeDisplayStyle,
+            expiryStyle: input.creditExpiryDisplayStyle,
             now: input.now)
     }
 }

--- a/Sources/CodexBar/MenuCardView+ModelInput.swift
+++ b/Sources/CodexBar/MenuCardView+ModelInput.swift
@@ -19,6 +19,7 @@ extension UsageMenuCardView.Model {
         let limitsAvailability: UsageLimitsAvailability?
         let usageBarsShowUsed: Bool
         let resetTimeDisplayStyle: ResetTimeDisplayStyle
+        let creditExpiryDisplayStyle: CreditExpiryDisplayStyle
         let tokenCostUsageEnabled: Bool
         let tokenCostInlineDashboardEnabled: Bool
         let tokenCostMenuSectionEnabled: Bool
@@ -51,6 +52,7 @@ extension UsageMenuCardView.Model {
             limitsAvailability: UsageLimitsAvailability? = nil,
             usageBarsShowUsed: Bool,
             resetTimeDisplayStyle: ResetTimeDisplayStyle,
+            creditExpiryDisplayStyle: CreditExpiryDisplayStyle = .list,
             tokenCostUsageEnabled: Bool,
             tokenCostInlineDashboardEnabled: Bool? = nil,
             tokenCostMenuSectionEnabled: Bool? = nil,
@@ -82,6 +84,7 @@ extension UsageMenuCardView.Model {
             self.limitsAvailability = limitsAvailability
             self.usageBarsShowUsed = usageBarsShowUsed
             self.resetTimeDisplayStyle = resetTimeDisplayStyle
+            self.creditExpiryDisplayStyle = creditExpiryDisplayStyle
             self.tokenCostUsageEnabled = tokenCostUsageEnabled
             self.tokenCostInlineDashboardEnabled = tokenCostInlineDashboardEnabled ?? tokenCostUsageEnabled
             self.tokenCostMenuSectionEnabled = tokenCostMenuSectionEnabled ?? tokenCostUsageEnabled

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -69,6 +69,11 @@ struct DisplayPane: View {
 
                 Toggle(L("show_reset_time_as_clock_title"), isOn: self.$settings.resetTimesShowAbsolute)
 
+                Picker(L("credit_expiry_style_title"), selection: self.$settings.creditExpiryDisplayStyle) {
+                    Text(L("credit_expiry_style_list")).tag(CreditExpiryDisplayStyle.list)
+                    Text(L("credit_expiry_style_runway")).tag(CreditExpiryDisplayStyle.runway)
+                }
+
                 Toggle(L("show_provider_changelog_links_title"), isOn: self.$settings.providerChangelogLinksEnabled)
 
                 Toggle(isOn: self.$settings.showOptionalCreditsAndExtraUsage) {

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -681,6 +681,7 @@ struct ProvidersPane: View {
             limitsAvailability: self.store.knownLimitsAvailability(for: provider),
             usageBarsShowUsed: self.settings.usageBarsShowUsed,
             resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
+            creditExpiryDisplayStyle: self.settings.creditExpiryDisplayStyle,
             tokenCostUsageEnabled: self.settings.isCostUsageEffectivelyEnabled(for: provider),
             tokenCostInlineDashboardEnabled: self.settings.costSummaryShowsInlineDashboard(for: provider),
             // Display style only controls the main menu. Provider details always expose

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1154,3 +1154,7 @@
 "section_diagnostics" = "التشخيصات";
 "section_updates" = "التحديثات";
 "section_links" = "روابط";
+
+"credit_expiry_style_title" = "نمط انتهاء الرصيد";
+"credit_expiry_style_list" = "قائمة";
+"credit_expiry_style_runway" = "الجدول الزمني";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1154,3 +1154,7 @@
 "section_diagnostics" = "Diagnostics";
 "section_updates" = "Updates";
 "section_links" = "Links";
+
+"credit_expiry_style_title" = "Credit expiry style";
+"credit_expiry_style_list" = "List";
+"credit_expiry_style_runway" = "Timeline";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1154,3 +1154,7 @@
 "section_diagnostics" = "عیب‌یابی";
 "section_updates" = "به‌روزرسانی‌ها";
 "section_links" = "پیوندها";
+
+"credit_expiry_style_title" = "سبک نمایش انقضای اعتبار";
+"credit_expiry_style_list" = "فهرست";
+"credit_expiry_style_runway" = "خط زمانی";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1154,3 +1154,7 @@
 "section_diagnostics" = "การวินิจฉัย";
 "section_updates" = "อัปเดต";
 "section_links" = "ลิงก์";
+
+"credit_expiry_style_title" = "รูปแบบวันหมดอายุเครดิต";
+"credit_expiry_style_list" = "รายการ";
+"credit_expiry_style_runway" = "ไทม์ไลน์";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -293,6 +293,14 @@ extension SettingsStore {
         }
     }
 
+    var creditExpiryDisplayStyle: CreditExpiryDisplayStyle {
+        get { CreditExpiryDisplayStyle(rawValue: self.defaultsState.creditExpiryDisplayStyleRaw) ?? .list }
+        set {
+            self.defaultsState.creditExpiryDisplayStyleRaw = newValue.rawValue
+            self.userDefaults.set(newValue.rawValue, forKey: "creditExpiryDisplayStyle")
+        }
+    }
+
     var showAllTokenAccountsInMenu: Bool {
         get { self.multiAccountMenuLayout == .stacked }
         set { self.multiAccountMenuLayout = newValue ? .stacked : .segmented }

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -31,6 +31,7 @@ extension SettingsStore {
         _ = self.kiroMenuBarDisplayMode
         _ = self.historicalTrackingEnabled
         _ = self.multiAccountMenuLayout
+        _ = self.creditExpiryDisplayStyle
         _ = self.menuBarMetricPreferencesRaw
         _ = self.copilotIconSecondaryWindowIDRaw
         _ = self.costUsageEnabled

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -391,11 +391,7 @@ extension SettingsStore {
         let statusChecksEnabled = userDefaults.object(forKey: "statusChecksEnabled") as? Bool ?? true
         let sessionQuotaNotificationsEnabled = Self.loadSessionQuotaNotificationsDefault(userDefaults: userDefaults)
         let quotaWarnings = Self.loadQuotaWarningDefaults(userDefaults: userDefaults)
-        let quotaWarningMarkersVisibleDefault = userDefaults.object(forKey: "quotaWarningMarkersVisible") as? Bool
-        let quotaWarningMarkersVisible = quotaWarningMarkersVisibleDefault ?? true
-        if Self.isRunningTests, quotaWarningMarkersVisibleDefault == nil {
-            userDefaults.set(true, forKey: "quotaWarningMarkersVisible")
-        }
+        let quotaWarningMarkersVisible = Self.loadQuotaWarningMarkersVisible(userDefaults: userDefaults)
         let weeklyProgressWorkDays = userDefaults.object(forKey: "weeklyProgressWorkDays") as? Int
         let usageBarsShowUsed = userDefaults.object(forKey: "usageBarsShowUsed") as? Bool ?? false
         let resetTimesShowAbsolute = userDefaults.object(forKey: "resetTimesShowAbsolute") as? Bool ?? false
@@ -410,6 +406,8 @@ extension SettingsStore {
             ?? KiroMenuBarDisplayMode.automatic.rawValue
         let historicalTrackingEnabled = userDefaults.object(forKey: "historicalTrackingEnabled") as? Bool ?? false
         let multiAccountMenuLayoutRaw = Self.loadMultiAccountMenuLayoutRaw(userDefaults: userDefaults)
+        let creditExpiryDisplayStyleRaw = userDefaults.string(forKey: "creditExpiryDisplayStyle")
+            ?? CreditExpiryDisplayStyle.list.rawValue
         let resolvedPreferences = Self.loadMenuBarMetricPreferences(userDefaults: userDefaults)
         let copilotBudgetExtrasEnabled = userDefaults.object(forKey: "copilotBudgetExtrasEnabled") as? Bool ?? false
         let copilotIconSecondaryWindowIDRaw = Self.loadCopilotIconSecondaryWindowIDRaw(userDefaults: userDefaults)
@@ -491,6 +489,7 @@ extension SettingsStore {
             kiroMenuBarDisplayModeRaw: kiroMenuBarDisplayModeRaw,
             historicalTrackingEnabled: historicalTrackingEnabled,
             multiAccountMenuLayoutRaw: multiAccountMenuLayoutRaw,
+            creditExpiryDisplayStyleRaw: creditExpiryDisplayStyleRaw,
             menuBarMetricPreferencesRaw: resolvedPreferences,
             copilotBudgetExtrasEnabled: copilotBudgetExtrasEnabled,
             copilotIconSecondaryWindowIDRaw: copilotIconSecondaryWindowIDRaw,
@@ -591,6 +590,14 @@ extension SettingsStore {
         userDefaults.set(migrated, forKey: "menuBarMetricPreferences")
         userDefaults.set(true, forKey: migrationKey)
         return migrated
+    }
+
+    private static func loadQuotaWarningMarkersVisible(userDefaults: UserDefaults) -> Bool {
+        let stored = userDefaults.object(forKey: "quotaWarningMarkersVisible") as? Bool
+        if Self.isRunningTests, stored == nil {
+            userDefaults.set(true, forKey: "quotaWarningMarkersVisible")
+        }
+        return stored ?? true
     }
 
     private static func loadMultiAccountMenuLayoutRaw(userDefaults: UserDefaults) -> String {

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -31,6 +31,7 @@ struct SettingsDefaultsState {
     var kiroMenuBarDisplayModeRaw: String?
     var historicalTrackingEnabled: Bool
     var multiAccountMenuLayoutRaw: String
+    var creditExpiryDisplayStyleRaw: String
     var menuBarMetricPreferencesRaw: [String: String]
     var copilotBudgetExtrasEnabled: Bool
     var copilotIconSecondaryWindowIDRaw: String

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -108,6 +108,7 @@ extension StatusItemController {
             limitsAvailability: self.store.knownLimitsAvailability(for: target),
             usageBarsShowUsed: self.settings.usageBarsShowUsed,
             resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
+            creditExpiryDisplayStyle: self.settings.creditExpiryDisplayStyle,
             tokenCostUsageEnabled: self.settings.isCostUsageEffectivelyEnabled(for: target),
             tokenCostInlineDashboardEnabled: self.settings.costSummaryShowsInlineDashboard(for: target),
             tokenCostMenuSectionEnabled: !UsageStore.tokenCostRequiresProviderSnapshot(target) &&

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -5,6 +5,14 @@ public enum ResetTimeDisplayStyle: String, Codable, Sendable {
     case absolute
 }
 
+/// How the Codex reset-credit row renders its inventory of expiring credits.
+public enum CreditExpiryDisplayStyle: String, Codable, Sendable, CaseIterable {
+    /// Compact "· "-separated list of the soonest expiries (current default).
+    case list
+    /// Horizontal timeline with one dot per credit.
+    case runway
+}
+
 public enum UsageFormatter {
     private final class BundleToken {}
 

--- a/Tests/CodexBarTests/CodexResetCreditRunwayTests.swift
+++ b/Tests/CodexBarTests/CodexResetCreditRunwayTests.swift
@@ -1,0 +1,137 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CodexResetCreditRunwayTests {
+    private let day: TimeInterval = 86400
+    private let hour: TimeInterval = 3600
+    private let now = Date(timeIntervalSince1970: 1_781_726_400)
+
+    @Test
+    func `markers are placed by remaining time over the longest credit lifetime`() {
+        // a: granted 1d ago, expires in 6d -> lifetime 7d, remaining 6d
+        // b: granted 1d ago, expires in 29d -> lifetime 30d, remaining 29d ; horizon = 30d
+        let markers = CodexResetCreditsPresentation.runwayMarkers(
+            credits: [
+                self.credit(id: "a", grantedAgo: self.day, expiresIn: 6 * self.day),
+                self.credit(id: "b", grantedAgo: self.day, expiresIn: 29 * self.day),
+            ],
+            resetStyle: .countdown,
+            now: self.now)
+
+        #expect(markers.count == 2)
+        #expect(markers[0].isNearest)
+        #expect(!markers[1].isNearest)
+        #expect(abs(markers[0].position - 6.0 / 30.0) < 0.001)
+        #expect(abs(markers[1].position - 29.0 / 30.0) < 0.001)
+        // Resting label rides the nearest credit only; every marker carries hover text.
+        #expect(markers[0].restingLabel == "6d")
+        #expect(markers[1].restingLabel == nil)
+        #expect(markers.allSatisfy { !$0.hoverText.isEmpty })
+    }
+
+    @Test
+    func `credits without an expiry stay off the track`() {
+        let markers = CodexResetCreditsPresentation.runwayMarkers(
+            credits: [
+                self.credit(id: "dated", grantedAgo: self.day, expiresIn: 5 * self.day),
+                self.credit(id: "forever", grantedAgo: self.day, expiresIn: nil),
+            ],
+            resetStyle: .countdown,
+            now: self.now)
+
+        #expect(markers.count == 1)
+    }
+
+    @Test
+    func `nearest credit under 48h is urgent`() {
+        let urgent = CodexResetCreditsPresentation.runwayMarkers(
+            credits: [
+                self.credit(id: "soon", grantedAgo: self.day, expiresIn: 37 * self.hour),
+                self.credit(id: "later", grantedAgo: self.day, expiresIn: 10 * self.day),
+            ],
+            resetStyle: .countdown,
+            now: self.now)
+        #expect(urgent[0].isUrgent)
+        #expect(!urgent[1].isUrgent)
+
+        let calm = CodexResetCreditsPresentation.runwayMarkers(
+            credits: [self.credit(id: "ok", grantedAgo: self.day, expiresIn: 5 * self.day)],
+            resetStyle: .countdown,
+            now: self.now)
+        #expect(!calm[0].isUrgent)
+    }
+
+    @Test
+    func `no dated future credits yields no markers`() {
+        let markers = CodexResetCreditsPresentation.runwayMarkers(
+            credits: [
+                self.credit(id: "expired", grantedAgo: 2 * self.day, expiresIn: -1 * self.hour),
+                self.credit(id: "forever", grantedAgo: self.day, expiresIn: nil),
+            ],
+            resetStyle: .countdown,
+            now: self.now)
+        #expect(markers.isEmpty)
+    }
+
+    @Test
+    func `horizon label reflects the longest lifetime`() {
+        let label = CodexResetCreditsPresentation.runwayHorizonLabel(
+            credits: [self.credit(id: "a", grantedAgo: self.day, expiresIn: 6 * self.day)],
+            now: self.now)
+        #expect(label == "7d")
+    }
+
+    @Test
+    func `make builds runway data only for the runway style`() throws {
+        let snapshot = self.snapshot(credits: [
+            self.credit(id: "a", grantedAgo: self.day, expiresIn: 6 * self.day),
+            self.credit(id: "b", grantedAgo: self.day, expiresIn: 20 * self.day),
+        ])
+
+        let list = try #require(CodexResetCreditsPresentation.make(
+            snapshot: snapshot, resetStyle: .countdown, expiryStyle: .list, now: self.now))
+        #expect(list.markers.isEmpty)
+        #expect(list.horizonLabel == nil)
+        #expect(!list.showsRunway)
+
+        let runway = try #require(CodexResetCreditsPresentation.make(
+            snapshot: snapshot, resetStyle: .countdown, expiryStyle: .runway, now: self.now))
+        #expect(runway.markers.count == 2)
+        #expect(runway.horizonLabel != nil)
+        #expect(runway.showsRunway)
+    }
+
+    @Test
+    func `runway falls back to the list when no dated credits exist`() throws {
+        let snapshot = self.snapshot(credits: [self.credit(id: "forever", grantedAgo: self.day, expiresIn: nil)])
+        let presentation = try #require(CodexResetCreditsPresentation.make(
+            snapshot: snapshot, resetStyle: .countdown, expiryStyle: .runway, now: self.now))
+        #expect(presentation.markers.isEmpty)
+        #expect(!presentation.showsRunway)
+        #expect(presentation.items.count == 1)
+    }
+
+    private func credit(
+        id: String,
+        status: CodexRateLimitResetCreditStatus = .available,
+        grantedAgo: TimeInterval,
+        expiresIn: TimeInterval?) -> CodexRateLimitResetCredit
+    {
+        CodexRateLimitResetCredit(
+            id: id,
+            resetType: "codex_rate_limits",
+            status: status,
+            grantedAt: self.now.addingTimeInterval(-grantedAgo),
+            expiresAt: expiresIn.map(self.now.addingTimeInterval),
+            redeemStartedAt: nil,
+            redeemedAt: nil,
+            title: nil,
+            description: nil)
+    }
+
+    private func snapshot(credits: [CodexRateLimitResetCredit]) -> CodexRateLimitResetCreditsSnapshot {
+        CodexRateLimitResetCreditsSnapshot(credits: credits, availableCount: credits.count, updatedAt: self.now)
+    }
+}


### PR DESCRIPTION
## Summary

An **opt-in** "expiry runway" view for the Codex reset-credits menu row: a horizontal timeline with one dot per credit, so all expiries are visible at a glance instead of clipped behind `+N` in the compact list. Addresses #1758 (show all reset-credit expirations, not only the soonest).

**Default is unchanged** — this ships behind a new `CreditExpiryDisplayStyle` picker (Display settings) defaulting to `.list`, so nobody's current row changes unless they opt in. Happy to flip the default or drop the setting entirely — see the open question below.

<!-- screenshots: list vs runway, light + dark, added on request -->

## Why

The 0.39.x compact list (#1902) reads well at 2–3 credits but at 4+ it clips (`7d 7h · 13d 5h · 22d 4h · +2`) and asks you to place four countdowns on a mental timeline. The runway makes *position* carry the timing: a far-right cluster reads "nothing expires for weeks" pre-attentively, and the nearest dot turns red under 48h. Hovering any dot reveals its exact countdown + absolute date (mirroring the `ZaiHourlyUsageChartMenuView` hover), so the runway is a strict **superset** of the list — no information is lost, and the row's `.help()` tooltip + accessibility label are untouched.

## Design notes (kept native)

- **Data-derived horizon** (`max(expiresAt − grantedAt)` across the inventory) — no hardcoded window; credits with no expiry stay counted/in the tooltip but off the track.
- **Theming via `MenuHighlightStyle`** (`progressTrack` / `progressTint` / `error`), mirroring `UsageProgressBar`, so the runway stays legible on the highlighted (blue) row rather than clashing with raw `.accentColor`/`.red`.
- **Reset-time style** is respected for free (the nearest label reuses `compactExpiryText`); hover shows both forms.
- **Reduce Motion**: hover scale/fade gate on `accessibilityReduceMotion` (per `QuotaWarningAlertOverlayController`).
- **Height fingerprint**: the runway is a distinct fixed-height row, so `CodexResetCreditsPresentation.heightFingerprint` gets a `runway` discriminator (the honest cost of gating — two heights).

## Open question for you

Straight **replacement**, or keep the **gate** (this PR)? Replacement is defensible since hover makes the runway a superset of the list and it drops the second height/settings surface; the gate keeps your fresh default untouched. I went with opt-in to be conservative on a surface you just built — flipping the default or removing the picker is a one-line change, your call.

Not in scope (declared): single-point resets (session/weekly/monthly, `CodexCreditLimitSnapshot.resetsAt`) stay as text — one timestamp needs no axis. A natural *future* adopter is OpenAI API credit grants (per-grant `expiresAt` exists but the snapshot currently collapses to `nextGrantExpiry`, so it'd need fetcher plumbing first) — happy to follow up if this direction lands.

## Commands run

- `swift build` — green
- `swift test --filter CodexResetCreditRunwayTests --filter CodexResetCreditsMenuCardTests --filter MenuCardHeightFingerprintTests` — green
- `make check` — SwiftFormat + SwiftLint + locale gate green

## Tests

`CodexResetCreditRunwayTests` covers marker placement over the data-derived horizon, the nearest-credit flag, `<48h` urgency, no-expiry exclusion, empty→list fallback, the horizon label, and that `make(…)` only builds runway data for `.runway`.
