### PR TITLE
feat: add claude-swap account switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Claude: show opt-in read-only claude-swap accounts as stacked usage cards without delaying ambient refreshes. Thanks @optimiz-r!
+- Claude: switch inactive claude-swap accounts directly from their stacked usage cards and refresh usage immediately.
 - Codex dashboard: show calendar-correct raw Today and 30-day credit totals without converting credits to billed dollars. Thanks @avenoxai!
 - Cursor: read the signed-in app token on Linux, with explicit manual-cookie web-source support and XDG config paths. Thanks @DonnieFi!
 - Devin: show remaining extra-usage balance in menus, CLI, and widgets while respecting optional-usage visibility. Thanks @FNDEVVE!

--- a/Sources/CodexBar/MenuCardView+ModelInput.swift
+++ b/Sources/CodexBar/MenuCardView+ModelInput.swift
@@ -14,6 +14,8 @@ extension UsageMenuCardView.Model {
         let tokenSnapshot: CostUsageTokenSnapshot?
         let tokenError: String?
         let account: AccountInfo
+        let accountIsAuthoritative: Bool
+        let planOverride: String?
         let isRefreshing: Bool
         let lastError: String?
         let limitsAvailability: UsageLimitsAvailability?
@@ -46,6 +48,8 @@ extension UsageMenuCardView.Model {
             tokenSnapshot: CostUsageTokenSnapshot?,
             tokenError: String?,
             account: AccountInfo,
+            accountIsAuthoritative: Bool = false,
+            planOverride: String? = nil,
             isRefreshing: Bool,
             lastError: String?,
             limitsAvailability: UsageLimitsAvailability? = nil,
@@ -77,6 +81,8 @@ extension UsageMenuCardView.Model {
             self.tokenSnapshot = tokenSnapshot
             self.tokenError = tokenError
             self.account = account
+            self.accountIsAuthoritative = accountIsAuthoritative
+            self.planOverride = planOverride
             self.isRefreshing = isRefreshing
             self.lastError = lastError
             self.limitsAvailability = limitsAvailability

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -142,6 +142,7 @@ struct UsageMenuCardView: View {
     let model: Model
     var layoutModel: Model?
     let width: CGFloat
+    var planAction: (() -> Void)?
     @Environment(\.menuItemHighlighted) private var isHighlighted
     @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
 
@@ -155,7 +156,9 @@ struct UsageMenuCardView: View {
     var body: some View {
         let liveModel = self.liveModel
         VStack(alignment: .leading, spacing: 0) {
-            UsageMenuCardHeaderView(model: self.layoutModel ?? self.model)
+            UsageMenuCardHeaderView(
+                model: self.layoutModel ?? self.model,
+                planAction: self.planAction)
 
             if Self.hasDetails(for: liveModel) {
                 Divider()
@@ -280,6 +283,7 @@ struct UsageMenuCardView: View {
 
 private struct UsageMenuCardHeaderView: View {
     let model: UsageMenuCardView.Model
+    var planAction: (() -> Void)?
     @Environment(\.menuItemHighlighted) private var isHighlighted
     @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
 
@@ -336,10 +340,20 @@ private struct UsageMenuCardHeaderView: View {
                         .accessibilityHidden(!showsCopyButton)
                 }
                 if let plan = self.model.planText {
-                    Text(plan)
-                        .font(.footnote)
-                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                        .lineLimit(1)
+                    Group {
+                        if let planAction {
+                            Button(action: planAction) {
+                                Text(plan)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(plan)
+                        } else {
+                            Text(plan)
+                        }
+                    }
+                    .font(.footnote)
+                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    .lineLimit(1)
                 }
             }
         }
@@ -539,7 +553,7 @@ struct UsageMenuCardHeaderSectionView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: UsageMenuCardLayout.headerContentSpacing) {
-            UsageMenuCardHeaderView(model: self.model)
+            UsageMenuCardHeaderView(model: self.model, planAction: nil)
 
             if self.showDivider {
                 Divider()
@@ -818,6 +832,7 @@ extension UsageMenuCardView.Model {
             for: input.provider,
             snapshot: input.snapshot,
             account: input.account,
+            override: input.planOverride,
             metadata: input.metadata)
         let metrics = Self.redactedMetrics(
             Self.metrics(input: input),
@@ -971,10 +986,11 @@ extension UsageMenuCardView.Model {
         for provider: UsageProvider,
         snapshot: UsageSnapshot?,
         account: AccountInfo,
-        metadata: ProviderMetadata) -> String
+        metadata: ProviderMetadata,
+        accountIsAuthoritative: Bool) -> String
     {
         if let email = snapshot?.accountEmail(for: provider), !email.isEmpty { return email }
-        if metadata.usesAccountFallback,
+        if metadata.usesAccountFallback || accountIsAuthoritative,
            let email = account.email, !email.isEmpty
         {
             return email
@@ -986,8 +1002,12 @@ extension UsageMenuCardView.Model {
         for provider: UsageProvider,
         snapshot: UsageSnapshot?,
         account: AccountInfo,
+        override: String?,
         metadata: ProviderMetadata) -> String?
     {
+        if let override, !override.isEmpty {
+            return override
+        }
         if provider == .kiro,
            let plan = kiroPlan(snapshot: snapshot)
         {
@@ -1105,7 +1125,8 @@ extension UsageMenuCardView.Model {
                 for: input.provider,
                 snapshot: input.snapshot,
                 account: input.account,
-                metadata: input.metadata),
+                metadata: input.metadata,
+                accountIsAuthoritative: input.accountIsAuthoritative),
             isEnabled: input.hidePersonalInfo)
         let subtitleText = PersonalInfoRedactor.redactEmails(in: subtitle.text, isEnabled: input.hidePersonalInfo)
             ?? subtitle.text

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -103,8 +103,8 @@ struct ClaudeProviderImplementation: ProviderImplementation {
             ProviderSettingsToggleDescriptor(
                 id: "claude-swap-accounts",
                 title: "Read accounts from claude-swap",
-                subtitle: "Shows usage for every claude-swap account by running `cswap --list --json`. " +
-                    "Read-only: CodexBar never reads claude-swap or Claude Code credentials.",
+                subtitle: "Shows usage and lets you switch accounts through `cswap`. " +
+                    "Credentials stay managed by claude-swap; CodexBar never reads them.",
                 binding: claudeSwapBinding,
                 statusText: { Self.claudeSwapStatusText(store: context.store, settings: context.settings) },
                 actions: [],

--- a/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeSwapRefresh.swift
+++ b/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeSwapRefresh.swift
@@ -1,10 +1,20 @@
 import CodexBarCore
 import Foundation
 
+/// External credential transactions must run to completion; configuration changes hide their state but do not
+/// cancel the subprocess halfway through a claude-swap transaction.
+struct ClaudeSwapTransientState {
+    var lastError: String?
+    var lastErrorAccountID: ProviderAccountIdentity?
+    var switchingAccountID: ProviderAccountIdentity?
+    var task: Task<Void, Never>?
+    var versionProbedPath: String?
+}
+
 extension UsageStore {
     /// True when the opt-in claude-swap adapter should run alongside the
-    /// ambient Claude refresh. The adapter is display-only: it never reads
-    /// credentials and its failures never affect the ambient Claude snapshot.
+    /// ambient Claude refresh. Listing is read-only; explicit account activation
+    /// stays external-process-owned and never exposes credentials to CodexBar.
     func shouldFetchClaudeSwapAccounts() -> Bool {
         self.isEnabled(.claude) && self.settings.claudeSwapEnabled &&
             !self.settings.claudeSwapExecutablePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -12,12 +22,18 @@ extension UsageStore {
 
     func clearClaudeSwapAccountState() {
         let hadState = !self.claudeSwapAccountSnapshots.isEmpty ||
-            self.claudeSwapLastRefreshAt != nil || self.claudeSwapLastError != nil
+            self.claudeSwapLastRefreshAt != nil || self.claudeSwapLastError != nil ||
+            self.claudeSwapTransientState.lastError != nil ||
+            self.claudeSwapTransientState.lastErrorAccountID != nil ||
+            self.claudeSwapTransientState.switchingAccountID != nil
         self.claudeSwapRefreshTask?.cancel()
         self.claudeSwapRefreshTask = nil
         self.claudeSwapAccountSnapshots = []
         self.claudeSwapLastRefreshAt = nil
         self.claudeSwapLastError = nil
+        self.claudeSwapTransientState.lastError = nil
+        self.claudeSwapTransientState.lastErrorAccountID = nil
+        self.claudeSwapTransientState.switchingAccountID = nil
         if hadState {
             self.claudeSwapRevision &+= 1
         }
@@ -68,11 +84,60 @@ extension UsageStore {
         }
     }
 
+    /// Activates one account through the configured claude-swap executable.
+    /// The numeric slot comes from the already validated list payload; requests
+    /// are serialized so two credential transactions can never overlap.
+    func switchClaudeSwapAccount(_ accountID: ProviderAccountIdentity) {
+        guard self.claudeSwapTransientState.task == nil,
+              self.shouldFetchClaudeSwapAccounts(),
+              accountID.source == ClaudeSwapAccountProjection.sourceName,
+              let account = self.claudeSwapAccountSnapshots.first(where: { $0.id == accountID }),
+              account.canActivate,
+              let accountNumber = Int(accountID.opaqueID),
+              accountNumber > 0
+        else {
+            return
+        }
+
+        let executablePath = self.settings.claudeSwapExecutablePath
+        self.claudeSwapTransientState.switchingAccountID = accountID
+        self.claudeSwapTransientState.lastError = nil
+        self.claudeSwapTransientState.lastErrorAccountID = nil
+        self.claudeSwapRevision &+= 1
+
+        self.claudeSwapTransientState.task = Task { @MainActor [weak self] in
+            var switchError: String?
+            do {
+                _ = try await ClaudeSwapAccountReader.switchAccount(
+                    executablePath: executablePath,
+                    accountNumber: accountNumber)
+            } catch {
+                switchError = (error as? LocalizedError)?.errorDescription
+                    ?? error.localizedDescription
+            }
+
+            guard let self else { return }
+            if self.isCurrentClaudeSwapConfiguration(executablePath: executablePath) {
+                // Claude Code owns the ambient credential, so reconcile both
+                // the provider snapshot and the adapter's active-row marker.
+                await self.refreshProvider(.claude)
+            }
+            let configurationIsCurrent = self.isCurrentClaudeSwapConfiguration(executablePath: executablePath)
+            self.claudeSwapTransientState.task = nil
+            self.claudeSwapTransientState.switchingAccountID = nil
+            if configurationIsCurrent {
+                self.claudeSwapTransientState.lastError = switchError
+                self.claudeSwapTransientState.lastErrorAccountID = switchError == nil ? nil : accountID
+            }
+            self.claudeSwapRevision &+= 1
+        }
+    }
+
     private func probeClaudeSwapVersionIfNeeded(executablePath: String) async {
-        guard self.claudeSwapVersionProbedPath != executablePath else { return }
+        guard self.claudeSwapTransientState.versionProbedPath != executablePath else { return }
         let version = await ClaudeSwapAccountReader.readVersion(executablePath: executablePath)
         guard self.isCurrentClaudeSwapConfiguration(executablePath: executablePath) else { return }
-        self.claudeSwapVersionProbedPath = executablePath
+        self.claudeSwapTransientState.versionProbedPath = executablePath
         self.claudeSwapDetectedVersion = version
     }
 

--- a/Sources/CodexBar/StatusItemController+ClaudeSwapMenu.swift
+++ b/Sources/CodexBar/StatusItemController+ClaudeSwapMenu.swift
@@ -1,0 +1,51 @@
+import AppKit
+import CodexBarCore
+
+extension StatusItemController {
+    func addClaudeSwapMenuCards(to menu: NSMenu, context: MenuCardContext) {
+        let cardRows = self.store.claudeSwapAccountSnapshots.compactMap { account ->
+            (account: ProviderAccountUsageSnapshot, model: UsageMenuCardView.Model)? in
+            guard let model = self.menuCardModel(
+                for: .claude,
+                snapshotOverride: account.snapshot,
+                errorOverride: ClaudeSwapAccountProjection.displayError(
+                    accountError: account.error,
+                    adapterError: self.store.claudeSwapLastError,
+                    switchError: self.store.claudeSwapTransientState.lastErrorAccountID == account.id
+                        ? self.store.claudeSwapTransientState.lastError
+                        : nil),
+                forceOverrideCard: account.snapshot == nil,
+                accountOverride: AccountInfo(
+                    email: account.displayLabel,
+                    plan: nil),
+                planOverride: self.claudeSwapAccountActionLabel(account))
+            else {
+                return nil
+            }
+            return (account, model)
+        }
+        self.addStackedMenuCards(
+            cardRows.map(\.model),
+            to: menu,
+            context: context,
+            planAction: { [weak self] index in
+                guard cardRows.indices.contains(index) else { return nil }
+                return self?.claudeSwapAccountSwitchAction(cardRows[index].account)
+            })
+    }
+
+    private func claudeSwapAccountActionLabel(_ account: ProviderAccountUsageSnapshot) -> String? {
+        if account.isActive { return L("Active") }
+        if self.store.claudeSwapTransientState.switchingAccountID == account.id { return L("Loading…") }
+        guard self.store.claudeSwapTransientState.task == nil, account.canActivate else { return nil }
+        return L("Switch Account...")
+    }
+
+    private func claudeSwapAccountSwitchAction(_ account: ProviderAccountUsageSnapshot) -> (() -> Void)? {
+        guard self.store.claudeSwapTransientState.task == nil, account.canActivate else { return nil }
+        let accountID = account.id
+        return { [weak self] in
+            self?.store.switchClaudeSwapAccount(accountID)
+        }
+    }
+}

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -613,17 +613,7 @@ extension StatusItemController {
             provider: context.currentProvider,
             accountCount: self.store.claudeSwapAccountSnapshots.count)
         {
-            let cards = self.store.claudeSwapAccountSnapshots.compactMap { account in
-                self.menuCardModel(
-                    for: .claude,
-                    snapshotOverride: account.snapshot,
-                    errorOverride: ClaudeSwapAccountProjection.displayError(
-                        accountError: account.error,
-                        adapterError: self.store.claudeSwapLastError),
-                    forceOverrideCard: account.snapshot == nil,
-                    accountOverride: AccountInfo(email: account.displayLabel, plan: nil))
-            }
-            self.addStackedMenuCards(cards, to: menu, context: context)
+            self.addClaudeSwapMenuCards(to: menu, context: context)
             return false
         }
 
@@ -689,10 +679,11 @@ extension StatusItemController {
         return false
     }
 
-    private func addStackedMenuCards(
+    func addStackedMenuCards(
         _ cards: [UsageMenuCardView.Model],
         to menu: NSMenu,
-        context: MenuCardContext)
+        context: MenuCardContext,
+        planAction: ((Int) -> (() -> Void)?)? = nil)
     {
         if cards.isEmpty, let model = self.menuCardModel(for: context.selectedProvider) {
             let renderedModel = self.menuCardRefreshMonitor.model(for: model.provider, fallback: model)
@@ -707,7 +698,10 @@ extension StatusItemController {
         } else {
             for (index, model) in cards.enumerated() {
                 menu.addItem(self.makeMenuCardItem(
-                    UsageMenuCardView(model: model, width: context.menuWidth),
+                    UsageMenuCardView(
+                        model: model,
+                        width: context.menuWidth,
+                        planAction: planAction?(index)),
                     id: "menuCard-\(index)",
                     width: context.menuWidth,
                     heightCacheScope: "\(context.currentProvider.rawValue)-\(index)",

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -7,7 +7,8 @@ extension StatusItemController {
         snapshotOverride: UsageSnapshot? = nil,
         errorOverride: String? = nil,
         forceOverrideCard: Bool = false,
-        accountOverride: AccountInfo? = nil) -> UsageMenuCardView.Model?
+        accountOverride: AccountInfo? = nil,
+        planOverride: String? = nil) -> UsageMenuCardView.Model?
     {
         let target = provider ?? self.store.enabledProvidersForDisplay().first ?? .codex
         let metadata = self.store.metadata(for: target)
@@ -101,6 +102,8 @@ extension StatusItemController {
             tokenSnapshot: tokenSnapshot,
             tokenError: tokenError,
             account: fallbackAccount,
+            accountIsAuthoritative: accountOverride != nil,
+            planOverride: planOverride,
             isRefreshing: self.store.shouldShowRefreshingMenuCardIndicator(for: target),
             // Provider-level errors can belong to a different account, so
             // override cards never inherit them (same rule as the snapshot,

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -153,7 +153,7 @@ final class UsageStore {
     var claudeSwapDetectedVersion: String?
     var claudeSwapRevision: UInt64 = 0
     @ObservationIgnored var claudeSwapRefreshTask: Task<Void, Never>?
-    @ObservationIgnored var claudeSwapVersionProbedPath: String?
+    @ObservationIgnored var claudeSwapTransientState = ClaudeSwapTransientState()
     var tokenSnapshots: [UsageProvider: CostUsageTokenSnapshot] = [:]
     var tokenErrors: [UsageProvider: String] = [:]
     var tokenRefreshInFlight: Set<UsageProvider> = []

--- a/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
+++ b/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
@@ -148,6 +148,29 @@ public enum SubprocessRunner {
 
     // MARK: - Public API
 
+    /// Runs a process to natural exit without letting caller cancellation or a
+    /// forced timeout interrupt an external mutation after launch.
+    public static func runToCompletion(
+        binary: String,
+        arguments: [String],
+        environment: [String: String],
+        currentDirectoryURL: URL? = nil,
+        acceptsNonZeroExit: Bool = false,
+        label: String) async throws -> SubprocessResult
+    {
+        let task = Task.detached(priority: .userInitiated) {
+            try await self.run(
+                binary: binary,
+                arguments: arguments,
+                environment: environment,
+                timeout: .infinity,
+                currentDirectoryURL: currentDirectoryURL,
+                acceptsNonZeroExit: acceptsNonZeroExit,
+                label: label)
+        }
+        return try await task.value
+    }
+
     public static func run(
         binary: String,
         arguments: [String],
@@ -208,15 +231,21 @@ public enum SubprocessRunner {
         }
 
         let killedByTimeout = KillFlag()
-        let timeoutTimer = DispatchSource.makeTimerSource(queue: self.timeoutQueue)
-        timeoutTimer.schedule(deadline: .now() + self.timeoutInterval(timeout))
-        timeoutTimer.setEventHandler {
-            guard process.isRunning else { return }
-            killedByTimeout.set()
-            self.terminateProcess(process, processGroup: processGroup)
+        let timeoutTimerBox: TimeoutTimer? = if timeout.isFinite {
+            {
+                let timeoutTimer = DispatchSource.makeTimerSource(queue: self.timeoutQueue)
+                timeoutTimer.schedule(deadline: .now() + self.timeoutInterval(timeout))
+                timeoutTimer.setEventHandler {
+                    guard process.isRunning else { return }
+                    killedByTimeout.set()
+                    self.terminateProcess(process, processGroup: processGroup)
+                }
+                timeoutTimer.resume()
+                return TimeoutTimer(timer: timeoutTimer)
+            }()
+        } else {
+            nil
         }
-        timeoutTimer.resume()
-        let timeoutTimerBox = TimeoutTimer(timer: timeoutTimer)
 
         do {
             let exitCode = try await withTaskCancellationHandler {
@@ -225,10 +254,10 @@ public enum SubprocessRunner {
                 try Task.checkCancellation()
                 return code
             } onCancel: {
-                timeoutTimerBox.cancel()
+                timeoutTimerBox?.cancel()
                 self.terminateProcess(process, processGroup: processGroup)
             }
-            timeoutTimerBox.cancel()
+            timeoutTimerBox?.cancel()
 
             let duration = Date().timeIntervalSince(start)
             // Race guard: the timeout timer may kill the process just before the

--- a/Sources/CodexBarCore/ProviderAccountSnapshot.swift
+++ b/Sources/CodexBarCore/ProviderAccountSnapshot.swift
@@ -26,6 +26,9 @@ public struct ProviderAccountUsageSnapshot: Identifiable, Sendable {
     /// responsible for privacy redaction. Never logged or persisted.
     public let displayLabel: String
     public let isActive: Bool
+    /// Whether the source can make this inactive account the provider's active account.
+    /// Activation remains source-owned; CodexBar never handles credential material.
+    public let canActivate: Bool
     public let snapshot: UsageSnapshot?
     public let error: String?
     public let sourceLabel: String?
@@ -35,6 +38,7 @@ public struct ProviderAccountUsageSnapshot: Identifiable, Sendable {
         provider: UsageProvider,
         displayLabel: String,
         isActive: Bool,
+        canActivate: Bool = false,
         snapshot: UsageSnapshot?,
         error: String?,
         sourceLabel: String?)
@@ -43,6 +47,7 @@ public struct ProviderAccountUsageSnapshot: Identifiable, Sendable {
         self.provider = provider
         self.displayLabel = displayLabel
         self.isActive = isActive
+        self.canActivate = canActivate
         self.snapshot = snapshot
         self.error = error
         self.sourceLabel = sourceLabel

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
@@ -23,14 +23,21 @@ public enum ClaudeSwapAccountProjection {
                 provider: .claude,
                 displayLabel: self.displayLabel(for: row),
                 isActive: row.isActive,
+                canActivate: !row.isActive && self.canActivate(row),
                 snapshot: self.usageSnapshot(for: row, now: now),
                 error: self.errorText(for: row),
                 sourceLabel: self.sourceLabel)
         }
     }
 
-    public static func displayError(accountError: String?, adapterError: String?) -> String? {
-        accountError ?? adapterError.map { "Showing the last successful update: \($0)" }
+    public static func displayError(
+        accountError: String?,
+        adapterError: String?,
+        switchError: String? = nil) -> String?
+    {
+        switchError.map { "Account switch failed: \($0)" }
+            ?? accountError
+            ?? adapterError.map { "Showing the last successful update: \($0)" }
     }
 
     static func displayLabel(for row: ClaudeSwapAccountRow) -> String {
@@ -81,6 +88,15 @@ public enum ClaudeSwapAccountProjection {
             "Usage fetch failed."
         case let .unknown(raw):
             "Unrecognized claude-swap status: \(raw)"
+        }
+    }
+
+    private static func canActivate(_ row: ClaudeSwapAccountRow) -> Bool {
+        switch row.usageStatus {
+        case .ok, .apiKey, .unavailable:
+            true
+        case .tokenExpired, .keychainUnavailable, .noCredentials, .unknown:
+            false
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountReader.swift
@@ -15,13 +15,13 @@ public enum ClaudeSwapAccountReaderError: LocalizedError, Sendable {
     }
 }
 
-/// Read-only adapter over the external `claude-swap` executable.
+/// Bounded adapter over the external `claude-swap` executable.
 ///
-/// Executes exactly `cswap --list --json` (never a shell, never config-defined
-/// passthrough arguments) with a bounded runtime and bounded output, per the
-/// Phase 1 contract in `docs/claude-multi-account-and-status-items.md`. CodexBar
-/// never reads claude-swap or Claude Code credential storage; the subprocess is
-/// solely responsible for its own credential access.
+/// Executes only the fixed list and explicit switch argument arrays (never a
+/// shell or config-defined passthrough arguments), per the contracts in
+/// `docs/claude-multi-account-and-status-items.md`. CodexBar never reads
+/// claude-swap or Claude Code credential storage; the subprocess is solely
+/// responsible for its own credential access.
 public enum ClaudeSwapAccountReader {
     public static let maxOutputBytes = 262_144
     public static let defaultTimeout: TimeInterval = 30
@@ -40,6 +40,32 @@ public enum ClaudeSwapAccountReader {
             acceptsNonZeroExit: true,
             label: "claude-swap list")
         return try ClaudeSwapListParser.parse(Data(result.utf8))
+    }
+
+    /// Activates one source-issued numeric slot through claude-swap.
+    ///
+    /// The external tool owns the credential transaction. CodexBar supplies no
+    /// credentials and accepts no config-defined arguments.
+    public static func switchAccount(
+        executablePath: String,
+        accountNumber: Int) async throws
+        -> ClaudeSwapAccountSwitchResult
+    {
+        guard accountNumber > 0 else {
+            throw ClaudeSwapSwitchParserError.malformedShape("requested account slot must be positive")
+        }
+        let result = try await self.runCredentialTransaction(
+            executablePath: executablePath,
+            arguments: ["--switch-to", String(accountNumber), "--json"],
+            acceptsNonZeroExit: true,
+            label: "claude-swap switch")
+        let parsed = try ClaudeSwapSwitchParser.parse(Data(result.utf8))
+        guard parsed.toAccountNumber == accountNumber else {
+            throw ClaudeSwapSwitchParserError.mismatchedTarget(
+                expected: accountNumber,
+                actual: parsed.toAccountNumber)
+        }
+        return parsed
     }
 
     /// Best-effort version probe (`cswap --version` prints `cswap <version>`).
@@ -84,6 +110,27 @@ public enum ClaudeSwapAccountReader {
             arguments: arguments,
             environment: ProcessInfo.processInfo.environment,
             timeout: timeout,
+            acceptsNonZeroExit: acceptsNonZeroExit,
+            label: label)
+        guard result.stdout.utf8.count <= self.maxOutputBytes else {
+            throw ClaudeSwapAccountReaderError.outputTooLarge(byteCount: result.stdout.utf8.count)
+        }
+        return result.stdout
+    }
+
+    /// Once launched, a credential mutation must reach the external tool's
+    /// natural exit; caller cancellation and read-probe timeouts must not kill it.
+    private static func runCredentialTransaction(
+        executablePath: String,
+        arguments: [String],
+        acceptsNonZeroExit: Bool,
+        label: String) async throws -> String
+    {
+        let binary = try self.resolvedExecutablePath(executablePath)
+        let result = try await SubprocessRunner.runToCompletion(
+            binary: binary,
+            arguments: arguments,
+            environment: ProcessInfo.processInfo.environment,
             acceptsNonZeroExit: acceptsNonZeroExit,
             label: label)
         guard result.stdout.utf8.count <= self.maxOutputBytes else {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountSwitch.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountSwitch.swift
@@ -1,0 +1,117 @@
+import CoreFoundation
+import Foundation
+
+/// Allow-listed result of `cswap --switch-to <slot> --json` (schema v1).
+public struct ClaudeSwapAccountSwitchResult: Equatable, Sendable {
+    public let switched: Bool
+    public let fromAccountNumber: Int?
+    public let toAccountNumber: Int
+    public let reason: String
+
+    public init(switched: Bool, fromAccountNumber: Int?, toAccountNumber: Int, reason: String) {
+        self.switched = switched
+        self.fromAccountNumber = fromAccountNumber
+        self.toAccountNumber = toAccountNumber
+        self.reason = reason
+    }
+}
+
+public enum ClaudeSwapSwitchParserError: LocalizedError, Equatable, Sendable {
+    case notJSONObject
+    case missingSchemaVersion
+    case unsupportedSchemaVersion(Int)
+    case reportedError(type: String, message: String)
+    case malformedShape(String)
+    case mismatchedTarget(expected: Int, actual: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notJSONObject:
+            "claude-swap returned switch output that is not a JSON object."
+        case .missingSchemaVersion:
+            "claude-swap switch output has no schemaVersion field."
+        case let .unsupportedSchemaVersion(version):
+            "claude-swap switch output uses unsupported schema version \(version); CodexBar supports version 1."
+        case let .reportedError(type, message):
+            "claude-swap reported \(type): \(message)"
+        case let .malformedShape(details):
+            "claude-swap switch output is malformed: \(details)"
+        case let .mismatchedTarget(expected, actual):
+            "claude-swap reported account slot \(actual) after CodexBar requested slot \(expected)."
+        }
+    }
+}
+
+public enum ClaudeSwapSwitchParser {
+    public static func parse(_ data: Data) throws -> ClaudeSwapAccountSwitchResult {
+        let raw: Any
+        do {
+            raw = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw ClaudeSwapSwitchParserError.notJSONObject
+        }
+        guard let object = raw as? [String: Any] else {
+            throw ClaudeSwapSwitchParserError.notJSONObject
+        }
+        guard let schemaVersion = self.integer(object["schemaVersion"]) else {
+            throw ClaudeSwapSwitchParserError.missingSchemaVersion
+        }
+        guard schemaVersion == ClaudeSwapListParser.supportedSchemaVersion else {
+            throw ClaudeSwapSwitchParserError.unsupportedSchemaVersion(schemaVersion)
+        }
+        if let errorObject = object["error"] as? [String: Any] {
+            throw ClaudeSwapSwitchParserError.reportedError(
+                type: errorObject["type"] as? String ?? "Error",
+                message: errorObject["message"] as? String ?? "unknown error")
+        }
+        guard let switched = object["switched"] as? Bool else {
+            throw ClaudeSwapSwitchParserError.malformedShape("missing switched flag")
+        }
+        guard let reason = (object["reason"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !reason.isEmpty
+        else {
+            throw ClaudeSwapSwitchParserError.malformedShape("missing reason")
+        }
+        let fromAccountNumber = try self.accountNumber(
+            in: object["from"],
+            field: "from",
+            allowsNull: true)
+        guard let toAccountNumber = try self.accountNumber(
+            in: object["to"],
+            field: "to",
+            allowsNull: false)
+        else {
+            throw ClaudeSwapSwitchParserError.malformedShape("to account has no numeric slot")
+        }
+        return ClaudeSwapAccountSwitchResult(
+            switched: switched,
+            fromAccountNumber: fromAccountNumber,
+            toAccountNumber: toAccountNumber,
+            reason: reason)
+    }
+
+    private static func accountNumber(in raw: Any?, field: String, allowsNull: Bool) throws -> Int? {
+        if raw is NSNull, allowsNull { return nil }
+        guard let account = raw as? [String: Any] else {
+            throw ClaudeSwapSwitchParserError.malformedShape("missing \(field) account")
+        }
+        guard let rawNumber = account["number"] else {
+            throw ClaudeSwapSwitchParserError.malformedShape("\(field) account has no number")
+        }
+        if rawNumber is NSNull, allowsNull { return nil }
+        guard let number = self.integer(rawNumber), number > 0
+        else {
+            throw ClaudeSwapSwitchParserError.malformedShape("\(field) account number is not a positive slot")
+        }
+        return number
+    }
+
+    private static func integer(_ raw: Any?) -> Int? {
+        guard let number = raw as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID()
+        else {
+            return nil
+        }
+        return raw as? Int
+    }
+}

--- a/Tests/CodexBarTests/ClaudeProviderRuntimeTests.swift
+++ b/Tests/CodexBarTests/ClaudeProviderRuntimeTests.swift
@@ -55,6 +55,128 @@ struct ClaudeProviderRuntimeTests {
         #expect(store.claudeSwapLastRefreshAt == nil)
     }
 
+    @Test
+    func `explicit account activation is serialized through claude swap and refreshes Claude`() async throws {
+        let (settings, store) = self.makeStore()
+        let marker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-swap-switch-args-\(UUID().uuidString)")
+        let executable = try self.makeSwitchExecutable(marker: marker)
+        let metadata = try #require(ProviderRegistry.shared.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        settings.claudeSwapExecutablePath = executable
+        settings.claudeSwapEnabled = true
+        let accountID = ProviderAccountIdentity(source: ClaudeSwapAccountProjection.sourceName, opaqueID: "2")
+        store.claudeSwapAccountSnapshots = [ProviderAccountUsageSnapshot(
+            id: accountID,
+            provider: .claude,
+            displayLabel: "switch@example.com",
+            isActive: false,
+            canActivate: true,
+            snapshot: nil,
+            error: nil,
+            sourceLabel: ClaudeSwapAccountProjection.sourceLabel)]
+        var refreshedProviders: [UsageProvider] = []
+        store._test_providerRefreshOverride = { refreshedProviders.append($0) }
+        defer { store._test_providerRefreshOverride = nil }
+
+        store.switchClaudeSwapAccount(accountID)
+        let task = try #require(store.claudeSwapTransientState.task)
+        await task.value
+
+        let arguments = try String(contentsOf: marker, encoding: .utf8)
+        #expect(arguments == "--switch-to\n2\n--json\n")
+        #expect(refreshedProviders == [.claude])
+        #expect(store.claudeSwapTransientState.task == nil)
+        #expect(store.claudeSwapTransientState.switchingAccountID == nil)
+        #expect(store.claudeSwapTransientState.lastError == nil)
+        #expect(store.claudeSwapTransientState.lastErrorAccountID == nil)
+    }
+
+    @Test
+    func `non actionable account cannot start credential transaction`() throws {
+        let (settings, store) = self.makeStore()
+        let metadata = try #require(ProviderRegistry.shared.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        settings.claudeSwapExecutablePath = "/path/to/cswap"
+        settings.claudeSwapEnabled = true
+        let accountID = ProviderAccountIdentity(source: ClaudeSwapAccountProjection.sourceName, opaqueID: "2")
+        store.claudeSwapAccountSnapshots = [ProviderAccountUsageSnapshot(
+            id: accountID,
+            provider: .claude,
+            displayLabel: "expired@example.com",
+            isActive: false,
+            canActivate: false,
+            snapshot: nil,
+            error: "Token expired",
+            sourceLabel: ClaudeSwapAccountProjection.sourceLabel)]
+
+        store.switchClaudeSwapAccount(accountID)
+
+        #expect(store.claudeSwapTransientState.task == nil)
+    }
+
+    @Test
+    func `failed activation stays scoped to its requested account`() async throws {
+        let (settings, store) = self.makeStore()
+        let executable = try self.makeFailedSwitchExecutable()
+        let metadata = try #require(ProviderRegistry.shared.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        settings.claudeSwapExecutablePath = executable
+        settings.claudeSwapEnabled = true
+        let accountID = ProviderAccountIdentity(source: ClaudeSwapAccountProjection.sourceName, opaqueID: "2")
+        store.claudeSwapAccountSnapshots = [ProviderAccountUsageSnapshot(
+            id: accountID,
+            provider: .claude,
+            displayLabel: "switch@example.com",
+            isActive: false,
+            canActivate: true,
+            snapshot: nil,
+            error: nil,
+            sourceLabel: ClaudeSwapAccountProjection.sourceLabel)]
+        store._test_providerRefreshOverride = { _ in }
+        defer { store._test_providerRefreshOverride = nil }
+
+        store.switchClaudeSwapAccount(accountID)
+        let task = try #require(store.claudeSwapTransientState.task)
+        await task.value
+
+        #expect(store.claudeSwapTransientState.lastError?.contains("credentials missing") == true)
+        #expect(store.claudeSwapTransientState.lastErrorAccountID == accountID)
+    }
+
+    @Test
+    func `configuration change during provider refresh discards switch result`() async throws {
+        let (settings, store) = self.makeStore()
+        let executable = try self.makeFailedSwitchExecutable()
+        let metadata = try #require(ProviderRegistry.shared.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        settings.claudeSwapExecutablePath = executable
+        settings.claudeSwapEnabled = true
+        let accountID = ProviderAccountIdentity(source: ClaudeSwapAccountProjection.sourceName, opaqueID: "2")
+        store.claudeSwapAccountSnapshots = [ProviderAccountUsageSnapshot(
+            id: accountID,
+            provider: .claude,
+            displayLabel: "switch@example.com",
+            isActive: false,
+            canActivate: true,
+            snapshot: nil,
+            error: nil,
+            sourceLabel: ClaudeSwapAccountProjection.sourceLabel)]
+        store._test_providerRefreshOverride = { _ in
+            settings.claudeSwapExecutablePath = "/new/path/to/cswap"
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        store.switchClaudeSwapAccount(accountID)
+        let task = try #require(store.claudeSwapTransientState.task)
+        await task.value
+
+        #expect(store.claudeSwapTransientState.task == nil)
+        #expect(store.claudeSwapTransientState.switchingAccountID == nil)
+        #expect(store.claudeSwapTransientState.lastError == nil)
+        #expect(store.claudeSwapTransientState.lastErrorAccountID == nil)
+    }
+
     private func makeStore() -> (SettingsStore, UsageStore) {
         let suite = "ClaudeProviderRuntimeTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
@@ -99,6 +221,36 @@ struct ClaudeProviderRuntimeTests {
           {"number":1,"email":"a@b.c","active":true,"usageStatus":"ok","usage":{"fiveHour":{"pct":12.5}}}
         ]}
         EOF
+        """
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
+    }
+
+    private func makeSwitchExecutable(marker: URL) throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-switch-runtime-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("cswap")
+        let script = """
+        #!/bin/sh
+        printf '%s\n' "$@" > '\(marker.path)'
+        echo '{"schemaVersion":1,"switched":true,"from":{"number":1},"to":{"number":2},"reason":"switched"}'
+        """
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
+    }
+
+    private func makeFailedSwitchExecutable() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-failed-switch-runtime-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("cswap")
+        let script = """
+        #!/bin/sh
+        echo '{"schemaVersion":1,"error":{"type":"SwitchError","message":"credentials missing"}}'
+        exit 1
         """
         try script.write(to: url, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)

--- a/Tests/CodexBarTests/ClaudeSwapAccountProjectionTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapAccountProjectionTests.swift
@@ -11,6 +11,14 @@ struct ClaudeSwapAccountProjectionTests {
         #expect(ClaudeSwapAccountProjection.displayError(
             accountError: "Token expired.",
             adapterError: "timed out") == "Token expired.")
+        #expect(ClaudeSwapAccountProjection.displayError(
+            accountError: nil,
+            adapterError: "timed out",
+            switchError: "store locked") == "Account switch failed: store locked")
+        #expect(ClaudeSwapAccountProjection.displayError(
+            accountError: "API-key account",
+            adapterError: nil,
+            switchError: "store locked") == "Account switch failed: store locked")
     }
 
     private let now = Date(timeIntervalSince1970: 1_782_000_000)
@@ -45,6 +53,7 @@ struct ClaudeSwapAccountProjectionTests {
         #expect(active.provider == .claude)
         #expect(active.displayLabel == "personal@example.com")
         #expect(active.isActive == true)
+        #expect(active.canActivate == false)
         #expect(active.error == nil)
         #expect(active.sourceLabel == "claude-swap")
         #expect(active.snapshot?.primary?.usedPercent == 80)
@@ -57,6 +66,7 @@ struct ClaudeSwapAccountProjectionTests {
         let inactive = try #require(snapshots.last)
         #expect(inactive.id.opaqueID == "1")
         #expect(inactive.isActive == false)
+        #expect(inactive.canActivate == true)
         #expect(inactive.snapshot?.primary?.resetsAt == reset)
         #expect(inactive.snapshot?.secondary?.usedPercent == 16.5)
         #expect(inactive.snapshot?.secondary?.windowMinutes == 10080)
@@ -90,6 +100,8 @@ struct ClaudeSwapAccountProjectionTests {
             #expect(snapshot.snapshot == nil)
             let error = try #require(snapshot.error)
             #expect(error.contains(entry.1))
+            let expectedCanActivate = entry.0 == .apiKey || entry.0 == .unavailable
+            #expect(snapshot.canActivate == expectedCanActivate)
         }
     }
 

--- a/Tests/CodexBarTests/ClaudeSwapAccountReaderTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapAccountReaderTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
-/// Reader tests use fake executables only, per the Phase 1 contract: no real
+/// Reader tests use fake executables only: no real
 /// claude-swap install, no credentials, no Keychain access.
 struct ClaudeSwapAccountReaderTests {
     private func makeFakeExecutable(_ script: String) throws -> String {
@@ -89,6 +89,72 @@ struct ClaudeSwapAccountReaderTests {
 
         let version = await ClaudeSwapAccountReader.readVersion(executablePath: path)
         #expect(version == "0.16.0")
+    }
+
+    @Test
+    func `switches only by validated numeric slot with fixed arguments`() async throws {
+        let path = try self.makeFakeExecutable("""
+        [ "$1" = "--switch-to" ] || exit 2
+        [ "$2" = "7" ] || exit 2
+        [ "$3" = "--json" ] || exit 2
+        [ -z "$4" ] || exit 2
+        echo '{"schemaVersion":1,"switched":true,"from":{"number":1},"to":{"number":7},"reason":"switched"}'
+        """)
+
+        let result = try await ClaudeSwapAccountReader.switchAccount(
+            executablePath: path,
+            accountNumber: 7)
+
+        #expect(result.switched)
+        #expect(result.fromAccountNumber == 1)
+        #expect(result.toAccountNumber == 7)
+    }
+
+    @Test
+    func `rejects switch result for another slot`() async throws {
+        let path = try self.makeFakeExecutable("""
+        echo '{"schemaVersion":1,"switched":true,"from":{"number":1},"to":{"number":8},"reason":"switched"}'
+        """)
+
+        await #expect(throws: ClaudeSwapSwitchParserError.mismatchedTarget(expected: 7, actual: 8)) {
+            try await ClaudeSwapAccountReader.switchAccount(executablePath: path, accountNumber: 7)
+        }
+    }
+
+    @Test
+    func `surfaces switch error envelope from non zero exit`() async throws {
+        let path = try self.makeFakeExecutable("""
+        echo '{"schemaVersion":1,"error":{"type":"SwitchError","message":"credentials missing"}}'
+        exit 1
+        """)
+
+        await #expect(throws: ClaudeSwapSwitchParserError.reportedError(
+            type: "SwitchError",
+            message: "credentials missing"))
+        {
+            try await ClaudeSwapAccountReader.switchAccount(executablePath: path, accountNumber: 2)
+        }
+    }
+
+    @Test
+    func `started credential switch reaches natural exit after caller cancellation`() async throws {
+        let marker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-swap-switch-finished-\(UUID().uuidString)")
+        let path = try self.makeFakeExecutable("""
+        sleep 0.3
+        touch '\(marker.path)'
+        echo '{"schemaVersion":1,"switched":true,"from":{"number":1},"to":{"number":2},"reason":"switched"}'
+        """)
+        let task = Task {
+            try await ClaudeSwapAccountReader.switchAccount(executablePath: path, accountNumber: 2)
+        }
+
+        try await Task.sleep(for: .milliseconds(100))
+        task.cancel()
+        let result = try await task.value
+
+        #expect(result.switched)
+        #expect(FileManager.default.fileExists(atPath: marker.path))
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeSwapSwitchParserTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapSwitchParserTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeSwapSwitchParserTests {
+    private func parse(_ json: String) throws -> ClaudeSwapAccountSwitchResult {
+        try ClaudeSwapSwitchParser.parse(Data(json.utf8))
+    }
+
+    @Test
+    func `parses direct switch result without retaining display identity`() throws {
+        let result = try self.parse("""
+        {
+          "schemaVersion": 1,
+          "switched": true,
+          "from": {"number": 1, "email": "old@example.com"},
+          "to": {"number": 2, "email": "new@example.com"},
+          "strategy": "direct",
+          "reason": "switched",
+          "message": "Switched",
+          "warnings": []
+        }
+        """)
+
+        #expect(result == ClaudeSwapAccountSwitchResult(
+            switched: true,
+            fromAccountNumber: 1,
+            toAccountNumber: 2,
+            reason: "switched"))
+    }
+
+    @Test
+    func `accepts unmanaged source and already active no op`() throws {
+        let freshActivation = try self.parse("""
+        {"schemaVersion":1,"switched":true,"from":null,
+         "to":{"number":2},"reason":"switched"}
+        """)
+        #expect(freshActivation.fromAccountNumber == nil)
+        #expect(freshActivation.toAccountNumber == 2)
+
+        let unmanaged = try self.parse("""
+        {"schemaVersion":1,"switched":true,"from":{"number":null},
+         "to":{"number":3},"reason":"switched"}
+        """)
+        #expect(unmanaged.fromAccountNumber == nil)
+        #expect(unmanaged.toAccountNumber == 3)
+
+        let active = try self.parse("""
+        {"schemaVersion":1,"switched":false,"from":{"number":3},
+         "to":{"number":3},"reason":"already-active"}
+        """)
+        #expect(active.switched == false)
+        #expect(active.reason == "already-active")
+    }
+
+    @Test
+    func `surfaces switch error envelope`() {
+        #expect(throws: ClaudeSwapSwitchParserError.reportedError(
+            type: "SwitchError",
+            message: "store locked"))
+        {
+            try self.parse("""
+            {"schemaVersion":1,"error":{"type":"SwitchError","message":"store locked"}}
+            """)
+        }
+    }
+
+    @Test
+    func `rejects malformed or unsupported switch results`() {
+        #expect(throws: ClaudeSwapSwitchParserError.notJSONObject) {
+            try self.parse("not json")
+        }
+        #expect(throws: ClaudeSwapSwitchParserError.missingSchemaVersion) {
+            try self.parse(#"{"switched":true}"#)
+        }
+        #expect(throws: ClaudeSwapSwitchParserError.missingSchemaVersion) {
+            try self.parse(#"{"schemaVersion":true}"#)
+        }
+        #expect(throws: ClaudeSwapSwitchParserError.unsupportedSchemaVersion(2)) {
+            try self.parse(#"{"schemaVersion":2}"#)
+        }
+        #expect(throws: ClaudeSwapSwitchParserError.malformedShape("missing switched flag")) {
+            try self.parse(#"{"schemaVersion":1}"#)
+        }
+        #expect(throws: (any Error).self) {
+            try self.parse("""
+            {"schemaVersion":1,"switched":true,"from":{"number":1},
+             "to":{"number":true},"reason":"switched"}
+            """)
+        }
+    }
+}

--- a/Tests/CodexBarTests/MenuCardClaudeSwapAccountTests.swift
+++ b/Tests/CodexBarTests/MenuCardClaudeSwapAccountTests.swift
@@ -7,7 +7,10 @@ import Testing
 /// projection renders as a regular Claude usage card with session/weekly
 /// windows, account identity, and Hide Personal Info redaction.
 struct MenuCardClaudeSwapAccountTests {
-    private func makeModel(hidePersonalInfo: Bool) throws -> UsageMenuCardView.Model {
+    private func makeModel(
+        hidePersonalInfo: Bool,
+        planOverride: String? = nil) throws -> UsageMenuCardView.Model
+    {
         let now = Date(timeIntervalSince1970: 1_782_000_000)
         let metadata = try #require(ProviderDefaults.metadata[.claude])
         let list = ClaudeSwapAccountList(
@@ -34,6 +37,7 @@ struct MenuCardClaudeSwapAccountTests {
             tokenSnapshot: nil,
             tokenError: nil,
             account: AccountInfo(email: account.displayLabel, plan: nil),
+            planOverride: planOverride,
             isRefreshing: false,
             lastError: account.error,
             usageBarsShowUsed: true,
@@ -42,6 +46,13 @@ struct MenuCardClaudeSwapAccountTests {
             showOptionalCreditsAndExtraUsage: false,
             hidePersonalInfo: hidePersonalInfo,
             now: now))
+    }
+
+    @Test
+    func `claude swap action overrides adapter login method`() throws {
+        let model = try self.makeModel(hidePersonalInfo: false, planOverride: "Switch Account...")
+
+        #expect(model.planText == "Switch Account...")
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuCardOverrideIsolationTests.swift
+++ b/Tests/CodexBarTests/MenuCardOverrideIsolationTests.swift
@@ -43,6 +43,7 @@ struct MenuCardOverrideIsolationTests {
             accountOverride: AccountInfo(email: "account@example.com", plan: nil)))
 
         #expect(model.tokenUsage == nil)
+        #expect(model.email == "account@example.com")
     }
 
     @Test

--- a/docs/claude-multi-account-and-status-items.md
+++ b/docs/claude-multi-account-and-status-items.md
@@ -8,8 +8,7 @@ read_when:
 
 # Claude multi-account and status item decision
 
-Status: **Phase 1 design accepted; do not merge an implementation until its independent adapter and model proof is
-complete.**
+Status: **Phase 1 account display implemented; Phase 2 explicit account activation accepted.**
 
 Related: [#1756](https://github.com/steipete/CodexBar/issues/1756),
 [#1268](https://github.com/steipete/CodexBar/issues/1268), and the bounded Claude sign-in repair in
@@ -17,12 +16,12 @@ Related: [#1756](https://github.com/steipete/CodexBar/issues/1756),
 
 ## Accepted direction
 
-1. Add an opt-in, read-only `claude-swap` adapter as the first Claude subscription multi-account source.
+1. Use an opt-in `claude-swap` adapter as the first Claude subscription multi-account source.
 2. Normalize its results behind a provider-neutral account snapshot before adding any status item UI.
 3. Make per-account status items opt-in, replace the provider item for that provider, cap selection at four, and keep
    them mutually exclusive with Merge Icons.
-4. Defer account switching. A later phase may invoke `cswap --switch-to <slot> --json` only after a separate product
-   decision and explicit user action.
+4. Allow an explicit click on an inactive account card to invoke exactly `cswap --switch-to <slot> --json`. Keep
+   automatic switching and session launching out of scope.
 
 This solves the durable OAuth refresh problem without making CodexBar a second credential vault. It also avoids a
 Claude-only status item implementation that would need to be redesigned for Codex and other providers.
@@ -57,16 +56,15 @@ Keychain and prompt behavior. The safer seam is a credential-free usage adapter 
 | Option | Credential ownership | Durability | Risk | Recommendation |
 | --- | --- | --- | --- | --- |
 | First-party OAuth account vault | CodexBar | High | New login, refresh, storage, revocation, migration, and security surface | Defer |
-| Read-only `claude-swap` adapter | `claude-swap` | High | External executable and schema dependency | **Phase 1** |
+| Bounded `claude-swap` adapter | `claude-swap` | High | External executable and schema dependency | **Phase 1–2** |
 | Discover Claude Code Keychain entries | Claude Code / ambiguous | Unknown | Undocumented enumeration; prompt and identity hazards | Reject |
 | Existing token accounts | CodexBar config | Low for OAuth | Access token expires without refresh metadata | Keep for current cookie/API-key uses |
 
-As of [`claude-swap` v0.16.0](https://github.com/realiti4/claude-swap/releases/tag/v0.16.0),
+As of [`claude-swap` v0.18.0](https://github.com/realiti4/claude-swap/releases/tag/v0.18.0),
 `cswap --list --json` still returns a versioned object with `schemaVersion: 1`, an active account number, account slots,
 redaction-sensitive email labels, 5-hour and 7-day usage percentages, and reset timestamps. Handled failures return an
-error object and non-zero exit. v0.16.0 also adds mutation-capable automatic switching; that does not expand this
-integration. CodexBar does not need `--token-status`, credential files, Keychain access, or raw OAuth values for the
-display-only phase.
+error object and non-zero exit. Direct switching returns the same versioned envelope. CodexBar does not need
+`--token-status`, credential files, Keychain access, or raw OAuth values for display or explicit activation.
 
 ## Phase 1 adapter contract
 
@@ -88,6 +86,20 @@ display-only phase.
 The executable is an optional external dependency, not a bundled component. Preferences should show detected version,
 last refresh, adapter errors, and a link to the upstream project; CodexBar should not install or update it.
 
+## Phase 2 explicit activation contract
+
+- Only an explicit click on an inactive, actionable account card can start a switch.
+- Derive the numeric slot from the already validated account snapshot and execute exactly
+  `cswap --switch-to <slot> --json`; never accept free-form arguments or invoke a shell.
+- Serialize switches, validate `schemaVersion == 1` and the returned target slot, and bound captured output.
+- Once launched, let the external credential transaction reach its natural exit without forced timeout or
+  cancellation. If the adapter setting changes, hide its UI state and discard its result when the original
+  configuration is no longer current.
+- Refresh ambient Claude usage and the adapter account list after completion. Show switch errors independently from
+  list-refresh errors and preserve the last successful usage snapshots.
+- Keep expired, missing, unknown, and Keychain-inaccessible credential slots non-actionable. Never auto-switch, launch
+  sessions, add/import/export/purge accounts, or mutate credentials directly.
+
 ## Provider-neutral account model
 
 Introduce one projection used by menus and status items rather than teaching status item code about Claude OAuth:
@@ -98,6 +110,7 @@ struct ProviderAccountUsageSnapshot: Identifiable {
     let provider: UsageProvider
     let displayLabel: String
     let isActive: Bool
+    let canActivate: Bool
     let snapshot: UsageSnapshot?
     let error: String?
     let sourceLabel: String?
@@ -147,14 +160,15 @@ No real credential, browser session, or provider call was used.
 
 ## Accepted decisions
 
-1. The optional external `claude-swap` dependency is accepted only for exact read-only `cswap --list --json` execution.
-2. Switching, automatic switching, account mutation, and session launching stay out of Phase 1.
+1. The optional external `claude-swap` dependency is accepted for exact `cswap --list --json` execution and explicit
+   `cswap --switch-to <slot> --json` activation.
+2. Automatic switching, account add/import/export/purge, and session launching stay out of scope.
 3. Provider-neutral account snapshots land before any per-account status item work.
 4. Per-account status items are capped at four and mutually exclusive with Merge Icons.
 5. Status item labels use aliases or privacy-safe ordinals, never email identity.
 
-Any change to these decisions requires a new product/auth review before implementation because it changes storage,
-status item migration, process authority, or the credential boundary.
+Any further change to these decisions requires a new product/auth review before implementation because it changes
+storage, status item migration, process authority, or the credential boundary.
 
 ## Implementation and validation sequence
 
@@ -163,6 +177,7 @@ status item migration, process authority, or the credential boundary.
 2. Add the opt-in adapter and provider-neutral projection. Verify no credential reads and no impact on ambient Claude.
 3. Add settings-state and menu-model tests. Keep AppKit status item creation out of headless tests.
 4. Add status item identity/migration tests, then implement account items behind the opt-in setting.
-5. Run focused tests, `make check`, `make test`, packaged synthetic proof, and macOS UI proof with redacted fixtures.
+5. Add exact-argv, strict switch-result, serialization, and refresh tests using a fake executable only.
+6. Run focused tests, `make check`, `make test`, packaged synthetic proof, and macOS UI proof with redacted fixtures.
 
-No credential import, account mutation, or compatibility shim is part of this proposal.
+No credential import, automatic switching, session launching, or compatibility shim is part of this proposal.

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -112,9 +112,9 @@ Admin API key setup:
   - Extra usage spend/limit (if enabled).
   - Account email + inferred plan.
 
-## claude-swap accounts (opt-in, read-only)
+## claude-swap accounts (opt-in)
 
-Phase 1 of the accepted multi-account design in
+The accepted multi-account design in
 [claude-multi-account-and-status-items.md](claude-multi-account-and-status-items.md).
 
 - Setup: Preferences → Providers → Claude → "Read accounts from claude-swap", then set the path to the
@@ -130,7 +130,12 @@ Phase 1 of the accepted multi-account design in
   stale data, surface the error in provider settings, and never affect the ambient Claude usage card.
 - Sentinel statuses (`token_expired`, `api_key`, `keychain_unavailable`, `no_credentials`,
   `unavailable`) render as per-account notes instead of usage bars.
-- Account switching is intentionally out of scope; use `cswap` directly to switch accounts.
+- Switching: an inactive account with usable source credentials shows “Switch Account…”. Clicking it runs exactly
+  `cswap --switch-to <slot> --json`, validates the versioned result and requested slot, then refreshes both ambient
+  Claude usage and every claude-swap account card. Switches are serialized; no automatic switching occurs.
+- Expired, missing, unknown, or Keychain-inaccessible credentials stay non-actionable. A failed switch remains visible
+  on that account without discarding its last successful usage. A running Claude Code process can take up to the
+  claude-swap Keychain cache interval to observe the new account.
 - When multiple claude-swap accounts are available, they take explicit precedence over Claude
   token-account presentation (stacked cards and the segmented switcher).
 


### PR DESCRIPTION
## Summary

- add explicit account activation to stacked Claude claude-swap cards
- validate versioned switch results and keep credential transactions alive through cancellation
- refresh ambient and per-account usage after switching while preserving scoped identity and errors
- keep account labels visible when quota data is unavailable
- document the bounded switching contract

Related: #1756

## Verification

- `swift test --filter ClaudeSwap`
- `swift test --filter MenuCardOverrideIsolationTests`
- `make check`
- `make test`
- packaged macOS app with claude-swap 0.18.0: seven account cards rendered; inactive account switched active and back; CLI and menu state agreed
