### PR TITLE
Fix quota refreshes after provider reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Antigravity: recover CLI listening ports from Linux procfs when `lsof` is unavailable, including process network namespaces. Thanks @junmo-kim!
 - Gemini: prefer Google's paid-tier plan label over generic Free, Workspace, or Paid fallbacks while preserving acronym casing in the CLI. Thanks @Yuxin-Qiao!
 - Codex: avoid false session-reset celebrations from transient zero-usage samples until the reset boundary advances. Thanks @kiranmagic7!
-- Settings: keep visual-only preference changes on cached UI paths instead of refreshing provider quotas, while preserving refreshes for data-affecting settings. Thanks @Zihao-Qi!
+- Settings: keep visual-only preferences and provider reordering on cached UI paths instead of refreshing provider quotas, while preserving refreshes for data-affecting settings. Thanks @Zihao-Qi!
 - Ollama: recognize current WorkOS AuthKit sessions during browser-cookie discovery and manual cookie validation. Thanks @joeVenner!
 - Ollama: classify current WorkOS sign-in redirects as expired sessions, enabling cookie-candidate fallback instead of a parser error. Thanks @joeVenner!
 - Widgets: show token-cost rows with their own age when they lag a fresh quota snapshot, and retry fast token-scan failures without waiting out the hourly cache. Thanks @irresi!

--- a/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
+++ b/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
@@ -4,48 +4,48 @@ import Foundation
 private enum ConfigChangeOrigin {
     case localUser
     case externalSync
-    case reload
 }
 
 private struct ConfigChangeContext {
     let origin: ConfigChangeOrigin
     let reason: String
+    let affectsBackgroundWork: Bool
 
-    static func local(reason: String) -> Self {
-        Self(origin: .localUser, reason: reason)
+    static func local(reason: String, affectsBackgroundWork: Bool) -> Self {
+        Self(origin: .localUser, reason: reason, affectsBackgroundWork: affectsBackgroundWork)
     }
 
-    static func external(reason: String) -> Self {
-        Self(origin: .externalSync, reason: reason)
-    }
-
-    static func reload(reason: String) -> Self {
-        Self(origin: .reload, reason: reason)
+    static func external(reason: String, affectsBackgroundWork: Bool) -> Self {
+        Self(origin: .externalSync, reason: reason, affectsBackgroundWork: affectsBackgroundWork)
     }
 
     var shouldBroadcast: Bool {
         switch self.origin {
         case .localUser:
             true
-        case .externalSync, .reload:
+        case .externalSync:
             false
         }
     }
 }
 
 extension SettingsStore {
-    private func updateConfig(reason: String, mutate: (inout CodexBarConfig) -> Void) {
+    private func updateConfig(
+        reason: String,
+        affectsBackgroundWork: Bool,
+        mutate: (inout CodexBarConfig) -> Void)
+    {
         guard !self.configLoading else { return }
         var config = self.config
         mutate(&config)
         self.config = config.normalized()
         self.updateProviderState(config: self.config)
         self.schedulePersistConfig()
-        self.bumpConfigRevision(.local(reason: reason))
+        self.bumpConfigRevision(.local(reason: reason, affectsBackgroundWork: affectsBackgroundWork))
     }
 
     func updateProviderConfig(provider: UsageProvider, mutate: (inout ProviderConfig) -> Void) {
-        self.updateConfig(reason: "provider-\(provider.rawValue)") { config in
+        self.updateConfig(reason: "provider-\(provider.rawValue)", affectsBackgroundWork: true) { config in
             if let index = config.providers.firstIndex(where: { $0.id == provider }) {
                 var entry = config.providers[index]
                 mutate(&entry)
@@ -69,7 +69,7 @@ extension SettingsStore {
                 "providers": "\(accounts.count)",
                 "summary": summary,
             ])
-        self.updateConfig(reason: "token-accounts") { config in
+        self.updateConfig(reason: "token-accounts", affectsBackgroundWork: true) { config in
             var seen: Set<UsageProvider> = []
             for index in config.providers.indices {
                 let provider = config.providers[index].id
@@ -83,7 +83,7 @@ extension SettingsStore {
     }
 
     func setProviderOrder(_ order: [UsageProvider]) {
-        self.updateConfig(reason: "order") { config in
+        self.updateConfig(reason: "order", affectsBackgroundWork: false) { config in
             let configsByID = Dictionary(uniqueKeysWithValues: config.providers.map { ($0.id, $0) })
             var seen: Set<UsageProvider> = []
             var ordered: [ProviderConfig] = []
@@ -103,23 +103,57 @@ extension SettingsStore {
         }
     }
 
-    func reloadConfig(reason: String) {
+    func reloadConfig(reason: String, affectsBackgroundWork: Bool? = nil) {
         guard !self.configLoading else { return }
         do {
             guard let loaded = try self.configStore.load() else { return }
-            self.applyExternalConfig(loaded, reason: "reload-\(reason)")
+            self.applyExternalConfig(
+                loaded,
+                reason: "reload-\(reason)",
+                affectsBackgroundWork: affectsBackgroundWork)
         } catch {
             CodexBarLog.logger(LogCategories.configStore).error("Failed to reload config: \(error)")
         }
     }
 
-    func applyExternalConfig(_ config: CodexBarConfig, reason: String) {
+    func applyExternalConfig(
+        _ config: CodexBarConfig,
+        reason: String,
+        affectsBackgroundWork: Bool? = nil)
+    {
         guard !self.configLoading else { return }
+        let normalized = config.normalized()
+        let inferredBackgroundWorkChange = Self.configChangeAffectsBackgroundWork(
+            from: self.config,
+            to: normalized)
+        let resolvedBackgroundWorkChange = (affectsBackgroundWork ?? false) || inferredBackgroundWorkChange
         self.configLoading = true
-        self.config = config
-        self.updateProviderState(config: config)
+        self.config = normalized
+        self.updateProviderState(config: normalized)
         self.configLoading = false
-        self.bumpConfigRevision(.external(reason: "sync-\(reason)"))
+        self.bumpConfigRevision(.external(
+            reason: "sync-\(reason)",
+            affectsBackgroundWork: resolvedBackgroundWorkChange))
+    }
+
+    private static func configChangeAffectsBackgroundWork(
+        from previous: CodexBarConfig,
+        to current: CodexBarConfig) -> Bool
+    {
+        guard let previousData = orderIndependentConfigData(previous),
+              let currentData = orderIndependentConfigData(current)
+        else {
+            return true
+        }
+        return previousData != currentData
+    }
+
+    private static func orderIndependentConfigData(_ config: CodexBarConfig) -> Data? {
+        var canonical = config.normalized()
+        canonical.providers.sort { $0.id.rawValue < $1.id.rawValue }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try? encoder.encode(canonical)
     }
 
     private func bumpConfigRevision(_ context: ConfigChangeContext) {
@@ -128,8 +162,13 @@ extension SettingsStore {
         self.invalidateCodexAccountReconciliationSnapshotCache()
         self.cachedCodexAccountMenuProjection = nil
         self.configRevision &+= 1
+        if context.affectsBackgroundWork {
+            self.noteBackgroundWorkSettingsChanged()
+        }
         CodexBarLog.logger(LogCategories.settings)
-            .debug("Config revision bumped (\(context.reason)) -> \(self.configRevision)")
+            .debug(
+                "Config revision bumped (\(context.reason)) -> \(self.configRevision)",
+                metadata: ["backgroundWork": context.affectsBackgroundWork ? "1" : "0"])
         guard context.shouldBroadcast else { return }
         NotificationCenter.default.post(
             name: .codexbarProviderConfigDidChange,
@@ -138,6 +177,7 @@ extension SettingsStore {
                 "config": self.config,
                 "reason": context.reason,
                 "revision": self.configRevision,
+                "affectsBackgroundWork": context.affectsBackgroundWork,
             ])
     }
 

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -5,7 +5,7 @@ import ServiceManagement
 extension SettingsStore {
     private static let mergedOverviewSelectionEditedActiveProvidersKey = "mergedOverviewSelectionEditedActiveProviders"
 
-    private func noteBackgroundWorkSettingsChanged() {
+    func noteBackgroundWorkSettingsChanged() {
         self.backgroundWorkSettingsRevision &+= 1
     }
 

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -571,13 +571,19 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         guard !self.isReleasedForTesting else { return }
         #endif
         let reason = notification.userInfo?["reason"] as? String ?? "unknown"
+        let affectsBackgroundWork = notification.userInfo?["affectsBackgroundWork"] as? Bool
         if let source = notification.object as? SettingsStore,
            source !== self.settings
         {
             if let config = notification.userInfo?["config"] as? CodexBarConfig {
-                self.settings.applyExternalConfig(config, reason: "external-\(reason)")
+                self.settings.applyExternalConfig(
+                    config,
+                    reason: "external-\(reason)",
+                    affectsBackgroundWork: affectsBackgroundWork)
             } else {
-                self.settings.reloadConfig(reason: "external-\(reason)")
+                self.settings.reloadConfig(
+                    reason: "external-\(reason)",
+                    affectsBackgroundWork: affectsBackgroundWork)
             }
         }
         self.handleProviderConfigChange(reason: "notification:\(reason)")

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -76,7 +76,6 @@ extension UsageStore {
 
     var backgroundWorkSettingsObservationToken: Int {
         _ = self.settings.backgroundWorkSettingsRevision
-        _ = self.settings.configRevision
         return 0
     }
 

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -25,11 +25,17 @@ struct SettingsStoreCoverageTests {
         #expect(ordered.first == .zai)
         #expect(ordered.contains(.minimax))
 
+        let configRevisionBeforeOrder = settings.configRevision
+        let backgroundRevisionBeforeOrder = settings.backgroundWorkSettingsRevision
         settings.moveProvider(fromOffsets: IndexSet(integer: 0), toOffset: 2)
         #expect(settings.orderedProviders() != ordered)
+        #expect(settings.configRevision == configRevisionBeforeOrder + 1)
+        #expect(settings.backgroundWorkSettingsRevision == backgroundRevisionBeforeOrder)
 
         let metadata = ProviderRegistry.shared.metadata
+        let backgroundRevisionBeforeEnablement = settings.backgroundWorkSettingsRevision
         try settings.setProviderEnabled(provider: .codex, metadata: #require(metadata[.codex]), enabled: true)
+        #expect(settings.backgroundWorkSettingsRevision == backgroundRevisionBeforeEnablement + 1)
         try settings.setProviderEnabled(provider: .claude, metadata: #require(metadata[.claude]), enabled: false)
         let enabled = settings.enabledProvidersOrdered(metadataByProvider: metadata)
         #expect(enabled.contains(.codex))

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -25,6 +25,23 @@ struct SettingsStoreTests {
         }
     }
 
+    private final class BoolRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [Bool] = []
+
+        func append(_ value: Bool) {
+            self.lock.lock()
+            self.values.append(value)
+            self.lock.unlock()
+        }
+
+        func get() -> [Bool] {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.values
+        }
+    }
+
     @Test
     func `default refresh frequency is five minutes`() throws {
         let suite = "SettingsStoreTests-default"
@@ -965,6 +982,61 @@ struct SettingsStoreTests {
         store.applyExternalConfig(store.configSnapshot, reason: "test-external")
 
         #expect(notifications.get() == 0)
+    }
+
+    @Test
+    func `config notifications classify order and provider changes`() throws {
+        let suite = "SettingsStoreTests-config-change-impact"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        let impacts = BoolRecorder()
+        let token = NotificationCenter.default.addObserver(
+            forName: .codexbarProviderConfigDidChange,
+            object: store,
+            queue: .main)
+        { notification in
+            impacts.append(notification.userInfo?["affectsBackgroundWork"] as? Bool ?? true)
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        store.setProviderOrder(Array(store.orderedProviders().reversed()))
+        store.codexUsageDataSource = .cli
+
+        #expect(impacts.get() == [false, true])
+    }
+
+    @Test
+    func `external config ignores order-only changes for background work`() throws {
+        let suite = "SettingsStoreTests-external-config-impact"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        let initialConfigRevision = store.configRevision
+        let initialBackgroundRevision = store.backgroundWorkSettingsRevision
+        var reordered = store.configSnapshot
+        reordered.providers.reverse()
+        store.applyExternalConfig(reordered, reason: "order-only")
+
+        #expect(store.configRevision == initialConfigRevision + 1)
+        #expect(store.backgroundWorkSettingsRevision == initialBackgroundRevision)
+        #expect(store.orderedProviders() == reordered.providers.map(\.id))
+
+        var changed = store.configSnapshot
+        let codexIndex = try #require(changed.providers.firstIndex(where: { $0.id == .codex }))
+        changed.providers[codexIndex].source = .cli
+        store.applyExternalConfig(changed, reason: "provider-source", affectsBackgroundWork: false)
+
+        #expect(store.backgroundWorkSettingsRevision == initialBackgroundRevision + 1)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -66,6 +66,42 @@ struct StatusItemControllerSplitLifecycleTests {
     }
 
     @Test
+    func `provider config notifications relay background work impact between settings stores`() {
+        self.disableMenuCardsForTesting()
+        let sourceSettings = self.makeSettings()
+        let controllerSettings = self.makeSettings()
+        controllerSettings.statusChecksEnabled = false
+        controllerSettings.refreshFrequency = .manual
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: controllerSettings)
+        let controller = StatusItemController(
+            store: store,
+            settings: controllerSettings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting(),
+            observeProviderConfigNotifications: true)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let initialBackgroundRevision = controllerSettings.backgroundWorkSettingsRevision
+        let reorderedProviders = Array(sourceSettings.orderedProviders().reversed())
+        sourceSettings.setProviderOrder(reorderedProviders)
+
+        #expect(controllerSettings.orderedProviders() == reorderedProviders)
+        #expect(controllerSettings.backgroundWorkSettingsRevision == initialBackgroundRevision)
+
+        sourceSettings.codexUsageDataSource = .cli
+
+        #expect(controllerSettings.codexUsageDataSource == .cli)
+        #expect(controllerSettings.backgroundWorkSettingsRevision == initialBackgroundRevision + 1)
+    }
+
+    @Test
     func `merged mode removes split provider status items`() throws {
         let (settings, controller) = try self.makeSplitController()
         defer { controller.releaseStatusItemsForTesting() }

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -900,6 +900,42 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `provider config notifications relay background work impact between settings stores`() {
+        self.disableMenuCardsForTesting()
+        let sourceSettings = self.makeSettings()
+        let controllerSettings = self.makeSettings()
+        controllerSettings.statusChecksEnabled = false
+        controllerSettings.refreshFrequency = .manual
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: controllerSettings)
+        let controller = StatusItemController(
+            store: store,
+            settings: controllerSettings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting(),
+            observeProviderConfigNotifications: true)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let initialBackgroundRevision = controllerSettings.backgroundWorkSettingsRevision
+        let reorderedProviders = Array(sourceSettings.orderedProviders().reversed())
+        sourceSettings.setProviderOrder(reorderedProviders)
+
+        #expect(controllerSettings.orderedProviders() == reorderedProviders)
+        #expect(controllerSettings.backgroundWorkSettingsRevision == initialBackgroundRevision)
+
+        sourceSettings.codexUsageDataSource = .cli
+
+        #expect(controllerSettings.codexUsageDataSource == .cli)
+        #expect(controllerSettings.backgroundWorkSettingsRevision == initialBackgroundRevision + 1)
+    }
+
+    @Test
     func `provider config changes preserve status item instances`() throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -900,42 +900,6 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `provider config notifications relay background work impact between settings stores`() {
-        self.disableMenuCardsForTesting()
-        let sourceSettings = self.makeSettings()
-        let controllerSettings = self.makeSettings()
-        controllerSettings.statusChecksEnabled = false
-        controllerSettings.refreshFrequency = .manual
-
-        let fetcher = UsageFetcher()
-        let store = UsageStore(
-            fetcher: fetcher,
-            browserDetection: BrowserDetection(cacheTTL: 0),
-            settings: controllerSettings)
-        let controller = StatusItemController(
-            store: store,
-            settings: controllerSettings,
-            account: fetcher.loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: self.makeStatusBarForTesting(),
-            observeProviderConfigNotifications: true)
-        defer { controller.releaseStatusItemsForTesting() }
-
-        let initialBackgroundRevision = controllerSettings.backgroundWorkSettingsRevision
-        let reorderedProviders = Array(sourceSettings.orderedProviders().reversed())
-        sourceSettings.setProviderOrder(reorderedProviders)
-
-        #expect(controllerSettings.orderedProviders() == reorderedProviders)
-        #expect(controllerSettings.backgroundWorkSettingsRevision == initialBackgroundRevision)
-
-        sourceSettings.codexUsageDataSource = .cli
-
-        #expect(controllerSettings.codexUsageDataSource == .cli)
-        #expect(controllerSettings.backgroundWorkSettingsRevision == initialBackgroundRevision + 1)
-    }
-
-    @Test
     func `provider config changes preserve status item instances`() throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -647,6 +647,7 @@ struct UsageStoreCoverageTests {
         settings.mergeIcons = true
         settings.randomBlinkEnabled = true
         settings.debugLoadingPattern = .pulse
+        settings.setProviderOrder(Array(settings.orderedProviders().reversed()))
         try? await Task.sleep(nanoseconds: 50_000_000)
         #expect(didChange.get() == false)
 
@@ -715,10 +716,12 @@ struct UsageStoreCoverageTests {
         settings.mergeIcons = true
         settings.randomBlinkEnabled = true
         settings.debugLoadingPattern = .pulse
+        settings.setProviderOrder(Array(settings.orderedProviders().reversed()))
         try? await Task.sleep(nanoseconds: 50_000_000)
         #expect(refreshedProviders.isEmpty)
 
-        await store.refreshForSettingsChange()
+        settings.codexUsageDataSource = .cli
+        try? await Task.sleep(nanoseconds: 100_000_000)
         #expect(refreshedProviders.contains(.codex))
     }
 


### PR DESCRIPTION
## Summary
- separate config revisions used for UI projection from settings revisions that require provider background work
- keep provider reordering visual-only while preserving conservative refreshes for substantive cross-window config changes
- cover local, external, notification-relay, and UsageStore refresh behavior

Fixes #1994.

## Verification
- focused settings/UsageStore/MiMo coverage: 189 tests pass
- cross-instance `StatusItemController` notification-relay regression: pass
- `make check`
- `make test`: all 49 shards pass
- exact-branch autoreview: clean, no actionable findings
- signed packaged app: macOS 27 build 26A5368g, arm64, Xcode 26.6 / SDK 26.5; Developer ID verification and Gatekeeper assessment pass
- isolated live endpoint proof with Keychain access disabled and one loopback-only provider:
  - initial quota request count: 1
  - drag Codex from fourth to first in Settings: count remains 1
  - persisted order changes to Codex, OpenAI, Azure OpenAI, Claude, Cursor
  - disable/re-enable provider positive control: count increments from 1 to 2
  - relaunch: one expected startup request and the reordered sidebar persists

Exact packaged commit: `5ce335f9`.

## Risk
Low. The change narrows refresh observation only for provider ordering; provider credentials, source, enablement, and externally detected substantive config changes still invalidate background work. Dependencies unchanged.
