### PR TITLE
Claude: distinguish Team seat tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - ZenMux: add Management API usage with five-hour and weekly quotas, subscription expiry, and USD PAYG balance. Thanks @kays0x!
 
 ### Fixed
+- Claude: distinguish Team Standard and Team Premium seats in web-account plan labels. Thanks @hegelty!
 - Claude: preserve each account’s last-good OAuth usage during rate limits and isolate retry cooldowns per credential. Thanks @ruushu!
 - Claude: recover a missing credentials file from a valid Claude Code Keychain item without showing Keychain UI when Never prompt is selected (#1975). Thanks @OfficialAbhinavSingh!
 - Codex cost usage: invalidate cached fork totals when the parent session appears, changes, or resolves to a different file, preventing stale inherited baselines. Thanks @xx205!

--- a/Sources/CodexBarCore/Providers/Claude/ClaudePlan.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudePlan.swift
@@ -115,6 +115,17 @@ public enum ClaudePlan: String, CaseIterable, Sendable {
             billingType: billingType)?.brandedLoginMethod(rateLimitTier: rateLimitTier)
     }
 
+    public static func webLoginMethod(rateLimitTier: String?, billingType: String?, seatTier: String?) -> String? {
+        switch self.normalized(seatTier) {
+        case "team_standard":
+            "Claude Team Standard"
+        case "team_tier_1":
+            "Claude Team Premium"
+        default:
+            self.webLoginMethod(rateLimitTier: rateLimitTier, billingType: billingType)
+        }
+    }
+
     public static func cliCompatibilityLoginMethod(_ loginMethod: String?) -> String? {
         guard let loginMethod = loginMethod?.trimmingCharacters(in: .whitespacesAndNewlines),
               !loginMethod.isEmpty

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -43,7 +43,9 @@ private actor ClaudeWebBrowserFetchGate {
     private var waiters: [Waiter] = []
 
     func acquire(id: UUID) async -> Bool {
-        if Task.isCancelled { return false }
+        if Task.isCancelled {
+            return false
+        }
         guard self.ownerID != nil else {
             self.ownerID = id
             return true
@@ -54,7 +56,9 @@ private actor ClaudeWebBrowserFetchGate {
     }
 
     func cancel(id: UUID) {
-        if self.ownerID == id { return }
+        if self.ownerID == id {
+            return
+        }
         guard let index = self.waiters.firstIndex(where: { $0.id == id }) else { return }
         let waiter = self.waiters.remove(at: index)
         waiter.continuation.resume(returning: false)
@@ -493,7 +497,9 @@ public enum ClaudeWebAPIFetcher {
         browserDetection: BrowserDetection,
         logger: ((String) -> Void)? = nil) throws -> SessionKeyInfo
     {
-        if let override = ClaudeWebSessionKeyImport.currentOverride { return override }
+        if let override = ClaudeWebSessionKeyImport.currentOverride {
+            return override
+        }
         let log: (String) -> Void = { msg in logger?(msg) }
 
         let cookieDomains = ["claude.ai"]
@@ -758,6 +764,12 @@ public enum ClaudeWebAPIFetcher {
 
         struct Membership: Decodable {
             let organization: Organization
+            let seatTier: String?
+
+            enum CodingKeys: String, CodingKey {
+                case organization
+                case seatTier = "seat_tier"
+            }
 
             struct Organization: Decodable {
                 let uuid: String?
@@ -806,7 +818,8 @@ public enum ClaudeWebAPIFetcher {
         let membership = Self.selectMembership(response.memberships, orgId: orgId)
         let plan = ClaudePlan.webLoginMethod(
             rateLimitTier: membership?.organization.rateLimitTier,
-            billingType: membership?.organization.billingType)
+            billingType: membership?.organization.billingType,
+            seatTier: membership?.seatTier)
         return WebAccountInfo(email: email, loginMethod: plan)
     }
 
@@ -816,7 +829,9 @@ public enum ClaudeWebAPIFetcher {
     {
         guard let memberships, !memberships.isEmpty else { return nil }
         if let orgId {
-            if let match = memberships.first(where: { $0.organization.uuid == orgId }) { return match }
+            if let match = memberships.first(where: { $0.organization.uuid == orgId }) {
+                return match
+            }
         }
         return memberships.first
     }
@@ -868,7 +883,9 @@ public enum ClaudeWebAPIFetcher {
         regex.enumerateMatches(in: text, options: [], range: range) { match, _, _ in
             guard let match, let r = Range(match.range(at: 0), in: text) else { return }
             let value = String(text[r]).trimmingCharacters(in: .whitespacesAndNewlines)
-            if !value.isEmpty { results.append(value) }
+            if !value.isEmpty {
+                results.append(value)
+            }
         }
         return Array(Set(results)).sorted()
     }
@@ -881,7 +898,9 @@ public enum ClaudeWebAPIFetcher {
         regex.enumerateMatches(in: text, options: [], range: range) { match, _, _ in
             guard let match, let r = Range(match.range(at: 1), in: text) else { return }
             let value = String(text[r]).trimmingCharacters(in: .whitespacesAndNewlines)
-            if !value.isEmpty { results.append(value) }
+            if !value.isEmpty {
+                results.append(value)
+            }
         }
         return Array(Set(results)).sorted()
     }
@@ -897,7 +916,9 @@ public enum ClaudeWebAPIFetcher {
         }
 
         func appendValue(_ keyPath: String, value: Any) {
-            if results.count >= 40 { return }
+            if results.count >= 40 {
+                return
+            }
             let rendered: String
             switch value {
             case let str as String:

--- a/Tests/CodexBarTests/ClaudePlanResolverTests.swift
+++ b/Tests/CodexBarTests/ClaudePlanResolverTests.swift
@@ -48,6 +48,60 @@ struct ClaudePlanResolverTests {
     }
 
     @Test
+    func `web team seat tiers map to specific labels`() {
+        #expect(
+            ClaudePlan.webLoginMethod(
+                rateLimitTier: "claude_team",
+                billingType: "stripe_subscription",
+                seatTier: "team_standard")
+                == "Claude Team Standard")
+        #expect(
+            ClaudePlan.webLoginMethod(
+                rateLimitTier: "claude_team",
+                billingType: "stripe_subscription",
+                seatTier: "team_tier_1")
+                == "Claude Team Premium")
+    }
+
+    @Test
+    func `web team seat tier near misses use existing plan inference`() {
+        #expect(
+            ClaudePlan.webLoginMethod(
+                rateLimitTier: "claude_team",
+                billingType: "stripe_subscription",
+                seatTier: "team_premium")
+                == "Claude Team")
+        #expect(
+            ClaudePlan.webLoginMethod(
+                rateLimitTier: "claude_team",
+                billingType: "stripe_subscription",
+                seatTier: "team_standard_plus")
+                == "Claude Team")
+    }
+
+    @Test
+    func `missing web seat tier preserves existing plan labels`() {
+        #expect(
+            ClaudePlan.webLoginMethod(
+                rateLimitTier: "default_claude_max_20x",
+                billingType: nil,
+                seatTier: nil)
+                == "Claude Max 20x")
+        #expect(
+            ClaudePlan.webLoginMethod(
+                rateLimitTier: "claude_pro",
+                billingType: "stripe_subscription",
+                seatTier: nil)
+                == "Claude Pro")
+        #expect(
+            ClaudePlan.webLoginMethod(
+                rateLimitTier: "claude_team",
+                billingType: "stripe_subscription",
+                seatTier: nil)
+                == "Claude Team")
+    }
+
+    @Test
     func `compatibility parser understands current labels`() {
         #expect(ClaudePlan.fromCompatibilityLoginMethod("Claude Max") == .max)
         #expect(ClaudePlan.fromCompatibilityLoginMethod("Max") == .max)

--- a/Tests/CodexBarTests/ClaudeWebAccountInfoTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebAccountInfoTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeWebAccountInfoTests {
+    @Test
+    func `selected organization determines the team seat label`() {
+        let json = """
+        {
+          "email_address": "steipete@gmail.com",
+          "memberships": [
+            {
+              "seat_tier": "team_standard",
+              "organization": {
+                "uuid": "org-standard",
+                "name": "Standard Org",
+                "rate_limit_tier": "claude_team",
+                "billing_type": "stripe_subscription"
+              }
+            },
+            {
+              "seat_tier": "team_tier_1",
+              "organization": {
+                "uuid": "org-premium",
+                "name": "Premium Org",
+                "rate_limit_tier": "claude_team",
+                "billing_type": "stripe_subscription"
+              }
+            }
+          ]
+        }
+        """
+        let data = Data(json.utf8)
+        let premium = ClaudeWebAPIFetcher._parseAccountInfoForTesting(data, orgId: "org-premium")
+        let standard = ClaudeWebAPIFetcher._parseAccountInfoForTesting(data, orgId: "org-standard")
+        #expect(premium?.loginMethod == "Claude Team Premium")
+        #expect(standard?.loginMethod == "Claude Team Standard")
+    }
+}


### PR DESCRIPTION
## Summary

- decode Claude web-account membership `seat_tier`
- label exact `team_standard` seats as Claude Team Standard
- label exact `team_tier_1` seats as Claude Team Premium
- preserve existing Max, Pro, and generic Team inference for missing or unknown seat tiers

## Maintainer rewrite

Rebased onto current `main` and narrowed the change to the selected web-account membership. The account parser uses the requested organization before reading its seat tier, so metadata cannot leak across organizations. OAuth and CLI account identity paths remain unchanged.

## Validation

- `swift test --filter ClaudePlanResolverTests`
- `swift test --filter ClaudeWebAccountInfoTests`
- `make check`
- strict `make test`: 654 selections, 55 groups, zero failures, retries, or timeouts
- source-blind behavior validation: 11 tests across 2 suites
- autoreview: clean, no accepted/actionable findings

Real Team Standard browser-account validation was not available; exact API values and organization selection are covered with synthetic parser fixtures. No live browser cookies or Keychain data were accessed.
