### PR TITLE
[codex] Fix Claude auto fallback for MCP-only keychain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Menus: stop completed provider cards and plan-utilization rows from remaining in “Refreshing…” while unrelated provider or token-cost work is still running. Thanks @Yuxin-Qiao!
 - Menu: keep native hover highlights aligned by deferring geometry-changing open-menu rebuilds until the pointer leaves the row. Thanks @Zihao-Qi!
 - Settings: keep visual-only preferences and provider reordering on cached UI paths instead of refreshing provider quotas, while preserving refreshes for data-affecting settings. Thanks @Zihao-Qi!
+- Claude: skip doomed background OAuth refreshes when Claude CLI credentials are expired and Keychain contains MCP-only state, allowing Auto mode to fall through. Thanks @janpollak!
 - Display settings: keep display mode, work days, multi-account layout, and cost summary selectors interactive on macOS 27. Thanks @jordanschwartz-js!
 - Quota warnings: keep compact per-window threshold editors available whenever notifications or usage-bar markers use them, preserve inherited overrides, and save edits on focus loss, Return, or window close. Thanks @Zihao-Qi!
 - CLI server: retain timed-out route and provider work until it actually exits, preventing repeated requests or config changes from stacking background fetches. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -272,7 +272,9 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
 
     private func loadNonInteractiveCredentialRecord(environment: [String: String]) -> ClaudeOAuthCredentialRecord? {
         #if DEBUG
-        if let override = Self.nonInteractiveCredentialRecordOverride { return override }
+        if let override = Self.nonInteractiveCredentialRecordOverride {
+            return override
+        }
         #endif
 
         return try? ClaudeOAuthCredentialsStore.loadRecord(
@@ -284,7 +286,9 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
 
     private func isClaudeCLIAvailable(environment: [String: String]) -> Bool {
         #if DEBUG
-        if let override = Self.claudeCLIAvailableOverride { return override }
+        if let override = Self.claudeCLIAvailableOverride {
+            return override
+        }
         #endif
         return ClaudeCLIResolver.isAvailable(environment: environment)
     }
@@ -321,15 +325,10 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
                 }
                 return true
             case .claudeCLI:
-                if sourceMode == .auto {
-                    if ProviderInteractionContext.current != .userInitiated,
-                       Self.hasMcpOAuthOnlyClaudeKeychainPayload(environment: environment)
-                    {
-                        return false
-                    }
-                    return claudeCLIAvailable
-                }
-                return true
+                guard sourceMode == .auto else { return true }
+                guard claudeCLIAvailable else { return false }
+                guard ProviderInteractionContext.current == .background else { return true }
+                return !Self.hasMcpOAuthOnlyClaudeKeychainPayload(environment: environment)
             case .environment:
                 return sourceMode != .auto
             }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -322,6 +322,11 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
                 return true
             case .claudeCLI:
                 if sourceMode == .auto {
+                    if ProviderInteractionContext.current != .userInitiated,
+                       Self.hasMcpOAuthOnlyClaudeKeychainPayload(environment: environment)
+                    {
+                        return false
+                    }
                     return claudeCLIAvailable
                 }
                 return true
@@ -353,6 +358,12 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
             return false
         }
         return ClaudeOAuthCredentialsStore.hasClaudeKeychainCredentialsWithoutPrompt()
+    }
+
+    private static func hasMcpOAuthOnlyClaudeKeychainPayload(environment: [String: String]) -> Bool {
+        ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
+            interaction: ProviderInteractionContext.current,
+            environment: environment)
     }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {

--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -58,6 +58,56 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                 await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
                     await strategy.isAvailable(context)
                 }
+        }
+        #expect(available == true)
+    }
+
+    @Test
+    func `auto mode expired CLI creds with MCP-only keychain returns unavailable in background`() async {
+        let context = self.makeContext(sourceMode: .auto)
+        let strategy = ClaudeOAuthFetchStrategy()
+        let mcpOAuthOnly = Data(#"{"mcpOAuth":{"plugin:test":{"accessToken":"synthetic"}}}"#.utf8)
+        let available = await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
+            .withValue(self.expiredRecord()) {
+                await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
+                    await KeychainAccessGate.withTaskOverrideForTesting(false) {
+                        await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
+                            await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+                                data: mcpOAuthOnly,
+                                fingerprint: nil)
+                            {
+                                await ProviderInteractionContext.$current.withValue(.background) {
+                                    await strategy.isAvailable(context)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        #expect(available == false)
+    }
+
+    @Test
+    func `auto mode expired CLI creds with MCP-only keychain remains available for user action`() async {
+        let context = self.makeContext(sourceMode: .auto)
+        let strategy = ClaudeOAuthFetchStrategy()
+        let mcpOAuthOnly = Data(#"{"mcpOAuth":{"plugin:test":{"accessToken":"synthetic"}}}"#.utf8)
+        let available = await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
+            .withValue(self.expiredRecord()) {
+                await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
+                    await KeychainAccessGate.withTaskOverrideForTesting(false) {
+                        await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
+                            await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+                                data: mcpOAuthOnly,
+                                fingerprint: nil)
+                            {
+                                await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                                    await strategy.isAvailable(context)
+                                }
+                            }
+                        }
+                    }
+                }
             }
         #expect(available == true)
     }

--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -58,58 +58,59 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                 await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
                     await strategy.isAvailable(context)
                 }
-        }
+            }
         #expect(available == true)
     }
 
     @Test
     func `auto mode expired CLI creds with MCP-only keychain returns unavailable in background`() async {
-        let context = self.makeContext(sourceMode: .auto)
-        let strategy = ClaudeOAuthFetchStrategy()
-        let mcpOAuthOnly = Data(#"{"mcpOAuth":{"plugin:test":{"accessToken":"synthetic"}}}"#.utf8)
-        let available = await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
-            .withValue(self.expiredRecord()) {
-                await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
-                    await KeychainAccessGate.withTaskOverrideForTesting(false) {
-                        await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
-                            await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
-                                data: mcpOAuthOnly,
-                                fingerprint: nil)
-                            {
-                                await ProviderInteractionContext.$current.withValue(.background) {
-                                    await strategy.isAvailable(context)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        #expect(available == false)
+        let available = await self.expiredCLIAvailability(
+            sourceMode: .auto,
+            interaction: .background,
+            keychainData: self.mcpOAuthOnlyKeychainPayload)
+
+        #expect(!available)
     }
 
     @Test
     func `auto mode expired CLI creds with MCP-only keychain remains available for user action`() async {
-        let context = self.makeContext(sourceMode: .auto)
-        let strategy = ClaudeOAuthFetchStrategy()
-        let mcpOAuthOnly = Data(#"{"mcpOAuth":{"plugin:test":{"accessToken":"synthetic"}}}"#.utf8)
-        let available = await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
-            .withValue(self.expiredRecord()) {
-                await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
-                    await KeychainAccessGate.withTaskOverrideForTesting(false) {
-                        await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
-                            await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
-                                data: mcpOAuthOnly,
-                                fingerprint: nil)
-                            {
-                                await ProviderInteractionContext.$current.withValue(.userInitiated) {
-                                    await strategy.isAvailable(context)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        #expect(available == true)
+        let available = await self.expiredCLIAvailability(
+            sourceMode: .auto,
+            interaction: .userInitiated,
+            keychainData: self.mcpOAuthOnlyKeychainPayload)
+
+        #expect(available)
+    }
+
+    @Test
+    func `explicit O auth keeps expired CLI credentials available with MCP-only keychain`() async {
+        let available = await self.expiredCLIAvailability(
+            sourceMode: .oauth,
+            interaction: .background,
+            keychainData: self.mcpOAuthOnlyKeychainPayload)
+
+        #expect(available)
+    }
+
+    @Test
+    func `auto mode keeps expired CLI credentials available with ordinary O auth keychain`() async {
+        let available = await self.expiredCLIAvailability(
+            sourceMode: .auto,
+            interaction: .background,
+            keychainData: self.ordinaryOAuthKeychainPayload)
+
+        #expect(available)
+    }
+
+    @Test
+    func `auto mode ignores MCP-only keychain when keychain access is disabled`() async {
+        let available = await self.expiredCLIAvailability(
+            sourceMode: .auto,
+            interaction: .background,
+            keychainData: self.mcpOAuthOnlyKeychainPayload,
+            keychainAccessDisabled: true)
+
+        #expect(available)
     }
 
     @Test
@@ -430,6 +431,41 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
         return try await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(
             true,
             operation: operation)
+    }
+
+    private var mcpOAuthOnlyKeychainPayload: Data {
+        Data(#"{"mcpOAuth":{"plugin:test":{"accessToken":"fixture"}}}"#.utf8)
+    }
+
+    private var ordinaryOAuthKeychainPayload: Data {
+        Data(#"{"claudeAiOauth":{"accessToken":"fixture"}}"#.utf8)
+    }
+
+    private func expiredCLIAvailability(
+        sourceMode: ProviderSourceMode,
+        interaction: ProviderInteraction,
+        keychainData: Data,
+        keychainAccessDisabled: Bool = false) async -> Bool
+    {
+        let context = self.makeContext(sourceMode: sourceMode)
+        let strategy = ClaudeOAuthFetchStrategy()
+        return await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
+            .withValue(self.expiredRecord()) {
+                await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
+                    await KeychainAccessGate.withTaskOverrideForTesting(keychainAccessDisabled) {
+                        await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
+                            await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+                                data: keychainData,
+                                fingerprint: nil)
+                            {
+                                await ProviderInteractionContext.$current.withValue(interaction) {
+                                    await strategy.isAvailable(context)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
     }
 }
 #endif


### PR DESCRIPTION
## Summary

- Skip Claude OAuth during background `Auto` planning when cached Claude CLI credentials are expired and the live Claude Keychain contains MCP-only OAuth state.
- Fall through directly to the CLI/Web strategy instead of attempting an OAuth refresh that is known to fail.
- Preserve user-initiated refreshes, explicit OAuth mode, ordinary OAuth Keychain payloads, and disabled-Keychain behavior.
- Avoid the MCP-only Keychain probe when the Claude CLI fallback is unavailable.

## Verification

- [x] `swift test --filter ClaudeOAuthFetchStrategyAvailabilityTests` (17 tests)
- [x] `make check`
- [x] `make test` (605 selections, 51 groups)
- [x] Autoreview: no accepted/actionable findings

The test matrix uses no-prompt Keychain overrides and covers background Auto, user-initiated Auto, explicit OAuth, ordinary OAuth payloads, disabled Keychain access, unavailable CLI, and existing startup/prompt-policy paths.
