### PR TITLE
fix: Give widget token rows their own updated time instead of inheriting snapshot freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Ollama: recognize current WorkOS AuthKit sessions during browser-cookie discovery and manual cookie validation. Thanks @joeVenner!
 - Ollama: classify current WorkOS sign-in redirects as expired sessions, enabling cookie-candidate fallback instead of a parser error. Thanks @joeVenner!
+- Widgets: show token-cost rows with their own age when they lag a fresh quota snapshot, and retry fast token-scan failures without waiting out the hourly cache. Thanks @irresi!
 
 ## 0.41.0 — 2026-07-06
 

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -107,7 +107,8 @@ extension UsageStore {
             last30DaysTokens: monthTokensValue,
             currencyCode: snapshot.currencyCode,
             sessionLabel: sessionLabel,
-            last30DaysLabel: monthLabel)
+            last30DaysLabel: monthLabel,
+            updatedAt: snapshot.updatedAt)
     }
 
     private func widgetUsageRows(

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -1634,6 +1634,10 @@ extension UsageStore {
             let durationText = String(format: "%.2f", duration)
             let message = "cost usage failed provider=\(providerText) duration=\(durationText)s error=\(msg)"
             self.tokenCostLogger.error(message)
+            if Self.tokenFetchFailureAllowsEarlyRetry(error) {
+                self.lastTokenFetchAt.removeValue(forKey: provider)
+                self.lastTokenFetchScope.removeValue(forKey: provider)
+            }
             let hadPriorData = self.tokenSnapshots[provider] != nil
             let shouldSurface = self.tokenFailureGates[provider]?
                 .shouldSurfaceError(onFailureWithPriorData: hadPriorData) ?? true
@@ -1644,5 +1648,12 @@ extension UsageStore {
                 self.tokenErrors[provider] = nil
             }
         }
+    }
+
+    /// Fast failures may retry on the next scheduled pass instead of waiting out the fetch
+    /// TTL; timed-out scans keep the TTL so a slow corpus cannot thrash back-to-back rescans.
+    nonisolated static func tokenFetchFailureAllowsEarlyRetry(_ error: Error) -> Bool {
+        if case CostUsageError.timedOut = error { return false }
+        return true
     }
 }

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -323,12 +323,15 @@ public struct CostUsageFetcher: Sendable {
             }
 
             guard !reports.isEmpty else { return nil }
+            // Cached snapshots must keep the cache's real scan time as updatedAt; stamping the
+            // hydration time would let stale token rows inherit app-start freshness (#1964).
             return CachedCodexTokenSnapshotResult(
                 snapshot: Self.tokenSnapshot(
                     from: CostUsageDailyReport.merged(reports),
                     now: now,
                     historyDays: clampedHistoryDays,
-                    projects: Self.mergedProjectBreakdowns(projects)),
+                    projects: Self.mergedProjectBreakdowns(projects),
+                    updatedAt: nativeLastRefreshAt),
                 lastRefreshAt: nativeLastRefreshAt)
         }
         return cachedSnapshot.flatMap(\.self)
@@ -352,7 +355,8 @@ public struct CostUsageFetcher: Sendable {
         now: Date,
         historyDays: Int = 30,
         useCurrentLocalDayForSession: Bool = true,
-        projects: [CostUsageProjectBreakdown] = []) -> CostUsageTokenSnapshot
+        projects: [CostUsageProjectBreakdown] = [],
+        updatedAt: Date? = nil) -> CostUsageTokenSnapshot
     {
         let sessionEntry = useCurrentLocalDayForSession
             ? CostUsageTokenSnapshot.entry(in: daily.data, forLocalDayContaining: now)
@@ -388,7 +392,7 @@ public struct CostUsageFetcher: Sendable {
             historyDays: historyDays,
             daily: daily.data,
             projects: projects,
-            updatedAt: now)
+            updatedAt: updatedAt ?? now)
     }
 
     private static func unknownProjectBreakdown(from daily: CostUsageDailyReport) -> CostUsageProjectBreakdown? {

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -283,7 +283,11 @@ public struct CostUsageFetcher: Sendable {
             let cache = CostUsageCacheIO.load(provider: .codex, cacheRoot: options.cacheRoot)
             var reports: [CostUsageDailyReport] = []
             var projects: [CostUsageProjectBreakdown] = []
-            var nativeLastRefreshAt: Date?
+            // Raw inputs for the derived result fields below: the native cache's own scan
+            // time, every constituent scan time, and whether a second source joined the merge.
+            var nativeScanAt: Date?
+            var scanTimes: [Date] = []
+            var piMerged = false
 
             if !cache.days.isEmpty,
                cache.roots == CostUsageScanner.codexRootsFingerprint(options: options),
@@ -296,8 +300,9 @@ public struct CostUsageFetcher: Sendable {
                 if !daily.data.isEmpty {
                     reports.append(daily)
                     if cache.lastScanUnixMs > 0 {
-                        nativeLastRefreshAt = Date(
-                            timeIntervalSince1970: TimeInterval(cache.lastScanUnixMs) / 1000)
+                        let scanAt = Date(timeIntervalSince1970: TimeInterval(cache.lastScanUnixMs) / 1000)
+                        nativeScanAt = scanAt
+                        scanTimes.append(scanAt)
                     }
                     if cache.codexProjectMetadataVersion == CostUsageScanner.codexProjectMetadataVersion {
                         projects.append(contentsOf: CostUsageScanner.buildCodexProjectBreakdownsFromCache(
@@ -308,31 +313,36 @@ public struct CostUsageFetcher: Sendable {
                 }
             }
 
-            if let piDaily = PiSessionCostScanner.loadCachedDailyReport(
+            if let piResult = PiSessionCostScanner.loadCachedDailyReportResult(
                 provider: .codex,
                 since: since,
                 until: until,
                 now: now,
                 cacheRoot: options.cacheRoot)
             {
-                reports.append(piDaily)
-                nativeLastRefreshAt = nil
-                if let piProject = Self.unknownProjectBreakdown(from: piDaily) {
+                reports.append(piResult.report)
+                piMerged = true
+                if let piLastScanAt = piResult.lastScanAt {
+                    scanTimes.append(piLastScanAt)
+                }
+                if let piProject = Self.unknownProjectBreakdown(from: piResult.report) {
                     projects.append(piProject)
                 }
             }
 
             guard !reports.isEmpty else { return nil }
-            // Cached snapshots must keep the cache's real scan time as updatedAt; stamping the
-            // hydration time would let stale token rows inherit app-start freshness (#1964).
+            // updatedAt keeps the caches' real (oldest) scan time; stamping the hydration time
+            // would let stale token rows inherit app-start freshness (#1964). lastRefreshAt
+            // drives TTL suppression and stays native-only: a merged load must never delay a
+            // rescan on the strength of another source's scan.
             return CachedCodexTokenSnapshotResult(
                 snapshot: Self.tokenSnapshot(
                     from: CostUsageDailyReport.merged(reports),
                     now: now,
                     historyDays: clampedHistoryDays,
                     projects: Self.mergedProjectBreakdowns(projects),
-                    updatedAt: nativeLastRefreshAt),
-                lastRefreshAt: nativeLastRefreshAt)
+                    updatedAt: scanTimes.min()),
+                lastRefreshAt: piMerged ? nil : nativeScanAt)
         }
         return cachedSnapshot.flatMap(\.self)
     }

--- a/Sources/CodexBarCore/PiSessionCostScanner.swift
+++ b/Sources/CodexBarCore/PiSessionCostScanner.swift
@@ -151,12 +151,32 @@ enum PiSessionCostScanner {
             pricingContext: pricingContext)
     }
 
+    struct CachedDailyReportResult {
+        let report: CostUsageDailyReport
+        let lastScanAt: Date?
+    }
+
     static func loadCachedDailyReport(
         provider: UsageProvider,
         since: Date,
         until: Date,
         now: Date = Date(),
         cacheRoot: URL? = nil) -> CostUsageDailyReport?
+    {
+        self.loadCachedDailyReportResult(
+            provider: provider,
+            since: since,
+            until: until,
+            now: now,
+            cacheRoot: cacheRoot)?.report
+    }
+
+    static func loadCachedDailyReportResult(
+        provider: UsageProvider,
+        since: Date,
+        until: Date,
+        now: Date = Date(),
+        cacheRoot: URL? = nil) -> CachedDailyReportResult?
     {
         guard provider == .codex || provider == .claude else { return nil }
 
@@ -173,7 +193,11 @@ enum PiSessionCostScanner {
             cache: cache,
             range: range,
             pricingContext: pricingContext)
-        return report.data.isEmpty ? nil : report
+        guard !report.data.isEmpty else { return nil }
+        let lastScanAt = cache.lastScanUnixMs > 0
+            ? Date(timeIntervalSince1970: TimeInterval(cache.lastScanUnixMs) / 1000)
+            : nil
+        return CachedDailyReportResult(report: report, lastScanAt: lastScanAt)
     }
 
     private static func requestedWindowExpandsCache(

--- a/Sources/CodexBarCore/WidgetSnapshot.swift
+++ b/Sources/CodexBarCore/WidgetSnapshot.swift
@@ -56,6 +56,10 @@ public struct WidgetSnapshot: Codable, Sendable {
     }
 
     public struct TokenUsageSummary: Codable, Sendable {
+        /// Token-cost rows refresh on a slower cadence than quota rows; beyond this lag the
+        /// widget discloses their own age instead of inheriting `ProviderEntry.updatedAt`.
+        public static let staleLagThreshold: TimeInterval = 10 * 60
+
         public let sessionCostUSD: Double?
         public let sessionTokens: Int?
         public let last30DaysCostUSD: Double?
@@ -63,6 +67,7 @@ public struct WidgetSnapshot: Codable, Sendable {
         public let currencyCode: String
         public let sessionLabel: String
         public let last30DaysLabel: String
+        public let updatedAt: Date?
 
         public init(
             sessionCostUSD: Double?,
@@ -71,7 +76,8 @@ public struct WidgetSnapshot: Codable, Sendable {
             last30DaysTokens: Int?,
             currencyCode: String = "USD",
             sessionLabel: String = "Today",
-            last30DaysLabel: String = "30d")
+            last30DaysLabel: String = "30d",
+            updatedAt: Date? = nil)
         {
             self.sessionCostUSD = sessionCostUSD
             self.sessionTokens = sessionTokens
@@ -86,6 +92,13 @@ public struct WidgetSnapshot: Codable, Sendable {
             self.last30DaysLabel = last30DaysLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ? "30d"
                 : last30DaysLabel
+            self.updatedAt = updatedAt
+        }
+
+        /// Unknown age (legacy snapshots) counts as fresh.
+        public func isStale(comparedTo entryUpdatedAt: Date) -> Bool {
+            guard let updatedAt else { return false }
+            return entryUpdatedAt.timeIntervalSince(updatedAt) > Self.staleLagThreshold
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -96,6 +109,7 @@ public struct WidgetSnapshot: Codable, Sendable {
             case currencyCode
             case sessionLabel
             case last30DaysLabel
+            case updatedAt
         }
 
         public init(from decoder: Decoder) throws {
@@ -107,7 +121,8 @@ public struct WidgetSnapshot: Codable, Sendable {
                 last30DaysTokens: container.decodeIfPresent(Int.self, forKey: .last30DaysTokens),
                 currencyCode: container.decodeIfPresent(String.self, forKey: .currencyCode) ?? "USD",
                 sessionLabel: container.decodeIfPresent(String.self, forKey: .sessionLabel) ?? "Today",
-                last30DaysLabel: container.decodeIfPresent(String.self, forKey: .last30DaysLabel) ?? "30d")
+                last30DaysLabel: container.decodeIfPresent(String.self, forKey: .last30DaysLabel) ?? "30d",
+                updatedAt: container.decodeIfPresent(Date.self, forKey: .updatedAt))
         }
     }
 

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -209,7 +209,7 @@ enum CompactMetricFormatter {
             } ?? "—"
             let detail = entry.tokenUsage?.sessionTokens.map(WidgetFormat.tokenCount)
             let label = entry.tokenUsage.map {
-                WidgetFormat.tokenRowTitle("\($0.sessionLabel) cost", token: $0, entryUpdatedAt: entry.updatedAt)
+                WidgetFormat.tokenRowTitle("\($0.sessionLabel) cost", summary: $0, entryUpdatedAt: entry.updatedAt)
             } ?? "Today cost"
             return CompactMetricDisplay(value: value, label: label, detail: detail)
         case .last30DaysCost:
@@ -218,7 +218,7 @@ enum CompactMetricFormatter {
             } ?? "—"
             let detail = entry.tokenUsage?.last30DaysTokens.map(WidgetFormat.tokenCount)
             let label = entry.tokenUsage.map {
-                WidgetFormat.tokenRowTitle("\($0.last30DaysLabel) cost", token: $0, entryUpdatedAt: entry.updatedAt)
+                WidgetFormat.tokenRowTitle("\($0.last30DaysLabel) cost", summary: $0, entryUpdatedAt: entry.updatedAt)
             } ?? "30d cost"
             return CompactMetricDisplay(value: value, label: label, detail: detail)
         }
@@ -372,7 +372,7 @@ private struct SwitcherSmallUsageView: View {
                 ValueLine(
                     title: WidgetFormat.tokenRowTitle(
                         token.sessionLabel,
-                        token: token,
+                        summary: token,
                         entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.sessionCostUSD,
@@ -407,7 +407,7 @@ private struct SwitcherMediumUsageView: View {
                 ValueLine(
                     title: WidgetFormat.tokenRowTitle(
                         token.sessionLabel,
-                        token: token,
+                        summary: token,
                         entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.sessionCostUSD,
@@ -446,7 +446,7 @@ private struct SwitcherLargeUsageView: View {
                     ValueLine(
                         title: WidgetFormat.tokenRowTitle(
                             token.sessionLabel,
-                            token: token,
+                            summary: token,
                             entryUpdatedAt: self.entry.updatedAt),
                         value: WidgetFormat.costAndTokens(
                             cost: token.sessionCostUSD,
@@ -455,7 +455,7 @@ private struct SwitcherLargeUsageView: View {
                     ValueLine(
                         title: WidgetFormat.tokenRowTitle(
                             token.last30DaysLabel,
-                            token: token,
+                            summary: token,
                             entryUpdatedAt: self.entry.updatedAt),
                         value: WidgetFormat.costAndTokens(
                             cost: token.last30DaysCostUSD,
@@ -500,7 +500,7 @@ private struct SmallUsageView: View {
                 ValueLine(
                     title: WidgetFormat.tokenRowTitle(
                         token.sessionLabel,
-                        token: token,
+                        summary: token,
                         entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.sessionCostUSD,
@@ -537,7 +537,7 @@ private struct MediumUsageView: View {
                 ValueLine(
                     title: WidgetFormat.tokenRowTitle(
                         token.sessionLabel,
-                        token: token,
+                        summary: token,
                         entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.sessionCostUSD,
@@ -578,7 +578,7 @@ private struct LargeUsageView: View {
                     ValueLine(
                         title: WidgetFormat.tokenRowTitle(
                             token.sessionLabel,
-                            token: token,
+                            summary: token,
                             entryUpdatedAt: self.entry.updatedAt),
                         value: WidgetFormat.costAndTokens(
                             cost: token.sessionCostUSD,
@@ -587,7 +587,7 @@ private struct LargeUsageView: View {
                     ValueLine(
                         title: WidgetFormat.tokenRowTitle(
                             token.last30DaysLabel,
-                            token: token,
+                            summary: token,
                             entryUpdatedAt: self.entry.updatedAt),
                         value: WidgetFormat.costAndTokens(
                             cost: token.last30DaysCostUSD,
@@ -832,7 +832,7 @@ private struct HistoryView: View {
                 ValueLine(
                     title: WidgetFormat.tokenRowTitle(
                         token.sessionLabel,
-                        token: token,
+                        summary: token,
                         entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.sessionCostUSD,
@@ -841,7 +841,7 @@ private struct HistoryView: View {
                 ValueLine(
                     title: WidgetFormat.tokenRowTitle(
                         token.last30DaysLabel,
-                        token: token,
+                        summary: token,
                         entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.last30DaysCostUSD,
@@ -1158,10 +1158,10 @@ enum WidgetFormat {
     /// freshness signal past `TokenUsageSummary.staleLagThreshold`.
     static func tokenRowTitle(
         _ base: String,
-        token: WidgetSnapshot.TokenUsageSummary,
+        summary: WidgetSnapshot.TokenUsageSummary,
         entryUpdatedAt: Date) -> String
     {
-        guard token.isStale(comparedTo: entryUpdatedAt), let updatedAt = token.updatedAt else { return base }
+        guard summary.isStale(comparedTo: entryUpdatedAt), let updatedAt = summary.updatedAt else { return base }
         return "\(base) · \(self.relativeDate(updatedAt))"
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -208,14 +208,18 @@ enum CompactMetricFormatter {
                 token.sessionCostUSD.map { WidgetFormat.currency($0, code: token.currencyCode) } ?? "—"
             } ?? "—"
             let detail = entry.tokenUsage?.sessionTokens.map(WidgetFormat.tokenCount)
-            let label = entry.tokenUsage.map { "\($0.sessionLabel) cost" } ?? "Today cost"
+            let label = entry.tokenUsage.map {
+                WidgetFormat.tokenRowTitle("\($0.sessionLabel) cost", token: $0, entryUpdatedAt: entry.updatedAt)
+            } ?? "Today cost"
             return CompactMetricDisplay(value: value, label: label, detail: detail)
         case .last30DaysCost:
             let value = entry.tokenUsage.map { token in
                 token.last30DaysCostUSD.map { WidgetFormat.currency($0, code: token.currencyCode) } ?? "—"
             } ?? "—"
             let detail = entry.tokenUsage?.last30DaysTokens.map(WidgetFormat.tokenCount)
-            let label = entry.tokenUsage.map { "\($0.last30DaysLabel) cost" } ?? "30d cost"
+            let label = entry.tokenUsage.map {
+                WidgetFormat.tokenRowTitle("\($0.last30DaysLabel) cost", token: $0, entryUpdatedAt: entry.updatedAt)
+            } ?? "30d cost"
             return CompactMetricDisplay(value: value, label: label, detail: detail)
         }
     }
@@ -398,7 +402,10 @@ private struct SwitcherMediumUsageView: View {
             }
             if let token = entry.tokenUsage {
                 ValueLine(
-                    title: token.sessionLabel,
+                    title: WidgetFormat.tokenRowTitle(
+                        token.sessionLabel,
+                        token: token,
+                        entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.sessionCostUSD,
                         tokens: token.sessionTokens,
@@ -434,7 +441,10 @@ private struct SwitcherLargeUsageView: View {
             if let token = entry.tokenUsage {
                 VStack(alignment: .leading, spacing: 4) {
                     ValueLine(
-                        title: token.sessionLabel,
+                        title: WidgetFormat.tokenRowTitle(
+                            token.sessionLabel,
+                            token: token,
+                            entryUpdatedAt: self.entry.updatedAt),
                         value: WidgetFormat.costAndTokens(
                             cost: token.sessionCostUSD,
                             tokens: token.sessionTokens,
@@ -482,7 +492,10 @@ private struct SmallUsageView: View {
             }
             if let token = WidgetUsageRow.compactTokenUsage(for: self.entry) {
                 ValueLine(
-                    title: token.sessionLabel,
+                    title: WidgetFormat.tokenRowTitle(
+                        token.sessionLabel,
+                        token: token,
+                        entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.sessionCostUSD,
                         tokens: token.sessionTokens,
@@ -516,7 +529,10 @@ private struct MediumUsageView: View {
             }
             if let token = entry.tokenUsage {
                 ValueLine(
-                    title: token.sessionLabel,
+                    title: WidgetFormat.tokenRowTitle(
+                        token.sessionLabel,
+                        token: token,
+                        entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.sessionCostUSD,
                         tokens: token.sessionTokens,
@@ -554,7 +570,10 @@ private struct LargeUsageView: View {
             if let token = entry.tokenUsage {
                 VStack(alignment: .leading, spacing: 4) {
                     ValueLine(
-                        title: token.sessionLabel,
+                        title: WidgetFormat.tokenRowTitle(
+                            token.sessionLabel,
+                            token: token,
+                            entryUpdatedAt: self.entry.updatedAt),
                         value: WidgetFormat.costAndTokens(
                             cost: token.sessionCostUSD,
                             tokens: token.sessionTokens,
@@ -802,7 +821,10 @@ private struct HistoryView: View {
                 .frame(height: self.isLarge ? 90 : 60)
             if let token = entry.tokenUsage {
                 ValueLine(
-                    title: token.sessionLabel,
+                    title: WidgetFormat.tokenRowTitle(
+                        token.sessionLabel,
+                        token: token,
+                        entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.sessionCostUSD,
                         tokens: token.sessionTokens,
@@ -1118,5 +1140,16 @@ enum WidgetFormat {
         formatter.locale = Locale(identifier: "en_US")
         formatter.unitsStyle = .short
         return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    /// Suffixes the title with the token snapshot's own age once it lags the entry's
+    /// freshness signal past `TokenUsageSummary.staleLagThreshold`.
+    static func tokenRowTitle(
+        _ base: String,
+        token: WidgetSnapshot.TokenUsageSummary,
+        entryUpdatedAt: Date) -> String
+    {
+        guard token.isStale(comparedTo: entryUpdatedAt), let updatedAt = token.updatedAt else { return base }
+        return "\(base) · \(self.relativeDate(updatedAt))"
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -370,7 +370,10 @@ private struct SwitcherSmallUsageView: View {
             }
             if let token = WidgetUsageRow.compactTokenUsage(for: self.entry) {
                 ValueLine(
-                    title: token.sessionLabel,
+                    title: WidgetFormat.tokenRowTitle(
+                        token.sessionLabel,
+                        token: token,
+                        entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.sessionCostUSD,
                         tokens: token.sessionTokens,
@@ -450,7 +453,10 @@ private struct SwitcherLargeUsageView: View {
                             tokens: token.sessionTokens,
                             currencyCode: token.currencyCode))
                     ValueLine(
-                        title: token.last30DaysLabel,
+                        title: WidgetFormat.tokenRowTitle(
+                            token.last30DaysLabel,
+                            token: token,
+                            entryUpdatedAt: self.entry.updatedAt),
                         value: WidgetFormat.costAndTokens(
                             cost: token.last30DaysCostUSD,
                             tokens: token.last30DaysTokens,
@@ -579,7 +585,10 @@ private struct LargeUsageView: View {
                             tokens: token.sessionTokens,
                             currencyCode: token.currencyCode))
                     ValueLine(
-                        title: token.last30DaysLabel,
+                        title: WidgetFormat.tokenRowTitle(
+                            token.last30DaysLabel,
+                            token: token,
+                            entryUpdatedAt: self.entry.updatedAt),
                         value: WidgetFormat.costAndTokens(
                             cost: token.last30DaysCostUSD,
                             tokens: token.last30DaysTokens,
@@ -830,7 +839,10 @@ private struct HistoryView: View {
                         tokens: token.sessionTokens,
                         currencyCode: token.currencyCode))
                 ValueLine(
-                    title: token.last30DaysLabel,
+                    title: WidgetFormat.tokenRowTitle(
+                        token.last30DaysLabel,
+                        token: token,
+                        entryUpdatedAt: self.entry.updatedAt),
                     value: WidgetFormat.costAndTokens(
                         cost: token.last30DaysCostUSD,
                         tokens: token.last30DaysTokens,

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -893,18 +893,18 @@ extension CodexBarWidgetProviderTests {
 
         let todayTitle = WidgetFormat.tokenRowTitle(
             staleToken.sessionLabel,
-            token: staleToken,
+            summary: staleToken,
             entryUpdatedAt: entryUpdatedAt)
         let historyTitle = WidgetFormat.tokenRowTitle(
             staleToken.last30DaysLabel,
-            token: staleToken,
+            summary: staleToken,
             entryUpdatedAt: entryUpdatedAt)
 
         #expect(todayTitle.hasPrefix("Today · "))
         #expect(historyTitle.hasPrefix("30d · "))
         #expect(WidgetFormat.tokenRowTitle(
             freshToken.sessionLabel,
-            token: freshToken,
+            summary: freshToken,
             entryUpdatedAt: entryUpdatedAt) == "Today")
     }
 

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -906,6 +906,22 @@ extension CodexBarWidgetProviderTests {
             freshToken.sessionLabel,
             summary: freshToken,
             entryUpdatedAt: entryUpdatedAt) == "Today")
+
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .codex,
+            updatedAt: entryUpdatedAt,
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: staleToken,
+            dailyUsage: [])
+        let todayMetric = CompactMetricFormatter.display(for: entry, metric: .todayCost)
+        let historyMetric = CompactMetricFormatter.display(for: entry, metric: .last30DaysCost)
+
+        #expect(todayMetric.label.hasPrefix("Today cost · "))
+        #expect(historyMetric.label.hasPrefix("30d cost · "))
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -876,6 +876,39 @@ struct CodexBarWidgetProviderTests {
 
 extension CodexBarWidgetProviderTests {
     @Test
+    func `widget token titles disclose stale age for today and history rows`() {
+        let entryUpdatedAt = Date()
+        let staleToken = WidgetSnapshot.TokenUsageSummary(
+            sessionCostUSD: 1.25,
+            sessionTokens: 4200,
+            last30DaysCostUSD: 12.50,
+            last30DaysTokens: 42000,
+            updatedAt: entryUpdatedAt.addingTimeInterval(-45 * 60))
+        let freshToken = WidgetSnapshot.TokenUsageSummary(
+            sessionCostUSD: 1.25,
+            sessionTokens: 4200,
+            last30DaysCostUSD: 12.50,
+            last30DaysTokens: 42000,
+            updatedAt: entryUpdatedAt.addingTimeInterval(-5 * 60))
+
+        let todayTitle = WidgetFormat.tokenRowTitle(
+            staleToken.sessionLabel,
+            token: staleToken,
+            entryUpdatedAt: entryUpdatedAt)
+        let historyTitle = WidgetFormat.tokenRowTitle(
+            staleToken.last30DaysLabel,
+            token: staleToken,
+            entryUpdatedAt: entryUpdatedAt)
+
+        #expect(todayTitle.hasPrefix("Today · "))
+        #expect(historyTitle.hasPrefix("30d · "))
+        #expect(WidgetFormat.tokenRowTitle(
+            freshToken.sessionLabel,
+            token: freshToken,
+            entryUpdatedAt: entryUpdatedAt) == "Today")
+    }
+
+    @Test
     func `usage history chart mode requires every point to expose cost`() {
         let costPoints = [
             WidgetSnapshot.DailyUsagePoint(dayKey: "2026-07-01", totalTokens: 100, costUSD: 1.2),

--- a/Tests/CodexBarTests/CostUsageFetcherCacheSnapshotTests.swift
+++ b/Tests/CodexBarTests/CostUsageFetcherCacheSnapshotTests.swift
@@ -62,13 +62,14 @@ struct CostUsageFetcherCacheSnapshotTests {
         let scanTime = Date(timeIntervalSince1970: TimeInterval(cache.lastScanUnixMs) / 1000)
 
         let hydratedAt = day.addingTimeInterval(50 * 60)
-        let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
+        let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshotResult(
             now: hydratedAt,
             historyDays: 1,
             scannerOptions: options)
 
-        #expect(cached?.updatedAt == scanTime)
-        #expect(cached?.updatedAt != hydratedAt)
+        #expect(cached?.snapshot.updatedAt == scanTime)
+        #expect(cached?.snapshot.updatedAt != hydratedAt)
+        #expect(cached?.lastRefreshAt == scanTime)
     }
 
     @Test
@@ -101,21 +102,60 @@ struct CostUsageFetcherCacheSnapshotTests {
             piScannerOptions: piOptions)
 
         let nativeCache = CostUsageCacheIO.load(provider: .codex, cacheRoot: env.cacheRoot)
-        let piCache = PiSessionCostCacheIO.load(cacheRoot: env.cacheRoot)
+        var piCache = PiSessionCostCacheIO.load(cacheRoot: env.cacheRoot)
         #expect(nativeCache.lastScanUnixMs > 0)
         #expect(piCache.lastScanUnixMs > 0)
-        let oldestScanTime = Date(
-            timeIntervalSince1970: TimeInterval(min(nativeCache.lastScanUnixMs, piCache.lastScanUnixMs)) / 1000)
+        piCache.lastScanUnixMs = nativeCache.lastScanUnixMs - 30 * 60 * 1000
+        PiSessionCostCacheIO.save(cache: piCache, cacheRoot: env.cacheRoot)
+        let oldestScanTime = Date(timeIntervalSince1970: TimeInterval(piCache.lastScanUnixMs) / 1000)
 
         let hydratedAt = day.addingTimeInterval(50 * 60)
-        let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
+        let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshotResult(
             now: hydratedAt,
             historyDays: 1,
             scannerOptions: options)
 
-        #expect(cached?.sessionTokens == 207)
-        #expect(cached?.updatedAt == oldestScanTime)
-        #expect(cached?.updatedAt != hydratedAt)
+        #expect(cached?.snapshot.sessionTokens == 207)
+        #expect(cached?.snapshot.updatedAt == oldestScanTime)
+        #expect(cached?.snapshot.updatedAt != hydratedAt)
+        #expect(cached?.lastRefreshAt == nil)
+    }
+
+    @Test
+    func `cached codex token snapshot keeps pi scan time when only pi sessions exist`() async throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 4, day: 8)
+        try Self.writePiCodexSessionFile(env: env, day: day, tokens: 165)
+
+        let options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            cacheRoot: env.cacheRoot)
+        let piOptions = PiSessionCostScanner.Options(
+            piSessionsRoot: env.piSessionsRoot,
+            cacheRoot: env.cacheRoot,
+            refreshMinIntervalSeconds: 0)
+        _ = try await CostUsageFetcher.loadTokenSnapshot(
+            provider: .codex,
+            now: day,
+            historyDays: 1,
+            refreshPricingInBackground: false,
+            scannerOptions: options,
+            piScannerOptions: piOptions)
+
+        let piCache = PiSessionCostCacheIO.load(cacheRoot: env.cacheRoot)
+        #expect(piCache.lastScanUnixMs > 0)
+        let piScanTime = Date(timeIntervalSince1970: TimeInterval(piCache.lastScanUnixMs) / 1000)
+
+        let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshotResult(
+            now: day.addingTimeInterval(50 * 60),
+            historyDays: 1,
+            scannerOptions: options)
+
+        #expect(cached?.snapshot.sessionTokens == 165)
+        #expect(cached?.snapshot.updatedAt == piScanTime)
+        #expect(cached?.lastRefreshAt == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/CostUsageFetcherCacheSnapshotTests.swift
+++ b/Tests/CodexBarTests/CostUsageFetcherCacheSnapshotTests.swift
@@ -36,6 +36,42 @@ struct CostUsageFetcherCacheSnapshotTests {
     }
 
     @Test
+    func `cached codex token snapshot keeps the cache scan time as updatedAt`() async throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 4, day: 8)
+        try Self.writeCodexSessionFile(
+            homeRoot: env.codexHomeRoot,
+            env: env,
+            day: day,
+            filename: "cached.jsonl",
+            tokens: 42)
+
+        let options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            cacheRoot: env.cacheRoot)
+        _ = try await CostUsageFetcher.loadTokenSnapshot(
+            provider: .codex,
+            now: day,
+            historyDays: 1,
+            scannerOptions: options)
+
+        let cache = CostUsageCacheIO.load(provider: .codex, cacheRoot: env.cacheRoot)
+        #expect(cache.lastScanUnixMs > 0)
+        let scanTime = Date(timeIntervalSince1970: TimeInterval(cache.lastScanUnixMs) / 1000)
+
+        let hydratedAt = day.addingTimeInterval(50 * 60)
+        let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
+            now: hydratedAt,
+            historyDays: 1,
+            scannerOptions: options)
+
+        #expect(cached?.updatedAt == scanTime)
+        #expect(cached?.updatedAt != hydratedAt)
+    }
+
+    @Test
     func `cached codex token snapshot refuses expanded or managed scopes`() async throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }

--- a/Tests/CodexBarTests/CostUsageFetcherCacheSnapshotTests.swift
+++ b/Tests/CodexBarTests/CostUsageFetcherCacheSnapshotTests.swift
@@ -72,6 +72,102 @@ struct CostUsageFetcherCacheSnapshotTests {
     }
 
     @Test
+    func `cached codex token snapshot keeps the oldest scan time when pi sessions merge`() async throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 4, day: 8)
+        try Self.writeCodexSessionFile(
+            homeRoot: env.codexHomeRoot,
+            env: env,
+            day: day,
+            filename: "cached.jsonl",
+            tokens: 42)
+        try Self.writePiCodexSessionFile(env: env, day: day, tokens: 165)
+
+        let options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            cacheRoot: env.cacheRoot)
+        let piOptions = PiSessionCostScanner.Options(
+            piSessionsRoot: env.piSessionsRoot,
+            cacheRoot: env.cacheRoot,
+            refreshMinIntervalSeconds: 0)
+        _ = try await CostUsageFetcher.loadTokenSnapshot(
+            provider: .codex,
+            now: day,
+            historyDays: 1,
+            refreshPricingInBackground: false,
+            scannerOptions: options,
+            piScannerOptions: piOptions)
+
+        let nativeCache = CostUsageCacheIO.load(provider: .codex, cacheRoot: env.cacheRoot)
+        let piCache = PiSessionCostCacheIO.load(cacheRoot: env.cacheRoot)
+        #expect(nativeCache.lastScanUnixMs > 0)
+        #expect(piCache.lastScanUnixMs > 0)
+        let oldestScanTime = Date(
+            timeIntervalSince1970: TimeInterval(min(nativeCache.lastScanUnixMs, piCache.lastScanUnixMs)) / 1000)
+
+        let hydratedAt = day.addingTimeInterval(50 * 60)
+        let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
+            now: hydratedAt,
+            historyDays: 1,
+            scannerOptions: options)
+
+        #expect(cached?.sessionTokens == 207)
+        #expect(cached?.updatedAt == oldestScanTime)
+        #expect(cached?.updatedAt != hydratedAt)
+    }
+
+    @Test
+    func `cached codex token snapshot keeps native scan time when pi cache lacks one`() async throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 4, day: 8)
+        try Self.writeCodexSessionFile(
+            homeRoot: env.codexHomeRoot,
+            env: env,
+            day: day,
+            filename: "cached.jsonl",
+            tokens: 42)
+        try Self.writePiCodexSessionFile(env: env, day: day, tokens: 165)
+
+        let options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            cacheRoot: env.cacheRoot)
+        let piOptions = PiSessionCostScanner.Options(
+            piSessionsRoot: env.piSessionsRoot,
+            cacheRoot: env.cacheRoot,
+            refreshMinIntervalSeconds: 0)
+        _ = try await CostUsageFetcher.loadTokenSnapshot(
+            provider: .codex,
+            now: day,
+            historyDays: 1,
+            refreshPricingInBackground: false,
+            scannerOptions: options,
+            piScannerOptions: piOptions)
+
+        var piCache = PiSessionCostCacheIO.load(cacheRoot: env.cacheRoot)
+        piCache.lastScanUnixMs = 0
+        PiSessionCostCacheIO.save(cache: piCache, cacheRoot: env.cacheRoot)
+
+        let nativeCache = CostUsageCacheIO.load(provider: .codex, cacheRoot: env.cacheRoot)
+        #expect(nativeCache.lastScanUnixMs > 0)
+        let nativeScanTime = Date(
+            timeIntervalSince1970: TimeInterval(nativeCache.lastScanUnixMs) / 1000)
+
+        let hydratedAt = day.addingTimeInterval(50 * 60)
+        let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
+            now: hydratedAt,
+            historyDays: 1,
+            scannerOptions: options)
+
+        #expect(cached?.sessionTokens == 207)
+        #expect(cached?.updatedAt == nativeScanTime)
+        #expect(cached?.updatedAt != hydratedAt)
+    }
+
+    @Test
     func `cached codex token snapshot refuses expanded or managed scopes`() async throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }

--- a/Tests/CodexBarTests/UsageStoreTokenRetryPolicyTests.swift
+++ b/Tests/CodexBarTests/UsageStoreTokenRetryPolicyTests.swift
@@ -1,0 +1,12 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct UsageStoreTokenRetryPolicyTests {
+    @Test
+    func `timed out token scans keep the fetch TTL while fast failures retry early`() {
+        #expect(!UsageStore.tokenFetchFailureAllowsEarlyRetry(CostUsageError.timedOut(seconds: 600)))
+        #expect(UsageStore.tokenFetchFailureAllowsEarlyRetry(CocoaError(.fileReadNoSuchFile)))
+    }
+}

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -416,4 +416,57 @@ struct UsageStoreWidgetSnapshotTests {
         let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .devin })
         #expect((entry.providerCost != nil) == showsExtraUsage)
     }
+
+    @Test
+    func `widget snapshot carries token usage age separately from entry freshness`() async throws {
+        let suite = "UsageStoreWidgetSnapshotTests-token-usage-age"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let entryUpdatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let tokenUpdatedAt = entryUpdatedAt.addingTimeInterval(-45 * 60)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 30, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: entryUpdatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .claude,
+                    accountEmail: nil,
+                    accountOrganization: nil,
+                    loginMethod: nil)),
+            provider: .claude)
+        store._setTokenSnapshotForTesting(
+            CostUsageTokenSnapshot(
+                sessionTokens: 4200,
+                sessionCostUSD: 1.25,
+                last30DaysTokens: 42000,
+                last30DaysCostUSD: 12.50,
+                daily: [],
+                updatedAt: tokenUpdatedAt),
+            provider: .claude)
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        store.persistWidgetSnapshot(reason: "token-usage-age-test")
+        await store.widgetSnapshotPersistTask?.value
+
+        let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .claude })
+        #expect(entry.updatedAt == entryUpdatedAt)
+        #expect(entry.tokenUsage?.updatedAt == tokenUpdatedAt)
+        #expect(entry.tokenUsage?.isStale(comparedTo: entry.updatedAt) == true)
+    }
 }

--- a/Tests/CodexBarTests/WidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/WidgetSnapshotTests.swift
@@ -206,4 +206,50 @@ struct WidgetSnapshotTests {
         #expect(decoded.entries.first?.tokenUsage?.last30DaysLabel == "30d")
         #expect(decoded.enabledProviders == [.codex])
     }
+
+    @Test
+    func `token usage summary round trips updatedAt and tolerates legacy payloads`() throws {
+        let updatedAt = Date(timeIntervalSince1970: 1_760_000_000)
+        let summary = WidgetSnapshot.TokenUsageSummary(
+            sessionCostUSD: 1.5,
+            sessionTokens: 100,
+            last30DaysCostUSD: 30,
+            last30DaysTokens: 2000,
+            updatedAt: updatedAt)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let decoded = try decoder.decode(
+            WidgetSnapshot.TokenUsageSummary.self,
+            from: encoder.encode(summary))
+        #expect(decoded.updatedAt == updatedAt)
+
+        let legacy = try decoder.decode(
+            WidgetSnapshot.TokenUsageSummary.self,
+            from: Data(#"{"sessionCostUSD": 1.5, "sessionTokens": 100}"#.utf8))
+        #expect(legacy.updatedAt == nil)
+    }
+
+    @Test
+    func `token usage staleness discloses only meaningful lag`() {
+        let entryUpdatedAt = Date()
+
+        func summary(updatedAt: Date?) -> WidgetSnapshot.TokenUsageSummary {
+            WidgetSnapshot.TokenUsageSummary(
+                sessionCostUSD: nil,
+                sessionTokens: nil,
+                last30DaysCostUSD: nil,
+                last30DaysTokens: nil,
+                updatedAt: updatedAt)
+        }
+
+        #expect(!summary(updatedAt: entryUpdatedAt.addingTimeInterval(-5 * 60))
+            .isStale(comparedTo: entryUpdatedAt))
+        #expect(summary(updatedAt: entryUpdatedAt.addingTimeInterval(-61 * 60))
+            .isStale(comparedTo: entryUpdatedAt))
+        #expect(!summary(updatedAt: nil).isStale(comparedTo: entryUpdatedAt))
+    }
 }


### PR DESCRIPTION
## Summary

- persist a token-specific `updatedAt` on `WidgetSnapshot.TokenUsageSummary` so the
  widget's cost rows (`Today`, `30d`) carry their own freshness instead of inheriting
  the provider entry's (#1964)
- disclose the lag on the token section's row title (`Today · 42 min. ago`; compact
  metrics render `Today cost · 42 min. ago`) once the token snapshot trails the
  entry's freshness by more than 10 minutes; fresher rows render unchanged
- clear the token-fetch TTL on fast failures so the next scheduled pass retries,
  while timed-out scans keep the TTL so a slow corpus cannot thrash back-to-back rescans
- legacy snapshots without the new field decode as fresh, so existing widget data
  renders exactly as before

Fixes #1964.

## Why a token-specific `updatedAt` and not coalescing the refresh

Regular refreshes schedule the token-cost refresh asynchronously and immediately
persist a widget snapshot that reads whatever `tokenSnapshots` currently holds, so
the snapshot's `generatedAt` and the entry's `updatedAt` go fresh while `tokenUsage`
still carries the previous scan. The issue triage offered two shapes: make snapshot
writes wait for the in-flight cost refresh, or persist a token-specific updated time.
This PR takes the second. Waiting/coalescing would couple every snapshot write to the
slowest cost scan (which can legitimately take minutes over a large corpus and is
exactly the case that times out), while the disclosure fix keeps provider scanners
and refresh scheduling untouched — the shape the triage review recommended.

Illustrative snapshot shape (same provider entry, before vs after):

```text
# main — stale cost rows are indistinguishable from fresh ones
"updatedAt": "<fresh>", "tokenUsage": { "sessionCostUSD": …, "sessionLabel": "Today" }

# this branch — the token rows carry their own age
"updatedAt": "<fresh>", "tokenUsage": { …, "updatedAt": "<42 min earlier>" }
# widget renders: "Today · 42 min. ago"
```

The TTL change covers the second half of the report: when a cost scan fails fast,
`lastTokenFetchAt` used to block any retry for the remainder of the fetch TTL, so the
stale rows outlived the next scheduled passes too. Fast failures now clear the TTL;
timeouts keep it (`tokenFetchFailureAllowsEarlyRetry`).

## Testing

- `swift test --filter "WidgetSnapshotTests|UsageStoreWidgetSnapshotTests|UsageStoreTokenRetryPolicyTests"` —
  18 tests in 4 suites passed, including the new
  `token usage summary round trips updatedAt and tolerates legacy payloads`,
  `token usage staleness discloses only meaningful lag`,
  `widget snapshot carries token usage age separately from entry freshness`, and
  `timed out token scans keep the fetch TTL while fast failures retry early`
- `make check` — SwiftFormat and SwiftLint clean
- `swift build` — clean
- full `make test` has one failing suite on my machine (`AdaptiveRefreshTimerTests`,
  timing-sensitive); it fails identically on unmodified `main` with the same
  expectations, so it is unrelated to this change
