### PR TITLE
fix: restore Kiro usage refresh across CLI transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - CLI: isolate interactive PATH probes from the caller's terminal so concurrent and redirected-stdin lookups cannot break `watch` or Ctrl+C. Thanks @possibilities!
 - Claude login: preserve the selected usage source after OAuth sign-in so Auto mode can still fall back to CLI or web data when OAuth is unavailable. Thanks @Chipagosfinest!
+- Kiro: restore usage refresh for current CLIs that stall under PTY by preferring bounded pipe capture while retaining PTY fallback for older releases (#1883). Thanks @txarly89!
 - Claude quotas: ignore synthetic no-session placeholders when tracking notifications, history, and reset events, preventing false restores and duplicate threshold or pace warnings while weekly usage continues updating. Thanks @vincent-peng!
 - German localization: label manual cookie-source and refresh options as “Manuell” instead of the handbook noun “Handbuch.” Thanks @fbrettnich!
 - Amp: parse the current percentage-based daily Amp Free usage output while preserving individual and workspace balances. Thanks @3kh0!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Fixed
 - CLI: isolate interactive PATH probes from the caller's terminal so concurrent and redirected-stdin lookups cannot break `watch` or Ctrl+C. Thanks @possibilities!
 - Claude login: preserve the selected usage source after OAuth sign-in so Auto mode can still fall back to CLI or web data when OAuth is unavailable. Thanks @Chipagosfinest!
-- Kiro: restore usage refresh for current CLIs that stall under PTY by preferring bounded pipe capture while retaining PTY fallback for older releases (#1883). Thanks @txarly89!
+- Kiro: restore usage refresh for current CLIs that stall under PTY by accepting complete pipe output first while retaining a same-deadline PTY fallback for older releases (#1883). Thanks @txarly89!
 - Claude quotas: ignore synthetic no-session placeholders when tracking notifications, history, and reset events, preventing false restores and duplicate threshold or pace warnings while weekly usage continues updating. Thanks @vincent-peng!
 - German localization: label manual cookie-source and refresh options as “Manuell” instead of the handbook noun “Handbuch.” Thanks @fbrettnich!
 - Amp: parse the current percentage-based daily Amp Free usage output while preserving individual and workspace balances. Thanks @3kh0!

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -365,6 +365,52 @@ public struct KiroStatusProbe: Sendable {
         case context
     }
 
+    private enum KiroTransportOutcome: Sendable {
+        case result(KiroCLIResult)
+        case failure(KiroStatusProbeError)
+        case cancelled
+    }
+
+    private enum KiroTransportEvent: Sendable {
+        case pipe(KiroTransportOutcome)
+        case pty(KiroTransportOutcome)
+        case fallbackReady
+    }
+
+    private final class KiroPipeActivityState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var lastActivity = ContinuousClock.now
+        private var receivedOutput = false
+
+        var lastActivityAt: ContinuousClock.Instant {
+            self.lock.withLock { self.lastActivity }
+        }
+
+        var hasReceivedOutput: Bool {
+            self.lock.withLock { self.receivedOutput }
+        }
+
+        func markActivity() {
+            self.lock.withLock {
+                self.lastActivity = .now
+                self.receivedOutput = true
+            }
+        }
+    }
+
+    private final class KiroTransportCancellationState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var cancelled = false
+
+        var isCancelled: Bool {
+            self.lock.withLock { self.cancelled }
+        }
+
+        func cancel() {
+            self.lock.withLock { self.cancelled = true }
+        }
+    }
+
     private enum KiroAccountProbeStatus: Equatable {
         case account(KiroAccountInfo)
         case notLoggedIn
@@ -514,80 +560,11 @@ public struct KiroStatusProbe: Sendable {
         return contextUsage
     }
 
-    /// Recent Kiro CLIs can keep their TUI alive indefinitely under a PTY even with `--no-interactive`,
-    /// while older releases emit no output through pipes. Prefer pipes and retain PTY as a bounded fallback.
-    private func runCommand(
-        arguments: [String],
-        timeout: TimeInterval,
-        idleTimeout: TimeInterval,
-        kind: KiroCommandKind) async throws -> KiroCLIResult
-    {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(max(0, timeout)))
-        let pipeBudget = min(max(0, self.pipeTimeoutCap), max(0, timeout / 2))
-
-        try Task.checkCancellation()
-        do {
-            let result = try await self.runViaPipe(
-                arguments: arguments,
-                timeout: pipeBudget,
-                idleTimeout: idleTimeout)
-            if self.shouldAcceptPipeResult(result, for: kind) {
-                try Task.checkCancellation()
-                guard clock.now <= deadline else { throw KiroStatusProbeError.timeout }
-                return result
-            }
-            Self.logger.debug("Kiro pipe \(kind.rawValue) output was incomplete; retrying through PTY")
-        } catch KiroStatusProbeError.timeout {
-            Self.logger.debug("Kiro pipe \(kind.rawValue) probe timed out; retrying through PTY")
-        }
-
-        try Task.checkCancellation()
-        let remaining = Self.timeInterval(from: clock.now.duration(to: deadline))
-        guard remaining > 0 else { throw KiroStatusProbeError.timeout }
-        let result = try self.runViaPTY(
-            arguments: arguments,
-            timeout: remaining,
-            idleTimeout: min(idleTimeout, remaining))
-        try Task.checkCancellation()
-        guard clock.now <= deadline else { throw KiroStatusProbeError.timeout }
-        return result
-    }
-
-    private func shouldAcceptPipeResult(_ result: KiroCLIResult, for kind: KiroCommandKind) -> Bool {
-        let output = result.output
-        if Self.isLoginRequired(output) {
-            return true
-        }
-
-        switch kind {
-        case .whoAmI:
-            let account = self.parseWhoAmIOutput(output)
-            return account.authMethod != nil || account.email != nil
-        case .usage:
-            return (try? self.parse(output: output)) != nil
-        case .context:
-            if self.parseContextUsage(output: output) != nil {
-                return true
-            }
-            return result.terminationStatus == 0
-                && !result.stoppedAfterOutput
-                && output.isEmpty
-        }
-    }
-
-    private static func timeInterval(from duration: Duration) -> TimeInterval {
-        let components = duration.components
-        return max(
-            0,
-            TimeInterval(components.seconds)
-                + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000)
-    }
-
     private func runViaPipe(
         arguments: [String],
         timeout: TimeInterval,
-        idleTimeout: TimeInterval) async throws -> KiroCLIResult
+        idleTimeout: TimeInterval,
+        activityState state: KiroPipeActivityState) async throws -> KiroCLIResult
     {
         try Task.checkCancellation()
         guard let binary = self.cliBinaryResolver() else {
@@ -597,7 +574,7 @@ public struct KiroStatusProbe: Sendable {
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
 
-        var env = ProcessInfo.processInfo.environment
+        var env = TTYCommandRunner.enrichedEnvironment()
         env["TERM"] = "xterm-256color"
 
         guard self.pipeProcessRegistry.beginLaunch() else {
@@ -610,28 +587,6 @@ public struct KiroStatusProbe: Sendable {
             }
         }
 
-        final class ActivityState: @unchecked Sendable {
-            private let lock = NSLock()
-            private var _lastActivityAt = ContinuousClock.now
-            private var _hasReceivedOutput = false
-
-            var lastActivityAt: ContinuousClock.Instant {
-                self.lock.withLock { self._lastActivityAt }
-            }
-
-            var hasReceivedOutput: Bool {
-                self.lock.withLock { self._hasReceivedOutput }
-            }
-
-            func markActivity() {
-                self.lock.withLock {
-                    self._lastActivityAt = .now
-                    self._hasReceivedOutput = true
-                }
-            }
-        }
-
-        let state = ActivityState()
         let stdoutCapture = ProcessPipeCapture(pipe: stdoutPipe, onData: { state.markActivity() })
         let stderrCapture = ProcessPipeCapture(pipe: stderrPipe, onData: { state.markActivity() })
         stdoutCapture.start()
@@ -744,7 +699,8 @@ public struct KiroStatusProbe: Sendable {
     private func runViaPTY(
         arguments: [String],
         timeout: TimeInterval,
-        idleTimeout: TimeInterval) throws -> KiroCLIResult
+        idleTimeout: TimeInterval,
+        cancellationState: KiroTransportCancellationState) throws -> KiroCLIResult
     {
         guard let binary = self.cliBinaryResolver() else {
             throw KiroStatusProbeError.cliNotFound
@@ -759,7 +715,10 @@ public struct KiroStatusProbe: Sendable {
                     timeout: timeout,
                     idleTimeout: idleTimeout,
                     extraArgs: arguments,
-                    returnOnEmptyProcessExit: true))
+                    returnOnEmptyProcessExit: true,
+                    cancellationCheck: {
+                        cancellationState.isCancelled || Task<Never, Never>.isCancelled
+                    }))
             switch result.completion {
             case let .processExited(status):
                 return KiroCLIResult(
@@ -782,6 +741,26 @@ public struct KiroStatusProbe: Sendable {
             throw KiroStatusProbeError.timeout
         } catch let TTYCommandRunner.Error.launchFailed(message) {
             throw KiroStatusProbeError.cliFailed(message)
+        }
+    }
+
+    private func runViaPTYAsync(
+        arguments: [String],
+        timeout: TimeInterval,
+        idleTimeout: TimeInterval,
+        cancellationState: KiroTransportCancellationState) async throws -> KiroCLIResult
+    {
+        let task = Task.detached(priority: .userInitiated) {
+            try self.runViaPTY(
+                arguments: arguments,
+                timeout: timeout,
+                idleTimeout: idleTimeout,
+                cancellationState: cancellationState)
+        }
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            cancellationState.cancel()
         }
     }
 
@@ -1116,6 +1095,264 @@ public struct KiroStatusProbe: Sendable {
         self.stripANSI(text)
             .replacingOccurrences(of: #"\x1B|\[[0-9;?]*[A-Za-z]"#, with: "", options: [.regularExpression])
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+extension KiroStatusProbe {
+    /// Recent Kiro CLIs can keep their TUI alive indefinitely under a PTY even with `--no-interactive`,
+    /// while older releases emit no output through pipes. Prefer pipes and retain PTY as a bounded fallback.
+    private func runCommand(
+        arguments: [String],
+        timeout: TimeInterval,
+        idleTimeout: TimeInterval,
+        kind: KiroCommandKind) async throws -> KiroCLIResult
+    {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(max(0, timeout)))
+        let fallbackDelay = min(max(0, self.pipeTimeoutCap), max(0, timeout / 2))
+        let pipeActivity = KiroPipeActivityState()
+        let cancellationState = KiroTransportCancellationState()
+
+        return try await withThrowingTaskGroup(of: KiroTransportEvent.self) { group in
+            defer {
+                cancellationState.cancel()
+                group.cancelAll()
+            }
+            group.addTask {
+                await .pipe(self.pipeOutcome(
+                    arguments: arguments,
+                    timeout: timeout,
+                    idleTimeout: idleTimeout,
+                    activityState: pipeActivity))
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(fallbackDelay))
+                return .fallbackReady
+            }
+
+            var ptyStarted = false
+            var pipeFinishedWithoutAcceptedResult = false
+            var pendingPTYResult: KiroCLIResult?
+            var pendingPTYFailure: KiroStatusProbeError?
+            while let event = try await group.next() {
+                try Task.checkCancellation()
+                switch event {
+                case .fallbackReady:
+                    guard !ptyStarted, !pipeActivity.hasReceivedOutput else { continue }
+                    let remaining = Self.timeInterval(from: clock.now.duration(to: deadline))
+                    guard remaining > 0 else { continue }
+                    ptyStarted = true
+                    group.addTask {
+                        await .pty(self.ptyOutcome(
+                            arguments: arguments,
+                            timeout: remaining,
+                            idleTimeout: min(idleTimeout, remaining),
+                            cancellationState: cancellationState))
+                    }
+
+                case let .pipe(.result(result)):
+                    if try self.shouldReturnPipeResult(
+                        result,
+                        for: kind,
+                        before: deadline,
+                        now: clock.now)
+                    {
+                        cancellationState.cancel()
+                        group.cancelAll()
+                        return result
+                    }
+                    pipeFinishedWithoutAcceptedResult = true
+                    Self.logger.debug("Kiro pipe \(kind.rawValue) output was incomplete; awaiting PTY fallback")
+                    if let pending = try Self.resolvePendingPTY(
+                        result: pendingPTYResult,
+                        failure: pendingPTYFailure,
+                        before: deadline,
+                        now: clock.now)
+                    {
+                        return pending
+                    }
+                    if !ptyStarted {
+                        let remaining = Self.timeInterval(from: clock.now.duration(to: deadline))
+                        guard remaining > 0 else { throw KiroStatusProbeError.timeout }
+                        ptyStarted = true
+                        group.addTask {
+                            await .pty(self.ptyOutcome(
+                                arguments: arguments,
+                                timeout: remaining,
+                                idleTimeout: min(idleTimeout, remaining),
+                                cancellationState: cancellationState))
+                        }
+                    }
+
+                case .pipe(.failure(.timeout)):
+                    pipeFinishedWithoutAcceptedResult = true
+                    Self.logger.debug("Kiro pipe \(kind.rawValue) probe timed out; awaiting PTY fallback")
+                    if let pending = try Self.resolvePendingPTY(
+                        result: pendingPTYResult,
+                        failure: pendingPTYFailure,
+                        before: deadline,
+                        now: clock.now)
+                    {
+                        return pending
+                    }
+
+                case let .pipe(.failure(error)):
+                    cancellationState.cancel()
+                    group.cancelAll()
+                    throw error
+
+                case .pipe(.cancelled), .pty(.cancelled):
+                    throw CancellationError()
+
+                case let .pty(.result(result)):
+                    guard self.shouldAcceptPTYResult(result, for: kind) else {
+                        if pipeFinishedWithoutAcceptedResult {
+                            try Self.ensureBeforeDeadline(clock.now, deadline: deadline)
+                            return result
+                        }
+                        pendingPTYResult = result
+                        continue
+                    }
+                    guard clock.now <= deadline else { throw KiroStatusProbeError.timeout }
+                    cancellationState.cancel()
+                    group.cancelAll()
+                    return result
+
+                case let .pty(.failure(error)):
+                    if pipeFinishedWithoutAcceptedResult {
+                        throw error
+                    }
+                    pendingPTYFailure = error
+                }
+            }
+            if let pending = try Self.resolvePendingPTY(
+                result: pendingPTYResult,
+                failure: pendingPTYFailure,
+                before: deadline,
+                now: clock.now)
+            {
+                return pending
+            }
+            throw KiroStatusProbeError.timeout
+        }
+    }
+
+    private func pipeOutcome(
+        arguments: [String],
+        timeout: TimeInterval,
+        idleTimeout: TimeInterval,
+        activityState: KiroPipeActivityState) async -> KiroTransportOutcome
+    {
+        do {
+            return try await .result(self.runViaPipe(
+                arguments: arguments,
+                timeout: timeout,
+                idleTimeout: idleTimeout,
+                activityState: activityState))
+        } catch is CancellationError {
+            return .cancelled
+        } catch let error as KiroStatusProbeError {
+            return .failure(error)
+        } catch {
+            return .failure(.cliFailed(error.localizedDescription))
+        }
+    }
+
+    private func ptyOutcome(
+        arguments: [String],
+        timeout: TimeInterval,
+        idleTimeout: TimeInterval,
+        cancellationState: KiroTransportCancellationState) async -> KiroTransportOutcome
+    {
+        do {
+            return try await .result(self.runViaPTYAsync(
+                arguments: arguments,
+                timeout: timeout,
+                idleTimeout: idleTimeout,
+                cancellationState: cancellationState))
+        } catch is CancellationError {
+            return .cancelled
+        } catch let error as KiroStatusProbeError {
+            return .failure(error)
+        } catch {
+            return .failure(.cliFailed(error.localizedDescription))
+        }
+    }
+
+    fileprivate static func resolvePendingPTY(
+        result: KiroCLIResult?,
+        failure: KiroStatusProbeError?,
+        before deadline: ContinuousClock.Instant,
+        now: ContinuousClock.Instant) throws -> KiroCLIResult?
+    {
+        if result != nil || failure != nil {
+            guard now <= deadline else { throw KiroStatusProbeError.timeout }
+        }
+        if let result {
+            return result
+        }
+        if let failure {
+            throw failure
+        }
+        return nil
+    }
+
+    private static func ensureBeforeDeadline(
+        _ now: ContinuousClock.Instant,
+        deadline: ContinuousClock.Instant) throws
+    {
+        guard now <= deadline else { throw KiroStatusProbeError.timeout }
+    }
+
+    private func shouldAcceptPipeResult(_ result: KiroCLIResult, for kind: KiroCommandKind) -> Bool {
+        let output = result.output
+        if Self.isLoginRequired(output) {
+            return true
+        }
+
+        switch kind {
+        case .whoAmI:
+            let account = self.parseWhoAmIOutput(output)
+            return account.authMethod != nil || account.email != nil
+        case .usage:
+            return (try? self.parse(output: output)) != nil
+        case .context:
+            if self.parseContextUsage(output: output) != nil {
+                return true
+            }
+            return result.terminationStatus == 0
+                && !result.stoppedAfterOutput
+                && output.isEmpty
+        }
+    }
+
+    private func shouldReturnPipeResult(
+        _ result: KiroCLIResult,
+        for kind: KiroCommandKind,
+        before deadline: ContinuousClock.Instant,
+        now: ContinuousClock.Instant) throws -> Bool
+    {
+        let accepted = self.shouldAcceptPipeResult(result, for: kind)
+        guard accepted else { return false }
+        if !Self.isLoginRequired(result.output), now > deadline {
+            throw KiroStatusProbeError.timeout
+        }
+        return true
+    }
+
+    private func shouldAcceptPTYResult(_ result: KiroCLIResult, for kind: KiroCommandKind) -> Bool {
+        if Self.isLoginRequired(result.output) {
+            return true
+        }
+        return result.terminationStatus == 0 && self.shouldAcceptPipeResult(result, for: kind)
+    }
+
+    fileprivate static func timeInterval(from duration: Duration) -> TimeInterval {
+        let components = duration.components
+        return max(
+            0,
+            TimeInterval(components.seconds)
+                + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -226,24 +226,57 @@ public enum KiroStatusProbeError: LocalizedError, Sendable {
 }
 
 public struct KiroStatusProbe: Sendable {
+    struct PipeProcessRegistry: Sendable {
+        let beginLaunch: @Sendable () -> Bool
+        let endLaunch: @Sendable () -> Void
+        let register: @Sendable (pid_t, String) -> Bool
+        let updateProcessGroup: @Sendable (pid_t, pid_t?) -> Void
+        let unregister: @Sendable (pid_t) -> Void
+
+        static let live = Self(
+            beginLaunch: { TTYCommandRunner.beginActiveProcessLaunchForAppShutdown() },
+            endLaunch: { TTYCommandRunner.endActiveProcessLaunchForAppShutdown() },
+            register: { pid, binary in
+                TTYCommandRunner.registerActiveProcessForAppShutdown(pid: pid, binary: binary)
+            },
+            updateProcessGroup: { pid, processGroup in
+                TTYCommandRunner.updateActiveProcessGroupForAppShutdown(pid: pid, processGroup: processGroup)
+            },
+            unregister: { pid in
+                TTYCommandRunner.unregisterActiveProcessForAppShutdown(pid: pid)
+            })
+    }
+
     private let cliBinaryResolver: @Sendable () -> String?
     private let accountProbeTimeout: TimeInterval
+    private let usageProbeTimeout: TimeInterval
+    private let contextProbeTimeout: TimeInterval
     private let pipeTimeoutCap: TimeInterval
+    private let pipeProcessRegistry: PipeProcessRegistry
 
     public init() {
         self.cliBinaryResolver = { TTYCommandRunner.which("kiro-cli") }
         self.accountProbeTimeout = 3.0
+        self.usageProbeTimeout = 20.0
+        self.contextProbeTimeout = 8.0
         self.pipeTimeoutCap = 5.0
+        self.pipeProcessRegistry = .live
     }
 
     init(
         cliBinaryResolver: @escaping @Sendable () -> String?,
         accountProbeTimeout: TimeInterval = 3.0,
-        pipeTimeoutCap: TimeInterval = 5.0)
+        usageProbeTimeout: TimeInterval = 20.0,
+        contextProbeTimeout: TimeInterval = 8.0,
+        pipeTimeoutCap: TimeInterval = 5.0,
+        pipeProcessRegistry: PipeProcessRegistry = .live)
     {
         self.cliBinaryResolver = cliBinaryResolver
         self.accountProbeTimeout = accountProbeTimeout
+        self.usageProbeTimeout = usageProbeTimeout
+        self.contextProbeTimeout = contextProbeTimeout
         self.pipeTimeoutCap = pipeTimeoutCap
+        self.pipeProcessRegistry = pipeProcessRegistry
     }
 
     private static let logger = CodexBarLog.logger(LogCategories.kiro)
@@ -311,17 +344,25 @@ public struct KiroStatusProbe: Sendable {
         let email: String?
     }
 
-    struct KiroCLIResult {
+    struct KiroCLIResult: Sendable {
         let stdout: String
         let stderr: String
         let terminationStatus: Int32
-        let terminatedForIdle: Bool
+        let stoppedAfterOutput: Bool
 
         var output: String {
-            self.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                ? self.stderr
-                : self.stdout
+            let stdout = self.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            let stderr = self.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return [stdout, stderr]
+                .filter { !$0.isEmpty }
+                .joined(separator: "\n")
         }
+    }
+
+    private enum KiroCommandKind: String, Sendable {
+        case whoAmI = "whoami"
+        case usage
+        case context
     }
 
     private enum KiroAccountProbeStatus: Equatable {
@@ -362,9 +403,10 @@ public struct KiroStatusProbe: Sendable {
         let result = try await self.runCommand(
             arguments: ["whoami"],
             timeout: self.accountProbeTimeout,
-            idleTimeout: 1.5)
-        if result.terminatedForIdle {
-            if Self.isWhoAmILoginRequired(result.output) {
+            idleTimeout: 1.5,
+            kind: .whoAmI)
+        if result.stoppedAfterOutput {
+            if Self.isLoginRequired(result.output) {
                 throw KiroStatusProbeError.notLoggedIn
             }
             throw KiroStatusProbeError.timeout
@@ -376,11 +418,13 @@ public struct KiroStatusProbe: Sendable {
     }
 
     func validateWhoAmIOutput(stdout: String, stderr: String, terminationStatus: Int32) throws -> KiroAccountInfo {
-        let trimmedStdout = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedStderr = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-        let combined = trimmedStderr.isEmpty ? trimmedStdout : trimmedStderr
+        let combined = KiroCLIResult(
+            stdout: stdout,
+            stderr: stderr,
+            terminationStatus: terminationStatus,
+            stoppedAfterOutput: false).output
 
-        if Self.isWhoAmILoginRequired(combined) {
+        if Self.isLoginRequired(combined) {
             throw KiroStatusProbeError.notLoggedIn
         }
 
@@ -398,9 +442,13 @@ public struct KiroStatusProbe: Sendable {
         return self.parseWhoAmIOutput(combined)
     }
 
-    private static func isWhoAmILoginRequired(_ output: String) -> Bool {
+    private static func isLoginRequired(_ output: String) -> Bool {
         let lowered = Self.stripANSI(output).lowercased()
-        return lowered.contains("not logged in") || lowered.contains("login required")
+        return lowered.contains("not logged in")
+            || lowered.contains("login required")
+            || lowered.contains("failed to initialize auth portal")
+            || lowered.contains("kiro-cli login")
+            || lowered.contains("oauth error")
     }
 
     func parseWhoAmIOutput(_ output: String) -> KiroAccountInfo {
@@ -437,34 +485,33 @@ public struct KiroStatusProbe: Sendable {
     private func runUsageCommand() async throws -> String {
         let result = try await self.runCommand(
             arguments: ["chat", "--no-interactive", "/usage"],
-            timeout: 20.0,
-            idleTimeout: 4.0)
+            timeout: self.usageProbeTimeout,
+            idleTimeout: 4.0,
+            kind: .usage)
         let output = result.output
-        let combinedStripped = Self.stripANSI(output).lowercased()
-
-        if combinedStripped.contains("not logged in")
-            || combinedStripped.contains("login required")
-            || combinedStripped.contains("failed to initialize auth portal")
-            || combinedStripped.contains("kiro-cli login")
-            || combinedStripped.contains("oauth error")
-        {
+        if Self.isLoginRequired(output) {
             throw KiroStatusProbeError.notLoggedIn
         }
 
         try Self.validateCommandCompletion(
             result,
             command: "usage",
-            allowIdleOutput: Self.isUsageOutputComplete(output))
+            allowIdleOutput: (try? self.parse(output: output)) != nil)
         return output
     }
 
     private func fetchContextUsage() async throws -> KiroContextUsageSnapshot? {
         let result = try await self.runCommand(
             arguments: ["chat", "--no-interactive", "/context"],
-            timeout: 8.0,
-            idleTimeout: 3.0)
-        try Self.validateCommandCompletion(result, command: "context", allowIdleOutput: true)
-        return self.parseContextUsage(output: result.output)
+            timeout: self.contextProbeTimeout,
+            idleTimeout: 3.0,
+            kind: .context)
+        let contextUsage = self.parseContextUsage(output: result.output)
+        try Self.validateCommandCompletion(
+            result,
+            command: "context",
+            allowIdleOutput: contextUsage != nil)
+        return contextUsage
     }
 
     /// Recent Kiro CLIs can keep their TUI alive indefinitely under a PTY even with `--no-interactive`,
@@ -472,20 +519,69 @@ public struct KiroStatusProbe: Sendable {
     private func runCommand(
         arguments: [String],
         timeout: TimeInterval,
-        idleTimeout: TimeInterval) async throws -> KiroCLIResult
+        idleTimeout: TimeInterval,
+        kind: KiroCommandKind) async throws -> KiroCLIResult
     {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(max(0, timeout)))
+        let pipeBudget = min(max(0, self.pipeTimeoutCap), max(0, timeout / 2))
+
+        try Task.checkCancellation()
         do {
-            return try await self.runViaPipe(
+            let result = try await self.runViaPipe(
                 arguments: arguments,
-                timeout: min(timeout, self.pipeTimeoutCap),
+                timeout: pipeBudget,
                 idleTimeout: idleTimeout)
+            if self.shouldAcceptPipeResult(result, for: kind) {
+                try Task.checkCancellation()
+                guard clock.now <= deadline else { throw KiroStatusProbeError.timeout }
+                return result
+            }
+            Self.logger.debug("Kiro pipe \(kind.rawValue) output was incomplete; retrying through PTY")
         } catch KiroStatusProbeError.timeout {
-            Self.logger.debug("Kiro pipe probe timed out; retrying through PTY")
-            return try self.runViaPTY(
-                arguments: arguments,
-                timeout: timeout,
-                idleTimeout: idleTimeout)
+            Self.logger.debug("Kiro pipe \(kind.rawValue) probe timed out; retrying through PTY")
         }
+
+        try Task.checkCancellation()
+        let remaining = Self.timeInterval(from: clock.now.duration(to: deadline))
+        guard remaining > 0 else { throw KiroStatusProbeError.timeout }
+        let result = try self.runViaPTY(
+            arguments: arguments,
+            timeout: remaining,
+            idleTimeout: min(idleTimeout, remaining))
+        try Task.checkCancellation()
+        guard clock.now <= deadline else { throw KiroStatusProbeError.timeout }
+        return result
+    }
+
+    private func shouldAcceptPipeResult(_ result: KiroCLIResult, for kind: KiroCommandKind) -> Bool {
+        let output = result.output
+        if Self.isLoginRequired(output) {
+            return true
+        }
+
+        switch kind {
+        case .whoAmI:
+            let account = self.parseWhoAmIOutput(output)
+            return account.authMethod != nil || account.email != nil
+        case .usage:
+            return (try? self.parse(output: output)) != nil
+        case .context:
+            if self.parseContextUsage(output: output) != nil {
+                return true
+            }
+            return result.terminationStatus == 0
+                && !result.stoppedAfterOutput
+                && output.isEmpty
+        }
+    }
+
+    private static func timeInterval(from duration: Duration) -> TimeInterval {
+        let components = duration.components
+        return max(
+            0,
+            TimeInterval(components.seconds)
+                + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000)
     }
 
     private func runViaPipe(
@@ -493,6 +589,7 @@ public struct KiroStatusProbe: Sendable {
         timeout: TimeInterval,
         idleTimeout: TimeInterval) async throws -> KiroCLIResult
     {
+        try Task.checkCancellation()
         guard let binary = self.cliBinaryResolver() else {
             throw KiroStatusProbeError.cliNotFound
         }
@@ -503,12 +600,22 @@ public struct KiroStatusProbe: Sendable {
         var env = ProcessInfo.processInfo.environment
         env["TERM"] = "xterm-256color"
 
+        guard self.pipeProcessRegistry.beginLaunch() else {
+            throw KiroStatusProbeError.cliFailed("App shutdown in progress")
+        }
+        var launchReservationHeld = true
+        defer {
+            if launchReservationHeld {
+                self.pipeProcessRegistry.endLaunch()
+            }
+        }
+
         final class ActivityState: @unchecked Sendable {
             private let lock = NSLock()
-            private var _lastActivityAt = Date()
+            private var _lastActivityAt = ContinuousClock.now
             private var _hasReceivedOutput = false
 
-            var lastActivityAt: Date {
+            var lastActivityAt: ContinuousClock.Instant {
                 self.lock.withLock { self._lastActivityAt }
             }
 
@@ -518,7 +625,7 @@ public struct KiroStatusProbe: Sendable {
 
             func markActivity() {
                 self.lock.withLock {
-                    self._lastActivityAt = Date()
+                    self._lastActivityAt = .now
                     self._hasReceivedOutput = true
                 }
             }
@@ -532,6 +639,7 @@ public struct KiroStatusProbe: Sendable {
 
         let process: SpawnedProcessGroup
         do {
+            try Task.checkCancellation()
             process = try SpawnedProcessGroup.launch(
                 binary: binary,
                 arguments: arguments,
@@ -544,19 +652,36 @@ public struct KiroStatusProbe: Sendable {
             throw error
         }
 
-        let deadline = Date().addingTimeInterval(timeout)
+        guard self.pipeProcessRegistry.register(
+            process.pid,
+            URL(fileURLWithPath: binary).lastPathComponent)
+        else {
+            await Self.terminateCancelledPipeProcess(
+                process,
+                stdoutCapture: stdoutCapture,
+                stderrCapture: stderrCapture)
+            throw KiroStatusProbeError.cliFailed("App shutdown in progress")
+        }
+        self.pipeProcessRegistry.updateProcessGroup(process.pid, process.processGroup)
+        self.pipeProcessRegistry.endLaunch()
+        launchReservationHeld = false
+        defer { self.pipeProcessRegistry.unregister(process.pid) }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(max(0, timeout)))
         var didHitDeadline = false
         var didTerminateForIdle = false
 
         do {
             while process.isRunning {
                 try Task.checkCancellation()
-                if Date() >= deadline {
+                let now = clock.now
+                if now >= deadline {
                     didHitDeadline = true
                     break
                 }
                 if state.hasReceivedOutput,
-                   Date().timeIntervalSince(state.lastActivityAt) >= idleTimeout
+                   state.lastActivityAt.duration(to: now) >= .seconds(max(0, idleTimeout))
                 {
                     didTerminateForIdle = true
                     break
@@ -564,9 +689,10 @@ public struct KiroStatusProbe: Sendable {
                 try await Task.sleep(for: .milliseconds(100))
             }
         } catch {
-            await process.terminate()
-            stdoutCapture.stop()
-            stderrCapture.stop()
+            await Self.terminateCancelledPipeProcess(
+                process,
+                stdoutCapture: stdoutCapture,
+                stderrCapture: stderrCapture)
             throw error
         }
 
@@ -577,18 +703,17 @@ public struct KiroStatusProbe: Sendable {
                 stderrCapture.stop()
                 throw KiroStatusProbeError.timeout
             }
-            if didHitDeadline || !state.hasReceivedOutput {
+            if !state.hasReceivedOutput {
                 stdoutCapture.stop()
                 stderrCapture.stop()
                 throw KiroStatusProbeError.timeout
             }
         }
-        if process.hasResidualProcessGroup {
-            await process.terminateResidualProcesses()
-        }
+        await process.terminateResidualProcesses()
 
-        let stdoutData = await stdoutCapture.finish(timeout: .seconds(1))
-        let stderrData = await stderrCapture.finish(timeout: .seconds(1))
+        async let stdoutDataTask = stdoutCapture.finish(timeout: .seconds(1))
+        async let stderrDataTask = stderrCapture.finish(timeout: .seconds(1))
+        let (stdoutData, stderrData) = await (stdoutDataTask, stderrDataTask)
         if !stdoutCapture.reachedEOF || !stderrCapture.reachedEOF {
             await process.terminateResidualProcesses()
         }
@@ -600,7 +725,20 @@ public struct KiroStatusProbe: Sendable {
             stdout: ProcessPipeCapture.decodeUTF8(stdoutData),
             stderr: ProcessPipeCapture.decodeUTF8(stderrData),
             terminationStatus: terminationStatus,
-            terminatedForIdle: didTerminateForIdle)
+            stoppedAfterOutput: didTerminateForIdle || didHitDeadline)
+    }
+
+    private static func terminateCancelledPipeProcess(
+        _ process: SpawnedProcessGroup,
+        stdoutCapture: ProcessPipeCapture,
+        stderrCapture: ProcessPipeCapture) async
+    {
+        let cleanupTask = Task.detached(priority: .userInitiated) {
+            await process.terminate()
+            stdoutCapture.stop()
+            stderrCapture.stop()
+        }
+        await cleanupTask.value
     }
 
     private func runViaPTY(
@@ -628,13 +766,13 @@ public struct KiroStatusProbe: Sendable {
                     stdout: result.text,
                     stderr: "",
                     terminationStatus: status,
-                    terminatedForIdle: false)
+                    stoppedAfterOutput: false)
             case .idleTimeout:
                 return KiroCLIResult(
                     stdout: result.text,
                     stderr: "",
                     terminationStatus: 0,
-                    terminatedForIdle: true)
+                    stoppedAfterOutput: true)
             case .outputCondition, .deadlineExceeded:
                 throw KiroStatusProbeError.timeout
             }
@@ -652,7 +790,7 @@ public struct KiroStatusProbe: Sendable {
         command: String,
         allowIdleOutput: Bool) throws
     {
-        if result.terminatedForIdle {
+        if result.stoppedAfterOutput {
             guard allowIdleOutput else { throw KiroStatusProbeError.timeout }
             return
         }
@@ -949,7 +1087,9 @@ public struct KiroStatusProbe: Sendable {
         return cleaned
             .split(separator: " ")
             .map { word in
-                if word.caseInsensitiveCompare("KIRO") == .orderedSame { return "Kiro" }
+                if word.caseInsensitiveCompare("KIRO") == .orderedSame {
+                    return "Kiro"
+                }
                 return word.prefix(1).uppercased() + word.dropFirst().lowercased()
             }
             .joined(separator: " ")
@@ -976,15 +1116,6 @@ public struct KiroStatusProbe: Sendable {
         self.stripANSI(text)
             .replacingOccurrences(of: #"\x1B|\[[0-9;?]*[A-Za-z]"#, with: "", options: [.regularExpression])
             .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private static func isUsageOutputComplete(_ output: String) -> Bool {
-        let stripped = self.stripANSI(output).lowercased()
-        return stripped.contains("covered in plan")
-            || stripped.contains("resets on")
-            || stripped.contains("bonus credits")
-            || stripped.contains("plan:")
-            || stripped.contains("managed by admin")
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -228,15 +228,22 @@ public enum KiroStatusProbeError: LocalizedError, Sendable {
 public struct KiroStatusProbe: Sendable {
     private let cliBinaryResolver: @Sendable () -> String?
     private let accountProbeTimeout: TimeInterval
+    private let pipeTimeoutCap: TimeInterval
 
     public init() {
         self.cliBinaryResolver = { TTYCommandRunner.which("kiro-cli") }
         self.accountProbeTimeout = 3.0
+        self.pipeTimeoutCap = 5.0
     }
 
-    init(cliBinaryResolver: @escaping @Sendable () -> String?, accountProbeTimeout: TimeInterval = 3.0) {
+    init(
+        cliBinaryResolver: @escaping @Sendable () -> String?,
+        accountProbeTimeout: TimeInterval = 3.0,
+        pipeTimeoutCap: TimeInterval = 5.0)
+    {
         self.cliBinaryResolver = cliBinaryResolver
         self.accountProbeTimeout = accountProbeTimeout
+        self.pipeTimeoutCap = pipeTimeoutCap
     }
 
     private static let logger = CodexBarLog.logger(LogCategories.kiro)
@@ -304,6 +311,19 @@ public struct KiroStatusProbe: Sendable {
         let email: String?
     }
 
+    struct KiroCLIResult {
+        let stdout: String
+        let stderr: String
+        let terminationStatus: Int32
+        let terminatedForIdle: Bool
+
+        var output: String {
+            self.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? self.stderr
+                : self.stdout
+        }
+    }
+
     private enum KiroAccountProbeStatus: Equatable {
         case account(KiroAccountInfo)
         case notLoggedIn
@@ -339,20 +359,20 @@ public struct KiroStatusProbe: Sendable {
     }
 
     private func ensureLoggedIn() async throws -> KiroAccountInfo {
-        let result = try self.runViaPTY(
+        let result = try await self.runCommand(
             arguments: ["whoami"],
             timeout: self.accountProbeTimeout,
             idleTimeout: 1.5)
-        guard case let .processExited(status) = result.completion else {
-            if Self.isWhoAmILoginRequired(result.text) {
+        if result.terminatedForIdle {
+            if Self.isWhoAmILoginRequired(result.output) {
                 throw KiroStatusProbeError.notLoggedIn
             }
             throw KiroStatusProbeError.timeout
         }
         return try self.validateWhoAmIOutput(
-            stdout: result.text,
-            stderr: "",
-            terminationStatus: status)
+            stdout: result.stdout,
+            stderr: result.stderr,
+            terminationStatus: result.terminationStatus)
     }
 
     func validateWhoAmIOutput(stdout: String, stderr: String, terminationStatus: Int32) throws -> KiroAccountInfo {
@@ -415,11 +435,11 @@ public struct KiroStatusProbe: Sendable {
     }
 
     private func runUsageCommand() async throws -> String {
-        let result = try self.runViaPTY(
+        let result = try await self.runCommand(
             arguments: ["chat", "--no-interactive", "/usage"],
             timeout: 20.0,
             idleTimeout: 4.0)
-        let output = result.text
+        let output = result.output
         let combinedStripped = Self.stripANSI(output).lowercased()
 
         if combinedStripped.contains("not logged in")
@@ -431,7 +451,7 @@ public struct KiroStatusProbe: Sendable {
             throw KiroStatusProbeError.notLoggedIn
         }
 
-        try Self.validatePTYCompletion(
+        try Self.validateCommandCompletion(
             result,
             command: "usage",
             allowIdleOutput: Self.isUsageOutputComplete(output))
@@ -439,28 +459,160 @@ public struct KiroStatusProbe: Sendable {
     }
 
     private func fetchContextUsage() async throws -> KiroContextUsageSnapshot? {
-        let result = try self.runViaPTY(
+        let result = try await self.runCommand(
             arguments: ["chat", "--no-interactive", "/context"],
             timeout: 8.0,
             idleTimeout: 3.0)
-        try Self.validatePTYCompletion(result, command: "context", allowIdleOutput: true)
-        return self.parseContextUsage(output: result.text)
+        try Self.validateCommandCompletion(result, command: "context", allowIdleOutput: true)
+        return self.parseContextUsage(output: result.output)
     }
 
-    /// Runs `kiro-cli` through a pseudo-terminal. The CLI (forked from Amazon Q Developer CLI)
-    /// performs terminal setup on startup and produces no output at all when launched without a
-    /// controlling terminal, so a plain pipe-backed launch hangs until it is killed. Routing every
-    /// invocation through a PTY (as the Codex/Claude probes do) is what makes it emit output.
+    /// Recent Kiro CLIs can keep their TUI alive indefinitely under a PTY even with `--no-interactive`,
+    /// while older releases emit no output through pipes. Prefer pipes and retain PTY as a bounded fallback.
+    private func runCommand(
+        arguments: [String],
+        timeout: TimeInterval,
+        idleTimeout: TimeInterval) async throws -> KiroCLIResult
+    {
+        do {
+            return try await self.runViaPipe(
+                arguments: arguments,
+                timeout: min(timeout, self.pipeTimeoutCap),
+                idleTimeout: idleTimeout)
+        } catch KiroStatusProbeError.timeout {
+            Self.logger.debug("Kiro pipe probe timed out; retrying through PTY")
+            return try self.runViaPTY(
+                arguments: arguments,
+                timeout: timeout,
+                idleTimeout: idleTimeout)
+        }
+    }
+
+    private func runViaPipe(
+        arguments: [String],
+        timeout: TimeInterval,
+        idleTimeout: TimeInterval) async throws -> KiroCLIResult
+    {
+        guard let binary = self.cliBinaryResolver() else {
+            throw KiroStatusProbeError.cliNotFound
+        }
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+
+        var env = ProcessInfo.processInfo.environment
+        env["TERM"] = "xterm-256color"
+
+        final class ActivityState: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _lastActivityAt = Date()
+            private var _hasReceivedOutput = false
+
+            var lastActivityAt: Date {
+                self.lock.withLock { self._lastActivityAt }
+            }
+
+            var hasReceivedOutput: Bool {
+                self.lock.withLock { self._hasReceivedOutput }
+            }
+
+            func markActivity() {
+                self.lock.withLock {
+                    self._lastActivityAt = Date()
+                    self._hasReceivedOutput = true
+                }
+            }
+        }
+
+        let state = ActivityState()
+        let stdoutCapture = ProcessPipeCapture(pipe: stdoutPipe, onData: { state.markActivity() })
+        let stderrCapture = ProcessPipeCapture(pipe: stderrPipe, onData: { state.markActivity() })
+        stdoutCapture.start()
+        stderrCapture.start()
+
+        let process: SpawnedProcessGroup
+        do {
+            process = try SpawnedProcessGroup.launch(
+                binary: binary,
+                arguments: arguments,
+                environment: env,
+                stdoutPipe: stdoutPipe,
+                stderrPipe: stderrPipe)
+        } catch {
+            stdoutCapture.stop()
+            stderrCapture.stop()
+            throw error
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        var didHitDeadline = false
+        var didTerminateForIdle = false
+
+        do {
+            while process.isRunning {
+                try Task.checkCancellation()
+                if Date() >= deadline {
+                    didHitDeadline = true
+                    break
+                }
+                if state.hasReceivedOutput,
+                   Date().timeIntervalSince(state.lastActivityAt) >= idleTimeout
+                {
+                    didTerminateForIdle = true
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(100))
+            }
+        } catch {
+            await process.terminate()
+            stdoutCapture.stop()
+            stderrCapture.stop()
+            throw error
+        }
+
+        if process.isRunning {
+            await process.terminate()
+            guard !process.isRunning else {
+                stdoutCapture.stop()
+                stderrCapture.stop()
+                throw KiroStatusProbeError.timeout
+            }
+            if didHitDeadline || !state.hasReceivedOutput {
+                stdoutCapture.stop()
+                stderrCapture.stop()
+                throw KiroStatusProbeError.timeout
+            }
+        }
+        if process.hasResidualProcessGroup {
+            await process.terminateResidualProcesses()
+        }
+
+        let stdoutData = await stdoutCapture.finish(timeout: .seconds(1))
+        let stderrData = await stderrCapture.finish(timeout: .seconds(1))
+        if !stdoutCapture.reachedEOF || !stderrCapture.reachedEOF {
+            await process.terminateResidualProcesses()
+        }
+        await process.finish()
+        guard let terminationStatus = process.terminationStatus else {
+            throw KiroStatusProbeError.timeout
+        }
+        return KiroCLIResult(
+            stdout: ProcessPipeCapture.decodeUTF8(stdoutData),
+            stderr: ProcessPipeCapture.decodeUTF8(stderrData),
+            terminationStatus: terminationStatus,
+            terminatedForIdle: didTerminateForIdle)
+    }
+
     private func runViaPTY(
         arguments: [String],
         timeout: TimeInterval,
-        idleTimeout: TimeInterval) throws -> TTYCommandRunner.Result
+        idleTimeout: TimeInterval) throws -> KiroCLIResult
     {
         guard let binary = self.cliBinaryResolver() else {
             throw KiroStatusProbeError.cliNotFound
         }
         do {
-            return try TTYCommandRunner().run(
+            let result = try TTYCommandRunner().run(
                 binary: binary,
                 send: "",
                 options: TTYCommandRunner.Options(
@@ -470,6 +622,22 @@ public struct KiroStatusProbe: Sendable {
                     idleTimeout: idleTimeout,
                     extraArgs: arguments,
                     returnOnEmptyProcessExit: true))
+            switch result.completion {
+            case let .processExited(status):
+                return KiroCLIResult(
+                    stdout: result.text,
+                    stderr: "",
+                    terminationStatus: status,
+                    terminatedForIdle: false)
+            case .idleTimeout:
+                return KiroCLIResult(
+                    stdout: result.text,
+                    stderr: "",
+                    terminationStatus: 0,
+                    terminatedForIdle: true)
+            case .outputCondition, .deadlineExceeded:
+                throw KiroStatusProbeError.timeout
+            }
         } catch TTYCommandRunner.Error.binaryNotFound {
             throw KiroStatusProbeError.cliNotFound
         } catch TTYCommandRunner.Error.timedOut {
@@ -479,22 +647,21 @@ public struct KiroStatusProbe: Sendable {
         }
     }
 
-    private static func validatePTYCompletion(
-        _ result: TTYCommandRunner.Result,
+    private static func validateCommandCompletion(
+        _ result: KiroCLIResult,
         command: String,
         allowIdleOutput: Bool) throws
     {
-        switch result.completion {
-        case let .processExited(status):
-            guard status == 0 else {
-                let message = Self.stripANSI(result.text).trimmingCharacters(in: .whitespacesAndNewlines)
-                throw KiroStatusProbeError.cliFailed(
-                    message.isEmpty ? "Kiro CLI \(command) failed with status \(status)." : message)
-            }
-        case .idleTimeout:
+        if result.terminatedForIdle {
             guard allowIdleOutput else { throw KiroStatusProbeError.timeout }
-        case .outputCondition, .deadlineExceeded:
-            throw KiroStatusProbeError.timeout
+            return
+        }
+        guard result.terminationStatus == 0 else {
+            let message = Self.stripANSI(result.output).trimmingCharacters(in: .whitespacesAndNewlines)
+            throw KiroStatusProbeError.cliFailed(
+                message.isEmpty
+                    ? "Kiro CLI \(command) failed with status \(result.terminationStatus)."
+                    : message)
         }
     }
 

--- a/Tests/CodexBarTests/KiroStatusProbeTestSupport.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTestSupport.swift
@@ -1,0 +1,83 @@
+import Foundation
+@testable import CodexBarCore
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+final class KiroTestProcessRegistry: @unchecked Sendable {
+    private struct Record {
+        var processGroup: pid_t?
+    }
+
+    private let lock = NSLock()
+    private let blockOnUnregister: Int?
+    private let blockStartedURL: URL?
+    private let unblock: DispatchSemaphore?
+    private var records: [pid_t: Record] = [:]
+    private var unregisteredPIDs: Set<pid_t> = []
+    private var unregisterCount = 0
+
+    init(
+        blockOnUnregister: Int? = nil,
+        blockStartedURL: URL? = nil,
+        unblock: DispatchSemaphore? = nil)
+    {
+        self.blockOnUnregister = blockOnUnregister
+        self.blockStartedURL = blockStartedURL
+        self.unblock = unblock
+    }
+
+    var dependencies: KiroStatusProbe.PipeProcessRegistry {
+        .init(
+            beginLaunch: { true },
+            endLaunch: {},
+            register: { pid, _ in
+                self.lock.withLock {
+                    self.records[pid] = Record(processGroup: nil)
+                }
+                return true
+            },
+            updateProcessGroup: { pid, processGroup in
+                self.lock.withLock {
+                    guard self.records[pid] != nil else { return }
+                    self.records[pid]?.processGroup = processGroup
+                }
+            },
+            unregister: { pid in
+                let shouldBlock = self.lock.withLock {
+                    self.records.removeValue(forKey: pid)
+                    self.unregisteredPIDs.insert(pid)
+                    self.unregisterCount += 1
+                    return self.unregisterCount == self.blockOnUnregister
+                }
+                if shouldBlock {
+                    if let blockStartedURL = self.blockStartedURL {
+                        _ = FileManager.default.createFile(atPath: blockStartedURL.path, contents: Data())
+                    }
+                    self.unblock?.wait()
+                }
+            })
+    }
+
+    func isRegistered(_ pid: pid_t) -> Bool {
+        self.lock.withLock { self.records[pid] != nil }
+    }
+
+    func didUnregister(_ pid: pid_t) -> Bool {
+        self.lock.withLock { self.unregisteredPIDs.contains(pid) }
+    }
+
+    func terminate(_ pid: pid_t) {
+        let processGroup = self.lock.withLock { () -> pid_t? in
+            self.records[pid]?.processGroup
+        }
+        if let processGroup, processGroup > 0, processGroup != getpgrp() {
+            _ = kill(-processGroup, SIGKILL)
+        }
+        if pid > 0 {
+            _ = kill(pid, SIGKILL)
+        }
+    }
+}

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -52,6 +52,108 @@ struct KiroStatusProbeTests {
     }
 
     @Test
+    func `pipe and PTY share the account deadline`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              if [ ! -t 1 ]; then
+                sleep 5
+                exit 1
+              fi
+              sleep 0.45
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let snapshot = try await KiroStatusProbe(
+            cliBinaryResolver: { cliURL.path },
+            accountProbeTimeout: 0.8,
+            pipeTimeoutCap: 0.4).fetch()
+
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(snapshot.accountEmail == nil)
+        #expect(snapshot.authMethod == nil)
+    }
+
+    @Test
+    func `accepted pipe output cannot overrun the usage deadline`() async throws {
+        let pipePIDFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-deadline-\(UUID().uuidString).pid")
+        let ptyMarker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-deadline-\(UUID().uuidString).pty")
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              if [ ! -t 1 ]; then
+                printf '%s\n' "$$" > '\(pipePIDFile.path)'
+                printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+                printf 'Credits (12.50 of 50 covered in plan)\n'
+                printf '████████████████████ 25%%\n'
+                trap '' TERM
+                while true; do sleep 1; done
+              fi
+              : > '\(ptyMarker.path)'
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+        defer {
+            if let text = try? String(contentsOf: pipePIDFile, encoding: .utf8),
+               let pipePID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            {
+                _ = kill(pipePID, SIGKILL)
+            }
+            try? FileManager.default.removeItem(at: pipePIDFile)
+            try? FileManager.default.removeItem(at: ptyMarker)
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+        }
+
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        let probe = KiroStatusProbe(
+            cliBinaryResolver: { cliURL.path },
+            usageProbeTimeout: 0.8,
+            pipeTimeoutCap: 0.4)
+
+        await #expect {
+            _ = try await probe.fetch()
+        } throws: { error in
+            guard case KiroStatusProbeError.timeout = error else { return false }
+            return true
+        }
+
+        #expect(startedAt.duration(to: clock.now) < .seconds(2))
+        #expect(!FileManager.default.fileExists(atPath: ptyMarker.path))
+        let pipePIDText = try String(contentsOf: pipePIDFile, encoding: .utf8)
+        let pipePID = try #require(pid_t(pipePIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        #expect(kill(pipePID, 0) == -1)
+    }
+
+    @Test
     func `fetch preserves account info when account probe succeeds`() async throws {
         let cliURL = try self.makeCLI(
             """
@@ -82,7 +184,9 @@ struct KiroStatusProbeTests {
         #expect(snapshot.accountEmail == "person@example.com")
         #expect(snapshot.authMethod == "Google")
     }
+}
 
+extension KiroStatusProbeTests {
     @Test
     func `fetch supports kiro cli that only completes through pipes`() async throws {
         let cliURL = try self.makeCLI(
@@ -162,6 +266,270 @@ struct KiroStatusProbeTests {
     }
 
     @Test
+    func `fetch falls back to PTY after incomplete pipe output`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ ! -t 1 ]; then
+              if [ "$1" = "whoami" ]; then
+                printf 'Logged in with Google\nEmail: person@example.com\n'
+                exit 0
+              fi
+              if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+                printf 'Plan: loading...\n'
+                exit 0
+              fi
+              if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+                exit 0
+              fi
+            fi
+
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let snapshot = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(snapshot.creditsUsed == 12.50)
+    }
+
+    @Test
+    func `pipe cleanup finishes before PTY fallback starts`() async throws {
+        let childPIDFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-pipe-child-\(UUID().uuidString).pid")
+        let ptyMarker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-pty-fallback-\(UUID().uuidString).started")
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              if [ ! -t 1 ]; then
+                (trap '' TERM; while true; do sleep 1; done) &
+                child=$!
+                printf '%s\n' "$child" > '\(childPIDFile.path)'
+                printf 'Plan: loading...\n'
+                exit 0
+              fi
+              if test -s '\(childPIDFile.path)' && kill -0 "$(cat '\(childPIDFile.path)')" 2>/dev/null; then
+                printf 'pipe child still running\n' >&2
+                exit 97
+              fi
+              : > '\(ptyMarker.path)'
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+        defer {
+            if let text = try? String(contentsOf: childPIDFile, encoding: .utf8),
+               let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            {
+                _ = kill(childPID, SIGKILL)
+            }
+            try? FileManager.default.removeItem(at: childPIDFile)
+            try? FileManager.default.removeItem(at: ptyMarker)
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+        }
+
+        let snapshot = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(FileManager.default.fileExists(atPath: ptyMarker.path))
+        let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
+        let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        #expect(kill(childPID, 0) == -1)
+    }
+
+    @Test
+    func `shutdown registry terminates an active pipe probe`() async throws {
+        let pipePIDFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-shutdown-\(UUID().uuidString).pid")
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              if [ -t 1 ]; then
+                exit 97
+              fi
+              printf '%s\n' "$$" > '\(pipePIDFile.path)'
+              printf 'Plan: loading...\n'
+              trap '' TERM
+              while true; do sleep 1; done
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+
+        let registry = KiroTestProcessRegistry()
+        let task = Task {
+            try await KiroStatusProbe(
+                cliBinaryResolver: { cliURL.path },
+                pipeProcessRegistry: registry.dependencies).fetch()
+        }
+        defer {
+            task.cancel()
+            if let text = try? String(contentsOf: pipePIDFile, encoding: .utf8),
+               let pipePID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            {
+                _ = kill(pipePID, SIGKILL)
+            }
+            try? FileManager.default.removeItem(at: pipePIDFile)
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+        }
+
+        try await waitForFile(pipePIDFile)
+        let pipePIDText = try String(contentsOf: pipePIDFile, encoding: .utf8)
+        let pipePID = try #require(pid_t(pipePIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        #expect(registry.isRegistered(pipePID))
+
+        let clock = ContinuousClock()
+        let shutdownStartedAt = clock.now
+        registry.terminate(pipePID)
+        await #expect(throws: (any Error).self) {
+            _ = try await task.value
+        }
+
+        #expect(shutdownStartedAt.duration(to: clock.now) < .seconds(2))
+        #expect(!registry.isRegistered(pipePID))
+        #expect(registry.didUnregister(pipePID))
+        #expect(kill(pipePID, 0) == -1)
+    }
+
+    @Test
+    func `fetch combines pipe stdout with stderr warnings`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ -t 1 ]; then
+              exit 91
+            fi
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              printf 'warning: cached session\n' >&2
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              printf 'warning: telemetry unavailable\n' >&2
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let snapshot = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(snapshot.accountEmail == "person@example.com")
+        #expect(snapshot.authMethod == "Google")
+    }
+
+    @Test
+    func `fetch falls back to PTY after pipe requires a terminal`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ ! -t 1 ]; then
+              printf 'terminal required\n' >&2
+              exit 2
+            fi
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              printf 'Context window: 7.5%% used (estimated)\n'
+              printf '█ Context files 2.5%% (estimated)\n'
+              exit 0
+            fi
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let snapshot = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(snapshot.accountEmail == "person@example.com")
+        #expect(snapshot.contextUsage?.totalPercentUsed == 7.5)
+        #expect(snapshot.contextUsage?.contextFilesPercent == 2.5)
+    }
+
+    @Test
+    func `pipe auth failure on stderr remains authoritative`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ ! -t 1 ]; then
+              printf 'Opening browser...\n'
+              printf 'Not logged in\n' >&2
+              exit 1
+            fi
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        await #expect {
+            _ = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+        } throws: { error in
+            guard case KiroStatusProbeError.notLoggedIn = error else { return false }
+            return true
+        }
+    }
+
+    @Test
     func `fetch rejects account markers from failed whoami`() async throws {
         let cliURL = try self.makeCLI(
             """
@@ -197,6 +565,19 @@ struct KiroStatusProbeTests {
         let cliURL = try self.makeCLI(
             """
             #!/bin/sh
+            if [ -t 1 ]; then
+              if [ "$1" = "whoami" ]; then
+                printf 'Logged in with Google\nEmail: person@example.com\n'
+                exit 0
+              fi
+              if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+                printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+                printf 'Credits (12.50 of 50 covered in plan)\n'
+                printf '████████████████████ 25%%\n'
+                exit 0
+              fi
+            fi
+
             if [ "$1" = "whoami" ]; then
               printf 'Logged in with Google\nEmail: person@example.com\n'
               exit 0
@@ -364,6 +745,56 @@ struct KiroStatusProbeTests {
             try await task.value
         }
         #expect(Date().timeIntervalSince(cancelledAt) < 4)
+    }
+
+    @Test
+    func `cancellation during pipe cleanup wins over an expired context deadline`() async throws {
+        let cleanupStarted = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-cleanup-\(UUID().uuidString).started")
+        let unblockCleanup = DispatchSemaphore(value: 0)
+        let registry = KiroTestProcessRegistry(
+            blockOnUnregister: 3,
+            blockStartedURL: cleanupStarted,
+            unblock: unblockCleanup)
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+        defer {
+            unblockCleanup.signal()
+            try? FileManager.default.removeItem(at: cleanupStarted)
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+        }
+
+        let probe = KiroStatusProbe(
+            cliBinaryResolver: { cliURL.path },
+            contextProbeTimeout: 0.2,
+            pipeProcessRegistry: registry.dependencies)
+        let task = Task { try await probe.fetch() }
+        defer { task.cancel() }
+
+        try await waitForFile(cleanupStarted)
+        task.cancel()
+        try await Task.sleep(for: .milliseconds(250))
+        unblockCleanup.signal()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -226,6 +226,40 @@ extension KiroStatusProbeTests {
     }
 
     @Test
+    func `slow pipe remains viable after PTY fallback starts`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ -t 1 ]; then
+              exit 97
+            fi
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              sleep 1
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let snapshot = try await KiroStatusProbe(
+            cliBinaryResolver: { cliURL.path },
+            usageProbeTimeout: 2,
+            pipeTimeoutCap: 0.2).fetch()
+
+        #expect(snapshot.planName == "KIRO FREE")
+    }
+
+    @Test
     func `fetch falls back to PTY for older kiro cli`() async throws {
         let cliURL = try self.makeCLI(
             """

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -84,6 +84,84 @@ struct KiroStatusProbeTests {
     }
 
     @Test
+    func `fetch supports kiro cli that only completes through pipes`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ -t 1 ]; then
+              sleep 30
+              exit 1
+            fi
+
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        let snapshot = try await probe.fetch()
+
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(snapshot.creditsUsed == 12.50)
+        #expect(snapshot.accountEmail == "person@example.com")
+    }
+
+    @Test
+    func `fetch falls back to PTY for older kiro cli`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ ! -t 1 ]; then
+              sleep 30
+              exit 1
+            fi
+
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let probe = KiroStatusProbe(
+            cliBinaryResolver: { cliURL.path },
+            pipeTimeoutCap: 0.2)
+        let snapshot = try await probe.fetch()
+
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(snapshot.creditsUsed == 12.50)
+        #expect(snapshot.accountEmail == "person@example.com")
+    }
+
+    @Test
     func `fetch rejects account markers from failed whoami`() async throws {
         let cliURL = try self.makeCLI(
             """

--- a/Tests/CodexBarTests/KiroTransportRaceTests.swift
+++ b/Tests/CodexBarTests/KiroTransportRaceTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct KiroTransportRaceTests {
+    @Test
+    func `empty nonzero pipe exit falls back to PTY`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ ! -t 1 ]; then
+              exit 42
+            fi
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let snapshot = try await KiroStatusProbe(
+            cliBinaryResolver: { cliURL.path },
+            pipeTimeoutCap: 0.2).fetch()
+
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(snapshot.accountEmail == "person@example.com")
+    }
+
+    @Test
+    func `failed PTY cannot preempt a valid slow pipe`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              if [ -t 1 ]; then
+                printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+                printf 'Credits (49 of 50 covered in plan)\n'
+                printf '████████████████████ 98%%\n'
+                exit 91
+              fi
+              sleep 1
+              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
+              printf 'Credits (12.50 of 50 covered in plan)\n'
+              printf '████████████████████ 25%%\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+              exit 0
+            fi
+            exit 1
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let snapshot = try await KiroStatusProbe(
+            cliBinaryResolver: { cliURL.path },
+            usageProbeTimeout: 2,
+            pipeTimeoutCap: 0.2).fetch()
+
+        #expect(snapshot.creditsUsed == 12.50)
+    }
+
+    @Test
+    func `pending failed PTY cannot escape the shared deadline`() async throws {
+        let cliURL = try self.makeCLI(
+            """
+            #!/bin/sh
+            if [ "$1" = "whoami" ]; then
+              printf 'Logged in with Google\nEmail: person@example.com\n'
+              exit 0
+            fi
+            if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              if [ -t 1 ]; then
+                exit 91
+              fi
+              sleep 5
+              exit 0
+            fi
+            exit 0
+            """)
+        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+
+        let probe = KiroStatusProbe(
+            cliBinaryResolver: { cliURL.path },
+            usageProbeTimeout: 0.6,
+            pipeTimeoutCap: 0.1)
+
+        await #expect {
+            try await probe.fetch()
+        } throws: { error in
+            guard case KiroStatusProbeError.timeout = error else { return false }
+            return true
+        }
+    }
+
+    private func makeCLI(_ script: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-race-\(UUID().uuidString)", isDirectory: true)
+        let cliURL = root.appendingPathComponent("kiro-cli")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try script.write(to: cliURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cliURL.path)
+        return cliURL
+    }
+}

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -14,7 +14,9 @@ Kiro uses the AWS `kiro-cli` tool to fetch usage data. No browser cookies or OAu
 
 1) **CLI command** (primary and only strategy)
    - Command: `kiro-cli chat --no-interactive "/usage"`
-   - Timeout: 20 seconds (idle cutoff after ~10s of no output once the CLI starts responding).
+   - Timeout: 20 seconds (idle cutoff after 4 seconds of no output once the CLI starts responding).
+   - CodexBar tries ordinary stdout/stderr pipes first for current Kiro CLI releases. Incomplete or unusable
+     pipe output falls back to a pseudo-terminal within the same overall command deadline for older releases.
    - Requires `kiro-cli` installed and logged in via AWS Builder ID.
    - Output is ANSI-decorated; CodexBar strips escape sequences before parsing.
 


### PR DESCRIPTION
## Summary

- Prefer semantically validated pipe-backed Kiro CLI probes for current releases.
- Retain a same-deadline PTY fallback for older or terminal-required Kiro CLIs.
- Make stdout/stderr, cancellation, process cleanup, and app-shutdown ownership deterministic.
- Add focused regressions for pipe, PTY, partial output, auth, deadlines, cancellation, and process cleanup.

Closes #1883.

## Root cause

Current Kiro CLI releases can return normally through pipes but stall when launched directly under a PTY. Older releases had the inverse behavior and required a terminal. The original candidate retried PTY only after a thrown pipe timeout, so incomplete or noisy pipe output could bypass the fallback, and each transport could consume a fresh timeout budget.

## Implementation

- Validate pipe results per command before accepting them; incomplete output falls through to PTY.
- Keep authentication failures authoritative while preventing failed transports from preempting a viable peer.
- Use one monotonic deadline across a staggered pipe/PTY race, cleanup, and result selection.
- Give pipe launches the same login-shell-enriched environment used by PTY launches so GUI refreshes resolve the same CLI.
- Combine stdout and stderr deterministically and drain both concurrently.
- Fully terminate and reap pipe roots, descendants, and output holders before starting PTY.
- Register pipe PIDs and process groups with the app-shutdown registry.
- Preserve cancellation before launch, between transports, during cleanup, and before return.

## Validation

- Exact head: `7846f59bc3ebebd87ff8432b8d016ca1e61f8b6f`, rebased onto current `main` after #2074.
- Exact-head focused Kiro matrix: 63/63 passed across four suites, including pipe-only current CLI, PTY-only legacy CLI, slow-pipe/PTY races, failed-transport authority, authentication rejection, shared deadlines, process cleanup, app shutdown, and cancellation.
- Exact-head `make check`: SwiftFormat and SwiftLint clean.
- Exact-head full local suite: 615 selections in 52 groups; every group passed first attempt, with zero retries, recoveries, or timeouts.
- Final autoreview: clean, no accepted/actionable findings; 0.86 correctness confidence.
- Controlled live-process fixtures exercised actual pipes, PTYs, child processes, cancellation, signals, and deadline cleanup. No fixture process survived its test.
- No dependency changes.

## Live-provider limitation

This machine does not have `kiro-cli` installed or an approved logged-in Kiro account, so a real authenticated provider request was intentionally not attempted. The transport state machine and OS-process behavior are covered by the exact-head integration matrix; contributor and maintainer authorization to land this repair waives the unavailable account-dependent proof.
