### PR TITLE
Preserve Claude usage source after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Settings: split provider pane "Settings" sections into "Menu bar" and "Connection" so metric pickers and auth/cookie/source controls are grouped by topic.
 
 ### Fixed
+- Claude login: preserve the selected usage source after OAuth sign-in so Auto mode can still fall back to CLI or web data when OAuth is unavailable. Thanks @Chipagosfinest!
 - Claude quotas: ignore synthetic no-session placeholders when tracking notifications, history, and reset events, preventing false restores and duplicate threshold or pace warnings while weekly usage continues updating. Thanks @vincent-peng!
 - German localization: label manual cookie-source and refresh options as “Manuell” instead of the handbook noun “Handbuch.” Thanks @fbrettnich!
 - Amp: parse the current percentage-based daily Amp Free usage output while preserving individual and workspace balances. Thanks @3kh0!

--- a/Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift
@@ -1,4 +1,9 @@
 import CodexBarCore
+import Foundation
+
+typealias ClaudeLoginFlowRunner = (
+    _ timeout: TimeInterval,
+    _ onPhaseChange: @escaping @Sendable (ClaudeLoginRunner.Phase) -> Void) async -> ClaudeLoginRunner.Result
 
 enum ClaudeLoginFlowPolicy {
     static func usageDataSourceAfterSuccessfulLogin(previous: ClaudeUsageDataSource) -> ClaudeUsageDataSource {
@@ -9,6 +14,13 @@ enum ClaudeLoginFlowPolicy {
 @MainActor
 extension StatusItemController {
     func runClaudeLoginFlow() async -> Bool {
+        await self.runClaudeLoginFlow(
+            loginRunner: { timeout, onPhaseChange in
+                await ClaudeLoginRunner.run(timeout: timeout, onPhaseChange: onPhaseChange)
+            })
+    }
+
+    func runClaudeLoginFlow(loginRunner: ClaudeLoginFlowRunner) async -> Bool {
         let phaseHandler: @Sendable (ClaudeLoginRunner.Phase) -> Void = { [weak self] phase in
             Task { @MainActor in
                 switch phase {
@@ -17,7 +29,7 @@ extension StatusItemController {
                 }
             }
         }
-        let result = await ClaudeLoginRunner.run(timeout: 120, onPhaseChange: phaseHandler)
+        let result = await loginRunner(120, phaseHandler)
         guard !Task.isCancelled else { return false }
         self.loginPhase = .idle
         self.presentClaudeLoginResult(result)

--- a/Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift
@@ -1,8 +1,8 @@
 import CodexBarCore
 
 enum ClaudeLoginFlowPolicy {
-    static func usageDataSourceAfterSuccessfulLogin(previous _: ClaudeUsageDataSource) -> ClaudeUsageDataSource {
-        .auto
+    static func usageDataSourceAfterSuccessfulLogin(previous: ClaudeUsageDataSource) -> ClaudeUsageDataSource {
+        previous
     }
 }
 

--- a/Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift
@@ -1,5 +1,11 @@
 import CodexBarCore
 
+enum ClaudeLoginFlowPolicy {
+    static func usageDataSourceAfterSuccessfulLogin(previous _: ClaudeUsageDataSource) -> ClaudeUsageDataSource {
+        .auto
+    }
+}
+
 @MainActor
 extension StatusItemController {
     func runClaudeLoginFlow() async -> Bool {
@@ -21,7 +27,8 @@ extension StatusItemController {
         if case .success = result.outcome {
             let metadata = self.store.metadata(for: .claude)
             self.settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
-            self.settings.claudeUsageDataSource = .oauth
+            self.settings.claudeUsageDataSource = ClaudeLoginFlowPolicy.usageDataSourceAfterSuccessfulLogin(
+                previous: self.settings.claudeUsageDataSource)
             self.postLoginNotification(for: .claude)
             return true
         }

--- a/Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift
@@ -5,12 +5,6 @@ typealias ClaudeLoginFlowRunner = (
     _ timeout: TimeInterval,
     _ onPhaseChange: @escaping @Sendable (ClaudeLoginRunner.Phase) -> Void) async -> ClaudeLoginRunner.Result
 
-enum ClaudeLoginFlowPolicy {
-    static func usageDataSourceAfterSuccessfulLogin(previous: ClaudeUsageDataSource) -> ClaudeUsageDataSource {
-        previous
-    }
-}
-
 @MainActor
 extension StatusItemController {
     func runClaudeLoginFlow() async -> Bool {
@@ -39,8 +33,6 @@ extension StatusItemController {
         if case .success = result.outcome {
             let metadata = self.store.metadata(for: .claude)
             self.settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
-            self.settings.claudeUsageDataSource = ClaudeLoginFlowPolicy.usageDataSourceAfterSuccessfulLogin(
-                previous: self.settings.claudeUsageDataSource)
             self.postLoginNotification(for: .claude)
             return true
         }

--- a/Tests/CodexBarTests/ClaudeLoginFlowPolicyTests.swift
+++ b/Tests/CodexBarTests/ClaudeLoginFlowPolicyTests.swift
@@ -2,11 +2,54 @@ import CodexBarCore
 import Testing
 @testable import CodexBar
 
+@MainActor
+@Suite(.serialized)
 struct ClaudeLoginFlowPolicyTests {
     @Test
     func `successful Claude login preserves selected source so auto fallback remains available`() {
         for source in ClaudeUsageDataSource.allCases {
             #expect(ClaudeLoginFlowPolicy.usageDataSourceAfterSuccessfulLogin(previous: source) == source)
+        }
+    }
+
+    @Test
+    func `successful Claude login controller flow preserves selected source and enables provider`() async throws {
+        let registry = ProviderRegistry.shared
+        let claudeMetadata = try #require(registry.metadata[.claude])
+
+        for source in ClaudeUsageDataSource.allCases {
+            let settings = testSettingsStore(
+                suiteName: "ClaudeLoginFlowPolicyTests-controller-\(source.rawValue)")
+            settings.statusChecksEnabled = false
+            settings.refreshFrequency = .manual
+            settings.providerDetectionCompleted = true
+            settings.claudeUsageDataSource = source
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMetadata, enabled: false)
+
+            let fetcher = UsageFetcher()
+            let store = UsageStore(
+                fetcher: fetcher,
+                browserDetection: BrowserDetection(cacheTTL: 0),
+                settings: settings)
+
+            await withStatusItemControllerForTesting(store: store, settings: settings, fetcher: fetcher) { controller in
+                let didLogin = await controller.runClaudeLoginFlow { _, onPhaseChange in
+                    onPhaseChange(.requesting)
+                    await Task.yield()
+                    onPhaseChange(.waitingBrowser)
+                    await Task.yield()
+                    return ClaudeLoginRunner.Result(
+                        outcome: .success,
+                        output: "Successfully logged in",
+                        authLink: nil)
+                }
+
+                #expect(didLogin)
+                #expect(controller.loginPhase == .idle)
+            }
+
+            #expect(settings.claudeUsageDataSource == source)
+            #expect(settings.isProviderEnabledCached(provider: .claude, metadataByProvider: registry.metadata))
         }
     }
 }

--- a/Tests/CodexBarTests/ClaudeLoginFlowPolicyTests.swift
+++ b/Tests/CodexBarTests/ClaudeLoginFlowPolicyTests.swift
@@ -1,0 +1,12 @@
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+struct ClaudeLoginFlowPolicyTests {
+    @Test
+    func `successful Claude login keeps source on auto so fallback remains available`() {
+        for source in ClaudeUsageDataSource.allCases {
+            #expect(ClaudeLoginFlowPolicy.usageDataSourceAfterSuccessfulLogin(previous: source) == .auto)
+        }
+    }
+}

--- a/Tests/CodexBarTests/ClaudeLoginFlowPolicyTests.swift
+++ b/Tests/CodexBarTests/ClaudeLoginFlowPolicyTests.swift
@@ -4,9 +4,9 @@ import Testing
 
 struct ClaudeLoginFlowPolicyTests {
     @Test
-    func `successful Claude login keeps source on auto so fallback remains available`() {
+    func `successful Claude login preserves selected source so auto fallback remains available`() {
         for source in ClaudeUsageDataSource.allCases {
-            #expect(ClaudeLoginFlowPolicy.usageDataSourceAfterSuccessfulLogin(previous: source) == .auto)
+            #expect(ClaudeLoginFlowPolicy.usageDataSourceAfterSuccessfulLogin(previous: source) == source)
         }
     }
 }

--- a/Tests/CodexBarTests/ClaudeLoginFlowPolicyTests.swift
+++ b/Tests/CodexBarTests/ClaudeLoginFlowPolicyTests.swift
@@ -4,14 +4,7 @@ import Testing
 
 @MainActor
 @Suite(.serialized)
-struct ClaudeLoginFlowPolicyTests {
-    @Test
-    func `successful Claude login preserves selected source so auto fallback remains available`() {
-        for source in ClaudeUsageDataSource.allCases {
-            #expect(ClaudeLoginFlowPolicy.usageDataSourceAfterSuccessfulLogin(previous: source) == source)
-        }
-    }
-
+struct ClaudeLoginFlowTests {
     @Test
     func `successful Claude login controller flow preserves selected source and enables provider`() async throws {
         let registry = ProviderRegistry.shared
@@ -19,7 +12,7 @@ struct ClaudeLoginFlowPolicyTests {
 
         for source in ClaudeUsageDataSource.allCases {
             let settings = testSettingsStore(
-                suiteName: "ClaudeLoginFlowPolicyTests-controller-\(source.rawValue)")
+                suiteName: "ClaudeLoginFlowTests-controller-\(source.rawValue)")
             settings.statusChecksEnabled = false
             settings.refreshFrequency = .manual
             settings.providerDetectionCompleted = true

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -79,8 +79,8 @@ Admin API key setup:
   - `seven_day_routines` / `seven_day_cowork` → Daily Routines extra window.
   - Claude Design/Omelette keys are ignored because Claude Design shares the main Claude usage limit.
   - `extra_usage` → Extra usage cost (monthly spend/limit).
-- Successful OAuth login enables Claude and keeps the usage source on Auto so OAuth remains preferred when readable,
-  while CLI/Web fallback stays available when OAuth credentials are not usable.
+- Successful OAuth login enables Claude and preserves the selected usage source. With the default Auto source, OAuth
+  remains preferred when readable, while CLI/Web fallback stays available when OAuth credentials are not usable.
 - Plan inference: `subscriptionType` is preferred when present; `rate_limit_tier` falls back to
   Max/Pro/Team/Enterprise. When a Max `rate_limit_tier` carries a usage multiplier
   (`default_claude_max_5x` / `default_claude_max_20x`), it is surfaced in the label as "Max 5x" / "Max 20x".

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -79,7 +79,8 @@ Admin API key setup:
   - `seven_day_routines` / `seven_day_cowork` → Daily Routines extra window.
   - Claude Design/Omelette keys are ignored because Claude Design shares the main Claude usage limit.
   - `extra_usage` → Extra usage cost (monthly spend/limit).
-- Successful OAuth login enables Claude and selects OAuth as the usage source.
+- Successful OAuth login enables Claude and keeps the usage source on Auto so OAuth remains preferred when readable,
+  while CLI/Web fallback stays available when OAuth credentials are not usable.
 - Plan inference: `subscriptionType` is preferred when present; `rate_limit_tier` falls back to
   Max/Pro/Team/Enterprise. When a Max `rate_limit_tier` carries a usage multiplier
   (`default_claude_max_5x` / `default_claude_max_20x`), it is surfaced in the label as "Max 5x" / "Max 20x".


### PR DESCRIPTION
Fixes #1970.

## Summary

- Preserve Claude's selected usage source after a successful Claude login flow instead of pinning it to `oauth`.
- Add a focused regression test for the post-login source policy.
- Update Claude provider docs so the documented login behavior matches the selected-source policy.

## Current-main verification

- Re-fetched `steipete/CodexBar` `main` on 2026-07-07; latest checked SHA: `aa401f1d8b7412b6a71abb6d13f57f5efc64d2ad`.
- `Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift` still forces `.oauth` after successful login on current `main`.
- The settings UI still documents Auto as fallback-capable: "Auto falls back to the next source if the preferred one fails."
- `SettingsStoreTests` still expects the default Claude source to be `.auto`.
- A dry merge / `git merge-tree` into refreshed `upstream/main` has no conflict and leaves the PR scoped to the Claude login source policy, focused test, and Claude docs.

## Why

CodexBar defaults Claude to Auto, and Auto is the fallback-capable source mode. The login flow currently persists `oauth` after the runner reports success. If OAuth credentials are not readable afterward, that removes the fallback path and can leave the app repeatedly asking for Claude credentials.

Preserving the selected source keeps the default setup resilient: default Auto remains Auto, so OAuth can still be preferred when available, but CLI/Web fallback remains available when OAuth is not usable. Explicit source choices remain explicit.

## After-fix proof

Verified on 2026-07-07 at PR head `c98779b7b2b03bc95da8fac409492d8a8faa559e` (`origin/codex/claude-login-auto-source`).

What the stronger proof covers:

- The production entry point `runClaudeLoginFlow()` still calls `ClaudeLoginRunner.run(timeout:onPhaseChange:)` unchanged.
- The shared success branch is now callable with an injected runner, so the focused test executes the actual `StatusItemController.runClaudeLoginFlow` post-login code path instead of stopping at the policy helper.
- The controller-flow test constructs real `SettingsStore`, `UsageStore`, and `StatusItemController` instances, simulates Claude login phases plus a successful runner result, then asserts:
  - the login returns `true`,
  - `loginPhase` returns to `.idle`,
  - Claude is enabled through `settings.setProviderEnabled`, and
  - every existing `ClaudeUsageDataSource` case (`auto`, `api`, `oauth`, `web`, `cli`) is preserved after successful login.
- The test transcript shows the app logger recording `Claude login` with `outcome=success` for each source, followed by `Provider mode updated provider=claude value=auto/api/oauth/web/cli`, proving the patched success path leaves the intended source intact.
- No external fork code was downloaded or used.

Relevant source anchors:

- [`Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift`](https://github.com/steipete/CodexBar/blob/c98779b7b2b03bc95da8fac409492d8a8faa559e/Sources/CodexBar/Providers/Claude/ClaudeLoginFlow.swift#L16-L45)
- [`Tests/CodexBarTests/ClaudeLoginFlowPolicyTests.swift`](https://github.com/steipete/CodexBar/blob/c98779b7b2b03bc95da8fac409492d8a8faa559e/Tests/CodexBarTests/ClaudeLoginFlowPolicyTests.swift#L15-L53)

Command output:

```text
$ swift test --filter ClaudeLoginFlowPolicyTests
◇ Suite ClaudeLoginFlowPolicyTests started.
✔ Test "successful Claude login preserves selected source so auto fallback remains available" passed after 0.001 seconds.
✔ Test "successful Claude login controller flow preserves selected source and enables provider" passed after 0.304 seconds.
✔ Suite ClaudeLoginFlowPolicyTests passed after 0.305 seconds.
✔ Test run with 2 tests in 1 suite passed after 0.305 seconds.

$ make check
SwiftFormat completed in 0.51s.
0/1289 files require formatting.
Done linting! Found 0 violations, 0 serious in 1288 files.
```


## Commands run

- `swift test --filter ClaudeLoginFlowPolicyTests`
- `swift test --filter ClaudeSourcePlannerTests`
- `swift test --filter ClaudeOAuthTests`
- `make check`
- `make test` (exits on the existing unrelated `AdaptiveRefreshTimerTests.swift:117` failure noted below)

## Existing unrelated test failures observed

- `make test` fails in `AdaptiveRefreshTimerTests.swift:117`, test `manual mode performs the initial refresh but no recurring ticks`: expected completed refresh count `1`, got `2`.
- `swift test --no-parallel --filter AdaptiveRefreshTimerTests` reproduces the same failure outside this PR.
- `swift test --filter SettingsStoreTests` also fails in `SettingsStoreTests.swift:1236`, test `menu observation token ignores merged switcher selection churn`: expected `didChange.get()` to be false but it was true.
- `swift test --no-parallel --filter "menu observation token ignores merged switcher selection churn"` reproduces the same failure.

## Live-provider proof

Attempted on 2026-07-07 at PR head `c98779b7b2b03bc95da8fac409492d8a8faa559e` after explicit live/browser proof escalation.

What could be verified live without exposing credentials:

- Installed Claude CLI: `2.1.201 (Claude Code)`.
- `claude auth status` reports a real `claude.ai` login with `loggedIn: true`, `apiProvider: firstParty`, and `subscriptionType: max` (email/org redacted from PR text).
- A live patched-branch Auto usage probe succeeds and resolves through the real Claude CLI source, showing fallback remains available when the selected source is Auto:

```text
$ .build/debug/CodexBarCLI usage --provider claude --source auto --format json --pretty --status
[
  {
    "provider" : "claude",
    "source" : "claude",
    "status" : {
      "description" : "All Systems Operational",
      "indicator" : "none",
      "url" : "https://status.claude.com/"
    },
    "version" : "2.1.201"
  }
]
```

Live OAuth login attempt result:

- `claude auth login --claudeai` launched a real OAuth flow and waited for a code.
- Opening the auth URL in `agent-browser` reached Claude/Cloudflare `Performing security verification` and could not advance past human verification.
- Retrying with Codex CI environment variables removed opened normal Google Chrome with the user profile, but the page was `Sign in - Claude`; completing it would require interactive credentials/human browser verification. The waiting CLI was stopped; no token, cookie, authorization code, or Keychain payload was captured or posted.

What this proves:

- The real local Claude provider can fetch through Auto using the installed Claude CLI (`source: claude`).
- The committed controller-flow test proves the patched successful-login branch preserves `auto` instead of forcing `oauth`.
- Together, preserving Auto after successful login leaves the observed real fallback path available.

Remaining proof gap:

- A full live OAuth login completion from automation is blocked by Claude/Cloudflare/sign-in. This now needs either a maintainer proof override or a maintainer-run redacted browser login transcript.


## Screenshots

Not applicable; this is a provider settings/source policy and docs change with no UI changes.
