### PR TITLE
Fix settings selectors on macOS 27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Widgets: make Kimi available with Weekly, Rate Limit, and Monthly quota rows. Thanks @joeVenner!
 
 ### Fixed
+- Settings: keep Language, Default Terminal, and Refresh cadence selectors interactive on macOS 27.
 - Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.
 - Codex quotas: show the session quota as unavailable while an exhausted weekly limit is still binding, including menu-bar icons and widgets. Thanks @Yuxin-Qiao!
 - Codex cost history: reuse cached aggregate pricing and one pricing catalog across daily and project reports, carry fresh cache state across launches, and treat unpriced models as migrated, avoiding repeated row scans, filesystem work, and duplicate background scans on large local histories.

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -82,27 +82,30 @@ struct GeneralPane: View {
     var body: some View {
         Form {
             Section {
-                Picker(selection: self.$settings.appLanguage) {
-                    ForEach(AppLanguage.allCases) { option in
-                        Text(verbatim: option.label).tag(option.rawValue)
-                    }
-                } label: {
-                    SettingsRowLabel(L("language_title"), subtitle: L("language_subtitle"))
-                }
+                SettingsMenuPicker(
+                    selection: self.$settings.appLanguage,
+                    options: GeneralSettingsMenuOptions.languages,
+                    label: {
+                        SettingsRowLabel(L("language_title"), subtitle: L("language_subtitle"))
+                    },
+                    optionLabel: { rawValue in
+                        Text(verbatim: AppLanguage(rawValue: rawValue)?.label ?? rawValue)
+                    })
 
-                Picker(selection: self.$settings.terminalApp) {
-                    ForEach(TerminalApp.pickerOptions(selected: self.settings.terminalApp)) { option in
+                SettingsMenuPicker(
+                    selection: self.$settings.terminalApp,
+                    options: GeneralSettingsMenuOptions.terminalApps(selected: self.settings.terminalApp),
+                    label: {
+                        SettingsRowLabel(L("terminal_app_title"), subtitle: L("terminal_app_subtitle"))
+                    },
+                    optionLabel: { option in
                         HStack(spacing: 6) {
                             if let icon = option.pickerIcon {
                                 Image(nsImage: icon)
                             }
                             Text(option.label)
                         }
-                        .tag(option)
-                    }
-                } label: {
-                    SettingsRowLabel(L("terminal_app_title"), subtitle: L("terminal_app_subtitle"))
-                }
+                    })
 
                 Toggle(L("start_at_login_title"), isOn: self.$settings.launchAtLogin)
             } header: {
@@ -110,11 +113,11 @@ struct GeneralPane: View {
             }
 
             Section {
-                Picker(L("refresh_cadence_title"), selection: self.$settings.refreshFrequency) {
-                    ForEach(RefreshFrequency.allCases) { option in
-                        Text(option.label).tag(option)
-                    }
-                }
+                SettingsMenuPicker(
+                    selection: self.$settings.refreshFrequency,
+                    options: GeneralSettingsMenuOptions.refreshFrequencies,
+                    label: { Text(L("refresh_cadence_title")) },
+                    optionLabel: { option in Text(option.label) })
 
                 Toggle(L("refresh_on_open_title"), isOn: self.$settings.refreshAllProvidersOnMenuOpen)
 

--- a/Sources/CodexBar/PreferencesMenuPicker.swift
+++ b/Sources/CodexBar/PreferencesMenuPicker.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// Menu-backed settings selector that avoids disabled `Picker` items on macOS 27 when built with the macOS 26 SDK.
+struct SettingsMenuPicker<Value: Hashable, Label: View, OptionLabel: View>: View {
+    @Binding private var selection: Value
+    private let options: [Value]
+    private let label: () -> Label
+    private let optionLabel: (Value) -> OptionLabel
+
+    init(
+        selection: Binding<Value>,
+        options: [Value],
+        @ViewBuilder label: @escaping () -> Label,
+        @ViewBuilder optionLabel: @escaping (Value) -> OptionLabel)
+    {
+        self._selection = selection
+        self.options = options
+        self.label = label
+        self.optionLabel = optionLabel
+    }
+
+    var body: some View {
+        LabeledContent {
+            Menu {
+                ForEach(self.options, id: \.self) { option in
+                    Button {
+                        self.selection = option
+                    } label: {
+                        HStack {
+                            if self.selection == option {
+                                Image(systemName: "checkmark")
+                            }
+                            self.optionLabel(option)
+                        }
+                    }
+                }
+            } label: {
+                self.optionLabel(self.selection)
+                    .foregroundStyle(.primary)
+            }
+            .menuStyle(.button)
+            .buttonStyle(.borderless)
+            .fixedSize()
+        } label: {
+            self.label()
+        }
+    }
+}
+
+enum GeneralSettingsMenuOptions {
+    static let languages = AppLanguage.allCases.map(\.rawValue)
+    static let refreshFrequencies = RefreshFrequency.allCases
+
+    static func terminalApps(selected: TerminalApp) -> [TerminalApp] {
+        TerminalApp.pickerOptions(selected: selected)
+    }
+
+    static func terminalApps(
+        selected: TerminalApp,
+        applicationURL: (String) -> URL?) -> [TerminalApp]
+    {
+        TerminalApp.pickerOptions(selected: selected, applicationURL: applicationURL)
+    }
+}

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -49,6 +49,40 @@ struct PreferencesPaneSmokeTests {
     }
 
     @Test
+    func `general menu options cover persisted settings`() {
+        let previousLanguage = UserDefaults.standard.object(forKey: "appLanguage")
+        let previousAppleLanguages = UserDefaults.standard.object(forKey: "AppleLanguages")
+        defer {
+            if let previousLanguage {
+                UserDefaults.standard.set(previousLanguage, forKey: "appLanguage")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "appLanguage")
+            }
+            if let previousAppleLanguages {
+                UserDefaults.standard.set(previousAppleLanguages, forKey: "AppleLanguages")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+            }
+        }
+
+        #expect(GeneralSettingsMenuOptions.languages == AppLanguage.allCases.map(\.rawValue))
+        #expect(GeneralSettingsMenuOptions.refreshFrequencies == RefreshFrequency.allCases)
+        #expect(GeneralSettingsMenuOptions.terminalApps(selected: .terminal) { _ in nil } == [.terminal])
+        #expect(GeneralSettingsMenuOptions.terminalApps(selected: .iTerm) { _ in nil } == [.terminal, .iTerm])
+
+        let suite = "PreferencesPaneSmokeTests-general-menu-persistence"
+        let settings = Self.makeSettingsStore(suite: suite)
+        settings.appLanguage = "ja"
+        settings.terminalApp = .iTerm
+        settings.refreshFrequency = .fiveMinutes
+
+        let reloaded = Self.makeSettingsStore(suite: suite, reset: false)
+        #expect(reloaded.appLanguage == "ja")
+        #expect(reloaded.terminalApp == .iTerm)
+        #expect(reloaded.refreshFrequency == .fiveMinutes)
+    }
+
+    @Test
     func `overview provider limit text formats numeric limit as object argument`() {
         let text = DisplayPane.overviewProviderLimitText(limit: 3)
 
@@ -180,10 +214,12 @@ struct PreferencesPaneSmokeTests {
         }
     }
 
-    private static func makeSettingsStore(suite: String) -> SettingsStore {
+    private static func makeSettingsStore(suite: String, reset: Bool = true) -> SettingsStore {
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-        let configStore = testConfigStore(suiteName: suite)
+        if reset {
+            defaults.removePersistentDomain(forName: suite)
+        }
+        let configStore = testConfigStore(suiteName: suite, reset: reset)
 
         return SettingsStore(
             userDefaults: defaults,


### PR DESCRIPTION
Fixes #1904.

## Summary

- Replace the three affected SwiftUI picker menu paths with explicit menu-backed settings selectors.
- Preserve language labels, installed-terminal filtering, settings bindings, and refresh cadence order.
- Add stable option and persistence regression coverage.

## Root cause

On macOS 27.0 (26A5368g), apps linked with the macOS 26.5 SDK produce disabled menu rows for these SwiftUI pickers. The same source linked with the macOS 27 SDK remains interactive. Signed 0.38.1 and 0.40.0 builds and current `main` built with the stable SDK reproduced the failure.

## Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter PreferencesPaneSmokeTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test` (all 48 shards)
- Exact-head debug app packaged with SDK 26.5 on macOS 27.0: Language, Default Terminal, and Refresh cadence menus all opened with enabled choices.
- Changed the three settings, terminated/relaunched the app, reopened Settings, and confirmed the persisted selections.
- Autoreview clean; Public Model Identifier Gate PASS; no dependency changes.

UI captures remain local and were not uploaded.
