### PR TITLE
Fix Claude stale reset rollover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - Ollama: validate API keys against an authenticated endpoint instead of the public model catalog while preserving refresh cancellation. Thanks @joeVenner!
+- Claude CLI: resolve yearless and time-only reset timestamps to their nearest occurrence so stale data cannot appear nearly a day or year away. Thanks @fanwenlin!
 - Quota warnings: use compact per-window threshold editors that save on focus loss, Return, or window close while preserving provider inheritance. Thanks @Zihao-Qi!
 - Display settings: keep display mode, work days, multi-account layout, and cost summary selectors interactive on macOS 27. Thanks @jordanschwartz-js!
 - Antigravity: recover CLI listening ports from Linux procfs when `lsof` is unavailable, including process network namespaces. Thanks @junmo-kim!

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -875,6 +875,9 @@ extension ClaudeStatusProbe {
         if date >= now {
             return date
         }
+        guard now.timeIntervalSince(date) > 180 * 24 * 60 * 60 else {
+            return date
+        }
         return calendar.date(byAdding: .year, value: 1, to: date)
     }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -832,15 +832,25 @@ extension ClaudeStatusProbe {
         calendar.timeZone = formatter.timeZone
 
         if let date = self.parseDate(raw, formats: Self.resetDateTimeWithMinutes, formatter: formatter) {
-            var comps = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+            var comps = calendar.dateComponents([.month, .day, .hour, .minute], from: date)
+            comps.year = calendar.component(.year, from: now)
             comps.second = 0
-            return self.bumpYearIfNeeded(calendar.date(from: comps), now: now, calendar: calendar)
+            return self.nearestOccurrence(
+                calendar.date(from: comps),
+                adjusting: .year,
+                now: now,
+                calendar: calendar)
         }
         if let date = self.parseDate(raw, formats: Self.resetDateTimeHourOnly, formatter: formatter) {
-            var comps = calendar.dateComponents([.year, .month, .day, .hour], from: date)
+            var comps = calendar.dateComponents([.month, .day, .hour], from: date)
+            comps.year = calendar.component(.year, from: now)
             comps.minute = 0
             comps.second = 0
-            return self.bumpYearIfNeeded(calendar.date(from: comps), now: now, calendar: calendar)
+            return self.nearestOccurrence(
+                calendar.date(from: comps),
+                adjusting: .year,
+                now: now,
+                calendar: calendar)
         }
 
         if let time = self.parseDate(raw, formats: Self.resetTimeWithMinutes, formatter: formatter) {
@@ -850,10 +860,7 @@ extension ClaudeStatusProbe {
                 minute: comps.minute ?? 0,
                 second: 0,
                 of: now) else { return nil }
-            if anchored >= now {
-                return anchored
-            }
-            return calendar.date(byAdding: .day, value: 1, to: anchored)
+            return self.nearestOccurrence(anchored, adjusting: .day, now: now, calendar: calendar)
         }
 
         guard let time = self.parseDate(raw, formats: Self.resetTimeHourOnly, formatter: formatter) else { return nil }
@@ -863,22 +870,28 @@ extension ClaudeStatusProbe {
             minute: 0,
             second: 0,
             of: now) else { return nil }
-        if anchored >= now {
-            return anchored
-        }
-        return calendar.date(byAdding: .day, value: 1, to: anchored)
+        return self.nearestOccurrence(anchored, adjusting: .day, now: now, calendar: calendar)
     }
 
-    /// Yearless dates parsed just before New Year's can otherwise land nearly a year in the past.
-    private static func bumpYearIfNeeded(_ date: Date?, now: Date, calendar: Calendar) -> Date? {
+    /// Yearless and time-only resets describe nearby quota boundaries, not distant calendar events.
+    private static func nearestOccurrence(
+        _ date: Date?,
+        adjusting component: Calendar.Component,
+        now: Date,
+        calendar: Calendar) -> Date?
+    {
         guard let date else { return nil }
-        if date >= now {
-            return date
+        let candidates = (-1...1).compactMap { offset in
+            calendar.date(byAdding: component, value: offset, to: date)
         }
-        guard now.timeIntervalSince(date) > 180 * 24 * 60 * 60 else {
-            return date
+        return candidates.min { lhs, rhs in
+            let lhsDistance = abs(lhs.timeIntervalSince(now))
+            let rhsDistance = abs(rhs.timeIntervalSince(now))
+            if lhsDistance != rhsDistance {
+                return lhsDistance < rhsDistance
+            }
+            return lhs >= now && rhs < now
         }
-        return calendar.date(byAdding: .year, value: 1, to: date)
     }
 
     private static let resetTimeWithMinutes = ["h:mma", "h:mm a", "HH:mm", "H:mm"]

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -630,17 +630,29 @@ struct StatusProbeTests {
     }
 
     @Test
-    func `parses claude reset time only`() throws {
-        let now = Date(timeIntervalSince1970: 1_733_690_000)
-        let parsed = ClaudeStatusProbe.parseResetDate(from: "Resets 12:59pm (Europe/Helsinki)", now: now)
-        let tz = try #require(TimeZone(identifier: "Europe/Helsinki"))
+    func `chooses nearest claude reset time across adjacent days`() throws {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = tz
-        var expected = try #require(calendar.date(bySettingHour: 12, minute: 59, second: 0, of: now))
-        if expected < now {
-            expected = try #require(calendar.date(byAdding: .day, value: 1, to: expected))
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+        let cases: [(now: DateComponents, text: String, expected: DateComponents)] = [
+            (
+                DateComponents(year: 2026, month: 7, day: 9, hour: 15, minute: 5),
+                "Resets 3pm (UTC)",
+                DateComponents(year: 2026, month: 7, day: 9, hour: 15, minute: 0)),
+            (
+                DateComponents(year: 2026, month: 7, day: 9, hour: 23, minute: 59),
+                "Resets 12:01am (UTC)",
+                DateComponents(year: 2026, month: 7, day: 10, hour: 0, minute: 1)),
+            (
+                DateComponents(year: 2026, month: 7, day: 10, hour: 0, minute: 1),
+                "Resets 11:59pm (UTC)",
+                DateComponents(year: 2026, month: 7, day: 9, hour: 23, minute: 59)),
+        ]
+
+        for item in cases {
+            let now = try #require(calendar.date(from: item.now))
+            let parsed = ClaudeStatusProbe.parseResetDate(from: item.text, now: now)
+            #expect(parsed == calendar.date(from: item.expected), "Failed nearest-day resolution: \(item.text)")
         }
-        #expect(parsed == expected)
     }
 
     @Test
@@ -660,38 +672,37 @@ struct StatusProbeTests {
     }
 
     @Test
-    func `rolls claude reset date forward across the year boundary`() throws {
+    func `chooses nearest claude reset date across adjacent years`() throws {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
-        let now = try #require(calendar.date(from: DateComponents(
-            year: 2026, month: 12, day: 31, hour: 23, minute: 0, second: 0)))
-        let cases = [
-            ("Resets Jan 2, 3:15am (UTC)", 15),
-            ("Resets Jan 2, 3am (UTC)", 0),
+        let cases: [(now: DateComponents, text: String, expected: DateComponents)] = [
+            (
+                DateComponents(year: 2026, month: 12, day: 31, hour: 23),
+                "Resets Jan 2, 3:15am (UTC)",
+                DateComponents(year: 2027, month: 1, day: 2, hour: 3, minute: 15)),
+            (
+                DateComponents(year: 2026, month: 12, day: 31, hour: 23),
+                "Resets Jan 2, 3am (UTC)",
+                DateComponents(year: 2027, month: 1, day: 2, hour: 3, minute: 0)),
+            (
+                DateComponents(year: 2027, month: 1, day: 1, hour: 0, minute: 5),
+                "Resets Dec 31, 11:59pm (UTC)",
+                DateComponents(year: 2026, month: 12, day: 31, hour: 23, minute: 59)),
+            (
+                DateComponents(year: 2027, month: 1, day: 1, hour: 0, minute: 5),
+                "Resets Dec 31, 11pm (UTC)",
+                DateComponents(year: 2026, month: 12, day: 31, hour: 23, minute: 0)),
+            (
+                DateComponents(year: 2026, month: 7, day: 9, hour: 15, minute: 5),
+                "Resets Jul 9, 3:00pm (UTC)",
+                DateComponents(year: 2026, month: 7, day: 9, hour: 15, minute: 0)),
         ]
 
-        for (text, minute) in cases {
-            let parsed = ClaudeStatusProbe.parseResetDate(from: text, now: now)
-            let expected = calendar.date(from: DateComponents(
-                year: 2027, month: 1, day: 2, hour: 3, minute: minute, second: 0))
-            #expect(parsed == expected, "Failed to roll forward: \(text)")
-            #expect(try #require(parsed) > now)
+        for item in cases {
+            let now = try #require(calendar.date(from: item.now))
+            let parsed = ClaudeStatusProbe.parseResetDate(from: item.text, now: now)
+            #expect(parsed == calendar.date(from: item.expected), "Failed nearest-year resolution: \(item.text)")
         }
-    }
-
-    @Test
-    func `does not roll stale same day claude reset into next year`() throws {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
-        let now = try #require(calendar.date(from: DateComponents(
-            year: 2026, month: 7, day: 9, hour: 15, minute: 5, second: 0)))
-
-        let parsed = ClaudeStatusProbe.parseResetDate(from: "Resets Jul 9, 3:00pm (UTC)", now: now)
-        let expected = calendar.date(from: DateComponents(
-            year: 2026, month: 7, day: 9, hour: 15, minute: 0, second: 0))
-
-        #expect(parsed == expected)
-        #expect(UsageFormatter.resetCountdownDescription(from: try #require(parsed), now: now) == "now")
     }
 
     @Test
@@ -727,10 +738,7 @@ struct StatusProbeTests {
         let parsedTimeOnly = ClaudeStatusProbe.parseResetDate(from: "Resets 1pm (UTC)", now: now)
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
-        var expected = try #require(calendar.date(bySettingHour: 13, minute: 0, second: 0, of: now))
-        if expected < now {
-            expected = try #require(calendar.date(byAdding: .day, value: 1, to: expected))
-        }
+        let expected = try #require(calendar.date(bySettingHour: 13, minute: 0, second: 0, of: now))
         #expect(parsedTimeOnly == expected)
 
         let parsedDateTime = ClaudeStatusProbe.parseResetDate(from: "Resets Dec 9, 9am", now: now)

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -680,6 +680,38 @@ struct StatusProbeTests {
     }
 
     @Test
+    func `does not roll stale same day claude reset into next year`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026, month: 7, day: 9, hour: 15, minute: 5, second: 0)))
+
+        let parsed = ClaudeStatusProbe.parseResetDate(from: "Resets Jul 9, 3:00pm (UTC)", now: now)
+        let expected = calendar.date(from: DateComponents(
+            year: 2026, month: 7, day: 9, hour: 15, minute: 0, second: 0))
+
+        #expect(parsed == expected)
+        #expect(UsageFormatter.resetCountdownDescription(from: try #require(parsed), now: now) == "now")
+    }
+
+    @Test
+    func `stale same day claude reset renders resets now`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026, month: 7, day: 9, hour: 15, minute: 5, second: 0)))
+        let resetText = "Resets Jul 9, 3:00pm (UTC)"
+        let resetDate = try #require(ClaudeStatusProbe.parseResetDate(from: resetText, now: now))
+        let window = RateWindow(
+            usedPercent: 73,
+            windowMinutes: 5 * 60,
+            resetsAt: resetDate,
+            resetDescription: resetText)
+
+        #expect(UsageFormatter.resetLine(for: window, style: .countdown, now: now) == "Resets now")
+    }
+
+    @Test
     func `parses claude reset with dot separated time`() throws {
         let now = Date(timeIntervalSince1970: 1_733_690_000)
         let parsed = ClaudeStatusProbe.parseResetDate(from: "Resets Dec 9 at 5.27am (UTC)", now: now)


### PR DESCRIPTION
## Summary

- Resolve Claude yearless reset dates to the nearest occurrence across the previous, current, or next year.
- Resolve time-only reset values to the nearest occurrence across the previous, current, or next day.
- Preserve the New Year forward rollover while correctly handling recently stale same-day, previous-day, and previous-year snapshots.

## Root cause

#1947 correctly fixed yearless Claude reset dates around New Year by rolling past parsed dates into the next year. A one-way rollover cannot distinguish a nearby stale reset from a future reset: a stale same-day timestamp could become nearly one year away, a stale time-only timestamp could become nearly one day away, and a stale December timestamp observed just after New Year could remain in the current December.

The parser now compares adjacent candidate occurrences and chooses the closest one, preferring the future candidate on an exact tie.

Original affected-state evidence from @fanwenlin:

<img width="319" height="728" alt="Claude reset rendered nearly one year away" src="https://github.com/user-attachments/assets/28e5843a-455d-44a6-8aed-eedb84a965a4" />

<img width="977" height="733" alt="Claude CLI stale reset source data" src="https://github.com/user-attachments/assets/da4ef513-9c46-49a1-9d23-435da61d4c23" />

## User-visible effect

A just-expired Claude reset renders as `Resets now` until the next refresh replaces the stale snapshot. Legitimate upcoming resets around midnight and New Year still resolve forward.

## Verification

Exact candidate: `a104082924c823f48f87e2975ff921cfbaf69f85`

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter StatusProbeTests` — 254 tests passed.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test` — all 50 shards passed.
- `make check` — SwiftFormat, SwiftLint, locale, packaging, repository, shell, and documentation checks passed.
- Structured autoreview — no actionable findings.
- Source-blind public-API harness — passed same-day stale date, stale time-only, next-year forward, and previous-year stale cases; the stale cases rendered `Resets now`.

No provider login, browser-cookie import, or Keychain access is required for this deterministic parser/formatter boundary.
