### PR TITLE
Keep fractional Claude web utilization instead of dropping it to 0%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Amp: open the current Usage page from the menu dashboard action. Thanks @3kh0!
 - Claude: keep yearless reset dates in the upcoming year when a quota crosses New Year's Day. Thanks @devYRPauli!
+- Claude web: preserve fractional session and weekly utilization instead of displaying it as zero or unavailable. Thanks @devYRPauli!
 - Settings: keep Language, Default Terminal, and Refresh cadence selectors interactive on macOS 27.
 - Usage formatting: show every positive sub-1% value as `<1%` instead of rounding values above 0.5% up to `1%`. Thanks @devYRPauli!
 - Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -614,9 +614,7 @@ public enum ClaudeWebAPIFetcher {
         var sessionResets: Date?
         let fiveHour = json["five_hour"] as? [String: Any]
         if let fiveHour {
-            if let utilization = fiveHour["utilization"] as? Int {
-                sessionPercent = Double(utilization)
-            }
+            sessionPercent = Self.percentValue(from: fiveHour["utilization"])
             if let resetsAt = fiveHour["resets_at"] as? String {
                 sessionResets = self.parseISO8601Date(resetsAt)
             }
@@ -631,9 +629,7 @@ public enum ClaudeWebAPIFetcher {
         var weeklyPercent: Double?
         var weeklyResets: Date?
         if let sevenDay = json["seven_day"] as? [String: Any] {
-            if let utilization = sevenDay["utilization"] as? Int {
-                weeklyPercent = Double(utilization)
-            }
+            weeklyPercent = Self.percentValue(from: sevenDay["utilization"])
             if let resetsAt = sevenDay["resets_at"] as? String {
                 weeklyResets = self.parseISO8601Date(resetsAt)
             }

--- a/Tests/CodexBarTests/RateWindowSyntheticPlaceholderTests.swift
+++ b/Tests/CodexBarTests/RateWindowSyntheticPlaceholderTests.swift
@@ -102,10 +102,7 @@ struct RateWindowSyntheticPlaceholderTests {
     }
 
     @Test
-    func `web mapping keeps a fractional utilization instead of dropping it to zero`() throws {
-        // Claude web can report a fractional utilization (the OAuth model types it as Double).
-        // A decimal like 45.5 must survive parsing; an Int-only cast drops it to nil -> a phantom
-        // "0% used" on a genuinely live, ~45%-used session.
+    func `web mapping keeps fractional session and weekly utilization`() throws {
         let json = """
         {
           "five_hour": { "utilization": 45.5, "resets_at": "2025-12-29T20:00:00.000Z" },
@@ -120,6 +117,7 @@ struct RateWindowSyntheticPlaceholderTests {
         let primary = ClaudeUsageFetcher.webPrimaryWindow(from: webData)
         #expect(primary.isSyntheticPlaceholder == false)
         #expect(primary.usedPercent == 45.5)
+        #expect(primary.remainingPercent == 54.5)
     }
 
     @Test

--- a/Tests/CodexBarTests/RateWindowSyntheticPlaceholderTests.swift
+++ b/Tests/CodexBarTests/RateWindowSyntheticPlaceholderTests.swift
@@ -102,6 +102,27 @@ struct RateWindowSyntheticPlaceholderTests {
     }
 
     @Test
+    func `web mapping keeps a fractional utilization instead of dropping it to zero`() throws {
+        // Claude web can report a fractional utilization (the OAuth model types it as Double).
+        // A decimal like 45.5 must survive parsing; an Int-only cast drops it to nil -> a phantom
+        // "0% used" on a genuinely live, ~45%-used session.
+        let json = """
+        {
+          "five_hour": { "utilization": 45.5, "resets_at": "2025-12-29T20:00:00.000Z" },
+          "seven_day": { "utilization": 12.25, "resets_at": "2025-12-29T23:00:00.000Z" }
+        }
+        """
+        let webData = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(Data(json.utf8))
+        #expect(webData.sessionPercentUsed == 45.5)
+        #expect(webData.weeklyPercentUsed == 12.25)
+        #expect(webData.hasLiveSessionWindow == true)
+
+        let primary = ClaudeUsageFetcher.webPrimaryWindow(from: webData)
+        #expect(primary.isSyntheticPlaceholder == false)
+        #expect(primary.usedPercent == 45.5)
+    }
+
+    @Test
     func `web mapping keeps a real zero-usage session that omits a reset`() throws {
         // A reported `five_hour` object at 0% with no `resets_at` is a real idle session, not the
         // `five_hour: null` placeholder. The flag keys off object presence (not percent/reset), so this


### PR DESCRIPTION
## Summary

- Preserve fractional utilization from Claude web's five-hour and seven-day quota windows.
- Reuse the established fractional parser already used by adjacent Claude quota lanes.
- Verify both decoded values plus the downstream session window's used and remaining percentages.
- Add changelog credit for @devYRPauli.

## User-visible effect

Claude web values such as `45.5` no longer fall through an integer-only cast and appear as a false `0% used` session or an unavailable weekly quota.

## Verification

- Focused placeholder/window suite: 8/8 passed.
- Source-blind compiled parser contract: 6/6 passed, including fractional and integer values, reset preservation, live-session classification, and the null-session fallback.
- `make check`: passed.
- Full local `make test`: all 48 shards passed.
- Autoreview: clean, 0.98 confidence.
- Public Model Identifier Gate: PASS; no model identifiers changed.
- Dependency freshness: no dependency changes.
