### PR TITLE
Fix serve deadline leaving orphan in-flight work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Quota warnings: add opt-in predictive pace alerts for Codex and Claude session and weekly limits, with one alert per risk episode. Thanks @vincent-peng!
 
 ### Fixed
+- CLI server: retain timed-out route and provider work until it actually exits, preventing repeated requests or config changes from stacking background fetches. Thanks @Yuxin-Qiao!
 - Ollama: validate API keys against an authenticated endpoint instead of the public model catalog while preserving refresh cancellation. Thanks @joeVenner!
 - Claude CLI: resolve yearless and time-only reset timestamps to their nearest occurrence so stale data cannot appear nearly a day or year away. Thanks @fanwenlin!
 - Catalan: complete current strings, align instructional voice, and enforce catalog parity. Thanks @pmontp19!

--- a/Sources/CodexBarCLI/CLICostCommand.swift
+++ b/Sources/CodexBarCLI/CLICostCommand.swift
@@ -351,7 +351,7 @@ struct CostOptions: CommanderParsable {
     var groupBy: String?
 }
 
-struct CostPayload: Encodable {
+struct CostPayload: Encodable, Sendable {
     let provider: String
     let source: String
     let updatedAt: Date?
@@ -397,7 +397,7 @@ struct CostPayload: Encodable {
     }
 }
 
-struct CostDailyEntryPayload: Encodable {
+struct CostDailyEntryPayload: Encodable, Sendable {
     let date: String
     let inputTokens: Int?
     let outputTokens: Int?
@@ -421,7 +421,7 @@ struct CostDailyEntryPayload: Encodable {
     }
 }
 
-struct CostModelBreakdownPayload: Encodable {
+struct CostModelBreakdownPayload: Encodable, Sendable {
     let modelName: String
     let costUSD: Double?
     let totalTokens: Int?
@@ -433,7 +433,7 @@ struct CostModelBreakdownPayload: Encodable {
     }
 }
 
-struct CostProjectPayload: Encodable {
+struct CostProjectPayload: Encodable, Sendable {
     let name: String
     let path: String?
     let totalTokens: Int?
@@ -471,7 +471,7 @@ struct CostProjectPayload: Encodable {
     }
 }
 
-struct CostProjectSourcePayload: Encodable {
+struct CostProjectSourcePayload: Encodable, Sendable {
     let name: String
     let path: String?
     let totalTokens: Int?
@@ -489,7 +489,7 @@ struct CostProjectSourcePayload: Encodable {
     }
 }
 
-struct CostTotalsPayload: Encodable {
+struct CostTotalsPayload: Encodable, Sendable {
     let totalInputTokens: Int?
     let totalOutputTokens: Int?
     let cacheReadTokens: Int?

--- a/Sources/CodexBarCLI/CLIErrorReporting.swift
+++ b/Sources/CodexBarCLI/CLIErrorReporting.swift
@@ -1,14 +1,14 @@
 import CodexBarCore
 import Foundation
 
-enum CLIErrorKind: String, Encodable {
+enum CLIErrorKind: String, Encodable, Sendable {
     case args
     case config
     case provider
     case runtime
 }
 
-struct ProviderErrorPayload: Encodable {
+struct ProviderErrorPayload: Encodable, Sendable {
     let code: Int32
     let message: String
     let kind: CLIErrorKind?

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -503,6 +503,7 @@ private struct CLIServeCostTimeoutError: LocalizedError {
 
 extension CodexBarCLI {
     static let defaultServeRequestTimeout: TimeInterval = 30
+    static let serveCostRefreshesPricingInBackground = true
     private static let maximumServeRequestTimeout: TimeInterval = 86400
 
     static func clampedServeRequestTimeout(_ requestTimeout: TimeInterval) -> TimeInterval {
@@ -1031,7 +1032,7 @@ extension CodexBarCLI {
                 let snapshot = try await fetcher.loadTokenSnapshot(
                     provider: provider,
                     forceRefresh: false,
-                    refreshPricingInBackground: false)
+                    refreshPricingInBackground: Self.serveCostRefreshesPricingInBackground)
                 return Self.makeCostPayload(provider: provider, snapshot: snapshot, error: nil)
             } catch {
                 return Self.makeCostPayload(provider: provider, snapshot: nil, error: error)
@@ -1046,9 +1047,9 @@ extension CodexBarCLI {
         context: ServeCostCollectionContext,
         fetch: @Sendable @escaping (UsageProvider) async -> CostPayload) async -> [CostPayload]
     {
-        // Preserve the established scan order. Each cost scan starts a
-        // best-effort pricing refresh, so parallel starts can duplicate that
-        // adjacent work even though the corpus scans themselves are coalesced.
+        // Preserve the established scan order. Pricing refresh stays best-effort
+        // background work so network latency never consumes a provider deadline;
+        // consecutive scans can still overlap that bounded adjacent work.
         var payload: [CostPayload] = []
         for provider in providers {
             let deadline = Self.serveCostProviderDeadline(

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -90,66 +90,6 @@ private struct ServeRuntime {
     let healthVersion: String?
 }
 
-private final class CLIServeDeadlineState: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<CLILocalHTTPResponse, Never>?
-    private var workTask: Task<Void, Never>?
-    private var timeoutTask: Task<Void, Never>?
-
-    init(continuation: CheckedContinuation<CLILocalHTTPResponse, Never>) {
-        self.continuation = continuation
-    }
-
-    func setWorkTask(_ task: Task<Void, Never>) {
-        var shouldCancel = false
-        self.lock.lock()
-        if self.continuation == nil {
-            shouldCancel = true
-        } else {
-            self.workTask = task
-        }
-        self.lock.unlock()
-
-        if shouldCancel {
-            task.cancel()
-        }
-    }
-
-    func setTimeoutTask(_ task: Task<Void, Never>) {
-        var shouldCancel = false
-        self.lock.lock()
-        if self.continuation == nil {
-            shouldCancel = true
-        } else {
-            self.timeoutTask = task
-        }
-        self.lock.unlock()
-
-        if shouldCancel {
-            task.cancel()
-        }
-    }
-
-    func finish(_ response: CLILocalHTTPResponse, cancelWork: Bool, cancelTimeout: Bool) {
-        let continuation: CheckedContinuation<CLILocalHTTPResponse, Never>?
-        let workTask: Task<Void, Never>?
-        let timeoutTask: Task<Void, Never>?
-
-        self.lock.lock()
-        continuation = self.continuation
-        self.continuation = nil
-        workTask = cancelWork ? self.workTask : nil
-        timeoutTask = cancelTimeout ? self.timeoutTask : nil
-        self.workTask = nil
-        self.timeoutTask = nil
-        self.lock.unlock()
-
-        workTask?.cancel()
-        timeoutTask?.cancel()
-        continuation?.resume(returning: response)
-    }
-}
-
 enum CLIServeCacheLookup {
     case response(CLILocalHTTPResponse)
     case miss
@@ -651,26 +591,23 @@ extension CodexBarCLI {
         }
         let nanoseconds = max(1, UInt64((clampedTimeout * 1_000_000_000).rounded(.up)))
 
-        return await withCheckedContinuation { continuation in
-            let state = CLIServeDeadlineState(continuation: continuation)
-            let workTask = Task {
-                let response = await makeResponse()
-                state.finish(response, cancelWork: false, cancelTimeout: true)
+        return await withTaskGroup(of: CLILocalHTTPResponse.self) { group in
+            group.addTask {
+                await makeResponse()
             }
-            state.setWorkTask(workTask)
-
-            let timeoutTask = Task {
+            group.addTask {
                 do {
                     try await Task.sleep(nanoseconds: nanoseconds)
                 } catch {
-                    return
+                    return Self.serveError(status: .gatewayTimeout, message: "request timed out")
                 }
-                state.finish(
-                    Self.serveError(status: .gatewayTimeout, message: "request timed out"),
-                    cancelWork: true,
-                    cancelTimeout: false)
+                return Self.serveError(status: .gatewayTimeout, message: "request timed out")
             }
-            state.setTimeoutTask(timeoutTask)
+
+            let first = await group.next()!
+            group.cancelAll()
+            while await group.next() != nil {}
+            return first
         }
     }
 

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -90,6 +90,79 @@ private struct ServeRuntime {
     let healthVersion: String?
 }
 
+private struct ServeDeadlineOutcome: Sendable {
+    let response: CLILocalHTTPResponse
+    let cleanupWork: Task<Void, Never>?
+}
+
+private final class CLIServeDeadlineState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<ServeDeadlineOutcome, Never>?
+    private var workTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    init(continuation: CheckedContinuation<ServeDeadlineOutcome, Never>) {
+        self.continuation = continuation
+    }
+
+    func setWorkTask(_ task: Task<Void, Never>) {
+        var shouldCancel = false
+        self.lock.lock()
+        if self.continuation == nil {
+            shouldCancel = true
+        } else {
+            self.workTask = task
+        }
+        self.lock.unlock()
+
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func setTimeoutTask(_ task: Task<Void, Never>) {
+        var shouldCancel = false
+        self.lock.lock()
+        if self.continuation == nil {
+            shouldCancel = true
+        } else {
+            self.timeoutTask = task
+        }
+        self.lock.unlock()
+
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func finish(_ outcome: ServeDeadlineOutcome, cancelWork: Bool, cancelTimeout: Bool) {
+        let continuation: CheckedContinuation<ServeDeadlineOutcome, Never>?
+        let capturedWorkTask: Task<Void, Never>?
+        let timeoutTask: Task<Void, Never>?
+
+        self.lock.lock()
+        continuation = self.continuation
+        self.continuation = nil
+        capturedWorkTask = self.workTask
+        timeoutTask = cancelTimeout ? self.timeoutTask : nil
+        self.workTask = nil
+        self.timeoutTask = nil
+        self.lock.unlock()
+
+        if cancelWork {
+            capturedWorkTask?.cancel()
+        }
+        timeoutTask?.cancel()
+
+        let resolved: ServeDeadlineOutcome = if cancelWork, let capturedWorkTask {
+            ServeDeadlineOutcome(response: outcome.response, cleanupWork: capturedWorkTask)
+        } else {
+            outcome
+        }
+        continuation?.resume(returning: resolved)
+    }
+}
+
 enum CLIServeCacheLookup {
     case response(CLILocalHTTPResponse)
     case miss
@@ -178,7 +251,8 @@ actor CLIServeResponseCache {
         for key: String,
         policy: CachePolicy,
         now: Date,
-        shouldCache: Bool) -> CLILocalHTTPResponse
+        shouldCache: Bool,
+        retainInFlight: Bool = false) -> CLILocalHTTPResponse
     {
         let delivered: CLILocalHTTPResponse
         let staleResponse = self.staleResponse(for: key, staleTTL: policy.staleTTL, now: now)
@@ -202,12 +276,23 @@ actor CLIServeResponseCache {
         } else {
             delivered = staleResponse ?? response
         }
-        self.inFlightKeys.remove(key)
+        if !retainInFlight {
+            self.inFlightKeys.remove(key)
+        }
         let waiters = self.waiters.removeValue(forKey: key) ?? []
         for waiter in waiters {
             waiter.resume(returning: .response(delivered))
         }
         return delivered
+    }
+
+    func releaseInFlight(for key: String) {
+        guard self.inFlightKeys.contains(key) else { return }
+        self.inFlightKeys.remove(key)
+        let waiters = self.waiters.removeValue(forKey: key) ?? []
+        for waiter in waiters {
+            waiter.resume(returning: .miss)
+        }
     }
 
     private func staleResponse(
@@ -332,6 +417,10 @@ actor CLIServeResponseCache {
 
     func cachedEntryCount() -> Int {
         self.entries.count
+    }
+
+    func inFlightKeyCount() -> Int {
+        self.inFlightKeys.count
     }
 
     func cachedStaleVariantCount() -> Int {
@@ -567,47 +656,95 @@ extension CodexBarCLI {
         case let .response(response):
             return response
         case .miss:
-            let response = await Self.serveResponseWithDeadline(seconds: requestTimeout) {
+            let outcome = await Self.serveResponseWithDeadline(seconds: requestTimeout) {
                 await makeResponse()
             }
+            let policy = CLIServeResponseCache.CachePolicy(
+                ttl: refreshInterval,
+                staleTTL: Self.serveStaleTTL(refreshInterval: refreshInterval))
+            let shouldCache = Self.shouldCacheServeResponse(outcome.response)
+            if let cleanupWork = outcome.cleanupWork {
+                let delivered = await cache.completeFetch(
+                    outcome.response,
+                    for: key,
+                    policy: policy,
+                    now: Date(),
+                    shouldCache: shouldCache,
+                    retainInFlight: true)
+                let cleanupGrace = Self.serveCleanupGrace(requestTimeout: requestTimeout)
+                Task {
+                    await Self.awaitServeWorkCleanup(cleanupWork, grace: cleanupGrace)
+                    await cache.releaseInFlight(for: key)
+                }
+                return delivered
+            }
             return await cache.completeFetch(
-                response,
+                outcome.response,
                 for: key,
-                policy: CLIServeResponseCache.CachePolicy(
-                    ttl: refreshInterval,
-                    staleTTL: Self.serveStaleTTL(refreshInterval: refreshInterval)),
+                policy: policy,
                 now: Date(),
-                shouldCache: Self.shouldCacheServeResponse(response))
+                shouldCache: shouldCache)
+        }
+    }
+
+    /// How long to keep a cache key in-flight after a timed-out serve response so
+    /// a second fetch cannot stack on canceled but still-running work.
+    static func serveCleanupGrace(requestTimeout: TimeInterval) -> TimeInterval {
+        guard requestTimeout > 0, requestTimeout.isFinite else { return 30 }
+        return min(requestTimeout, self.maximumServeRequestTimeout)
+    }
+
+    private static func awaitServeWorkCleanup(_ work: Task<Void, Never>, grace: TimeInterval) async {
+        guard grace > 0 else {
+            _ = await work.value
+            return
+        }
+        let nanoseconds = max(1, UInt64((grace * 1_000_000_000).rounded(.up)))
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { _ = await work.value }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: nanoseconds)
+            }
+            _ = await group.next()
+            group.cancelAll()
         }
     }
 
     private static func serveResponseWithDeadline(
         seconds timeout: TimeInterval,
-        makeResponse: @Sendable @escaping () async -> CLILocalHTTPResponse) async -> CLILocalHTTPResponse
+        makeResponse: @Sendable @escaping () async -> CLILocalHTTPResponse) async -> ServeDeadlineOutcome
     {
         let clampedTimeout = min(max(timeout, 0), Self.maximumServeRequestTimeout)
         guard clampedTimeout > 0 else {
-            return await makeResponse()
+            return await ServeDeadlineOutcome(response: makeResponse(), cleanupWork: nil)
         }
         let nanoseconds = max(1, UInt64((clampedTimeout * 1_000_000_000).rounded(.up)))
 
-        return await withTaskGroup(of: CLILocalHTTPResponse.self) { group in
-            group.addTask {
-                await makeResponse()
+        return await withCheckedContinuation { continuation in
+            let state = CLIServeDeadlineState(continuation: continuation)
+            let workTask = Task {
+                let response = await makeResponse()
+                state.finish(
+                    ServeDeadlineOutcome(response: response, cleanupWork: nil),
+                    cancelWork: false,
+                    cancelTimeout: true)
             }
-            group.addTask {
+            state.setWorkTask(workTask)
+
+            let timeoutTask = Task {
                 do {
                     try await Task.sleep(nanoseconds: nanoseconds)
                 } catch {
-                    return Self.serveError(status: .gatewayTimeout, message: "request timed out")
+                    return
                 }
-                return Self.serveError(status: .gatewayTimeout, message: "request timed out")
+                state.finish(
+                    ServeDeadlineOutcome(
+                        response: Self.serveError(status: .gatewayTimeout, message: "request timed out"),
+                        cleanupWork: nil),
+                    cancelWork: true,
+                    cancelTimeout: false)
             }
-
-            let first = await group.next()!
-            group.cancelAll()
-            while await group.next() != nil {}
-            return first
+            state.setTimeoutTask(timeoutTask)
         }
     }
 

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -234,18 +234,23 @@ actor CLIServeResponseCache {
 
     private func waitForInFlightRelease(key: String, requestTimeout: TimeInterval) async -> CLIServeCacheLookup {
         let waiterID = UUID()
-        let task = Task<CLIServeCacheLookup, Error> {
-            await self.awaitInFlightTurn(id: waiterID, key: key)
+        let clampedTimeout = CodexBarCLI.clampedServeRequestTimeout(requestTimeout)
+        guard clampedTimeout > 0 else {
+            return await self.awaitInFlightTurn(id: waiterID, key: key)
         }
-        let join = BoundedTaskJoin(sourceTask: task)
-        switch await join.value(joinGrace: Duration.seconds(requestTimeout)) {
-        case let .value(lookup):
-            return lookup
-        case .failure, .timedOut:
-            if let response = self.resumeWaiterTimeoutIfPending(id: waiterID, key: key) {
-                return .response(response)
+
+        return await withCheckedContinuation { (lookupContinuation: CheckedContinuation<CLIServeCacheLookup, Never>) in
+            self.enqueueWaiter(id: waiterID, key: key, continuation: lookupContinuation)
+
+            let nanoseconds = max(1, UInt64((clampedTimeout * 1_000_000_000).rounded(.up)))
+            Task {
+                do {
+                    try await Task.sleep(nanoseconds: nanoseconds)
+                } catch {
+                    return
+                }
+                _ = await self.resumeWaiterTimeoutIfPending(id: waiterID, key: key)
             }
-            return (try? await task.value) ?? .response(CodexBarCLI.serveTimeoutResponse())
         }
     }
 
@@ -514,11 +519,11 @@ extension CodexBarCLI {
     private static let maximumServeRequestTimeout: TimeInterval = 86400
 
     static func clampedServeRequestTimeout(_ requestTimeout: TimeInterval) -> TimeInterval {
-        min(max(requestTimeout, 0), Self.maximumServeRequestTimeout)
+        min(max(requestTimeout, 0), self.maximumServeRequestTimeout)
     }
 
     static func serveTimeoutResponse() -> CLILocalHTTPResponse {
-        Self.serveError(status: .gatewayTimeout, message: "request timed out")
+        self.serveError(status: .gatewayTimeout, message: "request timed out")
     }
 
     static func runServe(_ values: ParsedValues) async {
@@ -756,10 +761,19 @@ extension CodexBarCLI {
     }
 
     private static func awaitServeWorkCleanup(_ work: Task<Void, Never>, grace: TimeInterval) async {
-        guard grace > 0 else { return }
-        let nanoseconds = max(1, UInt64((grace * 1_000_000_000).rounded(.up)))
-        try? await Task.sleep(nanoseconds: nanoseconds)
-        work.cancel()
+        guard grace > 0 else {
+            work.cancel()
+            return
+        }
+        let join = BoundedTaskJoin(sourceTask: Task<Void, Error> {
+            await work.value
+        })
+        switch await join.value(joinGrace: .seconds(grace)) {
+        case .value:
+            return
+        case .failure, .timedOut:
+            work.cancel()
+        }
     }
 
     private static func serveResponseWithDeadline(

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -206,7 +206,48 @@ actor CLIServeResponseCache {
     private var lastGood: [String: LastGoodEntry] = [:]
     private var lastGoodUsageItems: [String: [UsageItemKey: LastGoodUsageItem]] = [:]
     private var inFlightKeys: Set<String> = []
-    private var waiters: [String: [CheckedContinuation<CLIServeCacheLookup, Never>]] = [:]
+    private var waiters: [String: [(UUID, CheckedContinuation<CLIServeCacheLookup, Never>)]] = [:]
+
+    private func enqueueWaiter(
+        id: UUID,
+        key: String,
+        continuation: CheckedContinuation<CLIServeCacheLookup, Never>)
+    {
+        self.waiters[key, default: []].append((id, continuation))
+    }
+
+    private func awaitInFlightTurn(id: UUID, key: String) async -> CLIServeCacheLookup {
+        await withCheckedContinuation { continuation in
+            self.enqueueWaiter(id: id, key: key, continuation: continuation)
+        }
+    }
+
+    private func resumeWaiterTimeoutIfPending(id: UUID, key: String) -> CLILocalHTTPResponse? {
+        guard var list = self.waiters[key],
+              let index = list.firstIndex(where: { $0.0 == id }) else { return nil }
+        let (_, continuation) = list.remove(at: index)
+        self.waiters[key] = list.isEmpty ? nil : list
+        let response = CodexBarCLI.serveTimeoutResponse()
+        continuation.resume(returning: .response(response))
+        return response
+    }
+
+    private func waitForInFlightRelease(key: String, requestTimeout: TimeInterval) async -> CLIServeCacheLookup {
+        let waiterID = UUID()
+        let task = Task<CLIServeCacheLookup, Error> {
+            await self.awaitInFlightTurn(id: waiterID, key: key)
+        }
+        let join = BoundedTaskJoin(sourceTask: task)
+        switch await join.value(joinGrace: Duration.seconds(requestTimeout)) {
+        case let .value(lookup):
+            return lookup
+        case .failure, .timedOut:
+            if let response = self.resumeWaiterTimeoutIfPending(id: waiterID, key: key) {
+                return .response(response)
+            }
+            return (try? await task.value) ?? .response(CodexBarCLI.serveTimeoutResponse())
+        }
+    }
 
     private func pruneExpiredEntries(now: Date) {
         self.entries = self.entries.filter { $0.value.expiresAt > now }
@@ -226,16 +267,21 @@ actor CLIServeResponseCache {
         return entry.response
     }
 
-    func responseOrStartFetch(for key: String, now: Date) async -> CLIServeCacheLookup {
+    func responseOrStartFetch(
+        for key: String,
+        requestTimeout: TimeInterval = 0,
+        now: Date) async -> CLIServeCacheLookup
+    {
         self.pruneExpiredEntries(now: now)
         if let cached = self.response(for: key) {
             return .response(cached)
         }
 
         if self.inFlightKeys.contains(key) {
-            return await withCheckedContinuation { continuation in
-                self.waiters[key, default: []].append(continuation)
+            if requestTimeout > 0 {
+                return await self.waitForInFlightRelease(key: key, requestTimeout: requestTimeout)
             }
+            return await self.awaitInFlightTurn(id: UUID(), key: key)
         }
 
         self.inFlightKeys.insert(key)
@@ -279,8 +325,8 @@ actor CLIServeResponseCache {
         if !retainInFlight {
             self.inFlightKeys.remove(key)
         }
-        let waiters = self.waiters.removeValue(forKey: key) ?? []
-        for waiter in waiters {
+        let pendingWaiters = self.waiters.removeValue(forKey: key) ?? []
+        for (_, waiter) in pendingWaiters {
             waiter.resume(returning: .response(delivered))
         }
         return delivered
@@ -288,11 +334,18 @@ actor CLIServeResponseCache {
 
     func releaseInFlight(for key: String) {
         guard self.inFlightKeys.contains(key) else { return }
+        var pending = self.waiters.removeValue(forKey: key) ?? []
         self.inFlightKeys.remove(key)
-        let waiters = self.waiters.removeValue(forKey: key) ?? []
-        for waiter in waiters {
-            waiter.resume(returning: .miss)
+
+        guard let (_, elected) = pending.first else { return }
+        pending.removeFirst()
+
+        self.inFlightKeys.insert(key)
+        if !pending.isEmpty {
+            self.waiters[key] = pending
         }
+
+        elected.resume(returning: .miss)
     }
 
     private func staleResponse(
@@ -459,6 +512,14 @@ private struct CLIServeProviderTimeoutError: LocalizedError {
 extension CodexBarCLI {
     static let defaultServeRequestTimeout: TimeInterval = 30
     private static let maximumServeRequestTimeout: TimeInterval = 86400
+
+    static func clampedServeRequestTimeout(_ requestTimeout: TimeInterval) -> TimeInterval {
+        min(max(requestTimeout, 0), Self.maximumServeRequestTimeout)
+    }
+
+    static func serveTimeoutResponse() -> CLILocalHTTPResponse {
+        Self.serveError(status: .gatewayTimeout, message: "request timed out")
+    }
 
     static func runServe(_ values: ParsedValues) async {
         let output = CLIOutputPreferences(format: .json, jsonOnly: true, pretty: false)
@@ -652,7 +713,7 @@ extension CodexBarCLI {
         requestTimeout: TimeInterval = CodexBarCLI.defaultServeRequestTimeout,
         makeResponse: @Sendable @escaping () async -> CLILocalHTTPResponse) async -> CLILocalHTTPResponse
     {
-        switch await cache.responseOrStartFetch(for: key, now: Date()) {
+        switch await cache.responseOrStartFetch(for: key, requestTimeout: requestTimeout, now: Date()) {
         case let .response(response):
             return response
         case .miss:
@@ -695,19 +756,10 @@ extension CodexBarCLI {
     }
 
     private static func awaitServeWorkCleanup(_ work: Task<Void, Never>, grace: TimeInterval) async {
-        guard grace > 0 else {
-            _ = await work.value
-            return
-        }
+        guard grace > 0 else { return }
         let nanoseconds = max(1, UInt64((grace * 1_000_000_000).rounded(.up)))
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask { _ = await work.value }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: nanoseconds)
-            }
-            _ = await group.next()
-            group.cancelAll()
-        }
+        try? await Task.sleep(nanoseconds: nanoseconds)
+        work.cancel()
     }
 
     private static func serveResponseWithDeadline(

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -115,8 +115,14 @@ private struct ServeUsageContext: Sendable {
 
 private struct ServeCostContext: Sendable {
     let config: CodexBarConfig
+    let collection: ServeCostCollectionContext
+}
+
+struct ServeCostCollectionContext: Sendable {
     let configFingerprint: String
-    let providerDeadline: ContinuousClock.Instant?
+    let providerTimeout: TimeInterval?
+    let requestDeadline: ContinuousClock.Instant?
+    let now: @Sendable () -> ContinuousClock.Instant
     let providerOperations: CLIServeOperationCoordinator<CostPayload>
 }
 
@@ -693,9 +699,12 @@ extension CodexBarCLI {
                         provider: provider,
                         context: ServeCostContext(
                             config: snapshot.config,
-                            configFingerprint: snapshot.cacheToken,
-                            providerDeadline: providerDeadline,
-                            providerOperations: runtime.costOperations))
+                            collection: ServeCostCollectionContext(
+                                configFingerprint: snapshot.cacheToken,
+                                providerTimeout: providerTimeout,
+                                requestDeadline: requestDeadline,
+                                now: { ContinuousClock().now },
+                                providerOperations: runtime.costOperations)))
                 })
         }
     }
@@ -908,8 +917,8 @@ extension CodexBarCLI {
             usageCacheKeys: output.payload.map(\.cacheAccountKey))
     }
 
-    /// Per-provider fetch budget for `/usage`. Finite provider work is bounded
-    /// below the outer request deadline so the empty 504 stays a last resort.
+    /// Per-provider fetch budget for `/usage` and `/cost`. Finite provider work
+    /// is bounded below the outer request deadline so the empty 504 stays a last resort.
     /// `nil` preserves the documented disabled serve deadline without changing
     /// provider-specific internal timeouts.
     static func serveProviderTimeout(requestTimeout: TimeInterval) -> TimeInterval? {
@@ -1016,9 +1025,7 @@ extension CodexBarCLI {
         let fetcher = CostUsageFetcher()
         let payload = await Self.serveCollectCostPayloads(
             providers: providers,
-            configFingerprint: context.configFingerprint,
-            deadline: context.providerDeadline,
-            operations: context.providerOperations)
+            context: context.collection)
         { provider in
             do {
                 let snapshot = try await fetcher.loadTokenSnapshot(
@@ -1036,9 +1043,7 @@ extension CodexBarCLI {
 
     static func serveCollectCostPayloads(
         providers: [UsageProvider],
-        configFingerprint: String,
-        deadline: ContinuousClock.Instant?,
-        operations: CLIServeOperationCoordinator<CostPayload>,
+        context: ServeCostCollectionContext,
         fetch: @Sendable @escaping (UsageProvider) async -> CostPayload) async -> [CostPayload]
     {
         // Preserve the established scan order. Each cost scan starts a
@@ -1046,13 +1051,17 @@ extension CodexBarCLI {
         // adjacent work even though the corpus scans themselves are coalesced.
         var payload: [CostPayload] = []
         for provider in providers {
+            let deadline = Self.serveCostProviderDeadline(
+                startedAt: context.now(),
+                providerTimeout: context.providerTimeout,
+                requestDeadline: context.requestDeadline)
             let timeout = Self.makeCostPayload(
                 provider: provider,
                 snapshot: nil,
                 error: CLIServeCostTimeoutError(provider: provider))
-            let item = await operations.value(
+            let item = await context.providerOperations.value(
                 for: provider.rawValue,
-                fingerprint: configFingerprint,
+                fingerprint: context.configFingerprint,
                 deadline: deadline,
                 timeoutValue: timeout)
             {
@@ -1061,6 +1070,19 @@ extension CodexBarCLI {
             payload.append(item)
         }
         return payload
+    }
+
+    /// Gives a sequential cost scan its full provider budget from the point it
+    /// actually starts, without allowing the overall HTTP request to overrun.
+    static func serveCostProviderDeadline(
+        startedAt: ContinuousClock.Instant,
+        providerTimeout: TimeInterval?,
+        requestDeadline: ContinuousClock.Instant?) -> ContinuousClock.Instant?
+    {
+        guard let providerTimeout else { return requestDeadline }
+        let providerDeadline = startedAt.advanced(by: .seconds(max(0, providerTimeout)))
+        guard let requestDeadline else { return providerDeadline }
+        return min(providerDeadline, requestDeadline)
     }
 
     private static func serveProviderSelection(

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -85,91 +85,48 @@ struct CLIServeConfigSnapshot {
 private struct ServeRuntime {
     let configStore: CodexBarConfigStore
     let cache: CLIServeResponseCache
+    let providerOperations: CLIServeOperationCoordinator<UsageCommandOutput>
+    let costOperations: CLIServeOperationCoordinator<CostPayload>
     let refreshInterval: TimeInterval
     let requestTimeout: TimeInterval
     let healthVersion: String?
 }
 
-private struct ServeDeadlineOutcome: Sendable {
+private struct ServeResponseRequest: Sendable {
+    let key: String
+    let configFingerprint: String
+    let refreshInterval: TimeInterval
+    let deadline: ContinuousClock.Instant?
+}
+
+struct CLIServeCoordinatedResponse: Sendable {
     let response: CLILocalHTTPResponse
-    let cleanupWork: Task<Void, Never>?
+    let isCommitted: Bool
 }
 
-private final class CLIServeDeadlineState: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<ServeDeadlineOutcome, Never>?
-    private var workTask: Task<Void, Never>?
-    private var timeoutTask: Task<Void, Never>?
-
-    init(continuation: CheckedContinuation<ServeDeadlineOutcome, Never>) {
-        self.continuation = continuation
-    }
-
-    func setWorkTask(_ task: Task<Void, Never>) {
-        var shouldCancel = false
-        self.lock.lock()
-        if self.continuation == nil {
-            shouldCancel = true
-        } else {
-            self.workTask = task
-        }
-        self.lock.unlock()
-
-        if shouldCancel {
-            task.cancel()
-        }
-    }
-
-    func setTimeoutTask(_ task: Task<Void, Never>) {
-        var shouldCancel = false
-        self.lock.lock()
-        if self.continuation == nil {
-            shouldCancel = true
-        } else {
-            self.timeoutTask = task
-        }
-        self.lock.unlock()
-
-        if shouldCancel {
-            task.cancel()
-        }
-    }
-
-    func finish(_ outcome: ServeDeadlineOutcome, cancelWork: Bool, cancelTimeout: Bool) {
-        let continuation: CheckedContinuation<ServeDeadlineOutcome, Never>?
-        let capturedWorkTask: Task<Void, Never>?
-        let timeoutTask: Task<Void, Never>?
-
-        self.lock.lock()
-        continuation = self.continuation
-        self.continuation = nil
-        capturedWorkTask = self.workTask
-        timeoutTask = cancelTimeout ? self.timeoutTask : nil
-        self.workTask = nil
-        self.timeoutTask = nil
-        self.lock.unlock()
-
-        if cancelWork {
-            capturedWorkTask?.cancel()
-        }
-        timeoutTask?.cancel()
-
-        let resolved: ServeDeadlineOutcome = if cancelWork, let capturedWorkTask {
-            ServeDeadlineOutcome(response: outcome.response, cleanupWork: capturedWorkTask)
-        } else {
-            outcome
-        }
-        continuation?.resume(returning: resolved)
-    }
+private struct ServeUsageContext: Sendable {
+    let config: CodexBarConfig
+    let configFingerprint: String
+    let refreshInterval: TimeInterval
+    let providerTimeout: TimeInterval?
+    let providerDeadline: ContinuousClock.Instant?
+    let providerOperations: CLIServeOperationCoordinator<UsageCommandOutput>
 }
 
-enum CLIServeCacheLookup {
-    case response(CLILocalHTTPResponse)
-    case miss
+private struct ServeCostContext: Sendable {
+    let config: CodexBarConfig
+    let configFingerprint: String
+    let providerDeadline: ContinuousClock.Instant?
+    let providerOperations: CLIServeOperationCoordinator<CostPayload>
 }
 
 actor CLIServeResponseCache {
     static let maximumStaleTTL: TimeInterval = 3600
+    nonisolated let operations: CLIServeOperationCoordinator<CLIServeCoordinatedResponse>
+
+    init(operations: CLIServeOperationCoordinator<CLIServeCoordinatedResponse> = CLIServeOperationCoordinator()) {
+        self.operations = operations
+    }
 
     private struct Entry {
         let expiresAt: Date
@@ -202,57 +159,20 @@ actor CLIServeResponseCache {
         let response: CLILocalHTTPResponse
     }
 
+    private struct LastGoodCostItem {
+        let recordedAt: Date
+        let data: Data
+    }
+
+    private struct CostMergeResult {
+        let response: CLILocalHTTPResponse
+    }
+
     private var entries: [String: Entry] = [:]
     private var lastGood: [String: LastGoodEntry] = [:]
     private var lastGoodUsageItems: [String: [UsageItemKey: LastGoodUsageItem]] = [:]
-    private var inFlightKeys: Set<String> = []
-    private var waiters: [String: [(UUID, CheckedContinuation<CLIServeCacheLookup, Never>)]] = [:]
-
-    private func enqueueWaiter(
-        id: UUID,
-        key: String,
-        continuation: CheckedContinuation<CLIServeCacheLookup, Never>)
-    {
-        self.waiters[key, default: []].append((id, continuation))
-    }
-
-    private func awaitInFlightTurn(id: UUID, key: String) async -> CLIServeCacheLookup {
-        await withCheckedContinuation { continuation in
-            self.enqueueWaiter(id: id, key: key, continuation: continuation)
-        }
-    }
-
-    private func resumeWaiterTimeoutIfPending(id: UUID, key: String) -> CLILocalHTTPResponse? {
-        guard var list = self.waiters[key],
-              let index = list.firstIndex(where: { $0.0 == id }) else { return nil }
-        let (_, continuation) = list.remove(at: index)
-        self.waiters[key] = list.isEmpty ? nil : list
-        let response = CodexBarCLI.serveTimeoutResponse()
-        continuation.resume(returning: .response(response))
-        return response
-    }
-
-    private func waitForInFlightRelease(key: String, requestTimeout: TimeInterval) async -> CLIServeCacheLookup {
-        let waiterID = UUID()
-        let clampedTimeout = CodexBarCLI.clampedServeRequestTimeout(requestTimeout)
-        guard clampedTimeout > 0 else {
-            return await self.awaitInFlightTurn(id: waiterID, key: key)
-        }
-
-        return await withCheckedContinuation { (lookupContinuation: CheckedContinuation<CLIServeCacheLookup, Never>) in
-            self.enqueueWaiter(id: waiterID, key: key, continuation: lookupContinuation)
-
-            let nanoseconds = max(1, UInt64((clampedTimeout * 1_000_000_000).rounded(.up)))
-            Task {
-                do {
-                    try await Task.sleep(nanoseconds: nanoseconds)
-                } catch {
-                    return
-                }
-                _ = await self.resumeWaiterTimeoutIfPending(id: waiterID, key: key)
-            }
-        }
-    }
+    private var lastGoodCostItems: [String: [String: LastGoodCostItem]] = [:]
+    private var lastGoodCostOrder: [String: [String]] = [:]
 
     private func pruneExpiredEntries(now: Date) {
         self.entries = self.entries.filter { $0.value.expiresAt > now }
@@ -265,6 +185,13 @@ actor CLIServeResponseCache {
             }
             return retained.isEmpty ? nil : retained
         }
+        self.lastGoodCostItems = self.lastGoodCostItems.compactMapValues { items in
+            let retained = items.filter {
+                now.timeIntervalSince($0.value.recordedAt) <= Self.maximumStaleTTL
+            }
+            return retained.isEmpty ? nil : retained
+        }
+        self.lastGoodCostOrder = self.lastGoodCostOrder.filter { self.lastGoodCostItems[$0.key] != nil }
     }
 
     private func response(for key: String) -> CLILocalHTTPResponse? {
@@ -272,29 +199,13 @@ actor CLIServeResponseCache {
         return entry.response
     }
 
-    func responseOrStartFetch(
-        for key: String,
-        requestTimeout: TimeInterval = 0,
-        now: Date) async -> CLIServeCacheLookup
-    {
+    func cachedResponse(for key: String, now: Date) -> CLILocalHTTPResponse? {
         self.pruneExpiredEntries(now: now)
-        if let cached = self.response(for: key) {
-            return .response(cached)
-        }
-
-        if self.inFlightKeys.contains(key) {
-            if requestTimeout > 0 {
-                return await self.waitForInFlightRelease(key: key, requestTimeout: requestTimeout)
-            }
-            return await self.awaitInFlightTurn(id: UUID(), key: key)
-        }
-
-        self.inFlightKeys.insert(key)
-        return .miss
+        return self.response(for: key)
     }
 
-    /// Completes an in-flight fetch and returns the response delivered to
-    /// waiters. Successful responses are cached normally. Failed non-usage
+    /// Transforms a fetched response through the cache's stale policy. Successful
+    /// responses are cached normally. Failed non-usage
     /// fetches may use a whole-response fallback within `staleTTL`; usage
     /// responses only replace keyed error rows from the same identified account.
     func completeFetch(
@@ -302,8 +213,7 @@ actor CLIServeResponseCache {
         for key: String,
         policy: CachePolicy,
         now: Date,
-        shouldCache: Bool,
-        retainInFlight: Bool = false) -> CLILocalHTTPResponse
+        shouldCache: Bool) -> CLILocalHTTPResponse
     {
         let delivered: CLILocalHTTPResponse
         let staleResponse = self.staleResponse(for: key, staleTTL: policy.staleTTL, now: now)
@@ -313,9 +223,15 @@ actor CLIServeResponseCache {
             staleTTL: policy.staleTTL,
             now: now,
             replaceCachedItems: shouldCache)
+        let costMerge = self.mergeLastGoodCostItems(
+            into: response,
+            for: key,
+            staleTTL: policy.staleTTL,
+            now: now,
+            replaceCachedItems: shouldCache)
         if shouldCache {
             self.store(response, for: key, ttl: policy.ttl, now: now)
-            if key.hasPrefix("usage:") {
+            if key.hasPrefix("usage:") || key.hasPrefix("cost:") {
                 self.lastGood[key] = nil
             } else {
                 self.lastGood[key] = LastGoodEntry(recordedAt: now, response: response)
@@ -324,33 +240,13 @@ actor CLIServeResponseCache {
         } else if let usageMerge {
             delivered = usageMerge.response
             self.lastGood[key] = nil
+        } else if let costMerge {
+            delivered = costMerge.response
+            self.lastGood[key] = nil
         } else {
             delivered = staleResponse ?? response
         }
-        if !retainInFlight {
-            self.inFlightKeys.remove(key)
-        }
-        let pendingWaiters = self.waiters.removeValue(forKey: key) ?? []
-        for (_, waiter) in pendingWaiters {
-            waiter.resume(returning: .response(delivered))
-        }
         return delivered
-    }
-
-    func releaseInFlight(for key: String) {
-        guard self.inFlightKeys.contains(key) else { return }
-        var pending = self.waiters.removeValue(forKey: key) ?? []
-        self.inFlightKeys.remove(key)
-
-        guard let (_, elected) = pending.first else { return }
-        pending.removeFirst()
-
-        self.inFlightKeys.insert(key)
-        if !pending.isEmpty {
-            self.waiters[key] = pending
-        }
-
-        elected.resume(returning: .miss)
     }
 
     private func staleResponse(
@@ -362,6 +258,9 @@ actor CLIServeResponseCache {
         // A timeout cannot prove which usage account is currently active.
         if key.hasPrefix("usage:") {
             return nil
+        }
+        if key.hasPrefix("cost:") {
+            return self.staleCostResponse(for: key, staleTTL: staleTTL, now: now)
         }
         if let entry = self.lastGood[key],
            now.timeIntervalSince(entry.recordedAt) <= staleTTL
@@ -468,6 +367,84 @@ actor CLIServeResponseCache {
         return !(error is NSNull)
     }
 
+    private func mergeLastGoodCostItems(
+        into response: CLILocalHTTPResponse,
+        for key: String,
+        staleTTL: TimeInterval,
+        now: Date,
+        replaceCachedItems: Bool) -> CostMergeResult?
+    {
+        guard key.hasPrefix("cost:"),
+              response.status == .ok,
+              staleTTL > 0,
+              var items = try? JSONSerialization.jsonObject(with: response.body) as? [[String: Any]]
+        else {
+            return nil
+        }
+
+        let providers = items.compactMap { item -> String? in
+            guard let provider = item["provider"] as? String, !provider.isEmpty else { return nil }
+            return provider
+        }
+        guard providers.count == items.count, Set(providers).count == providers.count else {
+            return CostMergeResult(response: response)
+        }
+
+        var cachedItems = replaceCachedItems ? [:] : self.lastGoodCostItems[key] ?? [:]
+        if !replaceCachedItems {
+            cachedItems = cachedItems.filter { now.timeIntervalSince($0.value.recordedAt) <= staleTTL }
+        }
+        for index in items.indices {
+            let provider = providers[index]
+            if Self.hasError(items[index]) {
+                if let cached = cachedItems[provider],
+                   let cachedItem = try? JSONSerialization.jsonObject(with: cached.data) as? [String: Any]
+                {
+                    items[index] = cachedItem
+                }
+            } else if let data = try? JSONSerialization.data(withJSONObject: items[index], options: [.sortedKeys]) {
+                cachedItems[provider] = LastGoodCostItem(recordedAt: now, data: data)
+            }
+        }
+        self.lastGoodCostItems[key] = cachedItems
+        self.lastGoodCostOrder[key] = providers
+
+        guard let body = try? JSONSerialization.data(withJSONObject: items, options: [.sortedKeys]) else {
+            return CostMergeResult(response: response)
+        }
+        return CostMergeResult(response: CLILocalHTTPResponse(
+            status: response.status,
+            body: body,
+            contentType: response.contentType,
+            usageCacheKeys: response.usageCacheKeys))
+    }
+
+    private func staleCostResponse(
+        for key: String,
+        staleTTL: TimeInterval,
+        now: Date) -> CLILocalHTTPResponse?
+    {
+        guard let order = self.lastGoodCostOrder[key], !order.isEmpty,
+              let cachedItems = self.lastGoodCostItems[key]
+        else {
+            return nil
+        }
+        let rows = order.compactMap { provider -> Any? in
+            guard let cached = cachedItems[provider],
+                  now.timeIntervalSince(cached.recordedAt) <= staleTTL
+            else {
+                return nil
+            }
+            return try? JSONSerialization.jsonObject(with: cached.data)
+        }
+        guard rows.count == order.count,
+              let body = try? JSONSerialization.data(withJSONObject: rows, options: [.sortedKeys])
+        else {
+            return nil
+        }
+        return CLILocalHTTPResponse(status: .ok, body: body)
+    }
+
     private func store(_ response: CLILocalHTTPResponse, for key: String, ttl: TimeInterval, now: Date) {
         guard ttl > 0, response.status == .ok else { return }
         self.entries[key] = Entry(expiresAt: now.addingTimeInterval(ttl), response: response)
@@ -477,12 +454,8 @@ actor CLIServeResponseCache {
         self.entries.count
     }
 
-    func inFlightKeyCount() -> Int {
-        self.inFlightKeys.count
-    }
-
     func cachedStaleVariantCount() -> Int {
-        self.lastGood.count + self.lastGoodUsageItems.count
+        self.lastGood.count + self.lastGoodUsageItems.count + self.lastGoodCostItems.count
     }
 }
 
@@ -511,6 +484,14 @@ private struct CLIServeProviderTimeoutError: LocalizedError {
 
     var errorDescription: String? {
         "\(self.provider.rawValue) usage timed out"
+    }
+}
+
+private struct CLIServeCostTimeoutError: LocalizedError {
+    let provider: UsageProvider
+
+    var errorDescription: String? {
+        "\(self.provider.rawValue) cost refresh timed out"
     }
 }
 
@@ -563,6 +544,8 @@ extension CodexBarCLI {
         let runtime = ServeRuntime(
             configStore: CodexBarConfigStore(),
             cache: CLIServeResponseCache(),
+            providerOperations: CLIServeOperationCoordinator(),
+            costOperations: CLIServeOperationCoordinator(),
             refreshInterval: refreshInterval,
             requestTimeout: requestTimeout,
             healthVersion: Self.currentVersion())
@@ -580,13 +563,16 @@ extension CodexBarCLI {
                 Self.writeStderr("CodexBar server listening on http://127.0.0.1:\(port)\n")
             }
         } catch {
-            await Self.shutdownServeSessions()
+            await Self.shutdownServeRuntime(runtime)
             Self.exit(code: .failure, message: error.localizedDescription, output: output, kind: .runtime)
         }
-        await Self.shutdownServeSessions()
+        await Self.shutdownServeRuntime(runtime)
     }
 
-    private static func shutdownServeSessions() async {
+    private static func shutdownServeRuntime(_ runtime: ServeRuntime) async {
+        await runtime.cache.operations.shutdown()
+        await runtime.providerOperations.shutdown()
+        await runtime.costOperations.shutdown()
         await ProviderCLISessionLifecycle.shutdownPersistentSessions()
         TTYCommandRunner.terminateActiveProcessesForAppShutdown()
     }
@@ -634,6 +620,14 @@ extension CodexBarCLI {
         _ request: CLILocalHTTPRequest,
         runtime: ServeRuntime) async -> CLILocalHTTPResponse
     {
+        let startedAt = ContinuousClock().now
+        let requestDeadline = Self.serveRequestDeadline(
+            startedAt: startedAt,
+            requestTimeout: runtime.requestTimeout)
+        let providerTimeout = Self.serveProviderTimeout(requestTimeout: runtime.requestTimeout)
+        let providerDeadline = Self.serveProviderDeadline(
+            startedAt: startedAt,
+            requestTimeout: runtime.requestTimeout)
         let route: CLIServeRoute
         do {
             route = try CLIServeRouter.route(
@@ -651,38 +645,58 @@ extension CodexBarCLI {
             return Self.serveHealthResponse(version: runtime.healthVersion)
         case let .usage(provider):
             let snapshot: CLIServeConfigSnapshot
+            let operationKey: String
             do {
                 snapshot = try Self.loadServeConfigSnapshot(configStore: runtime.configStore)
+                operationKey = try Self.serveOperationKey(kind: "usage", provider: provider)
             } catch {
-                return Self.serveError(status: .internalServerError, message: error.localizedDescription)
+                let status: CLIHTTPStatus = error is CLIServeArgumentError ? .badRequest : .internalServerError
+                return Self.serveError(status: status, message: error.localizedDescription)
             }
             return await Self.cachedServeResponse(
-                key: Self.serveCacheKey(kind: "usage", provider: provider, configToken: snapshot.cacheToken),
-                cache: runtime.cache,
-                refreshInterval: runtime.refreshInterval,
-                requestTimeout: runtime.requestTimeout)
-            {
-                await Self.serveUsage(
-                    provider: provider,
-                    config: snapshot.config,
+                request: ServeResponseRequest(
+                    key: operationKey,
+                    configFingerprint: snapshot.cacheToken,
                     refreshInterval: runtime.refreshInterval,
-                    requestTimeout: runtime.requestTimeout)
-            }
+                    deadline: requestDeadline),
+                cache: runtime.cache,
+                makeResponse: {
+                    await Self.serveUsage(
+                        provider: provider,
+                        context: ServeUsageContext(
+                            config: snapshot.config,
+                            configFingerprint: snapshot.cacheToken,
+                            refreshInterval: runtime.refreshInterval,
+                            providerTimeout: providerTimeout,
+                            providerDeadline: providerDeadline,
+                            providerOperations: runtime.providerOperations))
+                })
         case let .cost(provider):
             let snapshot: CLIServeConfigSnapshot
+            let operationKey: String
             do {
                 snapshot = try Self.loadServeConfigSnapshot(configStore: runtime.configStore)
+                operationKey = try Self.serveOperationKey(kind: "cost", provider: provider)
             } catch {
-                return Self.serveError(status: .internalServerError, message: error.localizedDescription)
+                let status: CLIHTTPStatus = error is CLIServeArgumentError ? .badRequest : .internalServerError
+                return Self.serveError(status: status, message: error.localizedDescription)
             }
             return await Self.cachedServeResponse(
-                key: Self.serveCacheKey(kind: "cost", provider: provider, configToken: snapshot.cacheToken),
+                request: ServeResponseRequest(
+                    key: operationKey,
+                    configFingerprint: snapshot.cacheToken,
+                    refreshInterval: runtime.refreshInterval,
+                    deadline: requestDeadline),
                 cache: runtime.cache,
-                refreshInterval: runtime.refreshInterval,
-                requestTimeout: runtime.requestTimeout)
-            {
-                await Self.serveCost(provider: provider, config: snapshot.config)
-            }
+                makeResponse: {
+                    await Self.serveCost(
+                        provider: provider,
+                        context: ServeCostContext(
+                            config: snapshot.config,
+                            configFingerprint: snapshot.cacheToken,
+                            providerDeadline: providerDeadline,
+                            providerOperations: runtime.costOperations))
+                })
         }
     }
 
@@ -695,8 +709,16 @@ extension CodexBarCLI {
             cacheToken: Self.serveConfigCacheToken(for: config))
     }
 
-    static func serveCacheKey(kind: String, provider: String?, configToken: String) -> String {
-        "\(kind):\(provider ?? ""):\(configToken)"
+    static func serveOperationKey(kind: String, provider: String?) throws -> String {
+        guard let provider else { return "\(kind):default" }
+        guard let selection = ProviderSelection(argument: provider) else {
+            throw CLIServeArgumentError.invalidProvider(provider)
+        }
+        return "\(kind):\(selection.asList.map(\.rawValue).joined(separator: ","))"
+    }
+
+    static func serveCacheKey(operationKey: String, configToken: String) -> String {
+        "\(operationKey):\(configToken)"
     }
 
     static func serveConfigCacheToken(for config: CodexBarConfig) throws -> String {
@@ -718,100 +740,85 @@ extension CodexBarCLI {
         requestTimeout: TimeInterval = CodexBarCLI.defaultServeRequestTimeout,
         makeResponse: @Sendable @escaping () async -> CLILocalHTTPResponse) async -> CLILocalHTTPResponse
     {
-        switch await cache.responseOrStartFetch(for: key, requestTimeout: requestTimeout, now: Date()) {
-        case let .response(response):
-            return response
-        case .miss:
-            let outcome = await Self.serveResponseWithDeadline(seconds: requestTimeout) {
-                await makeResponse()
-            }
-            let policy = CLIServeResponseCache.CachePolicy(
-                ttl: refreshInterval,
-                staleTTL: Self.serveStaleTTL(refreshInterval: refreshInterval))
-            let shouldCache = Self.shouldCacheServeResponse(outcome.response)
-            if let cleanupWork = outcome.cleanupWork {
-                let delivered = await cache.completeFetch(
-                    outcome.response,
-                    for: key,
-                    policy: policy,
-                    now: Date(),
-                    shouldCache: shouldCache,
-                    retainInFlight: true)
-                let cleanupGrace = Self.serveCleanupGrace(requestTimeout: requestTimeout)
-                Task {
-                    await Self.awaitServeWorkCleanup(cleanupWork, grace: cleanupGrace)
-                    await cache.releaseInFlight(for: key)
-                }
-                return delivered
-            }
-            return await cache.completeFetch(
-                outcome.response,
-                for: key,
-                policy: policy,
-                now: Date(),
-                shouldCache: shouldCache)
-        }
+        await self.cachedServeResponse(
+            request: ServeResponseRequest(
+                key: key,
+                configFingerprint: "",
+                refreshInterval: refreshInterval,
+                deadline: self.serveRequestDeadline(
+                    startedAt: ContinuousClock().now,
+                    requestTimeout: requestTimeout)),
+            cache: cache,
+            makeResponse: makeResponse)
     }
 
-    /// How long to keep a cache key in-flight after a timed-out serve response so
-    /// a second fetch cannot stack on canceled but still-running work.
-    static func serveCleanupGrace(requestTimeout: TimeInterval) -> TimeInterval {
-        guard requestTimeout > 0, requestTimeout.isFinite else { return 30 }
-        return min(requestTimeout, self.maximumServeRequestTimeout)
-    }
-
-    private static func awaitServeWorkCleanup(_ work: Task<Void, Never>, grace: TimeInterval) async {
-        guard grace > 0 else {
-            work.cancel()
-            return
-        }
-        let join = BoundedTaskJoin(sourceTask: Task<Void, Error> {
-            await work.value
-        })
-        switch await join.value(joinGrace: .seconds(grace)) {
-        case .value:
-            return
-        case .failure, .timedOut:
-            work.cancel()
-        }
-    }
-
-    private static func serveResponseWithDeadline(
-        seconds timeout: TimeInterval,
-        makeResponse: @Sendable @escaping () async -> CLILocalHTTPResponse) async -> ServeDeadlineOutcome
+    private static func cachedServeResponse(
+        request: ServeResponseRequest,
+        cache: CLIServeResponseCache,
+        makeResponse: @Sendable @escaping () async -> CLILocalHTTPResponse) async -> CLILocalHTTPResponse
     {
-        let clampedTimeout = min(max(timeout, 0), Self.maximumServeRequestTimeout)
-        guard clampedTimeout > 0 else {
-            return await ServeDeadlineOutcome(response: makeResponse(), cleanupWork: nil)
+        let cacheKey = Self.serveCacheKey(
+            operationKey: request.key,
+            configToken: request.configFingerprint)
+        if let response = await cache.cachedResponse(for: cacheKey, now: Date()) {
+            return response
         }
-        let nanoseconds = max(1, UInt64((clampedTimeout * 1_000_000_000).rounded(.up)))
 
-        return await withCheckedContinuation { continuation in
-            let state = CLIServeDeadlineState(continuation: continuation)
-            let workTask = Task {
-                let response = await makeResponse()
-                state.finish(
-                    ServeDeadlineOutcome(response: response, cleanupWork: nil),
-                    cancelWork: false,
-                    cancelTimeout: true)
-            }
-            state.setWorkTask(workTask)
-
-            let timeoutTask = Task {
-                do {
-                    try await Task.sleep(nanoseconds: nanoseconds)
-                } catch {
-                    return
+        let timeoutResponse = Self.serveTimeoutResponse()
+        let outcome = await cache.operations.value(
+            for: request.key,
+            fingerprint: request.configFingerprint,
+            deadline: request.deadline,
+            timeoutValue: CLIServeCoordinatedResponse(response: timeoutResponse, isCommitted: false),
+            accept: { fetched in
+                let committed = await cache.completeFetch(
+                    fetched.response,
+                    for: cacheKey,
+                    policy: CLIServeResponseCache.CachePolicy(
+                        ttl: request.refreshInterval,
+                        staleTTL: Self.serveStaleTTL(refreshInterval: request.refreshInterval)),
+                    now: Date(),
+                    shouldCache: Self.shouldCacheServeResponse(fetched.response))
+                return CLIServeCoordinatedResponse(response: committed, isCommitted: true)
+            },
+            operation: {
+                if let response = await cache.cachedResponse(for: cacheKey, now: Date()) {
+                    return CLIServeCoordinatedResponse(response: response, isCommitted: false)
                 }
-                state.finish(
-                    ServeDeadlineOutcome(
-                        response: Self.serveError(status: .gatewayTimeout, message: "request timed out"),
-                        cleanupWork: nil),
-                    cancelWork: true,
-                    cancelTimeout: false)
-            }
-            state.setTimeoutTask(timeoutTask)
+                let response = await makeResponse()
+                return CLIServeCoordinatedResponse(response: response, isCommitted: false)
+            })
+        if outcome.isCommitted {
+            return outcome.response
         }
+        // Timeout values are selected while the abandoned source stays owned.
+        // Project them through stale-row policy here; they contain no source
+        // result that could overwrite a newer generation.
+        return await cache.completeFetch(
+            outcome.response,
+            for: cacheKey,
+            policy: CLIServeResponseCache.CachePolicy(
+                ttl: request.refreshInterval,
+                staleTTL: Self.serveStaleTTL(refreshInterval: request.refreshInterval)),
+            now: Date(),
+            shouldCache: Self.shouldCacheServeResponse(outcome.response))
+    }
+
+    static func serveRequestDeadline(
+        startedAt: ContinuousClock.Instant,
+        requestTimeout: TimeInterval) -> ContinuousClock.Instant?
+    {
+        let timeout = Self.clampedServeRequestTimeout(requestTimeout)
+        guard timeout > 0 else { return nil }
+        return startedAt.advanced(by: .seconds(timeout))
+    }
+
+    static func serveProviderDeadline(
+        startedAt: ContinuousClock.Instant,
+        requestTimeout: TimeInterval) -> ContinuousClock.Instant?
+    {
+        guard let timeout = self.serveProviderTimeout(requestTimeout: requestTimeout) else { return nil }
+        return startedAt.advanced(by: .seconds(timeout))
     }
 
     /// How long a last-good response may be served in place of a failed
@@ -840,13 +847,11 @@ extension CodexBarCLI {
 
     private static func serveUsage(
         provider rawProvider: String?,
-        config: CodexBarConfig,
-        refreshInterval: TimeInterval,
-        requestTimeout: TimeInterval) async -> CLILocalHTTPResponse
+        context: ServeUsageContext) async -> CLILocalHTTPResponse
     {
         let selection: ProviderSelection
         do {
-            selection = try Self.serveProviderSelection(rawProvider: rawProvider, config: config)
+            selection = try Self.serveProviderSelection(rawProvider: rawProvider, config: context.config)
         } catch {
             return Self.serveError(status: .badRequest, message: error.localizedDescription)
         }
@@ -855,17 +860,11 @@ extension CodexBarCLI {
         do {
             tokenContext = try TokenAccountCLIContext(
                 selection: TokenAccountCLISelection(label: nil, index: nil, allAccounts: false),
-                config: config,
+                config: context.config,
                 verbose: false)
         } catch {
             return Self.serveError(status: .internalServerError, message: error.localizedDescription)
         }
-
-        // For finite request deadlines, bound each provider early enough to
-        // return the healthy rows before the outer deadline discards them all.
-        // A disabled request deadline adds no serve-level provider bound; the
-        // providers' existing internal timeouts still apply.
-        let providerTimeout = Self.serveProviderTimeout(requestTimeout: requestTimeout)
 
         let browserDetection = BrowserDetection()
         let command = UsageCommandContext(
@@ -875,7 +874,7 @@ extension CodexBarCLI {
             antigravityPlanDebug: false,
             augmentDebug: false,
             webDebugDumpHTML: false,
-            webTimeout: providerTimeout ?? 60,
+            webTimeout: context.providerTimeout ?? 60,
             verbose: false,
             useColor: false,
             resetStyle: Self.resetTimeDisplayStyleFromDefaults(),
@@ -886,11 +885,14 @@ extension CodexBarCLI {
             claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
             browserDetection: browserDetection,
             persistCLISessions: true,
-            persistentCLISessionIdleWindow: Self.serveCLISessionIdleWindow(refreshInterval: refreshInterval))
+            persistentCLISessionIdleWindow: Self.serveCLISessionIdleWindow(
+                refreshInterval: context.refreshInterval))
 
         let output = await Self.serveCollectUsageOutputs(
             providers: selection.asList,
-            providerTimeout: providerTimeout)
+            configFingerprint: context.configFingerprint,
+            deadline: context.providerDeadline,
+            operations: context.providerOperations)
         { provider in
             await ProviderInteractionContext.$current.withValue(.background) {
                 await Self.fetchUsageOutputs(
@@ -919,37 +921,52 @@ extension CodexBarCLI {
         return clampedTimeout * 0.8
     }
 
-    /// Collects usage for each provider concurrently. When `providerTimeout` is
-    /// non-nil, a provider that exceeds its budget contributes a provider error
+    /// Collects usage for each provider concurrently. When `deadline` is non-nil,
+    /// a provider that exceeds its budget contributes a provider error
     /// row instead of blocking the others, so the overall response still renders
     /// every healthy provider. (Per-account error rows that carry a
     /// cache key are merged with last-known-good by `CLIServeResponseCache`; a
     /// timeout row is account-agnostic and is not reconstructed, matching the
     /// existing "a timeout cannot prove the active account" cache rule.) Each
-    /// provider's timeout clock starts when its task is spawned, so a hung
-    /// provider cannot serialize the others' deadlines; results are merged in the
-    /// caller's provider order regardless of completion order.
+    /// deadline is absolute from HTTP request entry. The operation coordinator
+    /// retains timed-out sources until they really exit, preventing a later route
+    /// from stacking work for that provider. Results are merged in caller order.
     static func serveCollectUsageOutputs(
         providers: [UsageProvider],
         providerTimeout: TimeInterval?,
         fetch: @Sendable @escaping (UsageProvider) async -> UsageCommandOutput) async -> UsageCommandOutput
     {
-        let grace = providerTimeout.map { Duration.seconds(max(0, $0)) }
+        let deadline = providerTimeout.map {
+            ContinuousClock().now.advanced(by: .seconds(max(0, $0)))
+        }
+        return await Self.serveCollectUsageOutputs(
+            providers: providers,
+            configFingerprint: "",
+            deadline: deadline,
+            operations: CLIServeOperationCoordinator(),
+            fetch: fetch)
+    }
+
+    static func serveCollectUsageOutputs(
+        providers: [UsageProvider],
+        configFingerprint: String,
+        deadline: ContinuousClock.Instant?,
+        operations: CLIServeOperationCoordinator<UsageCommandOutput>,
+        fetch: @Sendable @escaping (UsageProvider) async -> UsageCommandOutput) async -> UsageCommandOutput
+    {
         let indexed = await withTaskGroup(of: (Int, UsageCommandOutput).self) { group in
             for (index, provider) in providers.enumerated() {
                 group.addTask {
-                    guard let grace else {
-                        let output = await fetch(provider)
-                        return (index, output)
+                    let timeout = Self.serveProviderTimeoutOutput(provider: provider)
+                    let output = await operations.value(
+                        for: provider.rawValue,
+                        fingerprint: configFingerprint,
+                        deadline: deadline,
+                        timeoutValue: timeout)
+                    {
+                        await fetch(provider)
                     }
-                    let task = Task<UsageCommandOutput, Error> { await fetch(provider) }
-                    let join = BoundedTaskJoin(sourceTask: task)
-                    switch await join.value(joinGrace: grace) {
-                    case let .value(output):
-                        return (index, output)
-                    case .failure, .timedOut:
-                        return (index, Self.serveProviderTimeoutOutput(provider: provider))
-                    }
+                    return (index, output)
                 }
             }
             var collected: [(Int, UsageCommandOutput)] = []
@@ -980,10 +997,13 @@ extension CodexBarCLI {
         return output
     }
 
-    private static func serveCost(provider rawProvider: String?, config: CodexBarConfig) async -> CLILocalHTTPResponse {
+    private static func serveCost(
+        provider rawProvider: String?,
+        context: ServeCostContext) async -> CLILocalHTTPResponse
+    {
         let selection: ProviderSelection
         do {
-            selection = try Self.serveProviderSelection(rawProvider: rawProvider, config: config)
+            selection = try Self.serveProviderSelection(rawProvider: rawProvider, config: context.config)
         } catch {
             return Self.serveError(status: .badRequest, message: error.localizedDescription)
         }
@@ -994,19 +1014,53 @@ extension CodexBarCLI {
         }
 
         let fetcher = CostUsageFetcher()
-        var payload: [CostPayload] = []
-        for provider in providers {
+        let payload = await Self.serveCollectCostPayloads(
+            providers: providers,
+            configFingerprint: context.configFingerprint,
+            deadline: context.providerDeadline,
+            operations: context.providerOperations)
+        { provider in
             do {
                 let snapshot = try await fetcher.loadTokenSnapshot(
                     provider: provider,
-                    forceRefresh: false)
-                payload.append(Self.makeCostPayload(provider: provider, snapshot: snapshot, error: nil))
+                    forceRefresh: false,
+                    refreshPricingInBackground: false)
+                return Self.makeCostPayload(provider: provider, snapshot: snapshot, error: nil)
             } catch {
-                payload.append(Self.makeCostPayload(provider: provider, snapshot: nil, error: error))
+                return Self.makeCostPayload(provider: provider, snapshot: nil, error: error)
             }
         }
 
         return Self.serveJSON(payload)
+    }
+
+    static func serveCollectCostPayloads(
+        providers: [UsageProvider],
+        configFingerprint: String,
+        deadline: ContinuousClock.Instant?,
+        operations: CLIServeOperationCoordinator<CostPayload>,
+        fetch: @Sendable @escaping (UsageProvider) async -> CostPayload) async -> [CostPayload]
+    {
+        // Preserve the established scan order. Each cost scan starts a
+        // best-effort pricing refresh, so parallel starts can duplicate that
+        // adjacent work even though the corpus scans themselves are coalesced.
+        var payload: [CostPayload] = []
+        for provider in providers {
+            let timeout = Self.makeCostPayload(
+                provider: provider,
+                snapshot: nil,
+                error: CLIServeCostTimeoutError(provider: provider))
+            let item = await operations.value(
+                for: provider.rawValue,
+                fingerprint: configFingerprint,
+                deadline: deadline,
+                timeoutValue: timeout)
+            {
+                await fetch(provider)
+            }
+            payload.append(item)
+        }
+        return payload
     }
 
     private static func serveProviderSelection(

--- a/Sources/CodexBarCLI/CLIServeOperationCoordinator.swift
+++ b/Sources/CodexBarCLI/CLIServeOperationCoordinator.swift
@@ -1,0 +1,551 @@
+import Foundation
+
+/// Owns at most one running source operation for each logical serve key.
+///
+/// Cancellation is advisory in Swift. Timed-out work therefore remains owned
+/// until its source body actually exits. A config successor can wait behind it,
+/// but can never overlap it.
+actor CLIServeOperationCoordinator<Value: Sendable> {
+    typealias Instant = ContinuousClock.Instant
+    typealias Now = @Sendable () -> Instant
+    typealias SleepUntil = @Sendable (Instant) async throws -> Void
+
+    struct Snapshot: Equatable, Sendable {
+        let operationCount: Int
+        let waiterCount: Int
+        let timerCount: Int
+        let isShutDown: Bool
+    }
+
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Value, Never>
+        let timeoutValue: Value
+    }
+
+    private enum OperationPhase {
+        case running
+        case accepting
+        case timedOut
+    }
+
+    private struct Operation {
+        let generation: UInt64
+        let fingerprint: String
+        var deadline: Instant?
+        let makeValue: @Sendable () async -> Value
+        let acceptValue: @Sendable (Value) async -> Value
+        var sourceTask: Task<Void, Never>?
+        var deadlineTask: Task<Void, Never>?
+        var waiters: [Waiter]
+        var phase: OperationPhase
+    }
+
+    private struct Slot {
+        var active: Operation?
+        var pending: Operation?
+    }
+
+    private struct OperationRequest: Sendable {
+        let key: String
+        let fingerprint: String
+        let deadline: Instant?
+        let timeoutValue: Value
+        let makeValue: @Sendable () async -> Value
+        let acceptValue: @Sendable (Value) async -> Value
+    }
+
+    private enum WaitTarget {
+        case active
+        case pending
+    }
+
+    private let now: Now
+    private let sleepUntil: SleepUntil
+    // Callers validate route keys and provider keys come from UsageProvider, so
+    // retained canceled work has a small, closed key space.
+    private var slots: [String: Slot] = [:]
+    private var nextGeneration: UInt64 = 0
+    private var isShutDown = false
+
+    init(
+        now: @escaping Now = { ContinuousClock().now },
+        sleepUntil: @escaping SleepUntil = { deadline in
+            try await ContinuousClock().sleep(until: deadline)
+        })
+    {
+        self.now = now
+        self.sleepUntil = sleepUntil
+    }
+
+    func value(
+        for key: String,
+        fingerprint: String,
+        deadline: Instant?,
+        timeoutValue: Value,
+        accept: @Sendable @escaping (Value) async -> Value = { $0 },
+        operation makeValue: @Sendable @escaping () async -> Value) async -> Value
+    {
+        let request = OperationRequest(
+            key: key,
+            fingerprint: fingerprint,
+            deadline: deadline,
+            timeoutValue: timeoutValue,
+            makeValue: makeValue,
+            acceptValue: accept)
+        guard !self.isShutDown, !self.isExpired(deadline) else { return timeoutValue }
+
+        self.expireOverdueOperations(for: key)
+        guard let slot = self.slots[key], let active = slot.active else {
+            return await self.installActive(request)
+        }
+
+        if active.fingerprint == fingerprint, active.phase != .timedOut {
+            guard self.deadlinesAreCompatible(active.deadline, deadline) else { return timeoutValue }
+            guard self.canJoinAccepting(active, deadline: deadline) else { return timeoutValue }
+            return await self.awaitValue(for: request, target: .active)
+        }
+
+        if let pending = slot.pending, pending.fingerprint == fingerprint {
+            guard self.deadlinesAreCompatible(pending.deadline, deadline) else { return timeoutValue }
+            return await self.awaitValue(for: request, target: .pending)
+        }
+
+        if let pending = self.slots[key]?.pending {
+            self.timeoutPending(for: key, generation: pending.generation)
+        }
+        return await self.installPending(request)
+    }
+
+    func shutdown() {
+        guard !self.isShutDown else { return }
+        self.isShutDown = true
+
+        let active = self.slots.compactMap { key, slot in
+            slot.active.map { (key, $0.generation) }
+        }
+        let pending = self.slots.compactMap { key, slot in
+            slot.pending.map { (key, $0.generation) }
+        }
+        for (key, generation) in pending {
+            self.timeoutPending(for: key, generation: generation)
+        }
+        for (key, generation) in active {
+            self.shutdownActive(for: key, generation: generation)
+        }
+    }
+
+    func snapshot() -> Snapshot {
+        let operations = self.slots.values.flatMap { slot in
+            [slot.active, slot.pending].compactMap(\.self)
+        }
+        return Snapshot(
+            operationCount: operations.count,
+            waiterCount: operations.reduce(0) { $0 + $1.waiters.count },
+            timerCount: operations.reduce(0) { $0 + ($1.deadlineTask == nil ? 0 : 1) },
+            isShutDown: self.isShutDown)
+    }
+
+    private func allocateGeneration() -> UInt64 {
+        self.nextGeneration &+= 1
+        return self.nextGeneration
+    }
+
+    private func installActive(_ request: OperationRequest) async -> Value {
+        let generation = self.allocateGeneration()
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled, !self.isShutDown, !self.isExpired(request.deadline) else {
+                    continuation.resume(returning: request.timeoutValue)
+                    return
+                }
+
+                var operation = self.makeOperation(
+                    request,
+                    generation: generation,
+                    waiter: Waiter(
+                        id: waiterID,
+                        continuation: continuation,
+                        timeoutValue: request.timeoutValue))
+                operation.sourceTask = self.makeSourceTask(
+                    key: request.key,
+                    generation: generation,
+                    makeValue: request.makeValue)
+                operation.deadlineTask = self.makeDeadlineTask(
+                    key: request.key,
+                    generation: generation,
+                    deadline: request.deadline)
+                self.slots[request.key] = Slot(active: operation, pending: nil)
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id: waiterID, for: request.key) }
+        }
+    }
+
+    private func installPending(_ request: OperationRequest) async -> Value {
+        guard self.slots[request.key]?.active != nil else {
+            return await self.installActive(request)
+        }
+
+        let generation = self.allocateGeneration()
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled, !self.isShutDown, !self.isExpired(request.deadline) else {
+                    continuation.resume(returning: request.timeoutValue)
+                    return
+                }
+                guard var slot = self.slots[request.key], slot.active != nil else {
+                    continuation.resume(returning: request.timeoutValue)
+                    return
+                }
+
+                var operation = self.makeOperation(
+                    request,
+                    generation: generation,
+                    waiter: Waiter(
+                        id: waiterID,
+                        continuation: continuation,
+                        timeoutValue: request.timeoutValue))
+                operation.deadlineTask = self.makeDeadlineTask(
+                    key: request.key,
+                    generation: generation,
+                    deadline: request.deadline)
+                slot.pending = operation
+                self.slots[request.key] = slot
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id: waiterID, for: request.key) }
+        }
+    }
+
+    private func awaitValue(for request: OperationRequest, target: WaitTarget) async -> Value {
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled, !self.isShutDown, !self.isExpired(request.deadline),
+                      var slot = self.slots[request.key]
+                else {
+                    continuation.resume(returning: request.timeoutValue)
+                    return
+                }
+
+                let waiter = Waiter(
+                    id: waiterID,
+                    continuation: continuation,
+                    timeoutValue: request.timeoutValue)
+                switch target {
+                case .active:
+                    guard var operation = slot.active,
+                          operation.fingerprint == request.fingerprint,
+                          operation.phase != .timedOut
+                    else {
+                        continuation.resume(returning: request.timeoutValue)
+                        return
+                    }
+                    guard self.canJoinAccepting(operation, deadline: request.deadline) else {
+                        continuation.resume(returning: request.timeoutValue)
+                        return
+                    }
+                    self.tightenDeadline(&operation, to: request.deadline, for: request.key)
+                    operation.waiters.append(waiter)
+                    slot.active = operation
+                case .pending:
+                    guard var operation = slot.pending,
+                          operation.fingerprint == request.fingerprint
+                    else {
+                        continuation.resume(returning: request.timeoutValue)
+                        return
+                    }
+                    self.tightenDeadline(&operation, to: request.deadline, for: request.key)
+                    operation.waiters.append(waiter)
+                    slot.pending = operation
+                }
+                self.slots[request.key] = slot
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id: waiterID, for: request.key) }
+        }
+    }
+
+    private func makeOperation(
+        _ request: OperationRequest,
+        generation: UInt64,
+        waiter: Waiter) -> Operation
+    {
+        Operation(
+            generation: generation,
+            fingerprint: request.fingerprint,
+            deadline: request.deadline,
+            makeValue: request.makeValue,
+            acceptValue: request.acceptValue,
+            sourceTask: nil,
+            deadlineTask: nil,
+            waiters: [waiter],
+            phase: .running)
+    }
+
+    private func makeSourceTask(
+        key: String,
+        generation: UInt64,
+        makeValue: @Sendable @escaping () async -> Value) -> Task<Void, Never>
+    {
+        Task.detached { [self] in
+            let value = await makeValue()
+            await self.sourceProduced(value, for: key, generation: generation)
+        }
+    }
+
+    private func makeDeadlineTask(
+        key: String,
+        generation: UInt64,
+        deadline: Instant?) -> Task<Void, Never>?
+    {
+        guard let deadline else { return nil }
+        let sleepUntil = self.sleepUntil
+        return Task.detached { [self] in
+            do {
+                try await sleepUntil(deadline)
+            } catch {
+                return
+            }
+            await self.deadlineReached(for: key, generation: generation)
+        }
+    }
+
+    private func cancelWaiter(id: UUID, for key: String) {
+        guard var slot = self.slots[key] else { return }
+        if var active = slot.active,
+           let index = active.waiters.firstIndex(where: { $0.id == id })
+        {
+            let waiter = active.waiters.remove(at: index)
+            slot.active = active
+            self.slots[key] = slot
+            waiter.continuation.resume(returning: waiter.timeoutValue)
+            if active.waiters.isEmpty, active.phase == .running {
+                self.timeoutActive(for: key, generation: active.generation)
+            }
+            return
+        }
+
+        guard var pending = slot.pending,
+              let index = pending.waiters.firstIndex(where: { $0.id == id })
+        else {
+            return
+        }
+        let waiter = pending.waiters.remove(at: index)
+        waiter.continuation.resume(returning: waiter.timeoutValue)
+        if pending.waiters.isEmpty {
+            pending.deadlineTask?.cancel()
+            slot.pending = nil
+        } else {
+            slot.pending = pending
+        }
+        self.store(slot, for: key)
+    }
+
+    private func deadlineReached(for key: String, generation: UInt64) {
+        if self.slots[key]?.active?.generation == generation {
+            self.timeoutActive(for: key, generation: generation)
+        } else if self.slots[key]?.pending?.generation == generation {
+            self.timeoutPending(for: key, generation: generation)
+        }
+    }
+
+    private func expireOverdueOperations(for key: String) {
+        if let active = self.slots[key]?.active,
+           active.phase == .running,
+           self.isExpired(active.deadline)
+        {
+            self.timeoutActive(for: key, generation: active.generation)
+        }
+        if let pending = self.slots[key]?.pending,
+           self.isExpired(pending.deadline)
+        {
+            self.timeoutPending(for: key, generation: pending.generation)
+        }
+    }
+
+    private func timeoutActive(for key: String, generation: UInt64) {
+        guard var slot = self.slots[key],
+              var operation = slot.active,
+              operation.generation == generation,
+              operation.phase == .running
+        else {
+            return
+        }
+
+        operation.phase = .timedOut
+        operation.sourceTask?.cancel()
+        operation.deadlineTask?.cancel()
+        operation.deadlineTask = nil
+        let waiters = operation.waiters
+        operation.waiters.removeAll()
+        slot.active = operation
+        self.slots[key] = slot
+
+        for waiter in waiters {
+            waiter.continuation.resume(returning: waiter.timeoutValue)
+        }
+    }
+
+    private func shutdownActive(for key: String, generation: UInt64) {
+        guard var slot = self.slots[key],
+              var operation = slot.active,
+              operation.generation == generation
+        else {
+            return
+        }
+        if operation.phase == .running {
+            self.timeoutActive(for: key, generation: generation)
+            return
+        }
+        guard operation.phase == .accepting else { return }
+
+        operation.phase = .timedOut
+        operation.sourceTask?.cancel()
+        let waiters = operation.waiters
+        operation.waiters.removeAll()
+        slot.active = operation
+        self.slots[key] = slot
+        for waiter in waiters {
+            waiter.continuation.resume(returning: waiter.timeoutValue)
+        }
+    }
+
+    private func timeoutPending(for key: String, generation: UInt64) {
+        guard var slot = self.slots[key],
+              let operation = slot.pending,
+              operation.generation == generation
+        else {
+            return
+        }
+
+        operation.deadlineTask?.cancel()
+        slot.pending = nil
+        self.store(slot, for: key)
+        for waiter in operation.waiters {
+            waiter.continuation.resume(returning: waiter.timeoutValue)
+        }
+    }
+
+    private func sourceProduced(_ value: Value, for key: String, generation: UInt64) async {
+        guard var slot = self.slots[key],
+              let observed = slot.active,
+              observed.generation == generation
+        else {
+            return
+        }
+
+        if observed.phase == .running, self.isExpired(observed.deadline) {
+            self.timeoutActive(for: key, generation: generation)
+            guard let refreshed = self.slots[key] else { return }
+            slot = refreshed
+        }
+        guard var operation = slot.active, operation.generation == generation else { return }
+
+        if operation.phase == .timedOut {
+            slot.active = nil
+            self.store(slot, for: key)
+            self.promotePending(for: key)
+            return
+        }
+
+        // Source completion wins the deadline only on this actor turn. `accept`
+        // is restricted to bounded in-process projection/cache work: keep the
+        // slot owned through that commit so a newer generation cannot start and
+        // then be overwritten by this older result. Shutdown still releases the
+        // waiters even if a commit is briefly queued on another actor.
+        operation.phase = .accepting
+        operation.deadlineTask?.cancel()
+        operation.deadlineTask = nil
+        slot.active = operation
+        self.slots[key] = slot
+        let acceptedValue = await operation.acceptValue(value)
+
+        guard var refreshed = self.slots[key],
+              let completed = refreshed.active,
+              completed.generation == generation
+        else {
+            return
+        }
+
+        refreshed.active = nil
+        self.store(refreshed, for: key)
+        if completed.phase == .accepting {
+            for waiter in completed.waiters {
+                waiter.continuation.resume(returning: acceptedValue)
+            }
+        }
+        self.promotePending(for: key)
+    }
+
+    private func promotePending(for key: String) {
+        guard !self.isShutDown,
+              var slot = self.slots[key],
+              slot.active == nil,
+              var pending = slot.pending
+        else {
+            return
+        }
+        if self.isExpired(pending.deadline) {
+            self.timeoutPending(for: key, generation: pending.generation)
+            return
+        }
+
+        pending.sourceTask = self.makeSourceTask(
+            key: key,
+            generation: pending.generation,
+            makeValue: pending.makeValue)
+        slot.active = pending
+        slot.pending = nil
+        self.slots[key] = slot
+    }
+
+    private func tightenDeadline(_ operation: inout Operation, to requested: Instant?, for key: String) {
+        guard operation.phase == .running,
+              let current = operation.deadline,
+              let requested,
+              requested < current
+        else {
+            return
+        }
+        operation.deadlineTask?.cancel()
+        operation.deadline = requested
+        operation.deadlineTask = self.makeDeadlineTask(
+            key: key,
+            generation: operation.generation,
+            deadline: requested)
+    }
+
+    private func deadlinesAreCompatible(_ active: Instant?, _ requested: Instant?) -> Bool {
+        (active == nil) == (requested == nil)
+    }
+
+    private func canJoinAccepting(_ operation: Operation, deadline: Instant?) -> Bool {
+        guard operation.phase == .accepting,
+              let activeDeadline = operation.deadline,
+              let deadline
+        else {
+            return true
+        }
+        // Source acceptance already canceled the shared timer. An older-budget
+        // follower cannot safely shorten that completed arbitration while the
+        // bounded cache commit is in progress, so fail it closed.
+        return deadline >= activeDeadline
+    }
+
+    private func isExpired(_ deadline: Instant?) -> Bool {
+        guard let deadline else { return false }
+        return deadline <= self.now()
+    }
+
+    private func store(_ slot: Slot, for key: String) {
+        if slot.active == nil, slot.pending == nil {
+            self.slots[key] = nil
+        } else {
+            self.slots[key] = slot
+        }
+    }
+}

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -203,9 +203,11 @@ struct CLIServeRouterTests {
         #expect(!firstSnapshot.config.enabledProviders().contains(.opencodego))
         #expect(secondSnapshot.config.enabledProviders().contains(.opencodego))
         #expect(firstSnapshot.cacheToken != secondSnapshot.cacheToken)
+        let operationKey = try CodexBarCLI.serveOperationKey(kind: "usage", provider: nil)
+        #expect(try operationKey == (CodexBarCLI.serveOperationKey(kind: "usage", provider: nil)))
         #expect(
-            CodexBarCLI.serveCacheKey(kind: "usage", provider: nil, configToken: firstSnapshot.cacheToken) !=
-                CodexBarCLI.serveCacheKey(kind: "usage", provider: nil, configToken: secondSnapshot.cacheToken))
+            CodexBarCLI.serveCacheKey(operationKey: operationKey, configToken: firstSnapshot.cacheToken) !=
+                CodexBarCLI.serveCacheKey(operationKey: operationKey, configToken: secondSnapshot.cacheToken))
     }
 
     @Test
@@ -246,215 +248,6 @@ struct CLIServeRouterTests {
             requestTimeout: .greatestFiniteMagnitude))
         #expect(abs(oversizedTimeout - 69120) < 1e-9)
         #expect(oversizedTimeout < 86400)
-    }
-
-    @Test
-    func `cleanup grace releases retained key while uncooperative work still runs`() async {
-        let cache = CLIServeResponseCache()
-        let key = "usage:cleanup-grace"
-
-        let response = await CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 0.05)
-        {
-            await ServeUncooperativeDelay.sleep(seconds: 2)
-            return Self.response("[{\"provider\":\"codex\"}]")
-        }
-
-        #expect(response.status == .gatewayTimeout)
-        try? await Task.sleep(nanoseconds: 70_000_000)
-        #expect(await cache.inFlightKeyCount() == 0)
-    }
-
-    @Test
-    func `queued serve request times out during retained in-flight cleanup`() async {
-        let cache = CLIServeResponseCache()
-        let key = "usage:queued-timeout"
-        let start = Date()
-
-        async let firstResponse = CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 0.1)
-        {
-            await ServeUncooperativeDelay.sleep(seconds: 2)
-            return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
-        }
-
-        try? await Task.sleep(nanoseconds: 70_000_000)
-
-        let queued = await CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 0.05)
-        {
-            Self.response("[{\"provider\":\"codex\",\"round\":2}]")
-        }
-        let elapsed = Date().timeIntervalSince(start)
-
-        let first = await firstResponse
-        #expect(first.status == .gatewayTimeout)
-        #expect(queued.status == .gatewayTimeout)
-        #expect(elapsed < 0.5)
-    }
-
-    @Test
-    func `releaseInFlight elects only one waiter to restart fetch`() async {
-        let cache = CLIServeResponseCache()
-        let key = "usage:elect-one"
-        let tracker = ServeActiveWorkTracker()
-        let fetchCounter = ServeTestCounter()
-
-        async let firstResponse = CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 0.05)
-        {
-            await ServeUncooperativeDelay.sleep(seconds: 0.2)
-            return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
-        }
-
-        try? await Task.sleep(nanoseconds: 70_000_000)
-
-        let responses = await withTaskGroup(of: CLILocalHTTPResponse.self) { group -> [CLILocalHTTPResponse] in
-            for round in 2...4 {
-                group.addTask {
-                    await CodexBarCLI.cachedServeResponse(
-                        key: key,
-                        cache: cache,
-                        refreshInterval: 60,
-                        requestTimeout: 0.2)
-                    {
-                        _ = await fetchCounter.increment()
-                        await tracker.enter()
-                        defer { Task { await tracker.leave() } }
-                        return Self.response("[{\"provider\":\"codex\",\"round\":\(round)}]")
-                    }
-                }
-            }
-
-            var collected: [CLILocalHTTPResponse] = []
-            for await response in group {
-                collected.append(response)
-            }
-            return collected
-        }
-
-        let first = await firstResponse
-        #expect(first.status == .gatewayTimeout)
-        #expect(await fetchCounter.current() == 1)
-        #expect(await tracker.peakCount() == 1)
-        #expect(responses.allSatisfy { $0.status == .ok })
-        #expect(await cache.inFlightKeyCount() == 0)
-    }
-
-    @Test
-    func `serve deadline returns before uncooperative work finishes`() async {
-        let start = Date()
-        let response = await CodexBarCLI.cachedServeResponse(
-            key: "usage:uncooperative",
-            cache: CLIServeResponseCache(),
-            refreshInterval: 60,
-            requestTimeout: 0.1)
-        {
-            await ServeUncooperativeDelay.sleep(seconds: 1)
-            return Self.response("[{\"provider\":\"codex\"}]")
-        }
-        let elapsed = Date().timeIntervalSince(start)
-
-        #expect(response.status == .gatewayTimeout)
-        #expect(elapsed < 0.5)
-    }
-
-    @Test
-    func `serve deadline cancels cooperative in-flight work after timeout`() async {
-        let tracker = ServeActiveWorkTracker()
-
-        let timeout = await CodexBarCLI.cachedServeResponse(
-            key: "usage:deadline-cancel",
-            cache: CLIServeResponseCache(),
-            refreshInterval: 60,
-            requestTimeout: 0.05)
-        {
-            await tracker.enter()
-            defer { Task { await tracker.leave() } }
-            try? await Task.sleep(nanoseconds: 500_000_000)
-            return Self.response("[{\"provider\":\"codex\"}]")
-        }
-
-        #expect(timeout.status == .gatewayTimeout)
-        try? await Task.sleep(nanoseconds: 150_000_000)
-        #expect(await tracker.activeCount() == 0)
-    }
-
-    @Test
-    func `timed out serve retains in-flight until cleanup releases the cache key`() async {
-        let cache = CLIServeResponseCache()
-        let key = "usage:hold-inflight"
-
-        async let firstResponse = CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 0.05)
-        {
-            await ServeUncooperativeDelay.sleep(seconds: 0.3)
-            return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
-        }
-
-        try? await Task.sleep(nanoseconds: 70_000_000)
-        #expect(await cache.inFlightKeyCount() == 1)
-
-        async let secondResponse = CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 0.05)
-        {
-            Self.response("[{\"provider\":\"codex\",\"round\":2}]")
-        }
-
-        try? await Task.sleep(nanoseconds: 10_000_000)
-        #expect(await cache.inFlightKeyCount() == 1)
-
-        let first = await firstResponse
-        let second = await secondResponse
-        #expect(first.status == .gatewayTimeout)
-        #expect(second.status == .ok)
-        #expect(Self.bodyString(second).contains("\"round\":2"))
-        #expect(await cache.inFlightKeyCount() == 0)
-    }
-
-    @Test
-    func `sequential serve deadline timeouts on one key do not stack in-flight work`() async {
-        let tracker = ServeActiveWorkTracker()
-        let cache = CLIServeResponseCache()
-        let key = "usage:stack-same"
-
-        for round in 1...3 {
-            let response = await CodexBarCLI.cachedServeResponse(
-                key: key,
-                cache: cache,
-                refreshInterval: 60,
-                requestTimeout: 0.05)
-            {
-                await tracker.enter()
-                defer { Task { await tracker.leave() } }
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                return Self.response("[{\"provider\":\"codex\",\"round\":\(round)}]")
-            }
-
-            #expect(response.status == .gatewayTimeout)
-            #expect(await tracker.activeCount() <= 1)
-            try? await Task.sleep(nanoseconds: 250_000_000)
-            #expect(await tracker.activeCount() == 0)
-            #expect(await cache.inFlightKeyCount() == 0)
-        }
     }
 
     @Test
@@ -664,6 +457,16 @@ struct CLIServeRouterTests {
         #expect(timeout.status == .gatewayTimeout)
         #expect(Self.bodyString(timeout).contains("request timed out"))
 
+        // Timeout delivery can win the actor race just before the canceled
+        // source reports completion. A successor must not start in that gap.
+        for _ in 0..<1000 {
+            if await cache.operations.snapshot().operationCount == 0 {
+                break
+            }
+            await Task.yield()
+        }
+        #expect(await cache.operations.snapshot().operationCount == 0)
+
         let success = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
             cache: cache,
@@ -776,6 +579,95 @@ struct CLIServeRouterTests {
 
         #expect(recovered.status == .ok)
         #expect(Self.bodyString(recovered).contains("\"call\":3"))
+    }
+
+    @Test
+    func `cost refresh timeout serves the last good payload`() async throws {
+        let cache = CLIServeResponseCache()
+        let counter = ServeTestCounter()
+
+        let first = await CodexBarCLI.cachedServeResponse(
+            key: "cost:",
+            cache: cache,
+            refreshInterval: 0.01,
+            requestTimeout: 1)
+        {
+            let call = await counter.increment()
+            return Self.response("[{\"provider\":\"codex\",\"call\":\(call)}]")
+        }
+        try? await Task.sleep(nanoseconds: 30_000_000)
+
+        let timedOut = await CodexBarCLI.cachedServeResponse(
+            key: "cost:",
+            cache: cache,
+            refreshInterval: 0.01,
+            requestTimeout: 0.01)
+        {
+            _ = await counter.increment()
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            return Self.response("[{\"provider\":\"codex\",\"call\":2}]")
+        }
+
+        #expect(timedOut.status == .ok)
+        let firstRows = try Self.jsonRows(first)
+        let timedOutRows = try Self.jsonRows(timedOut)
+        #expect(firstRows.first?["provider"] as? String == "codex")
+        #expect(timedOutRows.first?["provider"] as? String == "codex")
+        #expect(firstRows.first?["call"] as? Int == 1)
+        #expect(timedOutRows.first?["call"] as? Int == 1)
+        #expect(await counter.current() == 2)
+    }
+
+    @Test
+    func `cost refresh keeps fresh providers while replacing timed out rows`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "cost:",
+            cache: cache,
+            refreshInterval: 0.01,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","call":1},
+              {"provider":"claude","call":1}
+            ]
+            """)
+        }
+        try? await Task.sleep(nanoseconds: 30_000_000)
+
+        let partial = await CodexBarCLI.cachedServeResponse(
+            key: "cost:",
+            cache: cache,
+            refreshInterval: 0.01,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","call":2},
+              {"provider":"claude","error":{"message":"claude cost refresh timed out"}}
+            ]
+            """)
+        }
+        let partialRows = try Self.jsonRows(partial)
+        #expect(Self.row(partialRows, provider: "codex")?["call"] as? Int == 2)
+        #expect(Self.row(partialRows, provider: "claude")?["call"] as? Int == 1)
+        #expect(partialRows.allSatisfy { $0["error"] == nil })
+
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        let timedOut = await CodexBarCLI.cachedServeResponse(
+            key: "cost:",
+            cache: cache,
+            refreshInterval: 0.01,
+            requestTimeout: 0.01)
+        {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            return Self.response(#"[{"provider":"codex","call":3}]"#)
+        }
+        let timeoutRows = try Self.jsonRows(timedOut)
+        #expect(Self.row(timeoutRows, provider: "codex")?["call"] as? Int == 2)
+        #expect(Self.row(timeoutRows, provider: "claude")?["call"] as? Int == 1)
     }
 
     @Test
@@ -971,7 +863,6 @@ struct CLIServeRouterTests {
         let policy = CLIServeResponseCache.CachePolicy(ttl: 0, staleTTL: 10)
         let startedAt = Date(timeIntervalSince1970: 1000)
 
-        _ = await cache.responseOrStartFetch(for: "usage:", now: startedAt)
         _ = await cache.completeFetch(
             Self.response(
                 """
@@ -986,7 +877,6 @@ struct CLIServeRouterTests {
             shouldCache: true)
 
         let partialAt = startedAt.addingTimeInterval(9)
-        _ = await cache.responseOrStartFetch(for: "usage:", now: partialAt)
         _ = await cache.completeFetch(
             Self.response("""
             [
@@ -1000,7 +890,6 @@ struct CLIServeRouterTests {
             shouldCache: false)
 
         let timeoutAt = startedAt.addingTimeInterval(11)
-        _ = await cache.responseOrStartFetch(for: "usage:", now: timeoutAt)
         let timedOut = await cache.completeFetch(
             Self.response(#"{"error":"request timed out"}"#, status: .gatewayTimeout),
             for: "usage:",
@@ -1440,7 +1329,6 @@ struct CLIServeRouterTests {
             ttl: 0,
             staleTTL: CLIServeResponseCache.maximumStaleTTL)
 
-        _ = await cache.responseOrStartFetch(for: "config:old", now: startedAt)
         _ = await cache.completeFetch(
             Self.response(#"{"status":"ok"}"#),
             for: "config:old",
@@ -1448,7 +1336,6 @@ struct CLIServeRouterTests {
             now: startedAt,
             shouldCache: true)
 
-        _ = await cache.responseOrStartFetch(for: "usage:old", now: startedAt)
         _ = await cache.completeFetch(
             Self.response(
                 #"[{"provider":"codex","call":1}]"#,
@@ -1460,7 +1347,7 @@ struct CLIServeRouterTests {
         #expect(await cache.cachedStaleVariantCount() == 2)
 
         let expiredAt = startedAt.addingTimeInterval(CLIServeResponseCache.maximumStaleTTL + 1)
-        _ = await cache.responseOrStartFetch(for: "config:new", now: expiredAt)
+        _ = await cache.cachedResponse(for: "config:new", now: expiredAt)
         #expect(await cache.cachedStaleVariantCount() == 0)
         _ = await cache.completeFetch(
             Self.response(#"{"status":"ok"}"#),
@@ -1588,38 +1475,6 @@ struct CLIServeRouterTests {
             isLive: true,
             canReauthenticate: true,
             canRemove: false)
-    }
-}
-
-private enum ServeUncooperativeDelay {
-    static func sleep(seconds: TimeInterval) async {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global().asyncAfter(deadline: .now() + seconds) {
-                continuation.resume()
-            }
-        }
-    }
-}
-
-private actor ServeActiveWorkTracker {
-    private var active = 0
-    private var peak = 0
-
-    func enter() {
-        self.active += 1
-        self.peak = max(self.peak, self.active)
-    }
-
-    func leave() {
-        self.active = max(0, self.active - 1)
-    }
-
-    func activeCount() -> Int {
-        self.active
-    }
-
-    func peakCount() -> Int {
-        self.peak
     }
 }
 

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -249,6 +249,111 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `cleanup grace releases retained key while uncooperative work still runs`() async {
+        let cache = CLIServeResponseCache()
+        let key = "usage:cleanup-grace"
+
+        let response = await CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 0.05)
+        {
+            await ServeUncooperativeDelay.sleep(seconds: 2)
+            return Self.response("[{\"provider\":\"codex\"}]")
+        }
+
+        #expect(response.status == .gatewayTimeout)
+        try? await Task.sleep(nanoseconds: 70_000_000)
+        #expect(await cache.inFlightKeyCount() == 0)
+    }
+
+    @Test
+    func `queued serve request times out during retained in-flight cleanup`() async {
+        let cache = CLIServeResponseCache()
+        let key = "usage:queued-timeout"
+        let start = Date()
+
+        async let firstResponse = CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 0.1)
+        {
+            await ServeUncooperativeDelay.sleep(seconds: 2)
+            return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
+        }
+
+        try? await Task.sleep(nanoseconds: 70_000_000)
+
+        let queued = await CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 0.05)
+        {
+            Self.response("[{\"provider\":\"codex\",\"round\":2}]")
+        }
+        let elapsed = Date().timeIntervalSince(start)
+
+        let first = await firstResponse
+        #expect(first.status == .gatewayTimeout)
+        #expect(queued.status == .gatewayTimeout)
+        #expect(elapsed < 0.5)
+    }
+
+    @Test
+    func `releaseInFlight elects only one waiter to restart fetch`() async {
+        let cache = CLIServeResponseCache()
+        let key = "usage:elect-one"
+        let tracker = ServeActiveWorkTracker()
+        let fetchCounter = ServeTestCounter()
+
+        async let firstResponse = CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 0.05)
+        {
+            await ServeUncooperativeDelay.sleep(seconds: 0.2)
+            return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
+        }
+
+        try? await Task.sleep(nanoseconds: 70_000_000)
+
+        let responses = await withTaskGroup(of: CLILocalHTTPResponse.self) { group -> [CLILocalHTTPResponse] in
+            for round in 2...4 {
+                group.addTask {
+                    await CodexBarCLI.cachedServeResponse(
+                        key: key,
+                        cache: cache,
+                        refreshInterval: 60,
+                        requestTimeout: 0.2)
+                    {
+                        _ = await fetchCounter.increment()
+                        await tracker.enter()
+                        defer { Task { await tracker.leave() } }
+                        return Self.response("[{\"provider\":\"codex\",\"round\":\(round)}]")
+                    }
+                }
+            }
+
+            var collected: [CLILocalHTTPResponse] = []
+            for await response in group {
+                collected.append(response)
+            }
+            return collected
+        }
+
+        let first = await firstResponse
+        #expect(first.status == .gatewayTimeout)
+        #expect(await fetchCounter.current() == 1)
+        #expect(await tracker.peakCount() == 1)
+        #expect(responses.allSatisfy { $0.status == .ok })
+        #expect(await cache.inFlightKeyCount() == 0)
+    }
+
+    @Test
     func `serve deadline returns before uncooperative work finishes`() async {
         let start = Date()
         let response = await CodexBarCLI.cachedServeResponse(
@@ -1498,9 +1603,11 @@ private enum ServeUncooperativeDelay {
 
 private actor ServeActiveWorkTracker {
     private var active = 0
+    private var peak = 0
 
     func enter() {
         self.active += 1
+        self.peak = max(self.peak, self.active)
     }
 
     func leave() {
@@ -1509,6 +1616,10 @@ private actor ServeActiveWorkTracker {
 
     func activeCount() -> Int {
         self.active
+    }
+
+    func peakCount() -> Int {
+        self.peak
     }
 }
 

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -249,6 +249,51 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `serve deadline cancels in-flight work before returning timeout`() async {
+        let tracker = ServeActiveWorkTracker()
+
+        let timeout = await CodexBarCLI.cachedServeResponse(
+            key: "usage:deadline-cancel",
+            cache: CLIServeResponseCache(),
+            refreshInterval: 60,
+            requestTimeout: 0.05)
+        {
+            await tracker.enter()
+            defer { Task { await tracker.leave() } }
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            return Self.response("[{\"provider\":\"codex\"}]")
+        }
+
+        #expect(timeout.status == .gatewayTimeout)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        #expect(await tracker.activeCount() == 0)
+    }
+
+    @Test
+    func `sequential serve deadline timeouts do not stack in-flight work`() async {
+        let tracker = ServeActiveWorkTracker()
+        let cache = CLIServeResponseCache()
+
+        for round in 1...5 {
+            let response = await CodexBarCLI.cachedServeResponse(
+                key: "usage:stack:\(round)",
+                cache: cache,
+                refreshInterval: 60,
+                requestTimeout: 0.05)
+            {
+                await tracker.enter()
+                defer { Task { await tracker.leave() } }
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                return Self.response("[{\"provider\":\"codex\",\"round\":\(round)}]")
+            }
+
+            #expect(response.status == .gatewayTimeout)
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            #expect(await tracker.activeCount() == 0)
+        }
+    }
+
+    @Test
     func `serve usage collection bounds a hung provider without blocking others`() async {
         let providers: [UsageProvider] = [.codex, .claude, .gemini]
         let start = Date()
@@ -1379,6 +1424,22 @@ struct CLIServeRouterTests {
             isLive: true,
             canReauthenticate: true,
             canRemove: false)
+    }
+}
+
+private actor ServeActiveWorkTracker {
+    private var active = 0
+
+    func enter() {
+        self.active += 1
+    }
+
+    func leave() {
+        self.active = max(0, self.active - 1)
+    }
+
+    func activeCount() -> Int {
+        self.active
     }
 }
 

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -249,7 +249,25 @@ struct CLIServeRouterTests {
     }
 
     @Test
-    func `serve deadline cancels in-flight work before returning timeout`() async {
+    func `serve deadline returns before uncooperative work finishes`() async {
+        let start = Date()
+        let response = await CodexBarCLI.cachedServeResponse(
+            key: "usage:uncooperative",
+            cache: CLIServeResponseCache(),
+            refreshInterval: 60,
+            requestTimeout: 0.1)
+        {
+            await ServeUncooperativeDelay.sleep(seconds: 1)
+            return Self.response("[{\"provider\":\"codex\"}]")
+        }
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(response.status == .gatewayTimeout)
+        #expect(elapsed < 0.5)
+    }
+
+    @Test
+    func `serve deadline cancels cooperative in-flight work after timeout`() async {
         let tracker = ServeActiveWorkTracker()
 
         let timeout = await CodexBarCLI.cachedServeResponse(
@@ -265,31 +283,72 @@ struct CLIServeRouterTests {
         }
 
         #expect(timeout.status == .gatewayTimeout)
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        try? await Task.sleep(nanoseconds: 150_000_000)
         #expect(await tracker.activeCount() == 0)
     }
 
     @Test
-    func `sequential serve deadline timeouts do not stack in-flight work`() async {
+    func `timed out serve retains in-flight until cleanup releases the cache key`() async {
+        let cache = CLIServeResponseCache()
+        let key = "usage:hold-inflight"
+
+        async let firstResponse = CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 0.05)
+        {
+            await ServeUncooperativeDelay.sleep(seconds: 0.3)
+            return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
+        }
+
+        try? await Task.sleep(nanoseconds: 70_000_000)
+        #expect(await cache.inFlightKeyCount() == 1)
+
+        async let secondResponse = CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 0.05)
+        {
+            Self.response("[{\"provider\":\"codex\",\"round\":2}]")
+        }
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        #expect(await cache.inFlightKeyCount() == 1)
+
+        let first = await firstResponse
+        let second = await secondResponse
+        #expect(first.status == .gatewayTimeout)
+        #expect(second.status == .ok)
+        #expect(Self.bodyString(second).contains("\"round\":2"))
+        #expect(await cache.inFlightKeyCount() == 0)
+    }
+
+    @Test
+    func `sequential serve deadline timeouts on one key do not stack in-flight work`() async {
         let tracker = ServeActiveWorkTracker()
         let cache = CLIServeResponseCache()
+        let key = "usage:stack-same"
 
-        for round in 1...5 {
+        for round in 1...3 {
             let response = await CodexBarCLI.cachedServeResponse(
-                key: "usage:stack:\(round)",
+                key: key,
                 cache: cache,
                 refreshInterval: 60,
                 requestTimeout: 0.05)
             {
                 await tracker.enter()
                 defer { Task { await tracker.leave() } }
-                try? await Task.sleep(nanoseconds: 500_000_000)
+                try? await Task.sleep(nanoseconds: 200_000_000)
                 return Self.response("[{\"provider\":\"codex\",\"round\":\(round)}]")
             }
 
             #expect(response.status == .gatewayTimeout)
-            try? await Task.sleep(nanoseconds: 50_000_000)
+            #expect(await tracker.activeCount() <= 1)
+            try? await Task.sleep(nanoseconds: 250_000_000)
             #expect(await tracker.activeCount() == 0)
+            #expect(await cache.inFlightKeyCount() == 0)
         }
     }
 
@@ -1424,6 +1483,16 @@ struct CLIServeRouterTests {
             isLive: true,
             canReauthenticate: true,
             canRemove: false)
+    }
+}
+
+private enum ServeUncooperativeDelay {
+    static func sleep(seconds: TimeInterval) async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().asyncAfter(deadline: .now() + seconds) {
+                continuation.resume()
+            }
+        }
     }
 }
 

--- a/Tests/CodexBarTests/CLIServeTimeoutTests.swift
+++ b/Tests/CodexBarTests/CLIServeTimeoutTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+@testable import CodexBarCLI
+
+struct CLIServeTimeoutTests {
+    @Test
+    func `clamped serve request timeout rejects oversized finite values`() {
+        #expect(CodexBarCLI.clampedServeRequestTimeout(.greatestFiniteMagnitude) == 86400)
+        #expect(CodexBarCLI.clampedServeRequestTimeout(1e308) == 86400)
+        #expect(CodexBarCLI.clampedServeRequestTimeout(-5) == 0)
+    }
+
+    @Test
+    func `queued in flight wait clamps oversized finite request timeout`() async {
+        let cache = CLIServeResponseCache()
+        let key = "usage:oversized-timeout"
+        let gate = ServeFetchReleaseGate()
+
+        async let blocker = CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 5)
+        {
+            await gate.waitForProceed()
+            return Self.response("[{\"provider\":\"codex\"}]")
+        }
+
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        let lookup = await cache.responseOrStartFetch(
+            for: key,
+            requestTimeout: .greatestFiniteMagnitude,
+            now: Date())
+
+        await gate.proceed()
+        _ = await blocker
+
+        switch lookup {
+        case .response:
+            #expect(Bool(true))
+        case .miss:
+            Issue.record("expected coalesced response while key stayed in-flight")
+        }
+    }
+
+    @Test
+    func `same key waiter registered before fetch completes receives response`() async {
+        let cache = CLIServeResponseCache()
+        let key = "usage:sync-waiter"
+        let gate = ServeFetchReleaseGate()
+
+        async let first = CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 5)
+        {
+            await gate.waitForProceed()
+            return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
+        }
+
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        #expect(await cache.inFlightKeyCount() == 1)
+
+        async let second = CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 1)
+        {
+            Self.response("[{\"provider\":\"codex\",\"round\":2}]")
+        }
+
+        await gate.proceed()
+        let firstResponse = await first
+        let secondResponse = await second
+
+        #expect(firstResponse.status == .ok)
+        #expect(secondResponse.status == .ok)
+        #expect(Self.bodyString(secondResponse).contains("\"round\":1"))
+    }
+
+    @Test
+    func `cleanup releases retained key when cooperative work exits early`() async throws {
+        let cache = CLIServeResponseCache()
+        let key = "usage:early-release"
+        let start = Date()
+
+        let first = await CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 0.08)
+        {
+            try? await Task.sleep(nanoseconds: 40_000_000)
+            return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
+        }
+        #expect(first.status == .gatewayTimeout)
+
+        var clearedAt: TimeInterval?
+        for _ in 0..<50 {
+            if await cache.inFlightKeyCount() == 0 {
+                clearedAt = Date().timeIntervalSince(start)
+                break
+            }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        let cleared = try #require(clearedAt)
+        #expect(cleared < 0.14)
+
+        let second = await CodexBarCLI.cachedServeResponse(
+            key: key,
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 0.1)
+        {
+            Self.response("[{\"provider\":\"codex\",\"round\":2}]")
+        }
+        #expect(second.status == .ok)
+    }
+
+    private static func response(
+        _ body: String,
+        status: CLIHTTPStatus = .ok,
+        usageCacheKeys: [String?]? = nil) -> CLILocalHTTPResponse
+    {
+        let data = Data(body.utf8)
+        return CLILocalHTTPResponse(
+            status: status,
+            body: data,
+            usageCacheKeys: usageCacheKeys ?? Self.syntheticUsageCacheKeys(data))
+    }
+
+    private static func bodyString(_ response: CLILocalHTTPResponse) -> String {
+        String(data: response.body, encoding: .utf8) ?? ""
+    }
+
+    private static func syntheticUsageCacheKeys(_ data: Data) -> [String?]? {
+        guard let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return nil }
+        return rows.map { row in
+            guard let provider = row["provider"] as? String else { return nil }
+            let account = row["account"] as? String ?? "default"
+            return "test:\(provider):\(account)"
+        }
+    }
+}
+
+private actor ServeFetchReleaseGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func waitForProceed() async {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func proceed() {
+        self.continuation?.resume()
+        self.continuation = nil
+    }
+}

--- a/Tests/CodexBarTests/CLIServeTimeoutTests.swift
+++ b/Tests/CodexBarTests/CLIServeTimeoutTests.swift
@@ -93,7 +93,7 @@ struct CLIServeTimeoutTests {
             refreshInterval: 60,
             requestTimeout: 0.08)
         {
-            try? await Task.sleep(nanoseconds: 40_000_000)
+            try? await Task.sleep(nanoseconds: 120_000_000)
             return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
         }
         #expect(first.status == .gatewayTimeout)

--- a/Tests/CodexBarTests/CLIServeTimeoutTests.swift
+++ b/Tests/CodexBarTests/CLIServeTimeoutTests.swift
@@ -5,6 +5,11 @@ import Testing
 
 struct CLIServeTimeoutTests {
     @Test
+    func `serve cost keeps pricing refresh outside the request deadline`() {
+        #expect(CodexBarCLI.serveCostRefreshesPricingInBackground)
+    }
+
+    @Test
     func `serve deadlines clamp once from request entry`() throws {
         #expect(CodexBarCLI.clampedServeRequestTimeout(.greatestFiniteMagnitude) == 86400)
         #expect(CodexBarCLI.clampedServeRequestTimeout(1e308) == 86400)

--- a/Tests/CodexBarTests/CLIServeTimeoutTests.swift
+++ b/Tests/CodexBarTests/CLIServeTimeoutTests.swift
@@ -16,6 +16,20 @@ struct CLIServeTimeoutTests {
             requestTimeout: .greatestFiniteMagnitude))
         #expect(startedAt.duration(to: deadline) == .seconds(86400))
         #expect(CodexBarCLI.serveRequestDeadline(startedAt: startedAt, requestTimeout: 0) == nil)
+
+        let requestDeadline = startedAt.advanced(by: .seconds(40))
+        #expect(CodexBarCLI.serveCostProviderDeadline(
+            startedAt: startedAt,
+            providerTimeout: 30,
+            requestDeadline: requestDeadline) == startedAt.advanced(by: .seconds(30)))
+        #expect(CodexBarCLI.serveCostProviderDeadline(
+            startedAt: startedAt.advanced(by: .seconds(20)),
+            providerTimeout: 30,
+            requestDeadline: requestDeadline) == requestDeadline)
+        #expect(CodexBarCLI.serveCostProviderDeadline(
+            startedAt: startedAt,
+            providerTimeout: nil,
+            requestDeadline: nil) == nil)
     }
 
     @Test
@@ -509,14 +523,18 @@ struct CLIServeTimeoutTests {
         let late = CodexBarCLI.makeCostPayload(provider: .claude, snapshot: nil, error: nil)
         let blocked = ServeFetchGate<CostPayload>()
         let operations: CLIServeOperationCoordinator<CostPayload> = self.makeCoordinator(clock: clock)
-        let deadline = clock.now().advanced(by: .seconds(30))
+        let requestDeadline = clock.now().advanced(by: .seconds(40))
+        let firstContext = ServeCostCollectionContext(
+            configFingerprint: "config-a",
+            providerTimeout: 30,
+            requestDeadline: requestDeadline,
+            now: { clock.now() },
+            providerOperations: operations)
 
         let first = Task {
             await CodexBarCLI.serveCollectCostPayloads(
                 providers: [.claude, .codex],
-                configFingerprint: "config-a",
-                deadline: deadline,
-                operations: operations)
+                context: firstContext)
             { provider in
                 if provider == .claude {
                     return await blocked.run(late)
@@ -532,14 +550,18 @@ struct CLIServeTimeoutTests {
 
         #expect(firstPayload.map(\.provider) == ["claude", "codex"])
         #expect(firstPayload[0].error?.message == "claude cost refresh timed out")
-        #expect(firstPayload[1].error?.message == "codex cost refresh timed out")
+        #expect(firstPayload[1].error == nil)
 
+        let overlappingContext = ServeCostCollectionContext(
+            configFingerprint: "config-a",
+            providerTimeout: 30,
+            requestDeadline: requestDeadline.advanced(by: .seconds(20)),
+            now: { clock.now() },
+            providerOperations: operations)
         let overlappingVariant = Task {
             await CodexBarCLI.serveCollectCostPayloads(
                 providers: [.claude],
-                configFingerprint: "config-a",
-                deadline: deadline.advanced(by: .seconds(30)),
-                operations: operations)
+                context: overlappingContext)
             { _ in
                 await blocked.run(late)
             }

--- a/Tests/CodexBarTests/CLIServeTimeoutTests.swift
+++ b/Tests/CodexBarTests/CLIServeTimeoutTests.swift
@@ -1,163 +1,799 @@
 import Foundation
 import Testing
 @testable import CodexBarCLI
+@testable import CodexBarCore
 
 struct CLIServeTimeoutTests {
     @Test
-    func `clamped serve request timeout rejects oversized finite values`() {
+    func `serve deadlines clamp once from request entry`() throws {
         #expect(CodexBarCLI.clampedServeRequestTimeout(.greatestFiniteMagnitude) == 86400)
         #expect(CodexBarCLI.clampedServeRequestTimeout(1e308) == 86400)
         #expect(CodexBarCLI.clampedServeRequestTimeout(-5) == 0)
+
+        let startedAt = ContinuousClock().now
+        let deadline = try #require(CodexBarCLI.serveRequestDeadline(
+            startedAt: startedAt,
+            requestTimeout: .greatestFiniteMagnitude))
+        #expect(startedAt.duration(to: deadline) == .seconds(86400))
+        #expect(CodexBarCLI.serveRequestDeadline(startedAt: startedAt, requestTimeout: 0) == nil)
     }
 
     @Test
-    func `queued in flight wait clamps oversized finite request timeout`() async {
-        let cache = CLIServeResponseCache()
-        let key = "usage:oversized-timeout"
-        let gate = ServeFetchReleaseGate()
+    func `timed out source stays owned and later requests never overlap`() async {
+        let clock = ServeManualDeadlineClock()
+        let gate = ServeFetchGate<Int>()
+        let coordinator: CLIServeOperationCoordinator<Int> = self.makeCoordinator(clock: clock)
+        let deadline = clock.now().advanced(by: .seconds(30))
 
-        async let blocker = CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 5)
-        {
-            await gate.waitForProceed()
-            return Self.response("[{\"provider\":\"codex\"}]")
-        }
-
-        try? await Task.sleep(nanoseconds: 20_000_000)
-
-        let lookup = await cache.responseOrStartFetch(
-            for: key,
-            requestTimeout: .greatestFiniteMagnitude,
-            now: Date())
-
-        await gate.proceed()
-        _ = await blocker
-
-        switch lookup {
-        case .response:
-            #expect(Bool(true))
-        case .miss:
-            Issue.record("expected coalesced response while key stayed in-flight")
-        }
-    }
-
-    @Test
-    func `same key waiter registered before fetch completes receives response`() async {
-        let cache = CLIServeResponseCache()
-        let key = "usage:sync-waiter"
-        let gate = ServeFetchReleaseGate()
-
-        async let first = CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 5)
-        {
-            await gate.waitForProceed()
-            return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
-        }
-
-        try? await Task.sleep(nanoseconds: 20_000_000)
-        #expect(await cache.inFlightKeyCount() == 1)
-
-        async let second = CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 1)
-        {
-            Self.response("[{\"provider\":\"codex\",\"round\":2}]")
-        }
-
-        await gate.proceed()
-        let firstResponse = await first
-        let secondResponse = await second
-
-        #expect(firstResponse.status == .ok)
-        #expect(secondResponse.status == .ok)
-        #expect(Self.bodyString(secondResponse).contains("\"round\":1"))
-    }
-
-    @Test
-    func `cleanup releases retained key when cooperative work exits early`() async throws {
-        let cache = CLIServeResponseCache()
-        let key = "usage:early-release"
-        let start = Date()
-
-        let first = await CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 0.08)
-        {
-            try? await Task.sleep(nanoseconds: 120_000_000)
-            return Self.response("[{\"provider\":\"codex\",\"round\":1}]")
-        }
-        #expect(first.status == .gatewayTimeout)
-
-        var clearedAt: TimeInterval?
-        for _ in 0..<50 {
-            if await cache.inFlightKeyCount() == 0 {
-                clearedAt = Date().timeIntervalSince(start)
-                break
+        let first = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: deadline,
+                timeoutValue: -1)
+            {
+                await gate.run(1)
             }
-            try? await Task.sleep(nanoseconds: 5_000_000)
         }
+        await gate.waitForStarts(1)
+        await clock.waitForPendingSleeps(1)
+        await clock.fireAll()
 
-        let cleared = try #require(clearedAt)
-        #expect(cleared < 0.14)
+        #expect(await first.value == -1)
+        #expect(await coordinator.snapshot().operationCount == 1)
+        #expect(await coordinator.snapshot().timerCount == 0)
 
-        let second = await CodexBarCLI.cachedServeResponse(
-            key: key,
-            cache: cache,
-            refreshInterval: 60,
-            requestTimeout: 0.1)
+        let later = (0..<4).map { _ in
+            Task {
+                await coordinator.value(
+                    for: "usage:",
+                    fingerprint: "config-a",
+                    deadline: deadline.advanced(by: .seconds(30)),
+                    timeoutValue: -1)
+                {
+                    await gate.run(2)
+                }
+            }
+        }
+        await self.waitForOperationCount(2, coordinator: coordinator)
+        await clock.waitForPendingSleeps(1)
+        await clock.fireAll()
+        for task in later {
+            #expect(await task.value == -1)
+        }
+        #expect(await gate.startCount() == 1)
+        #expect(await gate.peakCount() == 1)
+
+        await gate.releaseAll()
+        await gate.waitForActive(0)
+        await self.waitForOperationCount(0, coordinator: coordinator)
+    }
+
+    @Test
+    func `earlier follower tightens the shared absolute budget`() async {
+        let clock = ServeManualDeadlineClock()
+        let gate = ServeFetchGate<Int>()
+        let coordinator: CLIServeOperationCoordinator<Int> = self.makeCoordinator(clock: clock)
+        let firstDeadline = clock.now().advanced(by: .seconds(30))
+
+        let first = Task {
+            await coordinator.value(
+                for: "cost:",
+                fingerprint: "config-a",
+                deadline: firstDeadline,
+                timeoutValue: -1)
+            {
+                await gate.run(1)
+            }
+        }
+        await gate.waitForStarts(1)
+        await clock.waitForPendingSleeps(1)
+
+        let shorterFollower = Task {
+            await coordinator.value(
+                for: "cost:",
+                fingerprint: "config-a",
+                deadline: firstDeadline.advanced(by: .seconds(-1)),
+                timeoutValue: -2)
+            {
+                await gate.run(2)
+            }
+        }
+        await self.waitForWaiterCount(2, coordinator: coordinator)
+        await clock.waitForCancellations(1)
+        await clock.waitForPendingSleeps(1)
+        clock.advance(by: .seconds(29))
+        await clock.fireAll()
+
+        #expect(await first.value == -1)
+        #expect(await shorterFollower.value == -2)
+        #expect(await gate.startCount() == 1)
+
+        await gate.releaseAll()
+        await gate.waitForActive(0)
+        await self.waitForOperationCount(0, coordinator: coordinator)
+        #expect(await coordinator.snapshot().operationCount == 0)
+    }
+
+    @Test
+    func `source completing at an overdue deadline cannot beat a delayed timer`() async {
+        let clock = ServeManualDeadlineClock()
+        let gate = ServeFetchGate<Int>()
+        let acceptance = ServeAcceptanceProbe<Int>()
+        let coordinator: CLIServeOperationCoordinator<Int> = self.makeCoordinator(clock: clock)
+
+        let result = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: clock.now().advanced(by: .seconds(30)),
+                timeoutValue: -1,
+                accept: { await acceptance.accept($0) },
+                operation: { await gate.run(7) })
+        }
+        await gate.waitForStarts(1)
+        await clock.waitForPendingSleeps(1)
+        clock.advance(by: .seconds(30))
+        await gate.releaseAll()
+
+        #expect(await result.value == -1)
+        #expect(await acceptance.callCount() == 0)
+        await clock.waitForCancellations(1)
+        await self.waitForOperationCount(0, coordinator: coordinator)
+    }
+
+    @Test
+    func `shared deadline returns each waiters own timeout value`() async {
+        let clock = ServeManualDeadlineClock()
+        let gate = ServeFetchGate<Int>()
+        let coordinator: CLIServeOperationCoordinator<Int> = self.makeCoordinator(clock: clock)
+        let deadline = clock.now().advanced(by: .seconds(30))
+
+        let leader = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: deadline,
+                timeoutValue: -1)
+            {
+                await gate.run(1)
+            }
+        }
+        await gate.waitForStarts(1)
+        await clock.waitForPendingSleeps(1)
+        let follower = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: deadline.advanced(by: .seconds(1)),
+                timeoutValue: -2)
+            {
+                await gate.run(2)
+            }
+        }
+        await self.waitForWaiterCount(2, coordinator: coordinator)
+        await clock.fireAll()
+
+        #expect(await leader.value == -1)
+        #expect(await follower.value == -2)
+        await gate.releaseAll()
+        await gate.waitForActive(0)
+        await self.waitForOperationCount(0, coordinator: coordinator)
+    }
+
+    @Test
+    func `finite follower fails closed behind deadline free source`() async {
+        let gate = ServeFetchGate<Int>()
+        let coordinator = CLIServeOperationCoordinator<Int>()
+
+        let first = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: nil,
+                timeoutValue: -1)
+            {
+                await gate.run(1)
+            }
+        }
+        await gate.waitForStarts(1)
+
+        let follower = await coordinator.value(
+            for: "usage:",
+            fingerprint: "config-a",
+            deadline: ContinuousClock().now.advanced(by: .seconds(30)),
+            timeoutValue: -2)
         {
-            Self.response("[{\"provider\":\"codex\",\"round\":2}]")
+            await gate.run(2)
         }
-        #expect(second.status == .ok)
+        #expect(follower == -2)
+        #expect(await gate.startCount() == 1)
+
+        await gate.releaseAll()
+        #expect(await first.value == 1)
     }
 
-    private static func response(
-        _ body: String,
-        status: CLIHTTPStatus = .ok,
-        usageCacheKeys: [String?]? = nil) -> CLILocalHTTPResponse
+    @Test
+    func `waiter cancellation unregisters and last waiter cancels source`() async {
+        let clock = ServeManualDeadlineClock()
+        let gate = ServeFetchGate<Int>()
+        let coordinator: CLIServeOperationCoordinator<Int> = self.makeCoordinator(clock: clock)
+        let deadline = clock.now().advanced(by: .seconds(30))
+
+        let leader = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: deadline,
+                timeoutValue: -1)
+            {
+                await gate.run(1)
+            }
+        }
+        await gate.waitForStarts(1)
+        await clock.waitForPendingSleeps(1)
+        let follower = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: deadline.advanced(by: .seconds(1)),
+                timeoutValue: -2)
+            {
+                await gate.run(2)
+            }
+        }
+        await self.waitForWaiterCount(2, coordinator: coordinator)
+        follower.cancel()
+        #expect(await follower.value == -2)
+        await self.waitForWaiterCount(1, coordinator: coordinator)
+        #expect(await coordinator.snapshot().operationCount == 1)
+
+        leader.cancel()
+        #expect(await leader.value == -1)
+        await clock.waitForCancellations(1)
+        let retained = await coordinator.snapshot()
+        #expect(retained.operationCount == 1)
+        #expect(retained.waiterCount == 0)
+        #expect(retained.timerCount == 0)
+
+        await gate.releaseAll()
+        await gate.waitForActive(0)
+        await self.waitForOperationCount(0, coordinator: coordinator)
+    }
+
+    @Test
+    func `source completion cancels the operation timer`() async {
+        let clock = ServeManualDeadlineClock()
+        let gate = ServeFetchGate<Int>()
+        let coordinator: CLIServeOperationCoordinator<Int> = self.makeCoordinator(clock: clock)
+
+        let result = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: clock.now().advanced(by: .seconds(30)),
+                timeoutValue: -1)
+            {
+                await gate.run(7)
+            }
+        }
+        await gate.waitForStarts(1)
+        await clock.waitForPendingSleeps(1)
+        await gate.releaseAll()
+
+        #expect(await result.value == 7)
+        await clock.waitForCancellations(1)
+        #expect(await clock.pendingSleepCount() == 0)
+        #expect(await coordinator.snapshot() == .init(
+            operationCount: 0,
+            waiterCount: 0,
+            timerCount: 0,
+            isShutDown: false))
+    }
+
+    @Test
+    func `accepted value stays owned through asynchronous commit`() async {
+        let source = ServeFetchGate<Int>()
+        let commit = ServeFetchGate<Int>()
+        let coordinator = CLIServeOperationCoordinator<Int>()
+        await source.releaseAll()
+
+        let first = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: nil,
+                timeoutValue: -1,
+                accept: { await commit.run($0) },
+                operation: { await source.run(1) })
+        }
+        await commit.waitForStarts(1)
+        let follower = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: nil,
+                timeoutValue: -2,
+                accept: { await commit.run($0) },
+                operation: { await source.run(2) })
+        }
+        await self.waitForWaiterCount(2, coordinator: coordinator)
+
+        #expect(await source.startCount() == 1)
+        #expect(await coordinator.snapshot().operationCount == 1)
+        await commit.releaseAll()
+        #expect(await first.value == 1)
+        #expect(await follower.value == 1)
+        #expect(await source.startCount() == 1)
+        await self.waitForOperationCount(0, coordinator: coordinator)
+    }
+
+    @Test
+    func `earlier finite follower fails closed during accepted commit`() async {
+        let source = ServeFetchGate<Int>()
+        let commit = ServeFetchGate<Int>()
+        let coordinator = CLIServeOperationCoordinator<Int>()
+        let leaderDeadline = ContinuousClock().now.advanced(by: .seconds(30))
+        await source.releaseAll()
+
+        let leader = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: leaderDeadline,
+                timeoutValue: -1,
+                accept: { await commit.run($0) },
+                operation: { await source.run(1) })
+        }
+        await commit.waitForStarts(1)
+        let follower = await coordinator.value(
+            for: "usage:",
+            fingerprint: "config-a",
+            deadline: leaderDeadline.advanced(by: .seconds(-1)),
+            timeoutValue: -2)
+        {
+            await source.run(2)
+        }
+
+        #expect(follower == -2)
+        #expect(await source.startCount() == 1)
+        let accepting = await coordinator.snapshot()
+        #expect(accepting.waiterCount == 1)
+        #expect(accepting.timerCount == 0)
+        await commit.releaseAll()
+        #expect(await leader.value == 1)
+        await self.waitForOperationCount(0, coordinator: coordinator)
+    }
+
+    @Test
+    func `config change queues a nonoverlapping successor without a deadline`() async {
+        let gate = ServeFetchGate<Int>()
+        let coordinator = CLIServeOperationCoordinator<Int>()
+
+        let old = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: nil,
+                timeoutValue: -1)
+            {
+                await gate.run(1)
+            }
+        }
+        await gate.waitForStarts(1)
+
+        let successor = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-b",
+                deadline: nil,
+                timeoutValue: -2)
+            {
+                await gate.run(2)
+            }
+        }
+        await self.waitForOperationCount(2, coordinator: coordinator)
+        #expect(await gate.startCount() == 1)
+        #expect(await gate.peakCount() == 1)
+
+        await gate.releaseAll()
+        #expect(await old.value == 1)
+        #expect(await successor.value == 2)
+        await gate.waitForActive(0)
+        await self.waitForOperationCount(0, coordinator: coordinator)
+        #expect(await gate.startCount() == 2)
+        #expect(await gate.peakCount() == 1)
+    }
+
+    @Test
+    func `shutdown cancels owned work and rejects new operations`() async {
+        let clock = ServeManualDeadlineClock()
+        let gate = ServeFetchGate<Int>()
+        let coordinator: CLIServeOperationCoordinator<Int> = self.makeCoordinator(clock: clock)
+
+        let active = Task {
+            await coordinator.value(
+                for: "usage:",
+                fingerprint: "config-a",
+                deadline: clock.now().advanced(by: .seconds(30)),
+                timeoutValue: -1)
+            {
+                await gate.run(1)
+            }
+        }
+        await gate.waitForStarts(1)
+        await clock.waitForPendingSleeps(1)
+        await coordinator.shutdown()
+
+        #expect(await active.value == -1)
+        await clock.waitForCancellations(1)
+        let rejected = await coordinator.value(
+            for: "cost:",
+            fingerprint: "config-a",
+            deadline: nil,
+            timeoutValue: -2)
+        {
+            2
+        }
+        #expect(rejected == -2)
+        let retained = await coordinator.snapshot()
+        #expect(retained.operationCount == 1)
+        #expect(retained.isShutDown)
+
+        await gate.releaseAll()
+        await gate.waitForActive(0)
+        await self.waitForOperationCount(0, coordinator: coordinator)
+    }
+
+    @Test
+    func `provider timeout preserves healthy rows and cannot stack provider work`() async {
+        let clock = ServeManualDeadlineClock()
+        let blocked = ServeFetchGate<UsageCommandOutput>()
+        let healthy = ServeFetchGate<UsageCommandOutput>()
+        let operations: CLIServeOperationCoordinator<UsageCommandOutput> = self.makeCoordinator(clock: clock)
+        let deadline = clock.now().advanced(by: .seconds(30))
+        await healthy.releaseAll()
+
+        let first = Task {
+            await CodexBarCLI.serveCollectUsageOutputs(
+                providers: [.claude, .gemini],
+                configFingerprint: "config-a",
+                deadline: deadline,
+                operations: operations)
+            { provider in
+                if provider == .claude {
+                    return await blocked.run(UsageCommandOutput(sections: ["late:claude"]))
+                }
+                return await healthy.run(UsageCommandOutput(sections: ["ok:gemini"]))
+            }
+        }
+        await blocked.waitForStarts(1)
+        await healthy.waitForStarts(1)
+        await self.waitForOperationCount(1, coordinator: operations)
+        await clock.waitForPendingSleeps(1)
+        clock.advance(by: .seconds(30))
+        await clock.fireAll()
+        let firstOutput = await first.value
+        #expect(firstOutput.sections == ["ok:gemini"])
+        #expect(firstOutput.payload.count == 1)
+        #expect(firstOutput.payload.first?.provider == UsageProvider.claude.rawValue)
+        #expect(firstOutput.payload.first?.error?.kind == .provider)
+
+        let second = Task {
+            await CodexBarCLI.serveCollectUsageOutputs(
+                providers: [.claude],
+                configFingerprint: "config-a",
+                deadline: deadline.advanced(by: .seconds(30)),
+                operations: operations)
+            { _ in
+                await blocked.run(UsageCommandOutput(sections: ["overlap"]))
+            }
+        }
+        await self.waitForOperationCount(2, coordinator: operations)
+        await clock.waitForPendingSleeps(1)
+        clock.advance(by: .seconds(30))
+        await clock.fireAll()
+        let secondOutput = await second.value
+        #expect(secondOutput.payload.first?.error?.kind == .provider)
+        #expect(await blocked.startCount() == 1)
+        #expect(await blocked.peakCount() == 1)
+
+        await blocked.releaseAll()
+        await blocked.waitForActive(0)
+        await self.waitForOperationCount(0, coordinator: operations)
+    }
+
+    @Test
+    func `cost route variants cannot stack the same provider scan`() async {
+        let clock = ServeManualDeadlineClock()
+        let late = CodexBarCLI.makeCostPayload(provider: .claude, snapshot: nil, error: nil)
+        let blocked = ServeFetchGate<CostPayload>()
+        let operations: CLIServeOperationCoordinator<CostPayload> = self.makeCoordinator(clock: clock)
+        let deadline = clock.now().advanced(by: .seconds(30))
+
+        let first = Task {
+            await CodexBarCLI.serveCollectCostPayloads(
+                providers: [.claude, .codex],
+                configFingerprint: "config-a",
+                deadline: deadline,
+                operations: operations)
+            { provider in
+                if provider == .claude {
+                    return await blocked.run(late)
+                }
+                return CodexBarCLI.makeCostPayload(provider: provider, snapshot: nil, error: nil)
+            }
+        }
+        await blocked.waitForStarts(1)
+        await clock.waitForPendingSleeps(1)
+        clock.advance(by: .seconds(30))
+        await clock.fireAll()
+        let firstPayload = await first.value
+
+        #expect(firstPayload.map(\.provider) == ["claude", "codex"])
+        #expect(firstPayload[0].error?.message == "claude cost refresh timed out")
+        #expect(firstPayload[1].error?.message == "codex cost refresh timed out")
+
+        let overlappingVariant = Task {
+            await CodexBarCLI.serveCollectCostPayloads(
+                providers: [.claude],
+                configFingerprint: "config-a",
+                deadline: deadline.advanced(by: .seconds(30)),
+                operations: operations)
+            { _ in
+                await blocked.run(late)
+            }
+        }
+        await self.waitForOperationCount(2, coordinator: operations)
+        await clock.waitForPendingSleeps(1)
+        clock.advance(by: .seconds(30))
+        await clock.fireAll()
+        let secondPayload = await overlappingVariant.value
+
+        #expect(secondPayload.first?.error?.message == "claude cost refresh timed out")
+        #expect(await blocked.startCount() == 1)
+        #expect(await blocked.peakCount() == 1)
+
+        await blocked.releaseAll()
+        await blocked.waitForActive(0)
+        await self.waitForOperationCount(0, coordinator: operations)
+    }
+
+    private func makeCoordinator<Value: Sendable>(
+        clock: ServeManualDeadlineClock) -> CLIServeOperationCoordinator<Value>
     {
-        let data = Data(body.utf8)
-        return CLILocalHTTPResponse(
-            status: status,
-            body: data,
-            usageCacheKeys: usageCacheKeys ?? Self.syntheticUsageCacheKeys(data))
+        CLIServeOperationCoordinator(
+            now: { clock.now() },
+            sleepUntil: { deadline in try await clock.sleep(until: deadline) })
     }
 
-    private static func bodyString(_ response: CLILocalHTTPResponse) -> String {
-        String(data: response.body, encoding: .utf8) ?? ""
+    private func waitForOperationCount(
+        _ expected: Int,
+        coordinator: CLIServeOperationCoordinator<some Sendable>) async
+    {
+        for _ in 0..<1000 {
+            if await coordinator.snapshot().operationCount == expected {
+                return
+            }
+            await Task.yield()
+        }
+        Issue.record("operation count did not reach \(expected)")
     }
 
-    private static func syntheticUsageCacheKeys(_ data: Data) -> [String?]? {
-        guard let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return nil }
-        return rows.map { row in
-            guard let provider = row["provider"] as? String else { return nil }
-            let account = row["account"] as? String ?? "default"
-            return "test:\(provider):\(account)"
+    private func waitForWaiterCount(
+        _ expected: Int,
+        coordinator: CLIServeOperationCoordinator<some Sendable>) async
+    {
+        for _ in 0..<1000 {
+            if await coordinator.snapshot().waiterCount == expected {
+                return
+            }
+            await Task.yield()
+        }
+        Issue.record("waiter count did not reach \(expected)")
+    }
+}
+
+private actor ServeAcceptanceProbe<Value: Sendable> {
+    private var calls = 0
+
+    func accept(_ value: Value) -> Value {
+        self.calls += 1
+        return value
+    }
+
+    func callCount() -> Int {
+        self.calls
+    }
+}
+
+private actor ServeFetchGate<Value: Sendable> {
+    private var starts = 0
+    private var active = 0
+    private var peak = 0
+    private var released = false
+    private var releaseContinuations: [CheckedContinuation<Void, Never>] = []
+    private var startWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var activeWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    func run(_ value: Value) async -> Value {
+        self.starts += 1
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        self.resumeStartWaiters()
+
+        if !self.released {
+            await withCheckedContinuation { continuation in
+                self.releaseContinuations.append(continuation)
+            }
+        }
+        self.active -= 1
+        self.resumeActiveWaiters()
+        return value
+    }
+
+    func waitForStarts(_ expected: Int) async {
+        guard self.starts < expected else { return }
+        await withCheckedContinuation { continuation in
+            self.startWaiters.append((expected, continuation))
+        }
+    }
+
+    func waitForActive(_ expected: Int) async {
+        guard self.active != expected else { return }
+        await withCheckedContinuation { continuation in
+            self.activeWaiters.append((expected, continuation))
+        }
+    }
+
+    func releaseAll() {
+        self.released = true
+        let continuations = self.releaseContinuations
+        self.releaseContinuations.removeAll()
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+
+    func startCount() -> Int {
+        self.starts
+    }
+
+    func peakCount() -> Int {
+        self.peak
+    }
+
+    private func resumeStartWaiters() {
+        let ready = self.startWaiters.filter { self.starts >= $0.0 }
+        self.startWaiters.removeAll { self.starts >= $0.0 }
+        for (_, continuation) in ready {
+            continuation.resume()
+        }
+    }
+
+    private func resumeActiveWaiters() {
+        let ready = self.activeWaiters.filter { self.active == $0.0 }
+        self.activeWaiters.removeAll { self.active == $0.0 }
+        for (_, continuation) in ready {
+            continuation.resume()
         }
     }
 }
 
-private actor ServeFetchReleaseGate {
-    private var continuation: CheckedContinuation<Void, Never>?
+private final class ServeManualDeadlineClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var instant = ContinuousClock().now
+    private let sleeper = ServeManualSleeper()
 
-    func waitForProceed() async {
+    func now() -> ContinuousClock.Instant {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.instant
+    }
+
+    func advance(by duration: Duration) {
+        self.lock.lock()
+        self.instant = self.instant.advanced(by: duration)
+        self.lock.unlock()
+    }
+
+    func sleep(until deadline: ContinuousClock.Instant) async throws {
+        try await self.sleeper.sleep(until: deadline)
+    }
+
+    func waitForPendingSleeps(_ expected: Int) async {
+        await self.sleeper.waitForPendingCount(expected)
+    }
+
+    func waitForCancellations(_ expected: Int) async {
+        await self.sleeper.waitForCancellationCount(expected)
+    }
+
+    func pendingSleepCount() async -> Int {
+        await self.sleeper.pendingCount()
+    }
+
+    func fireAll() async {
+        await self.sleeper.fireAll()
+    }
+}
+
+private actor ServeManualSleeper {
+    private typealias SleepContinuation = CheckedContinuation<Void, any Error>
+
+    private struct Pending {
+        let id: UUID
+        let continuation: SleepContinuation
+    }
+
+    private var pending: [Pending] = []
+    private var cancellationCount = 0
+    private var pendingWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var cancellationWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    func sleep(until _: ContinuousClock.Instant) async throws {
+        let id = UUID()
+        try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { (continuation: SleepContinuation) in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                self.pending.append(Pending(id: id, continuation: continuation))
+                self.resumePendingWaiters()
+            }
+        }, onCancel: {
+            Task { await self.cancel(id: id) }
+        })
+    }
+
+    func waitForPendingCount(_ expected: Int) async {
+        guard self.pending.count < expected else { return }
         await withCheckedContinuation { continuation in
-            self.continuation = continuation
+            self.pendingWaiters.append((expected, continuation))
         }
     }
 
-    func proceed() {
-        self.continuation?.resume()
-        self.continuation = nil
+    func waitForCancellationCount(_ expected: Int) async {
+        guard self.cancellationCount < expected else { return }
+        await withCheckedContinuation { continuation in
+            self.cancellationWaiters.append((expected, continuation))
+        }
+    }
+
+    func pendingCount() -> Int {
+        self.pending.count
+    }
+
+    func fireAll() {
+        let pending = self.pending
+        self.pending.removeAll()
+        for item in pending {
+            item.continuation.resume()
+        }
+    }
+
+    private func cancel(id: UUID) {
+        guard let index = self.pending.firstIndex(where: { $0.id == id }) else { return }
+        let item = self.pending.remove(at: index)
+        self.cancellationCount += 1
+        item.continuation.resume(throwing: CancellationError())
+        self.resumeCancellationWaiters()
+    }
+
+    private func resumePendingWaiters() {
+        let ready = self.pendingWaiters.filter { self.pending.count >= $0.0 }
+        self.pendingWaiters.removeAll { self.pending.count >= $0.0 }
+        for (_, continuation) in ready {
+            continuation.resume()
+        }
+    }
+
+    private func resumeCancellationWaiters() {
+        let ready = self.cancellationWaiters.filter { self.cancellationCount >= $0.0 }
+        self.cancellationWaiters.removeAll { self.cancellationCount >= $0.0 }
+        for (_, continuation) in ready {
+            continuation.resume()
+        }
     }
 }


### PR DESCRIPTION
## Summary

`codexbar serve` used to relinquish ownership as soon as a request timed out, even when canceled route or provider work kept running. A later request or configuration change could then start duplicate background work and eventually let an older completion overwrite newer cached state.

This revision:

- owns route and provider operations in an actor until their source work and cache commit actually finish;
- uses absolute `ContinuousClock` deadlines, with the earliest finite waiter tightening a shared operation while each waiter retains its own timeout value for errors;
- keeps one active operation and at most one pending configuration successor per logical key, so configuration changes do not overlap uncooperative work;
- keeps usage and cost provider work independently owned, and runs cost providers sequentially;
- gives each sequential cost provider a fresh budget from its actual start, capped by the original HTTP deadline, so a timed-out provider does not starve a later healthy provider;
- preserves fresh cost rows from successful providers while using provider-keyed last-good rows only for providers that failed;
- drains timers and waiters safely during completion and shutdown.

This deliberately leaves #1999 open; that issue still needs its requested process diagnostics.

## Proof

- `swift test --filter CLIServeTimeoutTests` — 15/15 passed.
- `swift test --filter CLIServeRouterTests` — 43/43 passed.
- `make check` — SwiftFormat and SwiftLint clean.
- `make test` — all 50 local shards passed.
- Independent source review — clean after fixes for deadline races, cache-commit ownership, cost-route overlap, and partial last-good merging.
- Source-blind packaged behavior validation — pass for finite concurrency, single retained FIFO work, resource bounds, health responsiveness, and termination.
- Public model identifier gate — pass; this change contains no model-bearing mutation.
- Dependencies — unchanged.

Exact-head signed proof used the Developer ID-signed helper from commit `a17af945` (`CodexBar 0.41.1`). With an isolated empty home and a missing pricing cache, `/cost?provider=codex` returned HTTP 200 in 0.014 seconds while the cache was still absent; the detached refresh then materialized the 845,630-byte catalog. The helper exited cleanly and released its listener.

The preceding coordinator head `4ea0fcb7` also passed an isolated FIFO-backed scan that intentionally ignored cancellation while seven waves of 12 concurrent finite `/cost` requests ran:

- 84/84 requests returned the expected HTTP 200 provider-timeout payload within 0.802–0.857 seconds;
- file descriptors stayed at 13 and the final three RSS samples stayed within 64 KiB;
- `/health` remained responsive under 250 ms throughout;
- `SIGTERM` exited cleanly in 0.288 seconds and released the listener.

A second finite `/cost?provider=both` run kept Codex busy with a cancellation-cooperative stream. Codex timed out, released the shared serial scan lane, and the same HTTP response preserved the healthy Claude row in provider order after 2.118 seconds; no FIFO reader or extra process remained.

The zero-timeout configuration-successor ordering is covered by deterministic coordinator tests rather than the black-box FIFO harness, whose scanner may reopen its input.
