### PR TITLE
Fix Display Mode picker in preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Agent Sessions: list and focus live local or SSH-discovered Codex and Claude Code sessions from the menu and CLI.
 
 ### Fixed
+- Display settings: keep display mode, work days, multi-account layout, and cost summary selectors interactive on macOS 27. Thanks @jordanschwartz-js!
 - Gemini: prefer Google's paid-tier plan label over generic Free, Workspace, or Paid fallbacks while preserving acronym casing in the CLI. Thanks @Yuxin-Qiao!
 - Codex: avoid false session-reset celebrations from transient zero-usage samples until the reset boundary advances. Thanks @kiranmagic7!
 - Settings: keep visual-only preference changes on cached UI paths instead of refreshing provider quotas, while preserving refreshes for data-affecting settings. Thanks @Zihao-Qi!

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -41,12 +41,18 @@ struct DisplayPane: View {
                         subtitle: L("menu_bar_shows_percent_subtitle"))
                 }
 
-                Picker(L("display_mode_title"), selection: self.$settings.menuBarDisplayMode) {
-                    ForEach(MenuBarDisplayMode.allCases) { mode in
-                        Text(mode.label).tag(mode)
-                    }
-                }
-                .disabled(!self.settings.menuBarShowsBrandIconWithPercent)
+                SettingsMenuPicker(
+                    selection: self.$settings.menuBarDisplayMode,
+                    options: MenuBarDisplayMode.allCases,
+                    label: {
+                        SettingsRowLabel(
+                            L("display_mode_title"),
+                            subtitle: self.settings.menuBarDisplayMode.description)
+                    },
+                    optionLabel: { mode in
+                        Text(mode.label)
+                    })
+                    .disabled(!self.settings.menuBarShowsBrandIconWithPercent)
             } header: {
                 Text(L("section_menu_bar"))
             }

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -43,7 +43,7 @@ struct DisplayPane: View {
 
                 SettingsMenuPicker(
                     selection: self.$settings.menuBarDisplayMode,
-                    options: MenuBarDisplayMode.allCases,
+                    options: DisplaySettingsMenuOptions.displayModes,
                     label: {
                         SettingsRowLabel(
                             L("display_mode_title"),
@@ -66,12 +66,15 @@ struct DisplayPane: View {
                         subtitle: L("show_quota_warning_markers_subtitle"))
                 }
 
-                Picker(L("weekly_progress_work_days_title"), selection: self.$settings.weeklyProgressWorkDays) {
-                    Text(L("Off")).tag(nil as Int?)
-                    Text(L("4 days")).tag(4 as Int?)
-                    Text(L("5 days")).tag(5 as Int?)
-                    Text(L("7 days")).tag(7 as Int?)
-                }
+                SettingsMenuPicker(
+                    selection: self.$settings.weeklyProgressWorkDays,
+                    options: DisplaySettingsMenuOptions.weeklyProgressWorkDays,
+                    label: {
+                        Text(L("weekly_progress_work_days_title"))
+                    },
+                    optionLabel: { workDays in
+                        Text(DisplaySettingsMenuOptions.weeklyProgressWorkDaysLabel(workDays))
+                    })
 
                 Toggle(L("show_reset_time_as_clock_title"), isOn: self.$settings.resetTimesShowAbsolute)
 
@@ -83,11 +86,15 @@ struct DisplayPane: View {
                         subtitle: L("show_credits_extra_usage_subtitle"))
                 }
 
-                Picker(L("multi_account_layout_title"), selection: self.$settings.multiAccountMenuLayout) {
-                    ForEach(MultiAccountMenuLayout.allCases) { layout in
-                        Text(layout.label).tag(layout)
-                    }
-                }
+                SettingsMenuPicker(
+                    selection: self.$settings.multiAccountMenuLayout,
+                    options: DisplaySettingsMenuOptions.multiAccountLayouts,
+                    label: {
+                        Text(L("multi_account_layout_title"))
+                    },
+                    optionLabel: { layout in
+                        Text(layout.label)
+                    })
             } header: {
                 Text(L("section_menu_content"))
             }
@@ -237,15 +244,17 @@ struct CostSummarySettingsSection: View {
             }
 
             if self.settings.costUsageEnabled {
-                Picker(selection: self.$settings.costSummaryDisplayStyle) {
-                    ForEach(CostSummaryDisplayStyle.allCases) { style in
-                        Text(style.label).tag(style)
-                    }
-                } label: {
-                    SettingsRowLabel(
-                        L("cost_summary_style_title"),
-                        subtitle: self.settings.costSummaryDisplayStyle.helpText)
-                }
+                SettingsMenuPicker(
+                    selection: self.$settings.costSummaryDisplayStyle,
+                    options: DisplaySettingsMenuOptions.costSummaryDisplayStyles,
+                    label: {
+                        SettingsRowLabel(
+                            L("cost_summary_style_title"),
+                            subtitle: self.settings.costSummaryDisplayStyle.helpText)
+                    },
+                    optionLabel: { style in
+                        Text(style.label)
+                    })
 
                 CostHistoryDaysEditor(settings: self.settings)
 

--- a/Sources/CodexBar/PreferencesMenuPicker.swift
+++ b/Sources/CodexBar/PreferencesMenuPicker.swift
@@ -62,3 +62,20 @@ enum GeneralSettingsMenuOptions {
         TerminalApp.pickerOptions(selected: selected, applicationURL: applicationURL)
     }
 }
+
+enum DisplaySettingsMenuOptions {
+    static let displayModes = MenuBarDisplayMode.allCases
+    static let weeklyProgressWorkDays: [Int?] = [nil, 4, 5, 7]
+    static let multiAccountLayouts = MultiAccountMenuLayout.allCases
+    static let costSummaryDisplayStyles = CostSummaryDisplayStyle.allCases
+
+    static func weeklyProgressWorkDaysLabel(_ workDays: Int?) -> String {
+        switch workDays {
+        case nil: L("Off")
+        case 4: L("4 days")
+        case 5: L("5 days")
+        case 7: L("7 days")
+        case let workDays?: L("%d days", workDays)
+        }
+    }
+}

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -83,6 +83,27 @@ struct PreferencesPaneSmokeTests {
     }
 
     @Test
+    func `display menu options cover persisted settings`() {
+        #expect(DisplaySettingsMenuOptions.displayModes == MenuBarDisplayMode.allCases)
+        #expect(DisplaySettingsMenuOptions.weeklyProgressWorkDays == [nil, 4, 5, 7])
+        #expect(DisplaySettingsMenuOptions.multiAccountLayouts == MultiAccountMenuLayout.allCases)
+        #expect(DisplaySettingsMenuOptions.costSummaryDisplayStyles == CostSummaryDisplayStyle.allCases)
+
+        let suite = "PreferencesPaneSmokeTests-display-menu-persistence"
+        let settings = Self.makeSettingsStore(suite: suite)
+        settings.menuBarDisplayMode = .resetTime
+        settings.weeklyProgressWorkDays = 7
+        settings.multiAccountMenuLayout = .stacked
+        settings.costSummaryDisplayStyle = .costSubmenu
+
+        let reloaded = Self.makeSettingsStore(suite: suite, reset: false)
+        #expect(reloaded.menuBarDisplayMode == .resetTime)
+        #expect(reloaded.weeklyProgressWorkDays == 7)
+        #expect(reloaded.multiAccountMenuLayout == .stacked)
+        #expect(reloaded.costSummaryDisplayStyle == .costSubmenu)
+    }
+
+    @Test
     func `overview provider limit text formats numeric limit as object argument`() {
         let text = DisplayPane.overviewProviderLimitText(limit: 3)
 


### PR DESCRIPTION
## Summary
- replace the Display Mode SwiftUI Picker with CodexBar's existing SettingsMenuPicker workaround
- keep the control disabled when brand icon + percent display is off
- show the selected mode description as the row subtitle

## Verification
- DEVELOPER_DIR=/Users/jordanschwartz/Downloads/Xcode-beta.app/Contents/Developer swift build
- DEVELOPER_DIR=/Users/jordanschwartz/Downloads/Xcode-beta.app/Contents/Developer make check
- DEVELOPER_DIR=/Users/jordanschwartz/Downloads/Xcode-beta.app/Contents/Developer swift test --filter PreferencesPaneSmokeTests
- DEVELOPER_DIR=/Users/jordanschwartz/Downloads/Xcode-beta.app/Contents/Developer swift test --filter SettingsStoreCoverageTests

## Safe runtime proof
- Built the branch as a complete local debug bundle with: CODEXBAR_SIGNING=adhoc CODEXBAR_ALLOW_LLDB=1 ARCHES=arm64 ./Scripts/package_app.sh debug
- Launched the resulting debug app bundle at /Users/jordanschwartz/Projects/CodexBar/CodexBar.app with bundle id com.steipete.codexbar.debug.
- Confirmed the branch build exposes the debug status item as CodexBar Debug and includes the Settings... status-menu action.
- Invoked AppKit's settings-window action inside the debug process; showSettingsWindow: returned YES.
- SettingsStoreCoverageTests includes the display-mode persistence path; the test "menu bar metric preferences and display modes" passed and verifies setting menuBarDisplayMode = .pace reads back as .pace.
- PreferencesPaneSmokeTests builds DisplayPane after this change with default and toggled settings.

I did not attach a screenshot/recording because this environment blocks full-screen capture that could include unrelated private on-screen content. The proof above avoids private screen capture while still covering branch build, settings entry availability, preferences-pane construction, and display-mode persistence.

Note: local SwiftPM test loading needed an ignored build-output symlink from .build/out/Products/Debug/PackageFrameworks/Sparkle.framework to ../Sparkle.framework so the test bundle could resolve Sparkle.framework.