### PR TITLE
fix: update amp usage dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Widgets: make Kimi available with Weekly, Rate Limit, and Monthly quota rows. Thanks @joeVenner!
 
 ### Fixed
+- Amp: open the current Usage page from the menu dashboard action. Thanks @3kh0!
 - Settings: keep Language, Default Terminal, and Refresh cadence selectors interactive on macOS 27.
 - Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.
 - Codex quotas: show the session quota as unavailable while an exhausted weekly limit is still binding, including menu-bar icons and widgets. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -21,7 +21,7 @@ public enum AmpProviderDescriptor {
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
                 browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
-                dashboardURL: "https://ampcode.com/settings#billing",
+                dashboardURL: "https://ampcode.com/settings/usage",
                 statusPageURL: nil),
             branding: ProviderBranding(
                 iconStyle: .amp,

--- a/Tests/CodexBarTests/AmpUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AmpUsageFetcherTests.swift
@@ -30,6 +30,11 @@ struct AmpUsageFetcherTests {
     }
 
     @Test
+    func `provider dashboard points to current usage page`() {
+        #expect(AmpProviderDescriptor.descriptor.metadata.dashboardURL == "https://ampcode.com/settings/usage")
+    }
+
+    @Test
     func `web fallback requires browser import or a manual session cookie`() {
         let disabled = ProviderSettingsSnapshot.AmpProviderSettings(cookieSource: .off, manualCookieHeader: nil)
         let invalidManual = ProviderSettingsSnapshot.AmpProviderSettings(


### PR DESCRIPTION
## Summary

- point Amp's Usage Dashboard action at the current `/settings/usage` route
- keep Amp fetch, sign-in, and cookie URLs unchanged
- add an exact metadata regression test and changelog credit

## Behavior proof

Before:

<img height="300" alt="Amp account page before the URL fix" src="https://github.com/user-attachments/assets/020ac747-60dd-4470-92b5-90fe885b846f" />

After:

<img height="300" alt="Amp Usage page after the URL fix" src="https://github.com/user-attachments/assets/0d92f4fc-ee8a-4683-b2e7-f71b99dfb103" />

A current read-only redirect check preserves the intended route through sign-in:

```text
/settings#billing -> returnTo=/settings
/settings/usage   -> returnTo=/settings/usage
```

The existing Chrome profile could not be attached for a fresh signed-in rerun; the contributor screenshots and redirect behavior remain consistent with the locked metadata contract.

## Testing

- `swift test --disable-sandbox --filter AmpUsageFetcherTests` (12 passed)
- `make check` (SwiftFormat clean; SwiftLint 0 violations)
- `make test` (48/48 shards passed)
- autoreview clean (0.99 confidence)
- `git diff --check`
