### PR TITLE
Show <1% for all sub-1% usage, not just under 0.5%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Amp: open the current Usage page from the menu dashboard action. Thanks @3kh0!
 - Settings: keep Language, Default Terminal, and Refresh cadence selectors interactive on macOS 27.
+- Usage formatting: show every positive sub-1% value as `<1%` instead of rounding values above 0.5% up to `1%`. Thanks @devYRPauli!
 - Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.
 - Codex quotas: show the session quota as unavailable while an exhausted weekly limit is still binding, including menu-bar icons and widgets. Thanks @Yuxin-Qiao!
 - Codex cost history: reuse cached aggregate pricing and one pricing catalog across daily and project reports, carry fresh cache state across launches, and treat unpriced models as migrated, avoiding repeated row scans, filesystem work, and duplicate background scans on large local histories.

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1015,6 +1015,7 @@
 "minimax_service_coding_plan_search" = "Coding Plan 搜尋";
 "Clearing removes old plan-mode files." = "會移除舊的 plan-mode 檔案。";
 "%.0f%% %@" = "%2$@ %1$.0f%%";
+"<1%% %@" = "%1$@ <1%%";
 "%@: %@%% used" = "%@：已使用 %@%%";
 "terminal_app_subtitle" = "「開啟終端」動作使用的終端";
 "Admin API key" = "Admin API 金鑰";

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -82,9 +82,10 @@ public enum UsageFormatter {
 
     public static func percentText(_ percent: Double, suffix: String) -> String {
         let clamped = min(100, max(0, percent))
-        let text = self.localized("%.0f%% %@", clamped, suffix)
-        guard clamped > 0, clamped < 1 else { return text }
-        return text.replacingOccurrences(of: "0%", with: "<1%")
+        if clamped > 0, clamped < 1 {
+            return self.localized("<1%% %@", suffix)
+        }
+        return self.localized("%.0f%% %@", clamped, suffix)
     }
 
     public static func usageLine(remaining: Double, used: Double, showUsed: Bool) -> String {

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -54,6 +54,12 @@ struct UsageFormatterTests {
         #expect(UsageFormatter.percentString(1) == "1%")
         #expect(UsageFormatter.percentString(101) == "100%")
         #expect(UsageFormatter.usageLine(remaining: 99.9, used: 0.1, showUsed: true) == "<1% used")
+        // Values in (0.5, 1) round up to "1%" under %.0f, so the old post-format
+        // "0%" -> "<1%" replacement missed them. percentText must show "<1%"
+        // across the whole sub-1% range, matching percentString above.
+        #expect(UsageFormatter.usageLine(remaining: 99.4, used: 0.6, showUsed: true) == "<1% used")
+        #expect(UsageFormatter.usageLine(remaining: 99.25, used: 0.75, showUsed: true) == "<1% used")
+        #expect(UsageFormatter.usageLine(remaining: 0.75, used: 99.25, showUsed: false) == "<1% left")
 
         let usedWindow = RateWindow(usedPercent: 0.1, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
         let leftWindow = RateWindow(usedPercent: 99.9, windowMinutes: nil, resetsAt: nil, resetDescription: nil)

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -72,6 +72,7 @@ struct UsageFormatterTests {
         UsageFormatter.setLocalizationProvider { key in
             switch key {
             case "%.0f%% %@": "%2$@ %1$.0f%%"
+            case "<1%% %@": "%1$@ <1%%"
             case "usage_percent_suffix_left": "剩余"
             case "usage_percent_suffix_used": "已使用"
             default: key
@@ -81,6 +82,8 @@ struct UsageFormatterTests {
 
         #expect(UsageFormatter.usageLine(remaining: 22, used: 78, showUsed: false) == "剩余 22%")
         #expect(UsageFormatter.usageLine(remaining: 22, used: 78, showUsed: true) == "已使用 78%")
+        #expect(UsageFormatter.usageLine(remaining: 0.75, used: 99.25, showUsed: false) == "剩余 <1%")
+        #expect(UsageFormatter.usageLine(remaining: 99.4, used: 0.6, showUsed: true) == "已使用 <1%")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- render every positive sub-1% usage value as `<1%` instead of rounding values above 0.5% to `1%`
- preserve zero, exact-one, and capped-at-100 behavior
- preserve Traditional Chinese suffix-first ordering and lock it with regression coverage
- add changelog credit for @devYRPauli

`percentText` previously formatted with `%.0f` before trying to rewrite `0%`. Values in `[0.5%, 1%)` therefore rounded to `1%` before the rewrite could apply. The fix handles the sub-1 range before integer formatting, matching `percentString`.

## Behavior proof

Before on `main`:

```text
0.6% used  -> 1% used
0.75% used -> 1% used
0.99% used -> 1% used
0.75% left -> 1% left
```

After on this branch:

```text
0.6% used  -> <1% used
0.75% used -> <1% used
0.99% used -> <1% used
0.75% left -> <1% left
```

A source-blind executable linked against the public `CodexBarCore` API passed 9/9 probes covering zero, one, the 100% cap, values below and above the old rounding boundary, used/left output, and suffix-first localization.

## Testing

- `swift test --disable-sandbox --filter UsageFormatterTests` (42 passed)
- source-blind public formatter contract (9/9 passed)
- `make check` (SwiftFormat clean; SwiftLint 0 violations)
- `make test` (48/48 shards passed)
- autoreview clean (0.98 confidence)
- `git diff --check`
