### PR TITLE
Point Ollama login recovery to the current sign-in page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Claude: distinguish Max 5x and Max 20x in the plan label instead of a flat "Max". Thanks @kes02!
 
 ### Fixed
+- Ollama: point missing-session recovery to the current `/signin` page instead of the protected settings page. Thanks @joeVenner!
 - Alibaba Token Plan: support International Model Studio while preserving China-mainland upgrades and isolating regional cookie caches. Thanks @harshav167!
 - Amp: open the current Usage page from the menu dashboard action. Thanks @3kh0!
 - Browser cookies: stop automatic Chromium-family probes after the first Safe Storage denial, while keeping an explicit Refresh retry available (#1952). Thanks @CoreyCole!

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -43,7 +43,7 @@ public enum OllamaUsageError: LocalizedError, Sendable {
         case .missingAPIKey:
             "Missing Ollama API key. Set apiKey in ~/.codexbar/config.json or OLLAMA_API_KEY."
         case .notLoggedIn:
-            "Not logged in to Ollama. Please log in via ollama.com/settings."
+            "Not signed in to Ollama. Please sign in at https://ollama.com/signin."
         case .invalidCredentials:
             "Ollama session cookie expired. Please log in again."
         case .apiUnauthorized:
@@ -53,7 +53,7 @@ public enum OllamaUsageError: LocalizedError, Sendable {
         case let .networkError(message):
             "Ollama request failed: \(message)"
         case .noSessionCookie:
-            "No Ollama session cookie found. Please log in to ollama.com in your browser."
+            "No Ollama session cookie found. Please sign in at https://ollama.com/signin in your browser."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -30,6 +30,8 @@ private func hasRecognizedOllamaSessionCookie(in header: String) -> Bool {
 }
 
 public enum OllamaUsageError: LocalizedError, Sendable {
+    private static let signInURL = "https://ollama.com/signin"
+
     case missingAPIKey
     case notLoggedIn
     case invalidCredentials
@@ -43,9 +45,9 @@ public enum OllamaUsageError: LocalizedError, Sendable {
         case .missingAPIKey:
             "Missing Ollama API key. Set apiKey in ~/.codexbar/config.json or OLLAMA_API_KEY."
         case .notLoggedIn:
-            "Not signed in to Ollama. Please sign in at https://ollama.com/signin."
+            "Not signed in to Ollama. Please sign in at \(Self.signInURL)."
         case .invalidCredentials:
-            "Ollama session cookie expired. Please log in again."
+            "Ollama session cookie expired. Please sign in again at \(Self.signInURL)."
         case .apiUnauthorized:
             "Ollama API key is invalid or revoked."
         case let .parseFailed(message):
@@ -53,7 +55,7 @@ public enum OllamaUsageError: LocalizedError, Sendable {
         case let .networkError(message):
             "Ollama request failed: \(message)"
         case .noSessionCookie:
-            "No Ollama session cookie found. Please sign in at https://ollama.com/signin in your browser."
+            "No Ollama session cookie found. Please sign in at \(Self.signInURL) in your browser."
         }
     }
 }

--- a/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
@@ -4,6 +4,12 @@ import Testing
 
 struct OllamaUsageFetcherTests {
     @Test
+    func `sign in errors point to current recovery page`() {
+        #expect(OllamaUsageError.notLoggedIn.errorDescription?.contains("https://ollama.com/signin") == true)
+        #expect(OllamaUsageError.noSessionCookie.errorDescription?.contains("https://ollama.com/signin") == true)
+    }
+
+    @Test
     func `attaches cookie for ollama hosts`() {
         #expect(OllamaUsageFetcher.shouldAttachCookie(to: URL(string: "https://ollama.com/settings")))
         #expect(OllamaUsageFetcher.shouldAttachCookie(to: URL(string: "https://www.ollama.com")))

--- a/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
@@ -4,8 +4,9 @@ import Testing
 
 struct OllamaUsageFetcherTests {
     @Test
-    func `sign in errors point to current recovery page`() {
+    func `session authentication errors point to current recovery page`() {
         #expect(OllamaUsageError.notLoggedIn.errorDescription?.contains("https://ollama.com/signin") == true)
+        #expect(OllamaUsageError.invalidCredentials.errorDescription?.contains("https://ollama.com/signin") == true)
         #expect(OllamaUsageError.noSessionCookie.errorDescription?.contains("https://ollama.com/signin") == true)
     }
 

--- a/docs/ollama.md
+++ b/docs/ollama.md
@@ -48,12 +48,12 @@ Ollama API keys currently do not expire, but they can be revoked from the key se
 
 ### “No Ollama session cookie found”
 
-Log in to `https://ollama.com/settings` in Chrome, then refresh in CodexBar.
+Sign in at `https://ollama.com/signin` in Chrome, then refresh CodexBar.
 If your active session is only in Safari (or another browser), use **Cookie source → Manual** and paste a cookie header.
 
 ### “Ollama session cookie expired”
 
-Sign out and back in at `https://ollama.com/settings`, then refresh.
+Sign out and back in at `https://ollama.com/signin`, then refresh.
 
 ### “Could not parse Ollama usage”
 


### PR DESCRIPTION
## Summary

- Point Ollama signed-out and missing-session recovery at `https://ollama.com/signin` instead of the protected settings page.
- Give expired session cookies the same direct recovery URL.
- Centralize the URL so all three session-auth errors stay consistent.
- Update troubleshooting docs and add a maintainer changelog entry with @joeVenner credit.

## Live proof

The contributor observed this signed-out response on 2026-07-06:

```text
GET https://ollama.com/settings
HTTP/2 303
location: /signin
```

Maintainer re-verification on 2026-07-06 opened both `https://ollama.com/settings` and `https://ollama.com/signin`; each reached Ollama's live sign-in service and rendered the Sign in page. No browser cookie or Keychain access was used.

## Implementation

`OllamaUsageError.notLoggedIn`, `.invalidCredentials`, and `.noSessionCookie` now share one canonical sign-in URL. The focused test locks all three error descriptions, while parser coverage confirms signed-out page classification still reaches the same error path.

## Validation

- `swift test --filter OllamaUsageFetcherTests` — 19 tests passed
- `swift test --filter OllamaUsageParserTests` — 9 tests passed
- `make check` — passed with 0 format or lint violations
- `make test` — all 49 current groups passed
- Final aggregate autoreview — no accepted/actionable findings
- Live redirect target re-verified on 2026-07-06

## Risk

Very low: error recovery copy, focused tests, docs, and changelog only. Dependencies and credential handling are unchanged.
