### PR TITLE
Add Kimi widget support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.40.1 — Unreleased
 
+### Added
+- Widgets: make Kimi available with Weekly, Rate Limit, and Monthly quota rows. Thanks @joeVenner!
+
 ### Fixed
 - Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.
 - Codex cost history: reuse cached aggregate pricing and one pricing catalog across daily and project reports, carry fresh cache state across launches, and treat unpriced models as migrated, avoiding repeated row scans, filesystem work, and duplicate background scans on large local histories.

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -178,6 +178,15 @@ extension UsageStore {
                 title: metadata?.opusLabel ?? "Opus",
                 percentLeft: snapshot.tertiary?.remainingPercent))
         }
+        if provider == .kimi,
+           let monthly = snapshot.extraRateWindows?.first(where: { $0.id == "kimi-monthly" }),
+           monthly.usageKnown
+        {
+            rows.append(WidgetSnapshot.WidgetUsageRowSnapshot(
+                id: monthly.id,
+                title: monthly.title,
+                percentLeft: monthly.window.remainingPercent))
+        }
         return rows.filter { $0.percentLeft != nil }
     }
 

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -18,6 +18,7 @@ enum ProviderChoice: String, AppEnum {
     case opencode
     case opencodego
     case mistral
+    case kimi
 
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Provider")
 
@@ -36,6 +37,7 @@ enum ProviderChoice: String, AppEnum {
         .opencode: DisplayRepresentation(title: "OpenCode"),
         .opencodego: DisplayRepresentation(title: "OpenCode Go"),
         .mistral: DisplayRepresentation(title: "Mistral"),
+        .kimi: DisplayRepresentation(title: "Kimi"),
     ]
 
     var provider: UsageProvider {
@@ -54,6 +56,7 @@ enum ProviderChoice: String, AppEnum {
         case .opencode: .opencode
         case .opencodego: .opencodego
         case .mistral: .mistral
+        case .kimi: .kimi
         }
     }
 
@@ -82,7 +85,7 @@ enum ProviderChoice: String, AppEnum {
         case .kiro: return nil // Kiro not yet supported in widgets
         case .augment: return nil // Augment not yet supported in widgets
         case .jetbrains: return nil // JetBrains not yet supported in widgets
-        case .kimi: return nil // Kimi not yet supported in widgets
+        case .kimi: self = .kimi
         case .kimik2: return nil // Kimi K2 not yet supported in widgets
         case .moonshot: return nil // Moonshot not yet supported in widgets
         case .amp: return nil // Amp not yet supported in widgets

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -591,11 +591,13 @@ struct WidgetUsageRow: Identifiable, Equatable {
     }
 
     static func smallWidgetRowLimit(for entry: WidgetSnapshot.ProviderEntry) -> Int? {
-        self.antigravityQuotaSummaryRowLimit(for: entry, limit: 2)
+        if entry.provider == .kimi { return 3 }
+        return self.antigravityQuotaSummaryRowLimit(for: entry, limit: 2)
     }
 
     static func mediumWidgetRowLimit(for entry: WidgetSnapshot.ProviderEntry) -> Int? {
-        self.antigravityQuotaSummaryRowLimit(for: entry, limit: 3)
+        if entry.provider == .kimi { return 3 }
+        return self.antigravityQuotaSummaryRowLimit(for: entry, limit: 3)
     }
 
     private static func antigravityQuotaSummaryRowLimit(

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -370,6 +370,12 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `provider choice supports Kimi`() {
+        #expect(ProviderChoice(provider: .kimi) == .kimi)
+        #expect(ProviderChoice.kimi.provider == .kimi)
+    }
+
+    @Test
     func `provider choice excludes unsupported Chutes widgets`() {
         #expect(ProviderChoice(provider: .chutes) == nil)
     }
@@ -433,6 +439,24 @@ struct CodexBarWidgetProviderTests {
         let snapshot = WidgetSnapshot(entries: [entry], enabledProviders: [.mistral], generatedAt: now)
 
         #expect(CodexBarSwitcherTimelineProvider.supportedProviders(from: snapshot) == [.mistral])
+    }
+
+    @Test
+    func `supported providers keep Kimi when it is the only enabled provider`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .kimi,
+            updatedAt: now,
+            primary: RateWindow(usedPercent: 25, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            tertiary: nil,
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+        let snapshot = WidgetSnapshot(entries: [entry], enabledProviders: [.kimi], generatedAt: now)
+
+        #expect(CodexBarSwitcherTimelineProvider.supportedProviders(from: snapshot) == [.kimi])
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -376,6 +376,38 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `small and medium Kimi widgets keep all three persisted lane rows`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .kimi,
+            updatedAt: now,
+            primary: RateWindow(usedPercent: 25, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            tertiary: nil,
+            usageRows: [
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "primary", title: "Weekly", percentLeft: 75),
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "secondary", title: "Rate Limit", percentLeft: 50),
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "kimi-monthly", title: "Monthly", percentLeft: 25),
+            ],
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+
+        let smallRows = WidgetUsageRow.rows(
+            for: entry,
+            limit: WidgetUsageRow.smallWidgetRowLimit(for: entry))
+        let mediumRows = WidgetUsageRow.rows(
+            for: entry,
+            limit: WidgetUsageRow.mediumWidgetRowLimit(for: entry))
+
+        #expect(WidgetUsageRow.smallWidgetRowLimit(for: entry) == 3)
+        #expect(WidgetUsageRow.mediumWidgetRowLimit(for: entry) == 3)
+        #expect(smallRows.map(\.id) == ["primary", "secondary", "kimi-monthly"])
+        #expect(mediumRows == smallRows)
+    }
+
+    @Test
     func `provider choice excludes unsupported Chutes widgets`() {
         #expect(ProviderChoice(provider: .chutes) == nil)
     }

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -6,6 +6,58 @@ import Testing
 @MainActor
 struct UsageStoreWidgetSnapshotTests {
     @Test
+    func `widget snapshot includes Kimi monthly quota`() async throws {
+        let suite = "UsageStoreWidgetSnapshotTests-kimi-monthly"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 25, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            tertiary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "kimi-monthly",
+                    title: "Monthly",
+                    window: RateWindow(
+                        usedPercent: 75,
+                        windowMinutes: nil,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+            ],
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .kimi,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: nil))
+        store._setSnapshotForTesting(snapshot, provider: .kimi)
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        store.persistWidgetSnapshot(reason: "kimi-monthly-test")
+        await store.widgetSnapshotPersistTask?.value
+
+        let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .kimi })
+        #expect(entry.usageRows?.map(\.id) == ["primary", "secondary", "kimi-monthly"])
+        #expect(entry.usageRows?.map(\.title) == ["Weekly", "Rate Limit", "Monthly"])
+        #expect(entry.usageRows?.compactMap(\.percentLeft) == [75, 50, 25])
+    }
+
+    @Test
     func `widget snapshot includes antigravity grouped usage rows`() async throws {
         let suite = "UsageStoreWidgetSnapshotTests-antigravity-grouped"
         let defaults = try #require(UserDefaults(suiteName: suite))

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -52,6 +52,7 @@ struct UsageStoreWidgetSnapshotTests {
         await store.widgetSnapshotPersistTask?.value
 
         let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .kimi })
+        // Widgets preserve persisted lane order; menu-only presentation may reorder these lanes.
         #expect(entry.usageRows?.map(\.id) == ["primary", "secondary", "kimi-monthly"])
         #expect(entry.usageRows?.map(\.title) == ["Weekly", "Rate Limit", "Monthly"])
         #expect(entry.usageRows?.compactMap(\.percentLeft) == [75, 50, 25])


### PR DESCRIPTION
## Summary
- expose Kimi in the widget provider selector and switcher timelines
- project Weekly, Rate Limit, and Monthly Kimi quota rows into widget snapshots
- deliberately preserve persisted widget lane order (Weekly, Rate Limit, Monthly), while the menu keeps its presentation-only Rate Limit-first order
- keep all three Kimi rows visible in small and medium widgets, with focused regression coverage

![Kimi widget proof](https://raw.githubusercontent.com/joeVenner/CodexBar/proof-assets/proof/kimi-widget-support.png)

## Maintainer verification
- exact head: `1e57f21fbe971e1be327e50e309c14266e53c813`
- focused widget/snapshot suite: 49 tests passed
- full local suite: all 48 shards passed
- `make check`: SwiftFormat and SwiftLint clean
- autoreview: clean on both the local diff and branch diff
- authenticated packaged QA: the real Kimi API returned Weekly and Rate Limit data; a Developer-ID-signed debug app and widget rendered both rows in small and medium without clipping
- ordering QA: widgets rendered Weekly before Rate Limit, while the menu rendered Rate Limit before Weekly, matching the deliberate persisted-lane contract
- three-row QA: the exact-head renderer displayed Weekly, Rate Limit, and Monthly in both small and medium from a controlled debug snapshot; no clipping or row loss
- package integrity: `codesign --verify --deep --strict` passed for app and widget, both with team `Y5PE65HELJ`
