### PR TITLE
fix(mistral): expand cookie import to Safari, Chrome, and Firefox

### DIFF
--- a/Sources/CodexBarCore/BrowserDetection.swift
+++ b/Sources/CodexBarCore/BrowserDetection.swift
@@ -201,13 +201,14 @@ public final class BrowserDetection: Sendable {
     }
 
     private func detectAppInstalled(for browser: Browser) -> Bool {
-        let appPaths = self.applicationPaths(for: browser)
-        for path in appPaths where self.fileExists(path) {
-            return true
+        self.applicationNames(for: browser).contains { appName in
+            let appPaths = [
+                "/Applications/\(appName).app",
+                "\(self.homeDirectory)/Applications/\(appName).app",
+            ]
+            return appPaths.contains(where: self.fileExists) ||
+                self.applicationURLs(appName).contains { self.fileExists($0.path) }
         }
-
-        guard let appName = self.applicationName(for: browser) else { return false }
-        return self.applicationURLs(appName).contains { self.fileExists($0.path) }
     }
 
     private func hasInstalledApplication(_ browser: Browser, applicationURL: URL?) -> Bool {
@@ -246,17 +247,11 @@ public final class BrowserDetection: Sendable {
         return self.hasValidCookieStore(for: browser, at: profilePath)
     }
 
-    private func applicationPaths(for browser: Browser) -> [String] {
-        guard let appName = self.applicationName(for: browser) else { return [] }
-
-        return [
-            "/Applications/\(appName).app",
-            "\(self.homeDirectory)/Applications/\(appName).app",
-        ]
-    }
-
-    private func applicationName(for browser: Browser) -> String? {
-        browser.appBundleName
+    private func applicationNames(for browser: Browser) -> [String] {
+        if browser == .firefox {
+            return [browser.appBundleName, "Firefox Developer Edition"]
+        }
+        return [browser.appBundleName]
     }
 
     private static func registeredApplicationURLs(named appName: String) -> [URL] {

--- a/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
@@ -40,14 +40,12 @@ public enum MistralCookieImporter {
         logger: ((String) -> Void)? = nil) throws -> SessionInfo
     {
         let log: (String) -> Void = { msg in logger?("[mistral-cookie] \(msg)") }
-        let order = preferredBrowsers ?? mistralCookieImportOrder
-        let installedBrowsers = order.isEmpty
-            ? Browser.defaultImportOrder.cookieImportCandidates(using: browserDetection)
-            : order.cookieImportCandidates(using: browserDetection)
+        let order = self.resolvedImportOrder(preferredBrowsers)
+        let installedBrowsers = order.cookieImportCandidates(using: browserDetection)
 
         for browserSource in installedBrowsers {
             do {
-                let query = BrowserCookieQuery(domains: self.cookieDomains)
+                let query = self.cookieQuery()
                 let sources = try Self.cookieClient.codexBarRecords(
                     matching: query,
                     in: browserSource,
@@ -70,6 +68,21 @@ public enum MistralCookieImporter {
         }
 
         throw MistralCookieImportError.noCookies
+    }
+
+    static func resolvedImportOrder(_ preferredBrowsers: [Browser]?) -> [Browser] {
+        guard let preferredBrowsers, !preferredBrowsers.isEmpty else {
+            return mistralCookieImportOrder
+        }
+        return preferredBrowsers
+    }
+
+    static func cookieQuery(referenceDate: Date = Date()) -> BrowserCookieQuery {
+        BrowserCookieQuery(
+            domains: self.cookieDomains,
+            domainMatch: .exact,
+            includeExpired: false,
+            referenceDate: referenceDate)
     }
 
     public static func hasSession(

--- a/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
@@ -39,9 +39,25 @@ public enum MistralCookieImporter {
         preferredBrowsers: [Browser]? = nil,
         logger: ((String) -> Void)? = nil) throws -> SessionInfo
     {
+        try self.importSessions(
+            browserDetection: browserDetection,
+            preferredBrowsers: preferredBrowsers,
+            excludingSourceLabels: [],
+            limit: 1,
+            logger: logger)[0]
+    }
+
+    static func importSessions(
+        browserDetection: BrowserDetection,
+        preferredBrowsers: [Browser]? = nil,
+        excludingSourceLabels: Set<String>,
+        limit: Int? = nil,
+        logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
+    {
         let log: (String) -> Void = { msg in logger?("[mistral-cookie] \(msg)") }
         let order = self.resolvedImportOrder(preferredBrowsers)
         let installedBrowsers = order.cookieImportCandidates(using: browserDetection)
+        var sessions: [SessionInfo] = []
 
         for browserSource in installedBrowsers {
             do {
@@ -51,6 +67,10 @@ public enum MistralCookieImporter {
                     in: browserSource,
                     logger: log)
                 for source in sources where !source.records.isEmpty {
+                    guard !excludingSourceLabels.contains(source.label) else {
+                        log("Skipping rejected cookie source \(source.label)")
+                        continue
+                    }
                     let httpCookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
                     if !httpCookies.isEmpty {
                         guard Self.hasSessionCookie(httpCookies) else {
@@ -58,7 +78,10 @@ public enum MistralCookieImporter {
                             continue
                         }
                         log("Found \(httpCookies.count) Mistral cookies in \(source.label)")
-                        return SessionInfo(cookies: httpCookies, sourceLabel: source.label)
+                        sessions.append(SessionInfo(cookies: httpCookies, sourceLabel: source.label))
+                        if sessions.count == limit {
+                            return sessions
+                        }
                     }
                 }
             } catch {
@@ -67,7 +90,8 @@ public enum MistralCookieImporter {
             }
         }
 
-        throw MistralCookieImportError.noCookies
+        guard !sessions.isEmpty else { throw MistralCookieImportError.noCookies }
+        return sessions
     }
 
     static func resolvedImportOrder(_ preferredBrowsers: [Browser]?) -> [Browser] {

--- a/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
@@ -36,13 +36,14 @@ public enum MistralCookieImporter {
 
     public static func importSession(
         browserDetection: BrowserDetection,
-        preferredBrowsers: [Browser] = [.chrome],
+        preferredBrowsers: [Browser]? = nil,
         logger: ((String) -> Void)? = nil) throws -> SessionInfo
     {
         let log: (String) -> Void = { msg in logger?("[mistral-cookie] \(msg)") }
-        let installedBrowsers = preferredBrowsers.isEmpty
-            ? mistralCookieImportOrder.cookieImportCandidates(using: browserDetection)
-            : preferredBrowsers.cookieImportCandidates(using: browserDetection)
+        let order = preferredBrowsers ?? mistralCookieImportOrder
+        let installedBrowsers = order.isEmpty
+            ? Browser.defaultImportOrder.cookieImportCandidates(using: browserDetection)
+            : order.cookieImportCandidates(using: browserDetection)
 
         for browserSource in installedBrowsers {
             do {
@@ -73,7 +74,7 @@ public enum MistralCookieImporter {
 
     public static func hasSession(
         browserDetection: BrowserDetection,
-        preferredBrowsers: [Browser] = [.chrome],
+        preferredBrowsers: [Browser]? = nil,
         logger: ((String) -> Void)? = nil) -> Bool
     {
         do {

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -52,11 +52,11 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         let cookieSource = context.settings?.mistral?.cookieSource ?? .auto
+        let session = try Self.resolveCookieSession(context: context, allowCached: true)
         do {
-            let (cookieHeader, csrfToken) = try Self.resolveCookieHeader(context: context, allowCached: true)
             let usage = try await Self.fetchUsageWithVibe(
-                cookieHeader: cookieHeader,
-                csrfToken: csrfToken,
+                cookieHeader: session.cookieHeader,
+                csrfToken: session.csrfToken,
                 timeout: context.webTimeout)
             return self.makeResult(
                 usage: usage,
@@ -64,11 +64,26 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
         } catch MistralUsageError.invalidCredentials where cookieSource != .manual {
             #if os(macOS)
             CookieHeaderCache.clear(provider: .mistral)
-            let (cookieHeader, csrfToken) = try Self.resolveCookieHeader(context: context, allowCached: false)
-            let usage = try await Self.fetchUsageWithVibe(
-                cookieHeader: cookieHeader,
-                csrfToken: csrfToken,
+            let excludedSourceLabels = if session.wasCached {
+                Set<String>()
+            } else {
+                Set([session.sourceLabel].compactMap(\.self))
+            }
+            let sessions: [MistralCookieImporter.SessionInfo]
+            do {
+                sessions = try MistralCookieImporter.importSessions(
+                    browserDetection: context.browserDetection,
+                    excludingSourceLabels: excludedSourceLabels)
+            } catch MistralCookieImportError.noCookies {
+                throw MistralUsageError.invalidCredentials
+            }
+            let (usage, session) = try await Self.fetchUsageFromSessions(
+                sessions,
                 timeout: context.webTimeout)
+            CookieHeaderCache.store(
+                provider: .mistral,
+                cookieHeader: session.cookieHeader,
+                sourceLabel: session.sourceLabel)
             return self.makeResult(
                 usage: usage,
                 sourceLabel: "web")
@@ -77,6 +92,29 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
             #endif
         }
     }
+
+    #if os(macOS)
+    static func fetchUsageFromSessions(
+        _ sessions: [MistralCookieImporter.SessionInfo],
+        timeout: TimeInterval,
+        transport: ProviderHTTPTransport = ProviderHTTPClient.shared) async throws
+        -> (usage: UsageSnapshot, session: MistralCookieImporter.SessionInfo)
+    {
+        for session in sessions {
+            do {
+                let usage = try await Self.fetchUsageWithVibe(
+                    cookieHeader: session.cookieHeader,
+                    csrfToken: session.csrfToken,
+                    timeout: timeout,
+                    transport: transport)
+                return (usage, session)
+            } catch MistralUsageError.invalidCredentials {
+                continue
+            }
+        }
+        throw MistralUsageError.invalidCredentials
+    }
+    #endif
 
     static func fetchUsageWithVibe(
         cookieHeader: String,
@@ -174,9 +212,10 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
         false
     }
 
-    private static func resolveCookieHeader(
+    private static func resolveCookieSession(
         context: ProviderFetchContext,
-        allowCached: Bool) throws -> (cookieHeader: String, csrfToken: String?)
+        allowCached: Bool) throws
+        -> (cookieHeader: String, csrfToken: String?, sourceLabel: String?, wasCached: Bool)
     {
         if let settings = context.settings?.mistral, settings.cookieSource == .manual {
             if let header = CookieHeaderNormalizer.normalize(settings.manualCookieHeader) {
@@ -184,7 +223,7 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
                 let hasSessionCookie = pairs.contains { $0.name.hasPrefix("ory_session_") }
                 if hasSessionCookie {
                     let csrfToken = pairs.first { $0.name == "csrftoken" }?.value
-                    return (header, csrfToken)
+                    return (header, csrfToken, nil, false)
                 }
             }
             throw MistralSettingsError.invalidCookie
@@ -197,14 +236,14 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
         {
             let pairs = CookieHeaderNormalizer.pairs(from: cached.cookieHeader)
             let csrfToken = pairs.first { $0.name == "csrftoken" }?.value
-            return (cached.cookieHeader, csrfToken)
+            return (cached.cookieHeader, csrfToken, cached.sourceLabel, true)
         }
         let session = try MistralCookieImporter.importSession(browserDetection: context.browserDetection)
         CookieHeaderCache.store(
             provider: .mistral,
             cookieHeader: session.cookieHeader,
             sourceLabel: session.sourceLabel)
-        return (session.cookieHeader, session.csrfToken)
+        return (session.cookieHeader, session.csrfToken, session.sourceLabel, false)
         #else
         throw MistralSettingsError.missingCookie
         #endif

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -20,7 +20,7 @@ public enum MistralProviderDescriptor {
                 defaultEnabled: false,
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
-                browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
+                browserCookieOrder: ProviderBrowserCookieDefaults.mistralCookieImportOrder,
                 dashboardURL: "https://admin.mistral.ai/organization/usage",
                 statusPageURL: nil,
                 statusLinkURL: "https://status.mistral.ai"),

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -54,9 +54,10 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
         let cookieSource = context.settings?.mistral?.cookieSource ?? .auto
         let session = try Self.resolveCookieSession(context: context, allowCached: true)
         do {
+            let csrf = session.csrfToken
             let usage = try await Self.fetchUsageWithVibe(
                 cookieHeader: session.cookieHeader,
-                csrfToken: session.csrfToken,
+                csrfToken: csrf,
                 timeout: context.webTimeout)
             return self.makeResult(
                 usage: usage,
@@ -102,9 +103,10 @@ struct MistralWebFetchStrategy: ProviderFetchStrategy {
     {
         for session in sessions {
             do {
+                let csrf = session.csrfToken
                 let usage = try await Self.fetchUsageWithVibe(
                     cookieHeader: session.cookieHeader,
-                    csrfToken: session.csrfToken,
+                    csrfToken: csrf,
                     timeout: timeout,
                     transport: transport)
                 return (usage, session)

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -308,12 +308,14 @@ public enum ProviderBrowserCookieDefaults {
         #endif
     }
 
-    /// Mistral Auto: Safari first (no Keychain prompt), Chrome next, then Firefox so users
-    /// signed in via Firefox or Firefox Developer Edition are detected without Manual mode.
-    /// Other Chromium forks stay on Manual import to avoid scanning the full default order.
+    /// Mistral Auto: Chrome first (matches the original Chrome-only behavior so
+    /// existing users see no change), then Firefox so users signed in via Firefox
+    /// or Firefox Developer Edition are detected without Manual mode. Safari
+    /// follows for Full Disk Access users. Other Chromium forks stay on Manual
+    /// import to avoid scanning the full default order.
     public static var mistralCookieImportOrder: BrowserCookieImportOrder? {
         #if os(macOS)
-        [.safari, .chrome, .firefox]
+        [.chrome, .firefox, .safari]
         #else
         nil
         #endif

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -307,4 +307,15 @@ public enum ProviderBrowserCookieDefaults {
         nil
         #endif
     }
+
+    /// Mistral Auto: Safari first (no Keychain prompt), Chrome next, then Firefox so users
+    /// signed in via Firefox or Firefox Developer Edition are detected without Manual mode.
+    /// Other Chromium forks stay on Manual import to avoid scanning the full default order.
+    public static var mistralCookieImportOrder: BrowserCookieImportOrder? {
+        #if os(macOS)
+        [.safari, .chrome, .firefox]
+        #else
+        nil
+        #endif
+    }
 }

--- a/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
@@ -88,11 +88,11 @@ struct BrowserCookieOrderStatusStringTests {
     }
 
     @Test
-    func `mistral cookie import order supports safari chrome and firefox`() {
+    func `mistral cookie import order supports chrome firefox and safari`() {
         let order = ProviderDefaults.metadata[.mistral]?.browserCookieOrder ?? Browser.defaultImportOrder
         #expect(order == ProviderBrowserCookieDefaults.mistralCookieImportOrder)
-        #expect(order == [.safari, .chrome, .firefox])
-        #expect(order.first == .safari)
+        #expect(order == [.chrome, .firefox, .safari])
+        #expect(order.first == .chrome)
         #expect(order.contains(.firefox))
         #expect(!order.contains(.edge))
         #expect(!order.contains(.arc))

--- a/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
@@ -96,6 +96,9 @@ struct BrowserCookieOrderStatusStringTests {
         #expect(order.contains(.firefox))
         #expect(!order.contains(.edge))
         #expect(!order.contains(.arc))
+        #expect(MistralCookieImporter.resolvedImportOrder(nil) == order)
+        #expect(MistralCookieImporter.resolvedImportOrder([]) == order)
+        #expect(MistralCookieImporter.resolvedImportOrder([.firefox]) == [.firefox])
     }
 
     @Test

--- a/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
@@ -88,6 +88,17 @@ struct BrowserCookieOrderStatusStringTests {
     }
 
     @Test
+    func `mistral cookie import order supports safari chrome and firefox`() {
+        let order = ProviderDefaults.metadata[.mistral]?.browserCookieOrder ?? Browser.defaultImportOrder
+        #expect(order == ProviderBrowserCookieDefaults.mistralCookieImportOrder)
+        #expect(order == [.safari, .chrome, .firefox])
+        #expect(order.first == .safari)
+        #expect(order.contains(.firefox))
+        #expect(!order.contains(.edge))
+        #expect(!order.contains(.arc))
+    }
+
+    @Test
     func `longcat cookie imports default to chrome only`() {
         #expect(ProviderDefaults.metadata[.longcat]?.browserCookieOrder == [.chrome])
         #expect(ProviderBrowserCookieDefaults.longcatCookieImportOrder == [.chrome])

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -421,8 +421,12 @@ struct BrowserDetectionTests {
             KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { service, account in
                 let label = Self.labelID(service: service, account: account)
                 queriedLabels.append(label)
-                if label == firstChromeLabel { return .allowed }
-                if label == firstDiaLabel { return .interactionRequired }
+                if label == firstChromeLabel {
+                    return .allowed
+                }
+                if label == firstDiaLabel {
+                    return .interactionRequired
+                }
                 return .notFound
             } operation: {
                 ProviderInteractionContext.$current.withValue(.userInitiated) {
@@ -681,6 +685,29 @@ struct BrowserDetectionTests {
         try FileManager.default.createDirectory(at: profile, withIntermediateDirectories: true)
         FileManager.default.createFile(atPath: profile.appendingPathComponent("cookies.sqlite").path, contents: Data())
         #expect(detection.isCookieSourceAvailable(.firefox) == true)
+    }
+
+    @Test
+    func `firefox developer edition unlocks the shared Firefox cookie store`() {
+        let home = "/tmp/codexbar-firefox-developer-edition"
+        let profiles = "\(home)/Library/Application Support/Firefox/Profiles"
+        let cookieDB = "\(profiles)/abc.default-release/cookies.sqlite"
+        let detection = BrowserDetection(
+            homeDirectory: home,
+            cacheTTL: 0,
+            now: Date.init,
+            fileExists: { path in
+                path == "/Applications/Firefox Developer Edition.app" ||
+                    path == profiles ||
+                    path == cookieDB
+            },
+            directoryContents: { path in
+                path == profiles ? ["abc.default-release"] : nil
+            },
+            applicationURLs: { _ in [] },
+            profileAccessIssue: { _ in nil })
+
+        #expect(detection.isCookieSourceAvailable(.firefox))
     }
 
     @Test

--- a/Tests/CodexBarTests/MistralVibeUsageTests.swift
+++ b/Tests/CodexBarTests/MistralVibeUsageTests.swift
@@ -45,6 +45,16 @@ struct MistralVibeUsageTests {
             "auth.mistral.ai",
             "console.mistral.ai",
         ])
+
+        let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let query = MistralCookieImporter.cookieQuery(referenceDate: referenceDate)
+        #expect(query.domains == MistralCookieImporter.cookieDomains)
+        #expect(query.includeExpired == false)
+        #expect(query.referenceDate == referenceDate)
+        guard case .exact = query.domainMatch else {
+            Issue.record("Expected exact Mistral cookie-domain matching")
+            return
+        }
     }
     #endif
 

--- a/Tests/CodexBarTests/MistralVibeUsageTests.swift
+++ b/Tests/CodexBarTests/MistralVibeUsageTests.swift
@@ -35,6 +35,21 @@ private final class MistralRequestPathLog: @unchecked Sendable {
     }
 }
 
+private final class MistralCookieHeaderLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedHeaders: [String] = []
+
+    var headers: [String] {
+        self.lock.withLock { self.storedHeaders }
+    }
+
+    func record(_ request: URLRequest) {
+        self.lock.withLock {
+            self.storedHeaders.append(request.value(forHTTPHeaderField: "Cookie") ?? "")
+        }
+    }
+}
+
 struct MistralVibeUsageTests {
     #if os(macOS)
     @Test
@@ -55,6 +70,39 @@ struct MistralVibeUsageTests {
             Issue.record("Expected exact Mistral cookie-domain matching")
             return
         }
+    }
+
+    @Test
+    func `tries later browser sessions after invalid credentials`() async throws {
+        let headerLog = MistralCookieHeaderLog()
+        let usageData = Data(Self.billingUsageResponseJSON.utf8)
+        let sessions = try [
+            Self.session(cookieName: "ory_session_chrome", value: "stale", sourceLabel: "Chrome"),
+            Self.session(cookieName: "ory_session_firefox", value: "stale", sourceLabel: "Firefox"),
+            Self.session(cookieName: "ory_session_safari", value: "valid", sourceLabel: "Safari"),
+        ]
+        let transport = ProviderHTTPTransportHandler { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            if url.host == "admin.mistral.ai", url.path == "/api/billing/v2/usage" {
+                headerLog.record(request)
+                let cookieHeader = request.value(forHTTPHeaderField: "Cookie") ?? ""
+                let statusCode = cookieHeader.contains("ory_session_safari=valid") ? 200 : 401
+                return try (usageData, Self.response(url: url, statusCode: statusCode))
+            }
+            return try (Data(), Self.response(url: url, statusCode: 404))
+        }
+
+        let (_, session) = try await MistralWebFetchStrategy.fetchUsageFromSessions(
+            sessions,
+            timeout: 2,
+            transport: transport)
+
+        #expect(session.sourceLabel == "Safari")
+        #expect(headerLog.headers == [
+            "ory_session_chrome=stale",
+            "ory_session_firefox=stale",
+            "ory_session_safari=valid",
+        ])
     }
     #endif
 
@@ -262,6 +310,20 @@ struct MistralVibeUsageTests {
         }}}}]
         """
     }
+
+    #if os(macOS)
+    private static func session(cookieName: String, value: String, sourceLabel: String) throws
+        -> MistralCookieImporter.SessionInfo
+    {
+        let cookie = try #require(HTTPCookie(properties: [
+            .domain: "admin.mistral.ai",
+            .path: "/",
+            .name: cookieName,
+            .value: value,
+        ]))
+        return MistralCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: sourceLabel)
+    }
+    #endif
 
     private static var billingUsageResponseJSON: String {
         """

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -355,7 +355,9 @@ struct ProviderSettingsDescriptorTests {
 
         #expect(detailLine == "web")
     }
+}
 
+extension ProviderSettingsDescriptorTests {
     @Test
     func `alibaba token plan settings expose cookie controls`() throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-alibaba-token-plan-settings")

--- a/docs/mistral.md
+++ b/docs/mistral.md
@@ -15,12 +15,16 @@ balance and, when the required CSRF/session cookies are present, best-effort Mis
 
 1. Open **Settings -> Providers**.
 2. Enable **Mistral**.
-3. Sign in to [Mistral Admin](https://admin.mistral.ai/organization/usage) in Chrome.
+3. Sign in to [Mistral Admin](https://admin.mistral.ai/organization/usage) in Chrome, Firefox, or Safari.
 4. Leave Cookie source on **Automatic**, or switch to **Manual** and paste a `Cookie:` header from a request to
    `admin.mistral.ai`.
 
 Manual cookies must include an `ory_session_*` cookie. A `csrftoken` cookie enables authenticated billing and Vibe
 requests that require the `X-CSRFTOKEN` header.
+
+Automatic import tries Chrome, Firefox (including Developer Edition), then Safari. Safari requires Full Disk Access.
+Other Chromium browsers remain available through Manual mode. Automatic import reads only unexpired cookies from
+the documented Mistral domains.
 
 ## Data Sources
 
@@ -55,7 +59,7 @@ codexbar usage --provider mistral --verbose
 
 ### "No Mistral session cookies found"
 
-Sign in to [Mistral Admin](https://admin.mistral.ai/organization/usage) in Chrome, then refresh.
+Sign in to [Mistral Admin](https://admin.mistral.ai/organization/usage) in Chrome, Firefox, or Safari, then refresh.
 
 ### "Mistral cookie header is invalid"
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -362,7 +362,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 
 ## Mistral
 - Session cookie (`ory_session_*`) from browser auto-import or manual `Cookie:` header.
-- Cookie import order: Safari → Chrome → Firefox. Users signed in via Firefox or Firefox Developer Edition are detected automatically; other Chromium forks use Manual mode.
+- Cookie import order: Chrome → Firefox → Safari. Chrome first preserves the original behavior for existing users; Firefox (including Developer Edition) is detected automatically; Safari follows for Full Disk Access users. Other Chromium forks use Manual mode.
 - CSRF token (`csrftoken` cookie) sent as `X-CSRFTOKEN` for billing and Vibe usage requests.
 - Domains: `admin.mistral.ai` for API billing and credit balance, and `console.mistral.ai` for optional Vibe subscription usage. Console requests forward only `csrftoken` and `ory_session_*`; all other admin cookies stay origin-bound.
 - Reads monthly usage and pricing from the billing usage endpoint, plus credit balance from the billing credits endpoint, using the Mistral web session.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -362,7 +362,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 
 ## Mistral
 - Session cookie (`ory_session_*`) from browser auto-import or manual `Cookie:` header.
-- Cookie import order: Chrome → Firefox → Safari. Chrome first preserves the original behavior for existing users; Firefox (including Developer Edition) is detected automatically; Safari follows for Full Disk Access users. Other Chromium forks use Manual mode.
+- Cookie import order: Chrome → Firefox → Safari. Chrome first preserves the original behavior for existing users; Firefox (including Developer Edition) is detected automatically; Safari follows for Full Disk Access users. Other Chromium forks use Manual mode. Automatic import reads only unexpired cookies from the documented Mistral domains.
 - CSRF token (`csrftoken` cookie) sent as `X-CSRFTOKEN` for billing and Vibe usage requests.
 - Domains: `admin.mistral.ai` for API billing and credit balance, and `console.mistral.ai` for optional Vibe subscription usage. Console requests forward only `csrftoken` and `ory_session_*`; all other admin cookies stay origin-bound.
 - Reads monthly usage and pricing from the billing usage endpoint, plus credit balance from the billing credits endpoint, using the Mistral web session.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -362,6 +362,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 
 ## Mistral
 - Session cookie (`ory_session_*`) from browser auto-import or manual `Cookie:` header.
+- Cookie import order: Safari → Chrome → Firefox. Users signed in via Firefox or Firefox Developer Edition are detected automatically; other Chromium forks use Manual mode.
 - CSRF token (`csrftoken` cookie) sent as `X-CSRFTOKEN` for billing and Vibe usage requests.
 - Domains: `admin.mistral.ai` for API billing and credit balance, and `console.mistral.ai` for optional Vibe subscription usage. Console requests forward only `csrftoken` and `ory_session_*`; all other admin cookies stay origin-bound.
 - Reads monthly usage and pricing from the billing usage endpoint, plus credit balance from the billing credits endpoint, using the Mistral web session.


### PR DESCRIPTION
## Summary

- Expand Mistral Automatic import through a bounded Chrome → Firefox → Safari order while preserving Chrome-first behavior.
- Recognize Firefox Developer Edition as the same shared Firefox profile source, including Developer Edition-only installs.
- Retry later browser/profile sessions after 401/403 instead of repeatedly selecting an earlier stale session, then cache the first successful source.
- Keep empty/default and explicit browser overrides bounded, import only unexpired cookies from exact Mistral domains, and document the behavior.

## Proof

- Focused Mistral/browser detection suite on current main: 55 tests across 3 suites; provider-settings coverage: 37 tests in 1 suite.
- `make check`: format, lint, locale, package, CI-path, repository-size, shell, and documentation gates clean.
- Source-blind behavior validation: 29/29 BrowserDetection cases passed, including the Developer Edition-only shared profile contract.
- Structured autoreview: product patch clean at 0.98 confidence; current-main rebase and adjacent lint split clean at 0.99.
- No live browser-cookie, provider, or Keychain probe was run; coverage uses synthetic stores and transport fixtures to avoid macOS prompts.

Thanks @djsavvy for the original Firefox import contribution.
