### PR TITLE
fix: add Model Studio region support to Alibaba Token Plan provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Kimi: show the subscription 7-day Code quota in menus and large widgets. Thanks @skyzer!
 
 ### Fixed
+- Alibaba Token Plan: support International Model Studio while preserving China-mainland upgrades and isolating regional cookie caches. Thanks @harshav167!
 - Amp: open the current Usage page from the menu dashboard action. Thanks @3kh0!
 - Browser cookies: stop automatic Chromium-family probes after the first Safe Storage denial, while keeping an explicit Refresh retry available (#1952). Thanks @CoreyCole!
 - Claude: keep yearless reset dates in the upcoming year when a quota crosses New Year's Day. Thanks @devYRPauli!

--- a/Sources/CodexBar/Providers/Alibaba/AlibabaTokenPlanProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Alibaba/AlibabaTokenPlanProviderImplementation.swift
@@ -17,6 +17,7 @@ struct AlibabaTokenPlanProviderImplementation: ProviderImplementation {
     func observeSettings(_ settings: SettingsStore) {
         _ = settings.alibabaTokenPlanCookieSource
         _ = settings.alibabaTokenPlanCookieHeader
+        _ = settings.alibabaTokenPlanAPIRegion
     }
 
     @MainActor
@@ -39,16 +40,25 @@ struct AlibabaTokenPlanProviderImplementation: ProviderImplementation {
             ProviderCookieSourceUI.subtitle(
                 source: context.settings.alibabaTokenPlanCookieSource,
                 keychainDisabled: context.settings.debugDisableKeychainAccess,
-                auto: "Automatic imports browser cookies from Bailian.",
-                manual: "Paste a Cookie header from bailian.console.aliyun.com.",
+                auto: "Automatic imports browser cookies from Model Studio/Bailian.",
+                manual: "Paste a Cookie header from modelstudio.console.alibabacloud.com.",
                 off: "Alibaba Token Plan cookies are disabled.")
+        }
+
+        let regionBinding = Binding(
+            get: { context.settings.alibabaTokenPlanAPIRegion.rawValue },
+            set: { raw in
+                context.settings.alibabaTokenPlanAPIRegion = AlibabaTokenPlanAPIRegion(rawValue: raw) ?? .international
+            })
+        let regionOptions = AlibabaTokenPlanAPIRegion.allCases.map {
+            ProviderSettingsPickerOption(id: $0.rawValue, title: $0.displayName)
         }
 
         return [
             ProviderSettingsPickerDescriptor(
                 id: "alibaba-token-plan-cookie-source",
                 title: "Cookie source",
-                subtitle: "Automatic imports browser cookies from Bailian.",
+                subtitle: "Automatic imports browser cookies from Model Studio/Bailian.",
                 dynamicSubtitle: cookieSubtitle,
                 binding: cookieBinding,
                 options: cookieOptions,
@@ -57,6 +67,14 @@ struct AlibabaTokenPlanProviderImplementation: ProviderImplementation {
                 trailingText: {
                     ProviderCookieSourceUI.cachedTrailingText(provider: .alibabatokenplan)
                 }),
+            ProviderSettingsPickerDescriptor(
+                id: "alibaba-token-plan-region",
+                title: "Gateway region",
+                subtitle: "Use international or China mainland console gateways for quota fetches.",
+                binding: regionBinding,
+                options: regionOptions,
+                isVisible: nil,
+                onChange: nil),
         ]
     }
 
@@ -77,7 +95,9 @@ struct AlibabaTokenPlanProviderImplementation: ProviderImplementation {
                         style: .link,
                         isVisible: nil,
                         perform: {
-                            NSWorkspace.shared.open(AlibabaTokenPlanUsageFetcher.dashboardURL)
+                            NSWorkspace.shared.open(
+                                AlibabaTokenPlanUsageFetcher.dashboardURL(
+                                    region: context.settings.alibabaTokenPlanAPIRegion))
                         }),
                 ],
                 isVisible: {

--- a/Sources/CodexBar/Providers/Alibaba/AlibabaTokenPlanProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Alibaba/AlibabaTokenPlanProviderImplementation.swift
@@ -37,11 +37,12 @@ struct AlibabaTokenPlanProviderImplementation: ProviderImplementation {
             allowsOff: false,
             keychainDisabled: context.settings.debugDisableKeychainAccess)
         let cookieSubtitle: () -> String? = {
-            ProviderCookieSourceUI.subtitle(
+            let host = context.settings.alibabaTokenPlanAPIRegion.dashboardURL.host ?? "the selected console"
+            return ProviderCookieSourceUI.subtitle(
                 source: context.settings.alibabaTokenPlanCookieSource,
                 keychainDisabled: context.settings.debugDisableKeychainAccess,
                 auto: "Automatic imports browser cookies from Model Studio/Bailian.",
-                manual: "Paste a Cookie header from modelstudio.console.alibabacloud.com.",
+                manual: "Paste a Cookie header from \(host).",
                 off: "Alibaba Token Plan cookies are disabled.")
         }
 
@@ -65,7 +66,9 @@ struct AlibabaTokenPlanProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    ProviderCookieSourceUI.cachedTrailingText(provider: .alibabatokenplan)
+                    ProviderCookieSourceUI.cachedTrailingText(
+                        provider: .alibabatokenplan,
+                        scope: context.settings.alibabaTokenPlanAPIRegion.cookieCacheScope)
                 }),
             ProviderSettingsPickerDescriptor(
                 id: "alibaba-token-plan-region",

--- a/Sources/CodexBar/Providers/Alibaba/AlibabaTokenPlanSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Alibaba/AlibabaTokenPlanSettingsStore.swift
@@ -22,9 +22,22 @@ extension SettingsStore {
         }
     }
 
+    var alibabaTokenPlanAPIRegion: AlibabaTokenPlanAPIRegion {
+        get {
+            let raw = self.configSnapshot.providerConfig(for: .alibabatokenplan)?.region
+            return AlibabaTokenPlanAPIRegion(rawValue: raw ?? "") ?? .international
+        }
+        set {
+            self.updateProviderConfig(provider: .alibabatokenplan) { entry in
+                entry.region = newValue.rawValue
+            }
+        }
+    }
+
     func alibabaTokenPlanSettingsSnapshot() -> ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings {
         ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings(
             cookieSource: self.alibabaTokenPlanCookieSource,
-            manualCookieHeader: self.alibabaTokenPlanCookieHeader)
+            manualCookieHeader: self.alibabaTokenPlanCookieHeader,
+            apiRegion: self.alibabaTokenPlanAPIRegion)
     }
 }

--- a/Sources/CodexBar/Providers/Alibaba/AlibabaTokenPlanSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Alibaba/AlibabaTokenPlanSettingsStore.swift
@@ -24,8 +24,8 @@ extension SettingsStore {
 
     var alibabaTokenPlanAPIRegion: AlibabaTokenPlanAPIRegion {
         get {
-            let raw = self.configSnapshot.providerConfig(for: .alibabatokenplan)?.region
-            return AlibabaTokenPlanAPIRegion(rawValue: raw ?? "") ?? .international
+            let raw = self.configSnapshot.providerConfig(for: .alibabatokenplan)?.sanitizedRegion
+            return AlibabaTokenPlanAPIRegion(rawValue: raw ?? "") ?? .chinaMainland
         }
         set {
             self.updateProviderConfig(provider: .alibabatokenplan) { entry in

--- a/Sources/CodexBar/Providers/Shared/ProviderCookieSourceUI.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderCookieSourceUI.swift
@@ -5,8 +5,8 @@ enum ProviderCookieSourceUI {
         "Keychain access is disabled in Advanced, so browser cookie import is unavailable."
 
     @MainActor
-    static func cachedTrailingText(provider: UsageProvider) -> String? {
-        guard let entry = CookieHeaderCache.loadForDisplay(provider: provider) else { return nil }
+    static func cachedTrailingText(provider: UsageProvider, scope: CookieHeaderCache.Scope? = nil) -> String? {
+        guard let entry = CookieHeaderCache.loadForDisplay(provider: provider, scope: scope) else { return nil }
         return self.cachedTrailingText(entry: entry)
     }
 

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -279,6 +279,11 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         if provider == .alibaba {
             return self.settings.alibabaCodingPlanAPIRegion.dashboardURL
         }
+        if provider == .alibabatokenplan {
+            return AlibabaTokenPlanUsageFetcher.dashboardURL(
+                region: self.settings.alibabaTokenPlanAPIRegion,
+                environment: environment)
+        }
         if provider == .minimax {
             return self.settings.minimaxAPIRegion.dashboardURL
         }

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -178,7 +178,11 @@ struct TokenAccountCLIContext {
                     manualCookieHeader: cookieSettings.manualCookieHeader,
                     apiRegion: self.resolveAlibabaCodingPlanRegion(config)))
         case .alibabatokenplan:
-            return self.makeSnapshot(alibabaTokenPlan: self.makeProviderCookieSettings(cookieSettings))
+            return self.makeSnapshot(
+                alibabaTokenPlan: ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings(
+                    cookieSource: cookieSettings.cookieSource,
+                    manualCookieHeader: cookieSettings.manualCookieHeader,
+                    apiRegion: self.resolveAlibabaTokenPlanRegion(config)))
         case .factory:
             return self.makeSnapshot(factory: self.makeProviderCookieSettings(cookieSettings))
         case .minimax:
@@ -604,6 +608,15 @@ struct TokenAccountCLIContext {
             return .international
         }
         return AlibabaCodingPlanAPIRegion(rawValue: raw) ?? .international
+    }
+
+    private func resolveAlibabaTokenPlanRegion(_ config: ProviderConfig?) -> AlibabaTokenPlanAPIRegion {
+        guard let raw = config?.region?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty
+        else {
+            return .chinaMainland
+        }
+        return AlibabaTokenPlanAPIRegion(rawValue: raw) ?? .chinaMainland
     }
 
     private static func kiloUsageDataSource(from source: ProviderSourceMode?) -> KiloUsageDataSource {

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -15,9 +15,10 @@ public struct CodexBarConfig: Codable, Sendable {
         metadata: [UsageProvider: ProviderMetadata] = ProviderDescriptorRegistry.metadata) -> CodexBarConfig
     {
         let providers = UsageProvider.allCases.map { provider in
-            ProviderConfig(
-                id: provider,
-                enabled: metadata[provider]?.defaultEnabled)
+            Self.defaultProviderConfig(
+                provider,
+                metadata: metadata,
+                alibabaTokenPlanRegion: .international)
         }
         return CodexBarConfig(version: Self.currentVersion, providers: providers)
     }
@@ -57,9 +58,10 @@ public struct CodexBarConfig: Codable, Sendable {
         }
 
         for provider in UsageProvider.allCases where !seen.contains(provider) {
-            normalized.append(ProviderConfig(
-                id: provider,
-                enabled: metadata[provider]?.defaultEnabled))
+            normalized.append(Self.defaultProviderConfig(
+                provider,
+                metadata: metadata,
+                alibabaTokenPlanRegion: .chinaMainland))
         }
 
         return CodexBarConfig(
@@ -90,6 +92,17 @@ public struct CodexBarConfig: Codable, Sendable {
         } else {
             self.providers.append(config)
         }
+    }
+
+    private static func defaultProviderConfig(
+        _ provider: UsageProvider,
+        metadata: [UsageProvider: ProviderMetadata],
+        alibabaTokenPlanRegion: AlibabaTokenPlanAPIRegion) -> ProviderConfig
+    {
+        ProviderConfig(
+            id: provider,
+            enabled: metadata[provider]?.defaultEnabled,
+            region: provider == .alibabatokenplan ? alibabaTokenPlanRegion.rawValue : nil)
     }
 }
 

--- a/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
@@ -271,6 +271,13 @@ public enum CodexBarConfigValidator {
                 isValid: AlibabaCodingPlanAPIRegion(rawValue: region) != nil,
                 displayName: "Alibaba Coding Plan",
                 issues: &issues)
+        case .alibabatokenplan:
+            self.validateKnownRegion(
+                region,
+                provider: provider,
+                isValid: AlibabaTokenPlanAPIRegion(rawValue: region) != nil,
+                displayName: "Alibaba Token Plan",
+                issues: &issues)
         case .moonshot:
             self.validateKnownRegion(
                 region,

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -15,6 +15,7 @@ public enum CookieHeaderCache {
         case managedAccount(UUID)
         case managedStoreUnreadable
         case profileHome(String)
+        case providerVariant(String)
 
         public var isolationIdentifier: String {
             switch self {
@@ -24,6 +25,8 @@ public enum CookieHeaderCache {
                 "managed-store-unreadable"
             case let .profileHome(path):
                 "profile-home.\(Self.profileHomeDigest(path))"
+            case let .providerVariant(variant):
+                "provider-variant.\(Self.providerVariantDigest(variant))"
             }
         }
 
@@ -39,6 +42,19 @@ public enum CookieHeaderCache {
                 .joined()
             #else
             let digest = standardized.utf8.reduce(UInt64(14_695_981_039_346_656_037)) { partial, byte in
+                (partial ^ UInt64(byte)) &* 1_099_511_628_211
+            }
+            return String(digest, radix: 16)
+            #endif
+        }
+
+        private static func providerVariantDigest(_ variant: String) -> String {
+            #if canImport(CryptoKit)
+            return SHA256.hash(data: Data(variant.utf8))
+                .map { String(format: "%02x", $0) }
+                .joined()
+            #else
+            let digest = variant.utf8.reduce(UInt64(14_695_981_039_346_656_037)) { partial, byte in
                 (partial ^ UInt64(byte)) &* 1_099_511_628_211
             }
             return String(digest, radix: 16)

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanAPIRegion.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanAPIRegion.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public enum AlibabaTokenPlanAPIRegion: String, CaseIterable, Sendable {
+    case international = "intl"
+    case chinaMainland = "cn"
+
+    public var displayName: String {
+        switch self {
+        case .international:
+            "International (modelstudio.console.alibabacloud.com)"
+        case .chinaMainland:
+            "China mainland (bailian.console.aliyun.com)"
+        }
+    }
+
+    public var gatewayBaseURLString: String {
+        switch self {
+        case .international:
+            "https://modelstudio.console.alibabacloud.com"
+        case .chinaMainland:
+            "https://bailian.console.aliyun.com"
+        }
+    }
+
+    public var dashboardOriginURLString: String {
+        self.gatewayBaseURLString
+    }
+
+    public var dashboardURL: URL {
+        switch self {
+        case .international:
+            URL(
+                string: "https://modelstudio.console.alibabacloud.com/ap-southeast-1/?tab=plan#/efm/subscription/token-plan")!
+        case .chinaMainland:
+            URL(string: "https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/token-plan")!
+        }
+    }
+
+    public var currentRegionID: String {
+        switch self {
+        case .international:
+            "ap-southeast-1"
+        case .chinaMainland:
+            "cn-beijing"
+        }
+    }
+
+    public var tokenPlanProductCode: String {
+        switch self {
+        case .international:
+            "sfm_tokenplanteams_dp_intl"
+        case .chinaMainland:
+            "sfm_tokenplanteams_dp_cn"
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanAPIRegion.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanAPIRegion.swift
@@ -53,4 +53,8 @@ public enum AlibabaTokenPlanAPIRegion: String, CaseIterable, Sendable {
             "sfm_tokenplanteams_dp_cn"
         }
     }
+
+    public var cookieCacheScope: CookieHeaderCache.Scope {
+        .providerVariant("alibaba-token-plan.\(self.rawValue)")
+    }
 }

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanCookieHeader.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanCookieHeader.swift
@@ -80,14 +80,15 @@ struct AlibabaTokenPlanCookieHeaders {
 enum AlibabaTokenPlanCookieHeader {
     static func headers(
         from cookies: [HTTPCookie],
+        region: AlibabaTokenPlanAPIRegion = .international,
         environment: [String: String] = ProcessInfo.processInfo.environment) -> AlibabaTokenPlanCookieHeaders?
     {
         guard let apiHeader = self.header(
             from: cookies,
-            targetURL: AlibabaTokenPlanUsageFetcher.resolveQuotaURL(environment: environment)),
+            targetURL: AlibabaTokenPlanUsageFetcher.resolveQuotaURL(region: region, environment: environment)),
             let dashboardHeader = self.header(
                 from: cookies,
-                targetURL: AlibabaTokenPlanUsageFetcher.dashboardURL(environment: environment))
+                targetURL: AlibabaTokenPlanUsageFetcher.dashboardURL(region: region, environment: environment))
         else {
             return nil
         }

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanProviderDescriptor.swift
@@ -102,11 +102,13 @@ struct AlibabaTokenPlanWebFetchStrategy: ProviderFetchStrategy {
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         let cookieSource = context.settings?.alibabaTokenPlan?.cookieSource ?? .auto
-        let cookieHeaders = try Self.resolveCookieHeaders(context: context, allowCached: true)
+        let region = context.settings?.alibabaTokenPlan?.apiRegion ?? .international
+        let cookieHeaders = try Self.resolveCookieHeaders(context: context, allowCached: true, region: region)
         do {
             let usage = try await AlibabaTokenPlanUsageFetcher.fetchUsage(
                 apiCookieHeader: cookieHeaders.apiCookieHeader,
                 dashboardCookieHeader: cookieHeaders.dashboardCookieHeader,
+                region: region,
                 environment: context.env)
             return self.makeResult(usage: usage.toUsageSnapshot(), sourceLabel: "web")
         } catch let error as AlibabaTokenPlanUsageError
@@ -114,10 +116,11 @@ struct AlibabaTokenPlanWebFetchStrategy: ProviderFetchStrategy {
         {
             #if os(macOS)
             CookieHeaderCache.clear(provider: .alibabatokenplan)
-            let refreshedHeaders = try Self.resolveCookieHeaders(context: context, allowCached: false)
+            let refreshedHeaders = try Self.resolveCookieHeaders(context: context, allowCached: false, region: region)
             let usage = try await AlibabaTokenPlanUsageFetcher.fetchUsage(
                 apiCookieHeader: refreshedHeaders.apiCookieHeader,
                 dashboardCookieHeader: refreshedHeaders.dashboardCookieHeader,
+                region: region,
                 environment: context.env)
             return self.makeResult(usage: usage.toUsageSnapshot(), sourceLabel: "web")
             #else
@@ -131,12 +134,14 @@ struct AlibabaTokenPlanWebFetchStrategy: ProviderFetchStrategy {
     }
 
     static func resolveCookieHeader(context: ProviderFetchContext, allowCached: Bool) throws -> String {
-        try self.resolveCookieHeaders(context: context, allowCached: allowCached).apiCookieHeader
+        try self.resolveCookieHeaders(context: context, allowCached: allowCached, region: .international)
+            .apiCookieHeader
     }
 
     static func resolveCookieHeaders(
         context: ProviderFetchContext,
-        allowCached: Bool) throws -> AlibabaTokenPlanCookieHeaders
+        allowCached: Bool,
+        region: AlibabaTokenPlanAPIRegion = .international) throws -> AlibabaTokenPlanCookieHeaders
     {
         if let settings = context.settings?.alibabaTokenPlan,
            settings.cookieSource == .manual
@@ -192,6 +197,7 @@ struct AlibabaTokenPlanWebFetchStrategy: ProviderFetchStrategy {
             let rawCookieNames = session.cookies.map(\.name).filter { !$0.isEmpty }.uniquedSorted()
             guard let headers = AlibabaTokenPlanCookieHeader.headers(
                 from: session.cookies,
+                region: region,
                 environment: context.env)
             else {
                 Self.log.warning(

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanProviderDescriptor.swift
@@ -77,6 +77,7 @@ struct AlibabaTokenPlanWebFetchStrategy: ProviderFetchStrategy {
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         guard context.settings?.alibabaTokenPlan?.cookieSource != .off else { return false }
+        let region = context.settings?.alibabaTokenPlan?.apiRegion ?? .international
 
         if AlibabaTokenPlanSettingsReader.cookieHeader(environment: context.env) != nil {
             return true
@@ -89,7 +90,7 @@ struct AlibabaTokenPlanWebFetchStrategy: ProviderFetchStrategy {
         }
 
         #if os(macOS)
-        if let cached = CookieHeaderCache.load(provider: .alibabatokenplan),
+        if let cached = Self.cachedCookieEntry(region: region),
            !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
             return true
@@ -115,7 +116,7 @@ struct AlibabaTokenPlanWebFetchStrategy: ProviderFetchStrategy {
             where error.isCredentialFailure && cookieSource != .manual
         {
             #if os(macOS)
-            CookieHeaderCache.clear(provider: .alibabatokenplan)
+            CookieHeaderCache.clear(provider: .alibabatokenplan, scope: region.cookieCacheScope)
             let refreshedHeaders = try Self.resolveCookieHeaders(context: context, allowCached: false, region: region)
             let usage = try await AlibabaTokenPlanUsageFetcher.fetchUsage(
                 apiCookieHeader: refreshedHeaders.apiCookieHeader,
@@ -175,7 +176,7 @@ struct AlibabaTokenPlanWebFetchStrategy: ProviderFetchStrategy {
 
         #if os(macOS)
         if allowCached,
-           let cached = CookieHeaderCache.load(provider: .alibabatokenplan),
+           let cached = Self.cachedCookieEntry(region: region),
            let headers = AlibabaTokenPlanCookieHeaders(cachedHeader: cached.cookieHeader)
         {
             Self.log.info(
@@ -211,6 +212,7 @@ struct AlibabaTokenPlanWebFetchStrategy: ProviderFetchStrategy {
             }
             CookieHeaderCache.store(
                 provider: .alibabatokenplan,
+                scope: region.cookieCacheScope,
                 cookieHeader: headers.cacheCookieHeader,
                 sourceLabel: session.sourceLabel)
             Self.log.info(
@@ -234,6 +236,31 @@ struct AlibabaTokenPlanWebFetchStrategy: ProviderFetchStrategy {
         throw AlibabaTokenPlanSettingsError.missingCookie()
         #endif
     }
+
+    #if os(macOS)
+    /// The former unscoped cache only ever represented the China gateway. Never expose it to
+    /// International requests; migrate it into the China scope after a successful scoped write.
+    private static func cachedCookieEntry(region: AlibabaTokenPlanAPIRegion) -> CookieHeaderCache.Entry? {
+        if let scoped = CookieHeaderCache.load(provider: .alibabatokenplan, scope: region.cookieCacheScope) {
+            return scoped
+        }
+        guard region == .chinaMainland,
+              let legacy = CookieHeaderCache.load(provider: .alibabatokenplan)
+        else { return nil }
+
+        CookieHeaderCache.store(
+            provider: .alibabatokenplan,
+            scope: region.cookieCacheScope,
+            cookieHeader: legacy.cookieHeader,
+            sourceLabel: legacy.sourceLabel,
+            now: legacy.storedAt)
+        if let migrated = CookieHeaderCache.load(provider: .alibabatokenplan, scope: region.cookieCacheScope) {
+            CookieHeaderCache.clear(provider: .alibabatokenplan)
+            return migrated
+        }
+        return legacy
+    }
+    #endif
 
     private static func missingCookieDetails(from error: Error) -> String? {
         if case let AlibabaCodingPlanSettingsError.missingCookie(details) = error {

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanSettingsReader.swift
@@ -5,6 +5,12 @@ public struct AlibabaTokenPlanSettingsReader: Sendable {
     public static let hostKey = "ALIBABA_TOKEN_PLAN_HOST"
     public static let quotaURLKey = "ALIBABA_TOKEN_PLAN_QUOTA_URL"
 
+    private static let endpointValidator = ProviderEndpointOverrideValidator(
+        allowedHosts: [
+            "modelstudio.console.alibabacloud.com",
+            "bailian.console.aliyun.com",
+        ])
+
     public static func cookieHeader(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
@@ -14,21 +20,17 @@ public struct AlibabaTokenPlanSettingsReader: Sendable {
     public static func hostOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        guard let raw = self.cleaned(environment[self.hostKey]) else { return nil }
-        if let scheme = URL(string: raw)?.scheme {
-            return scheme.lowercased() == "https" ? raw : nil
-        }
-        return raw
+        self.endpointValidator.validatedHost(
+            self.cleaned(environment[self.hostKey]),
+            policy: .allowAnyHTTPSHost)
     }
 
     public static func quotaURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
-        guard let raw = self.cleaned(environment[self.quotaURLKey]) else { return nil }
-        if let url = URL(string: raw), let scheme = url.scheme {
-            return scheme.lowercased() == "https" ? url : nil
-        }
-        return URL(string: "https://\(raw)")
+        self.endpointValidator.validatedURL(
+            self.cleaned(environment[self.quotaURLKey]),
+            policy: .allowAnyHTTPSHost)
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -53,7 +55,8 @@ public enum AlibabaTokenPlanSettingsError: LocalizedError, Sendable {
         switch self {
         case let .missingCookie(details):
             let base = "No Alibaba Token Plan session cookies found in browsers. " +
-                "Sign in to Bailian in Chrome, allow CodexBar to access Chrome Safe Storage in Keychain Access, " +
+                "Sign in to Model Studio/Bailian in Chrome, " +
+                "allow CodexBar to access Chrome Safe Storage in Keychain Access, " +
                 "or paste a manual Cookie header."
             guard let details, !details.isEmpty else { return base }
             return "\(base) \(details)"

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
@@ -29,12 +29,8 @@ public enum AlibabaTokenPlanUsageError: LocalizedError, Sendable, Equatable {
 // swiftlint:disable:next type_body_length
 public struct AlibabaTokenPlanUsageFetcher: Sendable {
     private static let log = CodexBarLog.logger("alibaba-token-plan")
-    private static let gatewayBaseURLString = "https://bailian.console.aliyun.com"
-    private static let dashboardOriginURLString = "https://bailian.console.aliyun.com"
-    private static let currentRegionID = "cn-beijing"
     private static let bssServiceCode = "BssOpenAPI-V3"
     private static let subscriptionSummaryAction = "GetSubscriptionSummary"
-    private static let tokenPlanProductCode = "sfm_tokenplanteams_dp_cn"
     private static let browserLikeUserAgent =
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
@@ -43,11 +39,29 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3 Safari/605.1.15"
 
     public static var dashboardURL: URL {
-        URL(string: "https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/token-plan")!
+        Self.dashboardURL(region: .international, environment: ProcessInfo.processInfo.environment)
+    }
+
+    public static func dashboardURL(
+        region: AlibabaTokenPlanAPIRegion,
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> URL
+    {
+        if let host = AlibabaTokenPlanSettingsReader.hostOverride(environment: environment),
+           let base = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: host),
+           var components = URLComponents(url: base, resolvingAgainstBaseURL: false),
+           let dashboardComponents = URLComponents(url: region.dashboardURL, resolvingAgainstBaseURL: false)
+        {
+            components.path = dashboardComponents.path
+            components.percentEncodedQuery = dashboardComponents.percentEncodedQuery
+            components.fragment = dashboardComponents.fragment
+            return components.url ?? region.dashboardURL
+        }
+        return region.dashboardURL
     }
 
     public static func fetchUsage(
         cookieHeader: String,
+        region: AlibabaTokenPlanAPIRegion = .international,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         now: Date = Date()) async throws -> AlibabaTokenPlanUsageSnapshot
     {
@@ -57,6 +71,7 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         return try await self.fetchUsage(
             apiCookieHeader: headers.apiCookieHeader,
             dashboardCookieHeader: headers.dashboardCookieHeader,
+            region: region,
             environment: environment,
             now: now)
     }
@@ -64,6 +79,7 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
     static func fetchUsage(
         apiCookieHeader: String,
         dashboardCookieHeader: String,
+        region: AlibabaTokenPlanAPIRegion = .international,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         now: Date = Date(),
         session overrideSession: URLSession? = nil) async throws -> AlibabaTokenPlanUsageSnapshot
@@ -74,7 +90,7 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
             throw AlibabaTokenPlanSettingsError.invalidCookie
         }
 
-        let url = self.resolveQuotaURL(environment: environment)
+        let url = self.resolveQuotaURL(region: region, environment: environment)
         let apiRedirectDiagnostics = RedirectDiagnostics(cookieHeader: normalizedAPIHeader)
         let dashboardRedirectDiagnostics: RedirectDiagnostics?
         let apiSession: URLSession
@@ -104,12 +120,14 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         let secToken = await self.resolveSECToken(
             dashboardCookieHeader: normalizedDashboardHeader,
             apiCookieHeader: normalizedAPIHeader,
+            region: region,
             environment: environment,
             session: dashboardSession)
         Self.log.info(
             "Fetching Alibaba Token Plan usage",
             metadata: [
                 "apiHost": url.host ?? "unknown",
+                "region": region.rawValue,
                 "apiCookieNames": self.cookieNamesDescription(from: normalizedAPIHeader),
                 "dashboardCookieNames": self.cookieNamesDescription(from: normalizedDashboardHeader),
                 "hasCSRF": self.hasCSRF(in: normalizedAPIHeader) ? "1" : "0",
@@ -119,7 +137,7 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = 20
-        request.httpBody = self.subscriptionSummaryRequestBody(secToken: secToken)
+        request.httpBody = self.subscriptionSummaryRequestBody(region: region, secToken: secToken)
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.setValue("*/*", forHTTPHeaderField: "Accept")
         request.setValue(normalizedAPIHeader, forHTTPHeaderField: "Cookie")
@@ -131,8 +149,10 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         }
         request.setValue("XMLHttpRequest", forHTTPHeaderField: "X-Requested-With")
         request.setValue(Self.browserLikeUserAgent, forHTTPHeaderField: "User-Agent")
-        request.setValue(Self.dashboardOriginURLString, forHTTPHeaderField: "Origin")
-        request.setValue(Self.dashboardURL.absoluteString, forHTTPHeaderField: "Referer")
+        request.setValue(region.dashboardOriginURLString, forHTTPHeaderField: "Origin")
+        request.setValue(
+            Self.dashboardURL(region: region, environment: environment).absoluteString,
+            forHTTPHeaderField: "Referer")
 
         let data: Data
         let response: URLResponse
@@ -185,7 +205,10 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         return try self.parseUsageSnapshot(from: data, now: now)
     }
 
-    static func resolveQuotaURL(environment: [String: String]) -> URL {
+    static func resolveQuotaURL(
+        region: AlibabaTokenPlanAPIRegion,
+        environment: [String: String]) -> URL
+    {
         if let override = AlibabaTokenPlanSettingsReader.quotaURL(environment: environment) {
             return override
         }
@@ -194,11 +217,15 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         {
             return hostURL
         }
-        return self.defaultQuotaURL
+        return self.defaultQuotaURL(region: region)
     }
 
     static var defaultQuotaURL: URL {
-        var components = URLComponents(string: Self.gatewayBaseURLString)!
+        self.defaultQuotaURL(region: .international)
+    }
+
+    static func defaultQuotaURL(region: AlibabaTokenPlanAPIRegion) -> URL {
+        var components = URLComponents(string: region.gatewayBaseURLString)!
         components.path = "/data/api.json"
         components.queryItems = [
             URLQueryItem(name: "action", value: Self.subscriptionSummaryAction),
@@ -253,8 +280,8 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
             updatedAt: now)
     }
 
-    private static func subscriptionSummaryRequestBody(secToken: String?) -> Data {
-        let paramsObject = ["ProductCode": Self.tokenPlanProductCode]
+    private static func subscriptionSummaryRequestBody(region: AlibabaTokenPlanAPIRegion, secToken: String?) -> Data {
+        let paramsObject = ["ProductCode": region.tokenPlanProductCode]
         guard let paramsData = try? JSONSerialization.data(withJSONObject: paramsObject, options: []),
               let paramsString = String(data: paramsData, encoding: .utf8)
         else {
@@ -266,7 +293,7 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
             URLQueryItem(name: "product", value: Self.bssServiceCode),
             URLQueryItem(name: "action", value: Self.subscriptionSummaryAction),
             URLQueryItem(name: "params", value: paramsString),
-            URLQueryItem(name: "region", value: Self.currentRegionID),
+            URLQueryItem(name: "region", value: region.currentRegionID),
         ]
         if let secToken, !secToken.isEmpty {
             queryItems.append(URLQueryItem(name: "sec_token", value: secToken))
@@ -278,12 +305,13 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
     private static func resolveSECToken(
         dashboardCookieHeader: String,
         apiCookieHeader: String,
+        region: AlibabaTokenPlanAPIRegion,
         environment: [String: String],
         session: URLSession) async -> String?
     {
         let cookieSECToken = self.extractCookieValue(name: "sec_token", from: dashboardCookieHeader) ??
             self.extractCookieValue(name: "sec_token", from: apiCookieHeader)
-        var request = URLRequest(url: self.dashboardURL(environment: environment))
+        var request = URLRequest(url: self.dashboardURL(region: region, environment: environment))
         request.httpMethod = "GET"
         request.timeoutInterval = 10
         request.setValue(dashboardCookieHeader, forHTTPHeaderField: "Cookie")
@@ -309,6 +337,7 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
 
         if let token = await self.fetchSECTokenFromUserInfo(
             cookieHeader: dashboardCookieHeader,
+            region: region,
             environment: environment,
             session: session)
         {
@@ -331,10 +360,11 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
 
     private static func fetchSECTokenFromUserInfo(
         cookieHeader: String,
+        region: AlibabaTokenPlanAPIRegion,
         environment: [String: String],
         session: URLSession) async -> String?
     {
-        let baseURL = self.consoleBaseURL(environment: environment)
+        let baseURL = self.consoleBaseURL(region: region, environment: environment)
         let userInfoURL = baseURL.appendingPathComponent("tool/user/info.json")
         var request = URLRequest(url: userInfoURL)
         request.httpMethod = "GET"
@@ -369,39 +399,29 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         return token
     }
 
-    private static func consoleBaseURL(environment: [String: String]) -> URL {
-        let dashboard = self.dashboardURL(environment: environment)
+    private static func consoleBaseURL(
+        region: AlibabaTokenPlanAPIRegion,
+        environment: [String: String]) -> URL
+    {
+        let dashboard = self.dashboardURL(region: region, environment: environment)
         var components = URLComponents()
         components.scheme = dashboard.scheme
         components.host = dashboard.host
         components.port = dashboard.port
-        return components.url ?? URL(string: Self.dashboardOriginURLString)!
+        return components.url ?? URL(string: region.dashboardOriginURLString)!
     }
 
     private static func quotaURL(from rawHost: String) -> URL? {
         let cleaned = AlibabaTokenPlanSettingsReader.cleaned(rawHost)
         guard let cleaned else { return nil }
-        let base = URL(string: cleaned)?.scheme == nil ? URL(string: "https://\(cleaned)") : URL(string: cleaned)
-        guard let base else { return nil }
+        guard let base = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: cleaned) else { return nil }
         var components = URLComponents(url: base, resolvingAgainstBaseURL: false)
-        let defaultComponents = URLComponents(url: Self.defaultQuotaURL, resolvingAgainstBaseURL: false)
+        let defaultComponents = URLComponents(
+            url: Self.defaultQuotaURL(region: .international),
+            resolvingAgainstBaseURL: false)
         components?.path = "/data/api.json"
         components?.queryItems = defaultComponents?.queryItems
         return components?.url
-    }
-
-    static func dashboardURL(environment: [String: String]) -> URL {
-        if let host = AlibabaTokenPlanSettingsReader.hostOverride(environment: environment),
-           let base = URL(string: host)?.scheme == nil ? URL(string: "https://\(host)") : URL(string: host),
-           var components = URLComponents(url: base, resolvingAgainstBaseURL: false),
-           let dashboardComponents = URLComponents(url: dashboardURL, resolvingAgainstBaseURL: false)
-        {
-            components.path = dashboardComponents.path
-            components.percentEncodedQuery = dashboardComponents.percentEncodedQuery
-            components.fragment = dashboardComponents.fragment
-            return components.url ?? self.dashboardURL
-        }
-        return Self.dashboardURL
     }
 
     private final class RedirectDiagnostics: NSObject, URLSessionTaskDelegate, @unchecked Sendable {

--- a/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
@@ -179,10 +179,20 @@ public struct ProviderSettingsSnapshot: Sendable {
     public struct AlibabaTokenPlanProviderSettings: ProviderCookieSettings {
         public let cookieSource: ProviderCookieSource
         public let manualCookieHeader: String?
+        public let apiRegion: AlibabaTokenPlanAPIRegion
 
-        public init(cookieSource: ProviderCookieSource = .auto, manualCookieHeader: String? = nil) {
+        public init(
+            cookieSource: ProviderCookieSource = .auto,
+            manualCookieHeader: String? = nil,
+            apiRegion: AlibabaTokenPlanAPIRegion = .international)
+        {
             self.cookieSource = cookieSource
             self.manualCookieHeader = manualCookieHeader
+            self.apiRegion = apiRegion
+        }
+
+        public init(cookieSource: ProviderCookieSource, manualCookieHeader: String?) {
+            self.init(cookieSource: cookieSource, manualCookieHeader: manualCookieHeader, apiRegion: .international)
         }
     }
 

--- a/Tests/CodexBarTests/AlibabaTokenPlanDashboardActionTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanDashboardActionTests.swift
@@ -1,0 +1,27 @@
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct AlibabaTokenPlanDashboardActionTests {
+    @Test
+    func `dashboard action follows selected region`() {
+        let settings = testSettingsStore(suiteName: "AlibabaTokenPlanDashboardActionTests")
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.alibabaTokenPlanAPIRegion = .chinaMainland
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+
+        withStatusItemControllerForTesting(store: store, settings: settings, fetcher: fetcher) { controller in
+            #expect(controller.dashboardURL(for: .alibabatokenplan) ==
+                AlibabaTokenPlanAPIRegion.chinaMainland.dashboardURL)
+        }
+    }
+}

--- a/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
@@ -47,13 +47,21 @@ struct AlibabaTokenPlanSettingsReaderTests {
         ])
 
         #expect(httpHost == nil)
-        #expect(httpsHost == "https://dashboard.token-plan.test")
+        #expect(httpsHost == "dashboard.token-plan.test")
         #expect(bareHost == "dashboard.token-plan.test")
     }
 
     @Test
     func `default quota URL targets subscription summary API`() {
         let url = AlibabaTokenPlanUsageFetcher.defaultQuotaURL
+        #expect(url.host == "modelstudio.console.alibabacloud.com")
+        #expect(url.absoluteString.contains("GetSubscriptionSummary"))
+        #expect(url.absoluteString.contains("BssOpenAPI-V3"))
+    }
+
+    @Test
+    func `default quota URL for china mainland targets bailian`() {
+        let url = AlibabaTokenPlanUsageFetcher.defaultQuotaURL(region: .chinaMainland)
         #expect(url.host == "bailian.console.aliyun.com")
         #expect(url.absoluteString.contains("GetSubscriptionSummary"))
         #expect(url.absoluteString.contains("BssOpenAPI-V3"))
@@ -64,6 +72,26 @@ struct AlibabaTokenPlanCookieHeaderTests {
     @Test
     func `builds URL scoped headers for API and dashboard`() throws {
         let cookies = [
+            self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".alibabacloud.com"),
+            self.cookie(name: "login_current_pk", value: "account", domain: ".alibabacloud.com"),
+            self.cookie(name: "sec_token", value: "shared", domain: ".console.alibabacloud.com"),
+            self.cookie(name: "sec_token", value: "dashboard", domain: "modelstudio.console.alibabacloud.com"),
+            self.cookie(name: "bailian_only", value: "bailian", domain: "bailian.console.aliyun.com"),
+        ]
+
+        let headers = try #require(AlibabaTokenPlanCookieHeader.headers(from: cookies))
+
+        #expect(headers.apiCookieHeader.contains("login_aliyunid_ticket=ticket"))
+        #expect(headers.apiCookieHeader.contains("login_current_pk=account"))
+        #expect(headers.apiCookieHeader.contains("sec_token=dashboard"))
+        #expect(!headers.apiCookieHeader.contains("bailian_only=bailian"))
+        #expect(headers.dashboardCookieHeader.contains("sec_token=dashboard"))
+        #expect(!headers.dashboardCookieHeader.contains("bailian_only=bailian"))
+    }
+
+    @Test
+    func `builds URL scoped headers for china mainland region`() throws {
+        let cookies = [
             self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".aliyun.com"),
             self.cookie(name: "login_current_pk", value: "account", domain: ".aliyun.com"),
             self.cookie(name: "sec_token", value: "shared", domain: ".console.aliyun.com"),
@@ -71,7 +99,7 @@ struct AlibabaTokenPlanCookieHeaderTests {
             self.cookie(name: "modelstudio_only", value: "modelstudio", domain: "modelstudio.console.alibabacloud.com"),
         ]
 
-        let headers = try #require(AlibabaTokenPlanCookieHeader.headers(from: cookies))
+        let headers = try #require(AlibabaTokenPlanCookieHeader.headers(from: cookies, region: .chinaMainland))
 
         #expect(headers.apiCookieHeader.contains("login_aliyunid_ticket=ticket"))
         #expect(headers.apiCookieHeader.contains("login_current_pk=account"))
@@ -101,8 +129,11 @@ struct AlibabaTokenPlanCookieHeaderTests {
             self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".token-plan.test"),
             self.cookie(name: "api_only", value: "api", domain: "quota.token-plan.test"),
             self.cookie(name: "dashboard_only", value: "dashboard", domain: "dashboard.token-plan.test"),
-            self.cookie(name: "prod_api_only", value: "prod-api", domain: "bailian.console.aliyun.com"),
-            self.cookie(name: "prod_dashboard_only", value: "prod-dashboard", domain: "bailian.console.aliyun.com"),
+            self.cookie(name: "prod_api_only", value: "prod-api", domain: "modelstudio.console.alibabacloud.com"),
+            self.cookie(
+                name: "prod_dashboard_only",
+                value: "prod-dashboard",
+                domain: "modelstudio.console.alibabacloud.com"),
         ]
 
         let headers = try #require(AlibabaTokenPlanCookieHeader.headers(
@@ -346,11 +377,19 @@ struct AlibabaTokenPlanUsageParsingTests {
             AlibabaTokenPlanStubURLProtocol.handler = nil
         }
 
+        let hostOverride = "https://alibaba-token-plan.test:9443"
+        let environment: [String: String] = [
+            AlibabaTokenPlanSettingsReader.hostKey: hostOverride,
+        ]
+        let expectedReferer = AlibabaTokenPlanUsageFetcher.dashboardURL(
+            region: .international,
+            environment: environment).absoluteString
+
         AlibabaTokenPlanStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
 
             if url.host == "alibaba-token-plan.test",
-               url.path == "/cn-beijing",
+               url.path == "/ap-southeast-1/",
                request.httpMethod == "GET"
             {
                 #expect(url.port == 9443)
@@ -378,15 +417,14 @@ struct AlibabaTokenPlanUsageParsingTests {
 
             if url.host == "alibaba-token-plan.test", request.httpMethod == "POST" {
                 #expect(request.value(forHTTPHeaderField: "Cookie") == "login_aliyunid_ticket=ticket; raw_only=keep")
-                #expect(request.value(forHTTPHeaderField: "Origin") == "https://bailian.console.aliyun.com")
-                #expect(request.value(forHTTPHeaderField: "Referer") == AlibabaTokenPlanUsageFetcher.dashboardURL
-                    .absoluteString)
+                #expect(request.value(forHTTPHeaderField: "Origin") == "https://modelstudio.console.alibabacloud.com")
+                #expect(request.value(forHTTPHeaderField: "Referer") == expectedReferer)
                 let body = Self.requestBodyString(from: request)
                 #expect(body.contains("sec_token=user-info-token"))
                 #expect(body.contains("GetSubscriptionSummary"))
                 #expect(body.contains("BssOpenAPI-V3"))
                 #expect(body.contains("ProductCode"))
-                #expect(body.contains("sfm_tokenplanteams_dp_cn"))
+                #expect(body.contains("sfm_tokenplanteams_dp_intl"))
                 let json = """
                 {
                   "Success": true,
@@ -409,7 +447,7 @@ struct AlibabaTokenPlanUsageParsingTests {
         let snapshot = try await AlibabaTokenPlanUsageFetcher.fetchUsage(
             apiCookieHeader: "login_aliyunid_ticket=ticket; raw_only=keep",
             dashboardCookieHeader: "login_aliyunid_ticket=ticket; raw_only=keep",
-            environment: [AlibabaTokenPlanSettingsReader.hostKey: "https://alibaba-token-plan.test:9443"],
+            environment: environment,
             session: session)
 
         #expect(snapshot.planName == "TOKEN PLAN")
@@ -634,14 +672,17 @@ struct AlibabaTokenPlanWebStrategyTests {
         AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
             AlibabaCodingPlanCookieImporter.SessionInfo(
                 cookies: [
-                    self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".aliyun.com"),
-                    self.cookie(name: "login_current_pk", value: "account", domain: ".aliyun.com"),
-                    self.cookie(name: "dashboard_only", value: "dashboard", domain: "bailian.console.aliyun.com"),
+                    self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".alibabacloud.com"),
+                    self.cookie(name: "login_current_pk", value: "account", domain: ".alibabacloud.com"),
                     self.cookie(
-                        name: "modelstudio_only",
-                        value: "modelstudio",
+                        name: "dashboard_only",
+                        value: "dashboard",
                         domain: "modelstudio.console.alibabacloud.com"),
-                    self.cookie(name: "alibabacloud_only", value: "cloud", domain: ".alibabacloud.com"),
+                    self.cookie(
+                        name: "bailian_only",
+                        value: "bailian",
+                        domain: "bailian.console.aliyun.com"),
+                    self.cookie(name: "aliyun_only", value: "aliyun", domain: ".aliyun.com"),
                 ],
                 sourceLabel: "Chrome Default")
         }
@@ -654,11 +695,11 @@ struct AlibabaTokenPlanWebStrategyTests {
 
         #expect(headers.apiCookieHeader == headers.dashboardCookieHeader)
         #expect(headers.apiCookieHeader.contains("dashboard_only=dashboard"))
-        #expect(!headers.apiCookieHeader.contains("modelstudio_only=modelstudio"))
-        #expect(!headers.apiCookieHeader.contains("alibabacloud_only=cloud"))
+        #expect(!headers.apiCookieHeader.contains("bailian_only=bailian"))
+        #expect(!headers.apiCookieHeader.contains("aliyun_only=aliyun"))
         #expect(headers.dashboardCookieHeader.contains("dashboard_only=dashboard"))
-        #expect(!headers.dashboardCookieHeader.contains("modelstudio_only=modelstudio"))
-        #expect(!headers.dashboardCookieHeader.contains("alibabacloud_only=cloud"))
+        #expect(!headers.dashboardCookieHeader.contains("bailian_only=bailian"))
+        #expect(!headers.dashboardCookieHeader.contains("aliyun_only=aliyun"))
 
         AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
             throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected import")

--- a/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
@@ -603,6 +603,13 @@ struct AlibabaTokenPlanWebStrategyTests {
         }
     }
 
+    private func clearCookieCaches() {
+        CookieHeaderCache.clear(provider: .alibabatokenplan)
+        for region in AlibabaTokenPlanAPIRegion.allCases {
+            CookieHeaderCache.clear(provider: .alibabatokenplan, scope: region.cookieCacheScope)
+        }
+    }
+
     @Test
     func `auto web strategy surfaces cookie import errors`() async throws {
         let strategy = AlibabaTokenPlanWebFetchStrategy()
@@ -623,13 +630,14 @@ struct AlibabaTokenPlanWebStrategyTests {
             claudeFetcher: StubClaudeFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0))
 
-        CookieHeaderCache.clear(provider: .alibabatokenplan)
+        self.clearCookieCaches()
         AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
             throw AlibabaCodingPlanSettingsError.missingCookie(
                 details: "macOS Keychain denied access to Chrome Safe Storage.")
         }
         defer {
             AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil
+            self.clearCookieCaches()
         }
 
         #expect(await strategy.isAvailable(context))
@@ -668,7 +676,7 @@ struct AlibabaTokenPlanWebStrategyTests {
             claudeFetcher: StubClaudeFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0))
 
-        CookieHeaderCache.clear(provider: .alibabatokenplan)
+        self.clearCookieCaches()
         AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
             AlibabaCodingPlanCookieImporter.SessionInfo(
                 cookies: [
@@ -688,7 +696,7 @@ struct AlibabaTokenPlanWebStrategyTests {
         }
         defer {
             AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil
-            CookieHeaderCache.clear(provider: .alibabatokenplan)
+            self.clearCookieCaches()
         }
 
         let headers = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
@@ -735,7 +743,7 @@ struct AlibabaTokenPlanWebStrategyTests {
             claudeFetcher: StubClaudeFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0))
 
-        CookieHeaderCache.clear(provider: .alibabatokenplan)
+        self.clearCookieCaches()
         AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
             AlibabaCodingPlanCookieImporter.SessionInfo(
                 cookies: [
@@ -752,7 +760,7 @@ struct AlibabaTokenPlanWebStrategyTests {
         }
         defer {
             AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil
-            CookieHeaderCache.clear(provider: .alibabatokenplan)
+            self.clearCookieCaches()
         }
 
         let headers = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
@@ -761,6 +769,109 @@ struct AlibabaTokenPlanWebStrategyTests {
         #expect(!headers.apiCookieHeader.contains("prod_api_only=prod-api"))
         #expect(headers.dashboardCookieHeader.contains("dashboard_only=dashboard"))
         #expect(!headers.dashboardCookieHeader.contains("prod_dashboard_only=prod-dashboard"))
+    }
+
+    @Test
+    func `cached browser cookies stay isolated by gateway region`() throws {
+        self.clearCookieCaches()
+        defer { self.clearCookieCaches() }
+        CookieHeaderCache.store(
+            provider: .alibabatokenplan,
+            scope: AlibabaTokenPlanAPIRegion.international.cookieCacheScope,
+            cookieHeader: "login_aliyunid_ticket=intl-ticket; gateway=intl",
+            sourceLabel: "International fixture")
+        CookieHeaderCache.store(
+            provider: .alibabatokenplan,
+            scope: AlibabaTokenPlanAPIRegion.chinaMainland.cookieCacheScope,
+            cookieHeader: "login_aliyunid_ticket=cn-ticket; gateway=cn",
+            sourceLabel: "China fixture")
+        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
+            throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected import")
+        }
+        defer { AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil }
+
+        let context = self.context(region: .international)
+        let international = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+            context: context,
+            allowCached: true,
+            region: .international)
+        let china = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+            context: context,
+            allowCached: true,
+            region: .chinaMainland)
+
+        #expect(international.apiCookieHeader.contains("gateway=intl"))
+        #expect(!international.apiCookieHeader.contains("gateway=cn"))
+        #expect(china.apiCookieHeader.contains("gateway=cn"))
+        #expect(!china.apiCookieHeader.contains("gateway=intl"))
+    }
+
+    @Test
+    func `legacy unscoped cache migrates only to China gateway`() throws {
+        self.clearCookieCaches()
+        defer {
+            AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil
+            self.clearCookieCaches()
+        }
+        CookieHeaderCache.store(
+            provider: .alibabatokenplan,
+            cookieHeader: "login_aliyunid_ticket=legacy; gateway=legacy-cn",
+            sourceLabel: "Legacy fixture")
+        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
+            AlibabaCodingPlanCookieImporter.SessionInfo(
+                cookies: [
+                    self.cookie(
+                        name: "login_aliyunid_ticket",
+                        value: "intl",
+                        domain: ".alibabacloud.com"),
+                    self.cookie(
+                        name: "gateway",
+                        value: "intl",
+                        domain: "modelstudio.console.alibabacloud.com"),
+                ],
+                sourceLabel: "International fixture")
+        }
+        let context = self.context(region: .international)
+
+        let international = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+            context: context,
+            allowCached: true,
+            region: .international)
+        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
+            throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected China import")
+        }
+        let china = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+            context: context,
+            allowCached: true,
+            region: .chinaMainland)
+
+        #expect(international.apiCookieHeader.contains("gateway=intl"))
+        #expect(!international.apiCookieHeader.contains("gateway=legacy-cn"))
+        #expect(china.apiCookieHeader.contains("gateway=legacy-cn"))
+        #expect(CookieHeaderCache.load(provider: .alibabatokenplan) == nil)
+        #expect(CookieHeaderCache.load(
+            provider: .alibabatokenplan,
+            scope: AlibabaTokenPlanAPIRegion.chinaMainland.cookieCacheScope) != nil)
+    }
+
+    private func context(region: AlibabaTokenPlanAPIRegion) -> ProviderFetchContext {
+        let settings = ProviderSettingsSnapshot.make(
+            alibabaTokenPlan: ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings(
+                cookieSource: .auto,
+                manualCookieHeader: nil,
+                apiRegion: region))
+        return ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: .web,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: settings,
+            fetcher: UsageFetcher(environment: [:]),
+            claudeFetcher: StubClaudeFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0))
     }
 
     private func cookie(

--- a/Tests/CodexBarTests/ConfigValidationTests.swift
+++ b/Tests/CodexBarTests/ConfigValidationTests.swift
@@ -4,6 +4,47 @@ import Testing
 
 struct ConfigValidationTests {
     @Test
+    func `fresh config defaults Alibaba Token Plan to International`() throws {
+        let config = CodexBarConfig.makeDefault()
+        let provider = try #require(config.providerConfig(for: .alibabatokenplan))
+        let issues = CodexBarConfigValidator.validate(config)
+
+        #expect(provider.region == AlibabaTokenPlanAPIRegion.international.rawValue)
+        #expect(!issues.contains(where: { $0.provider == .alibabatokenplan }))
+    }
+
+    @Test
+    func `normalization preserves legacy Alibaba Token Plan region`() throws {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .alibabatokenplan, region: nil),
+        ]).normalized()
+        let provider = try #require(config.providerConfig(for: .alibabatokenplan))
+
+        #expect(provider.region == nil)
+    }
+
+    @Test
+    func `normalization adds missing Alibaba Token Plan as China mainland`() throws {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .codex),
+        ]).normalized()
+        let provider = try #require(config.providerConfig(for: .alibabatokenplan))
+
+        #expect(provider.region == AlibabaTokenPlanAPIRegion.chinaMainland.rawValue)
+    }
+
+    @Test
+    func `reports invalid Alibaba Token Plan region`() {
+        var config = CodexBarConfig.makeDefault()
+        config.setProviderConfig(ProviderConfig(id: .alibabatokenplan, region: "nowhere"))
+        let issues = CodexBarConfigValidator.validate(config)
+
+        #expect(issues.contains(where: {
+            $0.provider == .alibabatokenplan && $0.code == "invalid_region"
+        }))
+    }
+
+    @Test
     func `reports unsupported source`() {
         var config = CodexBarConfig.makeDefault()
         config.setProviderConfig(ProviderConfig(id: .codex, source: .api))

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -139,16 +139,25 @@ func testConfigStore(suiteName: String, reset: Bool = true) -> CodexBarConfigSto
 @MainActor
 func testSettingsStore(
     suiteName: String,
-    tokenAccountStore: any ProviderTokenAccountStoring = InMemoryTokenAccountStore()) -> SettingsStore
+    tokenAccountStore: any ProviderTokenAccountStoring = InMemoryTokenAccountStore(),
+    config: CodexBarConfig? = nil) -> SettingsStore
 {
     let isolatedSuiteName = "\(suiteName)-\(UUID().uuidString)"
     guard let defaults = UserDefaults(suiteName: isolatedSuiteName) else {
         preconditionFailure("Could not create test defaults suite")
     }
     defaults.removePersistentDomain(forName: isolatedSuiteName)
+    let configStore = testConfigStore(suiteName: isolatedSuiteName)
+    if let config {
+        do {
+            try configStore.save(config)
+        } catch {
+            preconditionFailure("Could not save test config: \(error)")
+        }
+    }
     return SettingsStore(
         userDefaults: defaults,
-        configStore: testConfigStore(suiteName: isolatedSuiteName),
+        configStore: configStore,
         zaiTokenStore: NoopZaiTokenStore(),
         syntheticTokenStore: NoopSyntheticTokenStore(),
         codexCookieStore: InMemoryCookieHeaderStore(),

--- a/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
+++ b/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
@@ -5,6 +5,60 @@ import Testing
 @testable import CodexBarCLI
 
 @Suite(.serialized)
+struct AlibabaTokenPlanRegionSelectionTests {
+    @Test @MainActor
+    func `fresh app settings default to International`() {
+        let settings = testSettingsStore(suiteName: "AlibabaTokenPlanRegionSelectionTests-fresh")
+
+        #expect(settings.alibabaTokenPlanAPIRegion == .international)
+    }
+
+    @Test @MainActor
+    func `legacy app settings without region remain China mainland`() {
+        var config = CodexBarConfig.makeDefault()
+        config.setProviderConfig(ProviderConfig(id: .alibabatokenplan, region: nil))
+        let settings = testSettingsStore(
+            suiteName: "AlibabaTokenPlanRegionSelectionTests-legacy",
+            config: config)
+
+        #expect(settings.alibabaTokenPlanAPIRegion == .chinaMainland)
+    }
+
+    @Test @MainActor
+    func `app settings trim configured region`() {
+        var config = CodexBarConfig.makeDefault()
+        config.setProviderConfig(ProviderConfig(id: .alibabatokenplan, region: " intl "))
+        let settings = testSettingsStore(
+            suiteName: "AlibabaTokenPlanRegionSelectionTests-trimmed",
+            config: config)
+
+        #expect(settings.alibabaTokenPlanAPIRegion == .international)
+    }
+
+    @Test
+    func `CLI honors explicit region and keeps legacy config on China mainland`() throws {
+        let selection = TokenAccountCLISelection(label: nil, index: nil, allAccounts: false)
+        let internationalContext = try TokenAccountCLIContext(
+            selection: selection,
+            config: CodexBarConfig(providers: [
+                ProviderConfig(id: .alibabatokenplan, region: AlibabaTokenPlanAPIRegion.international.rawValue),
+            ]),
+            verbose: false)
+        let legacyContext = try TokenAccountCLIContext(
+            selection: selection,
+            config: CodexBarConfig(providers: [
+                ProviderConfig(id: .alibabatokenplan, region: nil),
+            ]),
+            verbose: false)
+
+        #expect(internationalContext.settingsSnapshot(for: .alibabatokenplan, account: nil)?
+            .alibabaTokenPlan?.apiRegion == .international)
+        #expect(legacyContext.settingsSnapshot(for: .alibabatokenplan, account: nil)?
+            .alibabaTokenPlan?.apiRegion == .chinaMainland)
+    }
+}
+
+@Suite(.serialized)
 struct ZaiTokenAccountEnvironmentPrecedenceTests {
     @Test
     func `zai CLI settings snapshot defaults to personal without account scope`() throws {


### PR DESCRIPTION
## Problem

The Alibaba Token Plan provider was hardcoded to `bailian.console.aliyun.com` (China mainland), but Alibaba has migrated international users to `modelstudio.console.alibabacloud.com`. This broke usage fetching for any international user whose browser cookies are scoped to the modelstudio domain.

The Alibaba **Coding Plan** provider already had region support for both domains (`AlibabaCodingPlanAPIRegion`), but the Token Plan never got the same update.

## Fix

Adds `AlibabaTokenPlanAPIRegion` (International + China mainland) following the same pattern already used by the Coding Plan provider. Fresh installs default to **International** (modelstudio); upgrades without an existing Token Plan provider retain the previous **China mainland** behavior.

### Changes

- **New:** `AlibabaTokenPlanAPIRegion` enum with per-region gateway URL, dashboard URL, region ID (`ap-southeast-1` / `cn-beijing`), and product code (`sfm_tokenplanteams_dp_intl` / `sfm_tokenplanteams_dp_cn`)
- **Updated:** `AlibabaTokenPlanUsageFetcher` accepts and propagates region through quota URL, dashboard URL, Origin/Referer headers, sec_token resolution, and subscription summary request body
- **Updated:** `AlibabaTokenPlanCookieHeader` scopes imported cookies against the correct regional domain
- **Updated:** `AlibabaTokenPlanSettingsReader` uses `ProviderEndpointOverrideValidator` for consistent host validation (same as Coding Plan)
- **Updated:** `ProviderSettingsSnapshot` adds `apiRegion` to `AlibabaTokenPlanProviderSettings`
- **Updated:** `AlibabaTokenPlanSettingsStore` adds region property backed by the existing config `region` field
- **Updated:** `AlibabaTokenPlanProviderImplementation` adds a "Gateway region" picker in Settings, and the "Open Token Plan" button now opens the correct regional dashboard
- **Updated:** Tests for the new international default region, plus a new China mainland cookie scoping test

### Maintainer hardening

- Region-specific cookie caches prevent International and China mainland credentials from crossing domains.
- Legacy unscoped cookies migrate only to China mainland, matching the previous provider behavior.
- Settings, CLI snapshots, menu dashboard actions, manual-cookie guidance, validation, and whitespace normalization all use the same resolved region.
- Regression coverage includes fresh installs, both legacy config shapes, regional cache isolation/migration, configuration validation, CLI routing, and dashboard routing.

### Why default to International?

Any international Alibaba Cloud user accessing the Token Plan console is now redirected to `modelstudio.console.alibabacloud.com`. Their browser cookies are scoped to `.alibabacloud.com`, not `.aliyun.com`, so the old hardcoded bailian endpoint would never match their cookies. China mainland users can switch to the China mainland region in Settings.

## Verification

- `swift test --filter 'AlibabaTokenPlan|ConfigValidationTests'` — 60 tests passed in 9 suites
- `make check` — SwiftFormat and strict SwiftLint passed
- `make test` — all 48 shards passed
- Both official regional dashboard URLs returned HTTP 200
- Developer ID-signed CLI probes for both regions completed without a Keychain prompt and reached the provider-specific cookie path. This Mac has no Model Studio/Bailian browser session, so authenticated quota retrieval could not be proven locally.
