### PR TITLE
Fix: Keep cost history chart steady while hovering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - CLI server: retain timed-out route and provider work until it actually exits, preventing repeated requests or config changes from stacking background fetches. Thanks @Yuxin-Qiao!
 - Token costs: coalesce bounded pricing-catalog refreshes when a newly observed model is still unpriced, preserving its exact usage until pricing arrives. Thanks @iam-brain!
+- Cost history: keep model breakdown menus steady while hovering, preserve compact rows, and make overflowing histories scrollable. Thanks @iam-brain!
 - Ollama: validate API keys against an authenticated endpoint instead of the public model catalog while preserving refresh cancellation. Thanks @joeVenner!
 - Claude CLI: resolve yearless and time-only reset timestamps against their quota window and exact calendar occurrence, keeping recently stale resets current without moving future, leap-day, or repeated-hour resets into the past. Thanks @fanwenlin!
 - Catalan: complete current strings, align instructional voice, and enforce catalog parity. Thanks @pmontp19!

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -158,62 +158,72 @@ struct CostHistoryChartMenuView: View {
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
-                    ScrollView(.vertical) {
-                        VStack(alignment: .leading, spacing: Self.detailSpacing) {
-                            ForEach(detail.rows) { row in
-                                HStack(alignment: .top, spacing: 8) {
-                                    Rectangle()
-                                        .fill(row.accentColor)
-                                        .frame(
-                                            width: 2,
-                                            height: Self.accentHeight(for: row))
-                                        .padding(.top, 1)
+                    if model.detailViewportRowCount > 0 {
+                        ScrollView(.vertical) {
+                            VStack(alignment: .leading, spacing: Self.detailSpacing) {
+                                ForEach(detail.rows) { row in
+                                    HStack(alignment: .top, spacing: 8) {
+                                        Rectangle()
+                                            .fill(row.accentColor)
+                                            .frame(
+                                                width: 2,
+                                                height: Self.accentHeight(for: row))
+                                            .padding(.top, 1)
 
-                                    VStack(alignment: .leading, spacing: 1) {
-                                        Text(row.title)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                            .lineLimit(1)
-                                            .truncationMode(.tail)
-                                            .frame(height: Self.detailTitleLineHeight, alignment: .leading)
-                                        if let subtitle = row.subtitle {
-                                            Text(subtitle)
-                                                .font(.caption2)
-                                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                        VStack(alignment: .leading, spacing: 1) {
+                                            Text(row.title)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
-                                                .frame(
-                                                    height: Self.detailSubtitleLineHeight,
-                                                    alignment: .leading)
-                                        }
-                                        if let modeSubtitle = row.modeSubtitle {
-                                            Text(modeSubtitle)
-                                                .font(.caption2)
-                                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                                                .lineLimit(1)
-                                                .truncationMode(.tail)
-                                                .frame(
-                                                    height: Self.detailSubtitleLineHeight,
-                                                    alignment: .leading)
+                                                .frame(height: Self.detailTitleLineHeight, alignment: .leading)
+                                            if let subtitle = row.subtitle {
+                                                Text(subtitle)
+                                                    .font(.caption2)
+                                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                                    .lineLimit(1)
+                                                    .truncationMode(.tail)
+                                                    .frame(
+                                                        height: Self.detailSubtitleLineHeight,
+                                                        alignment: .leading)
+                                            }
+                                            if let modeSubtitle = row.modeSubtitle {
+                                                Text(modeSubtitle)
+                                                    .font(.caption2)
+                                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                                    .lineLimit(1)
+                                                    .truncationMode(.tail)
+                                                    .frame(
+                                                        height: Self.detailSubtitleLineHeight,
+                                                        alignment: .leading)
+                                            }
                                         }
                                     }
+                                    .frame(height: Self.detailRowHeight, alignment: .leading)
                                 }
-                                .frame(height: Self.detailRowHeight(for: row), alignment: .leading)
                             }
                         }
-                    }
-                    .scrollIndicators(
-                        Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
-                    .frame(height: Self.detailRowsViewportHeight, alignment: .topLeading)
-                    .id(selectedDateKey)
+                        .scrollIndicators(
+                            Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
+                        .frame(
+                            height: Self.detailRowsViewportHeight(rowCount: model.detailViewportRowCount),
+                            alignment: .topLeading)
+                        .id(selectedDateKey)
 
-                    Text(Self.detailOverflowHint(itemCount: detail.rows.count) ?? " ")
-                        .font(.caption2)
-                        .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                        .frame(height: Self.detailHintHeight, alignment: .leading)
-                        .accessibilityHidden(!Self.detailRowsNeedScrolling(itemCount: detail.rows.count))
+                        if model.hasDetailOverflow {
+                            Text(Self.detailOverflowHint(itemCount: detail.rows.count) ?? " ")
+                                .font(.caption2)
+                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                .frame(height: Self.detailHintHeight, alignment: .leading)
+                                .accessibilityHidden(!Self.detailRowsNeedScrolling(itemCount: detail.rows.count))
+                        }
+                    }
                 }
-                .frame(height: Self.detailBlockHeight, alignment: .topLeading)
+                .frame(
+                    height: Self.detailBlockHeight(
+                        rowCount: model.detailViewportRowCount,
+                        hasOverflow: model.hasDetailOverflow),
+                    alignment: .topLeading)
             }
 
             if let total = self.totalCostUSD {
@@ -277,6 +287,8 @@ struct CostHistoryChartMenuView: View {
         let barColor: Color
         let peakKey: String?
         let maxCostUSD: Double
+        let detailViewportRowCount: Int
+        let hasDetailOverflow: Bool
     }
 
     private static let selectionBandColor = Color(nsColor: .labelColor).opacity(0.1)
@@ -284,8 +296,7 @@ struct CostHistoryChartMenuView: View {
     private static let detailPrimaryLineHeight: CGFloat = 16
     private static let detailTitleLineHeight: CGFloat = 16
     private static let detailSubtitleLineHeight: CGFloat = 13
-    private static let compactDetailRowHeight: CGFloat = 36
-    private static let expandedDetailRowHeight: CGFloat = 44
+    private static let detailRowHeight: CGFloat = 44
     private static let detailSpacing: CGFloat = 6
     private static let detailHintHeight: CGFloat = 13
     private static let chartHeight: CGFloat = 130
@@ -300,38 +311,6 @@ struct CostHistoryChartMenuView: View {
     private static let maxVisibleProjectSourceRows = 2
     static let verticalPadding: CGFloat = 10
 
-    private static func totalCardHeight(
-        hasTotal: Bool,
-        projects: [CostUsageProjectBreakdown] = []) -> CGFloat
-    {
-        var height = self.verticalPadding * 2
-        height += self.chartHeight
-        height += self.outerSpacing
-        height += self.detailBlockHeight
-        if hasTotal {
-            height += self.outerSpacing
-            height += self.detailPrimaryLineHeight
-        }
-        if !projects.isEmpty {
-            height += self.outerSpacing
-            height += self.projectBlockHeight(projects: projects)
-        }
-        return height
-    }
-
-    private static func totalCardHeight(hasTotal: Bool, projectCount: Int) -> CGFloat {
-        let projects = (0..<projectCount).map { index in
-            CostUsageProjectBreakdown(
-                name: "Project \(index)",
-                path: "/tmp/project-\(index)",
-                totalTokens: nil,
-                totalCostUSD: nil,
-                daily: [],
-                modelBreakdowns: nil)
-        }
-        return self.totalCardHeight(hasTotal: hasTotal, projects: projects)
-    }
-
     static func windowLabel(days: Int) -> String {
         if days == 1 {
             return L("Today")
@@ -339,16 +318,8 @@ struct CostHistoryChartMenuView: View {
         return String(format: L("Last %d days"), days)
     }
 
-    private static func detailRowHeight(for row: DetailRow) -> CGFloat {
-        self.detailRowHeight(hasModeSubtitle: row.modeSubtitle != nil)
-    }
-
-    private static func detailRowHeight(hasModeSubtitle: Bool) -> CGFloat {
-        hasModeSubtitle ? self.expandedDetailRowHeight : self.compactDetailRowHeight
-    }
-
     private static func accentHeight(for row: DetailRow) -> CGFloat {
-        row.subtitle == nil && row.modeSubtitle == nil ? 14 : self.detailRowHeight(for: row)
+        row.subtitle == nil && row.modeSubtitle == nil ? 14 : self.detailRowHeight
     }
 
     private static func capHeight(maxValue: Double) -> Double {
@@ -382,6 +353,7 @@ struct CostHistoryChartMenuView: View {
 
         var peak: (key: String, costUSD: Double)?
         var maxCostUSD: Double = 0
+        var maxDetailRows = 0
         for entry in sorted {
             guard let costUSD = entry.costUSD, costUSD >= 0 else { continue }
             guard let date = self.dateFromDayKey(entry.date) else { continue }
@@ -394,6 +366,7 @@ struct CostHistoryChartMenuView: View {
             pointsByKey[entry.date] = point
             entriesByKey[entry.date] = entry
             dateKeys.append((entry.date, date))
+            maxDetailRows = max(maxDetailRows, entry.modelBreakdowns?.count ?? 0)
             if let cur = peak {
                 if costUSD > cur.costUSD { peak = (entry.date, costUSD) }
             } else {
@@ -417,7 +390,9 @@ struct CostHistoryChartMenuView: View {
             axisDates: axisDates,
             barColor: barColor,
             peakKey: maxCostUSD > 0 ? peak?.key : nil,
-            maxCostUSD: maxCostUSD)
+            maxCostUSD: maxCostUSD,
+            detailViewportRowCount: min(maxDetailRows, self.maxVisibleDetailLines),
+            hasDetailOverflow: maxDetailRows > self.maxVisibleDetailLines)
     }
 
     private static func axisLabelPlacement(for dates: [Date]) -> AxisLabelPlacement {
@@ -470,16 +445,20 @@ struct CostHistoryChartMenuView: View {
         return model.pointsByDateKey[key]
     }
 
-    private static func hasModeSubtitle(_ item: CostUsageDailyReport.ModelBreakdown) -> Bool {
-        item.standardCostUSD != nil || item.priorityCostUSD != nil
+    private static func detailRowsViewportHeight(rowCount: Int) -> CGFloat {
+        guard rowCount > 0 else { return 0 }
+        return CGFloat(rowCount) * self.detailRowHeight + CGFloat(rowCount - 1) * self.detailSpacing
     }
 
-    private static let detailRowsViewportHeight =
-        CGFloat(maxVisibleDetailLines) * expandedDetailRowHeight +
-        CGFloat(maxVisibleDetailLines - 1) * detailSpacing
-
-    private static let detailBlockHeight = detailPrimaryLineHeight + detailSpacing +
-        detailRowsViewportHeight + detailSpacing + detailHintHeight
+    private static func detailBlockHeight(rowCount: Int, hasOverflow: Bool) -> CGFloat {
+        guard rowCount > 0 else { return self.detailPrimaryLineHeight }
+        var height = self.detailPrimaryLineHeight + self.detailSpacing
+        height += self.detailRowsViewportHeight(rowCount: rowCount)
+        if hasOverflow {
+            height += self.detailSpacing + self.detailHintHeight
+        }
+        return height
+    }
 
     private static func projectBlockHeight(projects: [CostUsageProjectBreakdown]) -> CGFloat {
         let visibleProjects = Array(projects.prefix(self.maxVisibleProjectRows))
@@ -783,48 +762,12 @@ extension CostHistoryChartMenuView {
         self.yAxisCostString(value, currencyCode: currencyCode)
     }
 
-    static var _detailViewportHeightForTesting: CGFloat {
-        self.detailRowsViewportHeight
-    }
-
-    static var _detailBlockHeightForTesting: CGFloat {
-        self.detailBlockHeight
-    }
-
-    static func _totalCardHeightForTesting(
-        modeSubtitlePresence: [Bool],
-        hasTotal: Bool,
-        projectCount: Int = 0) -> CGFloat
+    static func _detailViewportConfigurationForTesting(
+        provider: UsageProvider,
+        daily: [DailyEntry]) -> (rowCount: Int, hasOverflow: Bool)
     {
-        _ = modeSubtitlePresence
-        return self.totalCardHeight(hasTotal: hasTotal, projectCount: projectCount)
-    }
-
-    static func _totalCardHeightForTesting(
-        modeSubtitlePresence: [Bool],
-        hasTotal: Bool,
-        projectSourceCounts: [Int]) -> CGFloat
-    {
-        _ = modeSubtitlePresence
-        let projects = projectSourceCounts.enumerated().map { index, sourceCount in
-            CostUsageProjectBreakdown(
-                name: "Project \(index)",
-                path: "/tmp/project-\(index)",
-                totalTokens: nil,
-                totalCostUSD: nil,
-                daily: [],
-                modelBreakdowns: nil,
-                sources: (0..<sourceCount).map { sourceIndex in
-                    CostUsageProjectSourceBreakdown(
-                        name: "Source \(sourceIndex)",
-                        path: "/tmp/project-\(index)-source-\(sourceIndex)",
-                        totalTokens: nil,
-                        totalCostUSD: nil,
-                        daily: [],
-                        modelBreakdowns: nil)
-                })
-        }
-        return self.totalCardHeight(hasTotal: hasTotal, projects: projects)
+        let model = self.makeModel(provider: provider, daily: daily)
+        return (model.detailViewportRowCount, model.hasDetailOverflow)
     }
 }
 

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -167,7 +167,9 @@ struct CostHistoryChartMenuView: View {
                                             .fill(row.accentColor)
                                             .frame(
                                                 width: 2,
-                                                height: Self.accentHeight(for: row))
+                                                height: Self.accentHeight(
+                                                    for: row,
+                                                    rowHeight: model.detailRowHeight))
                                             .padding(.top, 1)
 
                                         VStack(alignment: .leading, spacing: 1) {
@@ -199,14 +201,16 @@ struct CostHistoryChartMenuView: View {
                                             }
                                         }
                                     }
-                                    .frame(height: Self.detailRowHeight, alignment: .leading)
+                                    .frame(height: model.detailRowHeight, alignment: .leading)
                                 }
                             }
                         }
                         .scrollIndicators(
                             Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
                         .frame(
-                            height: Self.detailRowsViewportHeight(rowCount: model.detailViewportRowCount),
+                            height: Self.detailRowsViewportHeight(
+                                rowCount: model.detailViewportRowCount,
+                                rowHeight: model.detailRowHeight),
                             alignment: .topLeading)
                         .id(selectedDateKey)
 
@@ -222,7 +226,8 @@ struct CostHistoryChartMenuView: View {
                 .frame(
                     height: Self.detailBlockHeight(
                         rowCount: model.detailViewportRowCount,
-                        hasOverflow: model.hasDetailOverflow),
+                        hasOverflow: model.hasDetailOverflow,
+                        rowHeight: model.detailRowHeight),
                     alignment: .topLeading)
             }
 
@@ -289,6 +294,7 @@ struct CostHistoryChartMenuView: View {
         let maxCostUSD: Double
         let detailViewportRowCount: Int
         let hasDetailOverflow: Bool
+        let detailRowHeight: CGFloat
     }
 
     private static let selectionBandColor = Color(nsColor: .labelColor).opacity(0.1)
@@ -296,7 +302,8 @@ struct CostHistoryChartMenuView: View {
     private static let detailPrimaryLineHeight: CGFloat = 16
     private static let detailTitleLineHeight: CGFloat = 16
     private static let detailSubtitleLineHeight: CGFloat = 13
-    private static let detailRowHeight: CGFloat = 44
+    private static let compactDetailRowHeight: CGFloat = 36
+    private static let expandedDetailRowHeight: CGFloat = 44
     private static let detailSpacing: CGFloat = 6
     private static let detailHintHeight: CGFloat = 13
     private static let chartHeight: CGFloat = 130
@@ -318,8 +325,8 @@ struct CostHistoryChartMenuView: View {
         return String(format: L("Last %d days"), days)
     }
 
-    private static func accentHeight(for row: DetailRow) -> CGFloat {
-        row.subtitle == nil && row.modeSubtitle == nil ? 14 : self.detailRowHeight
+    private static func accentHeight(for row: DetailRow, rowHeight: CGFloat) -> CGFloat {
+        row.subtitle == nil && row.modeSubtitle == nil ? 14 : rowHeight
     }
 
     private static func capHeight(maxValue: Double) -> Double {
@@ -354,6 +361,7 @@ struct CostHistoryChartMenuView: View {
         var peak: (key: String, costUSD: Double)?
         var maxCostUSD: Double = 0
         var maxDetailRows = 0
+        var hasModeDetails = false
         for entry in sorted {
             guard let costUSD = entry.costUSD, costUSD >= 0 else { continue }
             guard let date = self.dateFromDayKey(entry.date) else { continue }
@@ -366,9 +374,13 @@ struct CostHistoryChartMenuView: View {
             pointsByKey[entry.date] = point
             entriesByKey[entry.date] = entry
             dateKeys.append((entry.date, date))
-            maxDetailRows = max(maxDetailRows, entry.modelBreakdowns?.count ?? 0)
+            let modelBreakdowns = entry.modelBreakdowns ?? []
+            maxDetailRows = max(maxDetailRows, modelBreakdowns.count)
+            hasModeDetails = hasModeDetails || modelBreakdowns.contains { Self.hasModeSubtitle($0) }
             if let cur = peak {
-                if costUSD > cur.costUSD { peak = (entry.date, costUSD) }
+                if costUSD > cur.costUSD {
+                    peak = (entry.date, costUSD)
+                }
             } else {
                 peak = (entry.date, costUSD)
             }
@@ -377,7 +389,9 @@ struct CostHistoryChartMenuView: View {
 
         let axisDates: [Date] = {
             guard let first = dateKeys.first?.date, let last = dateKeys.last?.date else { return [] }
-            if Calendar.current.isDate(first, inSameDayAs: last) { return [first] }
+            if Calendar.current.isDate(first, inSameDayAs: last) {
+                return [first]
+            }
             return [first, last]
         }()
 
@@ -392,7 +406,8 @@ struct CostHistoryChartMenuView: View {
             peakKey: maxCostUSD > 0 ? peak?.key : nil,
             maxCostUSD: maxCostUSD,
             detailViewportRowCount: min(maxDetailRows, self.maxVisibleDetailLines),
-            hasDetailOverflow: maxDetailRows > self.maxVisibleDetailLines)
+            hasDetailOverflow: maxDetailRows > self.maxVisibleDetailLines,
+            detailRowHeight: hasModeDetails ? self.expandedDetailRowHeight : self.compactDetailRowHeight)
     }
 
     private static func axisLabelPlacement(for dates: [Date]) -> AxisLabelPlacement {
@@ -445,15 +460,19 @@ struct CostHistoryChartMenuView: View {
         return model.pointsByDateKey[key]
     }
 
-    private static func detailRowsViewportHeight(rowCount: Int) -> CGFloat {
-        guard rowCount > 0 else { return 0 }
-        return CGFloat(rowCount) * self.detailRowHeight + CGFloat(rowCount - 1) * self.detailSpacing
+    private static func hasModeSubtitle(_ item: CostUsageDailyReport.ModelBreakdown) -> Bool {
+        item.standardCostUSD != nil || item.priorityCostUSD != nil
     }
 
-    private static func detailBlockHeight(rowCount: Int, hasOverflow: Bool) -> CGFloat {
+    private static func detailRowsViewportHeight(rowCount: Int, rowHeight: CGFloat) -> CGFloat {
+        guard rowCount > 0 else { return 0 }
+        return CGFloat(rowCount) * rowHeight + CGFloat(rowCount - 1) * self.detailSpacing
+    }
+
+    private static func detailBlockHeight(rowCount: Int, hasOverflow: Bool, rowHeight: CGFloat) -> CGFloat {
         guard rowCount > 0 else { return self.detailPrimaryLineHeight }
         var height = self.detailPrimaryLineHeight + self.detailSpacing
-        height += self.detailRowsViewportHeight(rowCount: rowCount)
+        height += self.detailRowsViewportHeight(rowCount: rowCount, rowHeight: rowHeight)
         if hasOverflow {
             height += self.detailSpacing + self.detailHintHeight
         }
@@ -619,7 +638,9 @@ struct CostHistoryChartMenuView: View {
         for entry in model.dateKeys {
             let dist = abs(entry.date.timeIntervalSince(date))
             if let cur = best {
-                if dist < cur.distance { best = (entry.key, dist) }
+                if dist < cur.distance {
+                    best = (entry.key, dist)
+                }
             } else {
                 best = (entry.key, dist)
             }
@@ -670,11 +691,15 @@ struct CostHistoryChartMenuView: View {
         breakdown.sorted { lhs, rhs in
             let lCost = lhs.costUSD ?? -1
             let rCost = rhs.costUSD ?? -1
-            if lCost != rCost { return lCost > rCost }
+            if lCost != rCost {
+                return lCost > rCost
+            }
 
             let lTokens = lhs.totalTokens ?? -1
             let rTokens = rhs.totalTokens ?? -1
-            if lTokens != rTokens { return lTokens > rTokens }
+            if lTokens != rTokens {
+                return lTokens > rTokens
+            }
 
             return lhs.modelName > rhs.modelName
         }
@@ -764,10 +789,10 @@ extension CostHistoryChartMenuView {
 
     static func _detailViewportConfigurationForTesting(
         provider: UsageProvider,
-        daily: [DailyEntry]) -> (rowCount: Int, hasOverflow: Bool)
+        daily: [DailyEntry]) -> (rowCount: Int, hasOverflow: Bool, rowHeight: CGFloat)
     {
         let model = self.makeModel(provider: provider, daily: daily)
-        return (model.detailViewportRowCount, model.hasDetailOverflow)
+        return (model.detailViewportRowCount, model.hasDetailOverflow, model.detailRowHeight)
     }
 }
 

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -49,7 +49,6 @@ struct CostHistoryChartMenuView: View {
     private let windowLabel: String?
     private let projects: [CostUsageProjectBreakdown]
     private let width: CGFloat
-    private let onHeightChange: ((CGFloat) -> Void)?
     @State private var selectedDateKey: String?
 
     init(
@@ -60,7 +59,6 @@ struct CostHistoryChartMenuView: View {
         historyDays: Int = 30,
         windowLabel: String? = nil,
         projects: [CostUsageProjectBreakdown] = [],
-        onHeightChange: ((CGFloat) -> Void)? = nil,
         width: CGFloat)
     {
         self.provider = provider
@@ -70,7 +68,6 @@ struct CostHistoryChartMenuView: View {
         self.historyDays = max(1, min(365, historyDays))
         self.windowLabel = windowLabel
         self.projects = projects
-        self.onHeightChange = onHeightChange
         self.width = width
     }
 
@@ -161,62 +158,62 @@ struct CostHistoryChartMenuView: View {
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
-                    if !detail.rows.isEmpty {
-                        ScrollView(.vertical) {
-                            VStack(alignment: .leading, spacing: Self.detailSpacing) {
-                                ForEach(detail.rows) { row in
-                                    HStack(alignment: .top, spacing: 8) {
-                                        Rectangle()
-                                            .fill(row.accentColor)
-                                            .frame(
-                                                width: 2,
-                                                height: Self.accentHeight(for: row))
-                                            .padding(.top, 1)
+                    ScrollView(.vertical) {
+                        VStack(alignment: .leading, spacing: Self.detailSpacing) {
+                            ForEach(detail.rows) { row in
+                                HStack(alignment: .top, spacing: 8) {
+                                    Rectangle()
+                                        .fill(row.accentColor)
+                                        .frame(
+                                            width: 2,
+                                            height: Self.accentHeight(for: row))
+                                        .padding(.top, 1)
 
-                                        VStack(alignment: .leading, spacing: 1) {
-                                            Text(row.title)
-                                                .font(.caption)
-                                                .foregroundStyle(.secondary)
+                                    VStack(alignment: .leading, spacing: 1) {
+                                        Text(row.title)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                            .truncationMode(.tail)
+                                            .frame(height: Self.detailTitleLineHeight, alignment: .leading)
+                                        if let subtitle = row.subtitle {
+                                            Text(subtitle)
+                                                .font(.caption2)
+                                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
-                                                .frame(height: Self.detailTitleLineHeight, alignment: .leading)
-                                            if let subtitle = row.subtitle {
-                                                Text(subtitle)
-                                                    .font(.caption2)
-                                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                                                    .lineLimit(1)
-                                                    .truncationMode(.tail)
-                                                    .frame(
-                                                        height: Self.detailSubtitleLineHeight,
-                                                        alignment: .leading)
-                                            }
-                                            if let modeSubtitle = row.modeSubtitle {
-                                                Text(modeSubtitle)
-                                                    .font(.caption2)
-                                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                                                    .lineLimit(1)
-                                                    .truncationMode(.tail)
-                                                    .frame(
-                                                        height: Self.detailSubtitleLineHeight,
-                                                        alignment: .leading)
-                                            }
+                                                .frame(
+                                                    height: Self.detailSubtitleLineHeight,
+                                                    alignment: .leading)
+                                        }
+                                        if let modeSubtitle = row.modeSubtitle {
+                                            Text(modeSubtitle)
+                                                .font(.caption2)
+                                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                                .lineLimit(1)
+                                                .truncationMode(.tail)
+                                                .frame(
+                                                    height: Self.detailSubtitleLineHeight,
+                                                    alignment: .leading)
                                         }
                                     }
-                                    .frame(height: Self.detailRowHeight(for: row), alignment: .leading)
                                 }
+                                .frame(height: Self.detailRowHeight(for: row), alignment: .leading)
                             }
                         }
-                        .scrollIndicators(
-                            Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
-                        .frame(
-                            height: Self.detailRowsViewportHeight(rows: detail.rows),
-                            alignment: .topLeading)
-                        .id(selectedDateKey)
                     }
+                    .scrollIndicators(
+                        Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
+                    .frame(height: Self.detailRowsViewportHeight, alignment: .topLeading)
+                    .id(selectedDateKey)
+
+                    Text(Self.detailOverflowHint(itemCount: detail.rows.count) ?? " ")
+                        .font(.caption2)
+                        .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                        .frame(height: Self.detailHintHeight, alignment: .leading)
+                        .accessibilityHidden(!Self.detailRowsNeedScrolling(itemCount: detail.rows.count))
                 }
-                .frame(
-                    height: Self.detailBlockHeight(rows: detail.rows),
-                    alignment: .topLeading)
+                .frame(height: Self.detailBlockHeight, alignment: .topLeading)
             }
 
             if let total = self.totalCostUSD {
@@ -290,6 +287,7 @@ struct CostHistoryChartMenuView: View {
     private static let compactDetailRowHeight: CGFloat = 36
     private static let expandedDetailRowHeight: CGFloat = 44
     private static let detailSpacing: CGFloat = 6
+    private static let detailHintHeight: CGFloat = 13
     private static let chartHeight: CGFloat = 130
     private static let outerSpacing: CGFloat = 10
     private static let projectRowHeight: CGFloat = 31
@@ -302,19 +300,14 @@ struct CostHistoryChartMenuView: View {
     private static let maxVisibleProjectSourceRows = 2
     static let verticalPadding: CGFloat = 10
 
-    /// Deterministic total height of the rendered card for a given selection. NSMenu's modal
-    /// tracking run loop never delivers SwiftUI `onPreferenceChange`, so the live height can't be
-    /// measured via a GeometryReader while the menu is open. Every component height is fixed, so
-    /// we compute the total directly and resize from the hover handler instead.
     private static func totalCardHeight(
-        rows: [DetailRow],
         hasTotal: Bool,
         projects: [CostUsageProjectBreakdown] = []) -> CGFloat
     {
         var height = self.verticalPadding * 2
         height += self.chartHeight
         height += self.outerSpacing
-        height += self.detailBlockHeight(rows: rows)
+        height += self.detailBlockHeight
         if hasTotal {
             height += self.outerSpacing
             height += self.detailPrimaryLineHeight
@@ -326,7 +319,7 @@ struct CostHistoryChartMenuView: View {
         return height
     }
 
-    private static func totalCardHeight(rows: [DetailRow], hasTotal: Bool, projectCount: Int) -> CGFloat {
+    private static func totalCardHeight(hasTotal: Bool, projectCount: Int) -> CGFloat {
         let projects = (0..<projectCount).map { index in
             CostUsageProjectBreakdown(
                 name: "Project \(index)",
@@ -336,7 +329,7 @@ struct CostHistoryChartMenuView: View {
                 daily: [],
                 modelBreakdowns: nil)
         }
-        return self.totalCardHeight(rows: rows, hasTotal: hasTotal, projects: projects)
+        return self.totalCardHeight(hasTotal: hasTotal, projects: projects)
     }
 
     static func windowLabel(days: Int) -> String {
@@ -481,21 +474,12 @@ struct CostHistoryChartMenuView: View {
         item.standardCostUSD != nil || item.priorityCostUSD != nil
     }
 
-    private static func detailBlockHeight(rows: [DetailRow]) -> CGFloat {
-        guard !rows.isEmpty else { return self.detailPrimaryLineHeight }
-        return self.detailPrimaryLineHeight + self.detailRowsViewportHeight(rows: rows) + self.detailSpacing
-    }
+    private static let detailRowsViewportHeight =
+        CGFloat(maxVisibleDetailLines) * expandedDetailRowHeight +
+        CGFloat(maxVisibleDetailLines - 1) * detailSpacing
 
-    private static func detailRowsViewportHeight(rows: [DetailRow]) -> CGFloat {
-        let visibleRows = Array(rows.prefix(self.maxVisibleDetailLines))
-        guard !visibleRows.isEmpty else { return 0 }
-
-        let rowHeights = visibleRows.reduce(CGFloat(0)) { total, row in
-            total + self.detailRowHeight(for: row)
-        }
-        let spacing = CGFloat(max(visibleRows.count - 1, 0)) * self.detailSpacing
-        return rowHeights + spacing
-    }
+    private static let detailBlockHeight = detailPrimaryLineHeight + detailSpacing +
+        detailRowsViewportHeight + detailSpacing + detailHintHeight
 
     private static func projectBlockHeight(projects: [CostUsageProjectBreakdown]) -> CGFloat {
         let visibleProjects = Array(projects.prefix(self.maxVisibleProjectRows))
@@ -580,20 +564,7 @@ struct CostHistoryChartMenuView: View {
 
         if self.selectedDateKey != nearest {
             self.selectedDateKey = nearest
-            // Resize directly from the hover handler: this runs synchronously inside NSMenu's
-            // tracking run loop, unlike SwiftUI preference callbacks which are never delivered
-            // while the menu is open.
-            self.notifyHeightChange(selectedDateKey: nearest, model: model)
         }
-    }
-
-    private func notifyHeightChange(selectedDateKey: String?, model: Model) {
-        guard let onHeightChange = self.onHeightChange else { return }
-        let rows = selectedDateKey.map { self.breakdownRows(key: $0, model: model) } ?? []
-        onHeightChange(Self.totalCardHeight(
-            rows: rows,
-            hasTotal: self.totalCostUSD != nil,
-            projects: self.projects))
     }
 
     private func projectSummary(_ project: CostUsageProjectBreakdown) -> String {
@@ -738,6 +709,10 @@ struct CostHistoryChartMenuView: View {
         itemCount > self.maxVisibleDetailLines
     }
 
+    static func detailOverflowHint(itemCount: Int) -> String? {
+        self.detailRowsNeedScrolling(itemCount: itemCount) ? L("Scroll to see more models") : nil
+    }
+
     private func modelBreakdownTotalSubtitle(_ item: CostUsageDailyReport.ModelBreakdown) -> String? {
         UsageFormatter.modelCostDetail(
             item.modelName,
@@ -808,28 +783,12 @@ extension CostHistoryChartMenuView {
         self.yAxisCostString(value, currencyCode: currencyCode)
     }
 
-    static func _detailViewportHeightForTesting(modeSubtitlePresence: [Bool]) -> CGFloat {
-        let rows = modeSubtitlePresence.enumerated().map { index, hasModeSubtitle in
-            DetailRow(
-                id: "\(index)",
-                title: "Row \(index)",
-                subtitle: "Subtitle",
-                modeSubtitle: hasModeSubtitle ? "Mode" : nil,
-                accentColor: .blue)
-        }
-        return self.detailRowsViewportHeight(rows: rows)
+    static var _detailViewportHeightForTesting: CGFloat {
+        self.detailRowsViewportHeight
     }
 
-    static func _detailBlockHeightForTesting(modeSubtitlePresence: [Bool]) -> CGFloat {
-        let rows = modeSubtitlePresence.enumerated().map { index, hasModeSubtitle in
-            DetailRow(
-                id: "\(index)",
-                title: "Row \(index)",
-                subtitle: "Subtitle",
-                modeSubtitle: hasModeSubtitle ? "Mode" : nil,
-                accentColor: .blue)
-        }
-        return self.detailBlockHeight(rows: rows)
+    static var _detailBlockHeightForTesting: CGFloat {
+        self.detailBlockHeight
     }
 
     static func _totalCardHeightForTesting(
@@ -837,15 +796,8 @@ extension CostHistoryChartMenuView {
         hasTotal: Bool,
         projectCount: Int = 0) -> CGFloat
     {
-        let rows = modeSubtitlePresence.enumerated().map { index, hasModeSubtitle in
-            DetailRow(
-                id: "\(index)",
-                title: "Row \(index)",
-                subtitle: "Subtitle",
-                modeSubtitle: hasModeSubtitle ? "Mode" : nil,
-                accentColor: .blue)
-        }
-        return self.totalCardHeight(rows: rows, hasTotal: hasTotal, projectCount: projectCount)
+        _ = modeSubtitlePresence
+        return self.totalCardHeight(hasTotal: hasTotal, projectCount: projectCount)
     }
 
     static func _totalCardHeightForTesting(
@@ -853,14 +805,7 @@ extension CostHistoryChartMenuView {
         hasTotal: Bool,
         projectSourceCounts: [Int]) -> CGFloat
     {
-        let rows = modeSubtitlePresence.enumerated().map { index, hasModeSubtitle in
-            DetailRow(
-                id: "\(index)",
-                title: "Model \(index)",
-                subtitle: "Cost",
-                modeSubtitle: hasModeSubtitle ? "Mode" : nil,
-                accentColor: .blue)
-        }
+        _ = modeSubtitlePresence
         let projects = projectSourceCounts.enumerated().map { index, sourceCount in
             CostUsageProjectBreakdown(
                 name: "Project \(index)",
@@ -879,7 +824,7 @@ extension CostHistoryChartMenuView {
                         modelBreakdowns: nil)
                 })
         }
-        return self.totalCardHeight(rows: rows, hasTotal: hasTotal, projects: projects)
+        return self.totalCardHeight(hasTotal: hasTotal, projects: projects)
     }
 }
 

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1164,3 +1164,4 @@
 "section_links" = "روابط";
 "Show Codex Spark usage" = "عرض استخدام Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "يعرض صفوف حصة Codex Spark في القائمة ومعاينة المزوّد. يتطلب تفعيل «عرض الاعتمادات + الاستخدام الإضافي» في إعدادات العرض.";
+"Scroll to see more models" = "مرر لرؤية المزيد من النماذج";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1163,3 +1163,4 @@
 "section_links" = "Enllaços";
 "Show Codex Spark usage" = "Mostreu l'ús de Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Mostreu les files de quota de Codex Spark al menú i a la previsualització del proveïdor. Cal activar «Mostreu crèdits + ús addicional» a la configuració de Pantalla.";
+"Scroll to see more models" = "Desplaceu-vos per veure més models";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1157,3 +1157,4 @@
 "section_links" = "Links";
 "Show Codex Spark usage" = "Codex-Spark-Nutzung anzeigen";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Zeigt die Codex-Spark-Kontingentzeilen im Menü und in der Anbietervorschau an. Erfordert, dass „Credits + zusätzliche Nutzung anzeigen“ in den Anzeigeeinstellungen aktiviert ist.";
+"Scroll to see more models" = "Scrollen, um weitere Modelle zu sehen";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1164,3 +1164,4 @@
 "section_links" = "Links";
 "Show Codex Spark usage" = "Show Codex Spark usage";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings.";
+"Scroll to see more models" = "Scroll to see more models";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1018,3 +1018,4 @@
 "section_links" = "Enlaces";
 "Show Codex Spark usage" = "Mostrar el uso de Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Muestra las filas de cuota de Codex Spark en el menú y en la vista previa del proveedor. Requiere activar «Mostrar créditos + uso adicional» en los ajustes de Pantalla.";
+"Scroll to see more models" = "Desplázate para ver más modelos";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1164,3 +1164,4 @@
 "section_links" = "پیوندها";
 "Show Codex Spark usage" = "نمایش استفاده از Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "ردیف‌های سهمیه Codex Spark را در منو و پیش‌نمایش ارائه‌دهنده نمایش می‌دهد. لازم است «نمایش اعتبارها + استفاده اضافی» در تنظیمات نمایش فعال باشد.";
+"Scroll to see more models" = "برای دیدن مدل‌های بیشتر پیمایش کنید";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1157,3 +1157,4 @@
 "section_links" = "Liens";
 "Show Codex Spark usage" = "Afficher l’utilisation de Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Affiche les lignes de quota Codex Spark dans le menu et l’aperçu du fournisseur. Nécessite d’activer « Afficher les crédits + utilisation supplémentaire » dans les réglages Affichage.";
+"Scroll to see more models" = "Faites défiler pour voir plus de modèles";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1159,3 +1159,4 @@
 "≈ %d%% run-out risk" = "≈ %d%% de risco de esgotamento";
 "Show Codex Spark usage" = "Amosar o uso de Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Amosa as filas de cota de Codex Spark no menú e na previsualización do provedor. Require activar «Amosar créditos + uso adicional» nos axustes de Pantalla.";
+"Scroll to see more models" = "Desprázate para ver máis modelos";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1163,3 +1163,4 @@
 "section_links" = "Tautan";
 "Show Codex Spark usage" = "Tampilkan penggunaan Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Menampilkan baris kuota Codex Spark di menu dan pratinjau penyedia. Mengharuskan “Tampilkan kredit + penggunaan ekstra” diaktifkan di pengaturan Tampilan.";
+"Scroll to see more models" = "Gulir untuk melihat model lainnya";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1163,3 +1163,4 @@
 "section_links" = "Link";
 "Show Codex Spark usage" = "Mostra l’utilizzo di Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Mostra le righe della quota Codex Spark nel menu e nell’anteprima del provider. Richiede di attivare «Mostra crediti + uso extra» nelle impostazioni Aspetto.";
+"Scroll to see more models" = "Scorri per vedere altri modelli";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1158,3 +1158,4 @@
 "section_links" = "リンク";
 "Show Codex Spark usage" = "Codex Spark の使用量を表示";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "メニューとプロバイダのプレビューに Codex Spark のクォータ行を表示します。表示設定で「クレジットと追加使用量を表示」を有効にする必要があります。";
+"Scroll to see more models" = "スクロールして他のモデルを表示";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1126,3 +1126,4 @@
 "section_links" = "링크";
 "Show Codex Spark usage" = "Codex Spark 사용량 표시";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "메뉴와 공급자 미리보기에 Codex Spark 할당량 행을 표시합니다. 표시 설정에서 ‘크레딧 + 추가 사용량 표시’를 활성화해야 합니다.";
+"Scroll to see more models" = "스크롤하여 더 많은 모델 보기";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1157,3 +1157,4 @@
 "section_links" = "Links";
 "Show Codex Spark usage" = "Codex Spark-gebruik tonen";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Toont Codex Spark-quotumregels in het menu en de voorvertoning van de provider. Vereist dat ‘Toon credits + extra gebruik’ is ingeschakeld in de instellingen voor Weergave.";
+"Scroll to see more models" = "Scroll om meer modellen te bekijken";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1163,3 +1163,4 @@
 "section_links" = "Linki";
 "Show Codex Spark usage" = "Pokaż użycie Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Pokazuje wiersze limitu Codex Spark w menu i podglądzie dostawcy. Wymaga włączenia opcji „Pokaż kredyty + dodatkowe użycie” w ustawieniach Wyświetlanie.";
+"Scroll to see more models" = "Przewiń, aby zobaczyć więcej modeli";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1158,3 +1158,4 @@
 "section_links" = "Links";
 "Show Codex Spark usage" = "Mostrar uso do Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Mostra as linhas de cota do Codex Spark no menu e na prévia do provedor. Requer ativar “Mostrar créditos + uso extra” nos ajustes de Exibição.";
+"Scroll to see more models" = "Role para ver mais modelos";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1164,3 +1164,4 @@
 "section_links" = "Ссылки";
 "Show Codex Spark usage" = "Показывать использование Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Показывает строки квот Codex Spark в меню и предварительном просмотре провайдера. Требует включить «Показывать кредиты и доп. использование» в настройках «Отображение».";
+"Scroll to see more models" = "Прокрутите, чтобы увидеть больше моделей";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1156,3 +1156,4 @@
 "section_links" = "Länkar";
 "Show Codex Spark usage" = "Visa Codex Spark-användning";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Visar kvotrader för Codex Spark i menyn och i förhandsvisningen för leverantören. Kräver att ”Visa krediter och extra användning” är aktiverat under Visning i Inställningar.";
+"Scroll to see more models" = "Rulla för att se fler modeller";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1164,3 +1164,4 @@
 "section_links" = "ลิงก์";
 "Show Codex Spark usage" = "แสดงการใช้งาน Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "แสดงแถวโควตา Codex Spark ในเมนูและตัวอย่างผู้ให้บริการ ต้องเปิดใช้ “แสดงเครดิต + การใช้งานเพิ่มเติม” ในการตั้งค่าการแสดงผล";
+"Scroll to see more models" = "เลื่อนเพื่อดูโมเดลเพิ่มเติม";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1161,3 +1161,4 @@
 "section_links" = "Bağlantılar";
 "Show Codex Spark usage" = "Codex Spark kullanımını göster";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Codex Spark kota satırlarını menüde ve sağlayıcı önizlemesinde gösterir. Görünüm ayarlarında “Krediler + ekstra kullanımı göster” seçeneğinin etkin olmasını gerektirir.";
+"Scroll to see more models" = "Daha fazla model görmek için kaydırın";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1157,3 +1157,4 @@
 "section_links" = "Посилання";
 "Show Codex Spark usage" = "Показати використання Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Показує рядки квоти Codex Spark у меню та попередньому перегляді провайдера. Потрібно ввімкнути «Показати кредити + додаткове використання» в налаштуваннях «Відображення».";
+"Scroll to see more models" = "Прокрутіть, щоб побачити більше моделей";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1158,3 +1158,4 @@
 "section_links" = "Liên kết";
 "Show Codex Spark usage" = "Hiển thị mức sử dụng Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Hiển thị các hàng hạn mức Codex Spark trong menu và bản xem trước của nhà cung cấp. Yêu cầu bật “Hiển thị tín dụng + mức sử dụng bổ sung” trong phần cài đặt Hiển thị.";
+"Scroll to see more models" = "Cuộn để xem thêm mô hình";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1134,3 +1134,4 @@
 "section_links" = "链接";
 "Show Codex Spark usage" = "显示 Codex Spark 用量";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "在菜单和提供商预览中显示 Codex Spark 配额行。需要在“显示”设置中启用“显示额度 + 额外用量”。";
+"Scroll to see more models" = "滚动查看更多模型";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1193,3 +1193,4 @@
 "section_links" = "連結";
 "Show Codex Spark usage" = "顯示 Codex Spark 使用量";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "在選單和提供者預覽中顯示 Codex Spark 配額列。需要在「顯示」設定中啟用「顯示額度 + 額外使用量」。";
+"Scroll to see more models" = "捲動查看更多模型";

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -422,12 +422,6 @@ extension StatusItemController {
             return true
         }
 
-        // The SwiftUI view needs the callback at init, but the hosting view doesn't exist yet.
-        // A relay breaks the cycle: the closure captures relay strongly, relay holds the view weakly.
-        final class HostingRelay {
-            weak var hosting: MenuHostingView<CostHistoryChartMenuView>?
-        }
-        let relay = HostingRelay()
         let chartView = CostHistoryChartMenuView(
             provider: provider,
             daily: tokenSnapshot.daily,
@@ -436,18 +430,14 @@ extension StatusItemController {
             historyDays: tokenSnapshot.historyDays,
             windowLabel: tokenSnapshot.historyLabel,
             projects: provider == .codex ? tokenSnapshot.projects : [],
-            onHeightChange: { height in
-                relay.hosting?.applyMeasuredHeight(width: width, height: height)
-            },
             width: width)
-        let resolvedHosting = MenuHostingView(rootView: chartView)
-        relay.hosting = resolvedHosting
-        resolvedHosting.applyMeasuredHeight(
+        let hosting = MenuHostingView(rootView: chartView)
+        hosting.applyMeasuredHeight(
             width: width,
-            height: self.hostedSubviewFittingHeight(for: resolvedHosting, width: width))
+            height: self.hostedSubviewFittingHeight(for: hosting, width: width))
 
         let chartItem = NSMenuItem()
-        chartItem.view = resolvedHosting
+        chartItem.view = hosting
         chartItem.isEnabled = true
         chartItem.representedObject = Self.costHistoryChartID
         chartItem.toolTip = provider.rawValue

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -26,6 +26,8 @@ struct CostHistoryChartMenuViewTests {
         ])
         #expect(CostHistoryChartMenuView.detailViewportRowCount(itemCount: ordered.count) == 4)
         #expect(CostHistoryChartMenuView.detailRowsNeedScrolling(itemCount: ordered.count))
+        #expect(CostHistoryChartMenuView.detailOverflowHint(itemCount: ordered.count) == "Scroll to see more models")
+        #expect(CostHistoryChartMenuView.detailOverflowHint(itemCount: 4) == nil)
     }
 
     @Test
@@ -70,21 +72,9 @@ struct CostHistoryChartMenuViewTests {
 
     @Test
     @MainActor
-    func `cost history detail height follows visible rows and caps at viewport limit`() {
-        let singleRowHeight = CostHistoryChartMenuView._detailViewportHeightForTesting(modeSubtitlePresence: [false])
-        let twoRowHeight = CostHistoryChartMenuView._detailViewportHeightForTesting(modeSubtitlePresence: [false, true])
-        let fourRowHeight = CostHistoryChartMenuView._detailViewportHeightForTesting(
-            modeSubtitlePresence: [false, false, false, false])
-        let fiveRowHeight = CostHistoryChartMenuView._detailViewportHeightForTesting(
-            modeSubtitlePresence: [false, false, false, false, true])
-
-        #expect(singleRowHeight < twoRowHeight)
-        #expect(twoRowHeight < fourRowHeight)
-        #expect(fiveRowHeight == fourRowHeight)
-
-        let emptyBlockHeight = CostHistoryChartMenuView._detailBlockHeightForTesting(modeSubtitlePresence: [])
-        let populatedBlockHeight = CostHistoryChartMenuView._detailBlockHeightForTesting(modeSubtitlePresence: [false])
-        #expect(emptyBlockHeight < populatedBlockHeight)
+    func `cost history reserves a four-row detail viewport`() {
+        #expect(CostHistoryChartMenuView._detailViewportHeightForTesting == 194)
+        #expect(CostHistoryChartMenuView._detailBlockHeightForTesting > 194)
     }
 
     @Test
@@ -202,14 +192,14 @@ struct CostHistoryChartMenuViewTests {
 
     @Test
     @MainActor
-    func `cost history total card height grows with rows and the total line`() {
+    func `cost history total card height stays stable across model counts`() {
         let oneRow = CostHistoryChartMenuView._totalCardHeightForTesting(
             modeSubtitlePresence: [false],
             hasTotal: false)
         let threeRows = CostHistoryChartMenuView._totalCardHeightForTesting(
             modeSubtitlePresence: [false, false, false],
             hasTotal: false)
-        #expect(oneRow < threeRows)
+        #expect(oneRow == threeRows)
 
         let withoutTotal = CostHistoryChartMenuView._totalCardHeightForTesting(
             modeSubtitlePresence: [false],

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -230,17 +230,41 @@ struct CostHistoryChartMenuViewTests {
 
     @Test
     @MainActor
-    func `cost history fitting height stays stable across selected model counts`() {
-        let latestHasOneModel = [
+    func `cost history fitting height stays stable across compact overflow and mode selections`() {
+        let compactLatestHasOneModel = [
             Self.entry(date: "2026-06-07", modelCount: 3),
             Self.entry(date: "2026-06-08", modelCount: 1),
         ]
-        let latestHasThreeModels = [
+        let compactLatestHasThreeModels = [
             Self.entry(date: "2026-06-07", modelCount: 1),
             Self.entry(date: "2026-06-08", modelCount: 3),
         ]
+        let overflowLatestHasFourModels = [
+            Self.entry(date: "2026-06-07", modelCount: 6),
+            Self.entry(date: "2026-06-08", modelCount: 4),
+        ]
+        let overflowLatestHasSixModels = [
+            Self.entry(date: "2026-06-07", modelCount: 4),
+            Self.entry(date: "2026-06-08", modelCount: 6),
+        ]
+        let modeLatestHasOneModel = [
+            Self.entry(date: "2026-06-07", modelCount: 6),
+            Self.entry(date: "2026-06-08", modelCount: 1, hasModeDetails: true),
+        ]
+        let modeLatestHasSixModels = [
+            Self.entry(date: "2026-06-07", modelCount: 1, hasModeDetails: true),
+            Self.entry(date: "2026-06-08", modelCount: 6),
+        ]
 
-        #expect(Self.renderedHeight(daily: latestHasOneModel) == Self.renderedHeight(daily: latestHasThreeModels))
+        let compactHeight = Self.renderedHeight(daily: compactLatestHasOneModel)
+        let overflowHeight = Self.renderedHeight(daily: overflowLatestHasFourModels)
+        let modeHeight = Self.renderedHeight(daily: modeLatestHasOneModel)
+
+        #expect(compactHeight == Self.renderedHeight(daily: compactLatestHasThreeModels))
+        #expect(overflowHeight == Self.renderedHeight(daily: overflowLatestHasSixModels))
+        #expect(modeHeight == Self.renderedHeight(daily: modeLatestHasSixModels))
+        #expect(compactHeight < overflowHeight)
+        #expect(overflowHeight < modeHeight)
     }
 
     @Test

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -72,9 +72,23 @@ struct CostHistoryChartMenuViewTests {
 
     @Test
     @MainActor
-    func `cost history reserves a four-row detail viewport`() {
-        #expect(CostHistoryChartMenuView._detailViewportHeightForTesting == 194)
-        #expect(CostHistoryChartMenuView._detailBlockHeightForTesting > 194)
+    func `cost history sizes its viewport to the largest breakdown in the range`() {
+        let threeRows = CostHistoryChartMenuView._detailViewportConfigurationForTesting(
+            provider: .codex,
+            daily: [Self.entry(date: "2026-06-07", modelCount: 1), Self.entry(date: "2026-06-08", modelCount: 3)])
+        let cappedRows = CostHistoryChartMenuView._detailViewportConfigurationForTesting(
+            provider: .codex,
+            daily: [Self.entry(date: "2026-06-07", modelCount: 6)])
+        let noRows = CostHistoryChartMenuView._detailViewportConfigurationForTesting(
+            provider: .codex,
+            daily: [Self.entry(date: "2026-06-07", modelCount: 0)])
+
+        #expect(threeRows.rowCount == 3)
+        #expect(!threeRows.hasOverflow)
+        #expect(cappedRows.rowCount == 4)
+        #expect(cappedRows.hasOverflow)
+        #expect(noRows.rowCount == 0)
+        #expect(!noRows.hasOverflow)
     }
 
     @Test
@@ -192,34 +206,26 @@ struct CostHistoryChartMenuViewTests {
 
     @Test
     @MainActor
-    func `cost history total card height stays stable across model counts`() {
-        let oneRow = CostHistoryChartMenuView._totalCardHeightForTesting(
-            modeSubtitlePresence: [false],
-            hasTotal: false)
-        let threeRows = CostHistoryChartMenuView._totalCardHeightForTesting(
-            modeSubtitlePresence: [false, false, false],
-            hasTotal: false)
-        #expect(oneRow == threeRows)
+    func `cost history fitting height stays stable across selected model counts`() {
+        let latestHasOneModel = [
+            Self.entry(date: "2026-06-07", modelCount: 3),
+            Self.entry(date: "2026-06-08", modelCount: 1),
+        ]
+        let latestHasThreeModels = [
+            Self.entry(date: "2026-06-07", modelCount: 1),
+            Self.entry(date: "2026-06-08", modelCount: 3),
+        ]
 
-        let withoutTotal = CostHistoryChartMenuView._totalCardHeightForTesting(
-            modeSubtitlePresence: [false],
-            hasTotal: false)
-        let withTotal = CostHistoryChartMenuView._totalCardHeightForTesting(
-            modeSubtitlePresence: [false],
-            hasTotal: true)
-        #expect(withTotal > withoutTotal)
+        #expect(Self.renderedHeight(daily: latestHasOneModel) == Self.renderedHeight(daily: latestHasThreeModels))
+    }
 
-        let withProjects = CostHistoryChartMenuView._totalCardHeightForTesting(
-            modeSubtitlePresence: [false],
-            hasTotal: true,
-            projectCount: 3)
-        #expect(withProjects > withTotal)
+    @Test
+    @MainActor
+    func `cost history without model breakdown stays compact`() {
+        let noBreakdown = [Self.entry(date: "2026-06-07", modelCount: 0)]
+        let withBreakdown = [Self.entry(date: "2026-06-07", modelCount: 1)]
 
-        let withProjectSources = CostHistoryChartMenuView._totalCardHeightForTesting(
-            modeSubtitlePresence: [false],
-            hasTotal: true,
-            projectSourceCounts: [3])
-        #expect(withProjectSources > withProjects)
+        #expect(Self.renderedHeight(daily: noBreakdown) < Self.renderedHeight(daily: withBreakdown))
     }
 
     @Test
@@ -249,5 +255,35 @@ struct CostHistoryChartMenuViewTests {
                     daily: [],
                     modelBreakdowns: nil),
             ])
+    }
+
+    @MainActor
+    private static func renderedHeight(daily: [CostUsageDailyReport.Entry]) -> CGFloat {
+        let hosting = MenuHostingView(rootView: CostHistoryChartMenuView(
+            provider: .codex,
+            daily: daily,
+            totalCostUSD: nil,
+            width: 320))
+        hosting.frame = CGRect(x: 0, y: 0, width: 320, height: 1)
+        hosting.layoutSubtreeIfNeeded()
+        return ceil(hosting.fittingSize.height)
+    }
+
+    private static func entry(date: String, modelCount: Int) -> CostUsageDailyReport.Entry {
+        CostUsageDailyReport.Entry(
+            date: date,
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+            costUSD: 1,
+            modelsUsed: modelCount > 0 ? (0..<modelCount).map { "model-\($0)" } : nil,
+            modelBreakdowns: modelCount > 0
+                ? (0..<modelCount).map {
+                    CostUsageDailyReport.ModelBreakdown(
+                        modelName: "model-\($0)",
+                        costUSD: Double($0 + 1),
+                        totalTokens: ($0 + 1) * 100)
+                }
+                : nil)
     }
 }

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -79,16 +79,40 @@ struct CostHistoryChartMenuViewTests {
         let cappedRows = CostHistoryChartMenuView._detailViewportConfigurationForTesting(
             provider: .codex,
             daily: [Self.entry(date: "2026-06-07", modelCount: 6)])
+        let mixedRows = CostHistoryChartMenuView._detailViewportConfigurationForTesting(
+            provider: .codex,
+            daily: [Self.entry(date: "2026-06-07", modelCount: 6), Self.entry(date: "2026-06-08", modelCount: 1)])
         let noRows = CostHistoryChartMenuView._detailViewportConfigurationForTesting(
             provider: .codex,
             daily: [Self.entry(date: "2026-06-07", modelCount: 0)])
 
         #expect(threeRows.rowCount == 3)
         #expect(!threeRows.hasOverflow)
+        #expect(threeRows.rowHeight == 36)
         #expect(cappedRows.rowCount == 4)
         #expect(cappedRows.hasOverflow)
+        #expect(mixedRows.rowCount == 4)
+        #expect(mixedRows.hasOverflow)
         #expect(noRows.rowCount == 0)
         #expect(!noRows.hasOverflow)
+    }
+
+    @Test
+    @MainActor
+    func `cost history expands every row only when the range contains mode details`() {
+        let compact = CostHistoryChartMenuView._detailViewportConfigurationForTesting(
+            provider: .codex,
+            daily: [Self.entry(date: "2026-06-07", modelCount: 2)])
+        let expanded = CostHistoryChartMenuView._detailViewportConfigurationForTesting(
+            provider: .codex,
+            daily: [
+                Self.entry(date: "2026-06-07", modelCount: 2),
+                Self.entry(date: "2026-06-08", modelCount: 1, hasModeDetails: true),
+            ])
+
+        #expect(compact.rowHeight == 36)
+        #expect(expanded.rowHeight == 44)
+        #expect(compact.rowCount == expanded.rowCount)
     }
 
     @Test
@@ -269,7 +293,11 @@ struct CostHistoryChartMenuViewTests {
         return ceil(hosting.fittingSize.height)
     }
 
-    private static func entry(date: String, modelCount: Int) -> CostUsageDailyReport.Entry {
+    private static func entry(
+        date: String,
+        modelCount: Int,
+        hasModeDetails: Bool = false) -> CostUsageDailyReport.Entry
+    {
         CostUsageDailyReport.Entry(
             date: date,
             inputTokens: 100,
@@ -282,7 +310,8 @@ struct CostHistoryChartMenuViewTests {
                     CostUsageDailyReport.ModelBreakdown(
                         modelName: "model-\($0)",
                         costUSD: Double($0 + 1),
-                        totalTokens: ($0 + 1) * 100)
+                        totalTokens: ($0 + 1) * 100,
+                        standardCostUSD: hasModeDetails ? Double($0 + 1) * 0.75 : nil)
                 }
                 : nil)
     }


### PR DESCRIPTION
Fixes #2015

Keeps the cost history chart in place while hovering days with different model counts.

- sizes the model viewport to the busiest day in the displayed history, capped at four rows
- keeps histories without model breakdowns compact
- uses consistent row slots and keeps longer lists scrollable
- shows a subtle “Scroll to see more models” hint on overflowing days
- removes hover-driven AppKit host resizing

Validation on exact head `096521bd1586534e83aefb41b60f26a985763d7a`:

- focused cost-history, hosted-submenu, and localization suites: 53 tests passed
- `make check`: SwiftFormat, SwiftLint, locale parity, parser hash, packaging, and repository checks passed
- `make test`: all 50 local shards passed
- autoreview: clean, patch correctness 0.91
- Developer ID-signed debug bundle: strict codesign and Gatekeeper passed; bundled CLI reports 0.41.1
- isolated synthetic `CODEX_HOME`: packaged CLI produced 1-, 4-, and 6-row days
- live menu proof: the same submenu window stayed exactly 423×533 at (817,155) across all three hover states; the overflow hint appeared and scrolling revealed rows 5–6 without changing bounds
- no real credentials, Keychain reads, browser sessions, or provider calls were used

<img width="729" height="988" alt="Screenshot 2026-07-09 at 10 06 42 PM" src="https://github.com/user-attachments/assets/c159b3ea-bc60-417f-9e1f-fcc03e222ae3" />
