### PR TITLE
Reject invalid Kimi K2 timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.
 - Codex quotas: show the session quota as unavailable while an exhausted weekly limit is still binding, including menu-bar icons and widgets. Thanks @Yuxin-Qiao!
 - Codex cost history: reuse cached aggregate pricing and one pricing catalog across daily and project reports, carry fresh cache state across launches, and treat unpriced models as migrated, avoiding repeated row scans, filesystem work, and duplicate background scans on large local histories.
+- Kimi K2: reject invalid and out-of-range numeric timestamps while preserving valid second and millisecond values. Thanks @joeVenner!
 - Kimi K2: reject non-finite credit and token values before they reach menus, CLI output, or widgets. Thanks @joeVenner!
 - Kimi: show the five-hour rate limit before the weekly quota while preserving existing menu-bar metric preferences. Thanks @Zihao-Qi!
 

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -284,11 +284,10 @@ public struct KimiK2UsageFetcher: Sendable {
     }
 
     private static func dateFromNumeric(_ value: Double) -> Date? {
-        guard value > 0 else { return nil }
-        if value > 1_000_000_000_000 {
-            return Date(timeIntervalSince1970: value / 1000)
-        }
-        return Date(timeIntervalSince1970: value)
+        guard value.isFinite, value > 0 else { return nil }
+        let seconds = value > 1_000_000_000_000 ? value / 1000 : value
+        guard seconds.isFinite, seconds <= Date.distantFuture.timeIntervalSince1970 else { return nil }
+        return Date(timeIntervalSince1970: seconds)
     }
 
     private static func doubleValueFromHeaders(headers: [AnyHashable: Any], key: String) -> Double? {

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -142,11 +142,19 @@ public struct KimiK2UsageFetcher: Sendable {
         return KimiK2UsageSnapshot(summary: summary)
     }
 
-    static func _parseSummaryForTesting(_ data: Data, headers: [AnyHashable: Any] = [:]) throws -> KimiK2UsageSummary {
-        try self.parseSummary(data: data, headers: headers)
+    static func _parseSummaryForTesting(
+        _ data: Data,
+        headers: [AnyHashable: Any] = [:],
+        now: Date = Date()) throws -> KimiK2UsageSummary
+    {
+        try self.parseSummary(data: data, headers: headers, now: now)
     }
 
-    private static func parseSummary(data: Data, headers: [AnyHashable: Any]) throws -> KimiK2UsageSummary {
+    private static func parseSummary(
+        data: Data,
+        headers: [AnyHashable: Any],
+        now: Date = Date()) throws -> KimiK2UsageSummary
+    {
         guard let json = try? jsonSerializer.jsonObject(with: data),
               let dictionary = json as? [String: Any]
         else {
@@ -159,7 +167,7 @@ public struct KimiK2UsageFetcher: Sendable {
             ?? Self.doubleValueFromHeaders(headers: headers, key: "x-credits-remaining")
             ?? 0
         let averageTokens = Self.doubleValue(for: Self.averageTokenPaths, in: contexts)
-        let updatedAt = Self.dateValue(for: Self.timestampPaths, in: contexts) ?? Date()
+        let updatedAt = Self.dateValue(for: Self.timestampPaths, in: contexts) ?? now
 
         return KimiK2UsageSummary(
             consumed: consumed,
@@ -285,7 +293,7 @@ public struct KimiK2UsageFetcher: Sendable {
 
     private static func dateFromNumeric(_ value: Double) -> Date? {
         guard value.isFinite, value > 0 else { return nil }
-        let seconds = value > 1_000_000_000_000 ? value / 1000 : value
+        let seconds = value >= 1_000_000_000_000 ? value / 1000 : value
         guard seconds.isFinite, seconds <= Date.distantFuture.timeIntervalSince1970 else { return nil }
         return Date(timeIntervalSince1970: seconds)
     }

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -100,8 +100,24 @@ struct KimiK2UsageFetcherTests {
         #expect(abs(summary.updatedAt.timeIntervalSince1970 - expected.timeIntervalSince1970) < 0.5)
     }
 
-    @Test(arguments: ["1e309", "1e308"])
+    @Test
+    func `treats exact millisecond cutoff as milliseconds`() throws {
+        let json = """
+        {
+          "timestamp": 1000000000000,
+          "credits_remaining": 10,
+          "total_credits_consumed": 5
+        }
+        """
+
+        let summary = try KimiK2UsageFetcher._parseSummaryForTesting(Data(json.utf8))
+
+        #expect(summary.updatedAt == Date(timeIntervalSince1970: 1_000_000_000))
+    }
+
+    @Test(arguments: ["NaN", "Infinity", "1e308", "0", "-1"])
     func `ignores invalid numeric timestamps`(timestamp: String) throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
         let json = """
         {
           "timestamp": "\(timestamp)",
@@ -110,9 +126,26 @@ struct KimiK2UsageFetcherTests {
         }
         """
 
-        let summary = try KimiK2UsageFetcher._parseSummaryForTesting(Data(json.utf8))
+        let summary = try KimiK2UsageFetcher._parseSummaryForTesting(Data(json.utf8), now: now)
 
-        #expect(abs(summary.updatedAt.timeIntervalSinceNow) < 1)
+        #expect(summary.updatedAt == now)
+    }
+
+    @Test
+    func `ignores timestamps beyond distant future`() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let timestamp = Date.distantFuture.timeIntervalSince1970 + 1
+        let json = """
+        {
+          "timestamp": "\(timestamp)",
+          "credits_remaining": 10,
+          "total_credits_consumed": 5
+        }
+        """
+
+        let summary = try KimiK2UsageFetcher._parseSummaryForTesting(Data(json.utf8), now: now)
+
+        #expect(summary.updatedAt == now)
     }
 
     @Test

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -100,6 +100,21 @@ struct KimiK2UsageFetcherTests {
         #expect(abs(summary.updatedAt.timeIntervalSince1970 - expected.timeIntervalSince1970) < 0.5)
     }
 
+    @Test(arguments: ["1e309", "1e308"])
+    func `ignores invalid numeric timestamps`(timestamp: String) throws {
+        let json = """
+        {
+          "timestamp": "\(timestamp)",
+          "credits_remaining": 10,
+          "total_credits_consumed": 5
+        }
+        """
+
+        let summary = try KimiK2UsageFetcher._parseSummaryForTesting(Data(json.utf8))
+
+        #expect(abs(summary.updatedAt.timeIntervalSinceNow) < 1)
+    }
+
     @Test
     func `invalid root returns parse error`() {
         let json = """


### PR DESCRIPTION
## Summary

- reject non-finite, non-positive, and out-of-range Kimi K2 numeric timestamps
- preserve valid Unix seconds and milliseconds, including the exact millisecond cutoff
- fall back to the refresh time instead of constructing an unusable `Date`
- make fallback-time regression coverage deterministic and add changelog credit

## Production-path proof

A source-blind executable linked against `CodexBarCore` exercised the public fetcher through an isolated HTTP transport. It verified distinct seconds and milliseconds values, the exact cutoff, non-finite and extreme finite input, and unchanged credit totals:

```text
PASS seconds
PASS milliseconds
PASS cutoff
PASS nonfinite
PASS extreme
RESULT PASS 5/5
```

No live credentials, provider traffic, or Keychain access were used.

## Testing

- `swift test --disable-sandbox --filter KimiK2UsageFetcherTests` (10 passed)
- `make check` (SwiftFormat clean; SwiftLint 0 violations)
- `make test` (48/48 shards passed)
- autoreview clean (0.97 confidence)
- `git diff --check`
