### PR TITLE
docs: add Perplexity, Mistral, and Qoder provider references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Agent Sessions: list and focus live local or SSH-discovered Codex and Claude Code sessions from the menu and CLI.
 - Claude CLI: surface model-scoped weekly limits alongside all-model usage without duplicating matching web limits. Thanks @janpollak!
+- Documentation: add detailed setup and troubleshooting references for Perplexity, Mistral, and Qoder. Thanks @kiranmagic7!
 
 ### Fixed
 - Antigravity: recover CLI listening ports from Linux procfs when `lsof` is unavailable, including process network namespaces. Thanks @junmo-kim!

--- a/README.md
+++ b/README.md
@@ -107,18 +107,19 @@ See [CLI configuration](docs/cli-configuration.md) for the full flow.
 - [OpenRouter](docs/openrouter.md) — API token for credit-based usage tracking across multiple AI providers.
 - [Windsurf](docs/windsurf.md) — Browser localStorage session import or local SQLite cache for plan usage.
 - [Zed](docs/zed.md) — Zed editor Keychain session for plan, edit-prediction quota, billing cycle, and overdue invoices.
-- Perplexity — Account usage credits from Perplexity usage data.
+- [Perplexity](docs/perplexity.md) — Account usage credits from Perplexity usage data.
 - [Xiaomi MiMo](docs/mimo.md) — Browser cookies for balance and token-plan usage.
 - [Doubao](docs/doubao.md) — API key for Volcengine Ark request-limit probes.
 - [Sakana AI](docs/sakana.md) — Manual Cookie header for 5-hour and weekly quota windows.
 - [Abacus AI](docs/abacus.md) — Browser cookie auth for ChatLLM/RouteLLM compute credit tracking.
-- Mistral — Browser cookies for API spend, credit balance, and monthly-plan usage.
+- [Mistral](docs/mistral.md) — Browser cookies for API spend, credit balance, and monthly-plan usage.
 - [DeepSeek](docs/deepseek.md) — API key for credit balance tracking (paid vs. granted breakdown).
 - [Moonshot / Kimi API](docs/moonshot.md) — API key for Moonshot/Kimi API account balance tracking.
 - [Venice](docs/venice.md) — API key for DIEM or USD balance tracking.
 - [Codebuff](docs/codebuff.md) — API token (or `~/.config/manicode/credentials.json`) for credit balance + weekly rate limit.
 - [Crof](docs/crof.md) — API key for dollar credit balance and request quota tracking.
 - [Command Code](docs/command-code.md) — Browser or manual cookies for monthly USD credits from Command Code billing.
+- [Qoder](docs/qoder.md) — Browser or manual cookies for Qoder big model credit usage.
 - [StepFun](docs/stepfun.md) — Username + password login for Step Plan rate limits (5‑hour + weekly windows) and subscription plan name.
 - [AWS Bedrock](docs/bedrock.md) — AWS access keys or a named AWS profile (SSO/assume-role via the AWS CLI) for Cost Explorer spend, monthly budgets, and optional CloudWatch Claude activity.
 - [Grok](docs/grok.md) — Grok CLI billing RPC plus grok.com browser-session fallback.

--- a/docs/mistral.md
+++ b/docs/mistral.md
@@ -1,0 +1,76 @@
+---
+summary: "Mistral provider: browser cookie setup, billing usage, credit balance, and Vibe monthly-plan usage."
+read_when:
+  - Configuring Mistral usage
+  - Debugging Mistral billing or Vibe usage requests
+  - Adjusting Mistral cost, credit, or monthly-plan display
+---
+
+# Mistral Provider
+
+CodexBar reads Mistral billing usage with the Mistral web session from `admin.mistral.ai`. It can also fetch credit
+balance and, when the required CSRF/session cookies are present, best-effort Mistral Vibe monthly-plan usage.
+
+## Setup
+
+1. Open **Settings -> Providers**.
+2. Enable **Mistral**.
+3. Sign in to [Mistral Admin](https://admin.mistral.ai/organization/usage) in Chrome.
+4. Leave Cookie source on **Automatic**, or switch to **Manual** and paste a `Cookie:` header from a request to
+   `admin.mistral.ai`.
+
+Manual cookies must include an `ory_session_*` cookie. A `csrftoken` cookie enables authenticated billing and Vibe
+requests that require the `X-CSRFTOKEN` header.
+
+## Data Sources
+
+CodexBar requests the current UTC month from Mistral Admin:
+
+- `GET https://admin.mistral.ai/api/billing/v2/usage?month=<month>&year=<year>`
+- `GET https://admin.mistral.ai/api/billing/credits` (best-effort credit balance)
+
+When a CSRF token is available, CodexBar also makes a bounded best-effort request for Mistral Vibe plan usage:
+
+- `GET https://console.mistral.ai/api-ui/trpc/billing.vibeUsage?...`
+
+For the console request, CodexBar forwards only the `csrftoken` and `ory_session_*` cookies. Other
+`admin.mistral.ai` cookies stay origin-bound.
+
+## Display
+
+- API spend is computed locally from the billing usage response's token counts and pricing table.
+- Daily usage buckets feed the inline usage dashboard.
+- The provider card can show credit balance when the credits endpoint returns it.
+- The optional **Monthly Plan** window shows Vibe usage percentage and reset time when the console endpoint is
+  available.
+- Token-cost history is supported through the billing web session; no local log scan is used.
+
+## CLI Usage
+
+```bash
+codexbar usage --provider mistral --verbose
+```
+
+## Troubleshooting
+
+### "No Mistral session cookies found"
+
+Sign in to [Mistral Admin](https://admin.mistral.ai/organization/usage) in Chrome, then refresh.
+
+### "Mistral cookie header is invalid"
+
+In manual mode, paste a full `Cookie:` header from an `admin.mistral.ai` request. The header must include an
+`ory_session_*` cookie.
+
+### Credits or Vibe plan usage are missing
+
+The billing usage request is required. Credits and Vibe usage are best-effort; if either optional endpoint fails or
+does not expose data for the account, CodexBar keeps the main Mistral usage result.
+
+## Related Files
+
+- `Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift`
+- `Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift`
+- `Sources/CodexBarCore/Providers/Mistral/MistralModels.swift`
+- `Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift`
+- `Sources/CodexBar/Providers/Mistral/MistralProviderImplementation.swift`

--- a/docs/perplexity.md
+++ b/docs/perplexity.md
@@ -1,0 +1,85 @@
+---
+summary: "Perplexity provider: browser cookie setup, credits API, recurring/bonus/purchased credit display."
+read_when:
+  - Configuring Perplexity usage
+  - Debugging Perplexity browser cookie import or manual session tokens
+  - Adjusting Perplexity credit display
+---
+
+# Perplexity Provider
+
+CodexBar reads Perplexity account credit data with a Perplexity web session cookie. It does not use a Perplexity API
+key and does not support token-cost history.
+
+## Setup
+
+1. Open **Settings -> Providers**.
+2. Enable **Perplexity**.
+3. Sign in to [perplexity.ai](https://www.perplexity.ai/) in a supported browser.
+4. Leave Cookie source on **Automatic**, or switch to **Manual** and paste a full `Cookie:` header or a bare
+   Perplexity session-token value.
+
+Manual mode accepts these session cookie names:
+
+- `__Secure-authjs.session-token`
+- `authjs.session-token`
+- `__Secure-next-auth.session-token`
+- `next-auth.session-token`
+
+You can also provide credentials through the environment:
+
+```bash
+export PERPLEXITY_SESSION_TOKEN="..."
+export PERPLEXITY_COOKIE="__Secure-next-auth.session-token=..."
+```
+
+## Data Source
+
+CodexBar requests:
+
+- `GET https://www.perplexity.ai/rest/billing/credits?version=2.18&source=default`
+
+The request sends the resolved Perplexity session cookie, `Origin: https://www.perplexity.ai`, and
+`Referer: https://www.perplexity.ai/account/usage`.
+
+Automatic mode tries any cached Perplexity cookie first, then imports browser cookies, then falls back to environment
+variables. Browser-imported cookies are cached and invalid cached cookies are cleared after a rejected request.
+
+## Display
+
+- **Credits**: recurring account credits when Perplexity reports them.
+- **Bonus credits**: promotional or bonus credits.
+- **Purchased**: on-demand purchased credits.
+- **Renewal**: recurring credits use the renewal timestamp when the API returns one.
+
+Purchased credits do not reset, so the menu displays that balance without a reset prefix.
+
+## CLI Usage
+
+```bash
+codexbar usage --provider perplexity --verbose
+```
+
+## Troubleshooting
+
+### "Perplexity session token is missing"
+
+Sign in to [perplexity.ai](https://www.perplexity.ai/) and refresh CodexBar, or paste a fresh cookie/session token in
+manual mode.
+
+### "Perplexity session token is invalid or expired"
+
+Log out and back in to Perplexity. If manual mode is enabled, paste a new `Cookie:` header or session-token value.
+
+### Credits do not appear
+
+Open [Perplexity account usage](https://www.perplexity.ai/account/usage) in the same browser profile and confirm the
+account has visible credit data.
+
+## Related Files
+
+- `Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift`
+- `Sources/CodexBarCore/Providers/Perplexity/PerplexityUsageFetcher.swift`
+- `Sources/CodexBarCore/Providers/Perplexity/PerplexityUsageSnapshot.swift`
+- `Sources/CodexBarCore/Providers/Perplexity/PerplexityCookieHeader.swift`
+- `Sources/CodexBar/Providers/Perplexity/PerplexityProviderImplementation.swift`

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -321,6 +321,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Browser session cookie from automatic import, manual header/token, or `PERPLEXITY_SESSION_TOKEN` / `PERPLEXITY_COOKIE`.
 - Tracks recurring credits, bonus/promotional credits, purchased credits, and renewal date when present.
 - Status: `https://status.perplexity.com/` (link only, no auto-polling).
+- Details: `docs/perplexity.md`.
 
 ## Xiaomi MiMo
 - Browser cookies from automatic import or manual `Cookie:` header for `platform.xiaomimimo.com` balance and token-plan endpoints.
@@ -361,6 +362,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - The menu bar metric can show either pay-as-you-go API spend or monthly-plan usage; the provider card shows balance when the credits endpoint is available.
 - Resets at end of calendar month.
 - Status: `https://status.mistral.ai` (link only, no auto-polling).
+- Details: `docs/mistral.md`.
 
 ## DeepSeek
 - API key via `DEEPSEEK_API_KEY` / `DEEPSEEK_KEY` env var or DeepSeek token accounts.
@@ -411,6 +413,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Reads big model credit usage from the Qoder account dashboard on `qoder.com` or `qoder.com.cn`.
 - Shows used and total credits plus the usage percentage; invalid cached sessions retry freshly imported cookies.
 - Status: none yet.
+- Details: `docs/qoder.md`.
 
 ## Grok
 - `grok agent stdio` (ACP) JSON-RPC `x.ai/billing` method; requires `grok login` (SuperGrok OAuth/OIDC).

--- a/docs/qoder.md
+++ b/docs/qoder.md
@@ -1,0 +1,71 @@
+---
+summary: "Qoder provider: browser/manual cookie setup for big model credit usage on qoder.com and qoder.com.cn."
+read_when:
+  - Configuring Qoder usage
+  - Debugging Qoder cookie import, manual headers, or cURL captures
+  - Adjusting Qoder credit display
+---
+
+# Qoder Provider
+
+CodexBar reads Qoder big model credit usage from the Qoder account dashboard. It supports the international
+`qoder.com` site and the China mainland `qoder.com.cn` site.
+
+## Setup
+
+1. Open **Settings -> Providers**.
+2. Enable **Qoder**.
+3. Sign in to [qoder.com](https://qoder.com/account/usage) or [qoder.com.cn](https://qoder.com.cn/account/usage) in
+   Chrome.
+4. Leave Cookie source on **Automatic**, or switch to **Manual** and paste a `Cookie:` header or cURL capture from the
+   Qoder usage page.
+
+Manual cURL captures are parsed only when the target URL or header host clearly belongs to `qoder.com` or
+`qoder.com.cn`.
+
+## Data Source
+
+CodexBar requests:
+
+- `GET https://qoder.com/api/v2/me/usages/big_model_credits`
+- `GET https://qoder.com.cn/api/v2/me/usages/big_model_credits`
+
+The selected site controls the `Origin` and `Referer` headers. Automatic mode imports Qoder cookies from Chrome
+and caches valid cookie headers. Invalid cached sessions are skipped so a fresh browser cookie can be retried.
+
+## Display
+
+- Shows used credits, total credits, remaining credits, and usage percentage.
+- Merges `totalQuota` with `sharedQuota` when Qoder returns both.
+- Uses `nextResetAt` when the API includes a reset timestamp.
+- Token-cost history is not supported.
+
+## CLI Usage
+
+```bash
+codexbar usage --provider qoder --verbose
+```
+
+## Troubleshooting
+
+### "Qoder session cookie not found"
+
+Sign in to Qoder in Chrome, then refresh CodexBar. If browser import is unavailable, switch to
+manual mode and paste a fresh `Cookie:` header or cURL capture from the usage page.
+
+### "Qoder session is invalid or expired"
+
+Log in to Qoder again. CodexBar clears invalid cached cookies and retries fresh browser cookies in automatic mode.
+
+### Usage values look wrong
+
+Open the matching Qoder usage page and confirm whether the account is on `qoder.com` or `qoder.com.cn`; manual cURL
+captures should come from the same site.
+
+## Related Files
+
+- `Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift`
+- `Sources/CodexBarCore/Providers/Qoder/QoderUsageFetcher.swift`
+- `Sources/CodexBarCore/Providers/Qoder/QoderUsageSnapshot.swift`
+- `Sources/CodexBarCore/Providers/Qoder/QoderCookieImporter.swift`
+- `Sources/CodexBar/Providers/Qoder/QoderProviderImplementation.swift`

--- a/docs/qoder.md
+++ b/docs/qoder.md
@@ -17,11 +17,12 @@ CodexBar reads Qoder big model credit usage from the Qoder account dashboard. It
 2. Enable **Qoder**.
 3. Sign in to [qoder.com](https://qoder.com/account/usage) or [qoder.com.cn](https://qoder.com.cn/account/usage) in
    Chrome.
-4. Leave Cookie source on **Automatic**, or switch to **Manual** and paste a `Cookie:` header or cURL capture from the
-   Qoder usage page.
+4. Leave Cookie source on **Automatic**, or switch to **Manual**. For `qoder.com`, paste a `Cookie:` header or a cURL/
+   HTTP request capture from the usage page. For `qoder.com.cn`, paste a request capture that includes the China URL
+   or `Host` header so CodexBar can select the matching site.
 
-Manual cURL captures are parsed only when the target URL or header host clearly belongs to `qoder.com` or
-`qoder.com.cn`.
+Bare `Cookie:` headers default to `qoder.com`. Request captures are parsed only when the target URL or header host
+clearly belongs to `qoder.com` or `qoder.com.cn`.
 
 ## Data Source
 
@@ -50,8 +51,9 @@ codexbar usage --provider qoder --verbose
 
 ### "Qoder session cookie not found"
 
-Sign in to Qoder in Chrome, then refresh CodexBar. If browser import is unavailable, switch to
-manual mode and paste a fresh `Cookie:` header or cURL capture from the usage page.
+Sign in to Qoder in Chrome, then refresh CodexBar. If browser import is unavailable, switch to manual mode. Paste a
+fresh `Cookie:` header for `qoder.com`; for `qoder.com.cn`, paste a cURL/HTTP request capture containing the China URL
+or `Host` header.
 
 ### "Qoder session is invalid or expired"
 

--- a/docs/qoder.md
+++ b/docs/qoder.md
@@ -35,7 +35,7 @@ and caches valid cookie headers. Invalid cached sessions are skipped so a fresh 
 
 ## Display
 
-- Shows used credits, total credits, remaining credits, and usage percentage.
+- Shows used credits, total credits, and usage percentage.
 - Merges `totalQuota` with `sharedQuota` when Qoder returns both.
 - Uses `nextResetAt` when the API includes a reset timestamp.
 - Token-cost history is not supported.


### PR DESCRIPTION
## Summary
- Add source-backed provider detail pages for Perplexity, Mistral, and Qoder.
- Link Perplexity and Mistral from the README provider list, and add the missing Qoder README entry.
- Add provider overview Details links for the three new pages.

## Tests
- node Scripts/check-documentation-links.mjs
- node Scripts/check-site-locales.mjs
- node Scripts/generate-llms.mjs --check
- bash Scripts/lint.sh lint-linux
- git diff --check

## Compatibility risk
Docs-only. No provider behavior, auth handling, Keychain access, browser import behavior, dependencies, or build scripts changed.