### PR TITLE
Include Claude Desktop local-agent usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Settings: keep the sidebar fixed and visible while resizing, prevent collapse or over-expansion, and cap detail content width for readability. Thanks @Zihao-Qi!
 
 ### Fixed
-- Claude cost history: include local-agent logs from both legacy and current Claude Desktop session stores. Thanks @Zihao-Qi!
+- Claude cost history: include nested Claude Desktop local-agent logs while preserving current Code/Cowork coverage through the shared `~/.claude/projects` store. Thanks @Zihao-Qi!
 - Claude: give multiple claude-swap accounts precedence over token-account cards and segmented switching so adapter rows remain visible. Thanks @optimiz-r!
 - Menus: scope manual refresh state to the provider being refreshed, allowing independent provider refreshes without greying unrelated rows. Thanks @hhh2210!
 - Claude history: quarantine same-directory account-switch samples until credential ownership is stable, preventing plan-utilization history from crossing accounts. Thanks @ss251!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Settings: keep the sidebar fixed and visible while resizing, prevent collapse or over-expansion, and cap detail content width for readability. Thanks @Zihao-Qi!
 
 ### Fixed
+- Claude cost history: include local-agent logs from both legacy and current Claude Desktop session stores. Thanks @Zihao-Qi!
 - Claude: give multiple claude-swap accounts precedence over token-account cards and segmented switching so adapter rows remain visible. Thanks @optimiz-r!
 - Menus: scope manual refresh state to the provider being refreshed, allowing independent provider refreshes without greying unrelated rows. Thanks @hhh2210!
 - Claude history: quarantine same-directory account-switch samples until credential ownership is stable, preventing plan-utilization history from crossing accounts. Thanks @ss251!

--- a/Sources/CodexBar/SettingsStore+TokenCost.swift
+++ b/Sources/CodexBar/SettingsStore+TokenCost.swift
@@ -85,93 +85,9 @@ extension SettingsStore {
             return [
                 home.appendingPathComponent(".config/claude/projects", isDirectory: true),
                 home.appendingPathComponent(".claude/projects", isDirectory: true),
-            ] + self.claudeDesktopLocalAgentProjectsRoots(homeDirectory: home, fileManager: fileManager)
+            ] + ClaudeDesktopProjectsLocator.roots(homeDirectory: home, fileManager: fileManager)
         }()
 
         return claudeRoots.contains(where: hasAnyJsonl(in:))
-    }
-
-    private nonisolated static func claudeDesktopLocalAgentProjectsRoots(
-        homeDirectory: URL,
-        fileManager: FileManager) -> [URL]
-    {
-        let sessionsRoot = homeDirectory
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-            .appendingPathComponent("Claude", isDirectory: true)
-            .appendingPathComponent("local-agent-mode-sessions", isDirectory: true)
-        var roots: [URL] = []
-        var queue: [(url: URL, depth: Int)] = [(sessionsRoot, 0)]
-        var visited: Set<String> = [sessionsRoot.standardizedFileURL.path]
-        var nextIndex = 0
-        // Covers observed Desktop local-agent layouts through workspace/session/agent/local_agent
-        // without descending into arbitrary checked-out workspaces.
-        let maxDepth = 4
-
-        while nextIndex < queue.count {
-            let current = queue[nextIndex]
-            nextIndex += 1
-            if let projects = self.claudeProjectsRootUnderDesktopLocalAgentBase(
-                current.url,
-                fileManager: fileManager)
-            {
-                roots.append(projects)
-            }
-
-            guard current.depth < maxDepth else { continue }
-            for child in self.claudeDesktopLocalAgentChildDirectories(at: current.url, fileManager: fileManager) {
-                let standardized = child.standardizedFileURL
-                guard visited.insert(standardized.path).inserted else { continue }
-                queue.append((standardized, current.depth + 1))
-            }
-        }
-        return roots
-    }
-
-    private nonisolated static func claudeProjectsRootUnderDesktopLocalAgentBase(
-        _ base: URL,
-        fileManager: FileManager) -> URL?
-    {
-        let projects = base
-            .appendingPathComponent(".claude", isDirectory: true)
-            .appendingPathComponent("projects", isDirectory: true)
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: projects.path, isDirectory: &isDirectory),
-              isDirectory.boolValue
-        else { return nil }
-        return projects
-    }
-
-    private nonisolated static func claudeDesktopLocalAgentChildDirectories(
-        at url: URL,
-        fileManager: FileManager) -> [URL]
-    {
-        let skippedDirectoryNames = Set([
-            ".build",
-            ".git",
-            "build",
-            "DerivedData",
-            "node_modules",
-            "outputs",
-            "target",
-        ])
-        guard let children = try? fileManager.contentsOfDirectory(
-            at: url,
-            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
-            options: [.skipsHiddenFiles, .skipsPackageDescendants])
-        else {
-            return []
-        }
-
-        return children.compactMap { child in
-            guard !skippedDirectoryNames.contains(child.lastPathComponent) else { return nil }
-            guard let values = try? child.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
-                  values.isSymbolicLink != true,
-                  values.isDirectory == true
-            else {
-                return nil
-            }
-            return child
-        }
     }
 }

--- a/Sources/CodexBar/SettingsStore+TokenCost.swift
+++ b/Sources/CodexBar/SettingsStore+TokenCost.swift
@@ -29,8 +29,11 @@ extension SettingsStore {
 
     nonisolated static func hasAnyTokenCostUsageSources(
         env: [String: String] = ProcessInfo.processInfo.environment,
-        fileManager: FileManager = .default) -> Bool
+        fileManager: FileManager = .default,
+        homeDirectory: URL? = nil) -> Bool
     {
+        let home = homeDirectory ?? fileManager.homeDirectoryForCurrentUser
+
         func hasAnyJsonl(in root: URL) -> Bool {
             guard fileManager.fileExists(atPath: root.path) else { return false }
             guard let enumerator = fileManager.enumerator(
@@ -50,7 +53,7 @@ extension SettingsStore {
             if let raw, !raw.isEmpty {
                 return URL(fileURLWithPath: raw).appendingPathComponent("sessions", isDirectory: true)
             }
-            return fileManager.homeDirectoryForCurrentUser
+            return home
                 .appendingPathComponent(".codex", isDirectory: true)
                 .appendingPathComponent("sessions", isDirectory: true)
         }()
@@ -79,13 +82,96 @@ extension SettingsStore {
                 }
             }
 
-            let home = fileManager.homeDirectoryForCurrentUser
             return [
                 home.appendingPathComponent(".config/claude/projects", isDirectory: true),
                 home.appendingPathComponent(".claude/projects", isDirectory: true),
-            ]
+            ] + self.claudeDesktopLocalAgentProjectsRoots(homeDirectory: home, fileManager: fileManager)
         }()
 
         return claudeRoots.contains(where: hasAnyJsonl(in:))
+    }
+
+    private nonisolated static func claudeDesktopLocalAgentProjectsRoots(
+        homeDirectory: URL,
+        fileManager: FileManager) -> [URL]
+    {
+        let sessionsRoot = homeDirectory
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("local-agent-mode-sessions", isDirectory: true)
+        var roots: [URL] = []
+        var queue: [(url: URL, depth: Int)] = [(sessionsRoot, 0)]
+        var visited: Set<String> = [sessionsRoot.standardizedFileURL.path]
+        var nextIndex = 0
+        // Covers observed Desktop local-agent layouts through workspace/session/agent/local_agent
+        // without descending into arbitrary checked-out workspaces.
+        let maxDepth = 4
+
+        while nextIndex < queue.count {
+            let current = queue[nextIndex]
+            nextIndex += 1
+            if let projects = self.claudeProjectsRootUnderDesktopLocalAgentBase(
+                current.url,
+                fileManager: fileManager)
+            {
+                roots.append(projects)
+            }
+
+            guard current.depth < maxDepth else { continue }
+            for child in self.claudeDesktopLocalAgentChildDirectories(at: current.url, fileManager: fileManager) {
+                let standardized = child.standardizedFileURL
+                guard visited.insert(standardized.path).inserted else { continue }
+                queue.append((standardized, current.depth + 1))
+            }
+        }
+        return roots
+    }
+
+    private nonisolated static func claudeProjectsRootUnderDesktopLocalAgentBase(
+        _ base: URL,
+        fileManager: FileManager) -> URL?
+    {
+        let projects = base
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: projects.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else { return nil }
+        return projects
+    }
+
+    private nonisolated static func claudeDesktopLocalAgentChildDirectories(
+        at url: URL,
+        fileManager: FileManager) -> [URL]
+    {
+        let skippedDirectoryNames = Set([
+            ".build",
+            ".git",
+            "build",
+            "DerivedData",
+            "node_modules",
+            "outputs",
+            "target",
+        ])
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants])
+        else {
+            return []
+        }
+
+        return children.compactMap { child in
+            guard !skippedDirectoryNames.contains(child.lastPathComponent) else { return nil }
+            guard let values = try? child.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+                  values.isSymbolicLink != true,
+                  values.isDirectory == true
+            else {
+                return nil
+            }
+            return child
+        }
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeDesktopProjectsLocator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeDesktopProjectsLocator.swift
@@ -32,6 +32,8 @@ public enum ClaudeDesktopProjectsLocator {
         var queue = sessionRoots.map { (url: $0, depth: 0) }
         var visited = Set(sessionRoots.map(\.standardizedFileURL.path))
         var nextIndex = 0
+        // Current Desktop entries under claude-code-sessions are metadata whose cliSessionId maps to the
+        // shared ~/.claude/projects logs. Seed that root anyway so embedded project stores are found when present.
         // Covers observed Desktop layouts through account/workspace, session, agent, and local_agent
         // without descending into arbitrary checked-out workspaces.
         let maxDepth = 4

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeDesktopProjectsLocator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeDesktopProjectsLocator.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+public enum ClaudeDesktopProjectsLocator {
+    private static let sessionDirectoryNames = [
+        "local-agent-mode-sessions",
+        "claude-code-sessions",
+    ]
+
+    private static let skippedDirectoryNames = Set([
+        ".build",
+        ".git",
+        "build",
+        "DerivedData",
+        "node_modules",
+        "outputs",
+        "target",
+    ])
+
+    public static func roots(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default) -> [URL]
+    {
+        let claudeApplicationSupport = homeDirectory
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Claude", isDirectory: true)
+        let sessionRoots = self.sessionDirectoryNames.map {
+            claudeApplicationSupport.appendingPathComponent($0, isDirectory: true)
+        }
+
+        var roots: [URL] = []
+        var queue = sessionRoots.map { (url: $0, depth: 0) }
+        var visited = Set(sessionRoots.map(\.standardizedFileURL.path))
+        var nextIndex = 0
+        // Covers observed Desktop layouts through account/workspace, session, agent, and local_agent
+        // without descending into arbitrary checked-out workspaces.
+        let maxDepth = 4
+
+        while nextIndex < queue.count {
+            let current = queue[nextIndex]
+            nextIndex += 1
+            if let projects = self.projectsRoot(under: current.url, fileManager: fileManager) {
+                roots.append(projects)
+            }
+
+            guard current.depth < maxDepth else { continue }
+            for child in self.childDirectories(at: current.url, fileManager: fileManager) {
+                let standardized = child.standardizedFileURL
+                guard visited.insert(standardized.path).inserted else { continue }
+                queue.append((standardized, current.depth + 1))
+            }
+        }
+        return roots
+    }
+
+    private static func projectsRoot(under base: URL, fileManager: FileManager) -> URL? {
+        let projects = base
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: projects.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else { return nil }
+        return projects.standardizedFileURL
+    }
+
+    private static func childDirectories(at url: URL, fileManager: FileManager) -> [URL] {
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants])
+        else {
+            return []
+        }
+
+        return children.compactMap { child in
+            guard !self.skippedDirectoryNames.contains(child.lastPathComponent) else { return nil }
+            guard let values = try? child.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+                  values.isSymbolicLink != true,
+                  values.isDirectory == true
+            else {
+                return nil
+            }
+            return child
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -129,7 +129,8 @@ public enum ClaudeProviderDescriptor {
     }
 
     private static func noDataMessage() -> String {
-        "No Claude usage logs found in ~/.config/claude/projects or ~/.claude/projects."
+        "No Claude usage logs found in ~/.config/claude/projects, ~/.claude/projects, " +
+            "or Claude Desktop local-agent sessions."
     }
 
     public static func resolveUsageStrategy(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -130,7 +130,7 @@ public enum ClaudeProviderDescriptor {
 
     private static func noDataMessage() -> String {
         "No Claude usage logs found in ~/.config/claude/projects, ~/.claude/projects, " +
-            "or Claude Desktop local-agent sessions."
+            "or Claude Desktop sessions."
     }
 
     public static func resolveUsageStrategy(

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
@@ -24,12 +24,17 @@ extension CostUsageScanner {
         var unresolved = false
     }
 
-    private static func defaultClaudeProjectsRoots(options: Options) -> [URL] {
+    static func defaultClaudeProjectsRoots(
+        options: Options,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default) -> [URL]
+    {
         if let override = options.claudeProjectsRoots { return override }
 
         var roots: [URL] = []
 
-        if let env = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"]?
+        if let env = environment["CLAUDE_CONFIG_DIR"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
             !env.isEmpty
         {
@@ -44,12 +49,114 @@ extension CostUsageScanner {
                 }
             }
         } else {
-            let home = FileManager.default.homeDirectoryForCurrentUser
-            roots.append(home.appendingPathComponent(".config/claude/projects", isDirectory: true))
-            roots.append(home.appendingPathComponent(".claude/projects", isDirectory: true))
+            roots.append(homeDirectory.appendingPathComponent(".config/claude/projects", isDirectory: true))
+            roots.append(homeDirectory.appendingPathComponent(".claude/projects", isDirectory: true))
+            roots.append(contentsOf: self.claudeDesktopLocalAgentProjectsRoots(
+                homeDirectory: homeDirectory,
+                fileManager: fileManager))
         }
 
+        return self.deduplicatedClaudeProjectRoots(roots)
+    }
+
+    private static func claudeDesktopLocalAgentProjectsRoots(
+        homeDirectory: URL,
+        fileManager: FileManager) -> [URL]
+    {
+        let sessionsRoot = homeDirectory
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("local-agent-mode-sessions", isDirectory: true)
+        var roots: [URL] = []
+        var queue: [(url: URL, depth: Int)] = [(sessionsRoot, 0)]
+        var visited: Set<String> = [sessionsRoot.standardizedFileURL.path]
+        var nextIndex = 0
+        // Covers observed Desktop local-agent layouts through workspace/session/agent/local_agent
+        // without descending into arbitrary checked-out workspaces.
+        let maxDepth = 4
+
+        while nextIndex < queue.count {
+            let current = queue[nextIndex]
+            nextIndex += 1
+            if let projects = self.claudeProjectsRootUnderDesktopLocalAgentBase(
+                current.url,
+                fileManager: fileManager)
+            {
+                roots.append(projects)
+            }
+
+            guard current.depth < maxDepth else { continue }
+            for child in self.claudeDesktopLocalAgentChildDirectories(
+                at: current.url,
+                fileManager: fileManager)
+            {
+                let standardized = child.standardizedFileURL
+                guard visited.insert(standardized.path).inserted else { continue }
+                queue.append((standardized, current.depth + 1))
+            }
+        }
         return roots
+    }
+
+    private static func claudeProjectsRootUnderDesktopLocalAgentBase(
+        _ base: URL,
+        fileManager: FileManager) -> URL?
+    {
+        let projects = base
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: projects.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else { return nil }
+        return projects
+    }
+
+    private static func claudeDesktopLocalAgentChildDirectories(
+        at url: URL,
+        fileManager: FileManager) -> [URL]
+    {
+        let skippedDirectoryNames = Set([
+            ".build",
+            ".git",
+            "build",
+            "DerivedData",
+            "node_modules",
+            "outputs",
+            "target",
+        ])
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants])
+        else {
+            return []
+        }
+
+        return children.compactMap { child in
+            guard !skippedDirectoryNames.contains(child.lastPathComponent) else { return nil }
+            guard let values = try? child.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+                  values.isSymbolicLink != true,
+                  values.isDirectory == true
+            else {
+                return nil
+            }
+            return child
+        }
+    }
+
+    private static func deduplicatedClaudeProjectRoots(_ roots: [URL]) -> [URL] {
+        var seen: Set<String> = []
+        var out: [URL] = []
+        for root in roots {
+            let standardized = root.standardizedFileURL
+            let path = standardized.path
+            guard !seen.contains(path) else { continue }
+            seen.insert(path)
+            out.append(standardized)
+        }
+        return out
     }
 
     static func parseClaudeFile(
@@ -647,7 +754,6 @@ extension CostUsageScanner {
             || cache.lastScanUnixMs == 0
             || nowMs - cache.lastScanUnixMs > refreshMs
 
-        let roots = self.defaultClaudeProjectsRoots(options: options)
         let providerFilter = options.claudeLogProviderFilter
 
         var touched: Set<String> = []
@@ -667,6 +773,7 @@ extension CostUsageScanner {
                 modelsDevCacheRoot: options.cacheRoot,
                 checkCancellation: checkCancellation)
 
+            let roots = self.defaultClaudeProjectsRoots(options: options)
             for root in roots {
                 try Self.scanClaudeRoot(
                     root: root,

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
@@ -51,99 +51,12 @@ extension CostUsageScanner {
         } else {
             roots.append(homeDirectory.appendingPathComponent(".config/claude/projects", isDirectory: true))
             roots.append(homeDirectory.appendingPathComponent(".claude/projects", isDirectory: true))
-            roots.append(contentsOf: self.claudeDesktopLocalAgentProjectsRoots(
+            roots.append(contentsOf: ClaudeDesktopProjectsLocator.roots(
                 homeDirectory: homeDirectory,
                 fileManager: fileManager))
         }
 
         return self.deduplicatedClaudeProjectRoots(roots)
-    }
-
-    private static func claudeDesktopLocalAgentProjectsRoots(
-        homeDirectory: URL,
-        fileManager: FileManager) -> [URL]
-    {
-        let sessionsRoot = homeDirectory
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-            .appendingPathComponent("Claude", isDirectory: true)
-            .appendingPathComponent("local-agent-mode-sessions", isDirectory: true)
-        var roots: [URL] = []
-        var queue: [(url: URL, depth: Int)] = [(sessionsRoot, 0)]
-        var visited: Set<String> = [sessionsRoot.standardizedFileURL.path]
-        var nextIndex = 0
-        // Covers observed Desktop local-agent layouts through workspace/session/agent/local_agent
-        // without descending into arbitrary checked-out workspaces.
-        let maxDepth = 4
-
-        while nextIndex < queue.count {
-            let current = queue[nextIndex]
-            nextIndex += 1
-            if let projects = self.claudeProjectsRootUnderDesktopLocalAgentBase(
-                current.url,
-                fileManager: fileManager)
-            {
-                roots.append(projects)
-            }
-
-            guard current.depth < maxDepth else { continue }
-            for child in self.claudeDesktopLocalAgentChildDirectories(
-                at: current.url,
-                fileManager: fileManager)
-            {
-                let standardized = child.standardizedFileURL
-                guard visited.insert(standardized.path).inserted else { continue }
-                queue.append((standardized, current.depth + 1))
-            }
-        }
-        return roots
-    }
-
-    private static func claudeProjectsRootUnderDesktopLocalAgentBase(
-        _ base: URL,
-        fileManager: FileManager) -> URL?
-    {
-        let projects = base
-            .appendingPathComponent(".claude", isDirectory: true)
-            .appendingPathComponent("projects", isDirectory: true)
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: projects.path, isDirectory: &isDirectory),
-              isDirectory.boolValue
-        else { return nil }
-        return projects
-    }
-
-    private static func claudeDesktopLocalAgentChildDirectories(
-        at url: URL,
-        fileManager: FileManager) -> [URL]
-    {
-        let skippedDirectoryNames = Set([
-            ".build",
-            ".git",
-            "build",
-            "DerivedData",
-            "node_modules",
-            "outputs",
-            "target",
-        ])
-        guard let children = try? fileManager.contentsOfDirectory(
-            at: url,
-            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
-            options: [.skipsHiddenFiles, .skipsPackageDescendants])
-        else {
-            return []
-        }
-
-        return children.compactMap { child in
-            guard !skippedDirectoryNames.contains(child.lastPathComponent) else { return nil }
-            guard let values = try? child.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
-                  values.isSymbolicLink != true,
-                  values.isDirectory == true
-            else {
-                return nil
-            }
-            return child
-        }
     }
 
     private static func deduplicatedClaudeProjectRoots(_ roots: [URL]) -> [URL] {

--- a/Tests/CodexBarTests/CostUsageScannerClaudeDesktopTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerClaudeDesktopTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct CostUsageScannerClaudeDesktopTests {
     @Test
-    func `claude daily report includes desktop local agent projects`() throws {
+    func `claude daily report includes nested desktop local agent projects`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }
 
@@ -105,5 +105,57 @@ struct CostUsageScannerClaudeDesktopTests {
         #expect(report.data[0].cacheReadTokens == 20)
         #expect(report.data[0].outputTokens == 48)
         #expect(report.data[0].totalTokens == 235)
+    }
+
+    @Test
+    func `current desktop shared claude projects root remains discovered`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 7, day: 5)
+        let sessionID = "desktop-cli-session"
+        let assistant: [String: Any] = [
+            "type": "assistant",
+            "timestamp": env.isoString(for: day),
+            "message": [
+                "model": "claude-test-model",
+                "usage": [
+                    "input_tokens": 11,
+                    "cache_read_input_tokens": 13,
+                    "output_tokens": 4,
+                ],
+            ],
+        ]
+        // Current Desktop's cliSessionId points to the matching JSONL in this shared root.
+        let sharedProjectsRoot = try env.writeClaudeDesktopSharedProjectFile(
+            relativePath: "desktop-project/\(sessionID).jsonl",
+            contents: env.jsonl([assistant]))
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        let discovered = CostUsageScanner.defaultClaudeProjectsRoots(
+            options: CostUsageScanner.Options(cacheRoot: env.cacheRoot),
+            environment: [:],
+            homeDirectory: env.root)
+        #expect(discovered.contains(sharedProjectsRoot.standardizedFileURL))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: nil,
+            claudeProjectsRoots: discovered,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .claude,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 11)
+        #expect(report.data[0].cacheReadTokens == 13)
+        #expect(report.data[0].outputTokens == 4)
+        #expect(report.data[0].totalTokens == 28)
     }
 }

--- a/Tests/CodexBarTests/CostUsageScannerClaudeDesktopTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerClaudeDesktopTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct CostUsageScannerClaudeDesktopTests {
+    @Test
+    func `claude daily report includes desktop local agent projects`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 7, day: 5)
+        let iso0 = env.isoString(for: day)
+        let assistant: [String: Any] = [
+            "type": "assistant",
+            "timestamp": iso0,
+            "message": [
+                "model": "claude-test-model",
+                "usage": [
+                    "input_tokens": 120,
+                    "cache_creation_input_tokens": 30,
+                    "cache_read_input_tokens": 20,
+                    "output_tokens": 40,
+                ],
+            ],
+        ]
+        let nestedAssistant: [String: Any] = [
+            "type": "assistant",
+            "timestamp": iso0,
+            "message": [
+                "model": "claude-test-model",
+                "usage": [
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                ],
+            ],
+        ]
+        let decoyAssistant: [String: Any] = [
+            "type": "assistant",
+            "timestamp": iso0,
+            "message": [
+                "model": "claude-test-model",
+                "usage": [
+                    "input_tokens": 999,
+                    "output_tokens": 999,
+                ],
+            ],
+        ]
+        let projectsRoot = try env.writeClaudeDesktopLocalAgentProjectFile(
+            relativePath: "project-a/session-a.jsonl",
+            contents: env.jsonl([assistant]))
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let nestedProjectsRoot = try env.writeNestedClaudeDesktopLocalAgentProjectFile(
+            relativePath: "project-b/session-b.jsonl",
+            contents: env.jsonl([nestedAssistant]))
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let decoyProjectsRoot = try env.writeClaudeDesktopLocalAgentFile(
+            relativePath: "outputs/node_modules/package/.claude/projects/project-decoy/session-decoy.jsonl",
+            contents: env.jsonl([decoyAssistant]))
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        let discovered = CostUsageScanner.defaultClaudeProjectsRoots(
+            options: CostUsageScanner.Options(cacheRoot: env.cacheRoot),
+            environment: [:],
+            homeDirectory: env.root)
+        #expect(discovered.contains(projectsRoot.standardizedFileURL))
+        #expect(discovered.contains(nestedProjectsRoot.standardizedFileURL))
+        #expect(!discovered.contains(decoyProjectsRoot.standardizedFileURL))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: nil,
+            claudeProjectsRoots: discovered,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .claude,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 130)
+        #expect(report.data[0].cacheCreationTokens == 30)
+        #expect(report.data[0].cacheReadTokens == 20)
+        #expect(report.data[0].outputTokens == 45)
+        #expect(report.data[0].totalTokens == 225)
+    }
+}

--- a/Tests/CodexBarTests/CostUsageScannerClaudeDesktopTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerClaudeDesktopTests.swift
@@ -34,6 +34,17 @@ struct CostUsageScannerClaudeDesktopTests {
                 ],
             ],
         ]
+        let currentAssistant: [String: Any] = [
+            "type": "assistant",
+            "timestamp": iso0,
+            "message": [
+                "model": "claude-test-model",
+                "usage": [
+                    "input_tokens": 7,
+                    "output_tokens": 3,
+                ],
+            ],
+        ]
         let decoyAssistant: [String: Any] = [
             "type": "assistant",
             "timestamp": iso0,
@@ -55,6 +66,11 @@ struct CostUsageScannerClaudeDesktopTests {
             contents: env.jsonl([nestedAssistant]))
             .deletingLastPathComponent()
             .deletingLastPathComponent()
+        let currentProjectsRoot = try env.writeClaudeDesktopCodeSessionProjectFile(
+            relativePath: "project-c/session-c.jsonl",
+            contents: env.jsonl([currentAssistant]))
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
         let decoyProjectsRoot = try env.writeClaudeDesktopLocalAgentFile(
             relativePath: "outputs/node_modules/package/.claude/projects/project-decoy/session-decoy.jsonl",
             contents: env.jsonl([decoyAssistant]))
@@ -67,6 +83,7 @@ struct CostUsageScannerClaudeDesktopTests {
             homeDirectory: env.root)
         #expect(discovered.contains(projectsRoot.standardizedFileURL))
         #expect(discovered.contains(nestedProjectsRoot.standardizedFileURL))
+        #expect(discovered.contains(currentProjectsRoot.standardizedFileURL))
         #expect(!discovered.contains(decoyProjectsRoot.standardizedFileURL))
 
         var options = CostUsageScanner.Options(
@@ -83,10 +100,10 @@ struct CostUsageScannerClaudeDesktopTests {
             options: options)
 
         #expect(report.data.count == 1)
-        #expect(report.data[0].inputTokens == 130)
+        #expect(report.data[0].inputTokens == 137)
         #expect(report.data[0].cacheCreationTokens == 30)
         #expect(report.data[0].cacheReadTokens == 20)
-        #expect(report.data[0].outputTokens == 45)
-        #expect(report.data[0].totalTokens == 225)
+        #expect(report.data[0].outputTokens == 48)
+        #expect(report.data[0].totalTokens == 235)
     }
 }

--- a/Tests/CodexBarTests/CostUsageScannerTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerTests.swift
@@ -940,6 +940,45 @@ struct CostUsageTestEnvironment {
         return url
     }
 
+    func writeClaudeDesktopLocalAgentFile(relativePath: String, contents: String) throws -> URL {
+        let localAgentRoot = self.root
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("local-agent-mode-sessions", isDirectory: true)
+            .appendingPathComponent("workspace-id", isDirectory: true)
+            .appendingPathComponent("session-id", isDirectory: true)
+            .appendingPathComponent("local_agent", isDirectory: true)
+        let url = localAgentRoot.appendingPathComponent(relativePath, isDirectory: false)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    func writeClaudeDesktopLocalAgentProjectFile(relativePath: String, contents: String) throws -> URL {
+        try self.writeClaudeDesktopLocalAgentFile(
+            relativePath: ".claude/projects/\(relativePath)",
+            contents: contents)
+    }
+
+    func writeNestedClaudeDesktopLocalAgentProjectFile(relativePath: String, contents: String) throws -> URL {
+        let projectsRoot = self.root
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("local-agent-mode-sessions", isDirectory: true)
+            .appendingPathComponent("workspace-id", isDirectory: true)
+            .appendingPathComponent("session-id", isDirectory: true)
+            .appendingPathComponent("agent", isDirectory: true)
+            .appendingPathComponent("local_agent", isDirectory: true)
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+        let url = projectsRoot.appendingPathComponent(relativePath, isDirectory: false)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
     func writeCodexArchivedSessionFile(filename: String, contents: String) throws -> URL {
         let url = self.codexArchivedSessionsRoot.appendingPathComponent(filename, isDirectory: false)
         try contents.write(to: url, atomically: true, encoding: .utf8)

--- a/Tests/CodexBarTests/CostUsageScannerTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerTests.swift
@@ -977,6 +977,16 @@ struct CostUsageTestEnvironment {
         return url
     }
 
+    func writeClaudeDesktopSharedProjectFile(relativePath: String, contents: String) throws -> URL {
+        let projectsRoot = self.root
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+        let url = projectsRoot.appendingPathComponent(relativePath, isDirectory: false)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
     func writeNestedClaudeDesktopLocalAgentProjectFile(relativePath: String, contents: String) throws -> URL {
         let projectsRoot = self.root
             .appendingPathComponent("Library", isDirectory: true)

--- a/Tests/CodexBarTests/CostUsageScannerTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerTests.swift
@@ -961,6 +961,22 @@ struct CostUsageTestEnvironment {
             contents: contents)
     }
 
+    func writeClaudeDesktopCodeSessionProjectFile(relativePath: String, contents: String) throws -> URL {
+        let projectsRoot = self.root
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("claude-code-sessions", isDirectory: true)
+            .appendingPathComponent("account-id", isDirectory: true)
+            .appendingPathComponent("org-id", isDirectory: true)
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+        let url = projectsRoot.appendingPathComponent(relativePath, isDirectory: false)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
     func writeNestedClaudeDesktopLocalAgentProjectFile(relativePath: String, contents: String) throws -> URL {
         let projectsRoot = self.root
             .appendingPathComponent("Library", isDirectory: true)

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -391,6 +391,20 @@ struct SettingsStoreCoverageTests {
             env: ["CLAUDE_CONFIG_DIR": claudeRoot.path],
             fileManager: fileManager))
 
+        let metadataOnlyHome = fileManager.temporaryDirectory.appendingPathComponent(
+            "claude-desktop-metadata-\(UUID().uuidString)",
+            isDirectory: true)
+        let metadataFile = metadataOnlyHome
+            .appendingPathComponent("Library/Application Support/Claude/claude-code-sessions", isDirectory: true)
+            .appendingPathComponent("account-id/org-id/local_session.json", isDirectory: false)
+        try fileManager.createDirectory(at: metadataFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(#"{"cliSessionId":"desktop-cli-session"}"#.utf8).write(to: metadataFile)
+
+        #expect(!SettingsStore.hasAnyTokenCostUsageSources(
+            env: [:],
+            fileManager: fileManager,
+            homeDirectory: metadataOnlyHome))
+
         let desktopHome = fileManager.temporaryDirectory.appendingPathComponent(
             "claude-desktop-\(UUID().uuidString)",
             isDirectory: true)

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -390,6 +390,31 @@ struct SettingsStoreCoverageTests {
         #expect(SettingsStore.hasAnyTokenCostUsageSources(
             env: ["CLAUDE_CONFIG_DIR": claudeRoot.path],
             fileManager: fileManager))
+
+        let desktopHome = fileManager.temporaryDirectory.appendingPathComponent(
+            "claude-desktop-\(UUID().uuidString)",
+            isDirectory: true)
+        let desktopProjects = desktopHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("local-agent-mode-sessions", isDirectory: true)
+            .appendingPathComponent("workspace-id", isDirectory: true)
+            .appendingPathComponent("session-id", isDirectory: true)
+            .appendingPathComponent("local_agent", isDirectory: true)
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+        try fileManager.createDirectory(at: desktopProjects, withIntermediateDirectories: true)
+        let desktopFile = desktopProjects
+            .appendingPathComponent("project-a", isDirectory: true)
+            .appendingPathComponent("session-a.jsonl", isDirectory: false)
+        try fileManager.createDirectory(at: desktopFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        fileManager.createFile(atPath: desktopFile.path, contents: Data("{}".utf8))
+
+        #expect(SettingsStore.hasAnyTokenCostUsageSources(
+            env: [:],
+            fileManager: fileManager,
+            homeDirectory: desktopHome))
     }
 
     @Test

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -415,6 +415,23 @@ struct SettingsStoreCoverageTests {
             env: [:],
             fileManager: fileManager,
             homeDirectory: desktopHome))
+
+        let desktopCodeHome = fileManager.temporaryDirectory.appendingPathComponent(
+            "claude-desktop-code-\(UUID().uuidString)",
+            isDirectory: true)
+        let desktopCodeFile = desktopCodeHome
+            .appendingPathComponent("Library/Application Support/Claude/claude-code-sessions", isDirectory: true)
+            .appendingPathComponent("account-id/org-id/.claude/projects/project-a", isDirectory: true)
+            .appendingPathComponent("session-a.jsonl", isDirectory: false)
+        try fileManager.createDirectory(
+            at: desktopCodeFile.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        fileManager.createFile(atPath: desktopCodeFile.path, contents: Data("{}".utf8))
+
+        #expect(SettingsStore.hasAnyTokenCostUsageSources(
+            env: [:],
+            fileManager: fileManager,
+            homeDirectory: desktopCodeHome))
     }
 
     @Test

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -165,10 +165,12 @@ Packaged synthetic proof (fake `cswap` executable, no real accounts or credentia
     - `$CLAUDE_CONFIG_DIR` (comma-separated), each root uses `<root>/projects`.
     - Fallback roots:
       - `~/.config/claude/projects`
-      - `~/.claude/projects`
-      - Claude Desktop Code/Cowork sessions under:
+      - `~/.claude/projects` (Claude Code and current Claude Desktop Code/Cowork CLI sessions)
+      - Additional embedded Claude Desktop project stores, when present:
         - `~/Library/Application Support/Claude/local-agent-mode-sessions/**/.claude/projects`
         - `~/Library/Application Support/Claude/claude-code-sessions/**/.claude/projects`
+    - Current Claude Desktop metadata under `claude-code-sessions` points to shared CLI session JSONL by
+      `cliSessionId`; metadata-only directories are not treated as usage sources.
   - Supported pi sessions:
     - `~/.pi/agent/sessions/**/*.jsonl`
 - Files: `**/*.jsonl` under the native project roots, discovered Claude Desktop project roots,

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -166,9 +166,12 @@ Packaged synthetic proof (fake `cswap` executable, no real accounts or credentia
     - Fallback roots:
       - `~/.config/claude/projects`
       - `~/.claude/projects`
+      - Claude Desktop local-agent/Cowork sessions under
+        `~/Library/Application Support/Claude/local-agent-mode-sessions/**/.claude/projects`
   - Supported pi sessions:
     - `~/.pi/agent/sessions/**/*.jsonl`
-- Files: `**/*.jsonl` under the native project roots plus supported pi session files.
+- Files: `**/*.jsonl` under the native project roots, discovered Claude Desktop local-agent project roots,
+  plus supported pi session files.
 - Parsing:
   - Native Claude logs parse lines with `type: "assistant"` and `message.usage`.
   - Uses per-model token counts (input, cache read/create, output).

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -166,11 +166,12 @@ Packaged synthetic proof (fake `cswap` executable, no real accounts or credentia
     - Fallback roots:
       - `~/.config/claude/projects`
       - `~/.claude/projects`
-      - Claude Desktop local-agent/Cowork sessions under
-        `~/Library/Application Support/Claude/local-agent-mode-sessions/**/.claude/projects`
+      - Claude Desktop Code/Cowork sessions under:
+        - `~/Library/Application Support/Claude/local-agent-mode-sessions/**/.claude/projects`
+        - `~/Library/Application Support/Claude/claude-code-sessions/**/.claude/projects`
   - Supported pi sessions:
     - `~/.pi/agent/sessions/**/*.jsonl`
-- Files: `**/*.jsonl` under the native project roots, discovered Claude Desktop local-agent project roots,
+- Files: `**/*.jsonl` under the native project roots, discovered Claude Desktop project roots,
   plus supported pi session files.
 - Parsing:
   - Native Claude logs parse lines with `type: "assistant"` and `message.usage`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -106,7 +106,8 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - App Auto: OAuth API (`oauth`) → CLI PTY (`claude`) → Web API (`web`).
 - CLI Auto: Web API (`web`) → CLI PTY (`claude`).
 - Local cost usage: scans `CLAUDE_CONFIG_DIR` when set, otherwise `~/.config/claude/projects`,
-  `~/.claude/projects`, and Claude Desktop Code/Cowork session JSONL files for the configured history window.
+  `~/.claude/projects` (including current Claude Desktop Code/Cowork CLI sessions), and nested Claude Desktop
+  local-agent JSONL files for the configured history window.
 - Status: Statuspage.io (Anthropic).
 - Details: `docs/claude.md`.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -106,7 +106,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - App Auto: OAuth API (`oauth`) → CLI PTY (`claude`) → Web API (`web`).
 - CLI Auto: Web API (`web`) → CLI PTY (`claude`).
 - Local cost usage: scans `CLAUDE_CONFIG_DIR` when set, otherwise `~/.config/claude/projects`,
-  `~/.claude/projects`, and Claude Desktop local-agent session JSONL files for the configured history window.
+  `~/.claude/projects`, and Claude Desktop Code/Cowork session JSONL files for the configured history window.
 - Status: Statuspage.io (Anthropic).
 - Details: `docs/claude.md`.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -105,7 +105,8 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Admin API shows organization spend/messages summaries with the same inline dashboard pattern as OpenAI API.
 - App Auto: OAuth API (`oauth`) → CLI PTY (`claude`) → Web API (`web`).
 - CLI Auto: Web API (`web`) → CLI PTY (`claude`).
-- Local cost usage: scans `CLAUDE_CONFIG_DIR` when set, otherwise `~/.config/claude/projects` and `~/.claude/projects` JSONL files for the configured history window.
+- Local cost usage: scans `CLAUDE_CONFIG_DIR` when set, otherwise `~/.config/claude/projects`,
+  `~/.claude/projects`, and Claude Desktop local-agent session JSONL files for the configured history window.
 - Status: Statuspage.io (Anthropic).
 - Details: `docs/claude.md`.
 


### PR DESCRIPTION
## Summary

- Include Claude Desktop local-agent session logs when calculating Claude local cost usage.
- Discover embedded `.claude/projects` roots under both Claude Desktop session stores.
- Keep current Desktop Code/Cowork sessions covered through their shared `~/.claude/projects` CLI logs.
- Keep discovery bounded to known session layouts and skip heavy workspace folders like `.git`, `node_modules`, `build`, `DerivedData`, `target`, and `outputs`.
- Update no-data messaging, docs, and tests for the new Claude Desktop source.

## Why

Claude Desktop local-agent mode can write usage logs outside the usual Claude CLI paths (`~/.config/claude/projects` and `~/.claude/projects`). When that happens, CodexBar can miss real Claude usage from today and show no local usage even though Claude was used.

This change teaches CodexBar to also look in the Desktop local-agent session stores, while avoiding recursive scans through user project workspaces. Metadata-only `claude-code-sessions` directories do not enable cost history by themselves.

## Validation

- `swift test --filter 'CostUsageScannerClaudeDesktopTests|SettingsStoreCoverageTests'`
- `make check`
- `make test` (all 48 shards)
- Live Mac Studio QA (redacted): a current Claude Desktop `cliSessionId` matched its shared `~/.claude/projects` JSONL, and the branch CLI returned a nonzero refreshed local cost report.

# Screenshot

before
<img width="309" height="194" alt="Screenshot 2026-07-05 at 13 51 59" src="https://github.com/user-attachments/assets/0f823570-b33d-4a55-b640-629565713edc" />

after
<img width="310" height="194" alt="Screenshot 2026-07-05 at 13 19 37" src="https://github.com/user-attachments/assets/02e48fa1-0d6e-4928-aecc-96d8d82de964" />

