### PR TITLE
Roll Claude reset date forward across the year boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Amp: open the current Usage page from the menu dashboard action. Thanks @3kh0!
+- Claude: keep yearless reset dates in the upcoming year when a quota crosses New Year's Day. Thanks @devYRPauli!
 - Settings: keep Language, Default Terminal, and Refresh cadence selectors interactive on macOS 27.
 - Usage formatting: show every positive sub-1% value as `<1%` instead of rounding values above 0.5% up to `1%`. Thanks @devYRPauli!
 - Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -659,10 +659,7 @@ public struct ClaudeStatusProbe: Sendable {
         return calendar.date(byAdding: .day, value: 1, to: anchored)
     }
 
-    /// The date+time reset formats carry no year, so `defaultDate` fills in the
-    /// current year. Near a year boundary that puts a "Jan 2" reset read on
-    /// "Dec 31" into the past; roll it forward a year, mirroring the time-only
-    /// branches above and CodexStatusProbe.bumpYearIfNeeded.
+    /// Yearless dates parsed just before New Year's can otherwise land nearly a year in the past.
     private static func bumpYearIfNeeded(_ date: Date?, now: Date, calendar: Calendar) -> Date? {
         guard let date else { return nil }
         if date >= now { return date }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -628,13 +628,13 @@ public struct ClaudeStatusProbe: Sendable {
         if let date = self.parseDate(raw, formats: Self.resetDateTimeWithMinutes, formatter: formatter) {
             var comps = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: date)
             comps.second = 0
-            return calendar.date(from: comps)
+            return self.bumpYearIfNeeded(calendar.date(from: comps), now: now, calendar: calendar)
         }
         if let date = self.parseDate(raw, formats: Self.resetDateTimeHourOnly, formatter: formatter) {
             var comps = calendar.dateComponents([.year, .month, .day, .hour], from: date)
             comps.minute = 0
             comps.second = 0
-            return calendar.date(from: comps)
+            return self.bumpYearIfNeeded(calendar.date(from: comps), now: now, calendar: calendar)
         }
 
         if let time = self.parseDate(raw, formats: Self.resetTimeWithMinutes, formatter: formatter) {
@@ -657,6 +657,16 @@ public struct ClaudeStatusProbe: Sendable {
             of: now) else { return nil }
         if anchored >= now { return anchored }
         return calendar.date(byAdding: .day, value: 1, to: anchored)
+    }
+
+    /// The date+time reset formats carry no year, so `defaultDate` fills in the
+    /// current year. Near a year boundary that puts a "Jan 2" reset read on
+    /// "Dec 31" into the past; roll it forward a year, mirroring the time-only
+    /// branches above and CodexStatusProbe.bumpYearIfNeeded.
+    private static func bumpYearIfNeeded(_ date: Date?, now: Date, calendar: Calendar) -> Date? {
+        guard let date else { return nil }
+        if date >= now { return date }
+        return calendar.date(byAdding: .year, value: 1, to: date)
     }
 
     private static let resetTimeWithMinutes = ["h:mma", "h:mm a", "HH:mm", "H:mm"]

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -665,14 +665,18 @@ struct StatusProbeTests {
         calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
         let now = try #require(calendar.date(from: DateComponents(
             year: 2026, month: 12, day: 31, hour: 23, minute: 0, second: 0)))
-        // Reset text carries no year; on Dec 31 a "Jan 2" reset must resolve to
-        // next year (a few hours ahead), not the current year (~a year in the past).
-        let parsed = ClaudeStatusProbe.parseResetDate(from: "Resets Jan 2, 3:00am (UTC)", now: now)
-        let expected = calendar.date(from: DateComponents(
-            year: 2027, month: 1, day: 2, hour: 3, minute: 0, second: 0))
-        #expect(parsed == expected)
-        let resolved = try #require(parsed)
-        #expect(resolved > now)
+        let cases = [
+            ("Resets Jan 2, 3:15am (UTC)", 15),
+            ("Resets Jan 2, 3am (UTC)", 0),
+        ]
+
+        for (text, minute) in cases {
+            let parsed = ClaudeStatusProbe.parseResetDate(from: text, now: now)
+            let expected = calendar.date(from: DateComponents(
+                year: 2027, month: 1, day: 2, hour: 3, minute: minute, second: 0))
+            #expect(parsed == expected, "Failed to roll forward: \(text)")
+            #expect(try #require(parsed) > now)
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -660,6 +660,22 @@ struct StatusProbeTests {
     }
 
     @Test
+    func `rolls claude reset date forward across the year boundary`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026, month: 12, day: 31, hour: 23, minute: 0, second: 0)))
+        // Reset text carries no year; on Dec 31 a "Jan 2" reset must resolve to
+        // next year (a few hours ahead), not the current year (~a year in the past).
+        let parsed = ClaudeStatusProbe.parseResetDate(from: "Resets Jan 2, 3:00am (UTC)", now: now)
+        let expected = calendar.date(from: DateComponents(
+            year: 2027, month: 1, day: 2, hour: 3, minute: 0, second: 0))
+        #expect(parsed == expected)
+        let resolved = try #require(parsed)
+        #expect(resolved > now)
+    }
+
+    @Test
     func `parses claude reset with dot separated time`() throws {
         let now = Date(timeIntervalSince1970: 1_733_690_000)
         let parsed = ClaudeStatusProbe.parseResetDate(from: "Resets Dec 9 at 5.27am (UTC)", now: now)


### PR DESCRIPTION
## Summary

- Roll yearless Claude date-and-time quota resets into the next year when their current-year interpretation is already in the past.
- Apply the behavior to both minute-bearing and hour-only reset formats, matching the existing Codex parser contract.
- Add focused year-boundary coverage and changelog credit for @devYRPauli.

## User-visible effect

On December 31, a Claude reset such as `Jan 2, 3:15am` now remains an upcoming reset. Previously it parsed as January of the current year, causing countdown surfaces to show `now` and active-window checks to treat the quota as expired.

## Verification

- Focused status-probe selection: 253 passed.
- Source-blind public API contract: 5/5 passed for both changed formats, same-year preservation, downstream countdown text, and invalid input.
- `make check`: passed.
- Full local `make test`: all 48 shards passed.
- Autoreview: clean, 0.99 confidence.
- Public Model Identifier Gate: PASS; no model identifiers changed.
- Dependency freshness: no dependency changes.
