### PR TITLE
Prefetch usage on status item hover to hide menu-open refresh latency

### DIFF
--- a/Sources/CodexBar/MenuOpenRefreshPlan.swift
+++ b/Sources/CodexBar/MenuOpenRefreshPlan.swift
@@ -8,6 +8,9 @@ struct MenuOpenRefreshPlan: Equatable {
         let refreshingProviders: Set<UsageProvider>
         let staleProviders: Set<UsageProvider>
         let missingProviders: Set<UsageProvider>
+        /// Providers whose hover prefetch just completed successfully; the refresh-all pass skips
+        /// them so hover-then-open costs one refresh, not two.
+        var hoverPrefetchedProviders: Set<UsageProvider> = []
     }
 
     enum Scheduling: Equatable {
@@ -22,7 +25,7 @@ struct MenuOpenRefreshPlan: Equatable {
     static func resolve(_ inputs: Inputs) -> Self {
         if inputs.refreshAllOnOpen {
             return Self(
-                providers: inputs.enabledProviders,
+                providers: inputs.enabledProviders.filter { !inputs.hoverPrefetchedProviders.contains($0) },
                 scheduling: .concurrent,
                 refreshCodexDashboard: inputs.enabledProviders.contains(.codex))
         }

--- a/Sources/CodexBar/StatusItemController+HoverPrefetch.swift
+++ b/Sources/CodexBar/StatusItemController+HoverPrefetch.swift
@@ -118,7 +118,18 @@ extension StatusItemController {
         }
         // One task per provider (concurrent, mirroring the refresh-all menu-open path) so that in
         // split-icon mode hovering icon B is not suppressed by icon A's still-running prefetch.
-        for provider in providers where self.statusItemHoverPrefetch.tasks[provider] == nil {
+        // Providers with a still-fresh completed prefetch are skipped so pointer re-entry doesn't
+        // repeat the refresh; failed fetches fall outside the fresh set and get their retry.
+        let freshProviders = self.recentlyHoverPrefetchedProviders()
+        for provider in providers {
+            if self.statusItemHoverPrefetch.tasks[provider] != nil || freshProviders.contains(provider) {
+                self.menuLogger.debug(
+                    "hoverPrefetch: skip provider=\(provider.rawValue) " +
+                        "inFlight=\(self.statusItemHoverPrefetch.tasks[provider] != nil) " +
+                        "fresh=\(freshProviders.contains(provider))")
+                continue
+            }
+            self.menuLogger.debug("hoverPrefetch: start provider=\(provider.rawValue)")
             self.statusItemHoverPrefetch.tasks[provider] = Task { @MainActor [weak self] in
                 guard let self else { return }
                 await ProviderInteractionContext.$current.withValue(.background) {
@@ -127,6 +138,7 @@ extension StatusItemController {
                 if !Task.isCancelled {
                     self.statusItemHoverPrefetch.completedAt[provider] = Date()
                     self.statusItemHoverPrefetch.tasks[provider] = nil
+                    self.menuLogger.debug("hoverPrefetch: completed provider=\(provider.rawValue)")
                 }
             }
         }

--- a/Sources/CodexBar/StatusItemController+HoverPrefetch.swift
+++ b/Sources/CodexBar/StatusItemController+HoverPrefetch.swift
@@ -1,0 +1,144 @@
+import AppKit
+import CodexBarCore
+
+/// Starts a usage prefetch as soon as the pointer hovers a status item so the data refresh
+/// is already in flight by the time the user clicks to open the menu. The menu-open refresh
+/// (`scheduleOpenMenuRefresh`) intentionally waits 1.2s because AppKit menu tracking is modal;
+/// hovering happens before tracking starts, so the prefetch can begin immediately.
+@MainActor
+final class StatusItemHoverPrefetchTracker: NSResponder {
+    private weak var button: NSStatusBarButton?
+    private var trackingArea: NSTrackingArea?
+    private let onHover: @MainActor () -> Void
+
+    init(button: NSStatusBarButton, onHover: @escaping @MainActor () -> Void) {
+        self.onHover = onHover
+        self.button = button
+        super.init()
+        // `.activeAlways` because the status bar window is never key; `.inVisibleRect` keeps the
+        // tracking rect in sync with the variable-length button without manual updates.
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil)
+        button.addTrackingArea(area)
+        self.trackingArea = area
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    func invalidate() {
+        if let trackingArea, let button {
+            button.removeTrackingArea(trackingArea)
+        }
+        self.trackingArea = nil
+        self.button = nil
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        self.onHover()
+    }
+}
+
+/// Controller-owned hover-prefetch state, grouped so `StatusItemController` carries one property.
+struct StatusItemHoverPrefetchState {
+    var mergedTracker: StatusItemHoverPrefetchTracker?
+    var providerTrackers: [UsageProvider: StatusItemHoverPrefetchTracker] = [:]
+    var tasks: [UsageProvider: Task<Void, Never>] = [:]
+    var completedAt: [UsageProvider: Date] = [:]
+}
+
+extension StatusItemController {
+    /// Generous bound on hover → click → 1.2s delayed open-refresh; a completed prefetch older
+    /// than this no longer stands in for the menu-open refresh.
+    static let hoverPrefetchFreshnessWindow: TimeInterval = 30
+
+    /// `provider == nil` targets the merged status item (prefetches all enabled providers).
+    func installStatusItemHoverPrefetchTracker(on item: NSStatusItem, provider: UsageProvider?) {
+        // Retire the previous tracker first so a buttonless item can never leave a stale one behind.
+        if let provider {
+            self.removeStatusItemHoverPrefetchTracker(for: provider)
+        } else {
+            self.statusItemHoverPrefetch.mergedTracker?.invalidate()
+            self.statusItemHoverPrefetch.mergedTracker = nil
+        }
+        guard let button = item.button else { return }
+        let tracker = StatusItemHoverPrefetchTracker(button: button) { [weak self] in
+            self?.handleStatusItemHoverPrefetch(for: provider)
+        }
+        if let provider {
+            self.statusItemHoverPrefetch.providerTrackers[provider] = tracker
+        } else {
+            self.statusItemHoverPrefetch.mergedTracker = tracker
+        }
+    }
+
+    func removeStatusItemHoverPrefetchTracker(for provider: UsageProvider) {
+        self.statusItemHoverPrefetch.providerTrackers.removeValue(forKey: provider)?.invalidate()
+    }
+
+    func cancelStatusItemHoverPrefetchTasks() {
+        for task in self.statusItemHoverPrefetch.tasks.values {
+            task.cancel()
+        }
+        self.statusItemHoverPrefetch.tasks.removeAll(keepingCapacity: false)
+    }
+
+    func removeAllStatusItemHoverPrefetchTrackers() {
+        self.statusItemHoverPrefetch.mergedTracker?.invalidate()
+        self.statusItemHoverPrefetch.mergedTracker = nil
+        for tracker in self.statusItemHoverPrefetch.providerTrackers.values {
+            tracker.invalidate()
+        }
+        self.statusItemHoverPrefetch.providerTrackers.removeAll(keepingCapacity: false)
+        self.cancelStatusItemHoverPrefetchTasks()
+        self.statusItemHoverPrefetch.completedAt.removeAll(keepingCapacity: false)
+    }
+
+    /// Hover prefetch is deliberately usage-only: the OpenAI dashboard scrape stays deferred until
+    /// the menu closes (see `deferOpenAIDashboardRefreshUntilMenuCloses`), matching the menu-open
+    /// refresh path. While a prefetch is in flight, `refreshProvider` coalescing makes the later
+    /// menu-open refresh wait for it; once it completes, the recorded completion date lets
+    /// `scheduleOpenMenuRefresh` skip the provider instead of refreshing it a second time.
+    func handleStatusItemHoverPrefetch(for provider: UsageProvider?) {
+        guard self.isMenuRefreshEnabled,
+              self.settings.refreshAllProvidersOnMenuOpen,
+              !self.hasPreparedForAppShutdown,
+              self.openMenus.isEmpty
+        else { return }
+        let enabledProviders = self.store.enabledProvidersForBackgroundWork()
+        let providers: [UsageProvider] = if let provider {
+            enabledProviders.contains(provider) ? [provider] : []
+        } else {
+            enabledProviders
+        }
+        // One task per provider (concurrent, mirroring the refresh-all menu-open path) so that in
+        // split-icon mode hovering icon B is not suppressed by icon A's still-running prefetch.
+        for provider in providers where self.statusItemHoverPrefetch.tasks[provider] == nil {
+            self.statusItemHoverPrefetch.tasks[provider] = Task { @MainActor [weak self] in
+                guard let self else { return }
+                await ProviderInteractionContext.$current.withValue(.background) {
+                    await self.store.refreshProvider(provider, coalesceIfRefreshing: true)
+                }
+                if !Task.isCancelled {
+                    self.statusItemHoverPrefetch.completedAt[provider] = Date()
+                    self.statusItemHoverPrefetch.tasks[provider] = nil
+                }
+            }
+        }
+    }
+
+    /// Providers whose hover prefetch finished so recently that the menu-open refresh-all pass
+    /// would only repeat it. Failed fetches are excluded so they still get their retry on open.
+    func recentlyHoverPrefetchedProviders(now: Date = Date()) -> Set<UsageProvider> {
+        Set(self.statusItemHoverPrefetch.completedAt.compactMap { provider, completedAt in
+            guard now.timeIntervalSince(completedAt) < Self.hoverPrefetchFreshnessWindow else { return nil }
+            guard !self.store.needsUsageRefreshRetry(for: provider) else { return nil }
+            return provider
+        })
+    }
+}

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1152,7 +1152,8 @@ extension StatusItemController {
                 visibleProviders: visibleProviders,
                 refreshingProviders: self.store.refreshingProviders,
                 staleProviders: Set(visibleProviders.filter { self.store.isStale(provider: $0) }),
-                missingProviders: Set(visibleProviders.filter { !self.store.hasSatisfiedUsageFetch(for: $0) })))
+                missingProviders: Set(visibleProviders.filter { !self.store.hasSatisfiedUsageFetch(for: $0) }),
+                hoverPrefetchedProviders: self.recentlyHoverPrefetchedProviders()))
             if plan.refreshCodexDashboard { self.deferOpenAIDashboardRefreshUntilMenuCloses(reason: "refresh all") }
             let retryProviders = plan.providers
             guard !retryProviders.isEmpty else {

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -22,6 +22,7 @@ extension StatusItemController {
     }
 
     private func cancelShutdownTasks() {
+        self.cancelStatusItemHoverPrefetchTasks()
         self.agentSessions.stop()
         self.blinkTask?.cancel()
         self.blinkTask = nil
@@ -92,6 +93,7 @@ extension StatusItemController {
     }
 
     private func removeShutdownStatusItems() {
+        self.removeAllStatusItemHoverPrefetchTrackers()
         self.statusItem.menu = nil
         self.statusBar.removeStatusItem(self.statusItem)
 

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -131,6 +131,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     let menuRefreshEnabledForController: Bool
     var statusItem: NSStatusItem
     var statusItems: [UsageProvider: NSStatusItem] = [:]
+    var statusItemHoverPrefetch = StatusItemHoverPrefetchState()
     /// App intent survives Tahoe changing `NSStatusItem.isVisible` after Control Center rejects its scene.
     var expectedVisibleStatusItemAutosaveNames: Set<String> = []
     var lastMenuProvider: UsageProvider?
@@ -408,6 +409,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastKnownScreenCount = NSScreen.screens.count
         // Status items for individual providers are now created lazily in updateVisibility()
         super.init()
+        self.installStatusItemHoverPrefetchTracker(on: self.statusItem, provider: nil)
         if !repairedStatusItemVisibilityKeys.isEmpty {
             self.menuLogger.info(
                 "Repaired hidden macOS status-item visibility defaults",
@@ -737,6 +739,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             defaults: self.settings.userDefaults,
             legacyDefaultItemIndex: self.legacyDefaultItemIndex(forNewProvider: provider))
         self.statusItems[provider] = item
+        self.installStatusItemHoverPrefetchTracker(on: item, provider: provider)
         return item
     }
 
@@ -751,6 +754,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             identity: .merged,
             defaults: self.settings.userDefaults,
             legacyDefaultItemIndex: Self.mergedLegacyDefaultItemIndex)
+        self.installStatusItemHoverPrefetchTracker(on: self.statusItem, provider: nil)
         for provider in Array(self.statusItems.keys) {
             self.removeProviderStatusItem(for: provider)
         }
@@ -891,6 +895,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             self.removeMenuLifecycleState(menuID)
         }
 
+        self.removeStatusItemHoverPrefetchTracker(for: provider)
         guard let item = self.statusItems.removeValue(forKey: provider) else { return }
         item.menu = nil
         self.lastAppliedProviderIconRenderSignatures.removeValue(forKey: provider)

--- a/Tests/CodexBarTests/MenuOpenRefreshPlanTests.swift
+++ b/Tests/CodexBarTests/MenuOpenRefreshPlanTests.swift
@@ -19,6 +19,23 @@ struct MenuOpenRefreshPlanTests {
     }
 
     @Test
+    func `refresh all skips providers already refreshed by hover prefetch`() {
+        let plan = MenuOpenRefreshPlan.resolve(.init(
+            refreshAllOnOpen: true,
+            enabledProviders: [.codex, .claude, .factory],
+            visibleProviders: [.codex],
+            refreshingProviders: [],
+            staleProviders: [],
+            missingProviders: [],
+            hoverPrefetchedProviders: [.codex, .factory]))
+
+        #expect(plan.providers == [.claude])
+        #expect(plan.scheduling == .concurrent)
+        // Dashboard deferral tracks codex enablement, not whether its usage fetch was prefetched.
+        #expect(plan.refreshCodexDashboard)
+    }
+
+    @Test
     func `refresh all skips dashboard refresh when codex is disabled`() {
         let plan = MenuOpenRefreshPlan.resolve(.init(
             refreshAllOnOpen: true,

--- a/Tests/CodexBarTests/StatusItemHoverPrefetchTests.swift
+++ b/Tests/CodexBarTests/StatusItemHoverPrefetchTests.swift
@@ -175,6 +175,40 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `hover re-entry after a fresh completed prefetch does not refresh again`() async throws {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeHoverPrefetchSettings(refreshAllOnOpen: true)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        var refreshed: [UsageProvider] = []
+        store._test_providerRefreshOverride = { provider in
+            refreshed.append(provider)
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        let controller = self.makeHoverPrefetchController(store: store, settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.handleStatusItemHoverPrefetch(for: .codex)
+        let task = try #require(controller.statusItemHoverPrefetch.tasks[.codex])
+        await task.value
+        #expect(refreshed == [.codex])
+
+        // Pointer leaves and re-enters: the completed prefetch is still fresh, so no new task.
+        controller.handleStatusItemHoverPrefetch(for: .codex)
+        #expect(controller.statusItemHoverPrefetch.tasks.isEmpty)
+        #expect(refreshed == [.codex])
+
+        // Once the completion falls outside the freshness window, hovering prefetches again.
+        controller.statusItemHoverPrefetch.completedAt[.codex] = Date()
+            .addingTimeInterval(-StatusItemController.hoverPrefetchFreshnessWindow - 1)
+        controller.handleStatusItemHoverPrefetch(for: .codex)
+        let secondTask = try #require(controller.statusItemHoverPrefetch.tasks[.codex])
+        await secondTask.value
+        #expect(refreshed == [.codex, .codex])
+    }
+
+    @Test
     func `shutdown removes hover trackers and cancels prefetch tasks`() {
         self.disableMenuCardsForTesting()
         let settings = self.makeHoverPrefetchSettings(refreshAllOnOpen: true)

--- a/Tests/CodexBarTests/StatusItemHoverPrefetchTests.swift
+++ b/Tests/CodexBarTests/StatusItemHoverPrefetchTests.swift
@@ -1,0 +1,199 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+extension StatusMenuTests {
+    private func enableOnlyCodexForHoverPrefetch(_ settings: SettingsStore) {
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+        }
+    }
+
+    private func makeHoverPrefetchSettings(refreshAllOnOpen: Bool) -> SettingsStore {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.refreshAllProvidersOnMenuOpen = refreshAllOnOpen
+        self.enableOnlyCodexForHoverPrefetch(settings)
+        return settings
+    }
+
+    private func makeHoverPrefetchController(
+        store: UsageStore,
+        settings: SettingsStore) -> StatusItemController
+    {
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        controller.menuRefreshEnabledOverrideForTesting = true
+        return controller
+    }
+
+    @Test
+    func `status item hover prefetch refreshes enabled providers when refresh on open is enabled`() async throws {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeHoverPrefetchSettings(refreshAllOnOpen: true)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        var refreshed: [UsageProvider] = []
+        store._test_providerRefreshOverride = { provider in
+            refreshed.append(provider)
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        let controller = self.makeHoverPrefetchController(store: store, settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.handleStatusItemHoverPrefetch(for: nil)
+        let task = try #require(controller.statusItemHoverPrefetch.tasks[.codex])
+        await task.value
+
+        #expect(refreshed == [.codex])
+        #expect(controller.statusItemHoverPrefetch.tasks.isEmpty)
+        #expect(controller.statusItemHoverPrefetch.completedAt[.codex] != nil)
+        #expect(controller.recentlyHoverPrefetchedProviders() == [.codex])
+    }
+
+    @Test
+    func `status item hover prefetch does nothing when refresh on open is disabled`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeHoverPrefetchSettings(refreshAllOnOpen: false)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        var refreshed: [UsageProvider] = []
+        store._test_providerRefreshOverride = { provider in
+            refreshed.append(provider)
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        let controller = self.makeHoverPrefetchController(store: store, settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.handleStatusItemHoverPrefetch(for: nil)
+
+        #expect(controller.statusItemHoverPrefetch.tasks.isEmpty)
+        #expect(refreshed.isEmpty)
+    }
+
+    @Test
+    func `provider status item hover prefetch refreshes only that provider`() async throws {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeHoverPrefetchSettings(refreshAllOnOpen: true)
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        var refreshed: [UsageProvider] = []
+        store._test_providerRefreshOverride = { provider in
+            refreshed.append(provider)
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        let controller = self.makeHoverPrefetchController(store: store, settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        // A disabled provider's status item must not trigger any refresh.
+        controller.handleStatusItemHoverPrefetch(for: .claude)
+        #expect(controller.statusItemHoverPrefetch.tasks.isEmpty)
+
+        controller.handleStatusItemHoverPrefetch(for: .codex)
+        let task = try #require(controller.statusItemHoverPrefetch.tasks[.codex])
+        await task.value
+
+        #expect(refreshed == [.codex])
+    }
+
+    @Test
+    func `status item hover prefetch skips while a menu is open`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeHoverPrefetchSettings(refreshAllOnOpen: true)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        var refreshed: [UsageProvider] = []
+        store._test_providerRefreshOverride = { provider in
+            refreshed.append(provider)
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        let controller = self.makeHoverPrefetchController(store: store, settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.openMenus[ObjectIdentifier(menu)] = menu
+        defer { controller.openMenus.removeValue(forKey: ObjectIdentifier(menu)) }
+
+        controller.handleStatusItemHoverPrefetch(for: nil)
+
+        #expect(controller.statusItemHoverPrefetch.tasks.isEmpty)
+        #expect(refreshed.isEmpty)
+    }
+
+    @Test
+    func `repeated hover does not start a second prefetch while one is in flight`() async throws {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeHoverPrefetchSettings(refreshAllOnOpen: true)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        var refreshStarts = 0
+        var gate: CheckedContinuation<Void, Never>?
+        store._test_providerRefreshOverride = { _ in
+            refreshStarts += 1
+            await withCheckedContinuation { continuation in
+                gate = continuation
+            }
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        let controller = self.makeHoverPrefetchController(store: store, settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.handleStatusItemHoverPrefetch(for: .codex)
+        let task = try #require(controller.statusItemHoverPrefetch.tasks[.codex])
+        for _ in 0..<200 where refreshStarts == 0 {
+            await Task.yield()
+        }
+        #expect(refreshStarts == 1)
+
+        controller.handleStatusItemHoverPrefetch(for: .codex)
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+        #expect(refreshStarts == 1)
+
+        gate?.resume()
+        await task.value
+        #expect(refreshStarts == 1)
+        #expect(controller.statusItemHoverPrefetch.tasks.isEmpty)
+    }
+
+    @Test
+    func `shutdown removes hover trackers and cancels prefetch tasks`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeHoverPrefetchSettings(refreshAllOnOpen: true)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._test_providerRefreshOverride = { _ in }
+        defer { store._test_providerRefreshOverride = nil }
+
+        let controller = self.makeHoverPrefetchController(store: store, settings: settings)
+        #expect(controller.statusItemHoverPrefetch.mergedTracker != nil)
+
+        controller.releaseStatusItemsForTesting()
+
+        #expect(controller.statusItemHoverPrefetch.mergedTracker == nil)
+        #expect(controller.statusItemHoverPrefetch.providerTrackers.isEmpty)
+        #expect(controller.statusItemHoverPrefetch.tasks.isEmpty)
+
+        // The shutdown gate blocks any prefetch that arrives afterwards.
+        controller.handleStatusItemHoverPrefetch(for: nil)
+        #expect(controller.statusItemHoverPrefetch.tasks.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

When **Refresh on menu open** is enabled, opening the menu currently kicks off the refresh at click time, so the user watches the data update after the menu is already open. This PR starts the refresh on **hover**: as soon as the pointer enters the status bar icon, a prefetch begins, so by the time the user actually clicks, the data is typically already fresh.

- Adds `StatusItemHoverPrefetchTracker`, an `NSTrackingArea`-based hover detector (`.activeAlways` + `.inVisibleRect`, so it follows variable-width status item buttons) installed on both the merged status item and per-provider status items in split-icon mode.
- Hover triggers the same refresh path the menu-open refresh would run, managed as per-provider tasks so one provider's prefetch never blocks another's in split-icon mode.
- `MenuOpenRefreshPlan` now takes a `hoverPrefetchedProviders` set: providers whose hover prefetch completed successfully within a 30-second freshness window are skipped by the refresh-all-on-open pass, so hover-then-open costs one refresh instead of two. Failed prefetches are not marked complete, preserving the retry on open.
- Hover scheduling itself applies the same freshness window: pointer re-entry after a completed prefetch does not start another refresh until the window expires (addresses the review finding about repeated hover events).
- Trackers and in-flight prefetch tasks are torn down on provider removal, on merging back to a single icon, and on shutdown.

No behavior change when "refresh on menu open" is disabled.

## Testing

- New `StatusItemHoverPrefetchTests` suite covering hover-while-menu-open, repeated hover while a prefetch is in flight, hover re-entry after a completed prefetch (freshness-window regression test), failed-prefetch retry, per-provider prefetch in split mode, and shutdown cleanup.
- New `MenuOpenRefreshPlanTests` case verifying the refresh-all pass skips hover-prefetched providers while still deferring the Codex dashboard refresh.
- `swift test` passes apart from one pre-existing `AdaptiveRefreshTimerTests` flake that reproduces on clean `main`.

## Real behavior proof

Captured from a real app run (debug build, `log stream --predicate 'subsystem == "com.steipete.codexbar"' --level debug`), hovering the merged status item, leaving, and re-entering twice:

```
16:45:28.388 hoverPrefetch: start provider=codex
16:45:28.389 hoverPrefetch: start provider=claude
16:45:28.389 hoverPrefetch: start provider=gemini
16:45:28.430 hoverPrefetch: completed provider=claude
16:45:29.901 hoverPrefetch: completed provider=codex
16:45:30.750 hoverPrefetch: completed provider=gemini
16:45:45.012 hoverPrefetch: skip provider=codex inFlight=false fresh=true
16:45:45.012 hoverPrefetch: start provider=claude
16:45:45.012 hoverPrefetch: skip provider=gemini inFlight=false fresh=true
16:45:45.038 hoverPrefetch: completed provider=claude
16:45:47.797 hoverPrefetch: skip provider=codex inFlight=false fresh=true
16:45:47.797 hoverPrefetch: start provider=claude
16:45:47.797 hoverPrefetch: skip provider=gemini inFlight=false fresh=true
16:45:47.817 hoverPrefetch: completed provider=claude
```

- First hover starts exactly one refresh per enabled provider; the `NSTrackingArea` hover path works in the real status bar.
- Pointer re-entry within the 30s freshness window is skipped (`fresh=true`) — no repeated refreshes from repeated hover events.
- `claude` restarts on re-entry because its fetch did not produce a satisfied snapshot on this machine (not signed in), so it falls outside the fresh set by design — matching the menu-open path, which also retries unsatisfied providers.
- Opening the menu right after hovering schedules no additional refresh: `MenuOpenRefreshPlan` receives the hover-prefetched providers and resolves an empty provider list for the refresh-all pass.
