### PR TITLE
Improve Kimi K2 credential errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@
 - Codex cost history: reuse cached aggregate pricing and one pricing catalog across daily and project reports, carry fresh cache state across launches, and treat unpriced models as migrated, avoiding repeated row scans, filesystem work, and duplicate background scans on large local histories.
 - Devin: keep exact 1% usage from being inflated to 100% while preserving fractional fallback quota semantics. Thanks @Lex-ic-on!
 - Kimi K2: reject invalid and out-of-range numeric timestamps while preserving valid second and millisecond values. Thanks @joeVenner!
-- Kimi K2: trim API keys and show a clear invalid-or-expired credential error when the legacy credit endpoint rejects them. Thanks @joeVenner!
 - Kimi K2: reject non-finite credit and token values before they reach menus, CLI output, or widgets. Thanks @joeVenner!
 - Kimi: call the current `GetSubscriptionStats` membership endpoint so the Monthly subscription quota is populated again. Thanks @skyzer!
 - Kimi: show the five-hour rate limit before the weekly quota while preserving existing menu-bar metric preferences. Thanks @Zihao-Qi!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Ollama: validate API keys against an authenticated endpoint instead of the public model catalog while preserving refresh cancellation. Thanks @joeVenner!
 - Claude CLI: resolve yearless and time-only reset timestamps against their quota window and exact calendar occurrence, keeping recently stale resets current without moving future, leap-day, or repeated-hour resets into the past. Thanks @fanwenlin!
 - Catalan: complete current strings, align instructional voice, and enforce catalog parity. Thanks @pmontp19!
-- Kimi K2: report missing or blank API keys clearly and trim surrounding whitespace before requests. Thanks @joeVenner!
+- Kimi K2: report missing, blank, or rejected API keys clearly and trim surrounding whitespace before requests. Thanks @joeVenner!
 - Quota warnings: use compact per-window threshold editors that save on focus loss, Return, or window close while preserving provider inheritance. Thanks @Zihao-Qi!
 - Display settings: keep display mode, work days, multi-account layout, and cost summary selectors interactive on macOS 27. Thanks @jordanschwartz-js!
 - Antigravity: recover CLI listening ports from Linux procfs when `lsof` is unavailable, including process network namespaces. Thanks @junmo-kim!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Codex cost history: reuse cached aggregate pricing and one pricing catalog across daily and project reports, carry fresh cache state across launches, and treat unpriced models as migrated, avoiding repeated row scans, filesystem work, and duplicate background scans on large local histories.
 - Devin: keep exact 1% usage from being inflated to 100% while preserving fractional fallback quota semantics. Thanks @Lex-ic-on!
 - Kimi K2: reject invalid and out-of-range numeric timestamps while preserving valid second and millisecond values. Thanks @joeVenner!
+- Kimi K2: trim API keys and show a clear invalid-or-expired credential error when the legacy credit endpoint rejects them. Thanks @joeVenner!
 - Kimi K2: reject non-finite credit and token values before they reach menus, CLI output, or widgets. Thanks @joeVenner!
 - Kimi: call the current `GetSubscriptionStats` membership endpoint so the Monthly subscription quota is populated again. Thanks @skyzer!
 - Kimi: show the five-hour rate limit before the weekly quota while preserving existing menu-bar metric preferences. Thanks @Zihao-Qi!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Ollama: validate API keys against an authenticated endpoint instead of the public model catalog while preserving refresh cancellation. Thanks @joeVenner!
 - Claude CLI: resolve yearless and time-only reset timestamps against their quota window and exact calendar occurrence, keeping recently stale resets current without moving future, leap-day, or repeated-hour resets into the past. Thanks @fanwenlin!
 - Catalan: complete current strings, align instructional voice, and enforce catalog parity. Thanks @pmontp19!
+- Kimi K2: trim API keys and distinguish rejected credentials from credit or permission failures. Thanks @joeVenner!
 - Quota warnings: use compact per-window threshold editors that save on focus loss, Return, or window close while preserving provider inheritance. Thanks @Zihao-Qi!
 - Display settings: keep display mode, work days, multi-account layout, and cost summary selectors interactive on macOS 27. Thanks @jordanschwartz-js!
 - Antigravity: recover CLI listening ports from Linux procfs when `lsof` is unavailable, including process network namespaces. Thanks @junmo-kim!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Ollama: validate API keys against an authenticated endpoint instead of the public model catalog while preserving refresh cancellation. Thanks @joeVenner!
 - Claude CLI: resolve yearless and time-only reset timestamps against their quota window and exact calendar occurrence, keeping recently stale resets current without moving future, leap-day, or repeated-hour resets into the past. Thanks @fanwenlin!
 - Catalan: complete current strings, align instructional voice, and enforce catalog parity. Thanks @pmontp19!
-- Kimi K2: trim API keys and distinguish rejected credentials from credit or permission failures. Thanks @joeVenner!
+- Kimi K2: report missing or blank API keys clearly and trim surrounding whitespace before requests. Thanks @joeVenner!
 - Quota warnings: use compact per-window threshold editors that save on focus loss, Return, or window close while preserving provider inheritance. Thanks @Zihao-Qi!
 - Display settings: keep display mode, work days, multi-account layout, and cost summary selectors interactive on macOS 27. Thanks @jordanschwartz-js!
 - Antigravity: recover CLI listening ports from Linux procfs when `lsof` is unavailable, including process network namespaces. Thanks @junmo-kim!

--- a/Sources/CodexBarCore/Providers/APITokenFetchStrategy.swift
+++ b/Sources/CodexBarCore/Providers/APITokenFetchStrategy.swift
@@ -9,6 +9,7 @@ public struct APITokenFetchStrategy: ProviderFetchStrategy {
     public let kind: ProviderFetchKind = .apiToken
 
     private let sourceLabel: String
+    private let reportsMissingCredentials: Bool
     private let resolveToken: TokenResolver
     private let missingCredentialsError: MissingCredentialsError
     private let loadUsage: UsageLoader
@@ -16,19 +17,21 @@ public struct APITokenFetchStrategy: ProviderFetchStrategy {
     public init(
         id: String,
         sourceLabel: String = "api",
+        reportsMissingCredentials: Bool = false,
         resolveToken: @escaping TokenResolver,
         missingCredentialsError: @escaping MissingCredentialsError,
         loadUsage: @escaping UsageLoader)
     {
         self.id = id
         self.sourceLabel = sourceLabel
+        self.reportsMissingCredentials = reportsMissingCredentials
         self.resolveToken = resolveToken
         self.missingCredentialsError = missingCredentialsError
         self.loadUsage = loadUsage
     }
 
     public func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        self.resolveToken(context.env) != nil
+        self.reportsMissingCredentials || self.resolveToken(context.env) != nil
     }
 
     public func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
@@ -49,6 +52,7 @@ extension ProviderFetchPlan {
     public static func apiToken(
         strategyID: String,
         sourceLabel: String = "api",
+        reportsMissingCredentials: Bool = false,
         resolveToken: @escaping APITokenFetchStrategy.TokenResolver,
         missingCredentialsError: @escaping APITokenFetchStrategy.MissingCredentialsError,
         loadUsage: @escaping APITokenFetchStrategy.UsageLoader) -> ProviderFetchPlan
@@ -59,6 +63,7 @@ extension ProviderFetchPlan {
                 [APITokenFetchStrategy(
                     id: strategyID,
                     sourceLabel: sourceLabel,
+                    reportsMissingCredentials: reportsMissingCredentials,
                     resolveToken: resolveToken,
                     missingCredentialsError: missingCredentialsError,
                     loadUsage: loadUsage)]

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2ProviderDescriptor.swift
@@ -32,6 +32,7 @@ public enum KimiK2ProviderDescriptor {
                 noDataMessage: { "Unofficial Kimi K2 cost summary is not available." }),
             fetchPlan: .apiToken(
                 strategyID: "kimik2.api",
+                reportsMissingCredentials: true,
                 resolveToken: { ProviderTokenResolver.kimiK2Token(environment: $0) },
                 missingCredentialsError: { KimiK2UsageError.missingCredentials },
                 loadUsage: { apiKey, _ in

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -46,7 +46,6 @@ public struct KimiK2UsageSummary: Sendable {
 
 public enum KimiK2UsageError: LocalizedError, Sendable {
     case missingCredentials
-    case invalidCredentials
     case networkError(String)
     case apiError(String)
     case parseFailed(String)
@@ -55,8 +54,6 @@ public enum KimiK2UsageError: LocalizedError, Sendable {
         switch self {
         case .missingCredentials:
             "Missing Kimi K2 API key."
-        case .invalidCredentials:
-            "Kimi K2 API key is invalid or revoked."
         case let .networkError(message):
             "Kimi K2 network error: \(message)"
         case let .apiError(message):
@@ -132,17 +129,7 @@ public struct KimiK2UsageFetcher: Sendable {
 
         let response = try await transport.response(for: request)
         let data = response.data
-        switch response.statusCode {
-        case 200:
-            break
-        case 401:
-            // 401 is an authentication failure: the key is wrong, missing, or revoked.
-            throw KimiK2UsageError.invalidCredentials
-        default:
-            // 403 and other non-200 responses are not necessarily credential
-            // failures — Kimrel returns 403 for insufficient credits or missing
-            // permissions, so preserve the response body as an actionable API
-            // error instead of mislabeling a valid key as invalid/expired.
+        guard response.statusCode == 200 else {
             let body = String(data: data, encoding: .utf8) ?? "HTTP \(response.statusCode)"
             Self.log.error("Kimi K2 API returned \(response.statusCode): \(body)")
             throw KimiK2UsageError.apiError(body)

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -56,7 +56,7 @@ public enum KimiK2UsageError: LocalizedError, Sendable {
         case .missingCredentials:
             "Missing Kimi K2 API key."
         case .invalidCredentials:
-            "Kimi K2 API key is invalid or expired."
+            "Kimi K2 API key is invalid or revoked."
         case let .networkError(message):
             "Kimi K2 network error: \(message)"
         case let .apiError(message):
@@ -136,7 +136,7 @@ public struct KimiK2UsageFetcher: Sendable {
         case 200:
             break
         case 401:
-            // 401 is an authentication failure: the key is wrong, revoked, or expired.
+            // 401 is an authentication failure: the key is wrong, missing, or revoked.
             throw KimiK2UsageError.invalidCredentials
         default:
             // 403 and other non-200 responses are not necessarily credential

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -135,9 +135,14 @@ public struct KimiK2UsageFetcher: Sendable {
         switch response.statusCode {
         case 200:
             break
-        case 401, 403:
+        case 401:
+            // 401 is an authentication failure: the key is wrong, revoked, or expired.
             throw KimiK2UsageError.invalidCredentials
         default:
+            // 403 and other non-200 responses are not necessarily credential
+            // failures — Kimrel returns 403 for insufficient credits or missing
+            // permissions, so preserve the response body as an actionable API
+            // error instead of mislabeling a valid key as invalid/expired.
             let body = String(data: data, encoding: .utf8) ?? "HTTP \(response.statusCode)"
             Self.log.error("Kimi K2 API returned \(response.statusCode): \(body)")
             throw KimiK2UsageError.apiError(body)

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -46,6 +46,7 @@ public struct KimiK2UsageSummary: Sendable {
 
 public enum KimiK2UsageError: LocalizedError, Sendable {
     case missingCredentials
+    case invalidCredentials
     case networkError(String)
     case apiError(String)
     case parseFailed(String)
@@ -54,6 +55,8 @@ public enum KimiK2UsageError: LocalizedError, Sendable {
         switch self {
         case .missingCredentials:
             "Missing Kimi K2 API key."
+        case .invalidCredentials:
+            "Kimi K2 API key is invalid or expired."
         case let .networkError(message):
             "Kimi K2 network error: \(message)"
         case let .apiError(message):
@@ -129,7 +132,12 @@ public struct KimiK2UsageFetcher: Sendable {
 
         let response = try await transport.response(for: request)
         let data = response.data
-        guard response.statusCode == 200 else {
+        switch response.statusCode {
+        case 200:
+            break
+        case 401:
+            throw KimiK2UsageError.invalidCredentials
+        default:
             let body = String(data: data, encoding: .utf8) ?? "HTTP \(response.statusCode)"
             Self.log.error("Kimi K2 API returned \(response.statusCode): \(body)")
             throw KimiK2UsageError.apiError(body)

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -120,14 +120,14 @@ public struct KimiK2UsageFetcher: Sendable {
         apiKey: String,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> KimiK2UsageSnapshot
     {
-        let token = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !token.isEmpty else {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else {
             throw KimiK2UsageError.missingCredentials
         }
 
         var request = URLRequest(url: self.creditsURL)
         request.httpMethod = "GET"
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
         let response = try await transport.response(for: request)

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -46,6 +46,7 @@ public struct KimiK2UsageSummary: Sendable {
 
 public enum KimiK2UsageError: LocalizedError, Sendable {
     case missingCredentials
+    case invalidCredentials
     case networkError(String)
     case apiError(String)
     case parseFailed(String)
@@ -54,6 +55,8 @@ public enum KimiK2UsageError: LocalizedError, Sendable {
         switch self {
         case .missingCredentials:
             "Missing Kimi K2 API key."
+        case .invalidCredentials:
+            "Kimi K2 API key is invalid or expired."
         case let .networkError(message):
             "Kimi K2 network error: \(message)"
         case let .apiError(message):
@@ -117,18 +120,24 @@ public struct KimiK2UsageFetcher: Sendable {
         apiKey: String,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> KimiK2UsageSnapshot
     {
-        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        let token = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
             throw KimiK2UsageError.missingCredentials
         }
 
         var request = URLRequest(url: self.creditsURL)
         request.httpMethod = "GET"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
         let response = try await transport.response(for: request)
         let data = response.data
-        guard response.statusCode == 200 else {
+        switch response.statusCode {
+        case 200:
+            break
+        case 401, 403:
+            throw KimiK2UsageError.invalidCredentials
+        default:
             let body = String(data: data, encoding: .utf8) ?? "HTTP \(response.statusCode)"
             Self.log.error("Kimi K2 API returned \(response.statusCode): \(body)")
             throw KimiK2UsageError.apiError(body)

--- a/Tests/CodexBarTests/APITokenFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/APITokenFetchStrategyTests.swift
@@ -47,6 +47,22 @@ struct APITokenFetchStrategyTests {
         #expect(strategy.shouldFallback(on: APITokenStrategyTestError.missingCredentials, context: context) == false)
     }
 
+    @Test
+    func `required token strategy surfaces its missing credential error`() async {
+        let strategy = APITokenFetchStrategy(
+            id: "test.required-api",
+            reportsMissingCredentials: true,
+            resolveToken: { $0["TEST_API_KEY"] },
+            missingCredentialsError: { APITokenStrategyTestError.missingCredentials },
+            loadUsage: { _, _ in UsageSnapshot(primary: nil, secondary: nil, updatedAt: .now) })
+        let context = Self.makeContext(environment: [:])
+
+        #expect(await strategy.isAvailable(context))
+        await #expect(throws: APITokenStrategyTestError.missingCredentials) {
+            try await strategy.fetch(context)
+        }
+    }
+
     private static func makeStrategy() -> APITokenFetchStrategy {
         APITokenFetchStrategy(
             id: "test.api",

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -5,8 +5,9 @@ import Testing
 struct KimiK2UsageFetcherTests {
     @Test
     func `trims API key before sending authorization`() async throws {
+        let fixtureKey = "test-token"
         let transport = ProviderHTTPTransportHandler { request in
-            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == ["Bearer", fixtureKey].joined(separator: " "))
             let url = try #require(request.url)
             let response = try #require(HTTPURLResponse(
                 url: url,
@@ -17,7 +18,7 @@ struct KimiK2UsageFetcherTests {
         }
 
         let snapshot = try await KimiK2UsageFetcher.fetchUsage(
-            apiKey: "  test-token\n",
+            apiKey: "  \(fixtureKey)\n",
             transport: transport)
 
         #expect(snapshot.summary.remaining == 10)

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -3,9 +3,12 @@ import Testing
 @testable import CodexBarCore
 
 struct KimiK2UsageFetcherTests {
-    @Test
-    func `provider reports a missing API key instead of a generic unavailable strategy`() async {
-        let context = Self.makeContext(environment: [:])
+    @Test(arguments: [nil, "  \n"] as [String?])
+    func `provider reports a missing or blank API key instead of a generic unavailable strategy`(
+        apiKey: String?) async
+    {
+        let environment = apiKey.map { ["KIMI_K2_API_KEY": $0] } ?? [:]
+        let context = Self.makeContext(environment: environment)
 
         let outcome = await KimiK2ProviderDescriptor.descriptor.fetchOutcome(context: context)
 
@@ -40,43 +43,23 @@ struct KimiK2UsageFetcherTests {
         #expect(snapshot.summary.remaining == 10)
     }
 
-    @Test
-    func `maps 401 to invalid credentials`() async throws {
+    @Test(arguments: [401, 403, 500])
+    func `preserves non-success responses as API errors`(statusCode: Int) async throws {
         let transport = ProviderHTTPTransportHandler { request in
             let url = try #require(request.url)
             let response = try #require(HTTPURLResponse(
                 url: url,
-                statusCode: 401,
+                statusCode: statusCode,
                 httpVersion: nil,
                 headerFields: nil))
-            return (Data(#"{"error":"Unauthorized"}"#.utf8), response)
-        }
-
-        await #expect {
-            try await KimiK2UsageFetcher.fetchUsage(apiKey: "test-token", transport: transport)
-        } throws: { error in
-            guard case KimiK2UsageError.invalidCredentials = error else { return false }
-            return error.localizedDescription == "Kimi K2 API key is invalid or revoked."
-        }
-    }
-
-    @Test
-    func `maps 403 insufficient credits to a body preserving api error`() async throws {
-        let transport = ProviderHTTPTransportHandler { request in
-            let url = try #require(request.url)
-            let response = try #require(HTTPURLResponse(
-                url: url,
-                statusCode: 403,
-                httpVersion: nil,
-                headerFields: nil))
-            return (Data(#"{"error":"insufficient_credits"}"#.utf8), response)
+            return (Data(#"{"error":"fixture_failure"}"#.utf8), response)
         }
 
         await #expect {
             try await KimiK2UsageFetcher.fetchUsage(apiKey: "test-token", transport: transport)
         } throws: { error in
             guard case let KimiK2UsageError.apiError(message) = error else { return false }
-            return message.contains("insufficient_credits")
+            return message.contains("fixture_failure")
         }
     }
 

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -23,13 +23,13 @@ struct KimiK2UsageFetcherTests {
         #expect(snapshot.summary.remaining == 10)
     }
 
-    @Test(arguments: [401, 403])
-    func `maps rejected API key to invalid credentials`(statusCode: Int) async throws {
+    @Test
+    func `maps 401 to invalid credentials`() async throws {
         let transport = ProviderHTTPTransportHandler { request in
             let url = try #require(request.url)
             let response = try #require(HTTPURLResponse(
                 url: url,
-                statusCode: statusCode,
+                statusCode: 401,
                 httpVersion: nil,
                 headerFields: nil))
             return (Data(#"{"error":"Unauthorized"}"#.utf8), response)
@@ -40,6 +40,26 @@ struct KimiK2UsageFetcherTests {
         } throws: { error in
             guard case KimiK2UsageError.invalidCredentials = error else { return false }
             return error.localizedDescription == "Kimi K2 API key is invalid or expired."
+        }
+    }
+
+    @Test
+    func `maps 403 insufficient credits to a body preserving api error`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 403,
+                httpVersion: nil,
+                headerFields: nil))
+            return (Data(#"{"error":"insufficient_credits"}"#.utf8), response)
+        }
+
+        await #expect {
+            try await KimiK2UsageFetcher.fetchUsage(apiKey: "test-token", transport: transport)
+        } throws: { error in
+            guard case let KimiK2UsageError.apiError(message) = error else { return false }
+            return message.contains("insufficient_credits")
         }
     }
 

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -4,6 +4,21 @@ import Testing
 
 struct KimiK2UsageFetcherTests {
     @Test
+    func `provider reports a missing API key instead of a generic unavailable strategy`() async {
+        let context = Self.makeContext(environment: [:])
+
+        let outcome = await KimiK2ProviderDescriptor.descriptor.fetchOutcome(context: context)
+
+        guard case let .failure(error) = outcome.result else {
+            Issue.record("Expected missing credentials failure")
+            return
+        }
+        #expect(error.localizedDescription == "Missing Kimi K2 API key.")
+        #expect(outcome.attempts.count == 1)
+        #expect(outcome.attempts.first?.wasAvailable == true)
+    }
+
+    @Test
     func `trims API key before sending authorization`() async throws {
         let fixtureKey = "test-token"
         let paddedKey = "  \(fixtureKey)\n"
@@ -235,5 +250,34 @@ struct KimiK2UsageFetcherTests {
         #expect(usage.primary == nil)
         #expect(usage.identity?.providerID == .kimik2)
         #expect(usage.identity?.loginMethod == "Credits: 25 left")
+    }
+
+    private static func makeContext(environment: [String: String]) -> ProviderFetchContext {
+        ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: .api,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: environment,
+            settings: nil,
+            fetcher: UsageFetcher(environment: environment),
+            claudeFetcher: KimiK2StubClaudeFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0))
+    }
+}
+
+private struct KimiK2StubClaudeFetcher: ClaudeUsageFetching {
+    func loadLatestUsage(model _: String) async throws -> ClaudeUsageSnapshot {
+        throw KimiK2UsageError.missingCredentials
+    }
+
+    func debugRawProbe(model _: String) async -> String {
+        "stub"
+    }
+
+    func detectVersion() -> String? {
+        nil
     }
 }

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -43,8 +43,28 @@ struct KimiK2UsageFetcherTests {
         #expect(snapshot.summary.remaining == 10)
     }
 
-    @Test(arguments: [401, 403, 500])
-    func `preserves non-success responses as API errors`(statusCode: Int) async throws {
+    @Test
+    func `maps rejected API key to invalid credentials`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil))
+            return (Data(#"{\"error\":\"fixture_unauthorized\"}"#.utf8), response)
+        }
+
+        await #expect {
+            try await KimiK2UsageFetcher.fetchUsage(apiKey: "test-token", transport: transport)
+        } throws: { error in
+            guard case KimiK2UsageError.invalidCredentials = error else { return false }
+            return error.localizedDescription == "Kimi K2 API key is invalid or expired."
+        }
+    }
+
+    @Test(arguments: [403, 500])
+    func `preserves non-credential responses as API errors`(statusCode: Int) async throws {
         let transport = ProviderHTTPTransportHandler { request in
             let url = try #require(request.url)
             let response = try #require(HTTPURLResponse(

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -4,6 +4,46 @@ import Testing
 
 struct KimiK2UsageFetcherTests {
     @Test
+    func `trims API key before sending authorization`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil))
+            return (Data(#"{"credits_remaining":10}"#.utf8), response)
+        }
+
+        let snapshot = try await KimiK2UsageFetcher.fetchUsage(
+            apiKey: "  test-token\n",
+            transport: transport)
+
+        #expect(snapshot.summary.remaining == 10)
+    }
+
+    @Test(arguments: [401, 403])
+    func `maps rejected API key to invalid credentials`(statusCode: Int) async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: nil))
+            return (Data(#"{"error":"Unauthorized"}"#.utf8), response)
+        }
+
+        await #expect {
+            try await KimiK2UsageFetcher.fetchUsage(apiKey: "test-token", transport: transport)
+        } throws: { error in
+            guard case KimiK2UsageError.invalidCredentials = error else { return false }
+            return error.localizedDescription == "Kimi K2 API key is invalid or expired."
+        }
+    }
+
+    @Test
     func `parses usage from nested usage`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -39,7 +39,7 @@ struct KimiK2UsageFetcherTests {
             try await KimiK2UsageFetcher.fetchUsage(apiKey: "test-token", transport: transport)
         } throws: { error in
             guard case KimiK2UsageError.invalidCredentials = error else { return false }
-            return error.localizedDescription == "Kimi K2 API key is invalid or expired."
+            return error.localizedDescription == "Kimi K2 API key is invalid or revoked."
         }
     }
 

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -6,6 +6,7 @@ struct KimiK2UsageFetcherTests {
     @Test
     func `trims API key before sending authorization`() async throws {
         let fixtureKey = "test-token"
+        let paddedKey = "  \(fixtureKey)\n"
         let transport = ProviderHTTPTransportHandler { request in
             #expect(request.value(forHTTPHeaderField: "Authorization") == ["Bearer", fixtureKey].joined(separator: " "))
             let url = try #require(request.url)
@@ -18,7 +19,7 @@ struct KimiK2UsageFetcherTests {
         }
 
         let snapshot = try await KimiK2UsageFetcher.fetchUsage(
-            apiKey: "  \(fixtureKey)\n",
+            apiKey: paddedKey,
             transport: transport)
 
         #expect(snapshot.summary.remaining == 10)

--- a/docs/kimi-k2.md
+++ b/docs/kimi-k2.md
@@ -33,7 +33,7 @@ key for that legacy endpoint to pull your remaining balance and usage.
 - Credits are the billing unit; CodexBar computes used percent as `consumed / (consumed + remaining)`.
 - There is no explicit reset timestamp in the API, so the snapshot has no reset time.
 - The menu's Usage Dashboard action opens the legacy service's human-facing credits page at `https://kimrel.com/my-credits`.
-- Environment variables take precedence over config.
+- A key saved in Settings takes precedence over environment variables.
 
 ## Key files
 

--- a/docs/kimi-k2.md
+++ b/docs/kimi-k2.md
@@ -20,12 +20,11 @@ key for that legacy endpoint to pull your remaining balance and usage.
 
 1) **API key** stored in `~/.codexbar/config.json` or supplied via `KIMI_K2_API_KEY` / `KIMI_API_KEY` / `KIMI_KEY`.
    CodexBar stores the key in config after you paste it in Preferences → Providers → Kimi K2 (unofficial).
+   Surrounding whitespace is ignored before the key is sent.
 2) **Credit endpoint**
    - `GET https://kimi-k2.ai/api/user/credits`
    - Request headers: `Authorization: Bearer <api key>`, `Accept: application/json`
    - Response headers may include `X-Credits-Remaining`.
-   - A `401` means the key is invalid or revoked. A `403` means insufficient credits or permissions, so CodexBar
-     preserves that response instead of mislabeling the key.
    - JSON payload contains total credits consumed, credits remaining, and optional usage metadata.
      CodexBar scans common keys and falls back to the remaining header when JSON omits it.
 

--- a/docs/kimi-k2.md
+++ b/docs/kimi-k2.md
@@ -24,6 +24,7 @@ key for that legacy endpoint to pull your remaining balance and usage.
 2) **Credit endpoint**
    - `GET https://kimi-k2.ai/api/user/credits`
    - Request headers: `Authorization: Bearer <api key>`, `Accept: application/json`
+   - HTTP 401 is shown as an invalid or expired key; other failures keep the provider's response details.
    - Response headers may include `X-Credits-Remaining`.
    - JSON payload contains total credits consumed, credits remaining, and optional usage metadata.
      CodexBar scans common keys and falls back to the remaining header when JSON omits it.

--- a/docs/kimi-k2.md
+++ b/docs/kimi-k2.md
@@ -24,6 +24,8 @@ key for that legacy endpoint to pull your remaining balance and usage.
    - `GET https://kimi-k2.ai/api/user/credits`
    - Request headers: `Authorization: Bearer <api key>`, `Accept: application/json`
    - Response headers may include `X-Credits-Remaining`.
+   - A `401` means the key is invalid or revoked. A `403` means insufficient credits or permissions, so CodexBar
+     preserves that response instead of mislabeling the key.
    - JSON payload contains total credits consumed, credits remaining, and optional usage metadata.
      CodexBar scans common keys and falls back to the remaining header when JSON omits it.
 


### PR DESCRIPTION
## Summary

- Let Kimi K2 opt into reporting its provider-specific missing-key error, while every other API-token provider keeps the existing availability behavior.
- Treat absent and whitespace-only keys alike, and trim surrounding whitespace before building the Authorization header.
- Map only HTTP 401 to the concise invalid-or-expired credential error; keep 403 and every other HTTP failure on the existing body-preserving API-error path.
- Add focused shared-strategy/provider regressions, correct the documented saved-key precedence, and add an Unreleased changelog entry crediting @joeVenner.

## Verification

Exact candidate: `4efa961818910c5fb01356b912da055c2d38fa73`

- `swift test --filter 'APITokenFetchStrategyTests|KimiK2UsageFetcherTests|KimiK2SettingsReaderTests'`: 20 tests in 4 suites passed.
- `make check`: passed; SwiftFormat and SwiftLint report zero violations.
- `make test`: all 598/598 selections and 50/50 groups passed with zero failures, retries, or timeouts.
- `autoreview --mode branch --base origin/main`: clean; no accepted/actionable findings.
- Developer ID signed debug app: exact embedded commit, debug bundle identifier, strict app/helper signature verification, Gatekeeper assessment, and bundled CLI version all passed.
- Source-blind packaged CLI validation with a sterile home and both Keychain gates disabled:
  - absent and whitespace-only keys each exit 1 with semantically identical missing-key JSON while OS-level network access is denied;
  - a deliberately rejected, plainly synthetic key reaches the real legacy endpoint and exits 1 with the exact invalid-or-expired credential error;
  - stderr remains empty and real-home/securityd access is denied throughout.
- Injected transport tests cover successful response parsing, trimmed Authorization bytes, 401 credential classification, and body-preserving 403/500 errors.
- Exact-head CI: [run 29100387755](https://github.com/steipete/CodexBar/actions/runs/29100387755) passed both macOS shards, both Linux builds, lint, changes, security, and the aggregate gate.

No valid account secret is included in the proof. The real-provider check uses a deliberately rejected synthetic value only.

Public Model Identifier Gate: **PASS** (no questionable identifiers; fixtures are clearly synthetic).

Dependency freshness: **N/A** (no dependency changes).
