### PR TITLE
[codex] Surface Claude CLI scoped weekly limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Agent Sessions: list and focus live local or SSH-discovered Codex and Claude Code sessions from the menu and CLI.
+- Claude CLI: surface model-scoped weekly limits alongside all-model usage without duplicating matching web limits. Thanks @janpollak!
 
 ### Fixed
 - Codex: avoid false session-reset celebrations from transient zero-usage samples until the reset boundary advances. Thanks @kiranmagic7!

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -230,11 +230,10 @@ extension ClaudeStatusProbe {
         // Fallback: order-based percent scraping when labels are present but the surrounding layout moved.
         // Only apply the fallback when the corresponding label exists in the rendered panel; enterprise accounts
         // may omit the weekly panel entirely, and we should treat that as "unavailable" rather than guessing.
-        let hasAllModelsWeeklyLabel = labelContext.contains(
-            self.normalizedForLabelSearch("Current week (all models)"))
-        let hasOpusLabel = opusLabels.contains {
-            labelContext.contains(self.normalizedForLabelSearch($0))
-        }
+        let weeklyModels = Set(labelContext.lines.compactMap(self.weeklyModelName).map(self.normalizedForLabelSearch))
+        let hasAllModelsWeeklyLabel = weeklyModels.contains("allmodels")
+        let opusModels = Set(opusLabels.compactMap(self.weeklyModelName).map(self.normalizedForLabelSearch))
+        let hasOpusLabel = !weeklyModels.isDisjoint(with: opusModels)
 
         if sessionPct == nil {
             let ordered = self.allPercents(usagePanelText)
@@ -341,7 +340,15 @@ extension ClaudeStatusProbe {
     private static func extractPercent(labelSubstring: String, context: LabelSearchContext) -> Int? {
         let lines = context.lines
         let label = self.normalizedForLabelSearch(labelSubstring)
-        for (idx, normalizedLine) in context.normalizedLines.enumerated() where normalizedLine.contains(label) {
+        for (idx, line) in lines.enumerated() {
+            let normalizedLine = context.normalizedLines[idx]
+            guard self.matchesLabel(
+                line: line,
+                normalizedLine: normalizedLine,
+                labelSubstring: labelSubstring,
+                normalizedLabel: label)
+            else { continue }
+
             // Claude's usage panel can take a moment to render percentages (especially on enterprise accounts),
             // so scan a larger window than the original 3–4 lines.
             let window = lines.dropFirst(idx).prefix(12)
@@ -395,24 +402,10 @@ extension ClaudeStatusProbe {
     }
 
     private static func extractScopedWeeklyUsages(context: LabelSearchContext) -> [ScopedWeeklyUsage] {
-        guard let regex = try? NSRegularExpression(
-            pattern: #"current\s*week\s*\(([^)]+)\)"#,
-            options: [.caseInsensitive])
-        else { return [] }
-
-        func extractModelName(from line: String) -> String? {
-            let range = NSRange(line.startIndex..<line.endIndex, in: line)
-            guard let match = regex.firstMatch(in: line, options: [], range: range),
-                  match.numberOfRanges >= 2,
-                  let modelRange = Range(match.range(at: 1), in: line)
-            else { return nil }
-            return String(line[modelRange]).trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-
         var usageIndexByModel: [String: Int] = [:]
         var usages: [ScopedWeeklyUsage] = []
         for (index, line) in context.lines.enumerated() {
-            guard let modelName = extractModelName(from: line) else { continue }
+            guard let modelName = self.weeklyModelName(from: line) else { continue }
             let normalizedModel = self.normalizedForLabelSearch(modelName)
             guard normalizedModel != "allmodels", !normalizedModel.isEmpty else { continue }
 
@@ -420,7 +413,7 @@ extension ClaudeStatusProbe {
             var percentLeft: Int?
             var resetDescription: String?
             for candidate in window {
-                if let candidateModel = extractModelName(from: candidate),
+                if let candidateModel = self.weeklyModelName(from: candidate),
                    self.normalizedForLabelSearch(candidateModel) != normalizedModel
                 {
                     break
@@ -703,7 +696,15 @@ extension ClaudeStatusProbe {
     private static func extractReset(labelSubstring: String, context: LabelSearchContext) -> String? {
         let lines = context.lines
         let label = self.normalizedForLabelSearch(labelSubstring)
-        for (idx, normalizedLine) in context.normalizedLines.enumerated() where normalizedLine.contains(label) {
+        for (idx, line) in lines.enumerated() {
+            let normalizedLine = context.normalizedLines[idx]
+            guard self.matchesLabel(
+                line: line,
+                normalizedLine: normalizedLine,
+                labelSubstring: labelSubstring,
+                normalizedLabel: label)
+            else { continue }
+
             let window = lines.dropFirst(idx).prefix(14)
             for candidate in window {
                 let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -717,6 +718,32 @@ extension ClaudeStatusProbe {
             }
         }
         return nil
+    }
+
+    private static func matchesLabel(
+        line: String,
+        normalizedLine: String,
+        labelSubstring: String,
+        normalizedLabel: String) -> Bool
+    {
+        guard let expectedModel = self.weeklyModelName(from: labelSubstring) else {
+            return normalizedLine.contains(normalizedLabel)
+        }
+        guard let actualModel = self.weeklyModelName(from: line) else { return false }
+        return self.normalizedForLabelSearch(actualModel) == self.normalizedForLabelSearch(expectedModel)
+    }
+
+    private static func weeklyModelName(from line: String) -> String? {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"current\s*week\s*\(([^)]+)\)"#,
+            options: [.caseInsensitive])
+        else { return nil }
+        let range = NSRange(line.startIndex..<line.endIndex, in: line)
+        guard let match = regex.firstMatch(in: line, options: [], range: range),
+              match.numberOfRanges >= 2,
+              let modelRange = Range(match.range(at: 1), in: line)
+        else { return nil }
+        return String(line[modelRange]).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private static func extractReset(labelSubstrings: [String], context: LabelSearchContext) -> String? {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -403,20 +403,23 @@ extension ClaudeStatusProbe {
 
     private static func extractScopedWeeklyUsages(context: LabelSearchContext) -> [ScopedWeeklyUsage] {
         guard let regex = try? NSRegularExpression(
-            pattern: #"current\s+week\s*\(([^)]+)\)"#,
+            pattern: #"current\s*week\s*\(([^)]+)\)"#,
             options: [.caseInsensitive])
         else { return [] }
 
-        var usageIndexByModel: [String: Int] = [:]
-        var usages: [ScopedWeeklyUsage] = []
-        for (index, line) in context.lines.enumerated() {
+        func extractModelName(from line: String) -> String? {
             let range = NSRange(line.startIndex..<line.endIndex, in: line)
             guard let match = regex.firstMatch(in: line, options: [], range: range),
                   match.numberOfRanges >= 2,
                   let modelRange = Range(match.range(at: 1), in: line)
-            else { continue }
+            else { return nil }
+            return String(line[modelRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
 
-            let modelName = String(line[modelRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+        var usageIndexByModel: [String: Int] = [:]
+        var usages: [ScopedWeeklyUsage] = []
+        for (index, line) in context.lines.enumerated() {
+            guard let modelName = extractModelName(from: line) else { continue }
             let normalizedModel = self.normalizedForLabelSearch(modelName)
             guard normalizedModel != "allmodels", !normalizedModel.isEmpty else { continue }
 
@@ -424,8 +427,9 @@ extension ClaudeStatusProbe {
             var percentLeft: Int?
             var resetDescription: String?
             for candidate in window {
-                let normalized = self.normalizedForLabelSearch(candidate)
-                if normalized.hasPrefix("currentweek"), !normalized.contains(normalizedModel) {
+                if let candidateModel = extractModelName(from: candidate),
+                   self.normalizedForLabelSearch(candidateModel) != normalizedModel
+                {
                     break
                 }
                 if percentLeft == nil {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -219,7 +219,7 @@ extension ClaudeStatusProbe {
         let labelContext = LabelSearchContext(text: usagePanelText)
 
         var sessionPct = self.extractPercent(labelSubstring: "Current session", context: labelContext)
-        var weeklyPct = self.extractPercent(labelSubstring: "Current week (all models)", context: labelContext)
+        let weeklyPct = self.extractPercent(labelSubstring: "Current week (all models)", context: labelContext)
         let opusLabels = [
             "Current week (Opus)",
             "Current week (Sonnet only)",
@@ -236,13 +236,10 @@ extension ClaudeStatusProbe {
             labelContext.contains(self.normalizedForLabelSearch($0))
         }
 
-        if sessionPct == nil || (hasAllModelsWeeklyLabel && weeklyPct == nil) {
+        if sessionPct == nil {
             let ordered = self.allPercents(usagePanelText)
             if sessionPct == nil, ordered.indices.contains(0) {
                 sessionPct = ordered[0]
-            }
-            if hasAllModelsWeeklyLabel, weeklyPct == nil, ordered.indices.contains(1) {
-                weeklyPct = ordered[1]
             }
         }
 
@@ -349,6 +346,10 @@ extension ClaudeStatusProbe {
             // so scan a larger window than the original 3–4 lines.
             let window = lines.dropFirst(idx).prefix(12)
             for candidate in window {
+                let normalized = self.normalizedForLabelSearch(candidate)
+                if normalized.hasPrefix("current"), !normalized.contains(label) {
+                    break
+                }
                 if let pct = self.percentFromLine(candidate) {
                     return pct
                 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -163,7 +163,9 @@ public struct ClaudeStatusProbe: Sendable {
         guard !removed.isEmpty else { return }
         Self.log.debug("Claude probe session artifacts removed", metadata: ["count": "\(removed.count)"])
     }
+}
 
+extension ClaudeStatusProbe {
     // MARK: - Parsing helpers
 
     private struct LabelSearchContext {
@@ -229,17 +231,21 @@ public struct ClaudeStatusProbe: Sendable {
         // Fallback: order-based percent scraping when labels are present but the surrounding layout moved.
         // Only apply the fallback when the corresponding label exists in the rendered panel; enterprise accounts
         // may omit the weekly panel entirely, and we should treat that as "unavailable" rather than guessing.
-        let compactContext = usagePanelText.lowercased().filter { !$0.isWhitespace }
-        let hasWeeklyLabel =
-            labelContext.contains("currentweek")
-            || compactContext.contains("currentweek")
+        let hasAllModelsWeeklyLabel = labelContext.contains(
+            self.normalizedForLabelSearch("Current week (all models)"))
         let hasOpusLabel = labelContext.contains("opus") || labelContext.contains("sonnet")
 
-        if sessionPct == nil || (hasWeeklyLabel && weeklyPct == nil) || (hasOpusLabel && opusPct == nil) {
+        if sessionPct == nil || (hasAllModelsWeeklyLabel && weeklyPct == nil) || (hasOpusLabel && opusPct == nil) {
             let ordered = self.allPercents(usagePanelText)
-            if sessionPct == nil, ordered.indices.contains(0) { sessionPct = ordered[0] }
-            if hasWeeklyLabel, weeklyPct == nil, ordered.indices.contains(1) { weeklyPct = ordered[1] }
-            if hasOpusLabel, opusPct == nil, ordered.indices.contains(2) { opusPct = ordered[2] }
+            if sessionPct == nil, ordered.indices.contains(0) {
+                sessionPct = ordered[0]
+            }
+            if hasAllModelsWeeklyLabel, weeklyPct == nil, ordered.indices.contains(1) {
+                weeklyPct = ordered[1]
+            }
+            if hasOpusLabel, opusPct == nil, ordered.indices.contains(2) {
+                opusPct = ordered[2]
+            }
         }
 
         let identity = Self.parseIdentity(usageText: clean, statusText: statusClean)
@@ -260,7 +266,7 @@ public struct ClaudeStatusProbe: Sendable {
         }
 
         let sessionReset = self.extractReset(labelSubstring: "Current session", context: labelContext)
-        let weeklyReset = hasWeeklyLabel
+        let weeklyReset = hasAllModelsWeeklyLabel
             ? self.extractReset(labelSubstring: "Current week (all models)", context: labelContext)
             : nil
         let opusReset = hasOpusLabel
@@ -351,7 +357,9 @@ public struct ClaudeStatusProbe: Sendable {
             // so scan a larger window than the original 3–4 lines.
             let window = lines.dropFirst(idx).prefix(12)
             for candidate in window {
-                if let pct = self.percentFromLine(candidate) { return pct }
+                if let pct = self.percentFromLine(candidate) {
+                    return pct
+                }
             }
         }
         return nil
@@ -380,7 +388,9 @@ public struct ClaudeStatusProbe: Sendable {
 
     private static func extractPercent(labelSubstrings: [String], context: LabelSearchContext) -> Int? {
         for label in labelSubstrings {
-            if let value = self.extractPercent(labelSubstring: label, context: context) { return value }
+            if let value = self.extractPercent(labelSubstring: label, context: context) {
+                return value
+            }
         }
         return nil
     }
@@ -397,7 +407,7 @@ public struct ClaudeStatusProbe: Sendable {
             options: [.caseInsensitive])
         else { return [] }
 
-        var seenModels: Set<String> = []
+        var usageIndexByModel: [String: Int] = [:]
         var usages: [ScopedWeeklyUsage] = []
         for (index, line) in context.lines.enumerated() {
             let range = NSRange(line.startIndex..<line.endIndex, in: line)
@@ -409,14 +419,15 @@ public struct ClaudeStatusProbe: Sendable {
             let modelName = String(line[modelRange]).trimmingCharacters(in: .whitespacesAndNewlines)
             let normalizedModel = self.normalizedForLabelSearch(modelName)
             guard normalizedModel != "allmodels", !normalizedModel.isEmpty else { continue }
-            guard seenModels.insert(normalizedModel).inserted else { continue }
 
             let window = context.lines.dropFirst(index).prefix(14)
             var percentLeft: Int?
             var resetDescription: String?
             for candidate in window {
                 let normalized = self.normalizedForLabelSearch(candidate)
-                if normalized.hasPrefix("currentweek"), !normalized.contains(normalizedModel) { break }
+                if normalized.hasPrefix("currentweek"), !normalized.contains(normalizedModel) {
+                    break
+                }
                 if percentLeft == nil {
                     percentLeft = self.percentFromLine(candidate)
                 }
@@ -425,10 +436,16 @@ public struct ClaudeStatusProbe: Sendable {
                 }
             }
             guard let percentLeft else { continue }
-            usages.append(ScopedWeeklyUsage(
+            let usage = ScopedWeeklyUsage(
                 modelName: modelName,
                 percentLeft: percentLeft,
-                resetDescription: resetDescription))
+                resetDescription: resetDescription)
+            if let existingIndex = usageIndexByModel[normalizedModel] {
+                usages[existingIndex] = usage
+            } else {
+                usageIndexByModel[normalizedModel] = usages.endIndex
+                usages.append(usage)
+            }
         }
         return usages
     }
@@ -476,7 +493,9 @@ public struct ClaudeStatusProbe: Sendable {
     }
 
     private static func percentFromLine(_ line: String, assumeRemainingWhenUnclear: Bool = false) -> Int? {
-        if self.isLikelyStatusContextLine(line) { return nil }
+        if self.isLikelyStatusContextLine(line) {
+            return nil
+        }
 
         // Allow optional Unicode whitespace before % to handle CLI formatting changes.
         let pattern = #"([0-9]{1,3}(?:\.[0-9]+)?)\p{Zs}*%"#
@@ -558,7 +577,9 @@ public struct ClaudeStatusProbe: Sendable {
                 return nil
             }
             // Suppress org if it’s just the email prefix (common in CLI panels).
-            if let email, orgText.lowercased().hasPrefix(email.lowercased()) { return nil }
+            if let email, orgText.lowercased().hasPrefix(email.lowercased()) {
+                return nil
+            }
             return orgText
         }()
         // Prefer explicit login method from /status, then fall back to /usage header heuristics.
@@ -567,7 +588,9 @@ public struct ClaudeStatusProbe: Sendable {
     }
 
     private static func extractUsageError(text: String) -> String? {
-        if let jsonHint = self.extractUsageErrorJSON(text: text) { return jsonHint }
+        if let jsonHint = self.extractUsageErrorJSON(text: text) {
+            return jsonHint
+        }
 
         let lower = text.lowercased()
         let compact = lower.filter { !$0.isWhitespace }
@@ -652,7 +675,9 @@ public struct ClaudeStatusProbe: Sendable {
             || normalized.contains("remaining") || normalized.contains("available")
         let loadingOnly = hasLoading && !hasUsageWindows
         guard hasUsageWindows || hasLoading else { return [] }
-        if loadingOnly { return [] }
+        if loadingOnly {
+            return []
+        }
         guard hasUsagePercentKeywords else { return [] }
 
         // Keep this strict to avoid matching Claude's status-line context meter (e.g. "0%") as session usage when the
@@ -686,8 +711,12 @@ public struct ClaudeStatusProbe: Sendable {
             for candidate in window {
                 let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
                 let normalized = self.normalizedForLabelSearch(trimmed)
-                if normalized.hasPrefix("current"), !normalized.contains(label) { break }
-                if let reset = self.resetFromLine(candidate) { return reset }
+                if normalized.hasPrefix("current"), !normalized.contains(label) {
+                    break
+                }
+                if let reset = self.resetFromLine(candidate) {
+                    return reset
+                }
             }
         }
         return nil
@@ -695,7 +724,9 @@ public struct ClaudeStatusProbe: Sendable {
 
     private static func extractReset(labelSubstrings: [String], context: LabelSearchContext) -> String? {
         for label in labelSubstrings {
-            if let value = self.extractReset(labelSubstring: label, context: context) { return value }
+            if let value = self.extractReset(labelSubstring: label, context: context) {
+                return value
+            }
         }
         return nil
     }
@@ -735,7 +766,9 @@ public struct ClaudeStatusProbe: Sendable {
             options: .regularExpression)
         let openCount = cleaned.count(where: { $0 == "(" })
         let closeCount = cleaned.count(where: { $0 == ")" })
-        if openCount > closeCount { cleaned.append(")") }
+        if openCount > closeCount {
+            cleaned.append(")")
+        }
         return cleaned
     }
 
@@ -770,7 +803,9 @@ public struct ClaudeStatusProbe: Sendable {
                 minute: comps.minute ?? 0,
                 second: 0,
                 of: now) else { return nil }
-            if anchored >= now { return anchored }
+            if anchored >= now {
+                return anchored
+            }
             return calendar.date(byAdding: .day, value: 1, to: anchored)
         }
 
@@ -781,14 +816,18 @@ public struct ClaudeStatusProbe: Sendable {
             minute: 0,
             second: 0,
             of: now) else { return nil }
-        if anchored >= now { return anchored }
+        if anchored >= now {
+            return anchored
+        }
         return calendar.date(byAdding: .day, value: 1, to: anchored)
     }
 
     /// Yearless dates parsed just before New Year's can otherwise land nearly a year in the past.
     private static func bumpYearIfNeeded(_ date: Date?, now: Date, calendar: Calendar) -> Date? {
         guard let date else { return nil }
-        if date >= now { return date }
+        if date >= now {
+            return date
+        }
         return calendar.date(byAdding: .year, value: 1, to: date)
     }
 
@@ -840,7 +879,9 @@ public struct ClaudeStatusProbe: Sendable {
     private static func parseDate(_ text: String, formats: [String], formatter: DateFormatter) -> Date? {
         for pattern in formats {
             formatter.dateFormat = pattern
-            if let date = formatter.date(from: text) { return date }
+            if let date = formatter.date(from: text) {
+                return date
+            }
         }
         return nil
     }
@@ -910,7 +951,9 @@ public struct ClaudeStatusProbe: Sendable {
     @MainActor private static var recentDumps: [String] = []
 
     @MainActor private static func recordDump(_ text: String) {
-        if self.recentDumps.count >= 5 { self.recentDumps.removeFirst() }
+        if self.recentDumps.count >= 5 {
+            self.recentDumps.removeFirst()
+        }
         self.recentDumps.append(text)
     }
 
@@ -962,8 +1005,12 @@ public struct ClaudeStatusProbe: Sendable {
         }
 
         var parts: [String] = []
-        if let message, !message.isEmpty { parts.append(message) }
-        if let code, !code.isEmpty { parts.append("(\(code))") }
+        if let message, !message.isEmpty {
+            parts.append(message)
+        }
+        if let code, !code.isEmpty {
+            parts.append("(\(code))")
+        }
 
         guard !parts.isEmpty else { return nil }
         let hint = parts.joined(separator: " ")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -353,8 +353,11 @@ extension ClaudeStatusProbe {
             // so scan a larger window than the original 3–4 lines.
             let window = lines.dropFirst(idx).prefix(12)
             for candidate in window {
-                let normalized = self.normalizedForLabelSearch(candidate)
-                if normalized.hasPrefix("current"), !normalized.contains(label) {
+                if self.crossesLabelBoundary(
+                    line: candidate,
+                    labelSubstring: labelSubstring,
+                    normalizedLabel: label)
+                {
                     break
                 }
                 if let pct = self.percentFromLine(candidate) {
@@ -707,9 +710,11 @@ extension ClaudeStatusProbe {
 
             let window = lines.dropFirst(idx).prefix(14)
             for candidate in window {
-                let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
-                let normalized = self.normalizedForLabelSearch(trimmed)
-                if normalized.hasPrefix("current"), !normalized.contains(label) {
+                if self.crossesLabelBoundary(
+                    line: candidate,
+                    labelSubstring: labelSubstring,
+                    normalizedLabel: label)
+                {
                     break
                 }
                 if let reset = self.resetFromLine(candidate) {
@@ -731,6 +736,20 @@ extension ClaudeStatusProbe {
         }
         guard let actualModel = self.weeklyModelName(from: line) else { return false }
         return self.normalizedForLabelSearch(actualModel) == self.normalizedForLabelSearch(expectedModel)
+    }
+
+    private static func crossesLabelBoundary(
+        line: String,
+        labelSubstring: String,
+        normalizedLabel: String) -> Bool
+    {
+        let normalizedLine = self.normalizedForLabelSearch(line)
+        guard normalizedLine.hasPrefix("current") else { return false }
+        guard let expectedModel = self.weeklyModelName(from: labelSubstring) else {
+            return !normalizedLine.contains(normalizedLabel)
+        }
+        guard let actualModel = self.weeklyModelName(from: line) else { return true }
+        return self.normalizedForLabelSearch(actualModel) != self.normalizedForLabelSearch(expectedModel)
     }
 
     private static func weeklyModelName(from line: String) -> String? {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -416,8 +416,10 @@ extension ClaudeStatusProbe {
             var percentLeft: Int?
             var resetDescription: String?
             for candidate in window {
-                if let candidateModel = self.weeklyModelName(from: candidate),
-                   self.normalizedForLabelSearch(candidateModel) != normalizedModel
+                if self.crossesLabelBoundary(
+                    line: candidate,
+                    labelSubstring: line,
+                    normalizedLabel: self.normalizedForLabelSearch(line))
                 {
                     break
                 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -4,6 +4,7 @@ public struct ClaudeStatusSnapshot: Sendable {
     public let sessionPercentLeft: Int?
     public let weeklyPercentLeft: Int?
     public let opusPercentLeft: Int?
+    public let extraRateWindows: [NamedRateWindow]
     public let accountEmail: String?
     public let accountOrganization: String?
     public let loginMethod: String?
@@ -11,6 +12,32 @@ public struct ClaudeStatusSnapshot: Sendable {
     public let secondaryResetDescription: String?
     public let opusResetDescription: String?
     public let rawText: String
+
+    public init(
+        sessionPercentLeft: Int?,
+        weeklyPercentLeft: Int?,
+        opusPercentLeft: Int?,
+        accountEmail: String?,
+        accountOrganization: String?,
+        loginMethod: String?,
+        primaryResetDescription: String?,
+        secondaryResetDescription: String?,
+        opusResetDescription: String?,
+        rawText: String,
+        extraRateWindows: [NamedRateWindow] = [])
+    {
+        self.sessionPercentLeft = sessionPercentLeft
+        self.weeklyPercentLeft = weeklyPercentLeft
+        self.opusPercentLeft = opusPercentLeft
+        self.extraRateWindows = extraRateWindows
+        self.accountEmail = accountEmail
+        self.accountOrganization = accountOrganization
+        self.loginMethod = loginMethod
+        self.primaryResetDescription = primaryResetDescription
+        self.secondaryResetDescription = secondaryResetDescription
+        self.opusResetDescription = opusResetDescription
+        self.rawText = rawText
+    }
 }
 
 public struct ClaudeAccountIdentity: Sendable {
@@ -245,6 +272,10 @@ public struct ClaudeStatusProbe: Sendable {
                 ],
                 context: labelContext)
             : nil
+        let scopedWeeklyUsages = self.extractScopedWeeklyUsages(context: labelContext)
+        let extraRateWindows = self.extraRateWindows(
+            fromScopedWeeklyUsages: scopedWeeklyUsages,
+            fallbackResetDescription: weeklyReset)
 
         return ClaudeStatusSnapshot(
             sessionPercentLeft: sessionPct,
@@ -256,7 +287,8 @@ public struct ClaudeStatusProbe: Sendable {
             primaryResetDescription: sessionReset,
             secondaryResetDescription: weeklyReset,
             opusResetDescription: opusReset,
-            rawText: text + (statusText ?? ""))
+            rawText: text + (statusText ?? ""),
+            extraRateWindows: extraRateWindows)
     }
 
     public static func parseIdentity(usageText: String?, statusText: String?) -> ClaudeAccountIdentity {
@@ -351,6 +383,96 @@ public struct ClaudeStatusProbe: Sendable {
             if let value = self.extractPercent(labelSubstring: label, context: context) { return value }
         }
         return nil
+    }
+
+    private struct ScopedWeeklyUsage {
+        let modelName: String
+        let percentLeft: Int
+        let resetDescription: String?
+    }
+
+    private static func extractScopedWeeklyUsages(context: LabelSearchContext) -> [ScopedWeeklyUsage] {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"current\s+week\s*\(([^)]+)\)"#,
+            options: [.caseInsensitive])
+        else { return [] }
+
+        var seenModels: Set<String> = []
+        var usages: [ScopedWeeklyUsage] = []
+        for (index, line) in context.lines.enumerated() {
+            let range = NSRange(line.startIndex..<line.endIndex, in: line)
+            guard let match = regex.firstMatch(in: line, options: [], range: range),
+                  match.numberOfRanges >= 2,
+                  let modelRange = Range(match.range(at: 1), in: line)
+            else { continue }
+
+            let modelName = String(line[modelRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedModel = self.normalizedForLabelSearch(modelName)
+            guard normalizedModel != "allmodels", !normalizedModel.isEmpty else { continue }
+            guard seenModels.insert(normalizedModel).inserted else { continue }
+
+            let window = context.lines.dropFirst(index).prefix(14)
+            var percentLeft: Int?
+            var resetDescription: String?
+            for candidate in window {
+                let normalized = self.normalizedForLabelSearch(candidate)
+                if normalized.hasPrefix("currentweek"), !normalized.contains(normalizedModel) { break }
+                if percentLeft == nil {
+                    percentLeft = self.percentFromLine(candidate)
+                }
+                if resetDescription == nil {
+                    resetDescription = self.resetFromLine(candidate)
+                }
+            }
+            guard let percentLeft else { continue }
+            usages.append(ScopedWeeklyUsage(
+                modelName: modelName,
+                percentLeft: percentLeft,
+                resetDescription: resetDescription))
+        }
+        return usages
+    }
+
+    private static func extraRateWindows(
+        fromScopedWeeklyUsages usages: [ScopedWeeklyUsage],
+        fallbackResetDescription: String?) -> [NamedRateWindow]
+    {
+        usages.compactMap { usage in
+            let normalizedModel = self.normalizedForLabelSearch(usage.modelName)
+            guard normalizedModel != "opus",
+                  normalizedModel != "sonnet",
+                  normalizedModel != "sonnetonly"
+            else { return nil }
+
+            let usedPercent = max(0, min(100, 100 - Double(usage.percentLeft)))
+            let modelTitle = normalizedModel.hasSuffix("only")
+                ? usage.modelName
+                : "\(usage.modelName) only"
+            let resetDescription = usage.resetDescription ?? fallbackResetDescription
+            return NamedRateWindow(
+                id: "claude-weekly-scoped-\(self.slug(usage.modelName))",
+                title: modelTitle,
+                window: RateWindow(
+                    usedPercent: usedPercent,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: self.parseResetDate(from: resetDescription),
+                    resetDescription: resetDescription))
+        }
+    }
+
+    private static func slug(_ value: String) -> String {
+        var result = ""
+        var lastWasDash = false
+        for scalar in value.lowercased().unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                result.unicodeScalars.append(scalar)
+                lastWasDash = false
+            } else if !lastWasDash {
+                result.append("-")
+                lastWasDash = true
+            }
+        }
+        return result.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
     }
 
     private static func percentFromLine(_ line: String, assumeRemainingWhenUnclear: Bool = false) -> Int? {
@@ -579,7 +701,7 @@ public struct ClaudeStatusProbe: Sendable {
     }
 
     private static func resetFromLine(_ line: String) -> String? {
-        guard let range = line.range(of: "Resets", options: [.caseInsensitive]) else { return nil }
+        guard let range = line.range(of: #"(?i)\bresets?\b"#, options: .regularExpression) else { return nil }
         let raw = String(line[range.lowerBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
         return self.cleanResetLine(raw)
     }
@@ -588,9 +710,9 @@ public struct ClaudeStatusProbe: Sendable {
         String(text.lowercased().unicodeScalars.filter(CharacterSet.alphanumerics.contains))
     }
 
-    /// Capture all "Resets ..." strings to surface in the menu.
+    /// Capture all "Reset"/"Resets" strings to surface in the menu.
     private static func allResets(_ text: String) -> [String] {
-        let pat = #"Resets[^\r\n]*"#
+        let pat = #"\bResets?\b[^\r\n]*"#
         guard let regex = try? NSRegularExpression(pattern: pat, options: [.caseInsensitive]) else { return [] }
         let nsrange = NSRange(text.startIndex..<text.endIndex, in: text)
         var results: [String] = []
@@ -607,6 +729,10 @@ public struct ClaudeStatusProbe: Sendable {
         // TTY capture sometimes appends a stray ")" at line ends; trim it to keep snapshots stable.
         var cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         cleaned = cleaned.trimmingCharacters(in: CharacterSet(charactersIn: " )"))
+        cleaned = cleaned.replacingOccurrences(
+            of: #"(?i)\b([A-Za-z]{3}\s+\d{1,2})\s+t\s+(\d)"#,
+            with: "$1 at $2",
+            options: .regularExpression)
         let openCount = cleaned.count(where: { $0 == "(" })
         let closeCount = cleaned.count(where: { $0 == ")" })
         if openCount > closeCount { cleaned.append(")") }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -220,31 +220,29 @@ extension ClaudeStatusProbe {
 
         var sessionPct = self.extractPercent(labelSubstring: "Current session", context: labelContext)
         var weeklyPct = self.extractPercent(labelSubstring: "Current week (all models)", context: labelContext)
-        var opusPct = self.extractPercent(
-            labelSubstrings: [
-                "Current week (Opus)",
-                "Current week (Sonnet only)",
-                "Current week (Sonnet)",
-            ],
-            context: labelContext)
+        let opusLabels = [
+            "Current week (Opus)",
+            "Current week (Sonnet only)",
+            "Current week (Sonnet)",
+        ]
+        let opusPct = self.extractPercent(labelSubstrings: opusLabels, context: labelContext)
 
         // Fallback: order-based percent scraping when labels are present but the surrounding layout moved.
         // Only apply the fallback when the corresponding label exists in the rendered panel; enterprise accounts
         // may omit the weekly panel entirely, and we should treat that as "unavailable" rather than guessing.
         let hasAllModelsWeeklyLabel = labelContext.contains(
             self.normalizedForLabelSearch("Current week (all models)"))
-        let hasOpusLabel = labelContext.contains("opus") || labelContext.contains("sonnet")
+        let hasOpusLabel = opusLabels.contains {
+            labelContext.contains(self.normalizedForLabelSearch($0))
+        }
 
-        if sessionPct == nil || (hasAllModelsWeeklyLabel && weeklyPct == nil) || (hasOpusLabel && opusPct == nil) {
+        if sessionPct == nil || (hasAllModelsWeeklyLabel && weeklyPct == nil) {
             let ordered = self.allPercents(usagePanelText)
             if sessionPct == nil, ordered.indices.contains(0) {
                 sessionPct = ordered[0]
             }
             if hasAllModelsWeeklyLabel, weeklyPct == nil, ordered.indices.contains(1) {
                 weeklyPct = ordered[1]
-            }
-            if hasOpusLabel, opusPct == nil, ordered.indices.contains(2) {
-                opusPct = ordered[2]
             }
         }
 
@@ -270,13 +268,7 @@ extension ClaudeStatusProbe {
             ? self.extractReset(labelSubstring: "Current week (all models)", context: labelContext)
             : nil
         let opusReset = hasOpusLabel
-            ? self.extractReset(
-                labelSubstrings: [
-                    "Current week (Opus)",
-                    "Current week (Sonnet only)",
-                    "Current week (Sonnet)",
-                ],
-                context: labelContext)
+            ? self.extractReset(labelSubstrings: opusLabels, context: labelContext)
             : nil
         let scopedWeeklyUsages = self.extractScopedWeeklyUsages(context: labelContext)
         let extraRateWindows = self.extraRateWindows(
@@ -736,7 +728,9 @@ extension ClaudeStatusProbe {
     }
 
     private static func resetFromLine(_ line: String) -> String? {
-        guard let range = line.range(of: #"(?i)\bresets?\b"#, options: .regularExpression) else { return nil }
+        let range = line.range(of: #"(?i)\bresets?\b"#, options: .regularExpression)
+            ?? line.range(of: #"\b(?:Reset|Resets)(?=[A-Z0-9])"#, options: .regularExpression)
+        guard let range else { return nil }
         let raw = String(line[range.lowerBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
         return self.cleanResetLine(raw)
     }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -1428,11 +1428,17 @@ extension ClaudeUsageFetcher {
         guard !web.isEmpty else { return primary }
 
         let primaryScopedKeys = Set(primary.compactMap(self.scopedExtraRateWindowMergeKey))
+        var webScopedIDsByKey: [String: Set<String>] = [:]
+        for window in web {
+            guard let scopedKey = self.scopedExtraRateWindowMergeKey(window) else { continue }
+            webScopedIDsByKey[scopedKey, default: []].insert(window.id)
+        }
         var seenIDs = Set(primary.map(\.id))
         var merged = primary
         for window in web where seenIDs.insert(window.id).inserted {
             if let scopedKey = self.scopedExtraRateWindowMergeKey(window),
-               primaryScopedKeys.contains(scopedKey)
+               primaryScopedKeys.contains(scopedKey),
+               webScopedIDsByKey[scopedKey]?.count == 1
             {
                 continue
             }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -1346,7 +1346,7 @@ extension ClaudeUsageFetcher {
             primary: primary,
             secondary: weekly,
             opus: opus,
-            extraRateWindows: [],
+            extraRateWindows: snap.extraRateWindows,
             providerCost: nil,
             updatedAt: Date(),
             accountEmail: snap.accountEmail,
@@ -1375,8 +1375,9 @@ extension ClaudeUsageFetcher {
                     }
                 }
             // Only merge usage/cost extras; keep identity fields from the primary data source.
-            let mergedExtraRateWindows = snapshot.extraRateWindows.isEmpty ? webData.extraRateWindows : snapshot
-                .extraRateWindows
+            let mergedExtraRateWindows = Self.mergeExtraRateWindows(
+                primary: snapshot.extraRateWindows,
+                web: webData.extraRateWindows)
             let mergedProviderCost = snapshot.providerCost ?? webData.extraUsageCost
             if mergedProviderCost != snapshot.providerCost || mergedExtraRateWindows != snapshot.extraRateWindows {
                 return ClaudeUsageSnapshot(
@@ -1401,6 +1402,21 @@ extension ClaudeUsageFetcher {
             Self.log.debug("Claude web extras fetch failed: \(error.localizedDescription)")
         }
         return snapshot
+    }
+
+    private static func mergeExtraRateWindows(
+        primary: [NamedRateWindow],
+        web: [NamedRateWindow]) -> [NamedRateWindow]
+    {
+        guard !primary.isEmpty else { return web }
+        guard !web.isEmpty else { return primary }
+
+        var seenIDs = Set(primary.map(\.id))
+        var merged = primary
+        for window in web where seenIDs.insert(window.id).inserted {
+            merged.append(window)
+        }
+        return merged
     }
 
     // MARK: - Process helpers
@@ -1468,6 +1484,13 @@ extension ClaudeUsageFetcher {
 
 #if DEBUG
 extension ClaudeUsageFetcher {
+    public static func _mergeExtraRateWindowsForTesting(
+        primary: [NamedRateWindow],
+        web: [NamedRateWindow]) -> [NamedRateWindow]
+    {
+        Self.mergeExtraRateWindows(primary: primary, web: web)
+    }
+
     public static func _mapOAuthUsageForTesting(
         _ data: Data,
         rateLimitTier: String? = nil,

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -611,7 +611,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             do {
                 return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliAutoProbeTimeout)
             } catch {
-                if error is CancellationError { throw error }
+                if error is CancellationError {
+                    throw error
+                }
                 guard Self.shouldRetryCLIProbe(after: error) else { throw error }
                 return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliRetryProbeTimeout)
             }
@@ -621,7 +623,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             do {
                 return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliProbeTimeout)
             } catch {
-                if error is CancellationError { throw error }
+                if error is CancellationError {
+                    throw error
+                }
                 guard Self.shouldRetryCLIProbe(after: error) else { throw error }
                 return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliRetryProbeTimeout)
             }
@@ -636,7 +640,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             do {
                 snapshot = try await self.fetcher.loadViaPTY(model: model, timeout: timeout)
             } catch {
-                if error is CancellationError { throw error }
+                if error is CancellationError {
+                    throw error
+                }
                 if ClaudeUsageFetcher.isCLIRateLimitError(error) {
                     ClaudeCLIRateLimitGate.recordRateLimit()
                     throw error
@@ -647,7 +653,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     snapshot = try await self.fetcher.loadViaDirectCLI(
                         timeout: Self.directCLIUsageTimeout(for: timeout))
                 } catch let directError {
-                    if directError is CancellationError { throw directError }
+                    if directError is CancellationError {
+                        throw directError
+                    }
                     if ClaudeUsageFetcher.isCLIRateLimitError(directError) {
                         ClaudeCLIRateLimitGate.recordRateLimit()
                         throw directError
@@ -676,7 +684,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         }
 
         private static func shouldTryDirectCLIUsage(after error: Error) -> Bool {
-            if case ClaudeStatusProbeError.timedOut = error { return true }
+            if case ClaudeStatusProbeError.timedOut = error {
+                return true
+            }
             if case let ClaudeStatusProbeError.parseFailed(message) = error {
                 let lower = message.lowercased()
                 return lower.contains("still loading usage") || lower.contains("could not load usage data")
@@ -686,7 +696,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         }
 
         private static func shouldRetryCLIProbe(after error: Error) -> Bool {
-            if case ClaudeStatusProbeError.timedOut = error { return true }
+            if case ClaudeStatusProbeError.timedOut = error {
+                return true
+            }
             if case let ClaudeStatusProbeError.parseFailed(message) = error {
                 return message.lowercased().contains("still loading usage")
             }
@@ -719,7 +731,9 @@ extension ClaudeUsageFetcher {
 
         func firstWindowDict(_ keys: [String]) -> [String: Any]? {
             for key in keys {
-                if let dict = obj[key] as? [String: Any] { return dict }
+                if let dict = obj[key] as? [String: Any] {
+                    return dict
+                }
             }
             return nil
         }
@@ -795,7 +809,9 @@ extension ClaudeUsageFetcher {
             df.locale = Locale(identifier: "en_US_POSIX")
             df.timeZone = tz ?? TimeZone.current
             df.dateFormat = format
-            if let t = timePart, let date = df.date(from: t) { return date }
+            if let t = timePart, let date = df.date(from: t) {
+                return date
+            }
         }
         return nil
     }
@@ -1411,12 +1427,30 @@ extension ClaudeUsageFetcher {
         guard !primary.isEmpty else { return web }
         guard !web.isEmpty else { return primary }
 
+        let primaryScopedKeys = Set(primary.compactMap(self.scopedExtraRateWindowMergeKey))
         var seenIDs = Set(primary.map(\.id))
         var merged = primary
         for window in web where seenIDs.insert(window.id).inserted {
+            if let scopedKey = self.scopedExtraRateWindowMergeKey(window),
+               primaryScopedKeys.contains(scopedKey)
+            {
+                continue
+            }
             merged.append(window)
         }
         return merged
+    }
+
+    private static func scopedExtraRateWindowMergeKey(_ window: NamedRateWindow) -> String? {
+        guard window.id.hasPrefix("claude-weekly-scoped-") else { return nil }
+
+        let modelName = window.title.replacingOccurrences(
+            of: #"\s+only\s*$"#,
+            with: "",
+            options: [.regularExpression, .caseInsensitive])
+        let normalizedName = String(modelName.lowercased().unicodeScalars.filter(CharacterSet.alphanumerics.contains))
+        guard !normalizedName.isEmpty else { return nil }
+        return normalizedName
     }
 
     // MARK: - Process helpers
@@ -1488,7 +1522,7 @@ extension ClaudeUsageFetcher {
         primary: [NamedRateWindow],
         web: [NamedRateWindow]) -> [NamedRateWindow]
     {
-        Self.mergeExtraRateWindows(primary: primary, web: web)
+        self.mergeExtraRateWindows(primary: primary, web: web)
     }
 
     public static func _mapOAuthUsageForTesting(

--- a/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
@@ -118,6 +118,24 @@ struct ClaudeCLIScopedWeeklyUsageTests {
     }
 
     @Test
+    func `Sonnet prefixed scoped model does not become legacy quota`() throws {
+        let snapshot = try ClaudeStatusProbe.parse(text: """
+        Current session
+        9% used
+
+        Current week (all models)
+        20% used
+
+        Current week (Sonnet Test Variant)
+        42% used
+        """)
+
+        #expect(snapshot.opusPercentLeft == nil)
+        #expect(snapshot.extraRateWindows.map(\.title) == ["Sonnet Test Variant only"])
+        #expect(snapshot.extraRateWindows.first?.window.usedPercent == 42)
+    }
+
+    @Test
     func `later complete scoped panel replaces partial redraw`() throws {
         let spacer = Array(repeating: "rendering", count: 14).joined(separator: "\n")
         let cliUsage = """

--- a/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
@@ -144,6 +144,26 @@ struct ClaudeCLIScopedWeeklyUsageTests {
     }
 
     @Test
+    func `incomplete all models panel does not consume scoped percentage`() throws {
+        let cliUsage = """
+        Current session
+        9% used
+
+        Current week (all models)
+        rendering
+
+        Current week (Fable)
+        42% used
+        """
+
+        let snapshot = try ClaudeStatusProbe.parse(text: cliUsage)
+
+        #expect(snapshot.weeklyPercentLeft == nil)
+        #expect(snapshot.extraRateWindows.map(\.title) == ["Fable only"])
+        #expect(snapshot.extraRateWindows.first?.window.usedPercent == 42)
+    }
+
+    @Test
     func `later complete scoped panel replaces earlier complete value`() throws {
         let cliUsage = """
         Current session

--- a/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
@@ -67,6 +67,37 @@ struct ClaudeCLIScopedWeeklyUsageTests {
     }
 
     @Test
+    func `compact scoped weekly label is parsed`() throws {
+        let snapshot = try ClaudeStatusProbe.parse(text: """
+        Current session
+        9% used
+
+        Currentweek(Fable)
+        68% used
+        """)
+
+        #expect(snapshot.extraRateWindows.map(\.title) == ["Fable only"])
+        #expect(snapshot.extraRateWindows.first?.window.usedPercent == 68)
+    }
+
+    @Test
+    func `overlapping scoped model names do not cross panel boundaries`() throws {
+        let snapshot = try ClaudeStatusProbe.parse(text: """
+        Current session
+        9% used
+
+        Current week (Example Model)
+        rendering
+
+        Current week (Example Model Plus)
+        42% used
+        """)
+
+        #expect(snapshot.extraRateWindows.map(\.title) == ["Example Model Plus only"])
+        #expect(snapshot.extraRateWindows.first?.window.usedPercent == 42)
+    }
+
+    @Test
     func `later complete scoped panel replaces partial redraw`() throws {
         let spacer = Array(repeating: "rendering", count: 14).joined(separator: "\n")
         let cliUsage = """
@@ -171,6 +202,38 @@ struct ClaudeCLIScopedWeeklyUsageTests {
             web: webLimits)
 
         #expect(merged.map(\.id) == [
+            "claude-weekly-scoped-first-id",
+            "claude-weekly-scoped-second-id",
+        ])
+    }
+
+    @Test
+    func `ambiguous same title web limits survive CLI merge`() {
+        let cli = NamedRateWindow(
+            id: "claude-weekly-scoped-example-model",
+            title: "Example Model only",
+            window: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: nil))
+        let webLimits = ["first-id", "second-id"].map { id in
+            NamedRateWindow(
+                id: "claude-weekly-scoped-\(id)",
+                title: "Example Model only",
+                window: RateWindow(
+                    usedPercent: 25,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil))
+        }
+
+        let merged = ClaudeUsageFetcher._mergeExtraRateWindowsForTesting(
+            primary: [cli],
+            web: webLimits)
+
+        #expect(merged.map(\.id) == [
+            "claude-weekly-scoped-example-model",
             "claude-weekly-scoped-first-id",
             "claude-weekly-scoped-second-id",
         ])

--- a/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+struct ClaudeCLIScopedWeeklyUsageTests {
+    @Test
+    func `CLI usage surfaces Fable scoped weekly limit`() async throws {
+        let cliUsage = """
+        Settings  Status  Config  Usage  Stats
+
+        Current session
+        9% used
+        Resets 2:09pm (Europe/Prague)
+
+        Current week (all models)
+        67% used
+        Resets Jul 10 t 2:59am (Europe/Prague)
+
+        Current week (Fable)
+        68% used
+        Reset Jul 10 at 2:59am (Europe/Prague)
+
+        Current week (Example Model)
+        12% used
+        """
+        let status = try ClaudeStatusProbe.parse(text: cliUsage)
+        let fetcher = ClaudeUsageFetcher(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            environment: [:],
+            dataSource: .cli)
+        let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in status }
+
+        let snapshot = try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+            try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                try await fetcher.loadLatestUsage(model: "sonnet")
+            }
+        }
+
+        let fable = try #require(snapshot.extraRateWindows.first { $0.id == "claude-weekly-scoped-fable" })
+        #expect(fable.title == "Fable only")
+        #expect(fable.window.usedPercent == 68)
+        #expect(fable.window.resetDescription == "Reset Jul 10 at 2:59am (Europe/Prague)")
+        let example = try #require(
+            snapshot.extraRateWindows.first { $0.id == "claude-weekly-scoped-example-model" })
+        #expect(example.title == "Example Model only")
+        #expect(example.window.usedPercent == 12)
+        #expect(example.window.resetDescription == "Resets Jul 10 at 2:59am (Europe/Prague)")
+        #expect(snapshot.opus == nil)
+    }
+
+    @Test
+    func `scoped weekly panel does not become all models weekly usage`() throws {
+        let cliUsage = """
+        Current session
+        9% used
+
+        Current week (Fable)
+        68% used
+        """
+
+        let snapshot = try ClaudeStatusProbe.parse(text: cliUsage)
+
+        #expect(snapshot.weeklyPercentLeft == nil)
+        #expect(snapshot.secondaryResetDescription == nil)
+        #expect(snapshot.extraRateWindows.map(\.title) == ["Fable only"])
+    }
+
+    @Test
+    func `later complete scoped panel replaces partial redraw`() throws {
+        let spacer = Array(repeating: "rendering", count: 14).joined(separator: "\n")
+        let cliUsage = """
+        Current session
+        9% used
+
+        Current week (all models)
+        67% used
+
+        Current week (Fable)
+        \(spacer)
+
+        Current week (Fable)
+        70% used
+        Reset Jul 10 at 2:59am (Europe/Prague)
+        """
+
+        let snapshot = try ClaudeStatusProbe.parse(text: cliUsage)
+        let fable = try #require(snapshot.extraRateWindows.first)
+
+        #expect(snapshot.extraRateWindows.count == 1)
+        #expect(fable.window.usedPercent == 70)
+        #expect(fable.window.resetDescription == "Reset Jul 10 at 2:59am (Europe/Prague)")
+    }
+
+    @Test
+    func `later complete scoped panel replaces earlier complete value`() throws {
+        let cliUsage = """
+        Current session
+        9% used
+
+        Current week (all models)
+        67% used
+
+        Current week (Fable)
+        20% used
+
+        Current week (Fable)
+        70% used
+        """
+
+        let snapshot = try ClaudeStatusProbe.parse(text: cliUsage)
+        let fable = try #require(snapshot.extraRateWindows.first)
+
+        #expect(snapshot.extraRateWindows.count == 1)
+        #expect(fable.window.usedPercent == 70)
+    }
+
+    @Test
+    func `web extra windows merge with CLI scoped weekly limits`() throws {
+        let fable = NamedRateWindow(
+            id: "claude-weekly-scoped-fable",
+            title: "Fable only",
+            window: RateWindow(
+                usedPercent: 68,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "Resets Jul 10 at 2:59am (Europe/Prague)"))
+        let webFable = try #require(ClaudeScopedWeeklyLimitMapper.extraRateWindows(from: [
+            ClaudeScopedWeeklyLimitMapper.Limit(
+                kind: "weekly_scoped",
+                group: "weekly",
+                percent: 70,
+                resetsAt: nil,
+                modelID: "test-only-fable-id",
+                modelName: "Fable"),
+        ]).first)
+        let routines = NamedRateWindow(
+            id: "claude-routines",
+            title: "Daily Routines",
+            window: RateWindow(
+                usedPercent: 11,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: nil))
+
+        let merged = ClaudeUsageFetcher._mergeExtraRateWindowsForTesting(
+            primary: [fable],
+            web: [webFable, routines])
+
+        #expect(merged.map(\.id) == ["claude-weekly-scoped-fable", "claude-routines"])
+        #expect(webFable.id == "claude-weekly-scoped-test-only-fable-id")
+        #expect(merged.first?.window.usedPercent == 68)
+        #expect(merged.last?.title == "Daily Routines")
+    }
+
+    @Test
+    func `same title web limits keep distinct stable IDs`() {
+        let webLimits = ["first-id", "second-id"].map { id in
+            NamedRateWindow(
+                id: "claude-weekly-scoped-\(id)",
+                title: "Example Model only",
+                window: RateWindow(
+                    usedPercent: 25,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil))
+        }
+
+        let merged = ClaudeUsageFetcher._mergeExtraRateWindowsForTesting(
+            primary: [],
+            web: webLimits)
+
+        #expect(merged.map(\.id) == [
+            "claude-weekly-scoped-first-id",
+            "claude-weekly-scoped-second-id",
+        ])
+    }
+}

--- a/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
@@ -162,6 +162,26 @@ struct ClaudeCLIScopedWeeklyUsageTests {
     }
 
     @Test
+    func `incomplete scoped panel stops at session redraw`() throws {
+        let cliUsage = """
+        Current week (Fable)
+        rendering
+
+        Current session
+        9% used
+
+        Current week (all models)
+        20% used
+        """
+
+        let snapshot = try ClaudeStatusProbe.parse(text: cliUsage)
+
+        #expect(snapshot.sessionPercentLeft == 91)
+        #expect(snapshot.weeklyPercentLeft == 80)
+        #expect(snapshot.extraRateWindows.isEmpty)
+    }
+
+    @Test
     func `incomplete all models panel does not consume scoped percentage`() throws {
         let cliUsage = """
         Current session

--- a/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
@@ -182,6 +182,29 @@ struct ClaudeCLIScopedWeeklyUsageTests {
     }
 
     @Test
+    func `incomplete Opus panel does not consume prefixed scoped percentage`() throws {
+        let cliUsage = """
+        Current session
+        9% used
+
+        Current week (all models)
+        20% used
+
+        Current week (Opus)
+        rendering
+
+        Current week (Opus Test Variant)
+        42% used
+        """
+
+        let snapshot = try ClaudeStatusProbe.parse(text: cliUsage)
+
+        #expect(snapshot.opusPercentLeft == nil)
+        #expect(snapshot.extraRateWindows.map(\.title) == ["Opus Test Variant only"])
+        #expect(snapshot.extraRateWindows.first?.window.usedPercent == 42)
+    }
+
+    @Test
     func `later complete scoped panel replaces earlier complete value`() throws {
         let cliUsage = """
         Current session

--- a/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIScopedWeeklyUsageTests.swift
@@ -98,6 +98,26 @@ struct ClaudeCLIScopedWeeklyUsageTests {
     }
 
     @Test
+    func `informational Sonnet prose does not duplicate a scoped limit`() throws {
+        let snapshot = try ClaudeStatusProbe.parse(text: """
+        Current session
+        9% used
+
+        Current week (all models)
+        20% used
+
+        Current week (Fable)
+        42% used
+
+        Sonnet now has its own limit.
+        """)
+
+        #expect(snapshot.opusPercentLeft == nil)
+        #expect(snapshot.extraRateWindows.map(\.title) == ["Fable only"])
+        #expect(snapshot.extraRateWindows.first?.window.usedPercent == 42)
+    }
+
+    @Test
     func `later complete scoped panel replaces partial redraw`() throws {
         let spacer = Array(repeating: "rendering", count: 14).joined(separator: "\n")
         let cliUsage = """

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -48,6 +48,86 @@ struct ClaudeUsageTests {
     }
 
     @Test
+    func `CLI usage surfaces Fable scoped weekly limit`() async throws {
+        let cliUsage = """
+        Settings  Status  Config  Usage  Stats
+
+        Current session
+        9% used
+        Resets 2:09pm (Europe/Prague)
+
+        Current week (all models)
+        67% used
+        Resets Jul 10 t 2:59am (Europe/Prague)
+
+        Current week (Fable)
+        68% used
+        Reset Jul 10 at 2:59am (Europe/Prague)
+
+        Current week (Compass)
+        12% used
+        """
+        let status = try ClaudeStatusProbe.parse(text: cliUsage)
+        let fetcher = ClaudeUsageFetcher(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            environment: [:],
+            dataSource: .cli)
+        let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in status }
+
+        let snapshot = try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+            try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                try await fetcher.loadLatestUsage(model: "sonnet")
+            }
+        }
+
+        let fable = try #require(snapshot.extraRateWindows.first { $0.id == "claude-weekly-scoped-fable" })
+        #expect(fable.title == "Fable only")
+        #expect(fable.window.usedPercent == 68)
+        #expect(fable.window.resetDescription == "Reset Jul 10 at 2:59am (Europe/Prague)")
+        let compass = try #require(snapshot.extraRateWindows.first { $0.id == "claude-weekly-scoped-compass" })
+        #expect(compass.title == "Compass only")
+        #expect(compass.window.usedPercent == 12)
+        #expect(compass.window.resetDescription == "Resets Jul 10 at 2:59am (Europe/Prague)")
+        #expect(snapshot.opus == nil)
+    }
+
+    @Test
+    func `web extra windows merge with CLI scoped weekly limits`() {
+        let fable = NamedRateWindow(
+            id: "claude-weekly-scoped-fable",
+            title: "Fable only",
+            window: RateWindow(
+                usedPercent: 68,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "Resets Jul 10 at 2:59am (Europe/Prague)"))
+        let webFable = NamedRateWindow(
+            id: "claude-weekly-scoped-fable",
+            title: "Fable only",
+            window: RateWindow(
+                usedPercent: 70,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "Resets Jul 10 at 2:59am (Europe/Prague)"))
+        let routines = NamedRateWindow(
+            id: "claude-routines",
+            title: "Daily Routines",
+            window: RateWindow(
+                usedPercent: 11,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: nil))
+
+        let merged = ClaudeUsageFetcher._mergeExtraRateWindowsForTesting(
+            primary: [fable],
+            web: [webFable, routines])
+
+        #expect(merged.map(\.id) == ["claude-weekly-scoped-fable", "claude-routines"])
+        #expect(merged.first?.window.usedPercent == 68)
+        #expect(merged.last?.title == "Daily Routines")
+    }
+
+    @Test
     func `oauth delegated retry retries once then succeeds`() async throws {
         let loadCounter = AsyncCounter()
         let delegatedCounter = AsyncCounter()

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -17,16 +17,6 @@ struct ClaudeUsageTests {
         }
     }
 
-    private static func makeOAuthUsageResponse() throws -> OAuthUsageResponse {
-        let json = """
-        {
-          "five_hour": { "utilization": 7, "resets_at": "2025-12-23T16:00:00.000Z" },
-          "seven_day": { "utilization": 21, "resets_at": "2025-12-29T23:00:00.000Z" }
-        }
-        """
-        return try ClaudeOAuthUsageFetcher._decodeUsageResponseForTesting(Data(json.utf8))
-    }
-
     @Test
     func `parses usage JSON with sonnet limit`() {
         let json = """
@@ -45,86 +35,6 @@ struct ClaudeUsageTests {
         #expect(snap?.secondary?.usedPercent == 8)
         #expect(snap?.secondary?.windowMinutes == 10080)
         #expect(snap?.primary.resetDescription == "11am (Europe/Vienna)")
-    }
-
-    @Test
-    func `CLI usage surfaces Fable scoped weekly limit`() async throws {
-        let cliUsage = """
-        Settings  Status  Config  Usage  Stats
-
-        Current session
-        9% used
-        Resets 2:09pm (Europe/Prague)
-
-        Current week (all models)
-        67% used
-        Resets Jul 10 t 2:59am (Europe/Prague)
-
-        Current week (Fable)
-        68% used
-        Reset Jul 10 at 2:59am (Europe/Prague)
-
-        Current week (Compass)
-        12% used
-        """
-        let status = try ClaudeStatusProbe.parse(text: cliUsage)
-        let fetcher = ClaudeUsageFetcher(
-            browserDetection: BrowserDetection(cacheTTL: 0),
-            environment: [:],
-            dataSource: .cli)
-        let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in status }
-
-        let snapshot = try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
-            try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
-                try await fetcher.loadLatestUsage(model: "sonnet")
-            }
-        }
-
-        let fable = try #require(snapshot.extraRateWindows.first { $0.id == "claude-weekly-scoped-fable" })
-        #expect(fable.title == "Fable only")
-        #expect(fable.window.usedPercent == 68)
-        #expect(fable.window.resetDescription == "Reset Jul 10 at 2:59am (Europe/Prague)")
-        let compass = try #require(snapshot.extraRateWindows.first { $0.id == "claude-weekly-scoped-compass" })
-        #expect(compass.title == "Compass only")
-        #expect(compass.window.usedPercent == 12)
-        #expect(compass.window.resetDescription == "Resets Jul 10 at 2:59am (Europe/Prague)")
-        #expect(snapshot.opus == nil)
-    }
-
-    @Test
-    func `web extra windows merge with CLI scoped weekly limits`() {
-        let fable = NamedRateWindow(
-            id: "claude-weekly-scoped-fable",
-            title: "Fable only",
-            window: RateWindow(
-                usedPercent: 68,
-                windowMinutes: 7 * 24 * 60,
-                resetsAt: nil,
-                resetDescription: "Resets Jul 10 at 2:59am (Europe/Prague)"))
-        let webFable = NamedRateWindow(
-            id: "claude-weekly-scoped-fable",
-            title: "Fable only",
-            window: RateWindow(
-                usedPercent: 70,
-                windowMinutes: 7 * 24 * 60,
-                resetsAt: nil,
-                resetDescription: "Resets Jul 10 at 2:59am (Europe/Prague)"))
-        let routines = NamedRateWindow(
-            id: "claude-routines",
-            title: "Daily Routines",
-            window: RateWindow(
-                usedPercent: 11,
-                windowMinutes: 7 * 24 * 60,
-                resetsAt: nil,
-                resetDescription: nil))
-
-        let merged = ClaudeUsageFetcher._mergeExtraRateWindowsForTesting(
-            primary: [fable],
-            web: [webFable, routines])
-
-        #expect(merged.map(\.id) == ["claude-weekly-scoped-fable", "claude-routines"])
-        #expect(merged.first?.window.usedPercent == 68)
-        #expect(merged.last?.title == "Daily Routines")
     }
 
     @Test
@@ -653,8 +563,12 @@ struct ClaudeUsageTests {
                 "session_5h": ["pct_used": 0, "resets": ""],
                 "week_all_models": ["pct_used": 0, "resets": ""],
             ] as [String: Any]
-            if let email = entry["email"] { payload["account_email"] = email }
-            if let org = entry["org"] { payload["account_org"] = org }
+            if let email = entry["email"] {
+                payload["account_email"] = email
+            }
+            if let org = entry["org"] {
+                payload["account_org"] = org
+            }
             let data = try JSONSerialization.data(withJSONObject: payload)
             let snap = ClaudeUsageFetcher.parse(json: data)
             let emailRaw: String? = entry["email"] ?? String?.none
@@ -715,7 +629,9 @@ struct ClaudeUsageTests {
 
         try process.run()
         DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
-            if process.isRunning { process.terminate() }
+            if process.isRunning {
+                process.terminate()
+            }
         }
         process.waitUntilExit()
 
@@ -959,6 +875,18 @@ struct ClaudeUsageTests {
         #expect(defaultVersion?.isEmpty != true)
         #expect(webVersion?.isEmpty != true)
         #expect(cliVersion?.isEmpty != true)
+    }
+}
+
+extension ClaudeUsageTests {
+    private static func makeOAuthUsageResponse() throws -> OAuthUsageResponse {
+        let json = """
+        {
+          "five_hour": { "utilization": 7, "resets_at": "2025-12-23T16:00:00.000Z" },
+          "seven_day": { "utilization": 21, "resets_at": "2025-12-29T23:00:00.000Z" }
+        }
+        """
+        return try ClaudeOAuthUsageFetcher._decodeUsageResponseForTesting(Data(json.utf8))
     }
 }
 


### PR DESCRIPTION
- Preserve model-scoped weekly limits from the Claude CLI `/usage` parser as named extra windows.
- This surfaces `Current week (Fable)` from Claude CLI as `Fable only` in CodexBar, matching the OAuth/Web scoped-limit behavior.
- Handles live CLI reset variants (`Reset` vs `Resets`) and falls back to the all-model weekly reset when a scoped weekly reset line is omitted by the TUI capture.

Verification:
- `swift test --filter ClaudeUsageTests`
- Live proof: `.build/arm64-apple-macosx/debug/CodexBarCLI usage --provider claude --source cli --format json --pretty`
  - Claude CLI `2.1.204`
  - `extraRateWindows[0].id`: `claude-weekly-scoped-fable`
  - `extraRateWindows[0].title`: `Fable only`
  - `extraRateWindows[0].window.usedPercent`: `70`
  - `extraRateWindows[0].window.resetDescription`: `Resets Jul 10 at 3am (Europe/Prague)`
  - `extraRateWindows[0].window.resetsAt`: `2026-07-10T01:00:00Z`
