### PR TITLE
Fix Devin 1% usage inflating to 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.
 - Codex quotas: show the session quota as unavailable while an exhausted weekly limit is still binding, including menu-bar icons and widgets. Thanks @Yuxin-Qiao!
 - Codex cost history: reuse cached aggregate pricing and one pricing catalog across daily and project reports, carry fresh cache state across launches, and treat unpriced models as migrated, avoiding repeated row scans, filesystem work, and duplicate background scans on large local histories.
+- Devin: keep exact 1% usage from being inflated to 100% while preserving fractional fallback quota semantics. Thanks @Lex-ic-on!
 - Kimi K2: reject invalid and out-of-range numeric timestamps while preserving valid second and millisecond values. Thanks @joeVenner!
 - Kimi K2: reject non-finite credit and token values before they reach menus, CLI output, or widgets. Thanks @joeVenner!
 - Kimi: show the five-hour rate limit before the weekly quota while preserving existing menu-bar metric preferences. Thanks @Zihao-Qi!

--- a/Sources/CodexBarCore/Providers/Devin/DevinUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinUsageSnapshot.swift
@@ -146,7 +146,7 @@ public enum DevinUsageParser {
     private static func currentQuotaWindow(percent: Any?, resetsAt: Any?) -> DevinQuotaWindow? {
         guard let usedPercent = self.double(percent) else { return nil }
         return DevinQuotaWindow(
-            usedPercent: usedPercent <= 1 ? usedPercent * 100 : usedPercent,
+            usedPercent: usedPercent < 1 ? usedPercent * 100 : usedPercent,
             resetsAt: self.date(from: resetsAt))
     }
 
@@ -196,7 +196,7 @@ public enum DevinUsageParser {
 
     private static func percent(from object: Any) -> Double? {
         if let number = self.double(object) {
-            return number <= 1 ? number * 100 : number
+            return number < 1 ? number * 100 : number
         }
         guard let dictionary = object as? [String: Any] else { return nil }
 
@@ -211,14 +211,14 @@ public enum DevinUsageParser {
         ]
         for key in directKeys {
             if let value = self.double(dictionary[key]) {
-                return value <= 1 ? value * 100 : value
+                return value < 1 ? value * 100 : value
             }
         }
 
         let remainingKeys = ["remaining_percent", "remainingPercent", "percent_remaining", "percentRemaining"]
         for key in remainingKeys {
             if let value = self.double(dictionary[key]) {
-                let percent = value <= 1 ? value * 100 : value
+                let percent = value < 1 ? value * 100 : value
                 return 100 - percent
             }
         }

--- a/Sources/CodexBarCore/Providers/Devin/DevinUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinUsageSnapshot.swift
@@ -196,7 +196,7 @@ public enum DevinUsageParser {
 
     private static func percent(from object: Any) -> Double? {
         if let number = self.double(object) {
-            return number < 1 ? number * 100 : number
+            return number <= 1 ? number * 100 : number
         }
         guard let dictionary = object as? [String: Any] else { return nil }
 
@@ -211,15 +211,13 @@ public enum DevinUsageParser {
         ]
         for key in directKeys {
             if let value = self.double(dictionary[key]) {
-                return value < 1 ? value * 100 : value
+                return value <= 1 ? value * 100 : value
             }
         }
 
         let remainingKeys = ["remaining_percent", "remainingPercent", "percent_remaining", "percentRemaining"]
         for key in remainingKeys {
             if let value = self.double(dictionary[key]) {
-                // remaining_percent uses fractional representation (0..1), so 1 = 100% remaining = 0% used.
-                // Keep `<= 1` here unlike the used-percent paths where 1 means integer 1%.
                 let percent = value <= 1 ? value * 100 : value
                 return 100 - percent
             }

--- a/Sources/CodexBarCore/Providers/Devin/DevinUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinUsageSnapshot.swift
@@ -218,7 +218,9 @@ public enum DevinUsageParser {
         let remainingKeys = ["remaining_percent", "remainingPercent", "percent_remaining", "percentRemaining"]
         for key in remainingKeys {
             if let value = self.double(dictionary[key]) {
-                let percent = value < 1 ? value * 100 : value
+                // remaining_percent uses fractional representation (0..1), so 1 = 100% remaining = 0% used.
+                // Keep `<= 1` here unlike the used-percent paths where 1 means integer 1%.
+                let percent = value <= 1 ? value * 100 : value
                 return 100 - percent
             }
         }

--- a/Tests/CodexBarTests/DevinUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DevinUsageFetcherTests.swift
@@ -157,6 +157,27 @@ struct DevinUsageFetcherTests {
     }
 
     @Test
+    func `parses remaining percent 1 as fully unused quota`() throws {
+        let response: [String: Any] = [
+            "quota_usage": [
+                "daily_quota": [
+                    "used": 0,
+                    "limit": 10,
+                    "reset_at": "2026-06-01T08:00:00Z",
+                ],
+                "weekly_quota": [
+                    "remaining_percent": 1,
+                    "next_reset_at": 1_780_560_000,
+                ],
+            ],
+        ]
+
+        let snapshot = try DevinUsageParser.parse(response, organization: nil, now: Self.now)
+
+        #expect(snapshot.weekly?.usedPercent == 0)
+    }
+
+    @Test
     func `parses zero percentages from JSON response`() throws {
         let data = Data("""
         {

--- a/Tests/CodexBarTests/DevinUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DevinUsageFetcherTests.swift
@@ -142,18 +142,23 @@ struct DevinUsageFetcherTests {
     }
 
     @Test
-    func `parses integer 1 percent without inflating to 100`() throws {
-        let response: [String: Any] = [
-            "daily_percentage": 1,
-            "weekly_percentage": 1,
-            "daily_reset_at": "2026-06-11T00:00:00-08:00",
-            "weekly_reset_at": "2026-06-14T00:00:00-08:00",
+    func `normalizes mixed-scale current percentages at the one-percent boundary`() throws {
+        let cases: [(input: Double, expected: Double)] = [
+            (0.5, 50),
+            (1, 1),
+            (1.5, 1.5),
         ]
 
-        let snapshot = try DevinUsageParser.parse(response, organization: nil, now: Self.now)
+        for value in cases {
+            let response: [String: Any] = [
+                "daily_percentage": value.input,
+                "weekly_percentage": value.input,
+            ]
+            let snapshot = try DevinUsageParser.parse(response, organization: nil, now: Self.now)
 
-        #expect(snapshot.daily?.usedPercent == 1)
-        #expect(snapshot.weekly?.usedPercent == 1)
+            #expect(snapshot.daily?.usedPercent == value.expected)
+            #expect(snapshot.weekly?.usedPercent == value.expected)
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/DevinUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DevinUsageFetcherTests.swift
@@ -157,12 +157,11 @@ struct DevinUsageFetcherTests {
     }
 
     @Test
-    func `parses remaining percent 1 as fully unused quota`() throws {
+    func `preserves fractional boundaries for fallback quota percentages`() throws {
         let response: [String: Any] = [
             "quota_usage": [
                 "daily_quota": [
-                    "used": 0,
-                    "limit": 10,
+                    "used_percent": 1,
                     "reset_at": "2026-06-01T08:00:00Z",
                 ],
                 "weekly_quota": [
@@ -174,6 +173,7 @@ struct DevinUsageFetcherTests {
 
         let snapshot = try DevinUsageParser.parse(response, organization: nil, now: Self.now)
 
+        #expect(snapshot.daily?.usedPercent == 100)
         #expect(snapshot.weekly?.usedPercent == 0)
     }
 

--- a/Tests/CodexBarTests/DevinUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DevinUsageFetcherTests.swift
@@ -142,6 +142,21 @@ struct DevinUsageFetcherTests {
     }
 
     @Test
+    func `parses integer 1 percent without inflating to 100`() throws {
+        let response: [String: Any] = [
+            "daily_percentage": 1,
+            "weekly_percentage": 1,
+            "daily_reset_at": "2026-06-11T00:00:00-08:00",
+            "weekly_reset_at": "2026-06-14T00:00:00-08:00",
+        ]
+
+        let snapshot = try DevinUsageParser.parse(response, organization: nil, now: Self.now)
+
+        #expect(snapshot.daily?.usedPercent == 1)
+        #expect(snapshot.weekly?.usedPercent == 1)
+    }
+
+    @Test
     func `parses zero percentages from JSON response`() throws {
         let data = Data("""
         {


### PR DESCRIPTION
## Summary

- Treat exact `1` from Devin's current top-level daily and weekly percentage fields as one percent instead of multiplying it to one hundred percent.
- Preserve the existing fractional 0…1 contract for fallback quota objects.
- Lock the mixed-scale boundary below, at, and above one, plus both fallback boundary meanings.
- Credit @Lex-ic-on in the changelog.

## User-visible effect

Contributor live CLI proof shows the reported Devin daily and weekly state changing from `0% left` to the correct `99% left` after the fix.

## Verification

- Focused Devin suite: 26/26 passed.
- Source-blind public parser/snapshot contract: 6/6 passed for current and fallback percentage semantics.
- `make check`: passed.
- Full local `make test`: all 48 shards passed.
- Autoreview: clean, 0.98 confidence.
- Public Model Identifier Gate: PASS; no model identifiers changed.
- Dependency freshness: no dependency changes.

Exact locally proven head: `95d5048638f09a519fa271695aee2aa69eb07a2c`.
