### PR TITLE
Add Codex Custom API usage source for third-party providers

### DIFF
--- a/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
@@ -50,6 +50,7 @@ struct CodexProviderImplementation: ProviderImplementation {
         case .auto: .auto
         case .oauth: .oauth
         case .cli: .cli
+        case .custom: .api
         }
     }
 

--- a/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
@@ -154,6 +154,7 @@ extension SettingsStore {
             case .auto: .auto
             case .oauth: .oauth
             case .cli: .cli
+            case .custom: .api
             }
             self.updateProviderConfig(provider: .codex) { entry in
                 entry.source = source
@@ -702,8 +703,10 @@ extension SettingsStore {
     private static func codexUsageDataSource(from source: ProviderSourceMode?) -> CodexUsageDataSource {
         guard let source else { return .auto }
         switch source {
-        case .auto, .web, .api:
+        case .auto, .web:
             return .auto
+        case .api:
+            return .custom
         case .cli:
             return .cli
         case .oauth:

--- a/Sources/CodexBarCore/Providers/Codex/CodexCustomAPIFetchStrategy.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexCustomAPIFetchStrategy.swift
@@ -1,0 +1,79 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Fetch strategy for the Codex "Custom API" usage source.
+///
+/// A single strategy serves both pipelines: its `usage` carries the weekly
+/// limit as an `extraRateWindows` entry (no `primary`/`secondary` window, so the
+/// menu bar stays on the daily-remaining balance), and its `credits` carries
+/// the daily remaining balance + daily `codexCreditLimit`. The main usage fetch
+/// only applies `result.usage`; the credits pipeline only applies `result.credits`
+/// — so one fetch feeds both without touching either pipeline's apply logic or
+/// the credits pipeline's account-scoped guard. The `.auto` chain is unchanged;
+/// the custom source is opt-in only.
+struct CodexCustomAPIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "codex.custom"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        CodexCustomProviderCredentials.resolve(env: context.env) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let credentials = CodexCustomProviderCredentials.resolve(env: context.env) else {
+            throw CodexCustomUsageError.missingCredentials
+        }
+        let snapshot = try await Self.fetchSnapshot(credentials: credentials)
+        return self.makeResult(
+            usage: snapshot.usage,
+            credits: snapshot.credits,
+            sourceLabel: "custom")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+
+    /// Resolves `GET {baseURL}/v1/usage` from the custom provider base URL.
+    static func usageURL(baseURL: URL) -> URL {
+        let path = baseURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let versionedBaseURL = path.split(separator: "/").last == "v1"
+            ? baseURL
+            : baseURL.appendingPathComponent("v1")
+        return versionedBaseURL.appendingPathComponent("usage")
+    }
+
+    /// Fetches and maps the custom provider usage response. Exposed for tests.
+    static func fetchSnapshot(
+        credentials: (baseURL: URL, apiKey: String),
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        updatedAt: Date = Date()) async throws -> CodexCustomUsageSnapshot
+    {
+        var request = URLRequest(url: self.usageURL(baseURL: credentials.baseURL))
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(credentials.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let response = try await transport.response(for: request)
+        guard (200..<300).contains(response.statusCode) else {
+            throw CodexCustomUsageError.apiError(
+                "HTTP \(response.statusCode): \(Self.responseSummary(response.data))")
+        }
+        // The provider host is the stable account identifier for a custom API source
+        // (no OAuth email is available). Carrying it as the identity's accountEmail lets
+        // the credits pipeline's account-scoped guard resolve so credits are refreshed.
+        let accountEmail = credentials.baseURL.host
+        return try CodexCustomUsageMapper.map(
+            data: response.data,
+            accountEmail: accountEmail,
+            updatedAt: updatedAt)
+    }
+
+    private static func responseSummary(_ data: Data) -> String {
+        String(bytes: data.prefix(500), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? ""
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexCustomProviderCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexCustomProviderCredentials.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Zero-config credential resolution for the Codex "Custom API" usage source.
+///
+/// Reads the custom provider's base URL from `~/.codex/config.toml` (top-level
+/// `model_provider`, then `base_url` under `[model_providers.<that provider>]`)
+/// and the API key from `~/.codex/auth.json`'s `OPENAI_API_KEY`. Both honor
+/// `CODEX_HOME` so they track the same account switching as the rest of Codex.
+///
+/// This is a pure file reader: no network, no Keychain. The TOML handling is a
+/// small hand-written fragment scanner in the style of the existing
+/// `parseChatGPTBaseURL` line scanner, extended to track the current `[table]`
+/// header. No third-party TOML library is introduced.
+public enum CodexCustomProviderCredentials {
+    /// Resolves the custom provider credentials for the given environment.
+    ///
+    /// Returns `nil` (rather than a wrong host) when either the base URL or the
+    /// API key cannot be resolved — the custom source then surfaces as
+    /// unavailable instead of querying a guessed host.
+    public static func resolve(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default) -> (baseURL: URL, apiKey: String)?
+    {
+        guard let baseURL = self.resolveBaseURL(env: env, fileManager: fileManager) else { return nil }
+        guard let apiKey = self.resolveAPIKey(env: env, fileManager: fileManager) else { return nil }
+        return (baseURL, apiKey)
+    }
+
+    /// Returns the resolved base URL, or `nil` when `config.toml` has no
+    /// `model_provider` or the named provider has no `base_url`.
+    public static func resolveBaseURL(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default) -> URL?
+    {
+        let configURL = CodexHomeScope
+            .ambientHomeURL(env: env, fileManager: fileManager)
+            .appendingPathComponent("config.toml")
+        guard let contents = try? String(contentsOf: configURL, encoding: .utf8) else { return nil }
+        return self.baseURL(from: contents)
+    }
+
+    /// Returns `OPENAI_API_KEY` from `auth.json`, or `nil` when absent.
+    public static func resolveAPIKey(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default) -> String?
+    {
+        let authURL = CodexHomeScope
+            .ambientHomeURL(env: env, fileManager: fileManager)
+            .appendingPathComponent("auth.json")
+        guard let data = try? Data(contentsOf: authURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let apiKey = json["OPENAI_API_KEY"] as? String
+        else {
+            return nil
+        }
+        let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Parses `config.toml` contents into a base URL.
+    ///
+    /// Reads the top-level `model_provider` value, then resolves `base_url`
+    /// under `[model_providers.<model_provider>]`. Returns `nil` when the
+    /// provider is not configured or its `base_url` is missing/invalid.
+    static func baseURL(from contents: String) -> URL? {
+        let provider = self.modelProvider(from: contents)
+        guard let provider, !provider.isEmpty else { return nil }
+        guard let rawBaseURL = self.baseURL(forProvider: provider, from: contents) else { return nil }
+        guard let url = URL(string: rawBaseURL),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    /// Extracts the top-level `model_provider` value (the one outside any
+    /// `[table]` header).
+    static func modelProvider(from contents: String) -> String? {
+        var inTable = false
+        for rawLine in contents.split(whereSeparator: \.isNewline) {
+            let stripped = Self.stripComment(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !stripped.isEmpty else { continue }
+
+            if stripped.hasPrefix("[") {
+                inTable = true
+                continue
+            }
+            // A `model_provider = "…"` line before any table header is the top-level value.
+            // Once inside a table, skip — table-scoped `model_provider` keys are not the
+            // top-level selector.
+            if inTable { continue }
+            if let value = Self.value(forKey: "model_provider", in: stripped) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    /// Resolves `base_url` under the `[model_providers.<provider>]` table.
+    static func baseURL(forProvider provider: String, from contents: String) -> String? {
+        let targetHeader = "[model_providers.\(provider)]"
+        let targetHeaderQuoted = "[model_providers.\"\(provider)\"]"
+        var inTargetTable = false
+        for rawLine in contents.split(whereSeparator: \.isNewline) {
+            let stripped = Self.stripComment(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !stripped.isEmpty else { continue }
+
+            if stripped.hasPrefix("[") {
+                inTargetTable = stripped == targetHeader || stripped == targetHeaderQuoted
+                continue
+            }
+            guard inTargetTable else { continue }
+            if let value = Self.value(forKey: "base_url", in: stripped) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    /// Splits a `key = value` line, trimming surrounding quotes from the value.
+    private static func value(forKey key: String, in line: String) -> String? {
+        let parts = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: true)
+        guard parts.count == 2 else { return nil }
+        let parsedKey = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard parsedKey == key else { return nil }
+        var value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value = String(value.dropFirst().dropLast())
+        }
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    private static func stripComment(_ line: Substring) -> Substring {
+        line.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: true).first ?? ""
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexCustomUsageMapper.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexCustomUsageMapper.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// Errors surfaced by the Codex custom-provider usage mapper.
+public enum CodexCustomUsageError: LocalizedError, Sendable {
+    case missingCredentials
+    case invalidResponse
+    case parseFailed(String)
+    case apiError(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingCredentials:
+            "Custom API source unavailable: resolve OPENAI_API_KEY in ~/.codex/auth.json and base_url in config.toml."
+        case .invalidResponse:
+            "Custom provider usage endpoint reported the response is not valid."
+        case let .parseFailed(message):
+            "Custom provider usage parse error: \(message)"
+        case let .apiError(message):
+            "Custom provider usage error: \(message)"
+        }
+    }
+}
+
+/// A mapped Codex custom-provider `/v1/usage` response, split into the two
+/// payloads CodexBar's two independent pipelines consume.
+public struct CodexCustomUsageSnapshot: Sendable {
+    public let credits: CreditsSnapshot
+    public let usage: UsageSnapshot
+
+    public init(credits: CreditsSnapshot, usage: UsageSnapshot) {
+        self.credits = credits
+        self.usage = usage
+    }
+}
+
+/// Fixed mapper for a custom-provider-style `GET /v1/usage` response into CodexBar's
+/// existing display models. No user-configurable extractor.
+///
+/// - `remaining` (+ `unit`) → `CreditsSnapshot.remaining`.
+/// - `subscription.daily_limit_usd` / `daily_usage_usd` → `CreditsSnapshot.codexCreditLimit`
+///   titled "Daily limit".
+/// - `subscription.weekly_limit_usd` > 0 → a weekly `NamedRateWindow` in
+///   `usage.extraRateWindows`. When the weekly limit is 0/absent, no window.
+/// - No `primary`/`secondary` rate window is produced, so the menu bar stays on
+///   the daily-remaining balance.
+public struct CodexCustomUsageMapper: Sendable {
+    public static let weeklyWindowID = "codex-custom-weekly"
+    public static let weeklyWindowTitle = "Weekly limit"
+    public static let weeklyWindowMinutes = 10080
+
+    public init() {}
+
+    public static func map(
+        data: Data,
+        accountEmail: String? = nil,
+        updatedAt: Date = Date()) throws -> CodexCustomUsageSnapshot
+    {
+        let response = try Self.decode(data: data)
+        if response.isValid == false {
+            throw CodexCustomUsageError.invalidResponse
+        }
+        return Self.map(response: response, accountEmail: accountEmail, updatedAt: updatedAt)
+    }
+
+    /// Parses the response into the typed `Decodable` shape. Exposed for tests.
+    static func decode(data: Data) throws -> CodexCustomUsageResponse {
+        do {
+            return try JSONDecoder().decode(CodexCustomUsageResponse.self, from: data)
+        } catch let error as CodexCustomUsageError {
+            throw error
+        } catch {
+            throw CodexCustomUsageError.parseFailed(error.localizedDescription)
+        }
+    }
+
+    static func map(
+        response: CodexCustomUsageResponse,
+        accountEmail: String?,
+        updatedAt: Date) -> CodexCustomUsageSnapshot
+    {
+        let subscription = response.subscription
+        let dailyLimit = subscription?.dailyLimitUSD
+        let dailyUsage = subscription?.dailyUsageUSD ?? 0
+        let remaining = response.remaining ?? 0
+
+        let creditLimit = dailyLimit.map { limit -> CodexCreditLimitSnapshot in
+            let usedPercent = limit > 0
+                ? min(100, max(0, 100 * dailyUsage / limit))
+                : 100
+            let remainingPercent = max(0, 100 - usedPercent)
+            return CodexCreditLimitSnapshot(
+                title: "Daily limit",
+                used: dailyUsage,
+                limit: limit,
+                remainingPercent: remainingPercent,
+                resetsAt: subscription?.expiresAt,
+                updatedAt: updatedAt)
+        }
+
+        let credits = CreditsSnapshot(
+            remaining: remaining,
+            events: [],
+            updatedAt: updatedAt,
+            codexCreditLimit: creditLimit)
+
+        let weeklyWindow = Self.weeklyWindow(
+            limit: subscription?.weeklyLimitUSD,
+            usage: subscription?.weeklyUsageUSD ?? 0)
+        let extraRateWindows = weeklyWindow.map { [$0] }
+
+        let usage = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: extraRateWindows,
+            updatedAt: updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: accountEmail,
+                accountOrganization: response.planName,
+                loginMethod: "custom-api"))
+        return CodexCustomUsageSnapshot(credits: credits, usage: usage)
+    }
+
+    static func weeklyWindow(limit: Double?, usage: Double) -> NamedRateWindow? {
+        guard let limit, limit > 0 else { return nil }
+        let usedPercent = min(100, max(0, 100 * usage / limit))
+        return NamedRateWindow(
+            id: Self.weeklyWindowID,
+            title: Self.weeklyWindowTitle,
+            window: RateWindow(
+                usedPercent: usedPercent,
+                windowMinutes: Self.weeklyWindowMinutes,
+                resetsAt: nil,
+                resetDescription: nil))
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexCustomUsageResponse.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexCustomUsageResponse.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Decodable shape of a custom-provider-style `GET /v1/usage` response.
+///
+/// `daily_usage` and `model_stats` are decoded for forward compatibility but
+/// are not rendered in this iteration.
+struct CodexCustomUsageResponse: Decodable, Sendable {
+    let remaining: Double?
+    let unit: String?
+    let isValid: Bool?
+    let planName: String?
+    let subscription: Subscription?
+    let dailyUsage: [DailyUsage]?
+    let modelStats: [ModelStats]?
+
+    init(from decoder: Decoder) throws {
+        // The PRD records the top-level keys as camelCase (`isValid`, `planName`);
+        // tolerate the snake_case spellings too so the mapper is robust to either
+        // convention the provider settles on.
+        let container = try decoder.container(keyedBy: TopLevelCodingKeys.self)
+        self.remaining = try container.decodeIfPresent(Double.self, forKey: .remaining)
+        self.unit = try container.decodeIfPresent(String.self, forKey: .unit)
+        self.isValid = try container.decodeIfPresent(Bool.self, forKey: .isValid)
+            ?? container.decodeIfPresent(Bool.self, forKey: .isValidSnake)
+        self.planName = try container.decodeIfPresent(String.self, forKey: .planName)
+            ?? container.decodeIfPresent(String.self, forKey: .planNameSnake)
+        self.subscription = try container.decodeIfPresent(Subscription.self, forKey: .subscription)
+        self.dailyUsage = try container.decodeIfPresent([DailyUsage].self, forKey: .dailyUsage)
+        self.modelStats = try container.decodeIfPresent([ModelStats].self, forKey: .modelStats)
+    }
+
+    private enum TopLevelCodingKeys: String, CodingKey {
+        case remaining
+        case unit
+        case isValid
+        case isValidSnake = "is_valid"
+        case planName
+        case planNameSnake = "plan_name"
+        case subscription
+        case dailyUsage = "daily_usage"
+        case modelStats = "model_stats"
+    }
+
+    struct Subscription: Decodable, Sendable {
+        let dailyLimitUSD: Double?
+        let dailyUsageUSD: Double?
+        let weeklyLimitUSD: Double?
+        let weeklyUsageUSD: Double?
+        let monthlyLimitUSD: Double?
+        let monthlyUsageUSD: Double?
+        let expiresAt: Date?
+
+        private enum CodingKeys: String, CodingKey {
+            case dailyLimitUSD = "daily_limit_usd"
+            case dailyUsageUSD = "daily_usage_usd"
+            case weeklyLimitUSD = "weekly_limit_usd"
+            case weeklyUsageUSD = "weekly_usage_usd"
+            case monthlyLimitUSD = "monthly_limit_usd"
+            case monthlyUsageUSD = "monthly_usage_usd"
+            case expiresAt = "expires_at"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.dailyLimitUSD = try container.decodeIfPresent(Double.self, forKey: .dailyLimitUSD)
+            self.dailyUsageUSD = try container.decodeIfPresent(Double.self, forKey: .dailyUsageUSD)
+            self.weeklyLimitUSD = try container.decodeIfPresent(Double.self, forKey: .weeklyLimitUSD)
+            self.weeklyUsageUSD = try container.decodeIfPresent(Double.self, forKey: .weeklyUsageUSD)
+            self.monthlyLimitUSD = try container.decodeIfPresent(Double.self, forKey: .monthlyLimitUSD)
+            self.monthlyUsageUSD = try container.decodeIfPresent(Double.self, forKey: .monthlyUsageUSD)
+            self.expiresAt = try Self.decodeDate(from: container, forKey: .expiresAt)
+        }
+
+        private static func decodeDate(
+            from container: KeyedDecodingContainer<CodingKeys>,
+            forKey key: CodingKeys) throws -> Date?
+        {
+            guard let raw = try container.decodeIfPresent(String.self, forKey: key) else { return nil }
+            if let date = Self.iso8601(fractionalSeconds: true).date(from: raw) {
+                return date
+            }
+            return Self.iso8601(fractionalSeconds: false).date(from: raw)
+        }
+
+        private static func iso8601(fractionalSeconds: Bool) -> ISO8601DateFormatter {
+            let formatter = ISO8601DateFormatter()
+            if fractionalSeconds {
+                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            }
+            return formatter
+        }
+    }
+
+    struct DailyUsage: Decodable, Sendable {
+        let date: String?
+        let usageUSD: Double?
+
+        private enum CodingKeys: String, CodingKey {
+            case date
+            case usageUSD = "usage_usd"
+        }
+    }
+
+    struct ModelStats: Decodable, Sendable {
+        let model: String?
+        let usageUSD: Double?
+        let requests: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case model
+            case usageUSD = "usage_usd"
+            case requests
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case remaining
+        case unit
+        case isValid = "is_valid"
+        case planName = "plan_name"
+        case subscription
+        case dailyUsage = "daily_usage"
+        case modelStats = "model_stats"
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -33,7 +33,7 @@ public enum CodexProviderDescriptor {
                 supportsTokenCost: true,
                 noDataMessage: self.noDataMessage),
             fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web, .cli, .oauth],
+                sourceModes: [.auto, .web, .cli, .oauth, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "codex",
@@ -44,6 +44,7 @@ public enum CodexProviderDescriptor {
         let cli = CodexCLIUsageStrategy()
         let oauth = CodexOAuthFetchStrategy()
         let web = CodexWebDashboardStrategy()
+        let custom = CodexCustomAPIFetchStrategy()
 
         switch context.runtime {
         case .cli:
@@ -55,7 +56,7 @@ public enum CodexProviderDescriptor {
             case .cli:
                 return [cli]
             case .api:
-                return []
+                return [custom]
             case .auto:
                 return [oauth, cli]
             }
@@ -68,7 +69,7 @@ public enum CodexProviderDescriptor {
             case .web:
                 return [web]
             case .api:
-                return []
+                return [custom]
             case .auto:
                 return [oauth, cli]
             }

--- a/Sources/CodexBarCore/Providers/Codex/CodexUsageDataSource.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexUsageDataSource.swift
@@ -4,6 +4,7 @@ public enum CodexUsageDataSource: String, CaseIterable, Identifiable, Sendable {
     case auto
     case oauth
     case cli
+    case custom
 
     public var id: String {
         self.rawValue
@@ -14,6 +15,7 @@ public enum CodexUsageDataSource: String, CaseIterable, Identifiable, Sendable {
         case .auto: "Auto"
         case .oauth: "OAuth API"
         case .cli: "CLI (RPC/PTY)"
+        case .custom: "Custom API"
         }
     }
 
@@ -25,6 +27,8 @@ public enum CodexUsageDataSource: String, CaseIterable, Identifiable, Sendable {
             "oauth"
         case .cli:
             "cli"
+        case .custom:
+            "custom"
         }
     }
 }

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshCreditsTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshCreditsTests.swift
@@ -90,4 +90,43 @@ extension CodexAccountScopedRefreshTests {
         #expect(store.lastCreditsError == nil)
         #expect(store.lastCreditsSource == .api)
     }
+
+    @Test
+    func `custom api source refreshes credits using provider host as account identity`() async {
+        // Custom API source has no OAuth account; the provider host (from the resolved
+        // base_url) is carried as the usage snapshot's accountEmail so the credits
+        // pipeline's account-scoped guard resolves and credits are refreshed.
+        let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-custom-credits")
+        settings.refreshFrequency = .manual
+        settings.codexUsageDataSource = .custom
+        settings._test_liveSystemCodexAccount = nil
+
+        let store = self.makeUsageStore(settings: settings)
+        // Custom usage snapshot carries the provider host as accountEmail and no rate windows.
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "example.com",
+                    accountOrganization: "Plus 10x",
+                    loginMethod: "custom-api")),
+            provider: .codex)
+
+        var loaderCalled = false
+        store._test_codexCreditsLoaderOverride = {
+            loaderCalled = true
+            return self.credits(remaining: 77)
+        }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+
+        await store.refreshCreditsIfNeeded()
+
+        #expect(loaderCalled)
+        #expect(store.credits?.remaining == 77)
+        #expect(store.lastCreditsError == nil)
+        #expect(store.lastCreditsSource == .api)
+    }
 }

--- a/Tests/CodexBarTests/CodexConsumerProjectionTests.swift
+++ b/Tests/CodexBarTests/CodexConsumerProjectionTests.swift
@@ -470,6 +470,102 @@ struct CodexConsumerProjectionTests {
         #expect(session.resetsAt == sessionReset)
     }
 
+    // MARK: - Custom API source (no primary/secondary, optional weekly extra window)
+
+    @Test
+    func `custom api source with remaining balance falls back to credits in menu bar`() {
+        let store = self.makeStore(suite: "CodexConsumerProjectionTests-custom-credits-balance")
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // No primary/secondary window — the custom usage source emits none.
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                updatedAt: now),
+            provider: .codex)
+        store.credits = CreditsSnapshot(
+            remaining: 104.52,
+            events: [],
+            updatedAt: now)
+
+        let projection = store.codexConsumerProjection(surface: .menuBar, now: now)
+
+        #expect(projection.menuBarFallback == .creditsBalance)
+        #expect(projection.credits?.remaining == 104.52)
+        #expect(store.codexMenuBarCreditsRemaining(now: now) == 104.52)
+    }
+
+    @Test
+    func `custom api weekly limit does not steal the menu bar from the balance`() {
+        let store = self.makeStore(suite: "CodexConsumerProjectionTests-custom-weekly-extra")
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // Weekly limit surfaces as an extraRateWindow, never as a primary/secondary lane,
+        // so the menu bar must stay on the daily-remaining balance.
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                extraRateWindows: [
+                    NamedRateWindow(
+                        id: CodexCustomUsageMapper.weeklyWindowID,
+                        title: CodexCustomUsageMapper.weeklyWindowTitle,
+                        window: RateWindow(
+                            usedPercent: 25,
+                            windowMinutes: CodexCustomUsageMapper.weeklyWindowMinutes,
+                            resetsAt: nil,
+                            resetDescription: nil)),
+                ],
+                updatedAt: now),
+            provider: .codex)
+        store.credits = CreditsSnapshot(
+            remaining: 50,
+            events: [],
+            updatedAt: now)
+
+        let menuBarProjection = store.codexConsumerProjection(surface: .menuBar, now: now)
+        #expect(menuBarProjection.menuBarFallback == .creditsBalance)
+        #expect(store.codexMenuBarCreditsRemaining(now: now) == 50)
+
+        // The weekly window remains visible in the card-facing projection.
+        let cardProjection = store.codexConsumerProjection(surface: .liveCard, now: now)
+        #expect(cardProjection.menuBarFallback == .creditsBalance)
+        let weekly = store.snapshots[.codex]?.extraRateWindows?.first
+        #expect(weekly?.id == CodexCustomUsageMapper.weeklyWindowID)
+        #expect(weekly?.window.usedPercent == 25)
+    }
+
+    @Test
+    func `custom api source with zero remaining does not fake a credits menu bar`() {
+        let store = self.makeStore(suite: "CodexConsumerProjectionTests-custom-exhausted")
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                updatedAt: now),
+            provider: .codex)
+        store.credits = CreditsSnapshot(
+            remaining: 0,
+            events: [],
+            updatedAt: now,
+            codexCreditLimit: CodexCreditLimitSnapshot(
+                title: "Daily limit",
+                used: 100,
+                limit: 100,
+                remainingPercent: 0,
+                resetsAt: now.addingTimeInterval(3600),
+                updatedAt: now))
+
+        let projection = store.codexConsumerProjection(surface: .menuBar, now: now)
+
+        // Exhausted balance (remaining == 0) must not trip the credits-balance fallback.
+        #expect(projection.menuBarFallback == .none)
+        #expect(store.codexMenuBarCreditsRemaining(now: now) == nil)
+    }
+
     private func makeStore(suite: String) -> UsageStore {
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)

--- a/Tests/CodexBarTests/CodexCustomAPIFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/CodexCustomAPIFetchStrategyTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct CodexCustomAPIFetchStrategyTests {
+    @Test
+    func `usage url appends v1 when base url has no version`() throws {
+        let url = try CodexCustomAPIFetchStrategy.usageURL(baseURL: #require(URL(string: "https://example.com")))
+        #expect(url.absoluteString == "https://example.com/v1/usage")
+    }
+
+    @Test
+    func `usage url does not double the v1 segment`() throws {
+        let url = try CodexCustomAPIFetchStrategy.usageURL(baseURL: #require(URL(string: "https://example.com/v1")))
+        #expect(url.absoluteString == "https://example.com/v1/usage")
+    }
+
+    @Test
+    func `fetch maps response into usage and credits`() async throws {
+        let json = """
+        {
+          "remaining": 104.52,
+          "unit": "USD",
+          "is_valid": true,
+          "plan_name": "Pro Daily",
+          "subscription": {
+            "daily_limit_usd": 200,
+            "daily_usage_usd": 95.48,
+            "weekly_limit_usd": 500,
+            "weekly_usage_usd": 125,
+            "expires_at": "2026-07-09T00:00:00Z"
+          }
+        }
+        """
+        let transport = ProviderHTTPTransportHandler { request in
+            #expect(request.url?.absoluteString == "https://example.com/v1/usage")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-test")
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"])!
+            return (Data(json.utf8), response)
+        }
+
+        let snapshot = try await CodexCustomAPIFetchStrategy.fetchSnapshot(
+            credentials: (baseURL: #require(URL(string: "https://example.com")), apiKey: "sk-test"),
+            transport: transport,
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000))
+
+        #expect(snapshot.credits.remaining == 104.52)
+        #expect(snapshot.credits.codexCreditLimit?.title == "Daily limit")
+        #expect(snapshot.usage.extraRateWindows?.count == 1)
+        #expect(snapshot.usage.identity?.providerID == .codex)
+    }
+
+    @Test
+    func `fetch throws api error on non 2xx`() async {
+        let transport = ProviderHTTPTransportHandler { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 503,
+                httpVersion: nil,
+                headerFields: nil)!
+            return (Data("unavailable".utf8), response)
+        }
+
+        await #expect(throws: CodexCustomUsageError.self) {
+            _ = try await CodexCustomAPIFetchStrategy.fetchSnapshot(
+                credentials: (baseURL: #require(URL(string: "https://example.com")), apiKey: "sk-test"),
+                transport: transport)
+        }
+    }
+
+    @Test
+    func `is available returns false when credentials cannot resolve`() async {
+        let context = ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .api,
+            includeCredits: false,
+            includeOptionalUsage: false,
+            webTimeout: 60,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: ["CODEX_HOME": "/nonexistent-codex-home-\(UUID().uuidString)"],
+            settings: nil,
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: BrowserDetection(cacheTTL: 0)),
+            browserDetection: BrowserDetection(cacheTTL: 0))
+        let strategy = CodexCustomAPIFetchStrategy()
+        #expect(await strategy.isAvailable(context) == false)
+    }
+
+    @Test
+    func `is available returns true when credentials resolve`() async throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: home)
+        }
+        try """
+        model_provider = "OpenAI"
+        [model_providers.OpenAI]
+        base_url = "https://example.com"
+        """.write(to: home.appendingPathComponent("config.toml"), atomically: true, encoding: .utf8)
+        try #"{"OPENAI_API_KEY":"sk-test"}"#.write(
+            to: home.appendingPathComponent("auth.json"),
+            atomically: true,
+            encoding: .utf8)
+
+        let context = ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .api,
+            includeCredits: false,
+            includeOptionalUsage: false,
+            webTimeout: 60,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: ["CODEX_HOME": home.path],
+            settings: nil,
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: BrowserDetection(cacheTTL: 0)),
+            browserDetection: BrowserDetection(cacheTTL: 0))
+        let strategy = CodexCustomAPIFetchStrategy()
+        #expect(await strategy.isAvailable(context))
+    }
+
+    @Test
+    func `resolve strategies returns custom strategy for api source mode`() async {
+        // The custom source is opt-in: .auto must still resolve to OAuth/CLI,
+        // never the custom strategy.
+        let autoContext = ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .auto,
+            includeCredits: false,
+            includeOptionalUsage: false,
+            webTimeout: 60,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: nil,
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: BrowserDetection(cacheTTL: 0)),
+            browserDetection: BrowserDetection(cacheTTL: 0))
+        let autoStrategies = await CodexProviderDescriptor.descriptor.fetchPlan.pipeline
+            .resolveStrategies(autoContext)
+        #expect(autoStrategies.map(\.id) == ["codex.oauth", "codex.cli"])
+
+        let apiContext = ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .api,
+            includeCredits: false,
+            includeOptionalUsage: false,
+            webTimeout: 60,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: nil,
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: BrowserDetection(cacheTTL: 0)),
+            browserDetection: BrowserDetection(cacheTTL: 0))
+        let apiStrategies = await CodexProviderDescriptor.descriptor.fetchPlan.pipeline
+            .resolveStrategies(apiContext)
+        #expect(apiStrategies.map(\.id) == ["codex.custom"])
+    }
+}

--- a/Tests/CodexBarTests/CodexCustomProviderCredentialsTests.swift
+++ b/Tests/CodexBarTests/CodexCustomProviderCredentialsTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct CodexCustomProviderCredentialsTests {
+    // MARK: - TOML fragment parsing (in-memory string fixtures)
+
+    @Test
+    func `resolves base url from model provider and model_providers table`() throws {
+        let toml = """
+        model_provider = "OpenAI"
+        model_reasoning_effort = "medium"
+
+        [model_providers.OpenAI]
+        name = "OpenAI"
+        base_url = "https://example.com/v1"
+        wire_api = "responses"
+        """
+
+        let url = try #require(CodexCustomProviderCredentials.baseURL(from: toml))
+        #expect(url.absoluteString == "https://example.com/v1")
+    }
+
+    @Test
+    func `resolves base url when provider key is quoted`() throws {
+        let toml = """
+        model_provider = "My Provider"
+        [model_providers."My Provider"]
+        base_url = "https://example.com"
+        """
+
+        let url = try #require(CodexCustomProviderCredentials.baseURL(from: toml))
+        #expect(url.absoluteString == "https://example.com")
+    }
+
+    @Test
+    func `strips inline comments and surrounding quotes`() throws {
+        let toml = """
+        model_provider = "OpenAI" # the provider to use
+        [model_providers.OpenAI]
+        base_url = 'https://example.com' # custom endpoint
+        """
+
+        let url = try #require(CodexCustomProviderCredentials.baseURL(from: toml))
+        #expect(url.absoluteString == "https://example.com")
+    }
+
+    @Test
+    func `missing model provider resolves to nil`() {
+        let toml = """
+        [model_providers.OpenAI]
+        base_url = "https://example.com"
+        """
+        #expect(CodexCustomProviderCredentials.baseURL(from: toml) == nil)
+    }
+
+    @Test
+    func `named provider without base url resolves to nil`() {
+        let toml = """
+        model_provider = "OpenAI"
+        [model_providers.OpenAI]
+        name = "OpenAI"
+        """
+        #expect(CodexCustomProviderCredentials.baseURL(from: toml) == nil)
+    }
+
+    @Test
+    func `ignores base url under a different provider table`() {
+        let toml = """
+        model_provider = "OpenAI"
+        [model_providers.Other]
+        base_url = "https://wrong.com"
+        [model_providers.OpenAI]
+        name = "OpenAI"
+        """
+        #expect(CodexCustomProviderCredentials.baseURL(from: toml) == nil)
+    }
+
+    @Test
+    func `model provider value inside a table is not treated as the top-level selector`() {
+        // A `model_provider` key nested in a table must not be mistaken for the
+        // top-level selector that names the active provider.
+        let toml = """
+        [profile]
+        model_provider = "OpenAI"
+        """
+        #expect(CodexCustomProviderCredentials.modelProvider(from: toml) == nil)
+    }
+
+    @Test
+    func `invalid base url string resolves to nil`() {
+        let toml = """
+        model_provider = "OpenAI"
+        [model_providers.OpenAI]
+        base_url = "not a url"
+        """
+        #expect(CodexCustomProviderCredentials.baseURL(from: toml) == nil)
+    }
+
+    // MARK: - resolve(env:) honors CODEX_HOME with real (temp) files
+
+    @Test
+    func `resolve reads config and auth from CODEX_HOME`() throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: home)
+        }
+
+        let toml = """
+        model_provider = "OpenAI"
+        [model_providers.OpenAI]
+        base_url = "https://example.com"
+        """
+        try toml.write(
+            to: home.appendingPathComponent("config.toml"),
+            atomically: true,
+            encoding: .utf8)
+        let auth = #"{"OPENAI_API_KEY":"sk-test-123"}"#
+        try auth.write(
+            to: home.appendingPathComponent("auth.json"),
+            atomically: true,
+            encoding: .utf8)
+
+        let resolved = CodexCustomProviderCredentials.resolve(env: ["CODEX_HOME": home.path])
+        let credentials = try #require(resolved)
+        #expect(credentials.baseURL.absoluteString == "https://example.com")
+        #expect(credentials.apiKey == "sk-test-123")
+    }
+
+    @Test
+    func `resolve returns nil when auth json lacks OPENAI_API_KEY`() throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: home)
+        }
+
+        try """
+        model_provider = "OpenAI"
+        [model_providers.OpenAI]
+        base_url = "https://example.com"
+        """.write(
+            to: home.appendingPathComponent("config.toml"),
+            atomically: true,
+            encoding: .utf8)
+        // OAuth-style auth.json (no OPENAI_API_KEY) — custom source is unavailable.
+        try #"{"tokens":{"access_token":"tok","refresh_token":"ref"}}"#.write(
+            to: home.appendingPathComponent("auth.json"),
+            atomically: true,
+            encoding: .utf8)
+
+        #expect(CodexCustomProviderCredentials.resolve(env: ["CODEX_HOME": home.path]) == nil)
+    }
+
+    @Test
+    func `resolve returns nil when config lacks base url`() throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: home)
+        }
+
+        try "model_provider = \"OpenAI\"\n".write(
+            to: home.appendingPathComponent("config.toml"),
+            atomically: true,
+            encoding: .utf8)
+        try #"{"OPENAI_API_KEY":"sk-test"}"#.write(
+            to: home.appendingPathComponent("auth.json"),
+            atomically: true,
+            encoding: .utf8)
+
+        #expect(CodexCustomProviderCredentials.resolve(env: ["CODEX_HOME": home.path]) == nil)
+    }
+
+    @Test
+    func `resolve returns nil when files are absent`() {
+        let missingHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        #expect(CodexCustomProviderCredentials.resolve(env: ["CODEX_HOME": missingHome.path]) == nil)
+    }
+}

--- a/Tests/CodexBarTests/CodexCustomUsageMapperTests.swift
+++ b/Tests/CodexBarTests/CodexCustomUsageMapperTests.swift
@@ -1,0 +1,248 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CodexCustomUsageMapperTests {
+    private let updatedAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private static func date(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: components)!
+    }
+
+    @Test
+    func `daily only response maps credits and omits weekly window`() throws {
+        let json = """
+        {
+          "remaining": 104.52,
+          "unit": "USD",
+          "is_valid": true,
+          "plan_name": "Pro Daily",
+          "subscription": {
+            "daily_limit_usd": 200,
+            "daily_usage_usd": 95.48,
+            "weekly_limit_usd": 0,
+            "weekly_usage_usd": 0,
+            "expires_at": "2026-07-09T00:00:00Z"
+          }
+        }
+        """
+
+        let snapshot = try CodexCustomUsageMapper.map(
+            data: Data(json.utf8),
+            updatedAt: self.updatedAt)
+
+        #expect(snapshot.credits.remaining == 104.52)
+        let limit = try #require(snapshot.credits.codexCreditLimit)
+        #expect(limit.title == "Daily limit")
+        #expect(limit.used == 95.48)
+        #expect(limit.limit == 200)
+        #expect(limit.remaining == 104.52)
+        // 95.48 / 200 = 47.74% used → 52.26% remaining
+        #expect(abs(limit.remainingPercent - 52.26) < 0.01)
+        #expect(limit.resetsAt == Self.date(year: 2026, month: 7, day: 9))
+
+        #expect(snapshot.usage.primary == nil)
+        #expect(snapshot.usage.secondary == nil)
+        #expect(snapshot.usage.extraRateWindows == nil)
+        #expect(snapshot.usage.identity?.providerID == .codex)
+        #expect(snapshot.usage.identity?.accountOrganization == "Pro Daily")
+    }
+
+    @Test
+    func `daily and weekly response produces a weekly window with proportional usage`() throws {
+        let json = """
+        {
+          "remaining": 50,
+          "unit": "USD",
+          "is_valid": true,
+          "subscription": {
+            "daily_limit_usd": 100,
+            "daily_usage_usd": 50,
+            "weekly_limit_usd": 500,
+            "weekly_usage_usd": 125,
+            "expires_at": "2026-07-09T00:00:00Z"
+          }
+        }
+        """
+
+        let snapshot = try CodexCustomUsageMapper.map(
+            data: Data(json.utf8),
+            updatedAt: self.updatedAt)
+
+        let weekly = try #require(snapshot.usage.extraRateWindows?.first)
+        #expect(weekly.id == CodexCustomUsageMapper.weeklyWindowID)
+        #expect(weekly.title == CodexCustomUsageMapper.weeklyWindowTitle)
+        #expect(weekly.window.windowMinutes == 10080)
+        // 125 / 500 = 25% used
+        #expect(abs(weekly.window.usedPercent - 25) < 0.001)
+        // No primary/secondary window — the menu bar stays on the balance.
+        #expect(snapshot.usage.primary == nil)
+        #expect(snapshot.usage.secondary == nil)
+    }
+
+    @Test
+    func `weekly limit zero produces no weekly window`() throws {
+        let json = """
+        {
+          "remaining": 50,
+          "unit": "USD",
+          "is_valid": true,
+          "subscription": {
+            "daily_limit_usd": 100,
+            "daily_usage_usd": 50,
+            "weekly_limit_usd": 0,
+            "weekly_usage_usd": 0
+          }
+        }
+        """
+
+        let snapshot = try CodexCustomUsageMapper.map(
+            data: Data(json.utf8),
+            updatedAt: self.updatedAt)
+
+        #expect(snapshot.usage.extraRateWindows == nil)
+    }
+
+    @Test
+    func `weekly limit absent produces no weekly window`() throws {
+        let json = """
+        {
+          "remaining": 50,
+          "is_valid": true,
+          "subscription": {
+            "daily_limit_usd": 100,
+            "daily_usage_usd": 50
+          }
+        }
+        """
+
+        let snapshot = try CodexCustomUsageMapper.map(
+            data: Data(json.utf8),
+            updatedAt: self.updatedAt)
+
+        #expect(snapshot.usage.extraRateWindows == nil)
+    }
+
+    @Test
+    func `remaining zero preserves exhausted state`() throws {
+        let json = """
+        {
+          "remaining": 0,
+          "is_valid": true,
+          "subscription": {
+            "daily_limit_usd": 100,
+            "daily_usage_usd": 100
+          }
+        }
+        """
+
+        let snapshot = try CodexCustomUsageMapper.map(
+            data: Data(json.utf8),
+            updatedAt: self.updatedAt)
+
+        #expect(snapshot.credits.remaining == 0)
+        let limit = try #require(snapshot.credits.codexCreditLimit)
+        #expect(limit.remaining == 0)
+        #expect(limit.remainingPercent == 0)
+    }
+
+    @Test
+    func `is valid false throws instead of returning a partial snapshot`() {
+        let json = """
+        {
+          "remaining": 50,
+          "is_valid": false,
+          "subscription": {
+            "daily_limit_usd": 100,
+            "daily_usage_usd": 50
+          }
+        }
+        """
+
+        #expect(throws: CodexCustomUsageError.self) {
+            try CodexCustomUsageMapper.map(data: Data(json.utf8), updatedAt: self.updatedAt)
+        }
+    }
+
+    @Test
+    func `camelCase top level keys are also accepted`() throws {
+        // The PRD records top-level keys as camelCase (`isValid`, `planName`).
+        let json = """
+        {
+          "remaining": 10,
+          "unit": "USD",
+          "isValid": true,
+          "planName": "Starter",
+          "subscription": {
+            "daily_limit_usd": 20,
+            "daily_usage_usd": 10
+          }
+        }
+        """
+
+        let snapshot = try CodexCustomUsageMapper.map(
+            data: Data(json.utf8),
+            updatedAt: self.updatedAt)
+
+        #expect(snapshot.credits.remaining == 10)
+        #expect(snapshot.usage.identity?.accountOrganization == "Starter")
+    }
+
+    @Test
+    func `plan name is scoped to codex identity`() throws {
+        let json = """
+        {
+          "remaining": 10,
+          "is_valid": true,
+          "plan_name": "Team Plan",
+          "subscription": {
+            "daily_limit_usd": 20,
+            "daily_usage_usd": 10
+          }
+        }
+        """
+
+        let snapshot = try CodexCustomUsageMapper.map(
+            data: Data(json.utf8),
+            updatedAt: self.updatedAt)
+
+        // Plan name surfaces as the Codex provider's organization label only.
+        #expect(snapshot.usage.identity?.providerID == .codex)
+        #expect(snapshot.usage.identity?.accountOrganization == "Team Plan")
+    }
+
+    @Test
+    func `no daily limit omits codex credit limit but keeps remaining`() throws {
+        let json = """
+        {
+          "remaining": 42,
+          "is_valid": true,
+          "subscription": {
+            "weekly_limit_usd": 500,
+            "weekly_usage_usd": 100
+          }
+        }
+        """
+
+        let snapshot = try CodexCustomUsageMapper.map(
+            data: Data(json.utf8),
+            updatedAt: self.updatedAt)
+
+        #expect(snapshot.credits.remaining == 42)
+        #expect(snapshot.credits.codexCreditLimit == nil)
+        // Weekly window still renders from its own limit.
+        #expect(snapshot.usage.extraRateWindows?.count == 1)
+    }
+
+    @Test
+    func `invalid JSON throws parse failed`() {
+        #expect(throws: CodexCustomUsageError.self) {
+            try CodexCustomUsageMapper.map(data: Data("not json".utf8), updatedAt: self.updatedAt)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a fourth Codex usage data source — **Custom API** — for users who point Codex at a GPT-compatible third-party provider via `~/.codex/config.toml` (e.g. `model_provider` + `[model_providers.X].base_url`). Zero-config: reads the provider base URL from `config.toml` and `OPENAI_API_KEY` from `auth.json`, both respecting `CODEX_HOME`.

- **Menu bar** shows the daily remaining balance (via the existing `creditsBalance` fallback, since no primary/secondary rate window is produced).
- **Codex card** shows a daily limit progress bar (\"Daily limit\") and, when the provider reports one (`weekly_limit_usd > 0`), a weekly limit progress bar.
- **Auto mode is unchanged** — still OAuth/CLI. The custom source is opt-in only.

## Changes

- `CodexCustomProviderCredentials` — resolves base URL from `[model_providers.<model_provider>].base_url` (section-aware TOML fragment scanner) + `OPENAI_API_KEY` from `auth.json`, honoring `CODEX_HOME`; http/https scheme validation.
- `CodexCustomUsageMapper` / `CodexCustomUsageResponse` — fixed mapping of the `/v1/usage` response: `remaining` → `CreditsSnapshot`, daily limit → `codexCreditLimit`, weekly limit (>0) → `extraRateWindows`, `planName` → Codex-scoped identity label. `isValid: false` throws a typed error.
- `CodexCustomAPIFetchStrategy` — single strategy serving both usage and credits pipelines; carries the provider host as the usage identity's `accountEmail` so the credits pipeline's account-scoped guard resolves for API-key (non-OAuth) accounts.
- `.custom` case on `CodexUsageDataSource` → existing `ProviderSourceMode.api`; `resolveStrategies` returns the custom strategy for `.api`; picker persists `.custom`.
- No changes to `UsageProvider` enum, `ProviderConfig`, or `CodexBarConfig` schema. Local token-cost scan untouched.

## Testing

- `CodexCustomProviderCredentialsTests` — TOML fragment parsing + `resolve(env:)` with temp files (no Keychain, no network).
- `CodexCustomUsageMapperTests` — daily-only / daily+weekly / weekly-zero / `remaining == 0` / `isValid: false` / camelCase+snake_case top-level keys.
- `CodexCustomAPIFetchStrategyTests` — URL building, HTTP fetch mapping (mock transport), non-2xx error, availability, `resolveStrategies` returns custom for `.api` / OAuth+CLI for `.auto`.
- `CodexAccountScopedRefreshCreditsTests` — custom source refreshes credits through the account-scoped guard using the provider host as identity.
- `CodexConsumerProjectionTests` — menu-bar fallback + weekly-bar-doesn't-steal-menu-bar behavior.

`make check` (swiftformat + swiftlint) clean. Verified end-to-end against a real custom provider: daily balance in the menu bar, daily limit bar in the card.