### PR TITLE
Agent Sessions: track live Codex and Claude sessions across Macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.41.1 — Unreleased
 
+### Added
+- Agent Sessions: list and focus live local or SSH-discovered Codex and Claude Code sessions from the menu and CLI.
+
 ## 0.41.0 — 2026-07-06
 
 ### Added

--- a/Sources/CodexBar/AgentSessionsStore.swift
+++ b/Sources/CodexBar/AgentSessionsStore.swift
@@ -132,9 +132,7 @@ final class AgentSessionsStore {
         guard var generation = self.remoteRefreshGate.begin() else { return }
         while self.settings.agentSessionsEnabled {
             var hosts = self.manualHosts
-            if self.settings.agentSessionsTailscaleEnabled {
-                await hosts.append(contentsOf: self.remoteFetcher.discoveredHosts())
-            }
+            await hosts.append(contentsOf: self.remoteFetcher.discoveredHosts())
             let results = await self.remoteFetcher.fetch(hosts: hosts)
             let outcome = self.remoteRefreshGate.finish(generation: generation)
             guard !Task.isCancelled, self.settings.agentSessionsEnabled else { return }

--- a/Sources/CodexBar/AgentSessionsStore.swift
+++ b/Sources/CodexBar/AgentSessionsStore.swift
@@ -1,0 +1,157 @@
+import CodexBarCore
+import Foundation
+import Observation
+
+struct AgentSessionRemoteRefreshGate {
+    private(set) var generation = 0
+    private(set) var isInFlight = false
+    private(set) var isPending = false
+
+    mutating func settingsDidChange() {
+        self.generation += 1
+        self.isPending = self.isInFlight
+    }
+
+    mutating func begin() -> Int? {
+        guard !self.isInFlight else {
+            self.isPending = true
+            return nil
+        }
+        self.isInFlight = true
+        self.isPending = false
+        return self.generation
+    }
+
+    mutating func finish(generation: Int) -> (shouldPublish: Bool, shouldRetry: Bool) {
+        self.isInFlight = false
+        let outcome = (generation == self.generation, self.isPending)
+        self.isPending = false
+        return outcome
+    }
+}
+
+@MainActor
+@Observable
+final class AgentSessionsStore {
+    private let settings: SettingsStore
+    private let localScanner: LocalAgentSessionScanner
+    private let remoteFetcher: RemoteSessionFetcher
+    @ObservationIgnored private var localRefreshTask: Task<Void, Never>?
+    @ObservationIgnored private var remoteRefreshTask: Task<Void, Never>?
+    @ObservationIgnored private var localRefreshInFlight = false
+    @ObservationIgnored private var remoteRefreshGate = AgentSessionRemoteRefreshGate()
+    @ObservationIgnored var onUpdate: (@MainActor () -> Void)?
+
+    private(set) var localSessions: [AgentSession] = []
+    private(set) var remoteHosts: [RemoteSessionHostResult] = []
+    private(set) var lastUpdatedAt: Date?
+
+    init(
+        settings: SettingsStore,
+        localScanner: LocalAgentSessionScanner = LocalAgentSessionScanner(),
+        remoteFetcher: RemoteSessionFetcher = RemoteSessionFetcher())
+    {
+        self.settings = settings
+        self.localScanner = localScanner
+        self.remoteFetcher = remoteFetcher
+    }
+
+    var totalCount: Int {
+        self.localSessions.count + self.remoteHosts.reduce(0) { $0 + $1.sessions.count }
+    }
+
+    func start() {
+        guard self.localRefreshTask == nil, self.remoteRefreshTask == nil else { return }
+        self.localRefreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.refreshLocal()
+                try? await Task.sleep(for: .seconds(30))
+            }
+        }
+        self.remoteRefreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.refreshRemote()
+                try? await Task.sleep(for: .seconds(60))
+            }
+        }
+    }
+
+    func stop() {
+        self.localRefreshTask?.cancel()
+        self.remoteRefreshTask?.cancel()
+        self.localRefreshTask = nil
+        self.remoteRefreshTask = nil
+    }
+
+    func settingsDidChange() {
+        self.remoteRefreshGate.settingsDidChange()
+        guard self.settings.agentSessionsEnabled else {
+            self.localSessions = []
+            self.remoteHosts = []
+            self.onUpdate?()
+            return
+        }
+        guard !SettingsStore.isRunningTests else { return }
+        Task { [weak self] in
+            await self?.refreshLocal()
+            await self?.refreshRemote()
+        }
+    }
+
+    func refreshOnMenuOpen() {
+        guard self.settings.agentSessionsEnabled, !SettingsStore.isRunningTests else { return }
+        Task { [weak self] in
+            await self?.refreshLocal()
+            await self?.refreshRemote()
+        }
+    }
+
+    func focus(_ session: AgentSession, remoteHost: String?) {
+        if let remoteHost {
+            Task {
+                await self.remoteFetcher.focus(sessionID: session.id, host: remoteHost)
+            }
+        } else {
+            _ = SessionWindowFocuser.focus(session)
+        }
+    }
+
+    private func refreshLocal() async {
+        guard self.settings.agentSessionsEnabled, !self.localRefreshInFlight else { return }
+        self.localRefreshInFlight = true
+        let sessions = await self.localScanner.scan()
+        self.localRefreshInFlight = false
+        guard !Task.isCancelled, self.settings.agentSessionsEnabled else { return }
+        self.localSessions = sessions
+        self.lastUpdatedAt = Date()
+        self.onUpdate?()
+    }
+
+    private func refreshRemote() async {
+        guard self.settings.agentSessionsEnabled else { return }
+        guard var generation = self.remoteRefreshGate.begin() else { return }
+        while self.settings.agentSessionsEnabled {
+            var hosts = self.manualHosts
+            if self.settings.agentSessionsTailscaleEnabled {
+                await hosts.append(contentsOf: self.remoteFetcher.discoveredHosts())
+            }
+            let results = await self.remoteFetcher.fetch(hosts: hosts)
+            let outcome = self.remoteRefreshGate.finish(generation: generation)
+            guard !Task.isCancelled, self.settings.agentSessionsEnabled else { return }
+            if outcome.shouldPublish {
+                self.remoteHosts = results
+                self.lastUpdatedAt = Date()
+                self.onUpdate?()
+            }
+            guard outcome.shouldRetry, let nextGeneration = self.remoteRefreshGate.begin() else { return }
+            generation = nextGeneration
+        }
+    }
+
+    private var manualHosts: [String] {
+        self.settings.agentSessionsManualHosts
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+}

--- a/Sources/CodexBar/MenuContent.swift
+++ b/Sources/CodexBar/MenuContent.swift
@@ -71,6 +71,10 @@ struct MenuContent: View {
                 }
             }
             .buttonStyle(.plain)
+        case let .unavailable(title, tooltip):
+            Text(title)
+                .foregroundStyle(.secondary)
+                .help(tooltip ?? "")
         case let .submenu(title, systemImageName, submenuItems):
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {
@@ -142,6 +146,8 @@ struct MenuContent: View {
             self.actions.quit()
         case let .copyError(message):
             self.actions.copyError(message)
+        case .focusAgentSession:
+            return
         }
     }
 }

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -24,8 +24,16 @@ struct MenuDescriptor {
     enum Entry {
         case text(String, TextStyle)
         case action(String, MenuAction)
+        case unavailable(String, String?)
         case submenu(String, String?, [SubmenuItem])
         case divider
+
+        var isActionable: Bool {
+            switch self {
+            case .action, .submenu, .unavailable: true
+            case .text, .divider: false
+            }
+        }
     }
 
     enum MenuActionSystemImage: String {
@@ -68,6 +76,7 @@ struct MenuDescriptor {
         case about
         case quit
         case copyError(String)
+        case focusAgentSession(AgentSession, remoteHost: String?)
     }
 
     var sections: [Section]
@@ -80,7 +89,11 @@ struct MenuDescriptor {
         managedCodexAccountCoordinator: ManagedCodexAccountCoordinator? = nil,
         codexAccountPromotionCoordinator: CodexAccountPromotionCoordinator? = nil,
         updateReady: Bool,
-        includeContextualActions: Bool = true) -> MenuDescriptor
+        includeContextualActions: Bool = true,
+        agentSessionsEnabled: Bool = false,
+        localAgentSessions: [AgentSession] = [],
+        remoteAgentHosts: [RemoteSessionHostResult] = [],
+        now: Date = Date()) -> MenuDescriptor
     {
         var sections: [Section] = []
 
@@ -129,9 +142,69 @@ struct MenuDescriptor {
                 sections.append(actions)
             }
         }
+        if agentSessionsEnabled {
+            sections.append(Self.agentSessionsSection(
+                localSessions: localAgentSessions,
+                remoteHosts: remoteAgentHosts,
+                now: now))
+        }
         sections.append(Self.metaSection(updateReady: updateReady))
 
         return MenuDescriptor(sections: sections)
+    }
+
+    static func agentSessionsSection(
+        localSessions: [AgentSession],
+        remoteHosts: [RemoteSessionHostResult],
+        now: Date = Date()) -> Section
+    {
+        let totalCount = localSessions.count + remoteHosts.reduce(0) { $0 + $1.sessions.count }
+        var entries: [Entry] = [.text("Agent Sessions (\(totalCount))", .headline)]
+
+        for session in localSessions {
+            entries.append(.action(
+                self.agentSessionRowTitle(session, now: now),
+                .focusAgentSession(session, remoteHost: nil)))
+        }
+        for remoteHost in remoteHosts {
+            if let error = remoteHost.error {
+                entries.append(.unavailable("\(remoteHost.host) — unreachable", error))
+                continue
+            }
+            entries.append(.text("\(remoteHost.host) — \(remoteHost.sessions.count)", .secondary))
+            for session in remoteHost.sessions {
+                entries.append(.action(
+                    self.agentSessionRowTitle(session, now: now),
+                    .focusAgentSession(session, remoteHost: remoteHost.host)))
+            }
+        }
+        if totalCount == 0 {
+            entries.append(.unavailable("No agent sessions found", nil))
+        }
+        return Section(entries: entries)
+    }
+
+    private static func agentSessionRowTitle(_ session: AgentSession, now: Date) -> String {
+        let state = session.state == .active ? "●" : "○"
+        let providerGlyph = session.provider == .codex ? "⌘" : "✦"
+        let project = session.projectName ?? "Unknown project"
+        return "\(state) \(providerGlyph) \(project) — \(session.provider.rawValue) · " +
+            "\(session.source.rawValue) · \(self.agentSessionAge(session, now: now))"
+    }
+
+    private static func agentSessionAge(_ session: AgentSession, now: Date) -> String {
+        guard let activity = session.lastActivityAt ?? session.startedAt else { return "now" }
+        let seconds = max(0, Int(now.timeIntervalSince(activity)))
+        if seconds < 60 {
+            return "\(seconds)s"
+        }
+        if seconds < 3600 {
+            return "\(seconds / 60)m"
+        }
+        if seconds < 86400 {
+            return "\(seconds / 3600)h"
+        }
+        return "\(seconds / 86400)d"
     }
 
     private static func usageSection(
@@ -822,6 +895,8 @@ extension MenuDescriptor.MenuAction {
         case .openTerminal: MenuDescriptor.MenuActionSystemImage.openTerminal.rawValue
         case .loginToProvider: MenuDescriptor.MenuActionSystemImage.loginToProvider.rawValue
         case .copyError: MenuDescriptor.MenuActionSystemImage.copyError.rawValue
+        case .focusAgentSession:
+            nil
         }
     }
 }

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -157,17 +157,14 @@ struct GeneralPane: View {
             Section {
                 Toggle("Enable Agent Sessions", isOn: self.$settings.agentSessionsEnabled)
 
-                Toggle(
-                    "Auto-discover Macs with Tailscale",
-                    isOn: self.$settings.agentSessionsTailscaleEnabled)
-                    .disabled(!self.settings.agentSessionsEnabled)
-
                 TextField("Manual SSH hosts", text: self.$settings.agentSessionsManualHosts)
                     .disabled(!self.settings.agentSessionsEnabled)
             } header: {
                 Text("Sessions")
             } footer: {
-                Text("Local sessions refresh every 30 seconds; remote hosts every 60 seconds and when the menu opens.")
+                Text(
+                    "Macs on your tailnet are discovered automatically. Local sessions refresh every " +
+                        "30 seconds; remote hosts every 60 seconds and when the menu opens.")
             }
 
             Section {

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -155,6 +155,22 @@ struct GeneralPane: View {
             }
 
             Section {
+                Toggle("Enable Agent Sessions", isOn: self.$settings.agentSessionsEnabled)
+
+                Toggle(
+                    "Auto-discover Macs with Tailscale",
+                    isOn: self.$settings.agentSessionsTailscaleEnabled)
+                    .disabled(!self.settings.agentSessionsEnabled)
+
+                TextField("Manual SSH hosts", text: self.$settings.agentSessionsManualHosts)
+                    .disabled(!self.settings.agentSessionsEnabled)
+            } header: {
+                Text("Sessions")
+            } footer: {
+                Text("Local sessions refresh every 30 seconds; remote hosts every 60 seconds and when the menu opens.")
+            }
+
+            Section {
                 LabeledContent(L("open_menu_shortcut_title")) {
                     OpenMenuShortcutRecorder()
                 }

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -760,6 +760,30 @@ extension SettingsStore {
             self.userDefaults.set(newValue.rawValue, forKey: "terminalApp")
         }
     }
+
+    var agentSessionsEnabled: Bool {
+        get { self.defaultsState.agentSessionsEnabled }
+        set {
+            self.defaultsState.agentSessionsEnabled = newValue
+            self.userDefaults.set(newValue, forKey: "agentSessionsEnabled")
+        }
+    }
+
+    var agentSessionsTailscaleEnabled: Bool {
+        get { self.defaultsState.agentSessionsTailscaleEnabled }
+        set {
+            self.defaultsState.agentSessionsTailscaleEnabled = newValue
+            self.userDefaults.set(newValue, forKey: "agentSessionsTailscaleEnabled")
+        }
+    }
+
+    var agentSessionsManualHosts: String {
+        get { self.defaultsState.agentSessionsManualHosts }
+        set {
+            self.defaultsState.agentSessionsManualHosts = newValue
+            self.userDefaults.set(newValue, forKey: "agentSessionsManualHosts")
+        }
+    }
 }
 
 extension SettingsStore {

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -769,14 +769,6 @@ extension SettingsStore {
         }
     }
 
-    var agentSessionsTailscaleEnabled: Bool {
-        get { self.defaultsState.agentSessionsTailscaleEnabled }
-        set {
-            self.defaultsState.agentSessionsTailscaleEnabled = newValue
-            self.userDefaults.set(newValue, forKey: "agentSessionsTailscaleEnabled")
-        }
-    }
-
     var agentSessionsManualHosts: String {
         get { self.defaultsState.agentSessionsManualHosts }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -51,7 +51,6 @@ extension SettingsStore {
         _ = self.openAIWebBatterySaverEnabled
         _ = self.providerStorageFootprintsEnabled
         _ = self.agentSessionsEnabled
-        _ = self.agentSessionsTailscaleEnabled
         _ = self.agentSessionsManualHosts
         _ = self.codexUsageDataSource
         _ = self.codexActiveSource

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -50,6 +50,9 @@ extension SettingsStore {
         _ = self.openAIWebAccessEnabled
         _ = self.openAIWebBatterySaverEnabled
         _ = self.providerStorageFootprintsEnabled
+        _ = self.agentSessionsEnabled
+        _ = self.agentSessionsTailscaleEnabled
+        _ = self.agentSessionsManualHosts
         _ = self.codexUsageDataSource
         _ = self.codexActiveSource
         _ = self.claudeUsageDataSource

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -462,9 +462,6 @@ extension SettingsStore {
             forKey: "providersSortedAlphabetically") as? Bool ?? false
         let appLanguageRaw = userDefaults.string(forKey: "appLanguage")
         let agentSessionsEnabled = userDefaults.object(forKey: "agentSessionsEnabled") as? Bool ?? true
-        let tailscaleDefault = RemoteSessionFetcher().tailscaleIsAvailable()
-        let agentSessionsTailscaleEnabled = userDefaults.object(
-            forKey: "agentSessionsTailscaleEnabled") as? Bool ?? tailscaleDefault
         let agentSessionsManualHosts = userDefaults.string(forKey: "agentSessionsManualHosts") ?? ""
         return SettingsDefaultsState(
             refreshFrequency: refreshFrequency,
@@ -527,7 +524,6 @@ extension SettingsStore {
             appLanguageRaw: appLanguageRaw,
             terminalAppRaw: userDefaults.string(forKey: "terminalApp"),
             agentSessionsEnabled: agentSessionsEnabled,
-            agentSessionsTailscaleEnabled: agentSessionsTailscaleEnabled,
             agentSessionsManualHosts: agentSessionsManualHosts)
     }
 

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -369,6 +369,7 @@ extension SettingsStore {
         return hadExistingConfig
     }
 
+    // swiftlint:disable:next function_body_length
     private static func loadDefaultsState(userDefaults: UserDefaults) -> SettingsDefaultsState {
         let refreshDefault = userDefaults.string(forKey: "refreshFrequency")
             .flatMap(RefreshFrequency.init(rawValue:))
@@ -460,6 +461,11 @@ extension SettingsStore {
         let providersSortedAlphabetically = userDefaults.object(
             forKey: "providersSortedAlphabetically") as? Bool ?? false
         let appLanguageRaw = userDefaults.string(forKey: "appLanguage")
+        let agentSessionsEnabled = userDefaults.object(forKey: "agentSessionsEnabled") as? Bool ?? true
+        let tailscaleDefault = RemoteSessionFetcher().tailscaleIsAvailable()
+        let agentSessionsTailscaleEnabled = userDefaults.object(
+            forKey: "agentSessionsTailscaleEnabled") as? Bool ?? tailscaleDefault
+        let agentSessionsManualHosts = userDefaults.string(forKey: "agentSessionsManualHosts") ?? ""
         return SettingsDefaultsState(
             refreshFrequency: refreshFrequency,
             refreshAllProvidersOnMenuOpen: refreshAllProvidersOnMenuOpen,
@@ -519,7 +525,10 @@ extension SettingsStore {
             providerDetectionCompleted: providerDetectionCompleted,
             providersSortedAlphabetically: providersSortedAlphabetically,
             appLanguageRaw: appLanguageRaw,
-            terminalAppRaw: userDefaults.string(forKey: "terminalApp"))
+            terminalAppRaw: userDefaults.string(forKey: "terminalApp"),
+            agentSessionsEnabled: agentSessionsEnabled,
+            agentSessionsTailscaleEnabled: agentSessionsTailscaleEnabled,
+            agentSessionsManualHosts: agentSessionsManualHosts)
     }
 
     private static func loadCostSummaryDisplayStyleRaw(

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -61,6 +61,5 @@ struct SettingsDefaultsState {
     var appLanguageRaw: String?
     var terminalAppRaw: String?
     var agentSessionsEnabled: Bool
-    var agentSessionsTailscaleEnabled: Bool
     var agentSessionsManualHosts: String
 }

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -60,4 +60,7 @@ struct SettingsDefaultsState {
     var providersSortedAlphabetically: Bool
     var appLanguageRaw: String?
     var terminalAppRaw: String?
+    var agentSessionsEnabled: Bool
+    var agentSessionsTailscaleEnabled: Bool
+    var agentSessionsManualHosts: String
 }

--- a/Sources/CodexBar/StatusItemController+AgentSessions.swift
+++ b/Sources/CodexBar/StatusItemController+AgentSessions.swift
@@ -1,0 +1,19 @@
+import AppKit
+
+extension StatusItemController {
+    @objc func focusAgentSession(_ sender: NSMenuItem) {
+        guard let values = sender.representedObject as? [String],
+              let sessionID = values.first
+        else { return }
+        let remoteHost = values.count > 1 && !values[1].isEmpty ? values[1] : nil
+        let session = if let remoteHost {
+            self.agentSessions.remoteHosts
+                .first(where: { $0.host == remoteHost })?
+                .sessions.first(where: { $0.id == sessionID })
+        } else {
+            self.agentSessions.localSessions.first(where: { $0.id == sessionID })
+        }
+        guard let session else { return }
+        self.agentSessions.focus(session, remoteHost: remoteHost)
+    }
+}

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -70,6 +70,7 @@ extension StatusItemController {
     func menuWillOpen(_ menu: NSMenu) {
         // Records interaction and may bring an adaptive timer forward; never refreshes synchronously.
         self.store.noteMenuOpened()
+        self.agentSessions.refreshOnMenuOpen()
 
         let trace = self.beginMenuOperationTrace("menuWillOpen", breadcrumb: "menuWillOpen")
         defer { self.endMenuOperationTrace(trace, menu: menu, provider: self.menuProvider(for: menu)) }
@@ -787,13 +788,7 @@ extension StatusItemController {
         width: CGFloat,
         captureMenu: NSMenu? = nil)
     {
-        let actionableSections = sections.filter { section in
-            section.entries.contains { entry in
-                if case .action = entry { return true }
-                if case .submenu = entry { return true }
-                return false
-            }
-        }
+        let actionableSections = sections.filter { section in section.entries.contains(where: \ .isActionable) }
         for (index, section) in actionableSections.enumerated() {
             for entry in section.entries {
                 switch entry {
@@ -856,6 +851,11 @@ extension StatusItemController {
                         item.isEnabled = false
                         self.applySubtitle(subtitle, to: item, title: localizedTitle)
                     }
+                    menu.addItem(item)
+                case let .unavailable(title, tooltip):
+                    let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+                    item.isEnabled = false
+                    item.toolTip = tooltip
                     menu.addItem(item)
                 case let .submenu(title, systemImageName, submenuItems):
                     let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")

--- a/Sources/CodexBar/StatusItemController+MenuActionMapping.swift
+++ b/Sources/CodexBar/StatusItemController+MenuActionMapping.swift
@@ -20,6 +20,8 @@ extension StatusItemController {
         case .about: (#selector(self.showSettingsAbout), nil)
         case .quit: (#selector(self.quit), nil)
         case let .copyError(message): (#selector(self.copyError(_:)), message)
+        case let .focusAgentSession(session, remoteHost):
+            (#selector(self.focusAgentSession(_:)), [session.id, remoteHost ?? ""])
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+MenuWidthCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuWidthCache.swift
@@ -43,7 +43,10 @@ extension StatusItemController {
             managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
             codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
             updateReady: self.updater.updateStatus.isUpdateReady,
-            includeContextualActions: includeContextualActions)
+            includeContextualActions: includeContextualActions,
+            agentSessionsEnabled: self.settings.agentSessionsEnabled,
+            localAgentSessions: self.agentSessions.localSessions,
+            remoteAgentHosts: self.agentSessions.remoteHosts)
     }
 
     func measuredStandardMenuWidth(for sections: [MenuDescriptor.Section], baseWidth: CGFloat) -> CGFloat {
@@ -88,6 +91,8 @@ extension StatusItemController {
             "text:\(style):\(text)"
         case let .action(title, action):
             "action:\(title):\(self.measuredStandardMenuWidthCacheToken(for: action))"
+        case let .unavailable(title, tooltip):
+            "unavailable:\(title):\(tooltip ?? "")"
         case let .submenu(title, systemImageName, submenuItems):
             "submenu:\(title):\(systemImageName ?? ""):" + submenuItems.map { item in
                 [
@@ -136,6 +141,8 @@ extension StatusItemController {
             "quit"
         case let .copyError(message):
             "copyError:\(message)"
+        case let .focusAgentSession(session, remoteHost):
+            "focusAgentSession:\(remoteHost ?? "local"):\(session.id)"
         }
     }
 }

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -22,6 +22,7 @@ extension StatusItemController {
     }
 
     private func cancelShutdownTasks() {
+        self.agentSessions.stop()
         self.blinkTask?.cancel()
         self.blinkTask = nil
         self.menuBarCountdownRefreshTask?.cancel()

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -117,6 +117,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
     let store: UsageStore
     let settings: SettingsStore
+    let agentSessions: AgentSessionsStore
     lazy var menuCardRefreshMonitor = MenuCardRefreshMonitor { [weak self] provider in
         self?.menuCardModel(for: provider)
     }
@@ -243,6 +244,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private var lastMergeIcons: Bool
     private var lastSwitcherShowsIcons: Bool
     private var lastObservedUsageBarsShowUsed: Bool
+    private var lastAgentSessionsEnabled: Bool
+    private var lastAgentSessionsTailscaleEnabled: Bool
+    private var lastAgentSessionsManualHosts: String
     /// Tracks which `usageBarsShowUsed` mode the provider switcher was built with.
     /// Used to decide whether we can "smart update" menu content without rebuilding the switcher.
     var lastSwitcherUsageBarsShowUsed: Bool
@@ -372,6 +376,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         }
         self.store = store
         self.settings = settings
+        self.agentSessions = AgentSessionsStore(settings: settings)
         self.account = account
         self.updater = updater
         self.preferencesSelection = preferencesSelection
@@ -387,6 +392,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastMergeIcons = settings.mergeIcons
         self.lastSwitcherShowsIcons = settings.switcherShowsIcons
         self.lastObservedUsageBarsShowUsed = settings.usageBarsShowUsed
+        self.lastAgentSessionsEnabled = settings.agentSessionsEnabled
+        self.lastAgentSessionsTailscaleEnabled = settings.agentSessionsTailscaleEnabled
+        self.lastAgentSessionsManualHosts = settings.agentSessionsManualHosts
         self.lastSwitcherUsageBarsShowUsed = settings.usageBarsShowUsed
         self.menuCardRenderingEnabledForController = menuCardRenderingEnabled
         self.menuRefreshEnabledForController = menuRefreshEnabled
@@ -409,6 +417,12 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastMenuAdjunctReadinessSignature = self.menuAdjunctReadinessSignature()
         self.lastMenuAdjunctReadinessBaselineVersion = self.menuSession.contentVersion
         self.wireBindings()
+        self.agentSessions.onUpdate = { [weak self] in
+            self?.invalidateMenus(refreshOpenMenus: true)
+        }
+        if !SettingsStore.isRunningTests {
+            self.agentSessions.start()
+        }
         self.updateVisibility()
         self.updateIcons()
         self.scheduleCodexAccountMenuProjectionRevalidationIfNeeded(
@@ -640,6 +654,15 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
         #endif
+        let agentSessionsSettingsChanged = self.settings.agentSessionsEnabled != self.lastAgentSessionsEnabled ||
+            self.settings.agentSessionsTailscaleEnabled != self.lastAgentSessionsTailscaleEnabled ||
+            self.settings.agentSessionsManualHosts != self.lastAgentSessionsManualHosts
+        if agentSessionsSettingsChanged {
+            self.lastAgentSessionsEnabled = self.settings.agentSessionsEnabled
+            self.lastAgentSessionsTailscaleEnabled = self.settings.agentSessionsTailscaleEnabled
+            self.lastAgentSessionsManualHosts = self.settings.agentSessionsManualHosts
+            self.agentSessions.settingsDidChange()
+        }
         let configChanged = self.settings.configRevision != self.lastConfigRevision
         let orderChanged = self.settings.providerOrder != self.lastProviderOrder
         let localizationChanged = self.menuLocalizationSignature() != self.lastMenuLocalizationSignature

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -245,7 +245,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private var lastSwitcherShowsIcons: Bool
     private var lastObservedUsageBarsShowUsed: Bool
     private var lastAgentSessionsEnabled: Bool
-    private var lastAgentSessionsTailscaleEnabled: Bool
     private var lastAgentSessionsManualHosts: String
     /// Tracks which `usageBarsShowUsed` mode the provider switcher was built with.
     /// Used to decide whether we can "smart update" menu content without rebuilding the switcher.
@@ -393,7 +392,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastSwitcherShowsIcons = settings.switcherShowsIcons
         self.lastObservedUsageBarsShowUsed = settings.usageBarsShowUsed
         self.lastAgentSessionsEnabled = settings.agentSessionsEnabled
-        self.lastAgentSessionsTailscaleEnabled = settings.agentSessionsTailscaleEnabled
         self.lastAgentSessionsManualHosts = settings.agentSessionsManualHosts
         self.lastSwitcherUsageBarsShowUsed = settings.usageBarsShowUsed
         self.menuCardRenderingEnabledForController = menuCardRenderingEnabled
@@ -655,11 +653,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         guard !self.isReleasedForTesting else { return }
         #endif
         let agentSessionsSettingsChanged = self.settings.agentSessionsEnabled != self.lastAgentSessionsEnabled ||
-            self.settings.agentSessionsTailscaleEnabled != self.lastAgentSessionsTailscaleEnabled ||
             self.settings.agentSessionsManualHosts != self.lastAgentSessionsManualHosts
         if agentSessionsSettingsChanged {
             self.lastAgentSessionsEnabled = self.settings.agentSessionsEnabled
-            self.lastAgentSessionsTailscaleEnabled = self.settings.agentSessionsTailscaleEnabled
             self.lastAgentSessionsManualHosts = self.settings.agentSessionsManualHosts
             self.agentSessions.settingsDidChange()
         }

--- a/Sources/CodexBarCLI/CLIEntry.swift
+++ b/Sources/CodexBarCLI/CLIEntry.swift
@@ -48,6 +48,10 @@ enum CodexBarCLI {
                 await self.runUsage(invocation.parsedValues)
             case ["cost"]:
                 await self.runCost(invocation.parsedValues)
+            case ["sessions", "list"]:
+                await self.runSessions(invocation.parsedValues)
+            case ["sessions", "focus"]:
+                await self.runSessionsFocus(invocation.parsedValues)
             case ["serve"]:
                 await self.runServe(invocation.parsedValues)
             case ["config", "validate"]:
@@ -88,6 +92,8 @@ enum CodexBarCLI {
         let cardsSignature = CommandSignature.describe(CardsOptions())
         let usageSignature = CommandSignature.describe(UsageOptions())
         let costSignature = CommandSignature.describe(CostOptions())
+        let sessionsSignature = CommandSignature.describe(SessionsOptions())
+        let sessionsFocusSignature = CommandSignature.describe(SessionsFocusOptions())
         let serveSignature = CommandSignature.describe(ServeOptions())
         let configSignature = CommandSignature.describe(ConfigOptions())
         let configProviderToggleSignature = CommandSignature.describe(ConfigProviderToggleOptions())
@@ -111,6 +117,24 @@ enum CodexBarCLI {
                 abstract: "Print local cost usage as text or JSON",
                 discussion: nil,
                 signature: costSignature),
+            CommandDescriptor(
+                name: "sessions",
+                abstract: "List live Codex and Claude Code sessions",
+                discussion: nil,
+                signature: CommandSignature(),
+                subcommands: [
+                    CommandDescriptor(
+                        name: "list",
+                        abstract: "List live Codex and Claude Code sessions",
+                        discussion: nil,
+                        signature: sessionsSignature),
+                    CommandDescriptor(
+                        name: "focus",
+                        abstract: "Focus the window for a session",
+                        discussion: nil,
+                        signature: sessionsFocusSignature),
+                ],
+                defaultSubcommandName: "list"),
             CommandDescriptor(
                 name: "serve",
                 abstract: "Serve usage and cost JSON over localhost HTTP",

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -109,6 +109,26 @@ extension CodexBarCLI {
         """
     }
 
+    static func sessionsHelp(version: String) -> String {
+        """
+        CodexBar \(version)
+
+        Usage:
+          codexbar sessions [--json] [--pretty]
+          codexbar sessions focus <id>
+
+        Description:
+          List live local Codex and Claude Code agent sessions.
+          JSON uses stable AgentSession field names and ISO-8601 dates.
+          Focus activates the owning terminal or desktop app on macOS.
+
+        Examples:
+          codexbar sessions
+          codexbar sessions --json
+          codexbar sessions focus 019f3497-73bf-7df3-a173-4f67d968914a
+        """
+    }
+
     static func serveHelp(version: String) -> String {
         """
         CodexBar \(version)
@@ -256,6 +276,8 @@ extension CodexBarCLI {
                        [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>] [-v|--verbose]
                        [--provider \(ProviderHelp.list)] [--no-color] [--pretty] [--refresh]
                        [--days <days>] [--group-by project]
+          codexbar sessions [--json] [--pretty]
+          codexbar sessions focus <id>
           codexbar serve [--port <port>] [--refresh-interval <seconds>]
                        [--request-timeout <seconds>]
                        [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>] [-v|--verbose]
@@ -289,6 +311,7 @@ extension CodexBarCLI {
           codexbar cards --provider all --status
           codexbar cards --brief
           codexbar cost --provider claude --format json --pretty
+          codexbar sessions --json
           codexbar serve --port 8080
           codexbar config validate --format json --pretty
           codexbar config enable --provider grok

--- a/Sources/CodexBarCLI/CLIIO.swift
+++ b/Sources/CodexBarCLI/CLIIO.swift
@@ -31,6 +31,8 @@ extension CodexBarCLI {
             print(Self.usageHelp(version: version))
         case "cost":
             print(Self.costHelp(version: version))
+        case "sessions", "focus":
+            print(Self.sessionsHelp(version: version))
         case "serve":
             print(Self.serveHelp(version: version))
         case "config", "validate", "dump":

--- a/Sources/CodexBarCLI/CLISessionsCommand.swift
+++ b/Sources/CodexBarCLI/CLISessionsCommand.swift
@@ -1,0 +1,94 @@
+import CodexBarCore
+import Commander
+import Foundation
+
+extension CodexBarCLI {
+    static func runSessions(_ values: ParsedValues) async {
+        let sessions = await LocalAgentSessionScanner().scan()
+        if values.flags.contains("jsonShortcut") {
+            Self.printJSON(sessions, pretty: values.flags.contains("pretty"))
+        } else {
+            print(Self.renderSessionsTable(sessions))
+        }
+    }
+
+    static func runSessionsFocus(_ values: ParsedValues) async {
+        guard let sessionID = values.positional.first, !sessionID.isEmpty else {
+            writeStderr("Missing session id.\n")
+            platformExit(1)
+        }
+        let sessions = await LocalAgentSessionScanner().scan()
+        guard let session = sessions.first(where: { $0.id == sessionID }) else {
+            Self.writeStderr("Unknown session: \(sessionID)\n")
+            Self.platformExit(1)
+        }
+
+        #if os(macOS)
+        let result = await MainActor.run {
+            SessionWindowFocuser.focus(session)
+        }
+        switch result {
+        case .focused, .activatedApplicationOnly:
+            Self.platformExit(0)
+        case .failed:
+            Self.writeStderr("Could not focus session: \(sessionID)\n")
+            Self.platformExit(2)
+        }
+        #else
+        Self.writeStderr("Session focus is only available on macOS.\n")
+        Self.platformExit(2)
+        #endif
+    }
+
+    static func renderSessionsTable(_ sessions: [AgentSession], now: Date = Date()) -> String {
+        guard !sessions.isEmpty else { return "No agent sessions found." }
+        let rows = sessions.map { session in
+            [
+                session.state == .active ? "active" : "idle",
+                session.provider.rawValue,
+                session.source.rawValue,
+                session.projectName ?? "—",
+                Self.sessionAge(session, now: now),
+                session.id,
+            ]
+        }
+        let headers = ["STATE", "PROVIDER", "SOURCE", "PROJECT", "ACTIVITY", "ID"]
+        let widths = headers.indices.map { index in
+            ([headers[index]] + rows.map { $0[index] }).map(\ .count).max() ?? headers[index].count
+        }
+        let render: ([String]) -> String = { columns in
+            columns.indices.map { index in
+                columns[index].padding(toLength: widths[index], withPad: " ", startingAt: 0)
+            }.joined(separator: "  ")
+        }
+        return ([render(headers)] + rows.map(render)).joined(separator: "\n")
+    }
+
+    private static func sessionAge(_ session: AgentSession, now: Date) -> String {
+        guard let date = session.lastActivityAt ?? session.startedAt else { return "now" }
+        let seconds = max(0, Int(now.timeIntervalSince(date)))
+        if seconds < 60 {
+            return "\(seconds)s"
+        }
+        if seconds < 3600 {
+            return "\(seconds / 60)m"
+        }
+        if seconds < 86400 {
+            return "\(seconds / 3600)h"
+        }
+        return "\(seconds / 86400)d"
+    }
+}
+
+struct SessionsOptions: CommanderParsable {
+    @Flag(name: .long("json"), help: "Emit JSON")
+    var jsonShortcut: Bool = false
+
+    @Flag(name: .long("pretty"), help: "Pretty-print JSON output")
+    var pretty: Bool = false
+}
+
+struct SessionsFocusOptions: CommanderParsable {
+    @Argument(help: "Session identifier")
+    var id: String = ""
+}

--- a/Sources/CodexBarCore/AgentSession.swift
+++ b/Sources/CodexBarCore/AgentSession.swift
@@ -1,0 +1,445 @@
+import Foundation
+
+public struct AgentSession: Codable, Equatable, Sendable, Identifiable {
+    public enum Provider: String, Codable, Sendable {
+        case codex
+        case claude
+    }
+
+    public enum Source: String, Codable, Sendable {
+        case cli
+        case desktopApp
+        case ide
+        case unknown
+    }
+
+    public enum State: String, Codable, Sendable {
+        case active
+        case idle
+    }
+
+    public var id: String
+    public var provider: Provider
+    public var source: Source
+    public var state: State
+    public var pid: Int32?
+    public var cwd: String?
+    public var projectName: String?
+    public var startedAt: Date?
+    public var lastActivityAt: Date?
+    public var transcriptPath: String?
+    public var host: String
+
+    public init(
+        id: String,
+        provider: Provider,
+        source: Source,
+        state: State,
+        pid: Int32?,
+        cwd: String?,
+        projectName: String?,
+        startedAt: Date?,
+        lastActivityAt: Date?,
+        transcriptPath: String?,
+        host: String)
+    {
+        self.id = id
+        self.provider = provider
+        self.source = source
+        self.state = state
+        self.pid = pid
+        self.cwd = cwd
+        self.projectName = projectName
+        self.startedAt = startedAt
+        self.lastActivityAt = lastActivityAt
+        self.transcriptPath = transcriptPath
+        self.host = host
+    }
+}
+
+public struct SessionScanConfig: Equatable, Sendable {
+    public var activeWindow: TimeInterval
+    public var fileOnlyWindow: TimeInterval
+
+    public init(activeWindow: TimeInterval = 120, fileOnlyWindow: TimeInterval = 30 * 60) {
+        self.activeWindow = activeWindow
+        self.fileOnlyWindow = fileOnlyWindow
+    }
+
+    public func state(lastActivityAt: Date?, now: Date, hasLiveProcess: Bool) -> AgentSession.State {
+        guard let lastActivityAt else { return hasLiveProcess ? .active : .idle }
+        return now.timeIntervalSince(lastActivityAt) <= self.activeWindow ? .active : .idle
+    }
+}
+
+public struct AgentProcessRecord: Equatable, Sendable {
+    public let pid: Int32
+    public let ppid: Int32
+    public let startedAt: Date?
+    public let command: String
+
+    public init(pid: Int32, ppid: Int32, startedAt: Date?, command: String) {
+        self.pid = pid
+        self.ppid = ppid
+        self.startedAt = startedAt
+        self.command = command
+    }
+
+    public var executableBasename: String {
+        let firstToken = self.command.split(whereSeparator: \ .isWhitespace).first.map(String.init) ?? ""
+        let firstBasename = URL(fileURLWithPath: firstToken).lastPathComponent
+        if firstBasename == "disclaimer" {
+            return firstBasename
+        }
+        if self.command.contains("Application Support/Claude/claude-code/claude") {
+            return "claude"
+        }
+        return firstBasename
+    }
+}
+
+public enum AgentPSOutputParser {
+    public static func parse(_ output: String) -> [AgentProcessRecord] {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "EEE MMM d HH:mm:ss yyyy"
+        return output.split(whereSeparator: \ .isNewline).compactMap { rawLine -> AgentProcessRecord? in
+            let fields = rawLine.split(maxSplits: 7, omittingEmptySubsequences: true, whereSeparator: \ .isWhitespace)
+            guard fields.count == 8,
+                  let pid = Int32(fields[0]),
+                  let ppid = Int32(fields[1])
+            else { return nil }
+
+            let dateText = fields[2...6].joined(separator: " ")
+            return AgentProcessRecord(
+                pid: pid,
+                ppid: ppid,
+                startedAt: formatter.date(from: dateText),
+                command: String(fields[7]))
+        }
+    }
+
+    public static func agentProcesses(from records: [AgentProcessRecord]) -> [AgentProcessRecord] {
+        let candidates = records.filter { record in
+            let basename = record.executableBasename.lowercased()
+            if basename == "codex" {
+                let arguments = self.arguments(record.command)
+                return self.isCodexAgentExecutable(record.command) &&
+                    !arguments.contains("app-server") &&
+                    !arguments.contains("--help") &&
+                    !arguments.contains("--version")
+            }
+            if basename == "claude" {
+                return self.isClaudeAgentExecutable(record.command) && !self.isObviousClaudeHelper(record.command)
+            }
+            return basename == "disclaimer" && record.command.contains("claude")
+        }
+
+        let recordsByPID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.pid, $0) })
+        return candidates.filter { record in
+            guard record.executableBasename.lowercased() == "disclaimer" else { return true }
+            return !candidates.contains { child in
+                child.ppid == record.pid &&
+                    child.executableBasename.lowercased() == "claude" &&
+                    self.normalizedClaudeArguments(child.command) == self.normalizedClaudeArguments(record.command)
+            } && recordsByPID[record.ppid] == nil
+        }
+    }
+
+    public static func provider(for record: AgentProcessRecord) -> AgentSession.Provider? {
+        let basename = record.executableBasename.lowercased()
+        if basename == "codex" {
+            return .codex
+        }
+        if basename == "claude" || basename == "disclaimer" {
+            return .claude
+        }
+        return nil
+    }
+
+    public static func source(for record: AgentProcessRecord) -> AgentSession.Source {
+        guard self.provider(for: record) == .claude else { return .cli }
+        return record.command.contains("Application Support/Claude/claude-code") ? .desktopApp : .cli
+    }
+
+    public static func hasCodexAppServer(in records: [AgentProcessRecord]) -> Bool {
+        records.contains { record in
+            record.executableBasename.lowercased() == "codex" &&
+                self.isCodexAgentExecutable(record.command) &&
+                self.arguments(record.command).contains("app-server")
+        }
+    }
+
+    private static func arguments(_ command: String) -> [String] {
+        command.split(whereSeparator: \ .isWhitespace).dropFirst().map(String.init)
+    }
+
+    private static func normalizedClaudeArguments(_ command: String) -> [String] {
+        let arguments = self.arguments(command)
+        if let index = arguments.firstIndex(where: { URL(fileURLWithPath: $0).lastPathComponent == "claude" }) {
+            return Array(arguments.suffix(from: arguments.index(after: index)))
+        }
+        return arguments
+    }
+
+    private static func isObviousClaudeHelper(_ command: String) -> Bool {
+        let lowercased = command.lowercased()
+        return lowercased.contains("--version") ||
+            lowercased.contains("--help") ||
+            lowercased.contains("claude-code-acp")
+    }
+
+    private static func isCodexAgentExecutable(_ command: String) -> Bool {
+        let lowercased = command.lowercased()
+        guard lowercased.contains(".app/") else { return true }
+        return lowercased.hasPrefix("/applications/codex.app/contents/resources/codex ") ||
+            lowercased.hasPrefix("/applications/codex.app/contents/resources/codex\t")
+    }
+
+    private static func isClaudeAgentExecutable(_ command: String) -> Bool {
+        let lowercased = command.lowercased()
+        return !lowercased.contains(".app/") || lowercased.contains("application support/claude/claude-code/claude")
+    }
+}
+
+public enum LSOFCWDOutputParser {
+    public static func parse(_ output: String) -> [Int32: String] {
+        var result: [Int32: String] = [:]
+        var currentPID: Int32?
+        for line in output.split(whereSeparator: \ .isNewline).map(String.init) {
+            guard let prefix = line.first else { continue }
+            switch prefix {
+            case "p":
+                currentPID = Int32(line.dropFirst())
+            case "n":
+                if let currentPID {
+                    result[currentPID] = String(line.dropFirst())
+                }
+            default:
+                continue
+            }
+        }
+        return result
+    }
+}
+
+public enum ClaudeSessionProjectMapper {
+    public struct Transcript: Equatable, Sendable {
+        public let url: URL
+        public let modifiedAt: Date
+
+        public init(url: URL, modifiedAt: Date) {
+            self.url = url
+            self.modifiedAt = modifiedAt
+        }
+    }
+
+    public static func escapedCWD(_ cwd: String) -> String {
+        String(cwd.unicodeScalars.map { scalar in
+            let value = scalar.value
+            let isASCIIAlphanumeric = (48...57).contains(value) ||
+                (65...90).contains(value) ||
+                (97...122).contains(value)
+            return isASCIIAlphanumeric ? Character(scalar) : "-"
+        })
+    }
+
+    public static func projectDirectories(
+        cwd: String,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default) -> [URL]
+    {
+        let standardRoot = homeDirectory
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+        return ([standardRoot] + ClaudeDesktopProjectsLocator.roots(
+            homeDirectory: homeDirectory,
+            fileManager: fileManager))
+            .map { $0.appendingPathComponent(self.escapedCWD(cwd), isDirectory: true) }
+    }
+
+    public static func newestTranscript(
+        cwd: String,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default) -> (url: URL, modifiedAt: Date)?
+    {
+        self.transcripts(cwd: cwd, homeDirectory: homeDirectory, fileManager: fileManager).first
+            .map { (url: $0.url, modifiedAt: $0.modifiedAt) }
+    }
+
+    public static func transcripts(
+        cwd: String,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default) -> [Transcript]
+    {
+        self.projectDirectories(cwd: cwd, homeDirectory: homeDirectory, fileManager: fileManager)
+            .flatMap { directory -> [(URL, Date)] in
+                guard let files = try? fileManager.contentsOfDirectory(
+                    at: directory,
+                    includingPropertiesForKeys: [.contentModificationDateKey],
+                    options: [.skipsHiddenFiles])
+                else { return [] }
+                return files.compactMap { file in
+                    guard file.pathExtension == "jsonl",
+                          let modifiedAt = try? file.resourceValues(
+                              forKeys: [.contentModificationDateKey]).contentModificationDate
+                    else { return nil }
+                    return (file, modifiedAt)
+                }
+            }
+            .sorted { $0.1 > $1.1 }
+            .map { Transcript(url: $0.0, modifiedAt: $0.1) }
+    }
+}
+
+public enum AgentSessionCorrelation {
+    public static func newestProcessesFirst(_ processes: [AgentProcessRecord]) -> [AgentProcessRecord] {
+        processes.sorted { lhs, rhs in
+            let lhsDate = lhs.startedAt ?? .distantPast
+            let rhsDate = rhs.startedAt ?? .distantPast
+            if lhsDate != rhsDate { return lhsDate > rhsDate }
+            return lhs.pid > rhs.pid
+        }
+    }
+
+    public static func assignClaudeTranscripts(
+        processes: [AgentProcessRecord],
+        cwdByPID: [Int32: String],
+        transcriptsByCWD: [String: [ClaudeSessionProjectMapper.Transcript]])
+        -> [Int32: ClaudeSessionProjectMapper.Transcript]
+    {
+        var assigned: [Int32: ClaudeSessionProjectMapper.Transcript] = [:]
+        var usedPaths = Set<String>()
+        let unambiguousPIDs = self.unambiguousProcessIDs(processes: processes, cwdByPID: cwdByPID)
+        for process in self.newestProcessesFirst(processes) {
+            guard unambiguousPIDs.contains(process.pid),
+                  let cwd = cwdByPID[process.pid],
+                  let candidates = transcriptsByCWD[cwd]
+            else { continue }
+            let candidate = candidates.first { transcript in
+                guard !usedPaths.contains(transcript.url.path) else { return false }
+                guard let startedAt = process.startedAt else { return true }
+                return transcript.modifiedAt >= startedAt
+            }
+            if let candidate {
+                assigned[process.pid] = candidate
+                usedPaths.insert(candidate.url.path)
+            }
+        }
+        return assigned
+    }
+
+    public static func unambiguousProcessIDs(
+        processes: [AgentProcessRecord],
+        cwdByPID: [Int32: String]) -> Set<Int32>
+    {
+        let grouped = Dictionary(grouping: processes.compactMap { process -> (Int32, String)? in
+            guard let cwd = cwdByPID[process.pid] else { return nil }
+            return (process.pid, URL(fileURLWithPath: cwd).standardizedFileURL.path)
+        }, by: { $0.1 })
+        return Set(grouped.values.compactMap { records in
+            records.count == 1 ? records[0].0 : nil
+        })
+    }
+
+    public static func codexWorkingDirectoriesMatch(_ lhs: String?, _ rhs: String?) -> Bool {
+        guard let lhs, let rhs else { return false }
+        return URL(fileURLWithPath: lhs).standardizedFileURL.path ==
+            URL(fileURLWithPath: rhs).standardizedFileURL.path
+    }
+
+    public static func fileOnlyCodexSource(
+        metadataSource: AgentSession.Source,
+        appServerPresent: Bool) -> AgentSession.Source
+    {
+        metadataSource == .unknown && appServerPresent ? .desktopApp : metadataSource
+    }
+}
+
+public struct CodexRolloutMetadata: Equatable, Sendable {
+    public let sessionID: String
+    public let cwd: String?
+    public let originator: String?
+    public let source: String?
+
+    public init(sessionID: String, cwd: String?, originator: String?, source: String?) {
+        self.sessionID = sessionID
+        self.cwd = cwd
+        self.originator = originator
+        self.source = source
+    }
+
+    public var sessionSource: AgentSession.Source {
+        let value = [self.originator, self.source]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+        if value.contains("desktop") || value.contains("app-server") {
+            return .desktopApp
+        }
+        if value.contains("ide") || value.contains("vscode") || value.contains("cursor") || value.contains("zed") {
+            return .ide
+        }
+        if value.contains("codex_exec") || value.contains("exec") || value.contains("cli") {
+            return .cli
+        }
+        return .unknown
+    }
+}
+
+public enum CodexRolloutFirstLineParser {
+    public static func parse(_ line: String) -> CodexRolloutMetadata? {
+        guard let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              object["type"] as? String == "session_meta",
+              let payload = object["payload"] as? [String: Any],
+              let sessionID = (payload["session_id"] as? String) ?? (payload["id"] as? String)
+        else { return nil }
+        return CodexRolloutMetadata(
+            sessionID: sessionID,
+            cwd: payload["cwd"] as? String,
+            originator: payload["originator"] as? String,
+            source: payload["source"] as? String)
+    }
+
+    public static func read(from url: URL) -> CodexRolloutMetadata? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        var data = Data()
+        while data.count < 256 * 1024 {
+            guard let chunk = try? handle.read(upToCount: 4096), !chunk.isEmpty else { break }
+            if let newline = chunk.firstIndex(of: 0x0A) {
+                data.append(chunk.prefix(upTo: newline))
+                break
+            }
+            data.append(chunk)
+        }
+        guard let line = String(data: data, encoding: .utf8) else { return nil }
+        return self.parse(line)
+    }
+
+    public static func makeSession(
+        metadata: CodexRolloutMetadata,
+        transcriptURL: URL,
+        modifiedAt: Date,
+        pid: Int32? = nil,
+        startedAt: Date? = nil,
+        host: String,
+        config: SessionScanConfig = SessionScanConfig(),
+        now: Date = Date()) -> AgentSession?
+    {
+        guard pid != nil || now.timeIntervalSince(modifiedAt) <= config.fileOnlyWindow else { return nil }
+        let cwd = metadata.cwd
+        return AgentSession(
+            id: metadata.sessionID,
+            provider: .codex,
+            source: metadata.sessionSource,
+            state: config.state(lastActivityAt: modifiedAt, now: now, hasLiveProcess: pid != nil),
+            pid: pid,
+            cwd: cwd,
+            projectName: cwd.map { URL(fileURLWithPath: $0).lastPathComponent },
+            startedAt: startedAt,
+            lastActivityAt: modifiedAt,
+            transcriptPath: transcriptURL.path,
+            host: host)
+    }
+}

--- a/Sources/CodexBarCore/LocalAgentSessionScanner.swift
+++ b/Sources/CodexBarCore/LocalAgentSessionScanner.swift
@@ -1,0 +1,229 @@
+import Foundation
+
+public struct LocalAgentSessionScanner: Sendable {
+    private struct Rollout: Sendable {
+        let url: URL
+        let modifiedAt: Date
+        let metadata: CodexRolloutMetadata
+    }
+
+    private struct ScanContext: Sendable {
+        let homeDirectory: URL
+        let host: String
+        let now: Date
+    }
+
+    public let config: SessionScanConfig
+
+    public init(config: SessionScanConfig = SessionScanConfig()) {
+        self.config = config
+    }
+
+    public func scan(
+        now: Date = Date(),
+        environment: [String: String] = ProcessInfo.processInfo.environment) async -> [AgentSession]
+    {
+        let processOutput = await self.processOutput(environment: environment)
+        let allProcesses = AgentPSOutputParser.parse(processOutput)
+        let processes = AgentSessionCorrelation.newestProcessesFirst(
+            AgentPSOutputParser.agentProcesses(from: allProcesses))
+        let codexAppServerPresent = AgentPSOutputParser.hasCodexAppServer(in: allProcesses)
+        let cwdByPID = await self.cwdByPID(processes.map(\ .pid), environment: environment)
+        let homeDirectory = URL(fileURLWithPath: environment["HOME"] ?? NSHomeDirectory(), isDirectory: true)
+        let host = ProcessInfo.processInfo.hostName
+        let rollouts = self.codexRollouts(
+            now: now,
+            environment: environment,
+            homeDirectory: homeDirectory)
+        return self.sessions(
+            processes: processes,
+            cwdByPID: cwdByPID,
+            rollouts: rollouts,
+            codexAppServerPresent: codexAppServerPresent,
+            context: ScanContext(homeDirectory: homeDirectory, host: host, now: now))
+    }
+
+    private func sessions(
+        processes: [AgentProcessRecord],
+        cwdByPID: [Int32: String],
+        rollouts: [Rollout],
+        codexAppServerPresent: Bool,
+        context: ScanContext) -> [AgentSession]
+    {
+        var sessions: [AgentSession] = []
+        var matchedRolloutPaths = Set<String>()
+        let claudeProcesses = processes.filter { AgentPSOutputParser.provider(for: $0) == .claude }
+        let claudeCWDs = Set(claudeProcesses.compactMap { cwdByPID[$0.pid] })
+        let claudeTranscriptsByCWD = Dictionary(uniqueKeysWithValues: claudeCWDs.map { cwd in
+            (cwd, ClaudeSessionProjectMapper.transcripts(cwd: cwd, homeDirectory: context.homeDirectory))
+        })
+        let claudeTranscripts = AgentSessionCorrelation.assignClaudeTranscripts(
+            processes: claudeProcesses,
+            cwdByPID: cwdByPID,
+            transcriptsByCWD: claudeTranscriptsByCWD)
+
+        for process in processes {
+            guard let provider = AgentPSOutputParser.provider(for: process) else { continue }
+            let cwd = cwdByPID[process.pid]
+            switch provider {
+            case .claude:
+                let transcript = claudeTranscripts[process.pid]
+                sessions.append(AgentSession(
+                    id: transcript?.url.deletingPathExtension().lastPathComponent ?? "pid:\(process.pid)",
+                    provider: .claude,
+                    source: AgentPSOutputParser.source(for: process),
+                    state: self.config.state(
+                        lastActivityAt: transcript?.modifiedAt,
+                        now: context.now,
+                        hasLiveProcess: true),
+                    pid: process.pid,
+                    cwd: cwd,
+                    projectName: Self.projectName(cwd),
+                    startedAt: process.startedAt,
+                    lastActivityAt: transcript?.modifiedAt,
+                    transcriptPath: transcript?.url.path,
+                    host: context.host))
+            case .codex:
+                let rollout = rollouts.first { candidate in
+                    !matchedRolloutPaths.contains(candidate.url.path) &&
+                        AgentSessionCorrelation.codexWorkingDirectoriesMatch(candidate.metadata.cwd, cwd)
+                }
+                if let rollout {
+                    matchedRolloutPaths.insert(rollout.url.path)
+                }
+                let rolloutSource = rollout?.metadata.sessionSource
+                sessions.append(AgentSession(
+                    id: rollout?.metadata.sessionID ?? "pid:\(process.pid)",
+                    provider: .codex,
+                    source: rolloutSource == nil || rolloutSource == .unknown ? .cli : rolloutSource ?? .cli,
+                    state: self.config.state(
+                        lastActivityAt: rollout?.modifiedAt,
+                        now: context.now,
+                        hasLiveProcess: true),
+                    pid: process.pid,
+                    cwd: cwd ?? rollout?.metadata.cwd,
+                    projectName: Self.projectName(cwd ?? rollout?.metadata.cwd),
+                    startedAt: process.startedAt,
+                    lastActivityAt: rollout?.modifiedAt,
+                    transcriptPath: rollout?.url.path,
+                    host: context.host))
+            }
+        }
+
+        for rollout in rollouts where !matchedRolloutPaths.contains(rollout.url.path) {
+            guard var session = CodexRolloutFirstLineParser.makeSession(
+                metadata: rollout.metadata,
+                transcriptURL: rollout.url,
+                modifiedAt: rollout.modifiedAt,
+                host: context.host,
+                config: self.config,
+                now: context.now)
+            else { continue }
+            session.source = AgentSessionCorrelation.fileOnlyCodexSource(
+                metadataSource: session.source,
+                appServerPresent: codexAppServerPresent)
+            sessions.append(session)
+        }
+
+        var seen = Set<String>()
+        return sessions
+            .sorted { lhs, rhs in
+                if lhs.state != rhs.state {
+                    return lhs.state == .active
+                }
+                return (lhs.lastActivityAt ?? lhs.startedAt ?? .distantPast) >
+                    (rhs.lastActivityAt ?? rhs.startedAt ?? .distantPast)
+            }
+            .filter { seen.insert("\($0.host):\($0.id)").inserted }
+    }
+
+    private func processOutput(environment: [String: String]) async -> String {
+        let binary = ["/bin/ps", "/usr/bin/ps"].first { FileManager.default.isExecutableFile(atPath: $0) }
+        guard let binary,
+              let result = try? await SubprocessRunner.run(
+                  binary: binary,
+                  arguments: ["-axo", "pid=,ppid=,lstart=,command="],
+                  environment: environment,
+                  timeout: 5,
+                  label: "agent session process scan")
+        else { return "" }
+        return result.stdout
+    }
+
+    private func cwdByPID(_ pids: [Int32], environment: [String: String]) async -> [Int32: String] {
+        guard !pids.isEmpty else { return [:] }
+        if let lsof = self.findExecutable("lsof", environment: environment) {
+            let joinedPIDs = pids.map(String.init).joined(separator: ",")
+            if let result = try? await SubprocessRunner.run(
+                binary: lsof,
+                arguments: ["-a", "-d", "cwd", "-Fn", "-p", joinedPIDs],
+                environment: environment,
+                timeout: 5,
+                acceptsNonZeroExit: true,
+                label: "agent session cwd scan")
+            {
+                return LSOFCWDOutputParser.parse(result.stdout)
+            }
+        }
+
+        #if os(Linux)
+        return Dictionary(uniqueKeysWithValues: pids.compactMap { pid in
+            let path = "/proc/\(pid)/cwd"
+            guard let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: path) else { return nil }
+            return (pid, destination)
+        })
+        #else
+        return [:]
+        #endif
+    }
+
+    private func codexRollouts(
+        now: Date,
+        environment: [String: String],
+        homeDirectory: URL) -> [Rollout]
+    {
+        let root = URL(
+            fileURLWithPath: environment["CODEX_HOME"] ?? homeDirectory.appendingPathComponent(".codex").path,
+            isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        let calendar = Calendar(identifier: .gregorian)
+        let days = [now, calendar.date(byAdding: .day, value: -1, to: now)].compactMap(\.self)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy/MM/dd"
+        let fileManager = FileManager.default
+
+        return days.flatMap { day -> [Rollout] in
+            let directory = root.appendingPathComponent(formatter.string(from: day), isDirectory: true)
+            guard let files = try? fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles])
+            else { return [] }
+            return files.compactMap { file in
+                guard file.lastPathComponent.hasPrefix("rollout-"), file.pathExtension == "jsonl",
+                      let modifiedAt = try? file.resourceValues(
+                          forKeys: [.contentModificationDateKey]).contentModificationDate,
+                      let metadata = CodexRolloutFirstLineParser.read(from: file)
+                else { return nil }
+                return Rollout(url: file, modifiedAt: modifiedAt, metadata: metadata)
+            }
+        }.sorted { $0.modifiedAt > $1.modifiedAt }
+    }
+
+    private func findExecutable(_ name: String, environment: [String: String]) -> String? {
+        let path = environment["PATH"] ?? "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
+        return path.split(separator: ":")
+            .map { String($0) + "/" + name }
+            .first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    private static func standardized(_ path: String?) -> String? {
+        path.map { URL(fileURLWithPath: $0).standardizedFileURL.path }
+    }
+
+    private static func projectName(_ cwd: String?) -> String? {
+        guard let cwd, !cwd.isEmpty else { return nil }
+        return URL(fileURLWithPath: cwd).lastPathComponent
+    }
+}

--- a/Sources/CodexBarCore/RemoteSessionFetcher.swift
+++ b/Sources/CodexBarCore/RemoteSessionFetcher.swift
@@ -122,12 +122,6 @@ public struct RemoteSessionFetcher: Sendable {
             label: "focus remote agent session")
     }
 
-    public func tailscaleIsAvailable(
-        environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool
-    {
-        self.tailscaleBinary(environment: environment) != nil
-    }
-
     private func fetch(host: String, environment: [String: String]) async -> RemoteSessionHostResult {
         guard let ssh = self.findExecutable("ssh", environment: environment) ??
             (["/usr/bin/ssh", "/bin/ssh"].first { FileManager.default.isExecutableFile(atPath: $0) })

--- a/Sources/CodexBarCore/RemoteSessionFetcher.swift
+++ b/Sources/CodexBarCore/RemoteSessionFetcher.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+public struct RemoteSessionHostResult: Equatable, Sendable, Identifiable {
+    public let host: String
+    public let sessions: [AgentSession]
+    public let error: String?
+
+    public var id: String {
+        self.host
+    }
+
+    public var isReachable: Bool {
+        self.error == nil
+    }
+
+    public init(host: String, sessions: [AgentSession], error: String?) {
+        self.host = host
+        self.sessions = sessions
+        self.error = error
+    }
+}
+
+public enum TailscaleStatusParser {
+    public static func hosts(from data: Data, excludingLocalHost localHost: String? = nil) -> [String] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [] }
+        let peers: [[String: Any]] = if let dictionary = root["Peer"] as? [String: [String: Any]] {
+            Array(dictionary.values)
+        } else if let array = root["Peer"] as? [[String: Any]] {
+            array
+        } else {
+            []
+        }
+        let selfStatus = root["Self"] as? [String: Any]
+        let localLabels = Set([
+            localHost,
+            selfStatus?["DNSName"] as? String,
+            selfStatus?["HostName"] as? String,
+        ].compactMap(self.firstDNSLabel).map { $0.lowercased() })
+
+        var seen = Set<String>()
+        return peers.compactMap { peer in
+            guard peer["Online"] as? Bool == true,
+                  let operatingSystem = peer["OS"] as? String,
+                  operatingSystem == "macOS" || operatingSystem == "linux",
+                  let label = self.firstDNSLabel(peer["DNSName"] as? String)
+            else { return nil }
+            let normalized = label.lowercased()
+            guard !localLabels.contains(normalized), seen.insert(normalized).inserted else { return nil }
+            return label
+        }.sorted()
+    }
+
+    private static func firstDNSLabel(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        guard let label = trimmed.split(separator: ".").first, !label.isEmpty else { return nil }
+        return String(label)
+    }
+}
+
+public struct RemoteSessionFetcher: Sendable {
+    public static let bundledCLIFallback = "/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI"
+
+    public init() {}
+
+    public func discoveredHosts(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        localHost: String = ProcessInfo.processInfo.hostName) async -> [String]
+    {
+        guard let tailscale = self.tailscaleBinary(environment: environment),
+              let result = try? await SubprocessRunner.run(
+                  binary: tailscale,
+                  arguments: ["status", "--json"],
+                  environment: environment,
+                  timeout: 5,
+                  label: "Tailscale session host discovery"),
+              let data = result.stdout.data(using: .utf8)
+        else { return [] }
+        return TailscaleStatusParser.hosts(from: data, excludingLocalHost: localHost)
+    }
+
+    public func fetch(
+        hosts: [String],
+        environment: [String: String] = ProcessInfo.processInfo.environment) async -> [RemoteSessionHostResult]
+    {
+        let normalizedHosts = Self.sanitizedHosts(hosts)
+        return await withTaskGroup(
+            of: RemoteSessionHostResult.self,
+            returning: [RemoteSessionHostResult].self)
+        { group in
+            for host in normalizedHosts {
+                group.addTask {
+                    await self.fetch(host: host, environment: environment)
+                }
+            }
+            var results: [RemoteSessionHostResult] = []
+            for await result in group {
+                results.append(result)
+            }
+            return results
+                .sorted { lhs, rhs in lhs.host.localizedCaseInsensitiveCompare(rhs.host) == .orderedAscending }
+        }
+    }
+
+    public func focus(
+        sessionID: String,
+        host: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment) async
+    {
+        guard let host = Self.sanitizedHosts([host]).first else { return }
+        guard let ssh = self.findExecutable("ssh", environment: environment) ??
+            (["/usr/bin/ssh", "/bin/ssh"].first { FileManager.default.isExecutableFile(atPath: $0) })
+        else { return }
+        let command = "codexbar sessions focus \(Self.shellQuote(sessionID)) || " +
+            "\(Self.shellQuote(Self.bundledCLIFallback)) sessions focus \(Self.shellQuote(sessionID))"
+        _ = try? await SubprocessRunner.run(
+            binary: ssh,
+            arguments: ["-o", "BatchMode=yes", "-o", "ConnectTimeout=3", host, "sh", "-lc", Self.shellQuote(command)],
+            environment: environment,
+            timeout: 5,
+            acceptsNonZeroExit: true,
+            label: "focus remote agent session")
+    }
+
+    public func tailscaleIsAvailable(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool
+    {
+        self.tailscaleBinary(environment: environment) != nil
+    }
+
+    private func fetch(host: String, environment: [String: String]) async -> RemoteSessionHostResult {
+        guard let ssh = self.findExecutable("ssh", environment: environment) ??
+            (["/usr/bin/ssh", "/bin/ssh"].first { FileManager.default.isExecutableFile(atPath: $0) })
+        else {
+            return RemoteSessionHostResult(host: host, sessions: [], error: "ssh not found")
+        }
+        let command = "codexbar sessions --json || " +
+            "\(Self.shellQuote(Self.bundledCLIFallback)) sessions --json"
+        do {
+            let result = try await SubprocessRunner.run(
+                binary: ssh,
+                arguments: [
+                    "-o", "BatchMode=yes",
+                    "-o", "ConnectTimeout=3",
+                    host,
+                    "sh", "-lc", Self.shellQuote(command),
+                ],
+                environment: environment,
+                timeout: 5,
+                label: "fetch remote agent sessions")
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            var sessions = try decoder.decode([AgentSession].self, from: Data(result.stdout.utf8))
+            for index in sessions.indices {
+                sessions[index].host = host
+            }
+            return RemoteSessionHostResult(host: host, sessions: sessions, error: nil)
+        } catch {
+            return RemoteSessionHostResult(host: host, sessions: [], error: error.localizedDescription)
+        }
+    }
+
+    private func tailscaleBinary(environment: [String: String]) -> String? {
+        self.findExecutable("tailscale", environment: environment) ?? {
+            let bundled = "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+            return FileManager.default.isExecutableFile(atPath: bundled) ? bundled : nil
+        }()
+    }
+
+    private func findExecutable(_ name: String, environment: [String: String]) -> String? {
+        let path = environment["PATH"] ?? "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+        return path.split(separator: ":")
+            .map { String($0) + "/" + name }
+            .first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    public static func sanitizedHosts(_ hosts: [String]) -> [String] {
+        var seen = Set<String>()
+        return hosts.compactMap { rawHost in
+            let host = rawHost.trimmingCharacters(in: .whitespacesAndNewlines)
+            let hasUnsafeScalar = host.unicodeScalars.contains { scalar in
+                CharacterSet.controlCharacters.contains(scalar) ||
+                    CharacterSet.whitespacesAndNewlines.contains(scalar)
+            }
+            guard !host.isEmpty,
+                  !host.hasPrefix("-"),
+                  !hasUnsafeScalar,
+                  seen.insert(host.lowercased()).inserted
+            else { return nil }
+            return host
+        }
+    }
+
+    private static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Sources/CodexBarCore/SessionWindowFocuser.swift
+++ b/Sources/CodexBarCore/SessionWindowFocuser.swift
@@ -1,0 +1,107 @@
+#if os(macOS)
+import AppKit
+import ApplicationServices
+import Foundation
+
+public enum SessionFocusResult: Equatable, Sendable {
+    case focused
+    case activatedApplicationOnly
+    case failed
+}
+
+@MainActor
+public enum SessionWindowFocuser {
+    private static let knownBundleIdentifiers: Set<String> = [
+        "com.mitchellh.ghostty",
+        "com.googlecode.iterm2",
+        "com.apple.Terminal",
+        "dev.warp.Warp-Stable",
+        "com.github.wez.wezterm",
+        "net.kovidgoyal.kitty",
+        "org.alacritty",
+        "com.microsoft.VSCode",
+        "com.todesktop.230313mzl4w4u92",
+        "dev.zed.Zed",
+        "com.anthropic.claudefordesktop",
+    ]
+
+    @discardableResult
+    public static func focus(_ session: AgentSession, promptForAccessibility: Bool = true) -> SessionFocusResult {
+        guard let application = self.application(for: session) else { return .failed }
+        guard application.activate() else { return .failed }
+
+        let trusted = AXIsProcessTrustedWithOptions(
+            ["AXTrustedCheckOptionPrompt": promptForAccessibility] as CFDictionary)
+        guard trusted else { return .activatedApplicationOnly }
+
+        let appElement = AXUIElementCreateApplication(application.processIdentifier)
+        var windowsValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsValue) == .success,
+              let windows = windowsValue as? [AXUIElement],
+              let window = self.preferredWindow(windows, session: session) ?? windows.first
+        else { return .activatedApplicationOnly }
+        AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+        return .focused
+    }
+
+    private static func application(for session: AgentSession) -> NSRunningApplication? {
+        if let pid = session.pid {
+            var currentPID = pid
+            var fallback: NSRunningApplication?
+            var visited = Set<Int32>()
+            while currentPID > 0, visited.insert(currentPID).inserted {
+                if let application = NSRunningApplication(processIdentifier: currentPID) {
+                    fallback = fallback ?? application
+                    if let bundleIdentifier = application.bundleIdentifier,
+                       self.knownBundleIdentifiers.contains(bundleIdentifier)
+                    {
+                        return application
+                    }
+                }
+                guard let parent = self.parentPID(of: currentPID), parent != currentPID else { break }
+                currentPID = parent
+            }
+            if let fallback {
+                return fallback
+            }
+        }
+
+        let bundleIdentifier: String? = switch (session.provider, session.source) {
+        case (.claude, .desktopApp): "com.anthropic.claudefordesktop"
+        case (.codex, .desktopApp): "com.openai.codex"
+        default: nil
+        }
+        guard let bundleIdentifier else { return nil }
+        return NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first
+    }
+
+    private static func preferredWindow(_ windows: [AXUIElement], session: AgentSession) -> AXUIElement? {
+        let candidates = [session.projectName, session.cwd.map { URL(fileURLWithPath: $0).lastPathComponent }]
+            .compactMap { $0?.lowercased() }
+            .filter { !$0.isEmpty }
+        guard !candidates.isEmpty else { return nil }
+        return windows.first { window in
+            var titleValue: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
+                  let title = titleValue as? String
+            else { return false }
+            let lowercasedTitle = title.lowercased()
+            return candidates.contains { lowercasedTitle.contains($0) }
+        }
+    }
+
+    private static func parentPID(of pid: Int32) -> Int32? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-o", "ppid=", "-p", String(pid)]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        guard (try? process.run()) != nil else { return nil }
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8) else { return nil }
+        return Int32(output.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+}
+#endif

--- a/Tests/CodexBarTests/AgentSessionJSONTests.swift
+++ b/Tests/CodexBarTests/AgentSessionJSONTests.swift
@@ -1,0 +1,33 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct AgentSessionJSONTests {
+    @Test
+    func `sessions json round trip preserves stable schema`() throws {
+        let session = AgentSession(
+            id: "fixture-session",
+            provider: .codex,
+            source: .ide,
+            state: .active,
+            pid: 42,
+            cwd: "/tmp/project",
+            projectName: "project",
+            startedAt: Date(timeIntervalSince1970: 100),
+            lastActivityAt: Date(timeIntervalSince1970: 200),
+            transcriptPath: "/tmp/rollout.jsonl",
+            host: "local-mac")
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode([session])
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+        let keys = try #require(object.first).keys
+        #expect(Set(keys) == [
+            "id", "provider", "source", "state", "pid", "cwd", "projectName", "startedAt",
+            "lastActivityAt", "transcriptPath", "host",
+        ])
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        #expect(try decoder.decode([AgentSession].self, from: data) == [session])
+    }
+}

--- a/Tests/CodexBarTests/AgentSessionMenuDescriptorTests.swift
+++ b/Tests/CodexBarTests/AgentSessionMenuDescriptorTests.swift
@@ -1,0 +1,90 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct AgentSessionMenuDescriptorTests {
+    @Test
+    func `session section counts groups and renders unreachable hosts`() {
+        let now = Date(timeIntervalSince1970: 1000)
+        let local = Self.session(id: "local", host: "local-mac", activity: now.addingTimeInterval(-60))
+        let remote = Self.session(id: "remote", host: "clawmac", activity: now.addingTimeInterval(-720))
+        let section = MenuDescriptor.agentSessionsSection(
+            localSessions: [local],
+            remoteHosts: [
+                RemoteSessionHostResult(host: "clawmac", sessions: [remote], error: nil),
+                RemoteSessionHostResult(host: "offline", sessions: [], error: "Connection timed out"),
+            ],
+            now: now)
+
+        guard case let .text(header, .headline) = section.entries[0] else {
+            Issue.record("Expected session headline")
+            return
+        }
+        #expect(header == "Agent Sessions (2)")
+        guard case let .action(localTitle, .focusAgentSession(_, remoteHost)) = section.entries[1] else {
+            Issue.record("Expected local session action")
+            return
+        }
+        #expect(localTitle.contains("alpha — codex · cli · 1m"))
+        #expect(remoteHost == nil)
+        guard case let .text(remoteGroup, .secondary) = section.entries[2] else {
+            Issue.record("Expected remote group")
+            return
+        }
+        #expect(remoteGroup == "clawmac — 1")
+        guard case let .unavailable(title, tooltip) = section.entries[4] else {
+            Issue.record("Expected unreachable host")
+            return
+        }
+        #expect(title == "offline — unreachable")
+        #expect(tooltip == "Connection timed out")
+    }
+
+    @Test
+    func `reachable empty remote host keeps zero count section actionable`() {
+        let section = MenuDescriptor.agentSessionsSection(
+            localSessions: [],
+            remoteHosts: [RemoteSessionHostResult(host: "clawmac", sessions: [], error: nil)])
+
+        #expect(section.entries.contains { entry in
+            guard case let .unavailable(title, _) = entry else { return false }
+            return title == "No agent sessions found"
+        })
+    }
+
+    @Test
+    func `remote refresh gate retries changed settings and rejects stale result`() throws {
+        var gate = AgentSessionRemoteRefreshGate()
+        let initialGenerationCandidate = gate.begin()
+        let initialGeneration = try #require(initialGenerationCandidate)
+        gate.settingsDidChange()
+        #expect(gate.begin() == nil)
+
+        let staleOutcome = gate.finish(generation: initialGeneration)
+        #expect(!staleOutcome.shouldPublish)
+        #expect(staleOutcome.shouldRetry)
+
+        let currentGenerationCandidate = gate.begin()
+        let currentGeneration = try #require(currentGenerationCandidate)
+        let currentOutcome = gate.finish(generation: currentGeneration)
+        #expect(currentOutcome.shouldPublish)
+        #expect(!currentOutcome.shouldRetry)
+    }
+
+    private static func session(id: String, host: String, activity: Date) -> AgentSession {
+        AgentSession(
+            id: id,
+            provider: .codex,
+            source: .cli,
+            state: .active,
+            pid: 42,
+            cwd: "/Users/test/alpha",
+            projectName: "alpha",
+            startedAt: nil,
+            lastActivityAt: activity,
+            transcriptPath: nil,
+            host: host)
+    }
+}

--- a/Tests/CodexBarTests/AgentSessionParserTests.swift
+++ b/Tests/CodexBarTests/AgentSessionParserTests.swift
@@ -1,0 +1,74 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct AgentSessionParserTests {
+    @Test
+    func `ps parser deduplicates desktop wrapper and excludes app server and helpers`() throws {
+        let output = try Self.fixtureString("agent-sessions-ps", extension: "txt")
+        let records = AgentPSOutputParser.parse(output)
+        let agents = AgentPSOutputParser.agentProcesses(from: records)
+
+        #expect(records.count == 9)
+        #expect(agents.map(\ .pid) == [102, 201])
+        #expect(AgentPSOutputParser.provider(for: agents[0]) == .claude)
+        #expect(AgentPSOutputParser.source(for: agents[0]) == .desktopApp)
+        #expect(AgentPSOutputParser.provider(for: agents[1]) == .codex)
+        #expect(agents[1].command.hasSuffix("strange argv here"))
+        #expect(AgentPSOutputParser.hasCodexAppServer(in: records))
+    }
+
+    @Test
+    func `lsof parser maps batched cwd records`() throws {
+        let output = try Self.fixtureString("agent-sessions-lsof", extension: "txt")
+        let paths = LSOFCWDOutputParser.parse(output)
+
+        #expect(paths[102] == "/Users/test/Projects/alpha")
+        #expect(paths[201] == "/Users/test/Projects/project with spaces")
+    }
+
+    @Test
+    func `same cwd processes remain uncorrelated when ownership is ambiguous`() {
+        let olderStart = Date(timeIntervalSince1970: 100)
+        let newerStart = Date(timeIntervalSince1970: 200)
+        let older = AgentProcessRecord(pid: 10, ppid: 1, startedAt: olderStart, command: "claude")
+        let newer = AgentProcessRecord(pid: 20, ppid: 1, startedAt: newerStart, command: "claude")
+        let olderTranscript = ClaudeSessionProjectMapper.Transcript(
+            url: URL(fileURLWithPath: "/tmp/older.jsonl"),
+            modifiedAt: Date(timeIntervalSince1970: 150))
+        let newerTranscript = ClaudeSessionProjectMapper.Transcript(
+            url: URL(fileURLWithPath: "/tmp/newer.jsonl"),
+            modifiedAt: Date(timeIntervalSince1970: 250))
+
+        let assignments = AgentSessionCorrelation.assignClaudeTranscripts(
+            processes: [older, newer],
+            cwdByPID: [10: "/project", 20: "/project"],
+            transcriptsByCWD: ["/project": [newerTranscript, olderTranscript]])
+
+        #expect(assignments.isEmpty)
+    }
+
+    @Test
+    func `newest process sorts first for rollout correlation`() {
+        let older = AgentProcessRecord(
+            pid: 10,
+            ppid: 1,
+            startedAt: Date(timeIntervalSince1970: 100),
+            command: "codex exec")
+        let newer = AgentProcessRecord(
+            pid: 20,
+            ppid: 1,
+            startedAt: Date(timeIntervalSince1970: 200),
+            command: "codex exec")
+
+        #expect(AgentSessionCorrelation.newestProcessesFirst([older, newer]).map(\ .pid) == [20, 10])
+    }
+
+    static func fixtureURL(_ name: String, extension fileExtension: String) throws -> URL {
+        try #require(Bundle.module.url(forResource: name, withExtension: fileExtension, subdirectory: "Fixtures"))
+    }
+
+    static func fixtureString(_ name: String, extension fileExtension: String) throws -> String {
+        try String(contentsOf: self.fixtureURL(name, extension: fileExtension), encoding: .utf8)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeSessionMappingTests.swift
+++ b/Tests/CodexBarTests/ClaudeSessionMappingTests.swift
@@ -1,0 +1,36 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct ClaudeSessionMappingTests {
+    @Test
+    func `cwd escaping replaces every non alphanumeric ASCII byte`() {
+        #expect(ClaudeSessionProjectMapper.escapedCWD("/Users/test/My Project_v2") == "-Users-test-My-Project-v2")
+    }
+
+    @Test
+    func `newest transcript is selected from mapped project directory`() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeSessionMappingTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let cwd = "/Users/test/Projects/alpha"
+        let projectDirectory = home
+            .appendingPathComponent(".claude/projects", isDirectory: true)
+            .appendingPathComponent(ClaudeSessionProjectMapper.escapedCWD(cwd), isDirectory: true)
+        try FileManager.default.createDirectory(at: projectDirectory, withIntermediateDirectories: true)
+        let older = projectDirectory.appendingPathComponent("older.jsonl")
+        let newer = projectDirectory.appendingPathComponent("newer.jsonl")
+        try Data("fixture\n".utf8).write(to: older)
+        try Data("fixture\n".utf8).write(to: newer)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 100)],
+            ofItemAtPath: older.path)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 200)],
+            ofItemAtPath: newer.path)
+
+        let match = try #require(ClaudeSessionProjectMapper.newestTranscript(cwd: cwd, homeDirectory: home))
+        #expect(match.url.lastPathComponent == "newer.jsonl")
+        #expect(match.modifiedAt == Date(timeIntervalSince1970: 200))
+    }
+}

--- a/Tests/CodexBarTests/CodexSessionRolloutTests.swift
+++ b/Tests/CodexBarTests/CodexSessionRolloutTests.swift
@@ -1,0 +1,65 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CodexSessionRolloutTests {
+    @Test
+    func `first rollout line maps to file only agent session`() throws {
+        let url = try AgentSessionParserTests.fixtureURL("agent-session-rollout", extension: "jsonl")
+        let metadata = try #require(CodexRolloutFirstLineParser.read(from: url))
+        let now = Date(timeIntervalSince1970: 10000)
+        let modifiedAt = now.addingTimeInterval(-60)
+        let session = try #require(CodexRolloutFirstLineParser.makeSession(
+            metadata: metadata,
+            transcriptURL: url,
+            modifiedAt: modifiedAt,
+            host: "local-mac",
+            now: now))
+
+        #expect(session.id == "019f-session-fixture")
+        #expect(session.cwd == "/Users/test/Projects/alpha")
+        #expect(session.projectName == "alpha")
+        #expect(session.source == .cli)
+        #expect(session.state == .active)
+        #expect(session.pid == nil)
+    }
+
+    @Test
+    func `file only rollout outside window is excluded while live process remains`() throws {
+        let url = try AgentSessionParserTests.fixtureURL("agent-session-rollout", extension: "jsonl")
+        let metadata = try #require(CodexRolloutFirstLineParser.read(from: url))
+        let now = Date(timeIntervalSince1970: 10000)
+        let modifiedAt = now.addingTimeInterval(-1801)
+
+        #expect(CodexRolloutFirstLineParser.makeSession(
+            metadata: metadata,
+            transcriptURL: url,
+            modifiedAt: modifiedAt,
+            host: "local-mac",
+            now: now) == nil)
+        #expect(CodexRolloutFirstLineParser.makeSession(
+            metadata: metadata,
+            transcriptURL: url,
+            modifiedAt: modifiedAt,
+            pid: 42,
+            host: "local-mac",
+            now: now)?.state == .idle)
+    }
+
+    @Test
+    func `app server presence classifies unknown file only rollout as desktop`() {
+        #expect(AgentSessionCorrelation.fileOnlyCodexSource(
+            metadataSource: .unknown,
+            appServerPresent: true) == .desktopApp)
+        #expect(AgentSessionCorrelation.fileOnlyCodexSource(
+            metadataSource: .unknown,
+            appServerPresent: false) == .unknown)
+    }
+
+    @Test
+    func `codex cwd matching rejects missing paths`() {
+        #expect(AgentSessionCorrelation.codexWorkingDirectoriesMatch("/repo/alpha", "/repo/./alpha"))
+        #expect(!AgentSessionCorrelation.codexWorkingDirectoriesMatch(nil, nil))
+        #expect(!AgentSessionCorrelation.codexWorkingDirectoriesMatch("/repo/alpha", nil))
+    }
+}

--- a/Tests/CodexBarTests/Fixtures/agent-session-rollout.jsonl
+++ b/Tests/CodexBarTests/Fixtures/agent-session-rollout.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-07-06T16:00:00Z","type":"session_meta","payload":{"session_id":"019f-session-fixture","cwd":"/Users/test/Projects/alpha","originator":"codex_exec","source":"exec"}}
+{"this":"second line must never be read by the session parser"}

--- a/Tests/CodexBarTests/Fixtures/agent-sessions-lsof.txt
+++ b/Tests/CodexBarTests/Fixtures/agent-sessions-lsof.txt
@@ -1,0 +1,4 @@
+p102
+n/Users/test/Projects/alpha
+p201
+n/Users/test/Projects/project with spaces

--- a/Tests/CodexBarTests/Fixtures/agent-sessions-ps.txt
+++ b/Tests/CodexBarTests/Fixtures/agent-sessions-ps.txt
@@ -1,0 +1,9 @@
+  101     1 Mon Jul  6 09:00:00 2026 /Applications/Claude.app/Contents/Resources/disclaimer /Users/test/Library/Application Support/Claude/claude-code/claude --dangerously-skip-permissions
+  102   101 Mon Jul  6 09:00:01 2026 /Users/test/Library/Application Support/Claude/claude-code/claude --dangerously-skip-permissions
+  201     1 Mon Jul  6 09:01:00 2026 /opt/homebrew/bin/codex exec --full-auto strange argv here
+  202     1 Mon Jul  6 09:02:00 2026 /Applications/Codex.app/Contents/Resources/codex app-server --listen stdio
+  203     1 Mon Jul  6 09:03:00 2026 /usr/local/bin/codex --help
+  301     1 Mon Jul  6 09:04:00 2026 /Users/test/.local/bin/claude-code-acp --stdio
+  401     1 Mon Jul  6 09:05:00 2026 /Applications/Codex.app/Contents/Frameworks/Codex Framework.framework/Helpers/Codex (Renderer) --type=renderer
+  402     1 Mon Jul  6 09:06:00 2026 /Applications/Claude.app/Contents/MacOS/Claude
+  403     1 Mon Jul  6 09:07:00 2026 ./Codex Computer Use.app/Contents/MacOS/helper mcp

--- a/Tests/CodexBarTests/Fixtures/agent-sessions-tailscale.json
+++ b/Tests/CodexBarTests/Fixtures/agent-sessions-tailscale.json
@@ -1,0 +1,10 @@
+{
+  "Self": {"DNSName": "local-mac.example.ts.net.", "HostName": "local-mac"},
+  "Peer": {
+    "node-1": {"DNSName": "clawmac.example.ts.net.", "OS": "macOS", "Online": true},
+    "node-2": {"DNSName": "linuxbox.example.ts.net.", "OS": "linux", "Online": true},
+    "node-3": {"DNSName": "phone.example.ts.net.", "OS": "iOS", "Online": true},
+    "node-4": {"DNSName": "offline.example.ts.net.", "OS": "macOS", "Online": false},
+    "node-5": {"DNSName": "local-mac.example.ts.net.", "OS": "macOS", "Online": true}
+  }
+}

--- a/Tests/CodexBarTests/TailscaleSessionTests.swift
+++ b/Tests/CodexBarTests/TailscaleSessionTests.swift
@@ -1,0 +1,29 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct TailscaleSessionTests {
+    @Test
+    func `online mac and linux peers become hosts`() throws {
+        let url = try AgentSessionParserTests.fixtureURL("agent-sessions-tailscale", extension: "json")
+        let hosts = try TailscaleStatusParser.hosts(
+            from: Data(contentsOf: url),
+            excludingLocalHost: "local-mac")
+
+        #expect(hosts == ["clawmac", "linuxbox"])
+    }
+
+    @Test
+    func `ssh destinations reject options whitespace and controls`() {
+        let hosts = RemoteSessionFetcher.sanitizedHosts([
+            "user@clawmac",
+            "USER@CLAWMAC",
+            "-oProxyCommand=touch /tmp/unsafe",
+            "host with-space",
+            "host\nother",
+            "linuxbox",
+        ])
+
+        #expect(hosts == ["user@clawmac", "linuxbox"])
+    }
+}

--- a/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,77 @@
+{
+  "originHash" : "2c34a752ff5b5315e5bae001ccb84dbfa3f7ee7793a23b8862dbc8d096d771ba",
+  "pins" : [
+    {
+      "identity" : "commander",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/steipete/Commander",
+      "state" : {
+        "revision" : "b9fb00564aa3229deeb48090801fec2c185951f4",
+        "version" : "0.2.3"
+      }
+    },
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    },
+    {
+      "identity" : "sweetcookiekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/steipete/SweetCookieKit",
+      "state" : {
+        "revision" : "21bedea672a3e63ccad24d744051e76cdf0462dd",
+        "version" : "0.4.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
+      }
+    },
+    {
+      "identity" : "vortex",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zats/Vortex",
+      "state" : {
+        "revision" : "ef5392088d4aeb255c4eee83157dbdafcd31bf07"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/docs/agent-sessions-design.md
+++ b/docs/agent-sessions-design.md
@@ -1,0 +1,98 @@
+# Agent Sessions (prototype)
+
+Track live Codex + Claude Code agent sessions — local Mac first, other Macs on the tailnet second — and surface them in the CodexBar menu with click-to-focus of the owning terminal window.
+
+## Why in CodexBar
+
+CodexBar already parses `~/.claude/projects` JSONL (cost scanner) and ships a bundled CLI on macOS + Linux. Sessions reuse both: the local scanner feeds the menu UI, and the same scanner exposed as `codexbar sessions --json` is what remote Macs run over SSH. No daemon, no new app.
+
+## Data model (CodexBarCore)
+
+```swift
+public struct AgentSession: Codable, Sendable, Identifiable {
+    public enum Provider: String, Codable, Sendable { case codex, claude }
+    public enum Source: String, Codable, Sendable { case cli, desktopApp, ide, unknown }
+    public enum State: String, Codable, Sendable { case active, idle }
+
+    public var id: String            // session UUID when resolvable, else "pid:<pid>"
+    public var provider: Provider
+    public var source: Source
+    public var state: State
+    public var pid: Int32?           // nil for file-only (e.g. Codex desktop) sessions
+    public var cwd: String?
+    public var projectName: String?  // last path component of cwd
+    public var startedAt: Date?
+    public var lastActivityAt: Date? // transcript mtime
+    public var transcriptPath: String?
+    public var host: String          // local hostname, or remote host label
+}
+```
+
+`active` = last activity ≤ 120 s ago. `idle` = live process (or recent file) with older activity. Constants live in one `SessionScanConfig` struct (activeWindow 120 s, fileOnlyWindow 30 min) so thresholds are tunable/testable.
+
+## Local scanner (CodexBarCore, no new deps)
+
+`LocalAgentSessionScanner` combines two signals:
+
+1. **Process scan** — parse `ps -axo pid=,ppid=,lstart=,command=`.
+   - Claude: command basename `claude` (skip obvious non-agent helpers). Source: path contains `Application Support/Claude/claude-code` → `.desktopApp`, else `.cli`. Deduplicate the wrapper/child pair (desktop spawns `disclaimer` parent + `claude` child with same argv; keep the child).
+   - Codex: basename `codex` with no `app-server` argument → `.cli` (TUI or `exec`). `codex app-server` marks the desktop app as present but is not itself a session.
+   - cwd per pid via one batched `lsof -a -d cwd -Fn -p <pid,pid,…>` call (parse `p`/`n` records). Failure → cwd nil, session still listed.
+2. **Transcript correlation**
+   - Claude: cwd → `~/.claude/projects/<escaped-cwd>/` (escape: every non-alphanumeric ASCII → `-`), newest `*.jsonl` by mtime → session id (filename UUID), lastActivityAt (mtime). Also reuse `ClaudeDesktopProjectsLocator` roots so desktop local-agent-mode sessions resolve.
+   - Codex: enumerate `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` for today + yesterday (`$CODEX_HOME` respected). Read only the first line (`session_meta`: `session_id`, `cwd`, `originator`, `source`). File with mtime ≤ fileOnlyWindow and no matching live pid → file-only session, source from `originator` (`codex_exec`/`exec` → `.cli`; ide-ish originators → `.ide`; desktop → `.desktopApp`). Live `codex` pids match to rollouts by cwd (newest wins); unmatched live pid still listed with nil transcript.
+   - Never read more than the first line of any JSONL; never load whole transcripts.
+
+Scanner is `Sendable`, pure functions where possible; ps/lsof output parsing lives in dedicated parser types fed by strings so tests use fixtures.
+
+## CLI (CodexBarCLI)
+
+- `codexbar sessions` — table; `--json` — `[AgentSession]` (stable field names above; ISO-8601 dates).
+- `codexbar sessions focus <id>` — macOS only: focus the session's terminal window (see Focus). Exit 1 if id unknown, 2 if focus failed.
+- Follows existing `CLI*Command.swift` conventions. Works on Linux for listing (ps/proc paths guarded), focus is Darwin-only.
+
+## Remote hosts (CodexBarCore + app)
+
+`RemoteSessionFetcher`:
+
+- Host list = manual entries (settings, ssh destinations like `steipete@clawmac`) ∪ Tailscale auto-discovery when enabled: run `tailscale status --json` (PATH, then `/Applications/Tailscale.app/Contents/MacOS/Tailscale`), take online peers with `"OS": "macOS"|"linux"`, use first `DNSName` label as host. Local host excluded.
+- Fetch per host (parallel, 5 s budget): `ssh -o BatchMode=yes -o ConnectTimeout=3 <host> sh -lc 'codexbar sessions --json'` with fallback to the bundled app CLI path (resolve the canonical bundled location from `Scripts/package_app.sh` and hardcode it as fallback: `… || <bundled-path> sessions --json`). Host errors are non-fatal: host shown as unreachable, others still render.
+- Remote focus: fire-and-forget `ssh <host> sh -lc 'codexbar sessions focus <id>'`.
+- Refresh: local scan every 30 s while the status item exists (cheap), remote every 60 s and immediately on menu open; both skipped when the feature is off. Reuse existing refresh loop plumbing rather than new timers if it fits.
+
+## Menu UI (CodexBar app)
+
+- New menu section **Agent Sessions (N)** (N = total, all hosts) above the settings/footer area, built through the existing `MenuDescriptor`-style seam so it's testable headless.
+- Local sessions first, then one group per remote host (`clawmac — 2`, unreachable hosts greyed with a tooltip). Row: state dot (● active / ○ idle), provider glyph, `projectName — provider · source · 12m`.
+- Click local row → `SessionWindowFocuser`. Click remote row → remote focus ssh call.
+- Settings: "Sessions" group — enable toggle (default on), Tailscale auto-discover toggle (default on when tailscale binary found), manual hosts text field (comma-separated), staleness note. Persist in `SettingsStore` like neighboring prefs.
+
+## Focus (macOS, app + CLI shared in Core or app-adjacent target)
+
+`SessionWindowFocuser`:
+
+1. pid → walk ppid chain to the nearest ancestor whose `NSRunningApplication.bundleIdentifier` is a known terminal/editor host: Ghostty, iTerm2, Apple Terminal, Warp, WezTerm, kitty, Alacritty, VS Code, Cursor, Zed, Claude desktop (`com.anthropic.claudefordesktop`). Fallback: the app owning the pid.
+2. Activate the app, then AX (`AXUIElementCreateApplication` → `AXWindows`): raise the window whose title contains projectName or the cwd tail; fallback to frontmost window of that app. Requires Accessibility permission — call `AXIsProcessTrustedWithOptions` with prompt on first use; degrade gracefully (activate app only) when untrusted.
+3. File-only sessions (no pid): Claude desktop → activate Claude.app; Codex desktop → activate Codex.app; otherwise no-op with log.
+
+tmux pane / terminal-tab precision is out of scope for the prototype.
+
+## Tests (Tests/CodexBarTests)
+
+Fixture-driven, no live processes, no Keychain/AX:
+
+- ps output parser: desktop `disclaimer`+`claude` dedupe, codex vs `codex app-server`, weird argv.
+- lsof `-Fn` parser.
+- Claude cwd escaping → project dir mapping; newest-jsonl selection (temp dirs).
+- Codex rollout first-line parse → AgentSession (fixture JSONL), file-only window cutoff.
+- Tailscale status JSON → host list (fixture; offline/iOS peers excluded).
+- Sessions JSON round-trip (CLI output schema stability).
+- Menu section descriptor: counts, grouping, unreachable-host rendering.
+
+## Non-goals (prototype)
+
+Claude.ai chat sessions; Codex cloud tasks; historical session browsing/analytics; "waiting on permission" state; tmux pane/tab focus; Bonjour/mDNS; persistent remote daemon or push transport; widget changes. No new SPM dependencies.
+
+## Proof
+
+`make check` clean; `make test` (or focused `swift test --filter` covering the new tests) green; `swift run CodexBarCLI sessions --json` produces plausible output on this Mac.

--- a/docs/agent-sessions-design.md
+++ b/docs/agent-sessions-design.md
@@ -55,7 +55,7 @@ Scanner is `Sendable`, pure functions where possible; ps/lsof output parsing liv
 
 `RemoteSessionFetcher`:
 
-- Host list = manual entries (settings, ssh destinations like `steipete@clawmac`) ∪ Tailscale auto-discovery when enabled: run `tailscale status --json` (PATH, then `/Applications/Tailscale.app/Contents/MacOS/Tailscale`), take online peers with `"OS": "macOS"|"linux"`, use first `DNSName` label as host. Local host excluded.
+- Host list = manual entries (settings, ssh destinations like `steipete@clawmac`) ∪ automatic Tailscale discovery (no-op when tailscale is absent): run `tailscale status --json` (PATH, then `/Applications/Tailscale.app/Contents/MacOS/Tailscale`), take online peers with `"OS": "macOS"|"linux"`, use first `DNSName` label as host. Local host excluded.
 - Fetch per host (parallel, 5 s budget): `ssh -o BatchMode=yes -o ConnectTimeout=3 <host> sh -lc 'codexbar sessions --json'` with fallback to the bundled app CLI path (resolve the canonical bundled location from `Scripts/package_app.sh` and hardcode it as fallback: `… || <bundled-path> sessions --json`). Host errors are non-fatal: host shown as unreachable, others still render.
 - Remote focus: fire-and-forget `ssh <host> sh -lc 'codexbar sessions focus <id>'`.
 - Refresh: local scan every 30 s while the status item exists (cheap), remote every 60 s and immediately on menu open; both skipped when the feature is off. Reuse existing refresh loop plumbing rather than new timers if it fits.
@@ -65,7 +65,7 @@ Scanner is `Sendable`, pure functions where possible; ps/lsof output parsing liv
 - New menu section **Agent Sessions (N)** (N = total, all hosts) above the settings/footer area, built through the existing `MenuDescriptor`-style seam so it's testable headless.
 - Local sessions first, then one group per remote host (`clawmac — 2`, unreachable hosts greyed with a tooltip). Row: state dot (● active / ○ idle), provider glyph, `projectName — provider · source · 12m`.
 - Click local row → `SessionWindowFocuser`. Click remote row → remote focus ssh call.
-- Settings: "Sessions" group — enable toggle (default on), Tailscale auto-discover toggle (default on when tailscale binary found), manual hosts text field (comma-separated), staleness note. Persist in `SettingsStore` like neighboring prefs.
+- Settings: "Sessions" group — a single enable toggle (default on) plus a manual hosts text field (comma-separated); Tailscale discovery is always on while the feature is enabled. Persist in `SettingsStore` like neighboring prefs.
 
 ## Focus (macOS, app + CLI shared in Core or app-adjacent target)
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,17 @@
+# Agent Sessions
+
+CodexBar can list live Codex and Claude Code sessions on this Mac and other Macs or Linux hosts reachable over SSH.
+
+Enable **Settings → General → Sessions**. Local sessions refresh every 30 seconds. Remote sessions refresh every 60 seconds and whenever the menu opens. Tailscale discovery includes online macOS and Linux peers; add extra SSH destinations as a comma-separated list, such as `user@host`.
+
+The menu groups local sessions first, followed by each remote host. A filled dot is active; an empty dot is idle. Select a local row to activate its terminal, editor, or desktop app. The first focus attempt can request macOS Accessibility permission so CodexBar can raise the matching window. Remote rows run the same focus command over SSH.
+
+The CLI exposes the same scanner:
+
+```console
+codexbar sessions
+codexbar sessions --json
+codexbar sessions focus <session-id>
+```
+
+Remote hosts need key-based, non-interactive SSH and either `codexbar` on `PATH` or CodexBar installed in `/Applications`.


### PR DESCRIPTION
## Summary

Adds an **Agent Sessions** prototype: CodexBar now tracks live Codex and Claude Code agent sessions — on this Mac and on other Macs over the tailnet — shows them in the menu, and focuses the owning terminal window on click.

- **Local discovery**: process scan (`ps` + one batched `lsof` call) correlated with Codex rollout metadata (`~/.codex/sessions/.../rollout-*.jsonl`, first line only) and Claude project transcripts (`~/.claude/projects/<escaped-cwd>/*.jsonl`, plus Claude desktop local-agent-mode roots via the existing locator). Sessions that cannot be attributed unambiguously stay PID-only instead of risking a crossed focus target.
- **Menu**: "Agent Sessions (N)" section with active/idle state, provider/source, project, and age; remote hosts grouped per Mac, unreachable hosts greyed with the error as tooltip.
- **Click to focus**: walks the pid chain to the nearest known terminal/editor host (Ghostty, iTerm2, Terminal, Warp, WezTerm, kitty, Alacritty, VS Code, Cursor, Zed, Claude desktop), activates it, and AX-raises the window whose title matches the project. Degrades to app activation without Accessibility trust.
- **Multi-Mac**: hosts from `tailscale status --json` (online macOS/Linux peers) plus a manual SSH host list; fetched in parallel via `ssh -o BatchMode=yes <host> codexbar sessions --json`, falling back to the app-bundled CLI at `Contents/Helpers/CodexBarCLI`. Clicking a remote session triggers focus on that Mac.
- **CLI**: `codexbar sessions` (table / `--json`) and `codexbar sessions focus <id>`; the JSON is the same payload the remote fetch consumes.
- **Settings**: enable toggle, Tailscale auto-discovery toggle (defaults on when tailscale is present), manual hosts field. Local refresh 30 s, remote 60 s and on menu open.

Design notes: `docs/agent-sessions-design.md`. User docs: `docs/sessions.md`.

Also tracks the widget workspace `Package.resolved`: the widget extension builds with `-disableAutomaticPackageResolution` and packaging fails on checkouts where this untracked file is missing.

## Non-goals (prototype)

Claude.ai chat sessions, Codex cloud tasks, permission-waiting state, tmux pane/tab precision, Bonjour, historical analytics. No new SPM dependencies. Known gap: npm-shim `claude` processes surfacing as `node ...` in ps are not matched (native installs are).

## Commands run

- `make check` — 0 format/lint violations
- `make test` (full sharded suite) — green
- `swift test --filter Session` — 125 tests passed
- `swift run CodexBarCLI sessions` — live table listing real local sessions (Claude desktop worktrees with resolved transcript UUIDs, ambiguous sessions PID-only, idle Codex CLI run)
- `Scripts/compile_and_run.sh` — packaged app relaunched; menu visually verified showing 6 local sessions and 6 Tailscale-discovered Macs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
