### PR TITLE
fix: hide passive Codex credit errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.40.1 — Unreleased
 
 ### Fixed
+- Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.
 - Codex cost history: reuse cached aggregate pricing and one pricing catalog across daily and project reports, carry fresh cache state across launches, and treat unpriced models as migrated, avoiding repeated row scans, filesystem work, and duplicate background scans on large local histories.
 
 ## 0.40.0 — 2026-07-05
@@ -22,7 +23,6 @@
 - Usage bars: distinguish full-height quota-warning thresholds from subtle workday-boundary markers. Thanks @Alekstodo!
 
 ### Fixed
-- Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.
 - Codex cost history: reuse one pricing catalog while building project rollups and carry fresh cache state across launches, avoiding repeated filesystem work and duplicate background scans on large local histories.
 - Providers: detect Claude Desktop on fresh installs and ignore Gemini CLI installations without usable OAuth credentials.
 - Claude cost history: include nested Claude Desktop local-agent logs while preserving current Code/Cowork coverage through the shared `~/.claude/projects` store. Thanks @Zihao-Qi!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Usage bars: distinguish full-height quota-warning thresholds from subtle workday-boundary markers. Thanks @Alekstodo!
 
 ### Fixed
+- Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.
 - Codex cost history: reuse one pricing catalog while building project rollups and carry fresh cache state across launches, avoiding repeated filesystem work and duplicate background scans on large local histories.
 - Providers: detect Claude Desktop on fresh installs and ignore Gemini CLI installations without usable OAuth credentials.
 - Claude cost history: include nested Claude Desktop local-agent logs while preserving current Code/Cowork coverage through the shared `~/.claude/projects` store. Thanks @Zihao-Qi!

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -47,6 +47,7 @@ extension UsageMenuCardView.Model {
         error: String?) -> String?
     {
         guard metadata.supportsCredits else { return nil }
+        if metadata.id == .codex, credits == nil, error == nil { return nil }
         if metadata.id == .amp,
            let ampUsage = snapshot?.ampUsage,
            let ampCredits = self.ampCreditsLine(ampUsage)

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -13,6 +13,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
     @Binding var isEnabled: Bool
     let subtitle: String
     let model: UsageMenuCardView.Model
+    let openAIWebDiagnostic: String?
     let settingsPickers: [ProviderSettingsPickerDescriptor]
     let settingsToggles: [ProviderSettingsToggleDescriptor]
     let settingsFields: [ProviderSettingsFieldDescriptor]
@@ -32,6 +33,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
         isEnabled: Binding<Bool>,
         subtitle: String,
         model: UsageMenuCardView.Model,
+        openAIWebDiagnostic: String?,
         settingsPickers: [ProviderSettingsPickerDescriptor],
         settingsToggles: [ProviderSettingsToggleDescriptor],
         settingsFields: [ProviderSettingsFieldDescriptor],
@@ -50,6 +52,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
         self._isEnabled = isEnabled
         self.subtitle = subtitle
         self.model = model
+        self.openAIWebDiagnostic = openAIWebDiagnostic
         self.settingsPickers = settingsPickers
         self.settingsToggles = settingsToggles
         self.settingsFields = settingsFields
@@ -122,6 +125,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
                 ProviderMetricsInlineView(
                     provider: self.provider,
                     model: self.model,
+                    openAIWebDiagnostic: self.openAIWebDiagnostic,
                     isEnabled: self.isEnabled)
             } header: {
                 Text(L("Usage"))
@@ -326,17 +330,43 @@ private struct ProviderDetailInfoRow: View {
 struct ProviderMetricsInlineView: View {
     let provider: UsageProvider
     let model: UsageMenuCardView.Model
+    let openAIWebDiagnostic: String?
     let isEnabled: Bool
+
+    struct InfoRow: Identifiable, Equatable {
+        enum ID: Hashable {
+            case credits
+            case openAIWeb
+        }
+
+        let id: ID
+        let label: String
+        let value: String
+    }
+
+    static func infoRows(
+        for model: UsageMenuCardView.Model,
+        openAIWebDiagnostic: String?) -> [InfoRow]
+    {
+        var rows: [InfoRow] = []
+        if let credits = model.creditsText {
+            rows.append(InfoRow(id: .credits, label: L("Credits"), value: credits))
+        }
+        if let diagnostic = openAIWebDiagnostic {
+            rows.append(InfoRow(id: .openAIWeb, label: L("OpenAI web extras"), value: diagnostic))
+        }
+        return rows
+    }
 
     var body: some View {
         let hasMetrics = !self.model.metrics.isEmpty
         let hasUsageNotes = !self.model.usageNotes.isEmpty
-        let hasCredits = self.model.creditsText != nil
+        let infoRows = Self.infoRows(for: self.model, openAIWebDiagnostic: self.openAIWebDiagnostic)
         let hasProviderCost = self.model.providerCost != nil
         let hasTokenUsage = self.model.tokenUsage != nil
         let hasResetCredits = self.model.codexResetCredits != nil
 
-        if !hasMetrics, !hasUsageNotes, !hasProviderCost, !hasCredits, !hasTokenUsage, !hasResetCredits {
+        if !hasMetrics, !hasUsageNotes, !hasProviderCost, infoRows.isEmpty, !hasTokenUsage, !hasResetCredits {
             Text(self.placeholderText)
                 .font(.footnote)
                 .foregroundStyle(.secondary)
@@ -360,8 +390,8 @@ struct ProviderMetricsInlineView: View {
                 }
             }
 
-            if let credits = self.model.creditsText {
-                ProviderDetailInfoRow(label: L("Credits"), value: credits)
+            ForEach(infoRows) { row in
+                ProviderDetailInfoRow(label: row.label, value: row.value)
             }
 
             if let resetCredits = self.model.codexResetCredits {

--- a/Sources/CodexBar/PreferencesProvidersPane+Testing.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane+Testing.swift
@@ -75,6 +75,10 @@ extension ProvidersPane {
         self.menuCardModel(for: provider)
     }
 
+    func _test_openAIWebDiagnostic(for provider: UsageProvider) -> String? {
+        self.openAIWebDiagnostic(for: provider)
+    }
+
     func _test_providerErrorDisplay(for provider: UsageProvider) -> ProviderErrorDisplay? {
         self.providerErrorDisplay(provider)
     }
@@ -171,6 +175,7 @@ enum ProvidersPaneTestHarness {
             isEnabled: enabledBinding,
             subtitle: "Subtitle",
             model: model,
+            openAIWebDiagnostic: pane._test_openAIWebDiagnostic(for: .codex),
             settingsPickers: [descriptors.picker],
             settingsToggles: [descriptors.toggle],
             settingsFields: [descriptors.fieldPlain, descriptors.fieldSecure],

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -47,6 +47,7 @@ struct ProvidersPane: View {
             isEnabled: self.binding(for: self.provider),
             subtitle: self.providerSubtitle(self.provider),
             model: self.menuCardModel(for: self.provider),
+            openAIWebDiagnostic: self.openAIWebDiagnostic(for: self.provider),
             settingsPickers: self.extraSettingsPickers(for: self.provider),
             settingsToggles: self.extraSettingsToggles(for: self.provider),
             settingsFields: self.extraSettingsFields(for: self.provider),
@@ -697,6 +698,14 @@ struct ProvidersPane: View {
             workDaysPerWeek: self.settings.weeklyProgressWorkDays,
             now: now)
         return UsageMenuCardView.Model.make(input)
+    }
+
+    func openAIWebDiagnostic(for provider: UsageProvider) -> String? {
+        guard provider == .codex else { return nil }
+        let diagnostic = self.store.codexConsumerProjectionIfNeeded(
+            for: provider,
+            surface: .liveCard)?.userFacingErrors.dashboard
+        return PersonalInfoRedactor.redactEmails(in: diagnostic, isEnabled: self.settings.hidePersonalInfo)
     }
 
     private func quotaWarningMarkerThresholds(provider: UsageProvider, window: QuotaWarningWindow) -> [Int] {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1348,6 +1348,13 @@ extension StatusItemController {
                 submenu: costSubmenu,
                 width: width))
         }
+        if !hasCredits, webItems.hasCreditsHistory, self.settings.showOptionalCreditsAndExtraUsage {
+            addSectionSeparator()
+            _ = self.addCreditsHistorySubmenu(to: menu)
+        }
+        if !hasCredits, webItems.canShowBuyCredits {
+            menu.addItem(self.makeBuyCreditsItem())
+        }
     }
 
     private func switcherIcon(for provider: UsageProvider) -> NSImage {

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -45,9 +45,11 @@ extension StatusItemController {
         let tokenError: String?
         if let codexProjection {
             credits = codexProjection.credits?.snapshot
-            creditsError = codexProjection.credits?.userFacingError
+            // Credits and dashboard collection are optional adjuncts. Keep their setup diagnostics in
+            // provider Settings so a signed-out browser does not dominate the glanceable menu card.
+            creditsError = nil
             dashboard = nil
-            dashboardError = codexProjection.userFacingErrors.dashboard
+            dashboardError = nil
             if surface == .liveCard {
                 tokenSnapshot = projectedTokenSnapshot ?? storedTokenSnapshot
                 tokenError = self.store.tokenError(for: target)

--- a/Tests/CodexBarTests/CodexConsumerProjectionCharacterizationTests.swift
+++ b/Tests/CodexBarTests/CodexConsumerProjectionCharacterizationTests.swift
@@ -114,7 +114,7 @@ struct CodexConsumerProjectionCharacterizationTests {
             snapshotOverride: overrideSnapshot,
             errorOverride: "Override error"))
 
-        #expect(model.creditsText == "Credits unavailable; keep Codex running to refresh.")
+        #expect(model.creditsText == nil)
         #expect(model.tokenUsage == nil)
         #expect(model.metrics.contains { $0.id == "code-review" } == false)
         #expect(model.subtitleText == "Override error")

--- a/Tests/CodexBarTests/CodexUserFacingErrorTests.swift
+++ b/Tests/CodexBarTests/CodexUserFacingErrorTests.swift
@@ -208,6 +208,38 @@ struct CodexUserFacingErrorTests {
     }
 
     @Test
+    func `menu card hides optional codex setup diagnostics kept by providers pane`() throws {
+        let settings = self.makeSettingsStore(suite: "CodexUserFacingErrorTests-menu-diagnostics")
+        let store = self.makeUsageStore(settings: settings)
+        store.lastCreditsError = UsageError.noRateLimitsFound.errorDescription
+        store.lastOpenAIDashboardError =
+            "No matching OpenAI web session found. Sign in to chatgpt.com, then refresh OpenAI cookies."
+
+        let fetcher = UsageFetcher(environment: [:])
+        let menuModel = try withStatusItemControllerForTesting(
+            store: store,
+            settings: settings,
+            fetcher: fetcher)
+        { controller in
+            try #require(controller.menuCardModel(for: .codex))
+        }
+        let pane = ProvidersPane(settings: settings, store: store)
+        let settingsModel = pane._test_menuCardModel(for: .codex)
+        let settingsDiagnostic = pane._test_openAIWebDiagnostic(for: .codex)
+        let settingsInfoRows = ProviderMetricsInlineView.infoRows(
+            for: settingsModel,
+            openAIWebDiagnostic: settingsDiagnostic)
+
+        #expect(menuModel.creditsText == nil)
+        #expect(menuModel.creditsHintText == nil)
+        #expect(settingsModel.creditsText == UsageError.noRateLimitsFound.errorDescription)
+        #expect(settingsModel.creditsHintText?.contains("No matching OpenAI web session found") == true)
+        #expect(settingsInfoRows.contains { row in
+            row.id == .openAIWeb && row.value.contains("No matching OpenAI web session found")
+        })
+    }
+
+    @Test
     func `providers pane codex error display keeps raw full text for copy`() {
         let settings = self.makeSettingsStore(suite: "CodexUserFacingErrorTests-pane-error-display")
         let store = self.makeUsageStore(settings: settings)

--- a/Tests/CodexBarTests/StatusMenuNativeSectionSpacingTests.swift
+++ b/Tests/CodexBarTests/StatusMenuNativeSectionSpacingTests.swift
@@ -7,6 +7,65 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuNativeSectionSpacingTests {
     @Test
+    func `buy credits stays available without an error only credits section`() {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.showOptionalCreditsAndExtraUsage = true
+        self.enableOnlyCodex(settings)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store.lastCreditsError = UsageError.noRateLimitsFound.errorDescription
+        store.lastOpenAIDashboardError =
+            "No matching OpenAI web session found. Sign in to chatgpt.com, then refresh OpenAI cookies."
+        let event = CreditEvent(date: Date(), service: "CLI", creditsUsed: 1)
+        let breakdown = OpenAIDashboardSnapshot.makeDailyBreakdown(from: [event], maxDays: 30)
+        store.openAIDashboard = OpenAIDashboardSnapshot(
+            signedInEmail: "user@example.com",
+            codeReviewRemainingPercent: 100,
+            creditEvents: [event],
+            dailyBreakdown: breakdown,
+            usageBreakdown: breakdown,
+            creditsPurchaseURL: nil,
+            updatedAt: Date())
+        store.openAIDashboardAttachmentAuthorized = true
+        store.openAIDashboardRequiresLogin = false
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        #expect(menu.items.contains { ($0.representedObject as? String) == "menuCardCredits" } == false)
+        #expect(menu.items.contains { $0.title == "Buy Credits..." })
+        #expect(menu.items.contains { item in
+            item.submenu?.items.contains { ($0.representedObject as? String) == "creditsHistoryChart" } == true
+        })
+
+        settings.showOptionalCreditsAndExtraUsage = false
+        let hiddenMenu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(hiddenMenu)
+        #expect(hiddenMenu.items.contains { $0.title == "Buy Credits..." } == false)
+        #expect(hiddenMenu.items.contains { item in
+            item.submenu?.items.contains { ($0.representedObject as? String) == "creditsHistoryChart" } == true
+        } == false)
+    }
+
+    @Test
     func `usage history cost and storage stay together without adjacent separators`() throws {
         let previousRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = true

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -1214,12 +1214,13 @@ extension StatusMenuTests {
         controller.menuWillOpen(menu)
         let usageItem = menu.items.first { ($0.representedObject as? String) == "menuCardUsage" }
         let creditsItem = menu.items.first { ($0.representedObject as? String) == "menuCardCredits" }
+        let creditsHistoryItem = menu.items.first { item in
+            item.submenu?.items.contains { ($0.representedObject as? String) == "creditsHistoryChart" } == true
+        }
         #expect(
             usageItem?.submenu?.items
                 .contains { ($0.representedObject as? String) == "usageBreakdownChart" } == true)
-        #expect(
-            creditsItem?.submenu?.items
-                .contains { ($0.representedObject as? String) == "creditsHistoryChart" } == true)
+        #expect(creditsItem == nil && creditsHistoryItem != nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- hide error-only Codex Credits and OpenAI web setup text from the menu
- keep Buy Credits and enabled credit history accessible
- surface optional collection diagnostics in Codex Provider Settings

## Verification
- `make check`
- `make test` (48/48 shards)
- focused provider/menu suites
- clean structured autoreview
- packaged debug bundle; verified the menu stays clean after reopen and Settings shows the OpenAI web diagnostic
