### PR TITLE
Do not fabricate a 0% Gemini primary window when there is no Pro tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Amp: open the current Usage page from the menu dashboard action. Thanks @3kh0!
 - Claude: keep yearless reset dates in the upcoming year when a quota crosses New Year's Day. Thanks @devYRPauli!
 - Claude web: preserve fractional session and weekly utilization instead of displaying it as zero or unavailable. Thanks @devYRPauli!
+- Gemini: use the real Flash quota in menu-bar metrics when an account has no Pro quota. Thanks @devYRPauli!
 - Settings: keep Language, Default Terminal, and Refresh cadence selectors interactive on macOS 27.
 - Usage formatting: show every positive sub-1% value as `<1%` instead of rounding values above 0.5% up to `1%`. Thanks @devYRPauli!
 - Codex menu: hide error-only optional Credits and OpenAI web setup diagnostics while keeping them visible in provider Settings.

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -50,11 +50,17 @@ public struct GeminiStatusSnapshot: Sendable {
         let flashMin = flashQuotas.min(by: { $0.percentLeft < $1.percentLeft })
         let proMin = proQuotas.min(by: { $0.percentLeft < $1.percentLeft })
 
-        let primary = RateWindow(
-            usedPercent: proMin.map { 100 - $0.percentLeft } ?? 0,
-            windowMinutes: 1440,
-            resetsAt: proMin?.resetTime,
-            resetDescription: proMin?.resetDescription)
+        // Nil out the primary window when the account has no Pro-tier quota, mirroring
+        // secondary/tertiary. Fabricating a 0%-used Pro window (`?? 0`) makes an account
+        // with only Flash quotas report a phantom "0% used" primary that hides the real
+        // Flash usage downstream (the automatic resolver falls back to `primary ?? secondary`).
+        let primary: RateWindow? = proMin.map {
+            RateWindow(
+                usedPercent: 100 - $0.percentLeft,
+                windowMinutes: 1440,
+                resetsAt: $0.resetTime,
+                resetDescription: $0.resetDescription)
+        }
 
         let secondary: RateWindow? = flashMin.map {
             RateWindow(

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -50,10 +50,7 @@ public struct GeminiStatusSnapshot: Sendable {
         let flashMin = flashQuotas.min(by: { $0.percentLeft < $1.percentLeft })
         let proMin = proQuotas.min(by: { $0.percentLeft < $1.percentLeft })
 
-        // Nil out the primary window when the account has no Pro-tier quota, mirroring
-        // secondary/tertiary. Fabricating a 0%-used Pro window (`?? 0`) makes an account
-        // with only Flash quotas report a phantom "0% used" primary that hides the real
-        // Flash usage downstream (the automatic resolver falls back to `primary ?? secondary`).
+        // Keep missing tiers nil so downstream selectors can fall back to a quota the account actually reports.
         let primary: RateWindow? = proMin.map {
             RateWindow(
                 usedPercent: 100 - $0.percentLeft,

--- a/Tests/CodexBarTests/GeminiPrimaryWindowTests.swift
+++ b/Tests/CodexBarTests/GeminiPrimaryWindowTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct GeminiPrimaryWindowTests {
+    @Test
+    func `flash-only account does not fabricate a phantom 0% primary window`() {
+        // Account with only Flash / Flash-Lite quotas and no Pro-tier model.
+        let snapshot = GeminiStatusSnapshot(
+            modelQuotas: [
+                GeminiModelQuota(modelId: "gemini-2.5-flash", percentLeft: 5, resetTime: nil, resetDescription: nil),
+                GeminiModelQuota(
+                    modelId: "gemini-2.5-flash-lite", percentLeft: 60, resetTime: nil, resetDescription: nil),
+            ],
+            rawText: "",
+            accountEmail: nil,
+            accountPlan: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+
+        // No Pro quota -> primary must be nil, not a phantom 0%-used window that would win
+        // the automatic resolver's `primary ?? secondary` fallback and hide real Flash usage.
+        #expect(usage.primary == nil)
+        #expect(usage.secondary?.usedPercent == 95)
+        #expect(usage.tertiary?.usedPercent == 40)
+    }
+
+    @Test
+    func `pro quota still populates the primary window`() {
+        let snapshot = GeminiStatusSnapshot(
+            modelQuotas: [
+                GeminiModelQuota(modelId: "gemini-2.5-pro", percentLeft: 30, resetTime: nil, resetDescription: nil),
+                GeminiModelQuota(modelId: "gemini-2.5-flash", percentLeft: 70, resetTime: nil, resetDescription: nil),
+            ],
+            rawText: "",
+            accountEmail: nil,
+            accountPlan: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 70)
+        #expect(usage.secondary?.usedPercent == 30)
+    }
+}

--- a/Tests/CodexBarTests/GeminiPrimaryWindowTests.swift
+++ b/Tests/CodexBarTests/GeminiPrimaryWindowTests.swift
@@ -6,7 +6,6 @@ import Testing
 struct GeminiPrimaryWindowTests {
     @Test
     func `flash-only account does not fabricate a phantom 0% primary window`() {
-        // Account with only Flash / Flash-Lite quotas and no Pro-tier model.
         let snapshot = GeminiStatusSnapshot(
             modelQuotas: [
                 GeminiModelQuota(modelId: "gemini-2.5-flash", percentLeft: 5, resetTime: nil, resetDescription: nil),
@@ -19,8 +18,6 @@ struct GeminiPrimaryWindowTests {
 
         let usage = snapshot.toUsageSnapshot()
 
-        // No Pro quota -> primary must be nil, not a phantom 0%-used window that would win
-        // the automatic resolver's `primary ?? secondary` fallback and hide real Flash usage.
         #expect(usage.primary == nil)
         #expect(usage.secondary?.usedPercent == 95)
         #expect(usage.tertiary?.usedPercent == 40)

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -5,6 +5,25 @@ import Testing
 
 struct MenuBarMetricWindowResolverTests {
     @Test
+    func `gemini metrics fall back to Flash when Pro is unavailable`() {
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: RateWindow(usedPercent: 95, windowMinutes: 1440, resetsAt: nil, resetDescription: nil),
+            tertiary: RateWindow(usedPercent: 40, windowMinutes: 1440, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        for preference in [MenuBarMetricPreference.automatic, .primary, .average] {
+            let window = MenuBarMetricWindowResolver.rateWindow(
+                preference: preference,
+                provider: .gemini,
+                snapshot: snapshot,
+                supportsAverage: true)
+
+            #expect(window?.usedPercent == 95, "Failed preference: \(preference)")
+        }
+    }
+
+    @Test
     func `automatic metric uses zai 5-hour token lane when it is most constrained`() {
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 12, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),


### PR DESCRIPTION
## Summary

- Keep Gemini's primary Pro window absent when the account reports no Pro quota.
- Let existing metric selection fall back to the real Flash window instead of a fabricated `0% used` Pro window.
- Cover Flash-only and Pro-present snapshot mapping plus automatic, explicit-primary, and average menu-bar selection.
- Add changelog credit for @devYRPauli.

## User-visible effect

A Flash-only account that is 95% used now shows that real usage in the menu bar. It no longer shows a phantom `0% used` primary lane.

## Verification

- Focused snapshot/resolver suites: 25/25 passed.
- Source-blind public parser contract: 5/5 passed for Flash-only and Pro-present stats tables.
- `make check`: passed.
- Full local `make test`: all 48 shards passed.
- Autoreview: clean, 0.98 confidence.
- Public Model Identifier Gate: PASS; all test identifiers are established released Gemini 2.5 identifiers.
- Dependency freshness: no dependency changes.
