### PR TITLE
Fix Codex session reset celebration false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Agent Sessions: list and focus live local or SSH-discovered Codex and Claude Code sessions from the menu and CLI.
 
 ### Fixed
+- Codex: avoid false session-reset celebrations from transient zero-usage samples until the reset boundary advances. Thanks @kiranmagic7!
 - Ollama: recognize current WorkOS AuthKit sessions during browser-cookie discovery and manual cookie validation. Thanks @joeVenner!
 - Ollama: classify current WorkOS sign-in redirects as expired sessions, enabling cookie-candidate fallback instead of a parser error. Thanks @joeVenner!
 

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -487,8 +487,7 @@ extension UsageStore {
 
         let previousState = states[detectorKey]
         let sourceRawValue = observation.source?.rawValue
-        let sourceChanged = descriptor.seriesName == .session
-            && previousState?.sourceRawValue != nil
+        let sourceChanged = descriptor.seriesName == .session && previousState?.sourceRawValue != nil
             && previousState?.sourceRawValue != sourceRawValue
         let resetBoundaryAllowsPost = descriptor.seriesName != .session
             || Self.limitResetBoundaryAdvanced(
@@ -496,13 +495,14 @@ extension UsageStore {
                 current: observation.resetBoundary)
         let crossedBelowThreshold = !sourceChanged && previousState?.wasAboveThreshold == true && !wasAboveThreshold
         let shouldPost = crossedBelowThreshold && resetBoundaryAllowsPost
-        let shouldPreserveBaseline = crossedBelowThreshold && !resetBoundaryAllowsPost
+        let shouldPreserveBoundary = !sourceChanged && !resetBoundaryAllowsPost
+        let shouldPreserveBaseline = crossedBelowThreshold && shouldPreserveBoundary
         states[detectorKey] = LimitResetDetectorState(
             // A transient zero must not erase the baseline needed to recognize the real reset that follows.
             wasAboveThreshold: shouldPreserveBaseline ? true : wasAboveThreshold,
             lastObservedAt: currentObservedAt,
             sourceRawValue: sourceRawValue,
-            resetBoundary: shouldPreserveBaseline ? previousState?.resetBoundary : observation.resetBoundary)
+            resetBoundary: shouldPreserveBoundary ? previousState?.resetBoundary : observation.resetBoundary)
         self.persistLimitResetDetectorStates(
             states,
             defaultsKey: descriptor.defaultsKey,

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -494,15 +494,16 @@ extension UsageStore {
             || Self.limitResetBoundaryAdvanced(
                 previous: previousState?.resetBoundary,
                 current: observation.resetBoundary)
-        let shouldPost = !sourceChanged
-            && previousState?.wasAboveThreshold == true
+        let crossedBelowThreshold = !sourceChanged && previousState?.wasAboveThreshold == true
             && !wasAboveThreshold
-            && resetBoundaryAllowsPost
+        let shouldPost = crossedBelowThreshold && resetBoundaryAllowsPost
+        let shouldPreserveBaseline = crossedBelowThreshold && !resetBoundaryAllowsPost
         states[detectorKey] = LimitResetDetectorState(
-            wasAboveThreshold: wasAboveThreshold,
+            // A transient zero must not erase the baseline needed to recognize the real reset that follows.
+            wasAboveThreshold: shouldPreserveBaseline ? true : wasAboveThreshold,
             lastObservedAt: currentObservedAt,
             sourceRawValue: sourceRawValue,
-            resetBoundary: observation.resetBoundary)
+            resetBoundary: shouldPreserveBaseline ? previousState?.resetBoundary : observation.resetBoundary)
         self.persistLimitResetDetectorStates(
             states,
             defaultsKey: descriptor.defaultsKey,

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -494,8 +494,7 @@ extension UsageStore {
             || Self.limitResetBoundaryAdvanced(
                 previous: previousState?.resetBoundary,
                 current: observation.resetBoundary)
-        let crossedBelowThreshold = !sourceChanged && previousState?.wasAboveThreshold == true
-            && !wasAboveThreshold
+        let crossedBelowThreshold = !sourceChanged && previousState?.wasAboveThreshold == true && !wasAboveThreshold
         let shouldPost = crossedBelowThreshold && resetBoundaryAllowsPost
         let shouldPreserveBaseline = crossedBelowThreshold && !resetBoundaryAllowsPost
         states[detectorKey] = LimitResetDetectorState(
@@ -546,7 +545,8 @@ extension UsageStore {
     }
 
     private nonisolated static func limitResetBoundaryAdvanced(previous: Date?, current: Date?) -> Bool {
-        guard let previous, let current else { return true }
+        guard let previous else { return true }
+        guard let current else { return false }
         return !self.areEquivalentPlanUtilizationResetBoundaries(previous, current) && current > previous
     }
 

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -36,6 +36,7 @@ extension UsageStore {
         let wasAboveThreshold: Bool
         let lastObservedAt: Date
         let sourceRawValue: String?
+        var resetBoundary: Date?
     }
 
     func supportsPlanUtilizationHistory(for provider: UsageProvider) -> Bool {
@@ -82,6 +83,7 @@ extension UsageStore {
     private struct LimitResetObservation {
         let usedPercent: Double
         let observedAt: Date
+        let resetBoundary: Date?
         let source: SessionQuotaWindowSource?
     }
 
@@ -406,6 +408,7 @@ extension UsageStore {
                 LimitResetObservation(
                     usedPercent: $0.entry.usedPercent,
                     observedAt: $0.entry.capturedAt,
+                    resetBoundary: $0.entry.resetsAt,
                     source: nil)
             }
         } else {
@@ -415,6 +418,7 @@ extension UsageStore {
                     LimitResetObservation(
                         usedPercent: $0,
                         observedAt: context.capturedAt,
+                        resetBoundary: resolved.window.resetsAt,
                         source: resolved.source)
                 }
             }
@@ -431,6 +435,7 @@ extension UsageStore {
             LimitResetObservation(
                 usedPercent: $0.entry.usedPercent,
                 observedAt: $0.entry.capturedAt,
+                resetBoundary: $0.entry.resetsAt,
                 source: nil)
         }
         self.postLimitResetCelebrationIfNeeded(
@@ -485,13 +490,19 @@ extension UsageStore {
         let sourceChanged = descriptor.seriesName == .session
             && previousState?.sourceRawValue != nil
             && previousState?.sourceRawValue != sourceRawValue
+        let resetBoundaryAllowsPost = descriptor.seriesName != .session
+            || Self.limitResetBoundaryAdvanced(
+                previous: previousState?.resetBoundary,
+                current: observation.resetBoundary)
         let shouldPost = !sourceChanged
             && previousState?.wasAboveThreshold == true
             && !wasAboveThreshold
+            && resetBoundaryAllowsPost
         states[detectorKey] = LimitResetDetectorState(
             wasAboveThreshold: wasAboveThreshold,
             lastObservedAt: currentObservedAt,
-            sourceRawValue: sourceRawValue)
+            sourceRawValue: sourceRawValue,
+            resetBoundary: observation.resetBoundary)
         self.persistLimitResetDetectorStates(
             states,
             defaultsKey: descriptor.defaultsKey,
@@ -531,6 +542,11 @@ extension UsageStore {
         default:
             return
         }
+    }
+
+    private nonisolated static func limitResetBoundaryAdvanced(previous: Date?, current: Date?) -> Bool {
+        guard let previous, let current else { return true }
+        return !self.areEquivalentPlanUtilizationResetBoundaries(previous, current) && current > previous
     }
 
     private func planUtilizationSeriesSamples(

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
@@ -154,14 +154,10 @@ extension UsageStorePlanUtilizationTests {
             sessionUsed: 0,
             sessionReset: sessionReset,
             updatedAt: firstDate.addingTimeInterval(60))
-        let corrected = snapshot(
-            sessionUsed: 69,
-            sessionReset: sessionReset,
-            updatedAt: firstDate.addingTimeInterval(120))
         let realReset = snapshot(
             sessionUsed: 0,
             sessionReset: sessionReset.addingTimeInterval(5 * 3600),
-            updatedAt: firstDate.addingTimeInterval(180))
+            updatedAt: firstDate.addingTimeInterval(120))
 
         await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
         await store.recordPlanUtilizationHistorySample(
@@ -170,7 +166,6 @@ extension UsageStorePlanUtilizationTests {
             now: transientZero.updatedAt)
         #expect(recorder.events.isEmpty)
 
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: corrected, now: corrected.updatedAt)
         await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: realReset, now: realReset.updatedAt)
 
         #expect(recorder.events.count == 1)

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
@@ -116,6 +116,69 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
+    func `codex session celebration ignores transient zero when reset boundary is unchanged`() async {
+        let store = Self.makeStore()
+        let accountLabel = "codex-session-transient-zero@example.com"
+        let recorder = SessionLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessionReset = firstDate.addingTimeInterval(5 * 3600)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+
+        func snapshot(sessionUsed: Double, sessionReset: Date, updatedAt: Date) -> UsageSnapshot {
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: sessionUsed,
+                    windowMinutes: 300,
+                    resetsAt: sessionReset,
+                    resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 100,
+                    windowMinutes: 10080,
+                    resetsAt: weeklyReset,
+                    resetDescription: nil),
+                updatedAt: updatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: accountLabel,
+                    accountOrganization: nil,
+                    loginMethod: "pro"))
+        }
+
+        let before = snapshot(
+            sessionUsed: 67,
+            sessionReset: sessionReset,
+            updatedAt: firstDate)
+        let transientZero = snapshot(
+            sessionUsed: 0,
+            sessionReset: sessionReset,
+            updatedAt: firstDate.addingTimeInterval(60))
+        let corrected = snapshot(
+            sessionUsed: 69,
+            sessionReset: sessionReset,
+            updatedAt: firstDate.addingTimeInterval(120))
+        let realReset = snapshot(
+            sessionUsed: 0,
+            sessionReset: sessionReset.addingTimeInterval(5 * 3600),
+            updatedAt: firstDate.addingTimeInterval(180))
+
+        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: transientZero,
+            now: transientZero.updatedAt)
+        #expect(recorder.events.isEmpty)
+
+        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: corrected, now: corrected.updatedAt)
+        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: realReset, now: realReset.updatedAt)
+
+        #expect(recorder.events.count == 1)
+        #expect(recorder.events.first?.usedPercent == 0)
+    }
+
+    @MainActor
+    @Test
     func `weekly quota celebration posts when weekly usage resets to zero`() async {
         let store = Self.makeStore()
         let accountLabel = "reset-zero@example.com"

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
@@ -150,16 +150,24 @@ extension UsageStorePlanUtilizationTests {
             sessionUsed: 67,
             sessionReset: sessionReset,
             updatedAt: firstDate)
+        let regressedBoundaryHigh = snapshot(
+            sessionUsed: 68,
+            sessionReset: sessionReset.addingTimeInterval(-3600),
+            updatedAt: firstDate.addingTimeInterval(60))
         let transientZero = snapshot(
             sessionUsed: 0,
             sessionReset: sessionReset,
-            updatedAt: firstDate.addingTimeInterval(60))
+            updatedAt: firstDate.addingTimeInterval(120))
         let realReset = snapshot(
             sessionUsed: 0,
             sessionReset: sessionReset.addingTimeInterval(5 * 3600),
-            updatedAt: firstDate.addingTimeInterval(120))
+            updatedAt: firstDate.addingTimeInterval(180))
 
         await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: regressedBoundaryHigh,
+            now: regressedBoundaryHigh.updatedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: transientZero,
@@ -208,16 +216,24 @@ extension UsageStorePlanUtilizationTests {
             sessionUsed: 67,
             sessionReset: sessionReset,
             updatedAt: firstDate)
+        let missingBoundaryHigh = snapshot(
+            sessionUsed: 68,
+            sessionReset: nil,
+            updatedAt: firstDate.addingTimeInterval(60))
         let missingBoundary = snapshot(
             sessionUsed: 0,
             sessionReset: nil,
-            updatedAt: firstDate.addingTimeInterval(60))
+            updatedAt: firstDate.addingTimeInterval(120))
         let realReset = snapshot(
             sessionUsed: 0,
             sessionReset: sessionReset.addingTimeInterval(5 * 3600),
-            updatedAt: firstDate.addingTimeInterval(120))
+            updatedAt: firstDate.addingTimeInterval(180))
 
         await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: missingBoundaryHigh,
+            now: missingBoundaryHigh.updatedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: missingBoundary,

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
@@ -174,6 +174,64 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
+    func `codex session celebration ignores missing reset boundary after a known boundary`() async {
+        let store = Self.makeStore()
+        let accountLabel = "codex-session-missing-boundary@example.com"
+        let recorder = SessionLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessionReset = firstDate.addingTimeInterval(5 * 3600)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+
+        func snapshot(sessionUsed: Double, sessionReset: Date?, updatedAt: Date) -> UsageSnapshot {
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: sessionUsed,
+                    windowMinutes: 300,
+                    resetsAt: sessionReset,
+                    resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 100,
+                    windowMinutes: 10080,
+                    resetsAt: weeklyReset,
+                    resetDescription: nil),
+                updatedAt: updatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: accountLabel,
+                    accountOrganization: nil,
+                    loginMethod: "pro"))
+        }
+
+        let before = snapshot(
+            sessionUsed: 67,
+            sessionReset: sessionReset,
+            updatedAt: firstDate)
+        let missingBoundary = snapshot(
+            sessionUsed: 0,
+            sessionReset: nil,
+            updatedAt: firstDate.addingTimeInterval(60))
+        let realReset = snapshot(
+            sessionUsed: 0,
+            sessionReset: sessionReset.addingTimeInterval(5 * 3600),
+            updatedAt: firstDate.addingTimeInterval(120))
+
+        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: missingBoundary,
+            now: missingBoundary.updatedAt)
+        #expect(recorder.events.isEmpty)
+
+        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: realReset, now: realReset.updatedAt)
+
+        #expect(recorder.events.count == 1)
+        #expect(recorder.events.first?.usedPercent == 0)
+    }
+
+    @MainActor
+    @Test
     func `weekly quota celebration posts when weekly usage resets to zero`() async {
         let store = Self.makeStore()
         let accountLabel = "reset-zero@example.com"


### PR DESCRIPTION
## Summary
- store the observed reset boundary in the limit-reset detector state
- require Codex/session reset celebrations to see the reset boundary advance before posting
- keep weekly reset behavior unchanged and cover the transient-zero Codex session case

Fixes #1986

## Tests
- `swift test --filter "codex session celebration ignores transient zero"`
- `swift test --filter UsageStorePlanUtilizationTests`
- `swift test --filter CodexConsumerProjectionTests`
- `./Scripts/lint.sh lint-linux`
- `git diff --check`

## Review focus
- The reset-boundary gate is scoped to session reset celebrations so existing weekly reset coalescing behavior is preserved.
- When a reset boundary is unavailable, the detector keeps the existing usage-drop behavior for compatibility.