### PR TITLE
Add Kimi K2 usage dashboard shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Agent Sessions: list and focus live local or SSH-discovered Codex and Claude Code sessions from the menu and CLI.
+- Kimi K2: add a Usage Dashboard shortcut to the human-facing legacy credits page. Thanks @joeVenner!
 - Codex: add a provider option to hide Spark quota rows without hiding credits or other extra usage (#2013). Thanks @intellectronica!
 - Wayfinder: add opt-in local gateway health, routing, savings, and latency usage with configurable loopback URL support. Thanks @tcballard!
 - Claude CLI: surface model-scoped weekly limits alongside all-model usage without duplicating matching web limits. Thanks @janpollak!

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2ProviderDescriptor.swift
@@ -21,7 +21,7 @@ public enum KimiK2ProviderDescriptor {
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
                 browserCookieOrder: nil,
-                dashboardURL: nil,
+                dashboardURL: "https://kimrel.com/my-credits",
                 statusPageURL: nil),
             branding: ProviderBranding(
                 iconStyle: .kimi,

--- a/Tests/CodexBarTests/MenuDescriptorKimiK2Tests.swift
+++ b/Tests/CodexBarTests/MenuDescriptorKimiK2Tests.swift
@@ -1,5 +1,4 @@
 import CodexBarCore
-import Foundation
 import Testing
 @testable import CodexBar
 
@@ -7,7 +6,7 @@ import Testing
 @Suite(.serialized)
 struct MenuDescriptorKimiK2Tests {
     @Test
-    func `kimi K2 menu exposes the usage dashboard action`() throws {
+    func `kimi K2 menu exposes the usage dashboard action`() {
         let settings = testSettingsStore(suiteName: "MenuDescriptorKimiK2Tests-dashboard")
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
@@ -33,8 +32,5 @@ struct MenuDescriptorKimiK2Tests {
         #expect(actions.contains { title, action in
             title == "Usage Dashboard" && action == .dashboard
         })
-        #expect(
-            store.metadata(for: .kimik2).dashboardURL == "https://kimrel.com/my-credits",
-            "Dashboard action must open the human-facing credits page, not the bearer-token API endpoint")
     }
 }

--- a/Tests/CodexBarTests/MenuDescriptorKimiK2Tests.swift
+++ b/Tests/CodexBarTests/MenuDescriptorKimiK2Tests.swift
@@ -1,0 +1,45 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct MenuDescriptorKimiK2Tests {
+    @Test
+    func `kimi K2 menu exposes the usage dashboard action`() throws {
+        let suite = "MenuDescriptorKimiK2Tests-dashboard"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+
+        let descriptor = MenuDescriptor.build(
+            provider: .kimik2,
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updateReady: false)
+        let actions = descriptor.sections
+            .flatMap(\.entries)
+            .compactMap { entry -> (String, MenuDescriptor.MenuAction)? in
+                guard case let .action(title, action) = entry else { return nil }
+                return (title, action)
+            }
+
+        #expect(actions.contains { title, action in
+            title == "Usage Dashboard" && action == .dashboard
+        })
+        #expect(
+            store.metadata(for: .kimik2).dashboardURL == "https://kimrel.com/my-credits",
+            "Dashboard action must open the human-facing credits page, not the bearer-token API endpoint")
+    }
+}

--- a/Tests/CodexBarTests/MenuDescriptorKimiK2Tests.swift
+++ b/Tests/CodexBarTests/MenuDescriptorKimiK2Tests.swift
@@ -4,19 +4,14 @@ import Testing
 @testable import CodexBar
 
 @MainActor
+@Suite(.serialized)
 struct MenuDescriptorKimiK2Tests {
     @Test
     func `kimi K2 menu exposes the usage dashboard action`() throws {
-        let suite = "MenuDescriptorKimiK2Tests-dashboard"
-        let defaults = try #require(UserDefaults(suiteName: suite))
-        defaults.removePersistentDomain(forName: suite)
-
-        let settings = SettingsStore(
-            userDefaults: defaults,
-            configStore: testConfigStore(suiteName: suite),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+        let settings = testSettingsStore(suiteName: "MenuDescriptorKimiK2Tests-dashboard")
         settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
         let store = UsageStore(
             fetcher: UsageFetcher(environment: [:]),
             browserDetection: BrowserDetection(cacheTTL: 0),

--- a/Tests/CodexBarTests/ProviderMetadataStatusLinkTests.swift
+++ b/Tests/CodexBarTests/ProviderMetadataStatusLinkTests.swift
@@ -14,11 +14,13 @@ struct ProviderMetadataStatusLinkTests {
     }
 
     @Test
-    func `kimi K2 metadata does not present legacy endpoint as official`() throws {
+    func `kimi K2 metadata identifies the unofficial provider and its credits dashboard`() throws {
         let meta = try #require(ProviderDefaults.metadata[.kimik2])
 
         #expect(meta.displayName == "Kimi K2 (unofficial)")
         #expect(meta.toggleTitle == "Show unofficial Kimi K2 usage")
-        #expect(meta.dashboardURL == nil)
+        // The dashboard URL must be a human-facing browser page, not the bearer-token
+        // credits API endpoint (which returns HTTP 401 to an unauthenticated browser).
+        #expect(meta.dashboardURL == "https://kimrel.com/my-credits")
     }
 }

--- a/docs/kimi-k2.md
+++ b/docs/kimi-k2.md
@@ -31,6 +31,7 @@ key for that legacy endpoint to pull your remaining balance and usage.
 
 - Credits are the billing unit; CodexBar computes used percent as `consumed / (consumed + remaining)`.
 - There is no explicit reset timestamp in the API, so the snapshot has no reset time.
+- The menu's Usage Dashboard action opens the legacy service's human-facing credits page at `https://kimrel.com/my-credits`.
 - Environment variables take precedence over config.
 
 ## Key files


### PR DESCRIPTION
## Summary
- add a **Usage Dashboard** menu action for the unofficial Kimi K2 provider
- point it at the human-facing credits page (`https://kimrel.com/my-credits`), not the bearer-token API endpoint
- add a MenuDescriptor test covering the dashboard action and URL; update the metadata status-link test

## Why `kimrel.com/my-credits` and not the API endpoint

The first iteration pointed the shortcut at `https://kimi-k2.ai/api/user/credits`. That is the bearer-token credits API: an unauthenticated browser open returns **HTTP 401 JSON**, so the "Usage Dashboard" item would dump raw error JSON instead of opening a real dashboard. Live verification (resolves the open question I previously flagged):

```text
$ curl -sL -o /dev/null -w "%{http_code} %{url_effective}\n" https://kimi-k2.ai/api/user/credits
401 https://kimi-k2.ai/api/user/credits          # old URL — raw API; browser sees 401 JSON

$ curl -sL -o /dev/null -w "%{http_code} %{url_effective}\n" https://kimrel.com/my-credits
200 https://kimrel.com/auth/signin              # new URL — human Next.js credits page; unauthenticated → Sign In, authenticated → credit balance
```

`kimi-k2.ai` (the API host the descriptor already uses) 301-redirects to `kimrel.com`, and `kimrel.com/my-credits` is the human-facing credits page on the same service — unauthenticated users land on the Next.js **Sign In** page (HTML `Sign in`/`Sign In` body, confirmed live), and authenticated users see their credit balance. This resolves the "don't open the API endpoint as a dashboard" concern with a browser-safe destination that preserves the shortcut.

## Note for the maintainer
`kimrel.com` is where `kimi-k2.ai` redirects, so it is the canonical human-facing domain for this service; if steipete prefers a different Kimi credits/dashboard surface, swapping the single `dashboardURL` string and the two test assertions is a one-line change. No CHANGELOG entry is included (release-owned); the maintainer can credit `@joeVenner` at release time as with the merged Kimi K2 follow-ups.

## Testing
- `swift test --disable-sandbox --filter "MenuDescriptorKimiK2Tests|ProviderMetadataStatusLinkTests"` (3 passed, incl. `kimi K2 menu exposes the usage dashboard action` and `kimi K2 metadata identifies the unofficial provider and its credits dashboard`)
- live URL verification above (`kimrel.com/my-credits` → 200/signin; `kimi-k2.ai/api/user/credits` → 401)
- `swift build` clean