### PR TITLE
Improve provider quota warning settings

### DIFF
--- a/Sources/CodexBar/QuotaWarningSettingsViews.swift
+++ b/Sources/CodexBar/QuotaWarningSettingsViews.swift
@@ -86,7 +86,7 @@ struct ProviderQuotaWarningSettingsView: View {
                 .frame(minHeight: Self.windowRowMinHeight, alignment: .center)
                 .gridColumnAlignment(.leading)
 
-            Picker("", selection: self.overrideModeBinding(for: window)) {
+            Picker(window.localizedCapitalizedDisplayName, selection: self.overrideModeBinding(for: window)) {
                 Text(L("quota_warning_global")).tag(ProviderQuotaWarningOverrideMode.global)
                 Text(L("Custom")).tag(ProviderQuotaWarningOverrideMode.custom)
                 Text(L("quota_warning_off")).tag(ProviderQuotaWarningOverrideMode.off)
@@ -96,9 +96,6 @@ struct ProviderQuotaWarningSettingsView: View {
             .controlSize(.small)
             .fixedSize()
             .frame(minHeight: Self.windowRowMinHeight, alignment: .center)
-            .accessibilityLabel(Text(String(
-                format: L("quota_warning_mode_accessibility"),
-                window.localizedCapitalizedDisplayName)))
             .gridColumnAlignment(.leading)
 
             self.windowDetail(window)
@@ -111,31 +108,29 @@ struct ProviderQuotaWarningSettingsView: View {
     private func windowDetail(_ window: QuotaWarningWindow) -> some View {
         switch self.overrideMode(for: window) {
         case .custom:
-            HStack(alignment: .firstTextBaseline, spacing: 10) {
-                QuotaWarningThresholdField(
-                    title: "",
-                    subtitle: "",
-                    accessibilityContext: window.localizedCapitalizedDisplayName,
-                    shouldCommitOnDisappear: {
-                        self.shouldCommitThresholdEditorOnDisappear(for: window)
-                    },
-                    thresholds: {
-                        self.settings.resolvedQuotaWarningThresholds(provider: self.provider, window: window)
-                    },
-                    setThresholds: {
-                        self.settings.setQuotaWarningThresholdsIfOverridden(
-                            provider: self.provider,
-                            window: window,
-                            thresholds: $0)
-                    },
-                    fieldWidth: Self.thresholdFieldWidth,
-                    controlFont: .subheadline)
-            }
-            .fixedSize(horizontal: true, vertical: false)
+            QuotaWarningThresholdField(
+                title: "",
+                subtitle: "",
+                accessibilityContext: window.localizedCapitalizedDisplayName,
+                shouldCommitOnDisappear: {
+                    self.shouldCommitThresholdEditorOnDisappear(for: window)
+                },
+                thresholds: {
+                    self.settings.resolvedQuotaWarningThresholds(provider: self.provider, window: window)
+                },
+                setThresholds: {
+                    self.settings.setQuotaWarningThresholdsIfOverridden(
+                        provider: self.provider,
+                        window: window,
+                        thresholds: $0)
+                },
+                fieldWidth: Self.thresholdFieldWidth,
+                controlFont: .subheadline)
+                .fixedSize(horizontal: true, vertical: false)
         case .off:
             EmptyView()
         case .global:
-            Text(String(format: L("quota_warning_global_summary"), Self.thresholdText(
+            Text(String(format: L("quota_warning_inherited"), Self.thresholdText(
                 self.settings.quotaWarningThresholds(window),
                 enabled: self.settings.quotaWarningWindowEnabled(window))))
                 .font(.subheadline)

--- a/Sources/CodexBar/QuotaWarningSettingsViews.swift
+++ b/Sources/CodexBar/QuotaWarningSettingsViews.swift
@@ -56,13 +56,20 @@ struct GlobalQuotaWarningSettingsView: View {
 
 @MainActor
 struct ProviderQuotaWarningSettingsView: View {
+    private static let windowRowMinHeight: CGFloat = 26
+    private static let thresholdFieldWidth: CGFloat = 40
+
     let provider: UsageProvider
     @Bindable var settings: SettingsStore
 
     var body: some View {
         Section {
-            self.windowRow(.session)
-            self.windowRow(.weekly)
+            Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 8) {
+                self.windowRow(.session)
+                self.windowRow(.weekly)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .listRowSeparator(.hidden)
         } header: {
             Text(L("quota_warnings_title"))
         } footer: {
@@ -72,76 +79,116 @@ struct ProviderQuotaWarningSettingsView: View {
     }
 
     private func windowRow(_ window: QuotaWarningWindow) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Toggle(isOn: Binding(
-                get: { self.settings.hasQuotaWarningOverride(provider: self.provider, window: window) },
-                set: { isOn in
-                    if isOn {
-                        self.settings.setQuotaWarningOverride(
-                            provider: self.provider,
-                            window: window,
-                            thresholds: self.settings.quotaWarningThresholds(window),
-                            enabled: self.settings.quotaWarningWindowEnabled(window))
-                    } else {
-                        self.settings.setQuotaWarningOverride(
-                            provider: self.provider,
-                            window: window,
-                            thresholds: nil,
-                            enabled: nil)
-                    }
-                })) {
-                    Text(String(format: L("quota_warning_customize_thresholds"), window.localizedDisplayName))
-                        .font(.subheadline.weight(.semibold))
-                }
-                .toggleStyle(.checkbox)
+        GridRow(alignment: .firstTextBaseline) {
+            Text(window.localizedCapitalizedDisplayName)
+                .font(.subheadline.weight(.semibold))
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minHeight: Self.windowRowMinHeight, alignment: .center)
+                .gridColumnAlignment(.leading)
 
-            if self.settings.hasQuotaWarningOverride(provider: self.provider, window: window) {
-                Toggle(isOn: Binding(
-                    get: { self.settings.quotaWarningEnabled(provider: self.provider, window: window) },
-                    set: {
-                        self.settings.setQuotaWarningWindowEnabled(
-                            provider: self.provider,
-                            window: window,
-                            enabled: $0)
-                    })) {
-                        Text(String(format: L("quota_warning_enable_warnings"), window.localizedDisplayName))
-                            .font(.footnote)
-                    }
-                    .toggleStyle(.checkbox)
-                        .padding(.leading, 20)
-
-                if self.settings.quotaWarningEnabled(provider: self.provider, window: window) {
-                    QuotaWarningThresholdField(
-                        title: window.localizedCapitalizedDisplayName,
-                        subtitle: "",
-                        shouldCommitOnDisappear: {
-                            self.settings.hasQuotaWarningOverride(provider: self.provider, window: window)
-                        },
-                        thresholds: {
-                            self.settings.resolvedQuotaWarningThresholds(provider: self.provider, window: window)
-                        },
-                        setThresholds: {
-                            self.settings.setQuotaWarningThresholdsIfOverridden(
-                                provider: self.provider,
-                                window: window,
-                                thresholds: $0)
-                        })
-                        .padding(.leading, 20)
-                } else {
-                    Text(L("quota_warning_off"))
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .padding(.leading, 20)
-                }
-            } else {
-                Text(String(format: L("quota_warning_inherited"), Self.thresholdText(
-                    self.settings.quotaWarningThresholds(window),
-                    enabled: self.settings.quotaWarningWindowEnabled(window))))
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .padding(.leading, 20)
+            Picker("", selection: self.overrideModeBinding(for: window)) {
+                Text(L("quota_warning_global")).tag(ProviderQuotaWarningOverrideMode.global)
+                Text(L("Custom")).tag(ProviderQuotaWarningOverrideMode.custom)
+                Text(L("quota_warning_off")).tag(ProviderQuotaWarningOverrideMode.off)
             }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            .controlSize(.small)
+            .fixedSize()
+            .frame(minHeight: Self.windowRowMinHeight, alignment: .center)
+            .accessibilityLabel(Text(String(
+                format: L("quota_warning_mode_accessibility"),
+                window.localizedCapitalizedDisplayName)))
+            .gridColumnAlignment(.leading)
+
+            self.windowDetail(window)
+                .frame(minHeight: Self.windowRowMinHeight, alignment: .leading)
+                .gridColumnAlignment(.leading)
         }
+    }
+
+    @ViewBuilder
+    private func windowDetail(_ window: QuotaWarningWindow) -> some View {
+        switch self.overrideMode(for: window) {
+        case .custom:
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                QuotaWarningThresholdField(
+                    title: "",
+                    subtitle: "",
+                    accessibilityContext: window.localizedCapitalizedDisplayName,
+                    shouldCommitOnDisappear: {
+                        self.shouldCommitThresholdEditorOnDisappear(for: window)
+                    },
+                    thresholds: {
+                        self.settings.resolvedQuotaWarningThresholds(provider: self.provider, window: window)
+                    },
+                    setThresholds: {
+                        self.settings.setQuotaWarningThresholdsIfOverridden(
+                            provider: self.provider,
+                            window: window,
+                            thresholds: $0)
+                    },
+                    fieldWidth: Self.thresholdFieldWidth,
+                    controlFont: .subheadline)
+            }
+            .fixedSize(horizontal: true, vertical: false)
+        case .off:
+            EmptyView()
+        case .global:
+            Text(String(format: L("quota_warning_global_summary"), Self.thresholdText(
+                self.settings.quotaWarningThresholds(window),
+                enabled: self.settings.quotaWarningWindowEnabled(window))))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    func overrideModeBinding(for window: QuotaWarningWindow) -> Binding<ProviderQuotaWarningOverrideMode> {
+        Binding(
+            get: { self.overrideMode(for: window) },
+            set: { mode in
+                let currentMode = self.overrideMode(for: window)
+                guard mode != currentMode else { return }
+
+                switch mode {
+                case .custom:
+                    self.settings.setQuotaWarningOverride(
+                        provider: self.provider,
+                        window: window,
+                        thresholds: self.settings.explicitQuotaWarningThresholds(
+                            provider: self.provider,
+                            window: window),
+                        enabled: true)
+                case .off:
+                    self.settings.setQuotaWarningOverride(
+                        provider: self.provider,
+                        window: window,
+                        thresholds: currentMode == .custom
+                            ? self.settings.explicitQuotaWarningThresholds(
+                                provider: self.provider,
+                                window: window)
+                            : nil,
+                        enabled: false)
+                case .global:
+                    self.settings.setQuotaWarningOverride(
+                        provider: self.provider,
+                        window: window,
+                        thresholds: nil,
+                        enabled: nil)
+                }
+            })
+    }
+
+    func overrideMode(for window: QuotaWarningWindow) -> ProviderQuotaWarningOverrideMode {
+        guard self.settings.hasQuotaWarningOverride(provider: self.provider, window: window) else {
+            return .global
+        }
+        return self.settings.quotaWarningEnabled(provider: self.provider, window: window) ? .custom : .off
+    }
+
+    func shouldCommitThresholdEditorOnDisappear(for window: QuotaWarningWindow) -> Bool {
+        let mode = self.overrideMode(for: window)
+        return mode == .custom || mode == .off
     }
 
     static func thresholdText(_ thresholds: [Int], enabled: Bool) -> String {
@@ -161,6 +208,12 @@ struct ProviderQuotaWarningSettingsView: View {
     }
 }
 
+enum ProviderQuotaWarningOverrideMode: Hashable {
+    case global
+    case custom
+    case off
+}
+
 struct FocusResigningBackground: View {
     var body: some View {
         Color.clear
@@ -174,14 +227,7 @@ struct FocusResigningBackground: View {
 }
 
 extension QuotaWarningWindow {
-    fileprivate var localizedDisplayName: String {
-        switch self {
-        case .session: L("quota_warning_session")
-        case .weekly: L("quota_warning_weekly")
-        }
-    }
-
-    fileprivate var localizedCapitalizedDisplayName: String {
+    var localizedCapitalizedDisplayName: String {
         switch self {
         case .session: L("quota_warning_session_capitalized")
         case .weekly: L("quota_warning_weekly_capitalized")
@@ -229,7 +275,7 @@ private struct QuotaWarningWindowThresholdRows: View {
 
 @MainActor
 private struct QuotaWarningThresholdField: View {
-    private static let fieldWidth: CGFloat = 44
+    private static let defaultFieldWidth: CGFloat = 44
 
     let title: String
     let subtitle: String
@@ -237,6 +283,9 @@ private struct QuotaWarningThresholdField: View {
     var shouldCommitOnDisappear: () -> Bool = { true }
     let thresholds: () -> [Int]
     let setThresholds: ([Int]) -> Void
+    var fieldWidth: CGFloat = Self.defaultFieldWidth
+    var controlFont: Font = .footnote
+    var titleFont: Font = .footnote.weight(.semibold)
 
     @State private var draft = QuotaWarningThresholdEditorText.Draft()
     @FocusState private var focusedField: QuotaWarningThresholdEditorText.Field?
@@ -285,7 +334,7 @@ private struct QuotaWarningThresholdField: View {
     private var titleView: some View {
         if !self.title.isEmpty {
             Text(self.title)
-                .font(.footnote.weight(.semibold))
+                .font(self.titleFont)
                 .frame(width: 110, alignment: .leading)
         }
     }
@@ -314,15 +363,15 @@ private struct QuotaWarningThresholdField: View {
     {
         HStack(alignment: .firstTextBaseline, spacing: 5) {
             Text(label)
-                .font(.footnote)
+                .font(self.controlFont)
                 .foregroundStyle(.secondary)
 
             TextField(label, text: text, prompt: Text(verbatim: placeholder))
                 .labelsHidden()
                 .textFieldStyle(.roundedBorder)
-                .font(.footnote)
+                .font(self.controlFont)
                 .multilineTextAlignment(.trailing)
-                .frame(width: Self.fieldWidth)
+                .frame(width: self.fieldWidth)
                 .focused(self.$focusedField, equals: field)
                 .onSubmit {
                     self.commit()
@@ -331,7 +380,7 @@ private struct QuotaWarningThresholdField: View {
                 .accessibilityLabel(Text(self.accessibilityLabel(for: label)))
 
             Text(verbatim: "%")
-                .font(.footnote)
+                .font(self.controlFont)
                 .foregroundStyle(.secondary)
         }
     }

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -467,6 +467,7 @@
 "quota_warning_sound" = "تشغيل صوت الإشعار";
 "quota_warning_onscreen_alert" = "إظهار تنبيه نصي على الشاشة";
 "quota_warning_provider_inherits" = "يستخدم إعدادات تحذير الحصص العامة إلا إذا تم تخصيص نافذة هنا.";
+"quota_warning_global" = "عام";
 "quota_warning_customize_thresholds" = "تخصيص عتبات %@";
 "quota_warning_enable_warnings" = "تفعيل تحذيرات %@";
 "quota_warning_window_warn_at" = "%@ التحذير في";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -450,6 +450,7 @@
 "quota_warning_sound" = "Reprodueix el so de notificació";
 "quota_warning_onscreen_alert" = "Mostra una alerta de text a la pantalla";
 "quota_warning_provider_inherits" = "Fa servir la configuració global d'avís de quota llevat que es personalitzi una finestra aquí.";
+"quota_warning_global" = "Global";
 "quota_warning_customize_thresholds" = "Personalitza els llindars de %@";
 "quota_warning_enable_warnings" = "Activeu els avisos de %@";
 "quota_warning_window_warn_at" = "%@ avisa al";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -464,6 +464,7 @@
 "quota_warning_sound" = "Benachrichtigungston abspielen";
 "quota_warning_onscreen_alert" = "Bildschirm-Textwarnung anzeigen";
 "quota_warning_provider_inherits" = "Verwendet die globalen Einstellungen für Kontingentwarnungen, es sei denn, hier wird ein Fenster angepasst.";
+"quota_warning_global" = "Global";
 "quota_warning_customize_thresholds" = "Passen Sie die Schwellenwerte für %@ an";
 "quota_warning_enable_warnings" = "Aktivieren Sie %@-Warnungen";
 "quota_warning_window_warn_at" = "%@ warnen bei";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -467,6 +467,7 @@
 "quota_warning_sound" = "Play notification sound";
 "quota_warning_onscreen_alert" = "Show on-screen text alert";
 "quota_warning_provider_inherits" = "Uses the global quota warning settings unless a window is customized here.";
+"quota_warning_global" = "Global";
 "quota_warning_customize_thresholds" = "Customize %@ thresholds";
 "quota_warning_enable_warnings" = "Enable %@ warnings";
 "quota_warning_window_warn_at" = "%@ warn at";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -460,6 +460,7 @@
 "quota_warning_sound" = "Reproducir sonido de notificación";
 "quota_warning_onscreen_alert" = "Mostrar alerta de texto en pantalla";
 "quota_warning_provider_inherits" = "Usa los ajustes globales de aviso de cuota salvo que se personalice una ventana aquí.";
+"quota_warning_global" = "Global";
 "quota_warning_customize_thresholds" = "Personalizar umbrales de %@";
 "quota_warning_enable_warnings" = "Activar avisos de %@";
 "quota_warning_window_warn_at" = "%@ avisar al";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -467,6 +467,7 @@
 "quota_warning_sound" = "صدای اعلان پخش کن";
 "quota_warning_onscreen_alert" = "نمایش هشدار متنی روی صفحه";
 "quota_warning_provider_inherits" = "از تنظیمات هشدار سهمیه جهانی استفاده می کند مگر اینکه پنجره ای اینجا سفارشی شده باشد.";
+"quota_warning_global" = "سراسری";
 "quota_warning_customize_thresholds" = "آستانه های %@ شخصی سازی کنید";
 "quota_warning_enable_warnings" = "فعال کردن هشدارهای %@";
 "quota_warning_window_warn_at" = "%@ هشدار می دهد";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -466,6 +466,7 @@
 "quota_warning_sound" = "Lire un son de notification";
 "quota_warning_onscreen_alert" = "Afficher une alerte textuelle à l’écran";
 "quota_warning_provider_inherits" = "Utilise les réglages globaux d'alerte de quota, sauf personnalisation de cette fenêtre.";
+"quota_warning_global" = "Global";
 "quota_warning_customize_thresholds" = "Personnaliser les seuils %@";
 "quota_warning_enable_warnings" = "Activer les alertes %@";
 "quota_warning_window_warn_at" = "Alerte %@";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -448,6 +448,7 @@
 "quota_warning_global_threshold_subtitle" = "Porcentaxes restantes para as xanelas de sesión e semanal, a menos que un provedor as substitúa.";
 "quota_warning_sound" = "Reproducir o son de notificación";
 "quota_warning_provider_inherits" = "Usa a configuración global de aviso de cota a menos que se personalice unha xanela aquí.";
+"quota_warning_global" = "Global";
 "quota_warning_customize_thresholds" = "Personalizar os limiares de %@";
 "quota_warning_enable_warnings" = "Activar os avisos de %@";
 "quota_warning_window_warn_at" = "%@ avisa ao";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -469,6 +469,7 @@
 "quota_warning_sound" = "Mainkan suara notifikasi";
 "quota_warning_onscreen_alert" = "Tampilkan peringatan teks di layar";
 "quota_warning_provider_inherits" = "Menggunakan pengaturan peringatan kuota global kecuali jendela dikustomisasi di sini.";
+"quota_warning_global" = "Global";
 "quota_warning_customize_thresholds" = "Kustomisasi ambang batas %@";
 "quota_warning_enable_warnings" = "Aktifkan peringatan %@";
 "quota_warning_window_warn_at" = "Peringatan %@ pada";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -469,6 +469,7 @@
 "quota_warning_sound" = "Riproduci suono di notifica";
 "quota_warning_onscreen_alert" = "Mostra avviso di testo sullo schermo";
 "quota_warning_provider_inherits" = "Usa le impostazioni globali di avviso quota, salvo personalizzazione di una finestra qui.";
+"quota_warning_global" = "Globale";
 "quota_warning_customize_thresholds" = "Personalizza soglie %@";
 "quota_warning_enable_warnings" = "Abilita avvisi %@";
 "quota_warning_window_warn_at" = "Avvisa %@ a";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -463,6 +463,7 @@
 "quota_warning_sound" = "通知音を再生";
 "quota_warning_onscreen_alert" = "画面上にテキストアラートを表示";
 "quota_warning_provider_inherits" = "ここでウインドウをカスタマイズしない限り、グローバルのクォータ警告設定を使用します。";
+"quota_warning_global" = "グローバル";
 "quota_warning_customize_thresholds" = "%@ のしきい値をカスタマイズ";
 "quota_warning_enable_warnings" = "%@ の警告を有効にする";
 "quota_warning_window_warn_at" = "%@ の警告残量";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -461,6 +461,7 @@
 "quota_warning_sound" = "알림 소리 재생";
 "quota_warning_onscreen_alert" = "화면에 텍스트 알림 표시";
 "quota_warning_provider_inherits" = "여기서 범위를 사용자 설정하지 않는 한 전역 할당량 경고 설정을 사용합니다.";
+"quota_warning_global" = "전역";
 "quota_warning_customize_thresholds" = "%@ 임곗값 사용자 설정";
 "quota_warning_enable_warnings" = "%@ 경고 사용";
 "quota_warning_window_warn_at" = "%@ 경고 기준";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -466,6 +466,7 @@
 "quota_warning_sound" = "Meldingsgeluid afspelen";
 "quota_warning_onscreen_alert" = "Tekstwaarschuwing op het scherm tonen";
 "quota_warning_provider_inherits" = "Gebruikt de algemene instellingen voor quotawaarschuwingen, tenzij hier een venster wordt aangepast.";
+"quota_warning_global" = "Globaal";
 "quota_warning_customize_thresholds" = "Pas %@ drempels aan";
 "quota_warning_enable_warnings" = "Schakel %@ waarschuwingen in";
 "quota_warning_window_warn_at" = "%@ waarschuwen om";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -469,6 +469,7 @@
 "quota_warning_sound" = "Odtwarzaj dźwięk powiadomienia";
 "quota_warning_onscreen_alert" = "Pokaż alert tekstowy na ekranie";
 "quota_warning_provider_inherits" = "Używa globalnych ustawień ostrzeżeń limitu, chyba że to okno jest tutaj dostosowane.";
+"quota_warning_global" = "Globalne";
 "quota_warning_customize_thresholds" = "Dostosuj progi dla %@";
 "quota_warning_enable_warnings" = "Włącz ostrzeżenia dla %@";
 "quota_warning_window_warn_at" = "%@ — ostrzegaj przy";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -463,6 +463,7 @@
 "quota_warning_sound" = "Reproduzir som de notificação";
 "quota_warning_onscreen_alert" = "Mostrar alerta de texto na tela";
 "quota_warning_provider_inherits" = "Usa as configurações globais de alerta de cota, a menos que uma janela seja personalizada aqui.";
+"quota_warning_global" = "Global";
 "quota_warning_customize_thresholds" = "Personalizar limites de %@";
 "quota_warning_enable_warnings" = "Ativar alertas de %@";
 "quota_warning_window_warn_at" = "%@: alertar em";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -467,6 +467,7 @@
 "quota_warning_sound" = "Воспроизвести звук уведомления";
 "quota_warning_onscreen_alert" = "Показывать текстовое оповещение на экране";
 "quota_warning_provider_inherits" = "Использует глобальные настройки предупреждений о квоте, если окно не настроено отдельно.";
+"quota_warning_global" = "Глобально";
 "quota_warning_customize_thresholds" = "Настроить пороги %@";
 "quota_warning_enable_warnings" = "Включить предупреждения %@";
 "quota_warning_window_warn_at" = "Предупреждать для %@ при";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -466,6 +466,7 @@
 "quota_warning_sound" = "Spela aviseringsljud";
 "quota_warning_onscreen_alert" = "Visa textavisering på skärmen";
 "quota_warning_provider_inherits" = "Använder de globala kvotvarningsinställningarna om inte ett fönster anpassas här.";
+"quota_warning_global" = "Globalt";
 "quota_warning_customize_thresholds" = "Anpassa trösklar för %@";
 "quota_warning_enable_warnings" = "Aktivera varningar för %@";
 "quota_warning_window_warn_at" = "Varna vid för %@";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -467,6 +467,7 @@
 "quota_warning_sound" = "เล่นเสียงแจ้งเตือน";
 "quota_warning_onscreen_alert" = "แสดงการแจ้งเตือนข้อความบนหน้าจอ";
 "quota_warning_provider_inherits" = "ใช้การตั้งค่าคําเตือนโควต้าส่วนกลาง เว้นแต่จะมีการกําหนดหน้าต่างเองที่นี่";
+"quota_warning_global" = "ส่วนกลาง";
 "quota_warning_customize_thresholds" = "ปรับแต่งเกณฑ์ %@";
 "quota_warning_enable_warnings" = "เปิดใช้งานคําเตือน %@";
 "quota_warning_window_warn_at" = "%@ เตือนที่";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -467,6 +467,7 @@
 "quota_warning_sound" = "Bildirim sesi çal";
 "quota_warning_onscreen_alert" = "Ekranda metin uyarısı göster";
 "quota_warning_provider_inherits" = "Bir pencere burada özelleştirilmediği sürece genel kota uyarı ayarlarını kullanır.";
+"quota_warning_global" = "Genel";
 "quota_warning_customize_thresholds" = "%@ eşiklerini özelleştir";
 "quota_warning_enable_warnings" = "%@ uyarılarını etkinleştir";
 "quota_warning_window_warn_at" = "%@ uyarı eşiği";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -466,6 +466,7 @@
 "quota_warning_sound" = "Відтворити звук сповіщення";
 "quota_warning_onscreen_alert" = "Показувати текстове сповіщення на екрані";
 "quota_warning_provider_inherits" = "Використовує глобальні параметри попередження про квоту, якщо тут не налаштовано вікно.";
+"quota_warning_global" = "Глобально";
 "quota_warning_customize_thresholds" = "Налаштувати порогові значення %@";
 "quota_warning_enable_warnings" = "Увімкнути %@ попереджень";
 "quota_warning_window_warn_at" = "%@ попередити о";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -462,6 +462,7 @@
 "quota_warning_sound" = "Phát âm thanh thông báo";
 "quota_warning_onscreen_alert" = "Hiển thị cảnh báo văn bản trên màn hình";
 "quota_warning_provider_inherits" = "Sử dụng cảnh báo Hạn mức toàn cầu Cài đặt trừ khi một cửa sổ được tùy chỉnh tại đây.";
+"quota_warning_global" = "Toàn cục";
 "quota_warning_customize_thresholds" = "Tùy chỉnh %@ ngưỡng";
 "quota_warning_enable_warnings" = "Bật %@ cảnh báo";
 "quota_warning_window_warn_at" = "%@ cảnh báo lúc";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -458,6 +458,7 @@
 "quota_warning_sound" = "播放通知声音";
 "quota_warning_onscreen_alert" = "显示屏幕文字提醒";
 "quota_warning_provider_inherits" = "默认使用全局配额预警设置，除非在这里自定义窗口。";
+"quota_warning_global" = "全局";
 "quota_warning_customize_thresholds" = "自定义 %@ 阈值";
 "quota_warning_enable_warnings" = "启用 %@ 预警";
 "quota_warning_window_warn_at" = "%@ 预警阈值";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -471,6 +471,7 @@
 "quota_warning_sound" = "播放通知音效";
 "quota_warning_onscreen_alert" = "顯示螢幕文字提醒";
 "quota_warning_provider_inherits" = "預設使用全域配額提醒設定，除非在此自訂時段。";
+"quota_warning_global" = "全域";
 "quota_warning_customize_thresholds" = "自訂 %@ 門檻";
 "quota_warning_enable_warnings" = "啟用 %@ 提醒";
 "quota_warning_window_warn_at" = "%@ 提醒門檻";

--- a/Sources/CodexBar/SettingsStore+Config.swift
+++ b/Sources/CodexBar/SettingsStore+Config.swift
@@ -16,6 +16,12 @@ extension SettingsStore {
             global: self.quotaWarningThresholds(window))
     }
 
+    func explicitQuotaWarningThresholds(provider: UsageProvider, window: QuotaWarningWindow) -> [Int]? {
+        self.quotaWarningWindowConfig(provider: provider, window: window)?
+            .thresholds
+            .map(QuotaWarningThresholds.sanitized)
+    }
+
     func quotaWarningEnabled(provider: UsageProvider, window: QuotaWarningWindow) -> Bool {
         self.quotaWarningConfig(for: provider).isEnabled(
             for: window,

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -201,10 +201,6 @@ struct PreferencesPaneSmokeTests {
 
         CodexBarLocalizationOverride.$appLanguage.withValue("ru") {
             #expect(L("quota_warning_global") == "Глобально")
-            #expect(String(format: L("quota_warning_global_summary"), "Off") == "Глобально: Off")
-            #expect(String(
-                format: L("quota_warning_mode_accessibility"),
-                L("quota_warning_session_capitalized")) == "Режим предупреждений квоты для Сеанс")
             #expect(L("quota_warning_warning") == "Предупреждение")
             #expect(L("quota_warning_critical") == "Критично")
 
@@ -218,8 +214,8 @@ struct PreferencesPaneSmokeTests {
             let thresholdText = ProviderQuotaWarningSettingsView.thresholdText([80, 50, 20], enabled: true)
 
             #expect(thresholdText == "Warning 80%, Critical 50%, 20%")
-            #expect(String(format: L("quota_warning_global_summary"), thresholdText)
-                == "Global: Warning 80%, Critical 50%, 20%")
+            #expect(String(format: L("quota_warning_inherited"), thresholdText)
+                == "Inherited: Warning 80%, Critical 50%, 20%")
         }
     }
 

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -268,11 +268,18 @@ struct PreferencesPaneSmokeTests {
         #expect(settings.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [70, 30])
         #expect(view.shouldCommitThresholdEditorOnDisappear(for: .session))
 
+        mode.wrappedValue = .custom
+        #expect(mode.wrappedValue == .custom)
+        #expect(settings.quotaWarningEnabled(provider: .codex, window: .session))
+        #expect(settings.explicitQuotaWarningThresholds(provider: .codex, window: .session) == [70, 30])
+        #expect(settings.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [70, 30])
+
         mode.wrappedValue = .global
         #expect(mode.wrappedValue == .global)
         #expect(!settings.hasQuotaWarningOverride(provider: .codex, window: .session))
         #expect(settings.quotaWarningEnabled(provider: .codex, window: .session))
         #expect(settings.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [50, 20])
+        #expect(!view.shouldCommitThresholdEditorOnDisappear(for: .session))
 
         mode.wrappedValue = .custom
         #expect(settings.providerConfig(for: .codex)?.quotaWarnings?.session?.thresholds == nil)

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -200,6 +200,11 @@ struct PreferencesPaneSmokeTests {
         settings.quotaWarningNotificationsEnabled = true
 
         CodexBarLocalizationOverride.$appLanguage.withValue("ru") {
+            #expect(L("quota_warning_global") == "Глобально")
+            #expect(String(format: L("quota_warning_global_summary"), "Off") == "Глобально: Off")
+            #expect(String(
+                format: L("quota_warning_mode_accessibility"),
+                L("quota_warning_session_capitalized")) == "Режим предупреждений квоты для Сеанс")
             #expect(L("quota_warning_warning") == "Предупреждение")
             #expect(L("quota_warning_critical") == "Критично")
 
@@ -208,12 +213,80 @@ struct PreferencesPaneSmokeTests {
     }
 
     @Test
-    func `quota warning inherited summary keeps additional active thresholds visible`() {
+    func `provider quota warning inherited summary keeps additional active thresholds visible`() {
         CodexBarLocalizationOverride.$appLanguage.withValue("en") {
-            #expect(
-                ProviderQuotaWarningSettingsView.thresholdText([80, 50, 20], enabled: true)
-                    == "Warning 80%, Critical 50%, 20%")
+            let thresholdText = ProviderQuotaWarningSettingsView.thresholdText([80, 50, 20], enabled: true)
+
+            #expect(thresholdText == "Warning 80%, Critical 50%, 20%")
+            #expect(String(format: L("quota_warning_global_summary"), thresholdText)
+                == "Global: Warning 80%, Critical 50%, 20%")
         }
+    }
+
+    @Test
+    func `provider quota warning rows build for global custom and off states`() {
+        let settings = Self.makeSettingsStore(suite: "PreferencesPaneSmokeTests-provider-quota-warning-rows")
+        settings.quotaWarningNotificationsEnabled = true
+        settings.setQuotaWarningThresholds(.session, thresholds: [50, 20])
+        settings.setQuotaWarningThresholds(.weekly, thresholds: [80, 40])
+
+        _ = ProviderQuotaWarningSettingsView(provider: .codex, settings: settings).body
+
+        settings.setQuotaWarningOverride(provider: .codex, window: .session, thresholds: [70, 30], enabled: true)
+        settings.setQuotaWarningOverride(provider: .codex, window: .weekly, thresholds: [60, 10], enabled: false)
+
+        _ = ProviderQuotaWarningSettingsView(provider: .codex, settings: settings).body
+
+        #expect(settings.hasQuotaWarningOverride(provider: .codex, window: .session))
+        #expect(settings.hasQuotaWarningOverride(provider: .codex, window: .weekly))
+        #expect(settings.quotaWarningEnabled(provider: .codex, window: .session))
+        #expect(!settings.quotaWarningEnabled(provider: .codex, window: .weekly))
+        #expect(settings.resolvedQuotaWarningThresholds(provider: .codex, window: .weekly) == [60, 10])
+    }
+
+    @Test
+    func `provider quota warning mode binding applies global custom and off transitions`() {
+        let settings = Self.makeSettingsStore(suite: "PreferencesPaneSmokeTests-provider-quota-warning-mode-binding")
+        settings.quotaWarningNotificationsEnabled = true
+        settings.setQuotaWarningWindowEnabled(.session, enabled: true)
+        settings.setQuotaWarningThresholds(.session, thresholds: [50, 20])
+
+        let view = ProviderQuotaWarningSettingsView(provider: .codex, settings: settings)
+        let mode = view.overrideModeBinding(for: .session)
+
+        #expect(mode.wrappedValue == .global)
+
+        mode.wrappedValue = .custom
+        #expect(mode.wrappedValue == .custom)
+        #expect(settings.hasQuotaWarningOverride(provider: .codex, window: .session))
+        #expect(settings.quotaWarningEnabled(provider: .codex, window: .session))
+        #expect(settings.providerConfig(for: .codex)?.quotaWarnings?.session?.thresholds == nil)
+        #expect(settings.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [50, 20])
+        #expect(view.shouldCommitThresholdEditorOnDisappear(for: .session))
+
+        settings.setQuotaWarningThresholds(provider: .codex, window: .session, thresholds: [70, 30])
+        mode.wrappedValue = .off
+        #expect(mode.wrappedValue == .off)
+        #expect(settings.hasQuotaWarningOverride(provider: .codex, window: .session))
+        #expect(!settings.quotaWarningEnabled(provider: .codex, window: .session))
+        #expect(settings.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [70, 30])
+        #expect(view.shouldCommitThresholdEditorOnDisappear(for: .session))
+
+        mode.wrappedValue = .global
+        #expect(mode.wrappedValue == .global)
+        #expect(!settings.hasQuotaWarningOverride(provider: .codex, window: .session))
+        #expect(settings.quotaWarningEnabled(provider: .codex, window: .session))
+        #expect(settings.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [50, 20])
+
+        mode.wrappedValue = .custom
+        #expect(settings.providerConfig(for: .codex)?.quotaWarnings?.session?.thresholds == nil)
+
+        mode.wrappedValue = .off
+        let disabledInheritedConfig = settings.providerConfig(for: .codex)?.quotaWarnings?.session
+        #expect(disabledInheritedConfig?.enabled == false)
+        #expect(disabledInheritedConfig?.thresholds == nil)
+        #expect(settings.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [50, 20])
+        #expect(view.shouldCommitThresholdEditorOnDisappear(for: .session))
     }
 
     @Test

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -790,11 +790,14 @@ struct SettingsStoreTests {
         store.quotaWarningThresholds = [50, 20]
 
         #expect(store.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [50, 20])
+        #expect(store.explicitQuotaWarningThresholds(provider: .codex, window: .session) == nil)
         store.setQuotaWarningThresholds(provider: .codex, window: .session, thresholds: [10])
+        #expect(store.explicitQuotaWarningThresholds(provider: .codex, window: .session) == [10])
         #expect(store.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [10])
         #expect(store.resolvedQuotaWarningThresholds(provider: .codex, window: .weekly) == [50, 20])
 
         store.setQuotaWarningThresholds(provider: .codex, window: .session, thresholds: nil)
+        #expect(store.explicitQuotaWarningThresholds(provider: .codex, window: .session) == nil)
         #expect(store.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [50, 20])
     }
 


### PR DESCRIPTION
## Summary
- Redesign provider quota warning rows around a compact per-window `Global | Custom | Off` control with inline `Warning` and `Critical` threshold fields.
- Route provider threshold edits through the dirty draft save path so no-op blur, Return, outside clicks, or teardown do not create or restore explicit provider overrides.
- Preserve extra stored thresholds and show them in inherited summaries, while localizing the new `Global` picker label across app catalogs.

## Why
The provider quota warning settings needed the same hardening as the global quota warning layout: the old editor could churn provider refreshes on no-op lifecycle events and risk freezing inherited thresholds as explicit overrides. The new layout also keeps the rows aligned, makes inherited/custom/off state clearer, and avoids hiding historical/manual threshold values beyond the two fields exposed in the UI.

## Validation
- `swift test --filter SettingsStoreTests`
- `swift test --filter PreferencesPaneSmokeTests`
- `swift test --filter LocalizationLanguageCatalogTests`
- `git diff --check`
- `make check`

## Screenshot
before
<img width="600" alt="Image 7-7-26 at 22 35" src="https://github.com/user-attachments/assets/e5c9b5cc-d2ee-453e-a1d1-f6e93bb7db8c" />
after
<img width="600" alt="Screenshot 2026-07-09 at 10 59 32 AM" src="https://github.com/user-attachments/assets/05b6d7ac-4ea6-4b8d-9ad3-5e5c3ba9e634" />
