### PR TITLE
Fix Claude OAuth rate-limit isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - ZenMux: add Management API usage with five-hour and weekly quotas, subscription expiry, and USD PAYG balance. Thanks @kays0x!
 
 ### Fixed
+- Claude: preserve each account’s last-good OAuth usage during rate limits and isolate retry cooldowns per credential. Thanks @ruushu!
 - Claude: recover a missing credentials file from a valid Claude Code Keychain item without showing Keychain UI when Never prompt is selected (#1975). Thanks @OfficialAbhinavSingh!
 - Codex cost usage: invalidate cached fork totals when the parent session appears, changes, or resolves to a different file, preventing stale inherited baselines. Thanks @xx205!
 - Cursor: bind interactive account login to one readable browser, preserve the active session on cancellation or failure, and prevent background refreshes from replacing the selected account. Thanks @chapati23!

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -25,6 +25,7 @@ extension UsageStore {
         let generation: UInt64
         let codexExpectedGuard: CodexAccountScopedRefreshGuard?
         let tokenAccount: ProviderTokenAccount?
+        let priorTokenAccountSnapshot: TokenAccountUsageSnapshot?
         let codexLimitResetOwnerKey: CodexLimitResetOwnerKey?
         let claudeOAuthHistoryPersistentRefHash: String?
         let claudeOAuthActiveAccountObservation: ClaudeOAuthActiveAccountObservation
@@ -332,6 +333,7 @@ extension UsageStore {
             ? await Self.captureClaudeRefreshAuthState(invalidateCredentialsFile: true)
             : nil
         let tokenAccount = self.settings.effectiveSelectedTokenAccount(for: provider)
+        let priorTokenAccountSnapshot = self.tokenAccountSnapshot(provider: provider, account: tokenAccount)
         let fetchContext = self.makeFetchContext(provider: provider, override: nil)
         let descriptor = spec.descriptor
         let codexResetCreditsFetcher = self.codexResetCreditsFetcher()
@@ -437,6 +439,7 @@ extension UsageStore {
                 generation: generation,
                 codexExpectedGuard: codexExpectedGuard,
                 tokenAccount: tokenAccount,
+                priorTokenAccountSnapshot: priorTokenAccountSnapshot,
                 codexLimitResetOwnerKey: codexLimitResetOwnerKey,
                 claudeOAuthHistoryPersistentRefHash: claudeOAuthHistoryPersistentRefHash,
                 claudeOAuthActiveAccountObservation: claudeOAuthActiveAccountObservation))
@@ -641,7 +644,7 @@ extension UsageStore {
         await self.handleProviderFetchFailure(
             provider: provider,
             error: error,
-            generation: context.generation)
+            context: context)
     }
 
     private func bindCodexFailurePublicationOwner(
@@ -949,11 +952,11 @@ extension UsageStore {
     private func handleProviderFetchFailure(
         provider: UsageProvider,
         error: Error,
-        generation: UInt64) async
+        context: ProviderRefreshOutcomeContext) async
     {
         let shouldNotifyPermissionPrompt = Self.isPermissionPromptWaiting(error)
         await MainActor.run {
-            guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
+            guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             if provider == .gemini, Self.isGeminiConsumerTierDeprecationError(error) {
                 // This is a durable provider migration signal, not a transient fetch failure.
                 // Surface it immediately so a cached snapshot cannot hide the required handoff.
@@ -965,6 +968,35 @@ extension UsageStore {
                 self.lastSourceLabels.removeValue(forKey: provider)
                 self.failureGates[provider]?.reset()
                 return
+            }
+            if provider == .claude,
+               ClaudeUsageError.isClaudeOAuthUsageRateLimit(error)
+            {
+                if let (account, cached) = self.validatedClaudeOAuthTokenAccountFallback(context: context),
+                   let snapshot = cached.snapshot
+                {
+                    self.snapshots[provider] = snapshot
+                    self.lastKnownResetSnapshots[provider] = snapshot
+                    self.lastSourceLabels[provider] = "oauth"
+                    self.cacheTokenAccountSnapshot(
+                        provider: provider,
+                        account: account,
+                        snapshot: snapshot,
+                        sourceLabel: "oauth")
+                    self.errors[provider] = nil
+                    self.failureGates[provider]?.reset()
+                    return
+                }
+                // Credential-change cleanup runs before failure handling and removes all unscoped Claude state.
+                // A surviving OAuth snapshot therefore belongs to the credential observed across this refresh.
+                if context.tokenAccount == nil,
+                   self.snapshots[provider] != nil,
+                   self.lastSourceLabels[provider] == "oauth"
+                {
+                    self.errors[provider] = nil
+                    self.failureGates[provider]?.reset()
+                    return
+                }
             }
             let hadKnownUnavailableLimits = self.knownLimitsAvailabilityByProvider[provider]?.isUnavailable == true
             self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
@@ -1035,11 +1067,38 @@ extension UsageStore {
                 self.postPermissionPromptNotificationIfNeeded(provider: provider, error: error)
             }
         }
-        guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
+        guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
         if let runtime = self.providerRuntimes[provider] {
             let context = ProviderRuntimeContext(
                 provider: provider, settings: self.settings, store: self)
             runtime.providerDidFail(context: context, provider: provider, error: error)
+        }
+    }
+
+    private func validatedClaudeOAuthTokenAccountFallback(
+        context: ProviderRefreshOutcomeContext) -> (ProviderTokenAccount, TokenAccountUsageSnapshot)?
+    {
+        guard let fetchedAccount = context.tokenAccount,
+              let cached = context.priorTokenAccountSnapshot,
+              cached.account.id == fetchedAccount.id,
+              cached.sourceLabel == "oauth",
+              cached.snapshot != nil,
+              let currentAccount = self.uniqueTokenAccount(provider: .claude, accountID: fetchedAccount.id),
+              cached.cacheKey == self.tokenAccountSnapshotCacheKey(provider: .claude, account: currentAccount)
+        else {
+            return nil
+        }
+        return (currentAccount, cached)
+    }
+
+    private func tokenAccountSnapshot(
+        provider: UsageProvider,
+        account: ProviderTokenAccount?) -> TokenAccountUsageSnapshot?
+    {
+        guard let account else { return nil }
+        return self.accountSnapshots[provider]?.first { cached in
+            cached.account.id == account.id &&
+                cached.cacheKey == self.tokenAccountSnapshotCacheKey(provider: provider, account: account)
         }
     }
 

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -45,7 +45,6 @@ struct CodexAccountUsageSnapshot: Identifiable {
 extension UsageStore {
     func activateCachedTokenAccountSnapshot(provider: UsageProvider, accountID: UUID) {
         guard self.settings.effectiveSelectedTokenAccount(for: provider)?.id == accountID else { return }
-        self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
         self.tokenAccountLiveStateProviders.insert(provider)
         guard let account = self.uniqueTokenAccount(provider: provider, accountID: accountID),
               let cached = self.accountSnapshots[provider]?.first(where: {
@@ -55,11 +54,17 @@ extension UsageStore {
               })
         else {
             self.accountSnapshots[provider]?.removeAll { $0.account.id == accountID }
+            self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
             // Never show the previous account's usage under the newly selected account. Segmented layouts only
             // fetch the active account, so an uncached selection must render as refreshing until its fetch completes.
             self.clearTokenAccountLiveSnapshot(provider: provider)
             return
         }
+
+        self.knownLimitsAvailabilityByProvider[provider] = .resolve(
+            provider: provider,
+            snapshot: cached.snapshot,
+            lastErrorDescription: cached.error)
 
         if let snapshot = cached.snapshot {
             self.snapshots[provider] = snapshot
@@ -584,7 +589,9 @@ extension UsageStore {
         var snapshots: [TokenAccountUsageSnapshot] = []
         var historySamples: [(account: ProviderTokenAccount, snapshot: UsageSnapshot)] = []
         var selectedOutcome: ProviderFetchOutcome?
+        var resolvedSelectedAccount: ProviderTokenAccount?
         var selectedSnapshot: UsageSnapshot?
+        var selectedAccountSnapshot: TokenAccountUsageSnapshot?
         var sawAnyNonCancellationOutcome = false
 
         let results = await self.fetchTokenAccountOutcomes(provider: provider, accounts: limitedAccounts)
@@ -605,12 +612,14 @@ extension UsageStore {
             if let snapshot = resolved.snapshot {
                 snapshots.append(snapshot)
             }
-            if let usage = resolved.usage {
+            if let usage = resolved.freshUsage {
                 historySamples.append((account: account, snapshot: usage))
             }
             if account.id == effectiveSelected.id {
                 selectedOutcome = outcome
+                resolvedSelectedAccount = account
                 selectedSnapshot = resolved.usage
+                selectedAccountSnapshot = resolved.snapshot
             }
         }
 
@@ -625,12 +634,13 @@ extension UsageStore {
             }
         }
 
-        if let selectedOutcome {
+        if let selectedOutcome, let resolvedSelectedAccount {
             await self.applySelectedOutcome(
                 selectedOutcome,
                 provider: provider,
-                account: effectiveSelected,
+                account: resolvedSelectedAccount,
                 fallbackSnapshot: selectedSnapshot,
+                fallbackAccountSnapshot: selectedAccountSnapshot,
                 generation: generation)
         }
 
@@ -984,6 +994,7 @@ extension UsageStore {
     private struct ResolvedAccountOutcome {
         let snapshot: TokenAccountUsageSnapshot?
         let usage: UsageSnapshot?
+        let freshUsage: UsageSnapshot?
     }
 
     private struct ResolvedCodexAccountOutcome {
@@ -1279,20 +1290,38 @@ extension UsageStore {
                 error: nil,
                 sourceLabel: result.sourceLabel,
                 cacheKey: self.tokenAccountSnapshotCacheKey(provider: provider, account: account))
-            return ResolvedAccountOutcome(snapshot: snapshot, usage: labeled)
+            return ResolvedAccountOutcome(snapshot: snapshot, usage: labeled, freshUsage: labeled)
         case let .failure(error):
             // Preserve the last-good snapshot when the refresh was cancelled (e.g. the
             // user switched menu tabs mid-flight). Without this the per-account list
             // would briefly render error chips for accounts that already had data.
             if Self.errorIsCancellation(error) {
                 if let priorSnapshot, priorSnapshot.snapshot != nil {
-                    return ResolvedAccountOutcome(snapshot: priorSnapshot, usage: priorSnapshot.snapshot)
+                    return ResolvedAccountOutcome(
+                        snapshot: priorSnapshot,
+                        usage: priorSnapshot.snapshot,
+                        freshUsage: nil)
                 }
                 // No usable prior data: skip this row entirely. The caller will
                 // either preserve the existing per-account state or fall back to
                 // the single live card. Rendering a "cancelled" placeholder here
                 // produces visually duplicate cards with no useful data.
-                return ResolvedAccountOutcome(snapshot: nil, usage: nil)
+                return ResolvedAccountOutcome(snapshot: nil, usage: nil, freshUsage: nil)
+            }
+            if provider == .claude,
+               ClaudeUsageError.isClaudeOAuthUsageRateLimit(error),
+               let priorSnapshot,
+               priorSnapshot.sourceLabel == "oauth",
+               priorSnapshot.cacheKey == self.tokenAccountSnapshotCacheKey(provider: provider, account: account),
+               let priorUsage = priorSnapshot.snapshot
+            {
+                let snapshot = TokenAccountUsageSnapshot(
+                    account: account,
+                    snapshot: priorUsage,
+                    error: nil,
+                    sourceLabel: "oauth",
+                    cacheKey: priorSnapshot.cacheKey)
+                return ResolvedAccountOutcome(snapshot: snapshot, usage: priorUsage, freshUsage: nil)
             }
             let snapshot = TokenAccountUsageSnapshot(
                 account: account,
@@ -1300,7 +1329,7 @@ extension UsageStore {
                 error: self.tokenAccountSnapshotErrorMessage(error),
                 sourceLabel: nil,
                 cacheKey: self.tokenAccountSnapshotCacheKey(provider: provider, account: account))
-            return ResolvedAccountOutcome(snapshot: snapshot, usage: nil)
+            return ResolvedAccountOutcome(snapshot: snapshot, usage: nil, freshUsage: nil)
         }
     }
 
@@ -1452,6 +1481,7 @@ extension UsageStore {
         provider: UsageProvider,
         account: ProviderTokenAccount?,
         fallbackSnapshot: UsageSnapshot?,
+        fallbackAccountSnapshot: TokenAccountUsageSnapshot? = nil,
         generation: UInt64? = nil) async
     {
         await MainActor.run {
@@ -1497,6 +1527,30 @@ extension UsageStore {
                 account: account)
         case let .failure(error):
             await MainActor.run {
+                if provider == .claude,
+                   ClaudeUsageError.isClaudeOAuthUsageRateLimit(error),
+                   let account,
+                   let currentAccount = self.uniqueTokenAccount(provider: provider, accountID: account.id),
+                   let fallbackAccountSnapshot,
+                   fallbackAccountSnapshot.account.id == currentAccount.id,
+                   fallbackAccountSnapshot.sourceLabel == "oauth",
+                   fallbackAccountSnapshot.cacheKey == self.tokenAccountSnapshotCacheKey(
+                       provider: provider,
+                       account: currentAccount),
+                   let fallback = fallbackAccountSnapshot.snapshot
+                {
+                    self.snapshots[provider] = fallback
+                    self.lastKnownResetSnapshots[provider] = fallback
+                    self.lastSourceLabels[provider] = "oauth"
+                    self.cacheTokenAccountSnapshot(
+                        provider: provider,
+                        account: currentAccount,
+                        snapshot: fallback,
+                        sourceLabel: "oauth")
+                    self.errors[provider] = nil
+                    self.failureGates[provider]?.reset()
+                    return
+                }
                 self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
                 guard let message = self.tokenAccountErrorMessage(error) else {
                     self.errors[provider] = nil

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+Hashing.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+Hashing.swift
@@ -2,17 +2,18 @@ import Foundation
 
 #if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
 #endif
 
 extension ClaudeOAuthCredentialsStore {
+    static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
     static func sha256Prefix(_ data: Data) -> String? {
-        #if canImport(CryptoKit)
-        let digest = SHA256.hash(data: data)
-        let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
-        return String(hex.prefix(12))
-        #else
-        _ = data
-        return nil
-        #endif
+        String(self.sha256Hex(data).prefix(12))
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
@@ -10,13 +10,20 @@ public enum ClaudeOAuthFetchError: LocalizedError, Sendable {
     case serverError(Int, String?)
     case networkError(Error)
 
+    public static let usageRateLimitDescription =
+        "Claude OAuth usage endpoint is rate limited by Anthropic right now. Wait a few minutes, "
+            + "then click Refresh. If it keeps happening, run `claude logout && claude login`, then try again."
+
+    public static func isUsageRateLimitDescription(_ description: String?) -> Bool {
+        description == self.usageRateLimitDescription
+    }
+
     public var errorDescription: String? {
         switch self {
         case .unauthorized:
             return "Claude OAuth request unauthorized. Run `claude` to re-authenticate."
         case .rateLimited:
-            return "Claude OAuth usage endpoint is rate limited by Anthropic right now. Wait a few minutes, "
-                + "then click Refresh. If it keeps happening, run `claude logout && claude login`, then try again."
+            return Self.usageRateLimitDescription
         case .invalidResponse:
             return "Claude OAuth response was invalid."
         case let .serverError(code, body):
@@ -42,9 +49,10 @@ enum ClaudeOAuthUsageFetcher {
 
     static func fetchUsage(
         accessToken: String,
-        detectClaudeVersion: Bool = true) async throws -> OAuthUsageResponse
+        detectClaudeVersion: Bool = true,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> OAuthUsageResponse
     {
-        if let blockedUntil = ClaudeOAuthUsageRateLimitGate.blockedUntil() {
+        if let blockedUntil = ClaudeOAuthUsageRateLimitGate.blockedUntil(accessToken: accessToken) {
             throw ClaudeOAuthFetchError.rateLimited(retryAfter: blockedUntil)
         }
 
@@ -65,20 +73,23 @@ enum ClaudeOAuthUsageFetcher {
             forHTTPHeaderField: "User-Agent")
 
         do {
-            let response = try await ProviderHTTPClient.shared.response(for: request)
+            let response = try await transport.response(for: request)
             let data = response.data
             switch response.statusCode {
             case 200:
                 let usage = try Self.decodeUsageResponse(data)
-                ClaudeOAuthUsageRateLimitGate.recordSuccess()
+                ClaudeOAuthUsageRateLimitGate.recordSuccess(accessToken: accessToken)
                 return usage
             case 401:
                 throw ClaudeOAuthFetchError.unauthorized
             case 429:
                 let retryAfter = Self.retryAfterDate(from: response.response)
-                ClaudeOAuthUsageRateLimitGate.recordRateLimit(retryAfter: retryAfter)
+                ClaudeOAuthUsageRateLimitGate.recordRateLimit(
+                    accessToken: accessToken,
+                    retryAfter: retryAfter)
                 throw ClaudeOAuthFetchError.rateLimited(
-                    retryAfter: ClaudeOAuthUsageRateLimitGate.currentBlockedUntil() ?? retryAfter)
+                    retryAfter: ClaudeOAuthUsageRateLimitGate
+                        .currentBlockedUntil(accessToken: accessToken) ?? retryAfter)
             case 403:
                 let body = String(data: data, encoding: .utf8)
                 throw ClaudeOAuthFetchError.serverError(response.statusCode, body)
@@ -102,7 +113,9 @@ enum ClaudeOAuthUsageFetcher {
         guard let string, !string.isEmpty else { return nil }
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = formatter.date(from: string) { return date }
+        if let date = formatter.date(from: string) {
+            return date
+        }
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.date(from: string)
     }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageRateLimitGate.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageRateLimitGate.swift
@@ -1,46 +1,88 @@
 import Foundation
 
 enum ClaudeOAuthUsageRateLimitGate {
-    private static let blockedUntilKey = "claudeOAuthUsageRateLimitBlockedUntilV1"
-    private static let defaultCooldown: TimeInterval = 60 * 5
+    private static let legacyBlockedUntilKey = "claudeOAuthUsageRateLimitBlockedUntilV1"
+    private static let blockedUntilKeyPrefix = "claudeOAuthUsageRateLimitBlockedUntilV2."
+    static let defaultCooldown: TimeInterval = 60 * 5
+    private static let lock = NSLock()
 
     static func blockedUntil(
+        accessToken: String,
         interaction: ProviderInteraction = ProviderInteractionContext.current,
         now: Date = Date()) -> Date?
     {
         guard interaction != .userInitiated else { return nil }
-        return self.currentBlockedUntil(now: now)
+        return self.currentBlockedUntil(accessToken: accessToken, now: now)
     }
 
-    static func currentBlockedUntil(now: Date = Date()) -> Date? {
-        guard let raw = UserDefaults.standard.object(forKey: self.blockedUntilKey) as? Double else {
-            return nil
+    static func currentBlockedUntil(accessToken: String, now: Date = Date()) -> Date? {
+        self.lock.withLock {
+            self.purgeLegacyAndExpiredEntries(now: now)
+            let key = self.blockedUntilKey(accessToken: accessToken)
+            guard let raw = UserDefaults.standard.object(forKey: key) as? Double else {
+                return nil
+            }
+            return Date(timeIntervalSince1970: raw)
         }
-
-        let blockedUntil = Date(timeIntervalSince1970: raw)
-        guard blockedUntil > now else {
-            UserDefaults.standard.removeObject(forKey: self.blockedUntilKey)
-            return nil
-        }
-        return blockedUntil
     }
 
-    static func recordRateLimit(retryAfter: Date?, now: Date = Date()) {
-        let blockedUntil = if let retryAfter, retryAfter > now {
-            retryAfter
-        } else {
-            now.addingTimeInterval(self.defaultCooldown)
+    static func recordRateLimit(accessToken: String, retryAfter: Date?, now: Date = Date()) {
+        self.lock.withLock {
+            self.purgeLegacyAndExpiredEntries(now: now)
+            let key = self.blockedUntilKey(accessToken: accessToken)
+            let candidate = if let retryAfter, retryAfter > now {
+                retryAfter
+            } else {
+                now.addingTimeInterval(self.defaultCooldown)
+            }
+            let existing = (UserDefaults.standard.object(forKey: key) as? Double)
+                .map(Date.init(timeIntervalSince1970:))
+            let blockedUntil = max(existing ?? candidate, candidate)
+            UserDefaults.standard.set(blockedUntil.timeIntervalSince1970, forKey: key)
         }
-        UserDefaults.standard.set(blockedUntil.timeIntervalSince1970, forKey: self.blockedUntilKey)
     }
 
-    static func recordSuccess() {
-        UserDefaults.standard.removeObject(forKey: self.blockedUntilKey)
+    static func recordSuccess(accessToken: String, now: Date = Date()) {
+        self.lock.withLock {
+            self.purgeLegacyAndExpiredEntries(now: now)
+            UserDefaults.standard.removeObject(forKey: self.blockedUntilKey(accessToken: accessToken))
+        }
+    }
+
+    private static func blockedUntilKey(accessToken: String) -> String {
+        self.blockedUntilKeyPrefix + ClaudeOAuthCredentialsStore.sha256Hex(Data(accessToken.utf8))
+    }
+
+    private static func purgeLegacyAndExpiredEntries(now: Date) {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: self.legacyBlockedUntilKey)
+        for (key, value) in defaults.dictionaryRepresentation()
+            where key.hasPrefix(self.blockedUntilKeyPrefix)
+        {
+            guard let timestamp = value as? Double,
+                  Date(timeIntervalSince1970: timestamp) > now
+            else {
+                defaults.removeObject(forKey: key)
+                continue
+            }
+        }
     }
 
     #if DEBUG
+    static func storageKeyForTesting(accessToken: String) -> String {
+        self.blockedUntilKey(accessToken: accessToken)
+    }
+
     static func resetForTesting() {
-        UserDefaults.standard.removeObject(forKey: self.blockedUntilKey)
+        self.lock.withLock {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: self.legacyBlockedUntilKey)
+            for key in defaults.dictionaryRepresentation().keys
+                where key.hasPrefix(self.blockedUntilKeyPrefix)
+            {
+                defaults.removeObject(forKey: key)
+            }
+        }
     }
     #endif
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -76,6 +76,16 @@ public enum ClaudeUsageError: LocalizedError, Sendable {
     case parseFailed(String)
     case oauthFailed(String)
 
+    public static func isClaudeOAuthUsageRateLimit(_ error: Error) -> Bool {
+        if let fetchError = error as? ClaudeOAuthFetchError,
+           case .rateLimited = fetchError
+        {
+            return true
+        }
+        guard case let ClaudeUsageError.oauthFailed(message) = error else { return false }
+        return ClaudeOAuthFetchError.isUsageRateLimitDescription(message)
+    }
+
     public var errorDescription: String? {
         switch self {
         case .claudeNotInstalled:

--- a/Tests/CodexBarTests/ClaudeOAuthRateLimitResilienceTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthRateLimitResilienceTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct ClaudeOAuthRateLimitResilienceTests {
+    @Test
+    func `classifier accepts only the canonical O auth rate limit`() {
+        let canonical = ClaudeOAuthFetchError.usageRateLimitDescription
+
+        #expect(ClaudeUsageError.isClaudeOAuthUsageRateLimit(ClaudeOAuthFetchError.rateLimited(retryAfter: nil)))
+        #expect(ClaudeUsageError.isClaudeOAuthUsageRateLimit(ClaudeUsageError.oauthFailed(canonical)))
+        #expect(!ClaudeUsageError.isClaudeOAuthUsageRateLimit(ClaudeUsageError.oauthFailed(canonical + " extra")))
+        #expect(!ClaudeUsageError.isClaudeOAuthUsageRateLimit(ClaudeUsageError.oauthFailed("rate limited")))
+        #expect(!ClaudeUsageError.isClaudeOAuthUsageRateLimit(ClaudeUsageError.oauthFailed("HTTP 429")))
+        #expect(!ClaudeUsageError.isClaudeOAuthUsageRateLimit(NSError(
+            domain: "test",
+            code: 429,
+            userInfo: [NSLocalizedDescriptionKey: canonical])))
+    }
+
+    @MainActor
+    @Test
+    func `stable unscoped O auth refresh keeps the prior card on rate limit`() async throws {
+        let store = try self.makeStore(suite: "ClaudeOAuthRateLimit-unscoped")
+        let prior = self.snapshot(usedPercent: 28)
+        store._setSnapshotForTesting(prior, provider: .claude)
+        store.lastKnownResetSnapshots[.claude] = prior
+        store.lastSourceLabels[.claude] = "oauth"
+        try self.installRateLimitDescriptor(store)
+
+        await self.refreshWithStableClaudeCredentials(store)
+
+        #expect(store.snapshot(for: .claude)?.updatedAt == prior.updatedAt)
+        #expect(store.lastKnownResetSnapshots[.claude]?.updatedAt == prior.updatedAt)
+        #expect(store.lastSourceLabels[.claude] == "oauth")
+        #expect(store.error(for: .claude) == nil)
+    }
+
+    @MainActor
+    @Test
+    func `missing prior card surfaces the O auth rate limit`() async throws {
+        let store = try self.makeStore(suite: "ClaudeOAuthRateLimit-missing")
+        try self.installRateLimitDescriptor(store)
+
+        await self.refreshWithStableClaudeCredentials(store)
+
+        #expect(store.snapshot(for: .claude) == nil)
+        #expect(store.error(for: .claude)?.contains("rate limited") == true)
+    }
+
+    @MainActor
+    @Test
+    func `segmented account keeps only its exact O auth cache without recording history`() async throws {
+        let store = try self.makeStore(suite: "ClaudeOAuthRateLimit-segmented", layout: .segmented)
+        store.settings.addTokenAccount(provider: .claude, label: "Primary", token: "test-auth-token")
+        let account = try #require(store.settings.selectedTokenAccount(for: .claude))
+        let prior = self.snapshot(usedPercent: 31)
+        self.seedAccountSnapshot(store: store, account: account, snapshot: prior)
+        store._setKnownLimitsAvailabilityForTesting(.available, provider: .claude)
+        try self.installRateLimitDescriptor(store)
+
+        await self.refreshWithStableClaudeCredentials(store)
+
+        let row = try #require(store.accountSnapshots[.claude]?.first)
+        #expect(store.snapshot(for: .claude)?.updatedAt == prior.updatedAt)
+        #expect(store.error(for: .claude) == nil)
+        #expect(row.cacheKey == store.tokenAccountSnapshotCacheKey(provider: .claude, account: account))
+        #expect(row.snapshot?.updatedAt == prior.updatedAt)
+        #expect(row.error == nil)
+        #expect(store.knownLimitsAvailability(for: .claude) == .available)
+        #expect(store.planUtilizationHistory[.claude] == nil)
+    }
+
+    @MainActor
+    @Test
+    func `edited account cannot reuse its previous O auth cache`() async throws {
+        let store = try self.makeStore(suite: "ClaudeOAuthRateLimit-edited", layout: .segmented)
+        store.settings.addTokenAccount(provider: .claude, label: "Primary", token: "test-auth-token")
+        let original = try #require(store.settings.selectedTokenAccount(for: .claude))
+        self.seedAccountSnapshot(store: store, account: original, snapshot: self.snapshot(usedPercent: 47))
+        store.settings.updateTokenAccount(
+            provider: .claude,
+            accountID: original.id,
+            token: "test-token-placeholder")
+        try self.installRateLimitDescriptor(store)
+
+        await self.refreshWithStableClaudeCredentials(store)
+
+        #expect(store.snapshot(for: .claude) == nil)
+        #expect(store.error(for: .claude)?.contains("rate limited") == true)
+        #expect(store.accountSnapshots[.claude]?.first?.snapshot == nil)
+    }
+
+    @MainActor
+    @Test
+    func `stacked accounts keep exact O auth caches without recording cached history`() async throws {
+        let store = try self.makeStore(suite: "ClaudeOAuthRateLimit-stacked", layout: .stacked)
+        store.settings.addTokenAccount(provider: .claude, label: "Primary", token: "test-auth-token")
+        store.settings.addTokenAccount(provider: .claude, label: "Secondary", token: "test-token-placeholder")
+        let accounts = store.settings.tokenAccounts(for: .claude)
+        let primary = try #require(accounts.first)
+        let secondary = try #require(accounts.last)
+        let selected = try #require(store.settings.selectedTokenAccount(for: .claude))
+        let primaryPrior = self.snapshot(usedPercent: 21)
+        let secondaryPrior = self.snapshot(usedPercent: 64)
+        let selectedPrior = selected.id == primary.id ? primaryPrior : secondaryPrior
+        self.seedAccountSnapshots(
+            store: store,
+            values: [(primary, primaryPrior), (secondary, secondaryPrior)])
+        store._setKnownLimitsAvailabilityForTesting(.available, provider: .claude)
+        try self.installRateLimitDescriptor(store)
+
+        await self.refreshWithStableClaudeCredentials(store)
+
+        let rows = store.accountSnapshots[.claude] ?? []
+        #expect(rows.count == 2)
+        #expect(rows.first(where: { $0.account.id == primary.id })?.snapshot?.updatedAt == primaryPrior.updatedAt)
+        #expect(rows.first(where: { $0.account.id == secondary.id })?.snapshot?.updatedAt == secondaryPrior.updatedAt)
+        #expect(store.snapshot(for: .claude)?.updatedAt == selectedPrior.updatedAt)
+        #expect(store.error(for: .claude) == nil)
+        #expect(store.knownLimitsAvailability(for: .claude) == .available)
+        #expect(store.planUtilizationHistory[.claude] == nil)
+    }
+
+    @MainActor
+    private func makeStore(
+        suite: String,
+        layout: MultiAccountMenuLayout = .segmented) throws -> UsageStore
+    {
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.providerDetectionCompleted = true
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.claudeUsageDataSource = .oauth
+        settings.claudeOAuthKeychainPromptMode = .never
+        settings.multiAccountMenuLayout = layout
+        let metadata = try #require(ProviderRegistry.shared.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        return UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
+    }
+
+    @MainActor
+    private func installRateLimitDescriptor(_ store: UsageStore) throws {
+        let baseSpec = try #require(store.providerSpecs[.claude])
+        let descriptor = ProviderDescriptor(
+            id: .claude,
+            metadata: baseSpec.descriptor.metadata,
+            branding: baseSpec.descriptor.branding,
+            tokenCost: baseSpec.descriptor.tokenCost,
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.oauth],
+                pipeline: ProviderFetchPipeline { _ in [ClaudeOAuthRateLimitStrategy()] }),
+            cli: baseSpec.descriptor.cli)
+        store.providerSpecs[.claude] = ProviderSpec(
+            style: baseSpec.style,
+            isEnabled: baseSpec.isEnabled,
+            descriptor: descriptor,
+            makeFetchContext: baseSpec.makeFetchContext)
+    }
+
+    private func refreshWithStableClaudeCredentials(_ store: UsageStore) async {
+        await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+            let missingCredentialsURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+            await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(missingCredentialsURL) {
+                await store.refreshProvider(.claude)
+            }
+        }
+    }
+
+    @MainActor
+    private func seedAccountSnapshot(
+        store: UsageStore,
+        account: ProviderTokenAccount,
+        snapshot: UsageSnapshot)
+    {
+        self.seedAccountSnapshots(store: store, values: [(account, snapshot)])
+    }
+
+    @MainActor
+    private func seedAccountSnapshots(
+        store: UsageStore,
+        values: [(ProviderTokenAccount, UsageSnapshot)])
+    {
+        store.accountSnapshots[.claude] = values.map { account, snapshot in
+            TokenAccountUsageSnapshot(
+                account: account,
+                snapshot: snapshot,
+                error: nil,
+                sourceLabel: "oauth",
+                cacheKey: store.tokenAccountSnapshotCacheKey(provider: .claude, account: account))
+        }
+    }
+
+    private func snapshot(usedPercent: Double) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: usedPercent,
+                windowMinutes: 300,
+                resetsAt: Date(timeIntervalSince1970: 1_900_000_000 + usedPercent),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_000 + usedPercent),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "test@example.com",
+                accountOrganization: nil,
+                loginMethod: "OAuth"))
+    }
+}
+
+private struct ClaudeOAuthRateLimitStrategy: ProviderFetchStrategy {
+    let id = "test.claude-oauth-rate-limit"
+    let kind: ProviderFetchKind = .oauth
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        throw ClaudeUsageError.oauthFailed(ClaudeOAuthFetchError.usageRateLimitDescription)
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}

--- a/Tests/CodexBarTests/ClaudeOAuthTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+@Suite(.serialized)
 struct ClaudeOAuthTests {
     @Test
     func `parses O auth credentials`() throws {
@@ -486,15 +487,174 @@ struct ClaudeOAuthTests {
 
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let retryAfter = now.addingTimeInterval(120)
+        let accountA = "test-auth-token"
+        let accountB = "test-token-placeholder"
 
-        #expect(ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(now: now) == nil)
-        ClaudeOAuthUsageRateLimitGate.recordRateLimit(retryAfter: retryAfter, now: now)
+        #expect(ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(accessToken: accountA, now: now) == nil)
+        ClaudeOAuthUsageRateLimitGate.recordRateLimit(
+            accessToken: accountA,
+            retryAfter: retryAfter,
+            now: now)
 
-        #expect(ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(now: now) == retryAfter)
-        #expect(ClaudeOAuthUsageRateLimitGate.blockedUntil(interaction: .background, now: now) == retryAfter)
-        #expect(ClaudeOAuthUsageRateLimitGate.blockedUntil(interaction: .userInitiated, now: now) == nil)
-        #expect(ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(now: now.addingTimeInterval(119)) != nil)
-        #expect(ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(now: now.addingTimeInterval(121)) == nil)
+        #expect(ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(accessToken: accountA, now: now) == retryAfter)
+        #expect(ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(accessToken: accountB, now: now) == nil)
+        #expect(
+            ClaudeOAuthUsageRateLimitGate.blockedUntil(
+                accessToken: accountA,
+                interaction: .background,
+                now: now) == retryAfter)
+        #expect(
+            ClaudeOAuthUsageRateLimitGate.blockedUntil(
+                accessToken: accountA,
+                interaction: .userInitiated,
+                now: now) == nil)
+        #expect(
+            ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(
+                accessToken: accountA,
+                now: now.addingTimeInterval(119)) != nil)
+        #expect(
+            ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(
+                accessToken: accountA,
+                now: now.addingTimeInterval(121)) == nil)
+    }
+
+    @Test
+    func `O auth cooldown storage is private and cleans stale entries`() {
+        ClaudeOAuthUsageRateLimitGate.resetForTesting()
+        defer { ClaudeOAuthUsageRateLimitGate.resetForTesting() }
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let accessToken = "test-auth-token"
+        let preferenceName = ClaudeOAuthUsageRateLimitGate.storageKeyForTesting(accessToken: accessToken)
+        let prefix = "claudeOAuthUsageRateLimitBlockedUntilV2."
+        let legacyKey = "claudeOAuthUsageRateLimitBlockedUntilV1"
+        let expiredKey = prefix + "expired"
+        let malformedKey = prefix + "malformed"
+        UserDefaults.standard.set(now.addingTimeInterval(600).timeIntervalSince1970, forKey: legacyKey)
+        UserDefaults.standard.set(now.addingTimeInterval(-1).timeIntervalSince1970, forKey: expiredKey)
+        UserDefaults.standard.set("not-a-date", forKey: malformedKey)
+
+        ClaudeOAuthUsageRateLimitGate.recordRateLimit(
+            accessToken: accessToken,
+            retryAfter: now.addingTimeInterval(120),
+            now: now)
+
+        #expect(!preferenceName.contains(accessToken))
+        #expect(String(preferenceName.dropFirst(prefix.count)).count == 64)
+        #expect(UserDefaults.standard.object(forKey: preferenceName) != nil)
+        #expect(UserDefaults.standard.object(forKey: legacyKey) == nil)
+        #expect(UserDefaults.standard.object(forKey: expiredKey) == nil)
+        #expect(UserDefaults.standard.object(forKey: malformedKey) == nil)
+    }
+
+    @Test
+    func `concurrent O auth cooldown writes keep every account and latest deadline`() async {
+        ClaudeOAuthUsageRateLimitGate.resetForTesting()
+        defer { ClaudeOAuthUsageRateLimitGate.resetForTesting() }
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let shortDeadline = now.addingTimeInterval(60)
+        let longDeadline = now.addingTimeInterval(600)
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<100 {
+                group.addTask {
+                    ClaudeOAuthUsageRateLimitGate.recordRateLimit(
+                        accessToken: index.isMultiple(of: 2) ? "test-auth-token" : "test-token-placeholder",
+                        retryAfter: index.isMultiple(of: 3) ? longDeadline : shortDeadline,
+                        now: now)
+                }
+            }
+        }
+
+        #expect(
+            ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(
+                accessToken: "test-auth-token",
+                now: now) == longDeadline)
+        #expect(
+            ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(
+                accessToken: "test-token-placeholder",
+                now: now) == longDeadline)
+    }
+
+    @Test
+    func `O auth transport cooldown is isolated and user recovery clears one account`() async throws {
+        ClaudeOAuthUsageRateLimitGate.resetForTesting()
+        defer { ClaudeOAuthUsageRateLimitGate.resetForTesting() }
+
+        let accountA = "test-auth-token"
+        let accountB = "test-token-placeholder"
+        let recorder = OAuthUsageTransportRecorder()
+        let transport = ProviderHTTPTransportHandler { request in
+            let authorization = request.value(forHTTPHeaderField: "Authorization") ?? ""
+            let bearerValue = authorization.replacingOccurrences(of: "Bearer ", with: "")
+            let statusCode = await recorder.nextStatusCode(token: bearerValue)
+            let body = statusCode == 200
+                ? #"{"five_hour":{"utilization":12.5,"resets_at":"2026-07-09T18:00:00Z"}}"#
+                : #"{"type":"rate_limit_error"}"#
+            let requestURL = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: requestURL,
+                statusCode: statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: statusCode == 429 ? ["Retry-After": "300"] : nil))
+            return (Data(body.utf8), response)
+        }
+
+        do {
+            _ = try await ProviderInteractionContext.$current.withValue(.background) {
+                try await ClaudeOAuthUsageFetcher.fetchUsage(
+                    accessToken: accountA,
+                    detectClaudeVersion: false,
+                    transport: transport)
+            }
+            Issue.record("Expected account A rate limit")
+        } catch let error as ClaudeOAuthFetchError {
+            guard case .rateLimited = error else {
+                Issue.record("Expected account A rate limit, got \(error)")
+                return
+            }
+        }
+
+        do {
+            _ = try await ProviderInteractionContext.$current.withValue(.background) {
+                try await ClaudeOAuthUsageFetcher.fetchUsage(
+                    accessToken: accountA,
+                    detectClaudeVersion: false,
+                    transport: transport)
+            }
+            Issue.record("Expected account A cooldown")
+        } catch let error as ClaudeOAuthFetchError {
+            guard case .rateLimited = error else {
+                Issue.record("Expected account A cooldown, got \(error)")
+                return
+            }
+        }
+        #expect(await recorder.requestCount(token: accountA) == 1)
+
+        _ = try await ProviderInteractionContext.$current.withValue(.background) {
+            try await ClaudeOAuthUsageFetcher.fetchUsage(
+                accessToken: accountB,
+                detectClaudeVersion: false,
+                transport: transport)
+        }
+        #expect(await recorder.requestCount(token: accountB) == 1)
+
+        _ = try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+            try await ClaudeOAuthUsageFetcher.fetchUsage(
+                accessToken: accountA,
+                detectClaudeVersion: false,
+                transport: transport)
+        }
+        #expect(await recorder.requestCount(token: accountA) == 2)
+        #expect(ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(accessToken: accountA) == nil)
+
+        _ = try await ProviderInteractionContext.$current.withValue(.background) {
+            try await ClaudeOAuthUsageFetcher.fetchUsage(
+                accessToken: accountA,
+                detectClaudeVersion: false,
+                transport: transport)
+        }
+        #expect(await recorder.requestCount(token: accountA) == 3)
     }
 
     @Test
@@ -619,5 +779,19 @@ struct ClaudeOAuthTests {
             hasCLI: true,
             hasOAuthCredentials: false)
         #expect(strategy.dataSource == .cli)
+    }
+}
+
+private actor OAuthUsageTransportRecorder {
+    private var counts: [String: Int] = [:]
+
+    func nextStatusCode(token: String) -> Int {
+        let count = (self.counts[token] ?? 0) + 1
+        self.counts[token] = count
+        return token == "test-auth-token" && count == 1 ? 429 : 200
+    }
+
+    func requestCount(token: String) -> Int {
+        self.counts[token] ?? 0
     }
 }

--- a/TestsLinux/ClaudeOAuthUsageRateLimitGateLinuxTests.swift
+++ b/TestsLinux/ClaudeOAuthUsageRateLimitGateLinuxTests.swift
@@ -1,0 +1,29 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeOAuthUsageRateLimitGateLinuxTests {
+    @Test
+    func `rate limit gate isolates tokens without storing raw credentials`() {
+        ClaudeOAuthUsageRateLimitGate.resetForTesting()
+        defer { ClaudeOAuthUsageRateLimitGate.resetForTesting() }
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let tokenA = "linux-account-a"
+        let tokenB = "linux-account-b"
+        let keyA = ClaudeOAuthUsageRateLimitGate.storageKeyForTesting(accessToken: tokenA)
+        let keyB = ClaudeOAuthUsageRateLimitGate.storageKeyForTesting(accessToken: tokenB)
+
+        ClaudeOAuthUsageRateLimitGate.recordRateLimit(
+            accessToken: tokenA,
+            retryAfter: now.addingTimeInterval(120),
+            now: now)
+
+        #expect(keyA != keyB)
+        #expect(!keyA.contains(tokenA))
+        #expect(ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(accessToken: tokenA, now: now) != nil)
+        #expect(ClaudeOAuthUsageRateLimitGate.currentBlockedUntil(accessToken: tokenB, now: now) == nil)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- Isolate Claude OAuth background cooldowns by a full SHA-256 credential fingerprint; raw access tokens never enter persisted keys.
- Preserve only the current account's exact last-good OAuth snapshot during a 429, including segmented and stacked account layouts.
- Keep manual refresh able to bypass cooldown, clear only the recovered credential, and retain the latest concurrent retry deadline.
- Keep cached fallbacks out of fresh utilization history and preserve account-scoped availability metadata.
- Clean legacy, malformed, and expired cooldown entries under one serialized storage boundary.

This rewrites the stale branch on current `main` while preserving @ruushu's original resilience goal and contributor credit.

## Validation

Exact head: `e45c681aba91d0997681ecda41b4ee7d5ba0b905`

- Focused OAuth contract: 10 tests across 2 suites passed.
- Source-blind behavior validation: passed all cooldown, privacy, classifier, cache-ownership, and history contracts.
- Full macOS suite: 653 selections in 55 groups passed with zero retries, failures, or timeouts.
- `make check`: passed; SwiftFormat and SwiftLint reported zero violations.
- `autoreview --mode local`: clean; no accepted or actionable findings.

Controlled transport coverage proves account A rate limit, blocked background retry, independent account B success, user-initiated A recovery, and later A background success. No live provider 429 was intentionally induced.

No dependency changes. No model-bearing changes.
