### PR TITLE
feat(claude): show Max usage multiplier (5x/20x) in plan label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Antigravity: show pace details for legacy model-family and current session/weekly quota rows without changing compact icon lane semantics. Thanks @Zihao-Qi!
 - Widgets: make Kimi available with Weekly, Rate Limit, and Monthly quota rows. Thanks @joeVenner!
 - Kimi: show the subscription 7-day Code quota in menus and large widgets. Thanks @skyzer!
+- Claude: distinguish Max 5x and Max 20x in the plan label instead of a flat "Max". Thanks @kes02!
 
 ### Fixed
 - Alibaba Token Plan: support International Model Studio while preserving China-mainland upgrades and isolating regional cookie caches. Thanks @harshav167!

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -418,6 +418,11 @@ enum CLIRenderer {
         {
             let displayPlan = if provider == .codex {
                 CodexPlanFormatting.displayName(plan) ?? plan
+            } else if provider == .claude,
+                      plan.hasPrefix("Claude "),
+                      ClaudePlan.fromCompatibilityLoginMethod(plan) != nil
+            {
+                plan
             } else {
                 plan.capitalized
             }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudePlan.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudePlan.swift
@@ -22,11 +22,9 @@ public enum ClaudePlan: String, CaseIterable, Sendable {
         }
     }
 
-    /// Branded label including the Max usage multiplier when the rate-limit tier
-    /// carries one, e.g. "Claude Max 5x" / "Claude Max 20x". Falls back to the plain
-    /// branded label for tiers without a multiplier (Pro/Team/Enterprise, or a bare Max).
+    /// Branded label including the Max usage multiplier when the rate-limit tier carries one.
     public func brandedLoginMethod(rateLimitTier: String?) -> String {
-        guard let multiplier = Self.usageMultiplier(for: self, rateLimitTier: rateLimitTier) else {
+        guard self == .max, let multiplier = Self.maxUsageMultiplier(rateLimitTier: rateLimitTier) else {
             return self.brandedLoginMethod
         }
         return "\(self.brandedLoginMethod) \(multiplier)"
@@ -152,23 +150,19 @@ public enum ClaudePlan: String, CaseIterable, Sendable {
         return nil
     }
 
-    /// Extracts the usage multiplier ("5x" / "20x") that Anthropic encodes in the
-    /// rate-limit tier string (e.g. "default_claude_max_20x").
-    ///
-    /// The multiplier is only surfaced when the tier string actually names the resolved
-    /// plan. This keeps the label faithful to whatever tier Anthropic assigns — so a
-    /// future `default_claude_team_5x` would render "Claude Team 5x" — while never
-    /// leaking a stray multiplier onto a plan whose subscription type disagreed with the
-    /// rate-limit tier (e.g. a Team subscription reported alongside a `max_5x` tier).
-    private static func usageMultiplier(for plan: Self, rateLimitTier: String?) -> String? {
-        let tier = Self.normalized(rateLimitTier)
-        guard tier.contains(plan.rawValue) else {
+    private static func maxUsageMultiplier(rateLimitTier: String?) -> String? {
+        let words = Self.normalizedWords(rateLimitTier)
+        guard let maxIndex = words.firstIndex(of: Self.max.rawValue),
+              words.indices.contains(maxIndex + 1)
+        else {
             return nil
         }
-        guard let range = tier.range(of: "[0-9]+x", options: .regularExpression) else {
+
+        let multiplier = words[maxIndex + 1]
+        guard multiplier.last == "x", Int(multiplier.dropLast()) != nil else {
             return nil
         }
-        return String(tier[range])
+        return multiplier
     }
 
     private static func normalized(_ text: String?) -> String {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudePlan.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudePlan.swift
@@ -22,6 +22,16 @@ public enum ClaudePlan: String, CaseIterable, Sendable {
         }
     }
 
+    /// Branded label including the Max usage multiplier when the rate-limit tier
+    /// carries one, e.g. "Claude Max 5x" / "Claude Max 20x". Falls back to the plain
+    /// branded label for tiers without a multiplier (Pro/Team/Enterprise, or a bare Max).
+    public func brandedLoginMethod(rateLimitTier: String?) -> String {
+        guard let multiplier = Self.usageMultiplier(for: self, rateLimitTier: rateLimitTier) else {
+            return self.brandedLoginMethod
+        }
+        return "\(self.brandedLoginMethod) \(multiplier)"
+    }
+
     public var compactLoginMethod: String {
         switch self {
         case .max:
@@ -92,17 +102,19 @@ public enum ClaudePlan: String, CaseIterable, Sendable {
     }
 
     public static func oauthLoginMethod(rateLimitTier: String?) -> String? {
-        self.fromOAuthRateLimitTier(rateLimitTier)?.brandedLoginMethod
+        self.fromOAuthRateLimitTier(rateLimitTier)?.brandedLoginMethod(rateLimitTier: rateLimitTier)
     }
 
     public static func oauthLoginMethod(subscriptionType: String?, rateLimitTier: String?) -> String? {
         self.fromOAuthCredentials(
             subscriptionType: subscriptionType,
-            rateLimitTier: rateLimitTier)?.brandedLoginMethod
+            rateLimitTier: rateLimitTier)?.brandedLoginMethod(rateLimitTier: rateLimitTier)
     }
 
     public static func webLoginMethod(rateLimitTier: String?, billingType: String?) -> String? {
-        self.fromWebAccount(rateLimitTier: rateLimitTier, billingType: billingType)?.brandedLoginMethod
+        self.fromWebAccount(
+            rateLimitTier: rateLimitTier,
+            billingType: billingType)?.brandedLoginMethod(rateLimitTier: rateLimitTier)
     }
 
     public static func cliCompatibilityLoginMethod(_ loginMethod: String?) -> String? {
@@ -138,6 +150,25 @@ public enum ClaudePlan: String, CaseIterable, Sendable {
             return .enterprise
         }
         return nil
+    }
+
+    /// Extracts the usage multiplier ("5x" / "20x") that Anthropic encodes in the
+    /// rate-limit tier string (e.g. "default_claude_max_20x").
+    ///
+    /// The multiplier is only surfaced when the tier string actually names the resolved
+    /// plan. This keeps the label faithful to whatever tier Anthropic assigns — so a
+    /// future `default_claude_team_5x` would render "Claude Team 5x" — while never
+    /// leaking a stray multiplier onto a plan whose subscription type disagreed with the
+    /// rate-limit tier (e.g. a Team subscription reported alongside a `max_5x` tier).
+    private static func usageMultiplier(for plan: Self, rateLimitTier: String?) -> String? {
+        let tier = Self.normalized(rateLimitTier)
+        guard tier.contains(plan.rawValue) else {
+            return nil
+        }
+        guard let range = tier.range(of: "[0-9]+x", options: .regularExpression) else {
+            return nil
+        }
+        return String(tier[range])
     }
 
     private static func normalized(_ text: String?) -> String {

--- a/Tests/CodexBarTests/CLISnapshotTests.swift
+++ b/Tests/CodexBarTests/CLISnapshotTests.swift
@@ -225,6 +225,34 @@ struct CLISnapshotTests {
     }
 
     @Test
+    func `renders Claude Max multiplier without uppercasing x`() {
+        let identity = ProviderIdentitySnapshot(
+            providerID: .claude,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: "Claude Max 5x")
+        let snapshot = UsageSnapshot(
+            primary: .init(usedPercent: 2, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: Date(timeIntervalSince1970: 0),
+            identity: identity)
+
+        let output = CLIRenderer.renderText(
+            provider: .claude,
+            snapshot: snapshot,
+            credits: nil,
+            context: RenderContext(
+                header: "Claude (oauth)",
+                status: nil,
+                useColor: false,
+                resetStyle: .absolute))
+
+        #expect(output.contains("Plan: Claude Max 5x"))
+        #expect(!output.contains("Plan: Claude Max 5X"))
+    }
+
+    @Test
     func `renders warp unlimited as detail not reset`() {
         let meta = ProviderDescriptorRegistry.descriptor(for: .warp).metadata
         let snap = UsageSnapshot(

--- a/Tests/CodexBarTests/ClaudePlanResolverTests.swift
+++ b/Tests/CodexBarTests/ClaudePlanResolverTests.swift
@@ -14,9 +14,11 @@ struct ClaudePlanResolverTests {
     func `oauth rate limit tier preserves the Max usage multiplier`() {
         #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "default_claude_max_5x") == "Claude Max 5x")
         #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "default_claude_max_20x") == "Claude Max 20x")
+        #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "v2_default_claude_max_20x") == "Claude Max 20x")
         // A bare Max tier without a multiplier keeps the plain label.
         #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "claude_max") == "Claude Max")
-        // The multiplier is Max-only: a non-Max plan never inherits a stray "5x"/"20x".
+        #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "default_claude_team_5x") == "Claude Team")
+        // A resolved non-Max plan never inherits a Max multiplier from a disagreeing tier.
         #expect(
             ClaudePlan.oauthLoginMethod(subscriptionType: "team", rateLimitTier: "default_claude_max_5x")
                 == "Claude Team")

--- a/Tests/CodexBarTests/ClaudePlanResolverTests.swift
+++ b/Tests/CodexBarTests/ClaudePlanResolverTests.swift
@@ -5,10 +5,24 @@ import Testing
 struct ClaudePlanResolverTests {
     @Test
     func `oauth rate limit tier maps to branded plan`() {
-        #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "default_claude_max_20x") == "Claude Max")
         #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "claude_pro") == "Claude Pro")
         #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "claude_team") == "Claude Team")
         #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "claude_enterprise") == "Claude Enterprise")
+    }
+
+    @Test
+    func `oauth rate limit tier preserves the Max usage multiplier`() {
+        #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "default_claude_max_5x") == "Claude Max 5x")
+        #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "default_claude_max_20x") == "Claude Max 20x")
+        // A bare Max tier without a multiplier keeps the plain label.
+        #expect(ClaudePlan.oauthLoginMethod(rateLimitTier: "claude_max") == "Claude Max")
+        // The multiplier is Max-only: a non-Max plan never inherits a stray "5x"/"20x".
+        #expect(
+            ClaudePlan.oauthLoginMethod(subscriptionType: "team", rateLimitTier: "default_claude_max_5x")
+                == "Claude Team")
+        #expect(
+            ClaudePlan.webLoginMethod(rateLimitTier: "default_claude_max_20x", billingType: nil)
+                == "Claude Max 20x")
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -802,7 +802,7 @@ struct ClaudeUsageTests {
         let data = Data(json.utf8)
         let info = ClaudeWebAPIFetcher._parseAccountInfoForTesting(data, orgId: "org-123")
         #expect(info?.email == "steipete@gmail.com")
-        #expect(info?.loginMethod == "Claude Max")
+        #expect(info?.loginMethod == "Claude Max 20x")
     }
 
     @Test

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -81,7 +81,8 @@ Admin API key setup:
   - `extra_usage` → Extra usage cost (monthly spend/limit).
 - Successful OAuth login enables Claude and selects OAuth as the usage source.
 - Plan inference: `subscriptionType` is preferred when present; `rate_limit_tier` falls back to
-  Max/Pro/Team/Enterprise.
+  Max/Pro/Team/Enterprise. When a Max `rate_limit_tier` carries a usage multiplier
+  (`default_claude_max_5x` / `default_claude_max_20x`), it is surfaced in the label as "Max 5x" / "Max 20x".
 
 ## Web API (cookies)
 - Preferences → Providers → Claude → Cookie source (Automatic or Manual).


### PR DESCRIPTION
## Summary

- Surface the Max multiplier carried by Claude OAuth/web rate-limit tiers: `default_claude_max_5x` and `default_claude_max_20x` now render as **Claude Max 5x** and **Claude Max 20x**.
- Keep Pro, Team, Enterprise, bare Max, and subscription-type override labels unchanged.
- Preserve lowercase `x` in both menu and CLI output.
- Document the plan inference and add a changelog entry with @kes02 credit.

## Root cause and repair

Claude's central plan resolver identified Max from the rate-limit tier but discarded the adjacent multiplier token. The final implementation resolves the plan exactly as before, then appends only a numeric token immediately following the Max tier token. It deliberately does not invent multiplier labels for other plans, does not grab unrelated numeric prefixes, and does not let a conflicting rate-limit tier override an explicit subscription type.

OAuth and web account paths share that central label resolver. Existing compatibility parsing still normalizes multiplier-bearing labels back to `.max`, so history bucketing and subscription detection remain unchanged.

## Live contributor proof

The contributor verified the original branch minutes apart on the same real Max 5x OAuth account:

```console
# Installed 0.40.0 release
Plan: Claude Max

# Original PR branch
Plan: Claude Max 5X
```

That confirms the live account tier is `default_claude_max_5x` and the resolver surfaces it. The maintainer repair additionally locks the final CLI spelling to `Claude Max 5x`; no extra live credential probe was run during rebasing.

## Validation

- `swift test --filter ClaudePlanResolverTests` — passed
- `swift test --filter CLISnapshotTests` — 39 tests passed
- `swift test --filter ClaudeUsageTests` — 39 tests passed, including OAuth/web mapping
- `make check` — passed with 0 format or lint violations
- `make test` — all 48 shards passed
- Final aggregate autoreview — no accepted/actionable findings
- Release `CodexBarCLI` product — built successfully

## Risk

Low and contained to Claude plan-label presentation. Dependency manifests and lockfiles are unchanged.
