### PR TITLE
Fix visual settings refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Agent Sessions: list and focus live local or SSH-discovered Codex and Claude Code sessions from the menu and CLI.
 
 ### Fixed
+- Settings: keep visual-only preference changes on cached UI paths instead of refreshing provider quotas, while preserving refreshes for data-affecting settings. Thanks @Zihao-Qi!
 - Ollama: recognize current WorkOS AuthKit sessions during browser-cookie discovery and manual cookie validation. Thanks @joeVenner!
 - Ollama: classify current WorkOS sign-in redirects as expired sessions, enabling cookie-candidate fallback instead of a parser error. Thanks @joeVenner!
 

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -5,11 +5,16 @@ import ServiceManagement
 extension SettingsStore {
     private static let mergedOverviewSelectionEditedActiveProvidersKey = "mergedOverviewSelectionEditedActiveProviders"
 
+    private func noteBackgroundWorkSettingsChanged() {
+        self.backgroundWorkSettingsRevision &+= 1
+    }
+
     var refreshFrequency: RefreshFrequency {
         get { self.defaultsState.refreshFrequency }
         set {
             self.defaultsState.refreshFrequency = newValue
             self.userDefaults.set(newValue.rawValue, forKey: "refreshFrequency")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -49,6 +54,7 @@ extension SettingsStore {
                 Self.sharedDefaults?.set(newValue, forKey: "debugDisableKeychainAccess")
             }
             KeychainAccessGate.isDisabled = newValue
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -78,6 +84,7 @@ extension SettingsStore {
         set {
             self.defaultsState.debugKeepCLISessionsAlive = newValue
             self.userDefaults.set(newValue, forKey: "debugKeepCLISessionsAlive")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -102,6 +109,7 @@ extension SettingsStore {
         set {
             self.defaultsState.statusChecksEnabled = newValue
             self.userDefaults.set(newValue, forKey: "statusChecksEnabled")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -110,6 +118,7 @@ extension SettingsStore {
         set {
             self.defaultsState.sessionQuotaNotificationsEnabled = newValue
             self.userDefaults.set(newValue, forKey: "sessionQuotaNotificationsEnabled")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -118,6 +127,7 @@ extension SettingsStore {
         set {
             self.defaultsState.quotaWarningNotificationsEnabled = newValue
             self.userDefaults.set(newValue, forKey: "quotaWarningNotificationsEnabled")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -131,6 +141,7 @@ extension SettingsStore {
             self.userDefaults.set(sanitized, forKey: "quotaWarningThresholds")
             self.userDefaults.set(sanitized, forKey: "quotaWarningSessionThresholds")
             self.userDefaults.set(sanitized, forKey: "quotaWarningWeeklyThresholds")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -153,6 +164,7 @@ extension SettingsStore {
             self.defaultsState.quotaWarningWeeklyThresholdsRaw = sanitized
             self.userDefaults.set(sanitized, forKey: "quotaWarningWeeklyThresholds")
         }
+        self.noteBackgroundWorkSettingsChanged()
     }
 
     func quotaWarningWindowEnabled(_ window: QuotaWarningWindow) -> Bool {
@@ -173,6 +185,7 @@ extension SettingsStore {
             self.defaultsState.quotaWarningWeeklyEnabled = enabled
             self.userDefaults.set(enabled, forKey: "quotaWarningWeeklyEnabled")
         }
+        self.noteBackgroundWorkSettingsChanged()
     }
 
     var quotaWarningSoundEnabled: Bool {
@@ -180,6 +193,7 @@ extension SettingsStore {
         set {
             self.defaultsState.quotaWarningSoundEnabled = newValue
             self.userDefaults.set(newValue, forKey: "quotaWarningSoundEnabled")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -290,6 +304,7 @@ extension SettingsStore {
         set {
             self.defaultsState.multiAccountMenuLayoutRaw = newValue.rawValue
             self.userDefaults.set(newValue.rawValue, forKey: "multiAccountMenuLayout")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -303,6 +318,7 @@ extension SettingsStore {
         set {
             self.defaultsState.historicalTrackingEnabled = newValue
             self.userDefaults.set(newValue, forKey: "historicalTrackingEnabled")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -327,6 +343,7 @@ extension SettingsStore {
         set {
             self.defaultsState.costUsageEnabled = newValue
             self.userDefaults.set(newValue, forKey: "tokenCostUsageEnabled")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -336,6 +353,7 @@ extension SettingsStore {
             let clamped = max(1, min(365, newValue))
             self.defaultsState.costUsageHistoryDays = clamped
             self.userDefaults.set(clamped, forKey: "tokenCostUsageHistoryDays")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -408,6 +426,7 @@ extension SettingsStore {
         set {
             self.defaultsState.claudeOAuthKeychainPromptModeRaw = newValue.rawValue
             self.userDefaults.set(newValue.rawValue, forKey: "claudeOAuthKeychainPromptMode")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -422,6 +441,7 @@ extension SettingsStore {
         set {
             self.defaultsState.claudeOAuthKeychainReadStrategyRaw = newValue.rawValue
             self.userDefaults.set(newValue.rawValue, forKey: "claudeOAuthKeychainReadStrategy")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -450,6 +470,7 @@ extension SettingsStore {
             CodexBarLog.logger(LogCategories.settings).info(
                 "Copilot budget extras updated",
                 metadata: ["enabled": newValue ? "1" : "0"])
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -461,6 +482,7 @@ extension SettingsStore {
             CodexBarLog.logger(LogCategories.settings).info(
                 "Claude web extras updated",
                 metadata: ["enabled": newValue ? "1" : "0"])
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -469,6 +491,7 @@ extension SettingsStore {
         set {
             self.defaultsState.showOptionalCreditsAndExtraUsage = newValue
             self.userDefaults.set(newValue, forKey: "showOptionalCreditsAndExtraUsage")
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -480,6 +503,7 @@ extension SettingsStore {
             CodexBarLog.logger(LogCategories.settings).info(
                 "OpenAI web access updated",
                 metadata: ["enabled": newValue ? "1" : "0"])
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -491,6 +515,7 @@ extension SettingsStore {
             CodexBarLog.logger(LogCategories.settings).info(
                 "OpenAI web battery saver updated",
                 metadata: ["enabled": newValue ? "1" : "0"])
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 
@@ -502,6 +527,7 @@ extension SettingsStore {
             CodexBarLog.logger(LogCategories.settings).info(
                 "Provider storage footprints updated",
                 metadata: ["enabled": newValue ? "1" : "0"])
+            self.noteBackgroundWorkSettingsChanged()
         }
     }
 

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -491,6 +491,7 @@ extension SettingsStore {
         set {
             self.defaultsState.showOptionalCreditsAndExtraUsage = newValue
             self.userDefaults.set(newValue, forKey: "showOptionalCreditsAndExtraUsage")
+            // This flag also controls ProviderFetchContext.includeOptionalUsage, so it is not display-only.
             self.noteBackgroundWorkSettingsChanged()
         }
     }

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -209,6 +209,7 @@ final class SettingsStore {
     @ObservationIgnored var selectedMenuProviderRawStorage: String?
     var defaultsState: SettingsDefaultsState
     var configRevision: Int = 0
+    var backgroundWorkSettingsRevision: Int = 0
     var providerOrder: [UsageProvider] = []
     var providerEnablement: [UsageProvider: Bool] = [:]
 

--- a/Sources/CodexBar/StatusItemController+WidgetSnapshot.swift
+++ b/Sources/CodexBar/StatusItemController+WidgetSnapshot.swift
@@ -1,0 +1,16 @@
+extension StatusItemController {
+    func widgetDisplaySettingsSignature() -> String {
+        [
+            "enabled=\(self.store.enabledProvidersForDisplay().map(\.rawValue).joined(separator: ","))",
+            "showUsed=\(self.settings.usageBarsShowUsed ? "1" : "0")",
+            "optional=\(self.settings.showOptionalCreditsAndExtraUsage ? "1" : "0")",
+        ].joined(separator: "|")
+    }
+
+    func persistWidgetSnapshotIfWidgetDisplaySettingsChanged() {
+        let signature = self.widgetDisplaySettingsSignature()
+        guard signature != self.lastWidgetDisplaySettingsSignature else { return }
+        self.lastWidgetDisplaySettingsSignature = signature
+        self.store.persistWidgetSnapshot(reason: "settings-display")
+    }
+}

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -244,6 +244,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private var lastMergeIcons: Bool
     private var lastSwitcherShowsIcons: Bool
     private var lastObservedUsageBarsShowUsed: Bool
+    var lastWidgetDisplaySettingsSignature = ""
     private var lastAgentSessionsEnabled: Bool
     private var lastAgentSessionsManualHosts: String
     /// Tracks which `usageBarsShowUsed` mode the provider switcher was built with.
@@ -414,6 +415,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         }
         self.lastMenuAdjunctReadinessSignature = self.menuAdjunctReadinessSignature()
         self.lastMenuAdjunctReadinessBaselineVersion = self.menuSession.contentVersion
+        self.lastWidgetDisplaySettingsSignature = self.widgetDisplaySettingsSignature()
         self.wireBindings()
         self.agentSessions.onUpdate = { [weak self] in
             self?.invalidateMenus(refreshOpenMenus: true)
@@ -669,6 +671,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         }
         self.updateVisibility()
         self.updateIcons()
+        self.persistWidgetSnapshotIfWidgetDisplaySettingsChanged()
         if shouldRefreshOpenMenus {
             self.refreshOpenMenusAllowingParentRebuild(
                 deferParentRebuildDuringTracking: !localizationChanged)

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -75,29 +75,8 @@ extension UsageStore {
     }
 
     var backgroundWorkSettingsObservationToken: Int {
-        _ = self.settings.refreshFrequency
-        _ = self.settings.statusChecksEnabled
-        _ = self.settings.sessionQuotaNotificationsEnabled
-        _ = self.settings.quotaWarningNotificationsEnabled
-        _ = self.settings.quotaWarningThresholds
-        _ = self.settings.quotaWarningThresholds(.session)
-        _ = self.settings.quotaWarningThresholds(.weekly)
-        _ = self.settings.quotaWarningSoundEnabled
-        _ = self.settings.usageBarsShowUsed
-        _ = self.settings.costUsageEnabled
-        _ = self.settings.costUsageHistoryDays
-        _ = self.settings.randomBlinkEnabled
+        _ = self.settings.backgroundWorkSettingsRevision
         _ = self.settings.configRevision
-        for implementation in ProviderCatalog.all {
-            implementation.observeSettings(self.settings)
-        }
-        _ = self.settings.multiAccountMenuLayout
-        _ = self.settings.tokenAccountsByProvider
-        _ = self.settings.mergeIcons
-        _ = self.settings.debugLoadingPattern
-        _ = self.settings.debugKeepCLISessionsAlive
-        _ = self.settings.historicalTrackingEnabled
-        _ = self.settings.providerStorageFootprintsEnabled
         return 0
     }
 

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -13,6 +13,8 @@ struct StatusItemIconObservationSignatureTests {
             syntheticTokenStore: NoopSyntheticTokenStore())
         settings.statusChecksEnabled = true
         settings.refreshFrequency = .manual
+        settings.usageBarsShowUsed = false
+        settings.showOptionalCreditsAndExtraUsage = true
         settings.menuBarShowsBrandIconWithPercent = false
         settings.menuBarShowsHighestUsage = false
         settings.mergeIcons = true
@@ -241,6 +243,41 @@ struct StatusItemIconObservationSignatureTests {
         settings.menuBarHidesCritters = true
 
         #expect(controller.storeIconObservationSignature() != baseline)
+    }
+
+    @Test
+    func `display settings persist cached widget snapshot`() async {
+        let (settings, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-widget-display")
+        defer { controller.releaseStatusItemsForTesting() }
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        settings.usageBarsShowUsed = true
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        await store.widgetSnapshotPersistTask?.value
+
+        #expect(widgetSnapshots.last?.usageBarsShowUsed == true)
+        #expect(widgetSnapshots.last?.entries.contains(where: { $0.provider == .codex }) == true)
+    }
+
+    @Test
+    func `config only settings do not persist cached widget snapshot`() async {
+        let (settings, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-widget-config-only")
+        defer { controller.releaseStatusItemsForTesting() }
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        settings.zaiAPIToken = "config-only-token"
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        await store.widgetSnapshotPersistTask?.value
+
+        #expect(widgetSnapshots.isEmpty)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -273,7 +273,7 @@ struct StatusItemIconObservationSignatureTests {
         store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
         defer { store._test_widgetSnapshotSaveOverride = nil }
 
-        settings.zaiAPIToken = "config-only-token"
+        settings.zaiAPIToken = "test-token"
         try? await Task.sleep(nanoseconds: 100_000_000)
         await store.widgetSnapshotPersistTask?.value
 

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -624,6 +624,93 @@ struct UsageStoreCoverageTests {
     }
 
     @Test
+    func `background work settings observation ignores display only settings churn`() async throws {
+        let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-display-only-observation")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.mergeIcons = false
+        settings.randomBlinkEnabled = false
+        settings.usageBarsShowUsed = false
+        try Self.enableOnly(.codex, settings: settings)
+
+        let store = Self.makeUsageStore(settings: settings)
+        let didChange = ObservationFlag()
+
+        withObservationTracking {
+            _ = store.backgroundWorkSettingsObservationToken
+        } onChange: {
+            didChange.set()
+        }
+
+        settings.usageBarsShowUsed = true
+        settings.mergeIcons = true
+        settings.randomBlinkEnabled = true
+        settings.debugLoadingPattern = .pulse
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(didChange.get() == false)
+
+        let refreshDidChange = ObservationFlag()
+        withObservationTracking {
+            _ = store.backgroundWorkSettingsObservationToken
+        } onChange: {
+            refreshDidChange.set()
+        }
+
+        settings.statusChecksEnabled = true
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(refreshDidChange.get() == true)
+
+        let layoutDidChange = ObservationFlag()
+        withObservationTracking {
+            _ = store.backgroundWorkSettingsObservationToken
+        } onChange: {
+            layoutDidChange.set()
+        }
+
+        settings.multiAccountMenuLayout = .stacked
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(layoutDidChange.get() == true)
+    }
+
+    @Test
+    func `display only settings do not invoke provider refresh while background work is active`() async throws {
+        let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-display-only-no-provider-refresh")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.mergeIcons = false
+        settings.randomBlinkEnabled = false
+        settings.usageBarsShowUsed = false
+        try Self.enableOnly(.codex, settings: settings)
+
+        let store = Self.makeUsageStore(settings: settings)
+        var refreshedProviders: [UsageProvider] = []
+        store._test_providerRefreshOverride = { refreshedProviders.append($0) }
+        defer { store._test_providerRefreshOverride = nil }
+
+        func observeBackgroundSettingsForTest() {
+            withObservationTracking {
+                _ = store.backgroundWorkSettingsObservationToken
+            } onChange: {
+                Task { @MainActor in
+                    await store.refreshForSettingsChange()
+                }
+            }
+        }
+
+        observeBackgroundSettingsForTest()
+
+        settings.usageBarsShowUsed = true
+        settings.mergeIcons = true
+        settings.randomBlinkEnabled = true
+        settings.debugLoadingPattern = .pulse
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(refreshedProviders.isEmpty)
+
+        await store.refreshForSettingsChange()
+        #expect(refreshedProviders.contains(.codex))
+    }
+
+    @Test
     func `startup status network failure schedules bounded retry`() async throws {
         let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-startup-status-retry")
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -631,6 +631,7 @@ struct UsageStoreCoverageTests {
         settings.mergeIcons = false
         settings.randomBlinkEnabled = false
         settings.usageBarsShowUsed = false
+        settings.showOptionalCreditsAndExtraUsage = false
         try Self.enableOnly(.codex, settings: settings)
 
         let store = Self.makeUsageStore(settings: settings)
@@ -670,6 +671,17 @@ struct UsageStoreCoverageTests {
         settings.multiAccountMenuLayout = .stacked
         try? await Task.sleep(nanoseconds: 50_000_000)
         #expect(layoutDidChange.get() == true)
+
+        let optionalUsageDidChange = ObservationFlag()
+        withObservationTracking {
+            _ = store.backgroundWorkSettingsObservationToken
+        } onChange: {
+            optionalUsageDidChange.set()
+        }
+
+        settings.showOptionalCreditsAndExtraUsage = true
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(optionalUsageDidChange.get() == true)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1994 by separating visual/display settings changes from background provider refresh settings.

- Adds a dedicated background-work settings revision so visual-only settings no longer trigger provider quota refreshes.
- Keeps real background/data-affecting settings wired to refresh behavior.
- Persists cached widget snapshots only when widget-relevant display settings change, not on unrelated config edits.
- Adds focused coverage for display-only settings, provider refresh avoidance, and widget snapshot behavior.

## Why

Changing visual settings such as usage bar display mode, icon layout, loading pattern, or other menu presentation options should update cached UI only. Previously, those changes were observed by the background refresh path and could trigger provider quota probes, which risks hitting provider rate limits while the user is only adjusting display preferences.

This keeps quota refreshes scoped to settings that actually affect provider data, credentials, background checks, alerts, cost/history processing, or account layout behavior.

## Behavior Proof

I avoided live provider probes and real Keychain reads, per the repository guidance against validation that can display credential or Keychain prompts. The proof below uses redacted/no-credential test seams that would record provider refreshes if the settings observer triggered them.

Display-only settings do not refresh providers:

- `UsageStoreCoverageTests.display only settings do not invoke provider refresh while background work is active` installs `_test_providerRefreshOverride` to record every provider refresh request.
- The test observes `backgroundWorkSettingsObservationToken` with the same callback shape used by the background settings watcher: on change, call `refreshForSettingsChange()`.
- It changes only visual/display settings: `usageBarsShowUsed`, `mergeIcons`, `randomBlinkEnabled`, and `debugLoadingPattern`.
- After observation delivery, the recorded provider refresh list remains empty.
- The same test directly calls `refreshForSettingsChange()` and confirms `.codex` is recorded, proving the override would catch a provider refresh if one occurred.

Provider-affecting settings still refresh:

- `UsageStoreCoverageTests.background work settings observation ignores display only settings churn` first confirms the same display-only setting changes do not fire the background observer.
- It then changes `statusChecksEnabled` and observes the background-work token firing.
- It re-observes and changes `multiAccountMenuLayout`, then confirms the token fires again.

Cached UI/widget state updates without unrelated config churn:

- `StatusItemIconObservationSignatureTests.display settings persist cached widget snapshot` toggles `usageBarsShowUsed`, waits for `widgetSnapshotPersistTask`, and confirms the cached widget snapshot records `usageBarsShowUsed == true` with a Codex entry.
- `StatusItemIconObservationSignatureTests.config only settings do not persist cached widget snapshot` mutates `zaiAPIToken` and confirms no widget snapshot is persisted for that unrelated config-only change.

## Validation

- Manually checked display/settings changes.
- `swift test --filter UsageStoreCoverageTests`
- `swift test --filter StatusItemIconObservationSignatureTests`
- `swift test --filter UsageStoreWidgetSnapshotTests`
- `make check`
- `make test`