### PR TITLE
Fix repeated Chromium Safe Storage prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Amp: open the current Usage page from the menu dashboard action. Thanks @3kh0!
+- Browser cookies: stop automatic Chromium-family probes after the first Safe Storage denial, while keeping an explicit Refresh retry available (#1952). Thanks @CoreyCole!
 - Claude: keep yearless reset dates in the upcoming year when a quota crosses New Year's Day. Thanks @devYRPauli!
 - Claude web: preserve fractional session and weekly utilization instead of displaying it as zero or unavailable. Thanks @devYRPauli!
 - Gemini: use the real Flash quota in menu-bar metrics when an account has no Pro quota. Thanks @devYRPauli!

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -39,7 +39,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         refreshOpenMenusWhenComplete: Bool,
         interaction: ProviderInteraction) async
     {
-        await ProviderInteractionContext.$current.withValue(interaction) {
+        await self.withProviderInteraction(interaction) {
             await self.store.refresh(forceTokenUsage: forceTokenUsage)
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
             self.store.scheduleStorageFootprintRefreshForOverview(force: true)
@@ -56,7 +56,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         refreshOpenMenusWhenComplete: Bool,
         interaction: ProviderInteraction) async
     {
-        await ProviderInteractionContext.$current.withValue(interaction) {
+        await self.withProviderInteraction(interaction) {
             let refreshStartedAt = Date()
             await self.store.refreshProvider(provider)
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
@@ -84,6 +84,23 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
                 self.refreshOpenMenusAfterExplicitStoreAction()
             } else {
                 self.invalidateMenus()
+            }
+        }
+    }
+
+    private func withProviderInteraction(
+        _ interaction: ProviderInteraction,
+        operation: () async -> Void) async
+    {
+        if interaction == .userInitiated {
+            await BrowserCookieAccessGate.withExplicitRetry {
+                await ProviderInteractionContext.$current.withValue(interaction) {
+                    await operation()
+                }
+            }
+        } else {
+            await ProviderInteractionContext.$current.withValue(interaction) {
+                await operation()
             }
         }
     }

--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -19,12 +19,46 @@ public enum BrowserCookieAccessGate {
     private struct State {
         var loaded = false
         var deniedUntilByBrowser: [String: Date] = [:]
+        var chromiumFamilyDeniedUntil: Date?
+    }
+
+    private final class ExplicitRetryScope: @unchecked Sendable {
+        private struct State {
+            var selectedBrowser: Browser?
+            var cookieReadClaimed = false
+        }
+
+        private let lock = OSAllocatedUnfairLock<State>(initialState: State())
+
+        func allows(_ browser: Browser) -> Bool {
+            self.lock.withLock { state in
+                if let selectedBrowser = state.selectedBrowser {
+                    return selectedBrowser == browser && !state.cookieReadClaimed
+                }
+                state.selectedBrowser = browser
+                return true
+            }
+        }
+
+        func contains(_ browser: Browser) -> Bool {
+            self.lock.withLock { $0.selectedBrowser == browser }
+        }
+
+        func claimCookieRead(for browser: Browser) -> Bool {
+            self.lock.withLock { state in
+                guard state.selectedBrowser == browser, !state.cookieReadClaimed else { return false }
+                state.cookieReadClaimed = true
+                return true
+            }
+        }
     }
 
     private static let lock = OSAllocatedUnfairLock<State>(initialState: State())
     private static let defaultsKey = "browserCookieAccessDeniedUntil"
+    private static let chromiumFamilyDefaultsKey = "__chromiumFamily__"
     private static let cooldownInterval: TimeInterval = 60 * 60 * 6
     private static let log = CodexBarLog.logger(LogCategories.browserCookieGate)
+    @TaskLocal private static var explicitRetryScope: ExplicitRetryScope?
 
     static let allowTestCookieAccessEnvironmentKey = "CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"
 
@@ -51,6 +85,12 @@ public enum BrowserCookieAccessGate {
             self.loadIfNeeded(&state)
             if let blockedUntil = state.deniedUntilByBrowser[browser.rawValue] {
                 if blockedUntil > now {
+                    if self.isExplicitRetryAllowed(for: browser) {
+                        self.log.info(
+                            "Explicit browser cookie retry allowed",
+                            metadata: ["browser": browser.displayName])
+                        return true
+                    }
                     self.log.debug(
                         "Cookie access blocked",
                         metadata: ["browser": browser.displayName, "until": "\(blockedUntil.timeIntervalSince1970)"])
@@ -59,23 +99,64 @@ public enum BrowserCookieAccessGate {
                 state.deniedUntilByBrowser.removeValue(forKey: browser.rawValue)
                 self.persist(state)
             }
+            if let blockedUntil = state.chromiumFamilyDeniedUntil {
+                if blockedUntil > now {
+                    self.log.debug(
+                        "Chromium-family cookie access blocked",
+                        metadata: ["browser": browser.displayName, "until": "\(blockedUntil.timeIntervalSince1970)"])
+                    return false
+                }
+                state.chromiumFamilyDeniedUntil = nil
+                self.persist(state)
+            }
             return true
         }
         guard shouldCheckKeychain else { return false }
 
         let requiresInteraction = self.chromiumKeychainRequiresInteraction(for: browser)
-        return self.lock.withLock { state in
-            self.loadIfNeeded(&state)
-            if requiresInteraction {
-                state.deniedUntilByBrowser[browser.rawValue] = now.addingTimeInterval(self.cooldownInterval)
-                self.persist(state)
+        if requiresInteraction {
+            self.recordDenied(for: browser, now: now)
+            if self.isExplicitRetryAllowed(for: browser) {
                 self.log.info(
-                    "Cookie access requires keychain interaction; suppressing",
+                    "Browser cookie interaction allowed for explicit retry",
                     metadata: ["browser": browser.displayName])
-                return false
+                return true
             }
-            self.log.debug("Cookie access allowed", metadata: ["browser": browser.displayName])
-            return true
+            self.log.info(
+                "Cookie access requires keychain interaction; suppressing Chromium family",
+                metadata: ["browser": browser.displayName])
+            return false
+        }
+        self.log.debug("Cookie access allowed", metadata: ["browser": browser.displayName])
+        return true
+    }
+
+    public static func withExplicitRetry<T>(_ operation: () throws -> T) rethrows -> T {
+        try self.$explicitRetryScope.withValue(ExplicitRetryScope()) {
+            try operation()
+        }
+    }
+
+    public static func withExplicitRetry<T>(
+        isolation: isolated (any Actor)? = #isolation,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$explicitRetryScope.withValue(ExplicitRetryScope()) {
+            try await operation()
+        }
+    }
+
+    static func operationPreservingAccessContext<T: Sendable>(
+        _ operation: @escaping @Sendable () throws -> T) -> @Sendable () throws -> T
+    {
+        let interaction = ProviderInteractionContext.current
+        let retryScope = self.explicitRetryScope
+        return {
+            try ProviderInteractionContext.$current.withValue(interaction) {
+                try self.$explicitRetryScope.withValue(retryScope) {
+                    try operation()
+                }
+            }
         }
     }
 
@@ -91,23 +172,64 @@ public enum BrowserCookieAccessGate {
         self.lock.withLock { state in
             self.loadIfNeeded(&state)
             state.deniedUntilByBrowser[browser.rawValue] = blockedUntil
+            state.chromiumFamilyDeniedUntil = blockedUntil
             self.persist(state)
         }
         self.log
             .info(
-                "Browser cookie access denied; suppressing prompts",
+                "Browser cookie access denied; suppressing Chromium family",
                 metadata: [
                     "browser": browser.displayName,
                     "until": "\(blockedUntil.timeIntervalSince1970)",
                 ])
     }
 
+    static func recordAllowed(for browser: Browser) {
+        guard browser.usesKeychainForCookieDecryption,
+              ProviderInteractionContext.current == .userInitiated,
+              self.explicitRetryScope?.contains(browser) == true
+        else { return }
+        let clearedCooldown = self.lock.withLock { state in
+            self.loadIfNeeded(&state)
+            guard state.deniedUntilByBrowser[browser.rawValue] != nil,
+                  state.chromiumFamilyDeniedUntil != nil
+            else { return false }
+            state.deniedUntilByBrowser.removeValue(forKey: browser.rawValue)
+            state.chromiumFamilyDeniedUntil = state.deniedUntilByBrowser.values.max()
+            self.persist(state)
+            return true
+        }
+        guard clearedCooldown else { return }
+        self.log.info(
+            "Explicit browser cookie retry succeeded",
+            metadata: ["browser": browser.displayName])
+    }
+
+    static func claimExplicitRetryCookieReadIfNeeded(for browser: Browser) -> Bool {
+        guard browser.usesKeychainForCookieDecryption,
+              ProviderInteractionContext.current == .userInitiated,
+              let retryScope = self.explicitRetryScope,
+              retryScope.contains(browser)
+        else { return true }
+        let hasActiveBrowserCooldown = self.lock.withLock { state in
+            self.loadIfNeeded(&state)
+            return state.deniedUntilByBrowser[browser.rawValue] != nil
+        }
+        guard hasActiveBrowserCooldown else { return true }
+        return retryScope.claimCookieRead(for: browser)
+    }
+
     public static func resetForTesting() {
         self.lock.withLock { state in
             state.loaded = true
             state.deniedUntilByBrowser.removeAll()
+            state.chromiumFamilyDeniedUntil = nil
             UserDefaults.standard.removeObject(forKey: self.defaultsKey)
         }
+    }
+
+    private static func isExplicitRetryAllowed(for browser: Browser) -> Bool {
+        ProviderInteractionContext.current == .userInitiated && self.explicitRetryScope?.allows(browser) == true
     }
 
     private static func chromiumKeychainRequiresInteraction(for browser: Browser) -> Bool {
@@ -137,11 +259,19 @@ public enum BrowserCookieAccessGate {
         guard let raw = UserDefaults.standard.dictionary(forKey: self.defaultsKey) as? [String: Double] else {
             return
         }
-        state.deniedUntilByBrowser = raw.compactMapValues { Date(timeIntervalSince1970: $0) }
+        state.chromiumFamilyDeniedUntil = raw[self.chromiumFamilyDefaultsKey].map(Date.init(timeIntervalSince1970:))
+        state.deniedUntilByBrowser = raw
+            .filter { $0.key != self.chromiumFamilyDefaultsKey }
+            .mapValues { Date(timeIntervalSince1970: $0) }
+        if state.chromiumFamilyDeniedUntil == nil {
+            // Existing per-browser cooldowns become family-wide on upgrade.
+            state.chromiumFamilyDeniedUntil = state.deniedUntilByBrowser.values.max()
+        }
     }
 
     private static func persist(_ state: State) {
-        let raw = state.deniedUntilByBrowser.mapValues { $0.timeIntervalSince1970 }
+        var raw = state.deniedUntilByBrowser.mapValues { $0.timeIntervalSince1970 }
+        raw[self.chromiumFamilyDefaultsKey] = state.chromiumFamilyDeniedUntil?.timeIntervalSince1970
         UserDefaults.standard.set(raw, forKey: self.defaultsKey)
     }
 }
@@ -168,13 +298,32 @@ extension BrowserCookieClient {
             throw BrowserCookieStoreAccessSuppressedError()
         }
         guard BrowserCookieAccessGate.shouldAttempt(browser) else { return [] }
-        return try self.records(matching: query, in: browser, logger: logger)
+        guard BrowserCookieAccessGate.claimExplicitRetryCookieReadIfNeeded(for: browser) else { return [] }
+        do {
+            let records = try self.records(matching: query, in: browser, logger: logger)
+            BrowserCookieAccessGate.recordAllowed(for: browser)
+            return records
+        } catch {
+            BrowserCookieAccessGate.recordIfNeeded(error)
+            throw error
+        }
     }
 }
 #else
 public enum BrowserCookieAccessGate {
     public static func shouldAttempt(_ browser: Browser, now: Date = Date()) -> Bool {
         true
+    }
+
+    public static func withExplicitRetry<T>(_ operation: () throws -> T) rethrows -> T {
+        try operation()
+    }
+
+    public static func withExplicitRetry<T>(
+        isolation: isolated (any Actor)? = #isolation,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await operation()
     }
 
     public static func recordIfNeeded(_ error: Error, now: Date = Date()) {}

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter+Deadline.swift
@@ -47,14 +47,16 @@ extension OpenAIDashboardBrowserCookieImporter {
         timeoutObserver: (@Sendable () -> Void)? = nil,
         operation: @escaping @Sendable () throws -> T) async throws -> T
     {
+        // The detached/GCD loader does not inherit TaskLocal prompt policy or retry selection.
+        let contextualOperation = BrowserCookieAccessGate.operationPreservingAccessContext(operation)
         guard let deadline else {
-            return try await Task.detached(priority: .userInitiated, operation: operation).value
+            return try await Task.detached(priority: .userInitiated, operation: contextualOperation).value
         }
         let timeout = try self.remainingTimeout(until: deadline)
         let completion = CookieLoadCompletion()
         return try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
-                let result = Result(catching: operation)
+                let result = Result(catching: contextualOperation)
                 completion.finish { continuation.resume(with: result) }
             }
             self.deadlineQueue.asyncAfter(deadline: .now() + timeout) {

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -213,7 +213,7 @@ struct BrowserDetectionTests {
     }
 
     @Test
-    func `keychain interaction suppresses chromium cookie source during cooldown`() {
+    func `keychain interaction suppresses chromium family during cooldown`() {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 
@@ -221,7 +221,7 @@ struct BrowserDetectionTests {
         var preflightCount = 0
 
         KeychainAccessGate.withTaskOverrideForTesting(false) {
-            ProviderInteractionContext.$current.withValue(.userInitiated) {
+            ProviderInteractionContext.$current.withValue(.background) {
                 KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in
                     preflightCount += 1
                     return .interactionRequired
@@ -234,6 +234,7 @@ struct BrowserDetectionTests {
                     return .allowed
                 } operation: {
                     #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(60)) == false)
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.dia, now: start.addingTimeInterval(60)) == false)
                     #expect(
                         BrowserCookieAccessGate.shouldAttempt(
                             .chrome,
@@ -290,6 +291,68 @@ struct BrowserDetectionTests {
     }
 
     @Test
+    func `recorded browser denial suppresses automatic family and permits explicit source retry`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        let start = Date(timeIntervalSince1970: 1500)
+        var preflightCount = 0
+
+        KeychainAccessGate.withTaskOverrideForTesting(false) {
+            BrowserCookieAccessGate.recordIfNeeded(
+                BrowserCookieError.accessDenied(browser: .arc, details: "denied"),
+                now: start)
+            KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in
+                preflightCount += 1
+                return .allowed
+            } operation: {
+                ProviderInteractionContext.$current.withValue(.background) {
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(1)) == false)
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.edge, now: start.addingTimeInterval(1)) == false)
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.safari, now: start.addingTimeInterval(1)) == true)
+                }
+                BrowserCookieAccessGate.withExplicitRetry {
+                    ProviderInteractionContext.$current.withValue(.userInitiated) {
+                        #expect(BrowserCookieAccessGate
+                            .shouldAttempt(.chrome, now: start.addingTimeInterval(2)) == false)
+                        #expect(BrowserCookieAccessGate.shouldAttempt(.arc, now: start.addingTimeInterval(2)) == true)
+                        #expect(BrowserCookieAccessGate.claimExplicitRetryCookieReadIfNeeded(for: .arc))
+                        BrowserCookieAccessGate.recordAllowed(for: .arc)
+                    }
+                }
+                ProviderInteractionContext.$current.withValue(.background) {
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(3)) == true)
+                }
+            }
+        }
+
+        #expect(preflightCount == 2)
+    }
+
+    @Test
+    func `denied explicit cookie read closes retry scope`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        let start = Date(timeIntervalSince1970: 1700)
+        BrowserCookieAccessGate.recordDenied(for: .arc, now: start)
+
+        KeychainAccessGate.withTaskOverrideForTesting(false) {
+            BrowserCookieAccessGate.withExplicitRetry {
+                ProviderInteractionContext.$current.withValue(.userInitiated) {
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.arc, now: start.addingTimeInterval(1)))
+                    #expect(BrowserCookieAccessGate.claimExplicitRetryCookieReadIfNeeded(for: .arc))
+
+                    BrowserCookieAccessGate.recordDenied(for: .arc, now: start.addingTimeInterval(2))
+
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.arc, now: start.addingTimeInterval(3)) == false)
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.edge, now: start.addingTimeInterval(3)) == false)
+                }
+            }
+        }
+    }
+
+    @Test
     func `chrome keychain preflight queries only chrome labels`() {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
@@ -336,7 +399,7 @@ struct BrowserDetectionTests {
     }
 
     @Test
-    func `browser keychain interaction suppresses only that browser`() throws {
+    func `browser keychain interaction suppresses family and permits scoped explicit retry`() throws {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 
@@ -356,14 +419,25 @@ struct BrowserDetectionTests {
                 if label == firstDiaLabel { return .interactionRequired }
                 return .notFound
             } operation: {
-                #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start) == true)
-                #expect(BrowserCookieAccessGate.shouldAttempt(.dia, now: start.addingTimeInterval(1)) == false)
-                #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(60)) == true)
-                #expect(BrowserCookieAccessGate.shouldAttempt(.dia, now: start.addingTimeInterval(60)) == false)
+                ProviderInteractionContext.$current.withValue(.background) {
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start) == true)
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.dia, now: start.addingTimeInterval(1)) == false)
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(60)) == false)
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.dia, now: start.addingTimeInterval(60)) == false)
+                }
+                BrowserCookieAccessGate.withExplicitRetry {
+                    ProviderInteractionContext.$current.withValue(.userInitiated) {
+                        #expect(BrowserCookieAccessGate
+                            .shouldAttempt(.chrome, now: start.addingTimeInterval(61)) == false)
+                        #expect(BrowserCookieAccessGate.shouldAttempt(.dia, now: start.addingTimeInterval(61)) == true)
+                        #expect(BrowserCookieAccessGate
+                            .shouldAttempt(.edge, now: start.addingTimeInterval(61)) == false)
+                    }
+                }
             }
         }
 
-        #expect(queriedLabels == [firstChromeLabel, firstDiaLabel, firstChromeLabel])
+        #expect(queriedLabels == [firstChromeLabel, firstDiaLabel, firstDiaLabel])
         #expect(queriedLabels.allSatisfy { allowedLabels.contains($0) })
     }
 

--- a/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardBrowserCookieImporterTests.swift
@@ -189,6 +189,30 @@ struct OpenAIDashboardBrowserCookieImporterTests {
     }
 
     @Test
+    func `bounded cookie loads preserve explicit retry context`() async throws {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+        let start = Date()
+
+        for deadline in [nil, Date().addingTimeInterval(1)] {
+            BrowserCookieAccessGate.resetForTesting()
+            BrowserCookieAccessGate.recordDenied(for: .arc, now: start)
+
+            let allowed = try await BrowserCookieAccessGate.withExplicitRetry {
+                try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                    try await OpenAIDashboardBrowserCookieImporter.runBoundedCookieLoad(deadline: deadline) {
+                        KeychainAccessGate.withTaskOverrideForTesting(false) {
+                            ProviderInteractionContext.current == .userInitiated &&
+                                BrowserCookieAccessGate.shouldAttempt(.arc, now: start.addingTimeInterval(1))
+                        }
+                    }
+                }
+            }
+            #expect(allowed)
+        }
+    }
+
+    @Test
     func `timed out cookie cache work stays ordered before retry`() async throws {
         let log = CookieOperationLog()
         let firstOperationStarted = DispatchSemaphore(value: 0)

--- a/docs/keychain-prompts.md
+++ b/docs/keychain-prompts.md
@@ -68,6 +68,11 @@ on Keychain can still work where the provider supports them.
 
 ## Browser Safe Storage prompts
 
+If a Chromium-family Safe Storage check requires interaction or is denied, CodexBar pauses automatic cookie imports
+for every Chromium-family browser for six hours. This prevents a denial in Arc, Edge, Brave, or another Chromium
+browser from immediately moving to the next browser and showing another prompt. **Refresh Now** is an explicit retry
+for the browser that was blocked; Safari and Firefox-family cookie imports remain available during the pause.
+
 For normal browser-cookie import prompts, either allow CodexBar in the Keychain item's Access Control list or disable
 Keychain access:
 


### PR DESCRIPTION
## Summary

- persist one six-hour automatic backoff for the whole Chromium browser family after the first Safe Storage interaction requirement or denial
- let **Refresh Now** retry only the originally blocked browser, with one atomically claimed cookie read so concurrent provider refreshes cannot repeat the prompt
- preserve explicit retry context across the OpenAI dashboard's detached and GCD cookie loaders, and clear the pause after any successful browser-store read
- document the behavior and preserve Safari/Firefox-family imports during the Chromium pause

## Validation

- `swift test --filter BrowserDetectionTests` — 26 passed
- `swift test --filter OpenAIDashboardBrowserCookieImporterTests` — 17 passed
- `swift test --filter StatusMenuInstantOpenTests` — 29 passed
- `make check`
- `make test` — 48/48 shards passed
- autoreview — clean after two accepted fix cycles

No live Keychain or real browser-cookie probe was run. Validation uses the repository's non-interactive preflight and isolated test seams.

Closes #1952
