### PR TITLE
Add opt-in read-only claude-swap adapter for Claude multi-account usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.39.1 — Unreleased
 
 ### Added
-- Claude: opt-in read-only claude-swap adapter shows session and weekly usage for every claude-swap account as stacked menu cards, without CodexBar reading any credentials (#1756, #1268). Thanks @optimiz-r!
 - Codex dashboard: show calendar-correct raw Today and 30-day credit totals without converting credits to billed dollars. Thanks @avenoxai!
 - Cursor: read the signed-in app token on Linux, with explicit manual-cookie web-source support and XDG config paths. Thanks @DonnieFi!
 - Devin: show remaining extra-usage balance in menus, CLI, and widgets while respecting optional-usage visibility. Thanks @FNDEVVE!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.39.1 — Unreleased
 
 ### Added
+- Claude: opt-in read-only claude-swap adapter shows session and weekly usage for every claude-swap account as stacked menu cards, without CodexBar reading any credentials (#1756, #1268). Thanks @optimiz-r!
 - Codex dashboard: show calendar-correct raw Today and 30-day credit totals without converting credits to billed dollars. Thanks @avenoxai!
 - Cursor: read the signed-in app token on Linux, with explicit manual-cookie web-source support and XDG config paths. Thanks @DonnieFi!
 - Devin: show remaining extra-usage balance in menus, CLI, and widgets while respecting optional-usage visibility. Thanks @FNDEVVE!

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -48,6 +48,10 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         }
     }
 
+    func makeRuntime() -> (any ProviderRuntime)? {
+        ClaudeProviderRuntime()
+    }
+
     @MainActor
     func defaultSourceLabel(context: ProviderSourceLabelContext) -> String? {
         context.settings.claudeUsageDataSource.rawValue

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -25,6 +25,8 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         _ = settings.claudeOAuthKeychainPromptMode
         _ = settings.claudeOAuthKeychainReadStrategy
         _ = settings.claudeWebExtrasEnabled
+        _ = settings.claudeSwapEnabled
+        _ = settings.claudeSwapExecutablePath
     }
 
     @MainActor
@@ -77,6 +79,10 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                 context.settings.claudeOAuthPromptFreeCredentialsEnabled = enabled
             })
 
+        let claudeSwapBinding = Binding(
+            get: { context.settings.claudeSwapEnabled },
+            set: { context.settings.claudeSwapEnabled = $0 })
+
         return [
             ProviderSettingsToggleDescriptor(
                 id: "claude-oauth-prompt-free-credentials",
@@ -90,7 +96,40 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                 onChange: nil,
                 onAppDidBecomeActive: nil,
                 onAppearWhenEnabled: nil),
+            ProviderSettingsToggleDescriptor(
+                id: "claude-swap-accounts",
+                title: "Read accounts from claude-swap",
+                subtitle: "Shows usage for every claude-swap account by running `cswap --list --json`. " +
+                    "Read-only: CodexBar never reads claude-swap or Claude Code credentials.",
+                binding: claudeSwapBinding,
+                statusText: { Self.claudeSwapStatusText(store: context.store, settings: context.settings) },
+                actions: [],
+                isVisible: nil,
+                isEnabled: nil,
+                onChange: nil,
+                onAppDidBecomeActive: nil,
+                onAppearWhenEnabled: nil),
         ]
+    }
+
+    @MainActor
+    private static func claudeSwapStatusText(store: UsageStore, settings: SettingsStore) -> String? {
+        guard settings.claudeSwapEnabled else { return nil }
+        if settings.claudeSwapExecutablePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Set the cswap executable path below."
+        }
+        var parts: [String] = []
+        if let version = store.claudeSwapDetectedVersion {
+            parts.append("claude-swap \(version)")
+        }
+        if let error = store.claudeSwapLastError {
+            parts.append(error)
+        } else if let refreshedAt = store.claudeSwapLastRefreshAt {
+            let accounts = store.claudeSwapAccountSnapshots.count
+            let accountsText = accounts == 1 ? "1 account" : "\(accounts) accounts"
+            parts.append("\(accountsText), updated \(refreshedAt.relativeDescription())")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " — ")
     }
 
     @MainActor
@@ -195,6 +234,16 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                 binding: context.stringBinding(\.claudeAdminAPIKey),
                 actions: [],
                 isVisible: nil,
+                onActivate: nil),
+            ProviderSettingsFieldDescriptor(
+                id: "claude-swap-executable-path",
+                title: "claude-swap executable",
+                subtitle: "Path to the cswap executable (github.com/realiti4/claude-swap).",
+                kind: .plain,
+                placeholder: "~/.local/bin/cswap",
+                binding: context.stringBinding(\.claudeSwapExecutablePath),
+                actions: [],
+                isVisible: { context.settings.claudeSwapEnabled },
                 onActivate: nil),
         ]
     }

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderRuntime.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderRuntime.swift
@@ -1,0 +1,42 @@
+import CodexBarCore
+
+@MainActor
+final class ClaudeProviderRuntime: ProviderRuntime {
+    let id: UsageProvider = .claude
+    private var lastSwapConfiguration: Configuration?
+
+    func start(context: ProviderRuntimeContext) {
+        self.reconcileSwapConfiguration(context: context)
+    }
+
+    func stop(context: ProviderRuntimeContext) {
+        self.lastSwapConfiguration = nil
+        context.store.clearClaudeSwapAccountState()
+    }
+
+    func settingsDidChange(context: ProviderRuntimeContext) {
+        self.reconcileSwapConfiguration(context: context)
+    }
+
+    private func reconcileSwapConfiguration(context: ProviderRuntimeContext) {
+        let configuration = Configuration(
+            providerEnabled: context.store.isEnabled(.claude),
+            enabled: context.settings.claudeSwapEnabled,
+            executablePath: context.settings.claudeSwapExecutablePath)
+        guard configuration != self.lastSwapConfiguration else { return }
+        self.lastSwapConfiguration = configuration
+
+        // Cancel before clearing so an old executable can never repopulate the menu.
+        context.store.clearClaudeSwapAccountState()
+        guard configuration.providerEnabled, configuration.enabled, !configuration.executablePath.isEmpty else {
+            return
+        }
+        context.store.scheduleClaudeSwapAccountRefresh()
+    }
+
+    private struct Configuration: Equatable {
+        let providerEnabled: Bool
+        let enabled: Bool
+        let executablePath: String
+    }
+}

--- a/Sources/CodexBar/Providers/Claude/ClaudeSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeSettingsStore.swift
@@ -56,6 +56,29 @@ extension SettingsStore {
             self.logSecretUpdate(provider: .claude, field: "apiKey", value: newValue)
         }
     }
+
+    var claudeSwapEnabled: Bool {
+        get { self.configSnapshot.providerConfig(for: .claude)?.claudeSwapEnabled ?? false }
+        set {
+            self.updateProviderConfig(provider: .claude) { entry in
+                entry.claudeSwapEnabled = newValue
+            }
+            self.logProviderModeChange(provider: .claude, field: "claudeSwapEnabled", value: String(newValue))
+        }
+    }
+
+    var claudeSwapExecutablePath: String {
+        get { self.configSnapshot.providerConfig(for: .claude)?.sanitizedClaudeSwapExecutablePath ?? "" }
+        set {
+            self.updateProviderConfig(provider: .claude) { entry in
+                entry.claudeSwapExecutablePath = self.normalizedConfigValue(newValue)
+            }
+            self.logProviderModeChange(
+                provider: .claude,
+                field: "claudeSwapExecutablePath",
+                value: newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "cleared" : "set")
+        }
+    }
 }
 
 extension SettingsStore {

--- a/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeSwapRefresh.swift
+++ b/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeSwapRefresh.swift
@@ -1,0 +1,45 @@
+import CodexBarCore
+import Foundation
+
+extension UsageStore {
+    /// True when the opt-in claude-swap adapter should run alongside the
+    /// ambient Claude refresh. The adapter is display-only: it never reads
+    /// credentials and its failures never affect the ambient Claude snapshot.
+    func shouldFetchClaudeSwapAccounts() -> Bool {
+        self.settings.claudeSwapEnabled &&
+            !self.settings.claudeSwapExecutablePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func clearClaudeSwapAccountState() {
+        self.claudeSwapAccountSnapshots = []
+        self.claudeSwapLastRefreshAt = nil
+        self.claudeSwapLastError = nil
+    }
+
+    func refreshClaudeSwapAccounts(generation: UInt64? = nil) async {
+        let executablePath = self.settings.claudeSwapExecutablePath
+        await self.probeClaudeSwapVersionIfNeeded(executablePath: executablePath)
+
+        do {
+            let list = try await ClaudeSwapAccountReader.readAccountList(executablePath: executablePath)
+            let snapshots = ClaudeSwapAccountProjection.accountSnapshots(from: list)
+            guard self.isCurrentProviderRefreshGeneration(.claude, generation: generation) else { return }
+            self.claudeSwapAccountSnapshots = snapshots
+            self.claudeSwapLastRefreshAt = Date()
+            self.claudeSwapLastError = nil
+        } catch {
+            guard self.isCurrentProviderRefreshGeneration(.claude, generation: generation) else { return }
+            // Retain the last successful snapshots as stale data; the settings
+            // pane surfaces the adapter error and last refresh time.
+            self.claudeSwapLastError = (error as? LocalizedError)?.errorDescription
+                ?? error.localizedDescription
+        }
+    }
+
+    private func probeClaudeSwapVersionIfNeeded(executablePath: String) async {
+        guard self.claudeSwapVersionProbedPath != executablePath else { return }
+        let version = await ClaudeSwapAccountReader.readVersion(executablePath: executablePath)
+        self.claudeSwapVersionProbedPath = executablePath
+        self.claudeSwapDetectedVersion = version
+    }
+}

--- a/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeSwapRefresh.swift
+++ b/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeSwapRefresh.swift
@@ -11,9 +11,30 @@ extension UsageStore {
     }
 
     func clearClaudeSwapAccountState() {
+        let hadState = !self.claudeSwapAccountSnapshots.isEmpty ||
+            self.claudeSwapLastRefreshAt != nil || self.claudeSwapLastError != nil
+        self.claudeSwapRefreshTask?.cancel()
+        self.claudeSwapRefreshTask = nil
         self.claudeSwapAccountSnapshots = []
         self.claudeSwapLastRefreshAt = nil
         self.claudeSwapLastError = nil
+        if hadState {
+            self.claudeSwapRevision &+= 1
+        }
+    }
+
+    /// Runs the optional adapter independently so it cannot delay the ambient Claude card.
+    func scheduleClaudeSwapAccountRefresh(generation: UInt64) {
+        self.claudeSwapRefreshTask?.cancel()
+        guard self.shouldFetchClaudeSwapAccounts() else {
+            self.clearClaudeSwapAccountState()
+            return
+        }
+
+        self.claudeSwapRefreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.refreshClaudeSwapAccounts(generation: generation)
+        }
     }
 
     func refreshClaudeSwapAccounts(generation: UInt64? = nil) async {
@@ -27,12 +48,19 @@ extension UsageStore {
             self.claudeSwapAccountSnapshots = snapshots
             self.claudeSwapLastRefreshAt = Date()
             self.claudeSwapLastError = nil
+            self.claudeSwapRevision &+= 1
+        } catch is CancellationError {
+            return
         } catch {
             guard self.isCurrentProviderRefreshGeneration(.claude, generation: generation) else { return }
             // Retain the last successful snapshots as stale data; the settings
             // pane surfaces the adapter error and last refresh time.
-            self.claudeSwapLastError = (error as? LocalizedError)?.errorDescription
+            let message = (error as? LocalizedError)?.errorDescription
                 ?? error.localizedDescription
+            if self.claudeSwapLastError != message {
+                self.claudeSwapLastError = message
+                self.claudeSwapRevision &+= 1
+            }
         }
     }
 

--- a/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeSwapRefresh.swift
+++ b/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeSwapRefresh.swift
@@ -6,7 +6,7 @@ extension UsageStore {
     /// ambient Claude refresh. The adapter is display-only: it never reads
     /// credentials and its failures never affect the ambient Claude snapshot.
     func shouldFetchClaudeSwapAccounts() -> Bool {
-        self.settings.claudeSwapEnabled &&
+        self.isEnabled(.claude) && self.settings.claudeSwapEnabled &&
             !self.settings.claudeSwapExecutablePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
@@ -24,7 +24,7 @@ extension UsageStore {
     }
 
     /// Runs the optional adapter independently so it cannot delay the ambient Claude card.
-    func scheduleClaudeSwapAccountRefresh(generation: UInt64) {
+    func scheduleClaudeSwapAccountRefresh(generation: UInt64? = nil) {
         self.claudeSwapRefreshTask?.cancel()
         guard self.shouldFetchClaudeSwapAccounts() else {
             self.clearClaudeSwapAccountState()
@@ -44,7 +44,9 @@ extension UsageStore {
         do {
             let list = try await ClaudeSwapAccountReader.readAccountList(executablePath: executablePath)
             let snapshots = ClaudeSwapAccountProjection.accountSnapshots(from: list)
-            guard self.isCurrentProviderRefreshGeneration(.claude, generation: generation) else { return }
+            guard self.isCurrentClaudeSwapRefresh(executablePath: executablePath, generation: generation) else {
+                return
+            }
             self.claudeSwapAccountSnapshots = snapshots
             self.claudeSwapLastRefreshAt = Date()
             self.claudeSwapLastError = nil
@@ -52,7 +54,9 @@ extension UsageStore {
         } catch is CancellationError {
             return
         } catch {
-            guard self.isCurrentProviderRefreshGeneration(.claude, generation: generation) else { return }
+            guard self.isCurrentClaudeSwapRefresh(executablePath: executablePath, generation: generation) else {
+                return
+            }
             // Retain the last successful snapshots as stale data; the settings
             // pane surfaces the adapter error and last refresh time.
             let message = (error as? LocalizedError)?.errorDescription
@@ -67,7 +71,18 @@ extension UsageStore {
     private func probeClaudeSwapVersionIfNeeded(executablePath: String) async {
         guard self.claudeSwapVersionProbedPath != executablePath else { return }
         let version = await ClaudeSwapAccountReader.readVersion(executablePath: executablePath)
+        guard self.isCurrentClaudeSwapConfiguration(executablePath: executablePath) else { return }
         self.claudeSwapVersionProbedPath = executablePath
         self.claudeSwapDetectedVersion = version
+    }
+
+    private func isCurrentClaudeSwapRefresh(executablePath: String, generation: UInt64?) -> Bool {
+        self.isCurrentProviderRefreshGeneration(.claude, generation: generation) &&
+            self.isCurrentClaudeSwapConfiguration(executablePath: executablePath)
+    }
+
+    private func isCurrentClaudeSwapConfiguration(executablePath: String) -> Bool {
+        self.isEnabled(.claude) && self.settings.claudeSwapEnabled &&
+            self.settings.claudeSwapExecutablePath == executablePath
     }
 }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -633,6 +633,19 @@ extension StatusItemController {
             return false
         }
 
+        if context.currentProvider == .claude, self.store.claudeSwapAccountSnapshots.count > 1 {
+            let cards = self.store.claudeSwapAccountSnapshots.compactMap { account in
+                self.menuCardModel(
+                    for: .claude,
+                    snapshotOverride: account.snapshot,
+                    errorOverride: account.error,
+                    forceOverrideCard: account.snapshot == nil,
+                    accountOverride: AccountInfo(email: account.displayLabel, plan: nil))
+            }
+            self.addStackedMenuCards(cards, to: menu, context: context)
+            return false
+        }
+
         guard let model = self.menuCardModel(for: context.selectedProvider) else { return false }
         let renderedModel = self.menuCardRefreshMonitor.model(for: model.provider, fallback: model)
         if context.openAIContext.hasOpenAIWebMenuItems ||

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -638,7 +638,9 @@ extension StatusItemController {
                 self.menuCardModel(
                     for: .claude,
                     snapshotOverride: account.snapshot,
-                    errorOverride: account.error,
+                    errorOverride: ClaudeSwapAccountProjection.displayError(
+                        accountError: account.error,
+                        adapterError: self.store.claudeSwapLastError),
                     forceOverrideCard: account.snapshot == nil,
                     accountOverride: AccountInfo(email: account.displayLabel, plan: nil))
             }

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -102,9 +102,12 @@ extension StatusItemController {
             tokenError: tokenError,
             account: fallbackAccount,
             isRefreshing: self.store.shouldShowRefreshingMenuCardIndicator(for: target),
+            // Provider-level errors can belong to a different account, so
+            // override cards never inherit them (same rule as the snapshot,
+            // token-cost, and source-label fallbacks above).
             lastError: errorOverride
                 ?? codexProjection?.userFacingErrors.usage
-                ?? self.store.userFacingError(for: target),
+                ?? (surface == .liveCard ? self.store.userFacingError(for: target) : nil),
             limitsAvailability: self.store.knownLimitsAvailability(for: target),
             usageBarsShowUsed: self.settings.usageBarsShowUsed,
             resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -55,7 +55,7 @@ extension StatusItemController {
                 tokenError = nil
             }
         } else if ProviderDescriptorRegistry.descriptor(for: target).tokenCost.supportsTokenCost,
-                  snapshotOverride == nil
+                  surface == .liveCard
         {
             credits = nil
             creditsError = nil
@@ -72,7 +72,7 @@ extension StatusItemController {
             tokenError = nil
         }
 
-        let sourceLabel = snapshotOverride == nil ? self.store.sourceLabel(for: target) : nil
+        let sourceLabel = surface == .liveCard ? self.store.sourceLabel(for: target) : nil
         let kiloAutoMode = target == .kilo && self.settings.kiloUsageDataSource == .auto
         // Abacus uses primary for monthly credits (no secondary window)
         let paceWindow = target == .abacus ? snapshot?.primary : snapshot?.secondary

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -119,6 +119,7 @@ extension StatusItemController {
             "openAIUsage=\(Self.dashboardBreakdownReadinessSignature(dashboardUsageBreakdown))",
             "credits=\(self.store.credits == nil ? "0" : "1")",
             "planHistoryRevision=\(self.store.planUtilizationHistoryRevision)",
+            "claudeSwapRevision=\(self.store.claudeSwapRevision)",
         ]
 
         for provider in self.store.enabledProvidersForDisplay() {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -349,6 +349,7 @@ extension StatusItemController {
             }
 
             if target == .claude {
+                parts.append(Self.menuIdentityField(self.store.claudeSwapLastError ?? ""))
                 for accountSnapshot in self.store.claudeSwapAccountSnapshots {
                     parts.append(Self.menuIdentityField(accountSnapshot.id.opaqueID))
                     parts.append(accountSnapshot.isActive ? "active" : "inactive")

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -347,6 +347,14 @@ extension StatusItemController {
                     parts.append(self.providerIdentitySignature(scopeSnapshot.snapshot?.identity(for: target)))
                 }
             }
+
+            if target == .claude {
+                for accountSnapshot in self.store.claudeSwapAccountSnapshots {
+                    parts.append(Self.menuIdentityField(accountSnapshot.id.opaqueID))
+                    parts.append(accountSnapshot.isActive ? "active" : "inactive")
+                    parts.append(self.providerIdentitySignature(accountSnapshot.snapshot?.identity(for: target)))
+                }
+            }
         }
         return parts.joined(separator: "|")
     }

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -159,13 +159,8 @@ extension UsageStore {
             await MainActor.run { self.kiloScopeSnapshots = [] }
         }
 
-        if provider == .claude, self.shouldFetchClaudeSwapAccounts() {
-            await self.refreshClaudeSwapAccounts(generation: generation)
-            guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
-            // The ambient Claude refresh continues below; multi-element
-            // claudeSwapAccountSnapshots trigger stacked rendering.
-        } else if provider == .claude {
-            await MainActor.run { self.clearClaudeSwapAccountState() }
+        if provider == .claude {
+            self.scheduleClaudeSwapAccountRefresh(generation: generation)
         }
 
         let tokenAccounts = self.tokenAccounts(for: provider)

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -159,6 +159,15 @@ extension UsageStore {
             await MainActor.run { self.kiloScopeSnapshots = [] }
         }
 
+        if provider == .claude, self.shouldFetchClaudeSwapAccounts() {
+            await self.refreshClaudeSwapAccounts(generation: generation)
+            guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
+            // The ambient Claude refresh continues below; multi-element
+            // claudeSwapAccountSnapshots trigger stacked rendering.
+        } else if provider == .claude {
+            await MainActor.run { self.clearClaudeSwapAccountState() }
+        }
+
         let tokenAccounts = self.tokenAccounts(for: provider)
         if self.shouldFetchAllTokenAccounts(provider: provider, accounts: tokenAccounts) {
             await self.refreshTokenAccounts(
@@ -359,6 +368,9 @@ extension UsageStore {
             }
             if provider == .kilo {
                 self.kiloScopeSnapshots = []
+            }
+            if provider == .claude {
+                self.clearClaudeSwapAccountState()
             }
             self.tokenSnapshots.removeValue(forKey: provider)
             self.tokenErrors[provider] = nil

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -18,6 +18,8 @@ extension UsageStore {
         _ = self.codexAccountSnapshots
         _ = self.kiloScopeSnapshots
         _ = self.claudeSwapAccountSnapshots
+        _ = self.claudeSwapLastError
+        _ = self.claudeSwapRevision
         _ = self.tokenSnapshots
         _ = self.tokenErrors
         _ = self.tokenRefreshInFlight
@@ -149,6 +151,8 @@ final class UsageStore {
     var claudeSwapLastRefreshAt: Date?
     var claudeSwapLastError: String?
     var claudeSwapDetectedVersion: String?
+    var claudeSwapRevision: UInt64 = 0
+    @ObservationIgnored var claudeSwapRefreshTask: Task<Void, Never>?
     @ObservationIgnored var claudeSwapVersionProbedPath: String?
     var tokenSnapshots: [UsageProvider: CostUsageTokenSnapshot] = [:]
     var tokenErrors: [UsageProvider: String] = [:]

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -17,6 +17,7 @@ extension UsageStore {
         _ = self.accountSnapshots
         _ = self.codexAccountSnapshots
         _ = self.kiloScopeSnapshots
+        _ = self.claudeSwapAccountSnapshots
         _ = self.tokenSnapshots
         _ = self.tokenErrors
         _ = self.tokenRefreshInFlight
@@ -144,6 +145,11 @@ final class UsageStore {
     var accountSnapshots: [UsageProvider: [TokenAccountUsageSnapshot]] = [:]
     var codexAccountSnapshots: [CodexAccountUsageSnapshot] = []
     var kiloScopeSnapshots: [KiloScopeSnapshot] = []
+    var claudeSwapAccountSnapshots: [ProviderAccountUsageSnapshot] = []
+    var claudeSwapLastRefreshAt: Date?
+    var claudeSwapLastError: String?
+    var claudeSwapDetectedVersion: String?
+    @ObservationIgnored var claudeSwapVersionProbedPath: String?
     var tokenSnapshots: [UsageProvider: CostUsageTokenSnapshot] = [:]
     var tokenErrors: [UsageProvider: String] = [:]
     var tokenRefreshInFlight: Set<UsageProvider> = []

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -106,6 +106,8 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var workspaceID: String?
     public var enterpriseHost: String?
     public var tokenAccounts: ProviderTokenAccountData?
+    public var claudeSwapEnabled: Bool?
+    public var claudeSwapExecutablePath: String?
     public var codexActiveSource: CodexActiveSource?
     public var codexProfileHomePaths: [String]?
     public var quotaWarnings: QuotaWarningConfig?
@@ -127,6 +129,8 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         workspaceID: String? = nil,
         enterpriseHost: String? = nil,
         tokenAccounts: ProviderTokenAccountData? = nil,
+        claudeSwapEnabled: Bool? = nil,
+        claudeSwapExecutablePath: String? = nil,
         codexActiveSource: CodexActiveSource? = nil,
         codexProfileHomePaths: [String]? = nil,
         quotaWarnings: QuotaWarningConfig? = nil,
@@ -147,6 +151,8 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.workspaceID = workspaceID
         self.enterpriseHost = enterpriseHost
         self.tokenAccounts = tokenAccounts
+        self.claudeSwapEnabled = claudeSwapEnabled
+        self.claudeSwapExecutablePath = claudeSwapExecutablePath
         self.codexActiveSource = codexActiveSource
         self.codexProfileHomePaths = codexProfileHomePaths
         self.quotaWarnings = quotaWarnings
@@ -178,6 +184,10 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
 
     public var sanitizedEnterpriseHost: String? {
         Self.clean(self.enterpriseHost)
+    }
+
+    public var sanitizedClaudeSwapExecutablePath: String? {
+        Self.clean(self.claudeSwapExecutablePath)
     }
 
     public var sanitizedAWSProfile: String? {

--- a/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
+++ b/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
@@ -155,6 +155,7 @@ public enum SubprocessRunner {
         timeout: TimeInterval,
         standardInput: Any? = nil,
         currentDirectoryURL: URL? = nil,
+        acceptsNonZeroExit: Bool = false,
         label: String) async throws -> SubprocessResult
     {
         guard FileManager.default.isExecutableFile(atPath: binary) else {
@@ -249,7 +250,7 @@ public enum SubprocessRunner {
             let stdout = await ProcessPipeCapture.decodeUTF8(stdoutData)
             let stderr = await ProcessPipeCapture.decodeUTF8(stderrData)
 
-            if exitCode != 0 {
+            if exitCode != 0, !acceptsNonZeroExit {
                 let duration = Date().timeIntervalSince(start)
                 self.log.warning(
                     "Subprocess failed",

--- a/Sources/CodexBarCore/ProviderAccountSnapshot.swift
+++ b/Sources/CodexBarCore/ProviderAccountSnapshot.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Stable identity for one account row surfaced by a multi-account source adapter.
+///
+/// `source` names the adapter (for example `claude-swap`) and `opaqueID` is the
+/// source-issued identifier (for example a numeric slot). Identity never derives
+/// from emails or credential material, per
+/// `docs/claude-multi-account-and-status-items.md`.
+public struct ProviderAccountIdentity: Hashable, Sendable {
+    public let source: String
+    public let opaqueID: String
+
+    public init(source: String, opaqueID: String) {
+        self.source = source
+        self.opaqueID = opaqueID
+    }
+}
+
+/// Provider-neutral projection of one account's usage, consumed by menus (and,
+/// later, per-account status items) without teaching UI code about any specific
+/// credential source.
+public struct ProviderAccountUsageSnapshot: Identifiable, Sendable {
+    public let id: ProviderAccountIdentity
+    public let provider: UsageProvider
+    /// Display-only label (may contain personal data such as an email); UI is
+    /// responsible for privacy redaction. Never logged or persisted.
+    public let displayLabel: String
+    public let isActive: Bool
+    public let snapshot: UsageSnapshot?
+    public let error: String?
+    public let sourceLabel: String?
+
+    public init(
+        id: ProviderAccountIdentity,
+        provider: UsageProvider,
+        displayLabel: String,
+        isActive: Bool,
+        snapshot: UsageSnapshot?,
+        error: String?,
+        sourceLabel: String?)
+    {
+        self.id = id
+        self.provider = provider
+        self.displayLabel = displayLabel
+        self.isActive = isActive
+        self.snapshot = snapshot
+        self.error = error
+        self.sourceLabel = sourceLabel
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountList.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountList.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+/// Strictly parsed result of `cswap --list --json` (schema v1).
+///
+/// Only the fields allow-listed in `docs/claude-multi-account-and-status-items.md`
+/// are decoded: slot number, display email, active state, usage status, and the
+/// 5-hour/7-day windows (percent + reset timestamp). Everything else in the
+/// payload is ignored; unknown schema versions and partial top-level shapes are
+/// rejected.
+public struct ClaudeSwapAccountList: Equatable, Sendable {
+    public let activeAccountNumber: Int?
+    public let accounts: [ClaudeSwapAccountRow]
+
+    public init(activeAccountNumber: Int?, accounts: [ClaudeSwapAccountRow]) {
+        self.activeAccountNumber = activeAccountNumber
+        self.accounts = accounts
+    }
+}
+
+public struct ClaudeSwapAccountRow: Equatable, Sendable {
+    public let number: Int
+    /// Display-only sensitive value; never logged or persisted.
+    public let email: String
+    public let isActive: Bool
+    public let usageStatus: ClaudeSwapUsageStatus
+    public let fiveHour: ClaudeSwapUsageWindow?
+    public let sevenDay: ClaudeSwapUsageWindow?
+
+    public init(
+        number: Int,
+        email: String,
+        isActive: Bool,
+        usageStatus: ClaudeSwapUsageStatus,
+        fiveHour: ClaudeSwapUsageWindow?,
+        sevenDay: ClaudeSwapUsageWindow?)
+    {
+        self.number = number
+        self.email = email
+        self.isActive = isActive
+        self.usageStatus = usageStatus
+        self.fiveHour = fiveHour
+        self.sevenDay = sevenDay
+    }
+}
+
+public struct ClaudeSwapUsageWindow: Equatable, Sendable {
+    public let usedPercent: Double
+    public let resetsAt: Date?
+
+    public init(usedPercent: Double, resetsAt: Date?) {
+        self.usedPercent = usedPercent
+        self.resetsAt = resetsAt
+    }
+}
+
+/// The sentinel statuses `cswap` emits per account. Unknown values from newer
+/// claude-swap releases are preserved rather than failing the whole payload.
+public enum ClaudeSwapUsageStatus: Equatable, Sendable {
+    case ok
+    case tokenExpired
+    case apiKey
+    case keychainUnavailable
+    case noCredentials
+    case unavailable
+    case unknown(String)
+
+    init(rawValue: String) {
+        switch rawValue {
+        case "ok": self = .ok
+        case "token_expired": self = .tokenExpired
+        case "api_key": self = .apiKey
+        case "keychain_unavailable": self = .keychainUnavailable
+        case "no_credentials": self = .noCredentials
+        case "unavailable": self = .unavailable
+        default: self = .unknown(rawValue)
+        }
+    }
+}
+
+public enum ClaudeSwapListParserError: LocalizedError, Equatable, Sendable {
+    case notJSONObject
+    case missingSchemaVersion
+    case unsupportedSchemaVersion(Int)
+    case reportedError(type: String, message: String)
+    case malformedShape(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notJSONObject:
+            "claude-swap returned output that is not a JSON object."
+        case .missingSchemaVersion:
+            "claude-swap output has no schemaVersion field."
+        case let .unsupportedSchemaVersion(version):
+            "claude-swap output uses unsupported schema version \(version); CodexBar supports version 1."
+        case let .reportedError(type, message):
+            "claude-swap reported \(type): \(message)"
+        case let .malformedShape(details):
+            "claude-swap output is malformed: \(details)"
+        }
+    }
+}
+
+public enum ClaudeSwapListParser {
+    public static let supportedSchemaVersion = 1
+
+    public static func parse(_ data: Data) throws -> ClaudeSwapAccountList {
+        let raw: Any
+        do {
+            raw = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw ClaudeSwapListParserError.notJSONObject
+        }
+        guard let object = raw as? [String: Any] else {
+            throw ClaudeSwapListParserError.notJSONObject
+        }
+        guard let schemaVersion = object["schemaVersion"] as? Int else {
+            throw ClaudeSwapListParserError.missingSchemaVersion
+        }
+        guard schemaVersion == self.supportedSchemaVersion else {
+            throw ClaudeSwapListParserError.unsupportedSchemaVersion(schemaVersion)
+        }
+        if let errorObject = object["error"] as? [String: Any] {
+            throw ClaudeSwapListParserError.reportedError(
+                type: errorObject["type"] as? String ?? "Error",
+                message: errorObject["message"] as? String ?? "unknown error")
+        }
+        guard let rawAccounts = object["accounts"] as? [Any] else {
+            throw ClaudeSwapListParserError.malformedShape("missing accounts array")
+        }
+        let activeAccountNumber = object["activeAccountNumber"] as? Int
+        let accounts = try rawAccounts.map { rawRow -> ClaudeSwapAccountRow in
+            guard let row = rawRow as? [String: Any] else {
+                throw ClaudeSwapListParserError.malformedShape("account row is not an object")
+            }
+            return try self.parseRow(row)
+        }
+        return ClaudeSwapAccountList(activeAccountNumber: activeAccountNumber, accounts: accounts)
+    }
+
+    private static func parseRow(_ row: [String: Any]) throws -> ClaudeSwapAccountRow {
+        guard let number = row["number"] as? Int else {
+            throw ClaudeSwapListParserError.malformedShape("account row has no numeric slot")
+        }
+        guard let isActive = row["active"] as? Bool else {
+            throw ClaudeSwapListParserError.malformedShape("slot \(number) has no active flag")
+        }
+        guard let rawStatus = row["usageStatus"] as? String else {
+            throw ClaudeSwapListParserError.malformedShape("slot \(number) has no usageStatus")
+        }
+        let email = (row["email"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let usage = row["usage"] as? [String: Any]
+        return try ClaudeSwapAccountRow(
+            number: number,
+            email: email,
+            isActive: isActive,
+            usageStatus: ClaudeSwapUsageStatus(rawValue: rawStatus),
+            fiveHour: self.parseWindow(usage?["fiveHour"], slot: number, name: "fiveHour"),
+            sevenDay: self.parseWindow(usage?["sevenDay"], slot: number, name: "sevenDay"))
+    }
+
+    private static func parseWindow(_ raw: Any?, slot: Int, name: String) throws -> ClaudeSwapUsageWindow? {
+        guard let raw else { return nil }
+        guard let window = raw as? [String: Any] else {
+            throw ClaudeSwapListParserError.malformedShape("slot \(slot) \(name) window is not an object")
+        }
+        guard let pct = Self.finiteDouble(window["pct"]) else {
+            throw ClaudeSwapListParserError.malformedShape("slot \(slot) \(name) percent is not a finite number")
+        }
+        var resetsAt: Date?
+        if let rawResetsAt = window["resetsAt"] {
+            guard let text = rawResetsAt as? String, let date = Self.parseTimestamp(text) else {
+                throw ClaudeSwapListParserError.malformedShape("slot \(slot) \(name) resetsAt is not a timestamp")
+            }
+            resetsAt = date
+        }
+        return ClaudeSwapUsageWindow(usedPercent: min(max(pct, 0), 100), resetsAt: resetsAt)
+    }
+
+    private static func finiteDouble(_ raw: Any?) -> Double? {
+        guard let number = raw as? NSNumber else { return nil }
+        // JSON booleans bridge to NSNumber too; only accept genuine numbers.
+        guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
+        let value = number.doubleValue
+        return value.isFinite ? value : nil
+    }
+
+    private static func parseTimestamp(_ text: String) -> Date? {
+        let withFraction = ISO8601DateFormatter()
+        withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = withFraction.date(from: text) { return date }
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        return plain.date(from: text)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountList.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountList.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import Foundation
 
 /// Strictly parsed result of `cswap --list --json` (schema v1).

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountList.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountList.swift
@@ -127,12 +127,29 @@ public enum ClaudeSwapListParser {
         guard let rawAccounts = object["accounts"] as? [Any] else {
             throw ClaudeSwapListParserError.malformedShape("missing accounts array")
         }
-        let activeAccountNumber = object["activeAccountNumber"] as? Int
+        guard let rawActiveAccountNumber = object["activeAccountNumber"] else {
+            throw ClaudeSwapListParserError.malformedShape("missing activeAccountNumber")
+        }
+        let activeAccountNumber: Int? = switch rawActiveAccountNumber {
+        case is NSNull: nil
+        case let number as Int where number > 0: number
+        default:
+            throw ClaudeSwapListParserError.malformedShape("activeAccountNumber is not a numeric slot or null")
+        }
+        var seenSlots: Set<Int> = []
         let accounts = try rawAccounts.map { rawRow -> ClaudeSwapAccountRow in
             guard let row = rawRow as? [String: Any] else {
                 throw ClaudeSwapListParserError.malformedShape("account row is not an object")
             }
-            return try self.parseRow(row)
+            let account = try self.parseRow(row)
+            guard seenSlots.insert(account.number).inserted else {
+                throw ClaudeSwapListParserError.malformedShape("duplicate account slot \(account.number)")
+            }
+            return account
+        }
+        let activeSlots = accounts.filter(\.isActive).map(\.number)
+        guard activeSlots == (activeAccountNumber.map { [$0] } ?? []) else {
+            throw ClaudeSwapListParserError.malformedShape("active account fields disagree")
         }
         return ClaudeSwapAccountList(activeAccountNumber: activeAccountNumber, accounts: accounts)
     }
@@ -140,6 +157,9 @@ public enum ClaudeSwapListParser {
     private static func parseRow(_ row: [String: Any]) throws -> ClaudeSwapAccountRow {
         guard let number = row["number"] as? Int else {
             throw ClaudeSwapListParserError.malformedShape("account row has no numeric slot")
+        }
+        guard number > 0 else {
+            throw ClaudeSwapListParserError.malformedShape("account slot must be positive")
         }
         guard let isActive = row["active"] as? Bool else {
             throw ClaudeSwapListParserError.malformedShape("slot \(number) has no active flag")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Projects parsed `cswap --list --json` rows into the provider-neutral
+/// account snapshot consumed by menus. Identity uses the source-issued numeric
+/// slot (`claude-swap:<slot>`), never email or credential-derived values.
+public enum ClaudeSwapAccountProjection {
+    public static let sourceName = "claude-swap"
+    public static let sourceLabel = "claude-swap"
+    static let fiveHourWindowMinutes = 5 * 60
+    static let sevenDayWindowMinutes = 7 * 24 * 60
+
+    public static func accountSnapshots(
+        from list: ClaudeSwapAccountList,
+        now: Date = Date()) -> [ProviderAccountUsageSnapshot]
+    {
+        let ordered = list.accounts.sorted { lhs, rhs in
+            if lhs.isActive != rhs.isActive { return lhs.isActive }
+            return lhs.number < rhs.number
+        }
+        return ordered.map { row in
+            ProviderAccountUsageSnapshot(
+                id: ProviderAccountIdentity(source: self.sourceName, opaqueID: String(row.number)),
+                provider: .claude,
+                displayLabel: self.displayLabel(for: row),
+                isActive: row.isActive,
+                snapshot: self.usageSnapshot(for: row, now: now),
+                error: self.errorText(for: row),
+                sourceLabel: self.sourceLabel)
+        }
+    }
+
+    static func displayLabel(for row: ClaudeSwapAccountRow) -> String {
+        row.email.isEmpty ? "Account \(row.number)" : row.email
+    }
+
+    private static func usageSnapshot(for row: ClaudeSwapAccountRow, now: Date) -> UsageSnapshot? {
+        guard row.usageStatus == .ok else { return nil }
+        let primary = row.fiveHour.map { window in
+            RateWindow(
+                usedPercent: window.usedPercent,
+                windowMinutes: self.fiveHourWindowMinutes,
+                resetsAt: window.resetsAt,
+                resetDescription: nil)
+        }
+        let secondary = row.sevenDay.map { window in
+            RateWindow(
+                usedPercent: window.usedPercent,
+                windowMinutes: self.sevenDayWindowMinutes,
+                resetsAt: window.resetsAt,
+                resetDescription: nil)
+        }
+        guard primary != nil || secondary != nil else { return nil }
+        return UsageSnapshot(
+            primary: primary,
+            secondary: secondary,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: self.displayLabel(for: row),
+                accountOrganization: nil,
+                loginMethod: self.sourceLabel))
+    }
+
+    private static func errorText(for row: ClaudeSwapAccountRow) -> String? {
+        switch row.usageStatus {
+        case .ok:
+            row.fiveHour == nil && row.sevenDay == nil ? "No usage windows reported." : nil
+        case .tokenExpired:
+            "Token expired. Switch to this account in claude-swap to refresh it."
+        case .apiKey:
+            "API-key account; subscription usage is unavailable."
+        case .keychainUnavailable:
+            "claude-swap could not read the active account's Keychain entry."
+        case .noCredentials:
+            "No stored credentials for this account slot."
+        case .unavailable:
+            "Usage fetch failed."
+        case let .unknown(raw):
+            "Unrecognized claude-swap status: \(raw)"
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
@@ -29,6 +29,10 @@ public enum ClaudeSwapAccountProjection {
         }
     }
 
+    public static func displayError(accountError: String?, adapterError: String?) -> String? {
+        accountError ?? adapterError.map { "Showing the last successful update: \($0)" }
+    }
+
     static func displayLabel(for row: ClaudeSwapAccountRow) -> String {
         row.email.isEmpty ? "Account \(row.number)" : row.email
     }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountReader.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+public enum ClaudeSwapAccountReaderError: LocalizedError, Sendable {
+    case executablePathNotConfigured
+    case outputTooLarge(byteCount: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .executablePathNotConfigured:
+            "No claude-swap executable path is configured."
+        case let .outputTooLarge(byteCount):
+            "claude-swap produced \(byteCount) bytes of output; refusing to parse more than " +
+                "\(ClaudeSwapAccountReader.maxOutputBytes)."
+        }
+    }
+}
+
+/// Read-only adapter over the external `claude-swap` executable.
+///
+/// Executes exactly `cswap --list --json` (never a shell, never config-defined
+/// passthrough arguments) with a bounded runtime and bounded output, per the
+/// Phase 1 contract in `docs/claude-multi-account-and-status-items.md`. CodexBar
+/// never reads claude-swap or Claude Code credential storage; the subprocess is
+/// solely responsible for its own credential access.
+public enum ClaudeSwapAccountReader {
+    public static let maxOutputBytes = 262_144
+    public static let defaultTimeout: TimeInterval = 30
+
+    public static func readAccountList(
+        executablePath: String,
+        timeout: TimeInterval = ClaudeSwapAccountReader.defaultTimeout) async throws -> ClaudeSwapAccountList
+    {
+        // Handled claude-swap failures print a schema-v1 error envelope to stdout
+        // and exit non-zero, so non-zero exits still parse; the parser surfaces
+        // the envelope as `ClaudeSwapListParserError.reportedError`.
+        let result = try await self.run(
+            executablePath: executablePath,
+            arguments: ["--list", "--json"],
+            timeout: timeout,
+            acceptsNonZeroExit: true,
+            label: "claude-swap list")
+        return try ClaudeSwapListParser.parse(Data(result.utf8))
+    }
+
+    /// Best-effort version probe (`cswap --version` prints `cswap <version>`).
+    public static func readVersion(
+        executablePath: String,
+        timeout: TimeInterval = 10) async -> String?
+    {
+        guard let output = try? await self.run(
+            executablePath: executablePath,
+            arguments: ["--version"],
+            timeout: timeout,
+            label: "claude-swap version")
+        else {
+            return nil
+        }
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let version = trimmed.split(whereSeparator: \.isWhitespace).last, !version.isEmpty else {
+            return nil
+        }
+        return String(version)
+    }
+
+    public static func resolvedExecutablePath(_ configuredPath: String) throws -> String {
+        let trimmed = configuredPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ClaudeSwapAccountReaderError.executablePathNotConfigured
+        }
+        return (trimmed as NSString).expandingTildeInPath
+    }
+
+    private static func run(
+        executablePath: String,
+        arguments: [String],
+        timeout: TimeInterval,
+        acceptsNonZeroExit: Bool = false,
+        label: String) async throws -> String
+    {
+        let binary = try self.resolvedExecutablePath(executablePath)
+        let result = try await SubprocessRunner.run(
+            binary: binary,
+            arguments: arguments,
+            environment: ProcessInfo.processInfo.environment,
+            timeout: timeout,
+            acceptsNonZeroExit: acceptsNonZeroExit,
+            label: label)
+        guard result.stdout.utf8.count <= self.maxOutputBytes else {
+            throw ClaudeSwapAccountReaderError.outputTooLarge(byteCount: result.stdout.utf8.count)
+        }
+        return result.stdout
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountReader.swift
@@ -77,6 +77,7 @@ public enum ClaudeSwapAccountReader {
         acceptsNonZeroExit: Bool = false,
         label: String) async throws -> String
     {
+        try Task.checkCancellation()
         let binary = try self.resolvedExecutablePath(executablePath)
         let result = try await SubprocessRunner.run(
             binary: binary,

--- a/Tests/CodexBarTests/ClaudeProviderRuntimeTests.swift
+++ b/Tests/CodexBarTests/ClaudeProviderRuntimeTests.swift
@@ -1,0 +1,107 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct ClaudeProviderRuntimeTests {
+    @Test
+    func `disabling adapter immediately clears retained accounts`() {
+        let (settings, store) = self.makeStore()
+        store.claudeSwapAccountSnapshots = [self.accountSnapshot()]
+        store.claudeSwapLastRefreshAt = Date()
+        store.claudeSwapLastError = "stale"
+        let runtime = ClaudeProviderRuntime()
+
+        runtime.settingsDidChange(context: ProviderRuntimeContext(provider: .claude, settings: settings, store: store))
+
+        #expect(store.claudeSwapAccountSnapshots.isEmpty)
+        #expect(store.claudeSwapLastRefreshAt == nil)
+        #expect(store.claudeSwapLastError == nil)
+    }
+
+    @Test
+    func `disabled Claude provider does not restart adapter`() {
+        let (settings, store) = self.makeStore()
+        settings.claudeSwapExecutablePath = "/path/to/cswap"
+        settings.claudeSwapEnabled = true
+        let runtime = ClaudeProviderRuntime()
+        let context = ProviderRuntimeContext(provider: .claude, settings: settings, store: store)
+
+        runtime.stop(context: context)
+        runtime.settingsDidChange(context: context)
+
+        #expect(!store.isEnabled(.claude))
+        #expect(store.claudeSwapRefreshTask == nil)
+    }
+
+    @Test
+    func `late adapter result is rejected after executable path changes`() async throws {
+        let (settings, store) = self.makeStore()
+        let executable = try self.makeFakeExecutable()
+        let metadata = try #require(ProviderRegistry.shared.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        settings.claudeSwapExecutablePath = executable
+        settings.claudeSwapEnabled = true
+
+        let refresh = Task { @MainActor in
+            await store.refreshClaudeSwapAccounts()
+        }
+        try await Task.sleep(for: .milliseconds(100))
+        settings.claudeSwapExecutablePath = "/new/path/to/cswap"
+        await refresh.value
+
+        #expect(store.claudeSwapAccountSnapshots.isEmpty)
+        #expect(store.claudeSwapLastRefreshAt == nil)
+    }
+
+    private func makeStore() -> (SettingsStore, UsageStore) {
+        let suite = "ClaudeProviderRuntimeTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        return (settings, store)
+    }
+
+    private func accountSnapshot() -> ProviderAccountUsageSnapshot {
+        ProviderAccountUsageSnapshot(
+            id: ProviderAccountIdentity(source: ClaudeSwapAccountProjection.sourceName, opaqueID: "1"),
+            provider: .claude,
+            displayLabel: "account@example.com",
+            isActive: false,
+            snapshot: nil,
+            error: "Token expired",
+            sourceLabel: ClaudeSwapAccountProjection.sourceLabel)
+    }
+
+    private func makeFakeExecutable() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-runtime-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("cswap")
+        let script = """
+        #!/bin/sh
+        if [ "$1" = "--version" ]; then
+          echo 'cswap 0.16.0'
+          exit 0
+        fi
+        sleep 0.3
+        cat <<'EOF'
+        {"schemaVersion":1,"activeAccountNumber":1,"accounts":[
+          {"number":1,"email":"a@b.c","active":true,"usageStatus":"ok","usage":{"fiveHour":{"pct":12.5}}}
+        ]}
+        EOF
+        """
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
+    }
+}

--- a/Tests/CodexBarTests/ClaudeSwapAccountProjectionTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapAccountProjectionTests.swift
@@ -3,6 +3,16 @@ import Testing
 @testable import CodexBarCore
 
 struct ClaudeSwapAccountProjectionTests {
+    @Test
+    func `adapter failures mark retained account snapshots as stale`() {
+        #expect(ClaudeSwapAccountProjection.displayError(
+            accountError: nil,
+            adapterError: "timed out") == "Showing the last successful update: timed out")
+        #expect(ClaudeSwapAccountProjection.displayError(
+            accountError: "Token expired.",
+            adapterError: "timed out") == "Token expired.")
+    }
+
     private let now = Date(timeIntervalSince1970: 1_782_000_000)
 
     @Test

--- a/Tests/CodexBarTests/ClaudeSwapAccountProjectionTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapAccountProjectionTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeSwapAccountProjectionTests {
+    private let now = Date(timeIntervalSince1970: 1_782_000_000)
+
+    @Test
+    func `projects rows into provider neutral snapshots with active account first`() throws {
+        let reset = Date(timeIntervalSince1970: 1_782_170_999)
+        let list = ClaudeSwapAccountList(
+            activeAccountNumber: 2,
+            accounts: [
+                ClaudeSwapAccountRow(
+                    number: 1,
+                    email: "work@example.com",
+                    isActive: false,
+                    usageStatus: .ok,
+                    fiveHour: ClaudeSwapUsageWindow(usedPercent: 25, resetsAt: reset),
+                    sevenDay: ClaudeSwapUsageWindow(usedPercent: 16.5, resetsAt: nil)),
+                ClaudeSwapAccountRow(
+                    number: 2,
+                    email: "personal@example.com",
+                    isActive: true,
+                    usageStatus: .ok,
+                    fiveHour: ClaudeSwapUsageWindow(usedPercent: 80, resetsAt: nil),
+                    sevenDay: nil),
+            ])
+
+        let snapshots = ClaudeSwapAccountProjection.accountSnapshots(from: list, now: self.now)
+        #expect(snapshots.count == 2)
+
+        let active = try #require(snapshots.first)
+        #expect(active.id == ProviderAccountIdentity(source: "claude-swap", opaqueID: "2"))
+        #expect(active.provider == .claude)
+        #expect(active.displayLabel == "personal@example.com")
+        #expect(active.isActive == true)
+        #expect(active.error == nil)
+        #expect(active.sourceLabel == "claude-swap")
+        #expect(active.snapshot?.primary?.usedPercent == 80)
+        #expect(active.snapshot?.primary?.windowMinutes == 300)
+        #expect(active.snapshot?.secondary == nil)
+        #expect(active.snapshot?.updatedAt == self.now)
+        #expect(active.snapshot?.identity?.accountEmail == "personal@example.com")
+        #expect(active.snapshot?.identity?.loginMethod == "claude-swap")
+
+        let inactive = try #require(snapshots.last)
+        #expect(inactive.id.opaqueID == "1")
+        #expect(inactive.isActive == false)
+        #expect(inactive.snapshot?.primary?.resetsAt == reset)
+        #expect(inactive.snapshot?.secondary?.usedPercent == 16.5)
+        #expect(inactive.snapshot?.secondary?.windowMinutes == 10080)
+    }
+
+    @Test
+    func `maps sentinel statuses to per account errors without usage`() throws {
+        let rows: [(ClaudeSwapUsageStatus, String)] = [
+            (.tokenExpired, "Token expired"),
+            (.apiKey, "API-key account"),
+            (.keychainUnavailable, "Keychain"),
+            (.noCredentials, "No stored credentials"),
+            (.unavailable, "Usage fetch failed"),
+            (.unknown("mystery"), "mystery"),
+        ]
+
+        for (index, entry) in rows.enumerated() {
+            let list = ClaudeSwapAccountList(
+                activeAccountNumber: nil,
+                accounts: [
+                    ClaudeSwapAccountRow(
+                        number: index + 1,
+                        email: "a@b.c",
+                        isActive: false,
+                        usageStatus: entry.0,
+                        fiveHour: nil,
+                        sevenDay: nil),
+                ])
+            let snapshot = try #require(
+                ClaudeSwapAccountProjection.accountSnapshots(from: list, now: self.now).first)
+            #expect(snapshot.snapshot == nil)
+            let error = try #require(snapshot.error)
+            #expect(error.contains(entry.1))
+        }
+    }
+
+    @Test
+    func `ok row without windows reports missing usage instead of an empty card`() throws {
+        let list = ClaudeSwapAccountList(
+            activeAccountNumber: 1,
+            accounts: [
+                ClaudeSwapAccountRow(
+                    number: 1,
+                    email: "a@b.c",
+                    isActive: true,
+                    usageStatus: .ok,
+                    fiveHour: nil,
+                    sevenDay: nil),
+            ])
+
+        let snapshot = try #require(ClaudeSwapAccountProjection.accountSnapshots(from: list, now: self.now).first)
+        #expect(snapshot.snapshot == nil)
+        #expect(snapshot.error == "No usage windows reported.")
+    }
+
+    @Test
+    func `falls back to ordinal label when email is empty`() throws {
+        let list = ClaudeSwapAccountList(
+            activeAccountNumber: nil,
+            accounts: [
+                ClaudeSwapAccountRow(
+                    number: 3,
+                    email: "",
+                    isActive: false,
+                    usageStatus: .noCredentials,
+                    fiveHour: nil,
+                    sevenDay: nil),
+            ])
+
+        let snapshot = try #require(ClaudeSwapAccountProjection.accountSnapshots(from: list, now: self.now).first)
+        #expect(snapshot.displayLabel == "Account 3")
+    }
+}

--- a/Tests/CodexBarTests/ClaudeSwapAccountReaderTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapAccountReaderTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+/// Reader tests use fake executables only, per the Phase 1 contract: no real
+/// claude-swap install, no credentials, no Keychain access.
+struct ClaudeSwapAccountReaderTests {
+    private func makeFakeExecutable(_ script: String) throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-swap-reader-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("cswap")
+        try "#!/bin/sh\n\(script)\n".write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
+    }
+
+    @Test
+    func `reads and parses a schema v1 list from the executable`() async throws {
+        let path = try self.makeFakeExecutable("""
+        [ "$1" = "--list" ] || exit 2
+        [ "$2" = "--json" ] || exit 2
+        cat <<'EOF'
+        {"schemaVersion": 1, "activeAccountNumber": 1, "accounts": [
+          {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
+           "usage": {"fiveHour": {"pct": 12.5}}}
+        ]}
+        EOF
+        """)
+
+        let list = try await ClaudeSwapAccountReader.readAccountList(executablePath: path)
+        #expect(list.activeAccountNumber == 1)
+        #expect(list.accounts.first?.fiveHour?.usedPercent == 12.5)
+    }
+
+    @Test
+    func `surfaces the error envelope from a non zero exit`() async throws {
+        let path = try self.makeFakeExecutable("""
+        echo '{"schemaVersion": 1, "error": {"type": "SwitchError", "message": "store locked"}}'
+        exit 1
+        """)
+
+        await #expect(throws: ClaudeSwapListParserError.reportedError(type: "SwitchError", message: "store locked")) {
+            try await ClaudeSwapAccountReader.readAccountList(executablePath: path)
+        }
+    }
+
+    @Test
+    func `terminates executables that exceed the timeout`() async throws {
+        let path = try self.makeFakeExecutable("sleep 30")
+
+        await #expect(throws: (any Error).self) {
+            try await ClaudeSwapAccountReader.readAccountList(executablePath: path, timeout: 0.5)
+        }
+    }
+
+    @Test
+    func `rejects oversized output before parsing`() async throws {
+        let path = try self.makeFakeExecutable("""
+        i=0
+        while [ $i -lt 5000 ]; do
+          printf '%s' '{"filler": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}'
+          i=$((i+1))
+        done
+        """)
+
+        await #expect(throws: (any Error).self) {
+            try await ClaudeSwapAccountReader.readAccountList(executablePath: path)
+        }
+    }
+
+    @Test
+    func `fails cleanly when the executable is missing`() async throws {
+        await #expect(throws: (any Error).self) {
+            try await ClaudeSwapAccountReader.readAccountList(
+                executablePath: "/nonexistent/path/to/cswap")
+        }
+        await #expect(throws: ClaudeSwapAccountReaderError.self) {
+            try await ClaudeSwapAccountReader.readAccountList(executablePath: "   ")
+        }
+    }
+
+    @Test
+    func `reads the executable version`() async throws {
+        let path = try self.makeFakeExecutable("""
+        [ "$1" = "--version" ] || exit 2
+        echo 'cswap 0.16.0'
+        """)
+
+        let version = await ClaudeSwapAccountReader.readVersion(executablePath: path)
+        #expect(version == "0.16.0")
+    }
+
+    @Test
+    func `version probe returns nil when the executable fails`() async throws {
+        let path = try self.makeFakeExecutable("exit 3")
+
+        let version = await ClaudeSwapAccountReader.readVersion(executablePath: path)
+        #expect(version == nil)
+    }
+
+    @Test
+    func `expands tilde in configured paths`() throws {
+        let resolved = try ClaudeSwapAccountReader.resolvedExecutablePath("~/bin/cswap")
+        #expect(resolved.hasPrefix("/"))
+        #expect(!resolved.contains("~"))
+        #expect(resolved.hasSuffix("/bin/cswap"))
+    }
+}

--- a/Tests/CodexBarTests/ClaudeSwapAccountReaderTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapAccountReaderTests.swift
@@ -100,6 +100,32 @@ struct ClaudeSwapAccountReaderTests {
     }
 
     @Test
+    func `cancellation during version probe prevents account list launch`() async throws {
+        let marker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-swap-list-launched-\(UUID().uuidString)")
+        let path = try self.makeFakeExecutable("""
+        if [ "$1" = "--version" ]; then
+          sleep 30
+          exit 0
+        fi
+        touch '\(marker.path)'
+        echo '{"schemaVersion":1,"activeAccountNumber":null,"accounts":[]}'
+        """)
+        let task = Task {
+            _ = await ClaudeSwapAccountReader.readVersion(executablePath: path)
+            return try await ClaudeSwapAccountReader.readAccountList(executablePath: path)
+        }
+
+        try await Task.sleep(for: .milliseconds(100))
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(!FileManager.default.fileExists(atPath: marker.path))
+    }
+
+    @Test
     func `expands tilde in configured paths`() throws {
         let resolved = try ClaudeSwapAccountReader.resolvedExecutablePath("~/bin/cswap")
         #expect(resolved.hasPrefix("/"))

--- a/Tests/CodexBarTests/ClaudeSwapListParserTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapListParserTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeSwapListParserTests {
+    private func parse(_ json: String) throws -> ClaudeSwapAccountList {
+        try ClaudeSwapListParser.parse(Data(json.utf8))
+    }
+
+    @Test
+    func `parses schema v1 list payload`() throws {
+        let json = """
+        {
+          "schemaVersion": 1,
+          "activeAccountNumber": 2,
+          "accounts": [
+            {
+              "number": 1,
+              "email": "work@example.com",
+              "organizationName": "",
+              "organizationUuid": "",
+              "isOrganization": false,
+              "active": false,
+              "usageStatus": "ok",
+              "usage": {
+                "fiveHour": {"pct": 25.0, "resetsAt": "2026-06-22T23:29:59Z", "countdown": "1h"},
+                "sevenDay": {"pct": 16.5, "resetsAt": "2026-06-26T17:59:59Z"}
+              },
+              "usageFetchedAt": "2026-06-22T20:00:00Z",
+              "usageAgeSeconds": 42.0
+            },
+            {
+              "number": 2,
+              "email": "personal@example.com",
+              "active": true,
+              "usageStatus": "ok",
+              "usage": {"fiveHour": {"pct": 80}}
+            }
+          ]
+        }
+        """
+
+        let list = try self.parse(json)
+        #expect(list.activeAccountNumber == 2)
+        #expect(list.accounts.count == 2)
+
+        let first = try #require(list.accounts.first)
+        #expect(first.number == 1)
+        #expect(first.email == "work@example.com")
+        #expect(first.isActive == false)
+        #expect(first.usageStatus == .ok)
+        #expect(first.fiveHour?.usedPercent == 25.0)
+        #expect(first.fiveHour?.resetsAt == Date(timeIntervalSince1970: 1_782_170_999))
+        #expect(first.sevenDay?.usedPercent == 16.5)
+
+        let second = try #require(list.accounts.last)
+        #expect(second.isActive == true)
+        #expect(second.fiveHour?.usedPercent == 80)
+        #expect(second.fiveHour?.resetsAt == nil)
+        #expect(second.sevenDay == nil)
+    }
+
+    @Test
+    func `parses empty account list without accounts configured`() throws {
+        let json = """
+        {"schemaVersion": 1, "activeAccountNumber": null, "accounts": []}
+        """
+
+        let list = try self.parse(json)
+        #expect(list.activeAccountNumber == nil)
+        #expect(list.accounts.isEmpty)
+    }
+
+    @Test
+    func `maps usage status sentinels including unknown values`() throws {
+        let json = """
+        {
+          "schemaVersion": 1,
+          "activeAccountNumber": 1,
+          "accounts": [
+            {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "token_expired", "usage": null},
+            {"number": 2, "email": "d@e.f", "active": false, "usageStatus": "api_key", "usage": null},
+            {"number": 3, "email": "g@h.i", "active": false, "usageStatus": "keychain_unavailable", "usage": null},
+            {"number": 4, "email": "j@k.l", "active": false, "usageStatus": "no_credentials", "usage": null},
+            {"number": 5, "email": "m@n.o", "active": false, "usageStatus": "unavailable", "usage": null},
+            {"number": 6, "email": "p@q.r", "active": false, "usageStatus": "brand_new_status", "usage": null}
+          ]
+        }
+        """
+
+        let statuses = try self.parse(json).accounts.map(\.usageStatus)
+        #expect(statuses == [
+            .tokenExpired,
+            .apiKey,
+            .keychainUnavailable,
+            .noCredentials,
+            .unavailable,
+            .unknown("brand_new_status"),
+        ])
+    }
+
+    @Test
+    func `surfaces schema v1 error envelope`() throws {
+        let json = """
+        {"schemaVersion": 1, "error": {"type": "SwitchError", "message": "boom"}}
+        """
+
+        #expect(throws: ClaudeSwapListParserError.reportedError(type: "SwitchError", message: "boom")) {
+            try self.parse(json)
+        }
+    }
+
+    @Test
+    func `rejects unknown schema versions`() throws {
+        let json = """
+        {"schemaVersion": 2, "activeAccountNumber": 1, "accounts": []}
+        """
+
+        #expect(throws: ClaudeSwapListParserError.unsupportedSchemaVersion(2)) {
+            try self.parse(json)
+        }
+    }
+
+    @Test
+    func `rejects payloads without schema version or accounts`() throws {
+        #expect(throws: ClaudeSwapListParserError.missingSchemaVersion) {
+            try self.parse(#"{"accounts": []}"#)
+        }
+        #expect(throws: ClaudeSwapListParserError.malformedShape("missing accounts array")) {
+            try self.parse(#"{"schemaVersion": 1}"#)
+        }
+        #expect(throws: ClaudeSwapListParserError.notJSONObject) {
+            try self.parse("not json at all")
+        }
+        #expect(throws: ClaudeSwapListParserError.notJSONObject) {
+            try self.parse(#"["schemaVersion", 1]"#)
+        }
+    }
+
+    @Test
+    func `rejects rows with missing required fields`() throws {
+        #expect(throws: (any Error).self) {
+            try self.parse(
+                #"{"schemaVersion": 1, "accounts": [{"email": "a@b.c", "active": true, "usageStatus": "ok"}]}"#)
+        }
+        #expect(throws: (any Error).self) {
+            try self.parse(
+                #"{"schemaVersion": 1, "accounts": [{"number": 1, "email": "a@b.c", "usageStatus": "ok"}]}"#)
+        }
+        #expect(throws: (any Error).self) {
+            try self.parse(
+                #"{"schemaVersion": 1, "accounts": [{"number": 1, "email": "a@b.c", "active": true}]}"#)
+        }
+    }
+
+    @Test
+    func `rejects invalid percentages and timestamps`() throws {
+        #expect(throws: (any Error).self) {
+            try self.parse("""
+            {"schemaVersion": 1, "accounts": [
+              {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
+               "usage": {"fiveHour": {"pct": "not-a-number"}}}
+            ]}
+            """)
+        }
+        #expect(throws: (any Error).self) {
+            try self.parse("""
+            {"schemaVersion": 1, "accounts": [
+              {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
+               "usage": {"fiveHour": {"pct": true}}}
+            ]}
+            """)
+        }
+        #expect(throws: (any Error).self) {
+            try self.parse("""
+            {"schemaVersion": 1, "accounts": [
+              {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
+               "usage": {"fiveHour": {"pct": 10, "resetsAt": "yesterday-ish"}}}
+            ]}
+            """)
+        }
+    }
+
+    @Test
+    func `clamps out of range percentages`() throws {
+        let json = """
+        {"schemaVersion": 1, "accounts": [
+          {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
+           "usage": {"fiveHour": {"pct": 130.5}, "sevenDay": {"pct": -4}}}
+        ]}
+        """
+
+        let row = try #require(self.parse(json).accounts.first)
+        #expect(row.fiveHour?.usedPercent == 100)
+        #expect(row.sevenDay?.usedPercent == 0)
+    }
+
+    @Test
+    func `parses fractional second timestamps`() throws {
+        let json = """
+        {"schemaVersion": 1, "accounts": [
+          {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
+           "usage": {"fiveHour": {"pct": 10, "resetsAt": "2026-06-22T23:29:59.500Z"}}}
+        ]}
+        """
+
+        let row = try #require(self.parse(json).accounts.first)
+        #expect(row.fiveHour?.resetsAt == Date(timeIntervalSince1970: 1_782_170_999.5))
+    }
+}

--- a/Tests/CodexBarTests/ClaudeSwapListParserTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapListParserTests.swift
@@ -129,6 +129,9 @@ struct ClaudeSwapListParserTests {
         #expect(throws: ClaudeSwapListParserError.malformedShape("missing accounts array")) {
             try self.parse(#"{"schemaVersion": 1}"#)
         }
+        #expect(throws: ClaudeSwapListParserError.malformedShape("missing activeAccountNumber")) {
+            try self.parse(#"{"schemaVersion": 1, "accounts": []}"#)
+        }
         #expect(throws: ClaudeSwapListParserError.notJSONObject) {
             try self.parse("not json at all")
         }
@@ -138,18 +141,59 @@ struct ClaudeSwapListParserTests {
     }
 
     @Test
+    func `rejects invalid or duplicate account slots`() throws {
+        #expect(throws: ClaudeSwapListParserError.malformedShape("account slot must be positive")) {
+            try self.parse("""
+            {"schemaVersion": 1, "activeAccountNumber": null, "accounts": [
+              {"number": 0, "active": false, "usageStatus": "ok"}
+            ]}
+            """)
+        }
+        #expect(throws: ClaudeSwapListParserError.malformedShape("duplicate account slot 1")) {
+            try self.parse("""
+            {"schemaVersion": 1, "activeAccountNumber": 1, "accounts": [
+              {"number": 1, "active": true, "usageStatus": "ok"},
+              {"number": 1, "active": false, "usageStatus": "ok"}
+            ]}
+            """)
+        }
+        #expect(throws: ClaudeSwapListParserError.malformedShape(
+            "activeAccountNumber is not a numeric slot or null"))
+        {
+            try self.parse(#"{"schemaVersion": 1, "activeAccountNumber": "1", "accounts": []}"#)
+        }
+        #expect(throws: ClaudeSwapListParserError.malformedShape("active account fields disagree")) {
+            try self.parse("""
+            {"schemaVersion": 1, "activeAccountNumber": 2, "accounts": [
+              {"number": 1, "active": true, "usageStatus": "ok"},
+              {"number": 2, "active": false, "usageStatus": "ok"}
+            ]}
+            """)
+        }
+    }
+
+    @Test
     func `rejects rows with missing required fields`() throws {
         #expect(throws: (any Error).self) {
-            try self.parse(
-                #"{"schemaVersion": 1, "accounts": [{"email": "a@b.c", "active": true, "usageStatus": "ok"}]}"#)
+            try self.parse("""
+            {"schemaVersion": 1, "activeAccountNumber": 1, "accounts": [
+              {"email": "a@b.c", "active": true, "usageStatus": "ok"}
+            ]}
+            """)
         }
         #expect(throws: (any Error).self) {
-            try self.parse(
-                #"{"schemaVersion": 1, "accounts": [{"number": 1, "email": "a@b.c", "usageStatus": "ok"}]}"#)
+            try self.parse("""
+            {"schemaVersion": 1, "activeAccountNumber": 1, "accounts": [
+              {"number": 1, "email": "a@b.c", "usageStatus": "ok"}
+            ]}
+            """)
         }
         #expect(throws: (any Error).self) {
-            try self.parse(
-                #"{"schemaVersion": 1, "accounts": [{"number": 1, "email": "a@b.c", "active": true}]}"#)
+            try self.parse("""
+            {"schemaVersion": 1, "activeAccountNumber": 1, "accounts": [
+              {"number": 1, "email": "a@b.c", "active": true}
+            ]}
+            """)
         }
     }
 
@@ -157,7 +201,7 @@ struct ClaudeSwapListParserTests {
     func `rejects invalid percentages and timestamps`() throws {
         #expect(throws: (any Error).self) {
             try self.parse("""
-            {"schemaVersion": 1, "accounts": [
+            {"schemaVersion": 1, "activeAccountNumber": 1, "accounts": [
               {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
                "usage": {"fiveHour": {"pct": "not-a-number"}}}
             ]}
@@ -165,7 +209,7 @@ struct ClaudeSwapListParserTests {
         }
         #expect(throws: (any Error).self) {
             try self.parse("""
-            {"schemaVersion": 1, "accounts": [
+            {"schemaVersion": 1, "activeAccountNumber": 1, "accounts": [
               {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
                "usage": {"fiveHour": {"pct": true}}}
             ]}
@@ -173,7 +217,7 @@ struct ClaudeSwapListParserTests {
         }
         #expect(throws: (any Error).self) {
             try self.parse("""
-            {"schemaVersion": 1, "accounts": [
+            {"schemaVersion": 1, "activeAccountNumber": 1, "accounts": [
               {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
                "usage": {"fiveHour": {"pct": 10, "resetsAt": "yesterday-ish"}}}
             ]}
@@ -184,7 +228,7 @@ struct ClaudeSwapListParserTests {
     @Test
     func `clamps out of range percentages`() throws {
         let json = """
-        {"schemaVersion": 1, "accounts": [
+        {"schemaVersion": 1, "activeAccountNumber": 1, "accounts": [
           {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
            "usage": {"fiveHour": {"pct": 130.5}, "sevenDay": {"pct": -4}}}
         ]}
@@ -198,7 +242,7 @@ struct ClaudeSwapListParserTests {
     @Test
     func `parses fractional second timestamps`() throws {
         let json = """
-        {"schemaVersion": 1, "accounts": [
+        {"schemaVersion": 1, "activeAccountNumber": 1, "accounts": [
           {"number": 1, "email": "a@b.c", "active": true, "usageStatus": "ok",
            "usage": {"fiveHour": {"pct": 10, "resetsAt": "2026-06-22T23:29:59.500Z"}}}
         ]}

--- a/Tests/CodexBarTests/MenuCardClaudeSwapAccountTests.swift
+++ b/Tests/CodexBarTests/MenuCardClaudeSwapAccountTests.swift
@@ -1,0 +1,65 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+/// Menu-model coverage for claude-swap account cards: the provider-neutral
+/// projection renders as a regular Claude usage card with session/weekly
+/// windows, account identity, and Hide Personal Info redaction.
+struct MenuCardClaudeSwapAccountTests {
+    private func makeModel(hidePersonalInfo: Bool) throws -> UsageMenuCardView.Model {
+        let now = Date(timeIntervalSince1970: 1_782_000_000)
+        let metadata = try #require(ProviderDefaults.metadata[.claude])
+        let list = ClaudeSwapAccountList(
+            activeAccountNumber: 2,
+            accounts: [
+                ClaudeSwapAccountRow(
+                    number: 2,
+                    email: "personal@example.com",
+                    isActive: true,
+                    usageStatus: .ok,
+                    fiveHour: ClaudeSwapUsageWindow(usedPercent: 25, resetsAt: now.addingTimeInterval(3600)),
+                    sevenDay: ClaudeSwapUsageWindow(usedPercent: 60, resetsAt: now.addingTimeInterval(86400))),
+            ])
+        let account = try #require(ClaudeSwapAccountProjection.accountSnapshots(from: list, now: now).first)
+
+        return UsageMenuCardView.Model.make(.init(
+            provider: .claude,
+            metadata: metadata,
+            snapshot: account.snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: account.displayLabel, plan: nil),
+            isRefreshing: false,
+            lastError: account.error,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: false,
+            hidePersonalInfo: hidePersonalInfo,
+            now: now))
+    }
+
+    @Test
+    func `claude swap account snapshot renders session and weekly metrics with identity`() throws {
+        let model = try self.makeModel(hidePersonalInfo: false)
+
+        #expect(model.email == "personal@example.com")
+        let primary = try #require(model.metrics.first(where: { $0.id == "primary" }))
+        #expect(primary.percent == 25)
+        let secondary = try #require(model.metrics.first(where: { $0.id == "secondary" }))
+        #expect(secondary.percent == 60)
+    }
+
+    @Test
+    func `claude swap account card respects hide personal info`() throws {
+        let model = try self.makeModel(hidePersonalInfo: true)
+
+        #expect(!model.email.contains("personal@example.com"))
+        #expect(!model.email.contains("example.com"))
+    }
+}

--- a/Tests/CodexBarTests/MenuCardOverrideIsolationTests.swift
+++ b/Tests/CodexBarTests/MenuCardOverrideIsolationTests.swift
@@ -44,4 +44,47 @@ struct MenuCardOverrideIsolationTests {
 
         #expect(model.tokenUsage == nil)
     }
+
+    @Test
+    func `account card without its own error does not inherit the ambient Claude error`() throws {
+        let suite = "MenuCardOverrideIsolationTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setErrorForTesting("Claude OAuth credentials unavailable", provider: .claude)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        let accountSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "account@example.com",
+                accountOrganization: nil,
+                loginMethod: "claude-swap"))
+
+        let model = try #require(controller.menuCardModel(
+            for: .claude,
+            snapshotOverride: accountSnapshot,
+            accountOverride: AccountInfo(email: "account@example.com", plan: nil)))
+
+        #expect(model.subtitleStyle != .error)
+        #expect(!model.subtitleText.contains("Claude OAuth credentials unavailable"))
+
+        let liveModel = try #require(controller.menuCardModel(for: .claude))
+        #expect(liveModel.subtitleStyle == .error)
+        #expect(liveModel.subtitleText == "Claude OAuth credentials unavailable")
+    }
 }

--- a/Tests/CodexBarTests/MenuCardOverrideIsolationTests.swift
+++ b/Tests/CodexBarTests/MenuCardOverrideIsolationTests.swift
@@ -1,0 +1,47 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct MenuCardOverrideIsolationTests {
+    @Test
+    func `nil snapshot account card does not inherit ambient Claude costs`() throws {
+        let suite = "MenuCardOverrideIsolationTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.costUsageEnabled = true
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setTokenSnapshotForTesting(
+            CostUsageTokenSnapshot(
+                sessionTokens: 123,
+                sessionCostUSD: 0.12,
+                last30DaysTokens: 456,
+                last30DaysCostUSD: 1.23,
+                daily: [],
+                updatedAt: Date()),
+            provider: .claude)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+
+        let model = try #require(controller.menuCardModel(
+            for: .claude,
+            errorOverride: "Token expired",
+            forceOverrideCard: true,
+            accountOverride: AccountInfo(email: "account@example.com", plan: nil)))
+
+        #expect(model.tokenUsage == nil)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -7,6 +7,30 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuHostedSubmenuRefreshTests {
     @Test
+    func `claude swap completion changes open menu readiness`() {
+        let settings = Self.makeSettings()
+        settings.setProviderEnabled(
+            provider: .claude,
+            metadata: ProviderDescriptorRegistry.descriptor(for: .claude).metadata,
+            enabled: true)
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let before = controller.menuAdjunctReadinessSignature()
+        store.claudeSwapRevision &+= 1
+
+        #expect(controller.menuAdjunctReadinessSignature() != before)
+    }
+
+    @Test
     func `status components change open menu readiness`() {
         let settings = Self.makeSettings()
         settings.statusChecksEnabled = true

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -119,8 +119,8 @@ Phase 1 of the accepted multi-account design in
 
 - Setup: Preferences → Providers → Claude → "Read accounts from claude-swap", then set the path to the
   [`cswap`](https://github.com/realiti4/claude-swap) executable (for example `~/.local/bin/cswap`).
-- Behavior: on each Claude refresh, CodexBar executes exactly `cswap --list --json` (no shell, fixed
-  arguments, bounded runtime and output), requires `schemaVersion == 1`, and parses only slot number,
+- Behavior: on each Claude refresh, CodexBar runs `cswap --list --json` independently of the ambient Claude fetch (no
+  shell, fixed arguments, bounded runtime and output), requires `schemaVersion == 1`, and parses only slot number,
   active state, usage status, email (display only), and the 5-hour/7-day windows.
 - Display: when claude-swap reports more than one account, the Claude menu shows one stacked card per
   account (active account first) alongside nothing else changing; with zero or one account the menu is

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -112,6 +112,26 @@ Admin API key setup:
   - Extra usage spend/limit (if enabled).
   - Account email + inferred plan.
 
+## claude-swap accounts (opt-in, read-only)
+
+Phase 1 of the accepted multi-account design in
+[claude-multi-account-and-status-items.md](claude-multi-account-and-status-items.md).
+
+- Setup: Preferences → Providers → Claude → "Read accounts from claude-swap", then set the path to the
+  [`cswap`](https://github.com/realiti4/claude-swap) executable (for example `~/.local/bin/cswap`).
+- Behavior: on each Claude refresh, CodexBar executes exactly `cswap --list --json` (no shell, fixed
+  arguments, bounded runtime and output), requires `schemaVersion == 1`, and parses only slot number,
+  active state, usage status, email (display only), and the 5-hour/7-day windows.
+- Display: when claude-swap reports more than one account, the Claude menu shows one stacked card per
+  account (active account first) alongside nothing else changing; with zero or one account the menu is
+  unchanged. Account identity is `claude-swap:<slot>`.
+- Isolation: CodexBar never reads claude-swap or Claude Code credential storage for this feature; the
+  subprocess handles its own credential access. Adapter failures keep the last successful accounts as
+  stale data, surface the error in provider settings, and never affect the ambient Claude usage card.
+- Sentinel statuses (`token_expired`, `api_key`, `keychain_unavailable`, `no_credentials`,
+  `unavailable`) render as per-account notes instead of usage bars.
+- Account switching is intentionally out of scope; use `cswap` directly to switch accounts.
+
 ## CLI PTY (fallback)
 - Runs `claude` in a PTY session (`ClaudeCLISession`).
 - Default behavior: exit after each probe; Debug → "Keep CLI sessions alive" keeps it running between probes.


### PR DESCRIPTION
## Summary

Implements Phase 1 of the accepted [Claude multi-account design](https://github.com/steipete/CodexBar/blob/main/docs/claude-multi-account-and-status-items.md): an opt-in, read-only [claude-swap](https://github.com/realiti4/claude-swap) adapter that shows every account's session and weekly usage as stacked Claude cards.

Addresses the Claude-subscription portion of #1756 and #1268. Account switching and per-account status items remain out of scope.

## User experience

- Adds **Providers → Claude → Read accounts from claude-swap**, off by default.
- Runs the explicitly configured executable with fixed argv: `cswap --list --json`.
- Shows active account first; sentinel states such as expired/no credentials become account-specific notes.
- Preserves the last successful account snapshot as visibly stale when a later adapter refresh fails.
- Redacts account emails through the existing Hide Personal Info path.
- Leaves the ambient Claude card and refresh path unchanged when disabled, missing, slow, or failing.

## Maintainer hardening

- Runs the optional adapter independently from the required Claude refresh; a 30-second adapter timeout cannot delay ambient usage.
- Cancels and clears adapter work immediately when Claude, the adapter, or its executable path changes.
- Rejects late results from an old executable/configuration and checks cancellation before every subprocess launch.
- Rebuilds an open menu when background account results arrive.
- Prevents account cards from inheriting ambient Claude costs, source labels, identity, or provider-level errors.
- Requires a strict schema-v1 envelope, positive unique account slots, and one consistent active-account declaration.
- Bounds subprocess runtime and output; never uses a shell or config-defined arguments.

## Security boundary

- CodexBar does not read claude-swap storage, Claude Code storage, or Keychain entries for this feature.
- The external process owns any credential access. Raw stdout is neither logged nor persisted.
- Only allow-listed display/usage fields enter in-memory provider-neutral snapshots; stable identity is `claude-swap:<slot>`, never an email or credential value.
- Non-zero exits are accepted only so the schema-v1 error envelope on stdout can be parsed and surfaced.

## Validation

Fake executables and model/state seams only; no real credentials or Keychain access:

- `swift test --filter 'ClaudeSwap|ClaudeProviderRuntimeTests|StatusMenuHostedSubmenuRefreshTests|MenuCardOverrideIsolationTests'`
- `make check` — SwiftFormat clean; SwiftLint 0 violations; docs/locales/repository checks pass.
- `make test` — full 47-shard suite.
- Maintainer autoreview: no accepted/actionable findings after fixes.

Focused coverage includes strict parsing, fixed argv, error envelopes, timeout/output bounds, cancellation-before-launch, stale/config result rejection, disabled-provider lifecycle, projection ordering, privacy redaction, open-menu readiness, and ambient account-data isolation.
