### PR TITLE
fix: isolate Codex OAuth quota requests per account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Quota warnings: add opt-in predictive pace alerts for Codex and Claude session and weekly limits, with one alert per risk episode. Thanks @vincent-peng!
 
 ### Fixed
+- Codex accounts: isolate authenticated OAuth and browser-cookie requests from shared URL caches and cookie stores, preventing one account's cached quota or identity response from appearing under another account and triggering false reset alerts (#1987, #2019). Thanks @harjothkhara!
 - CLI server: retain timed-out route and provider work until it actually exits, preventing repeated requests or config changes from stacking background fetches. Thanks @Yuxin-Qiao!
 - Token costs: coalesce bounded pricing-catalog refreshes when a newly observed model is still unpriced, preserving its exact usage until pricing arrives. Thanks @iam-brain!
 - Cost history: keep model breakdown menus steady while hovering, preserve compact rows, and make overflowing histories scrollable. Thanks @iam-brain!

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -675,7 +675,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
         }
     }
 
-    private func fetchSignedInEmailFromAPI(
+    func fetchSignedInEmailFromAPI(
         cookies: [HTTPCookie],
         deadline: Date?,
         logger: (String) -> Void) async throws -> String?
@@ -695,14 +695,13 @@ public struct OpenAIDashboardBrowserCookieImporter {
         for urlString in endpoints {
             let requestTimeout = try Self.remainingTimeout(until: deadline, cappedAt: 10)
             guard let url = URL(string: urlString) else { continue }
-            var request = URLRequest(url: url)
-            request.httpMethod = "GET"
-            request.timeoutInterval = requestTimeout
-            request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            let request = OpenAIDashboardFetcher.dashboardIdentityAPIRequest(
+                url: url,
+                cookieHeader: cookieHeader,
+                timeout: requestTimeout)
 
             do {
-                let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
+                let (data, response) = try await CodexAuthenticatedHTTPTransport.current.data(for: request)
                 let status = (response as? HTTPURLResponse)?.statusCode ?? -1
                 logger("API \(url.host ?? "chatgpt.com") \(url.path) status=\(status)")
                 guard status >= 200, status < 300 else { continue }

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -760,7 +760,7 @@ public struct OpenAIDashboardFetcher {
         return await self.fetchDashboardUsageAPI(cookieHeader: cookieHeader, deadline: nil, logger: logger)
     }
 
-    private static func fetchDashboardUsageAPI(
+    static func fetchDashboardUsageAPI(
         cookieHeader: String,
         deadline: Date?,
         logger: @escaping (String) -> Void) async -> DashboardAPIData?
@@ -770,7 +770,7 @@ public struct OpenAIDashboardFetcher {
         guard remaining > 0 else { return nil }
 
         do {
-            let (data, response) = try await ProviderHTTPClient.shared.data(
+            let (data, response) = try await CodexAuthenticatedHTTPTransport.current.data(
                 for: self.dashboardUsageAPIRequest(cookieHeader: cookieHeader, timeout: min(4, remaining)))
             let status = (response as? HTTPURLResponse)?.statusCode ?? -1
             logger("usage api status=\(status)")
@@ -787,7 +787,7 @@ public struct OpenAIDashboardFetcher {
         }
     }
 
-    private static func fetchSignedInEmailFromAPI(
+    static func fetchSignedInEmailFromAPI(
         cookieHeader: String,
         deadline: Date?,
         logger: @escaping (String) -> Void) async -> String?
@@ -803,7 +803,7 @@ public struct OpenAIDashboardFetcher {
             let remaining = deadline.map { self.remainingTimeout(until: $0) } ?? 2
             guard remaining > 0 else { return nil }
             do {
-                let (data, response) = try await ProviderHTTPClient.shared.data(
+                let (data, response) = try await CodexAuthenticatedHTTPTransport.current.data(
                     for: self.dashboardIdentityAPIRequest(
                         url: url,
                         cookieHeader: cookieHeader,
@@ -1004,9 +1004,11 @@ extension OpenAIDashboardFetcher {
         cookieHeader: String,
         timeout: TimeInterval = 4) -> URLRequest
     {
-        var request = URLRequest(url: Self.dashboardUsageAPIURL)
+        var request = URLRequest(
+            url: Self.dashboardUsageAPIURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: timeout)
         request.httpMethod = "GET"
-        request.timeoutInterval = timeout
         request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
@@ -1019,9 +1021,11 @@ extension OpenAIDashboardFetcher {
         cookieHeader: String,
         timeout: TimeInterval = 2) -> URLRequest
     {
-        var request = URLRequest(url: url)
+        var request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: timeout)
         request.httpMethod = "GET"
-        request.timeoutInterval = timeout
         request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")

--- a/Sources/CodexBarCore/Providers/Codex/CodexAuthenticatedHTTPTransport.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexAuthenticatedHTTPTransport.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+enum CodexAuthenticatedHTTPTransport {
+    static let shared = Self.makeClient()
+
+    @TaskLocal static var overrideForTesting: (any ProviderHTTPTransport)?
+
+    static var current: any ProviderHTTPTransport {
+        if let override = self.overrideForTesting {
+            return override
+        }
+        return self.shared
+    }
+
+    static func makeConfiguration() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.httpCookieStorage = nil
+        configuration.httpShouldSetCookies = false
+        configuration.urlCredentialStorage = nil
+        return configuration
+    }
+
+    static func makeClient(configuration: URLSessionConfiguration? = nil) -> ProviderHTTPClient {
+        let configuration = configuration ?? self.makeConfiguration()
+        let session = ProviderHTTPClient.redirectGuardedSession(configuration: configuration)
+        return ProviderHTTPClient(session: session)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -349,11 +349,14 @@ public enum CodexOAuthUsageFetcher {
     public static func fetchUsage(
         accessToken: String,
         accountId: String?,
-        env: [String: String] = ProcessInfo.processInfo.environment) async throws -> CodexUsageResponse
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> CodexUsageResponse
     {
-        var request = URLRequest(url: Self.resolveUsageURL(env: env))
+        var request = URLRequest(
+            url: Self.resolveUsageURL(env: env),
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 30)
         request.httpMethod = "GET"
-        request.timeoutInterval = 30
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -363,7 +366,7 @@ public enum CodexOAuthUsageFetcher {
         }
 
         do {
-            let response = try await ProviderHTTPClient.shared.response(for: request)
+            let response = try await transport.response(for: request)
             let data = response.data
 
             switch response.statusCode {
@@ -399,7 +402,10 @@ public enum CodexOAuthUsageFetcher {
         session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws
         -> CodexRateLimitResetCreditsSnapshot
     {
-        var request = URLRequest(url: Self.resolveRateLimitResetCreditsURL(env: env), timeoutInterval: timeout)
+        var request = URLRequest(
+            url: Self.resolveRateLimitResetCreditsURL(env: env),
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: timeout)
         request.httpMethod = "GET"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -349,8 +349,20 @@ public enum CodexOAuthUsageFetcher {
     public static func fetchUsage(
         accessToken: String,
         accountId: String?,
+        env: [String: String] = ProcessInfo.processInfo.environment) async throws -> CodexUsageResponse
+    {
+        try await self.fetchUsage(
+            accessToken: accessToken,
+            accountId: accountId,
+            env: env,
+            session: CodexAuthenticatedHTTPTransport.current)
+    }
+
+    public static func fetchUsage(
+        accessToken: String,
+        accountId: String?,
         env: [String: String] = ProcessInfo.processInfo.environment,
-        session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> CodexUsageResponse
+        session transport: any ProviderHTTPTransport) async throws -> CodexUsageResponse
     {
         var request = URLRequest(
             url: Self.resolveUsageURL(env: env),
@@ -398,8 +410,22 @@ public enum CodexOAuthUsageFetcher {
         accessToken: String,
         accountId: String?,
         env: [String: String] = ProcessInfo.processInfo.environment,
+        timeout: TimeInterval = 4) async throws -> CodexRateLimitResetCreditsSnapshot
+    {
+        try await self.fetchRateLimitResetCredits(
+            accessToken: accessToken,
+            accountId: accountId,
+            env: env,
+            timeout: timeout,
+            session: CodexAuthenticatedHTTPTransport.current)
+    }
+
+    public static func fetchRateLimitResetCredits(
+        accessToken: String,
+        accountId: String?,
+        env: [String: String] = ProcessInfo.processInfo.environment,
         timeout: TimeInterval = 4,
-        session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws
+        session transport: any ProviderHTTPTransport) async throws
         -> CodexRateLimitResetCreditsSnapshot
     {
         var request = URLRequest(

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift
@@ -31,13 +31,22 @@ public enum CodexTokenRefresher {
     }
 
     public static func refresh(_ credentials: CodexOAuthCredentials) async throws -> CodexOAuthCredentials {
+        try await self.refresh(credentials, session: CodexAuthenticatedHTTPTransport.current)
+    }
+
+    static func refresh(
+        _ credentials: CodexOAuthCredentials,
+        session transport: any ProviderHTTPTransport) async throws -> CodexOAuthCredentials
+    {
         guard !credentials.refreshToken.isEmpty else {
             return credentials
         }
 
-        var request = URLRequest(url: Self.refreshEndpoint)
+        var request = URLRequest(
+            url: Self.refreshEndpoint,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 30)
         request.httpMethod = "POST"
-        request.timeoutInterval = 30
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         let body: [String: String] = [
@@ -49,7 +58,7 @@ public enum CodexTokenRefresher {
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         do {
-            let response = try await ProviderHTTPClient.shared.response(for: request)
+            let response = try await transport.response(for: request)
             let data = response.data
             guard response.statusCode == 200 else {
                 throw Self.refreshFailureError(statusCode: response.statusCode, data: data)

--- a/Sources/CodexBarCore/Providers/Codex/CodexOpenAIWorkspaceResolver.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOpenAIWorkspaceResolver.swift
@@ -36,10 +36,13 @@ public enum CodexOpenAIWorkspaceResolver {
 
     private static let accountsURL = URL(string: "https://chatgpt.com/backend-api/accounts")!
 
+    public static func resolve(credentials: CodexOAuthCredentials) async throws -> CodexOpenAIWorkspaceIdentity? {
+        try await self.resolve(credentials: credentials, session: CodexAuthenticatedHTTPTransport.current)
+    }
+
     public static func resolve(
         credentials: CodexOAuthCredentials,
-        session transport: any ProviderHTTPTransport = ProviderHTTPClient
-            .shared) async throws -> CodexOpenAIWorkspaceIdentity?
+        session transport: any ProviderHTTPTransport) async throws -> CodexOpenAIWorkspaceIdentity?
     {
         guard let workspaceAccountID = normalizeWorkspaceAccountID(credentials.accountId) else {
             return nil
@@ -56,13 +59,20 @@ public enum CodexOpenAIWorkspaceResolver {
     }
 
     public static func listWorkspaces(
-        credentials: CodexOAuthCredentials,
-        session transport: any ProviderHTTPTransport = ProviderHTTPClient
-            .shared) async throws -> [CodexOpenAIWorkspaceIdentity]
+        credentials: CodexOAuthCredentials) async throws -> [CodexOpenAIWorkspaceIdentity]
     {
-        var request = URLRequest(url: self.accountsURL)
+        try await self.listWorkspaces(credentials: credentials, session: CodexAuthenticatedHTTPTransport.current)
+    }
+
+    public static func listWorkspaces(
+        credentials: CodexOAuthCredentials,
+        session transport: any ProviderHTTPTransport) async throws -> [CodexOpenAIWorkspaceIdentity]
+    {
+        var request = URLRequest(
+            url: self.accountsURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 20)
         request.httpMethod = "GET"
-        request.timeoutInterval = 20
         request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("codex-cli", forHTTPHeaderField: "User-Agent")
         request.setValue("application/json", forHTTPHeaderField: "Accept")

--- a/Tests/CodexBarTests/CodexOAuthRequestTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthRequestTests.swift
@@ -5,21 +5,40 @@ import Testing
 import FoundationNetworking
 #endif
 
+@Suite(.serialized)
 struct CodexOAuthRequestTests {
     @Test
-    func `usage requests do not reuse refreshed quota response across accounts`() async throws {
-        let transport = CodexOAuthAccountCachingTransport()
+    func `authenticated transport disables shared network state`() {
+        let configuration = CodexAuthenticatedHTTPTransport.makeConfiguration()
 
-        let refreshed = try await CodexOAuthUsageFetcher.fetchUsage(
-            accessToken: "token-a",
-            accountId: "account-a",
-            env: ["CODEX_HOME": "/tmp/codexbar-oauth-request-test"],
-            session: transport)
-        let depleted = try await CodexOAuthUsageFetcher.fetchUsage(
-            accessToken: "token-b",
-            accountId: "account-b",
-            env: ["CODEX_HOME": "/tmp/codexbar-oauth-request-test"],
-            session: transport)
+        #expect(configuration.urlCache == nil)
+        #expect(configuration.requestCachePolicy == .reloadIgnoringLocalCacheData)
+        #expect(configuration.httpCookieStorage == nil)
+        #expect(configuration.httpShouldSetCookies == false)
+        #expect(configuration.urlCredentialStorage == nil)
+    }
+
+    @Test
+    func `usage requests fetch distinct cacheable responses for each account`() async throws {
+        defer { CodexOAuthAccountURLProtocol.reset() }
+        CodexOAuthAccountURLProtocol.reset()
+
+        let configuration = CodexAuthenticatedHTTPTransport.makeConfiguration()
+        configuration.protocolClasses = [CodexOAuthAccountURLProtocol.self]
+        let transport = CodexAuthenticatedHTTPTransport.makeClient(configuration: configuration)
+
+        let (refreshed, depleted) = try await CodexAuthenticatedHTTPTransport.$overrideForTesting
+            .withValue(transport) {
+                let refreshed = try await CodexOAuthUsageFetcher.fetchUsage(
+                    accessToken: "token-a",
+                    accountId: "account-a",
+                    env: ["CODEX_HOME": "/tmp/codexbar-oauth-request-test"])
+                let depleted = try await CodexOAuthUsageFetcher.fetchUsage(
+                    accessToken: "token-b",
+                    accountId: "account-b",
+                    env: ["CODEX_HOME": "/tmp/codexbar-oauth-request-test"])
+                return (refreshed, depleted)
+            }
 
         #expect(refreshed.rateLimit?.primaryWindow?.usedPercent == 7)
         #expect(refreshed.rateLimit?.secondaryWindow?.usedPercent == 9)
@@ -27,52 +46,176 @@ struct CodexOAuthRequestTests {
         #expect(depleted.rateLimit?.secondaryWindow?.usedPercent == 63)
         #expect(depleted.additionalRateLimits?.first?.rateLimit?.primaryWindow?.usedPercent == 4)
 
-        let requests = await transport.requests()
+        let requests = CodexOAuthAccountURLProtocol.recordedRequests
         #expect(requests.count == 2)
         #expect(requests.allSatisfy { $0.cachePolicy == .reloadIgnoringLocalCacheData })
         #expect(requests.map { $0.value(forHTTPHeaderField: "ChatGPT-Account-Id") } == ["account-a", "account-b"])
     }
+
+    #if os(macOS)
+    @MainActor
+    @Test
+    func `dashboard cookie requests fetch distinct cacheable responses`() async {
+        defer { CodexOAuthAccountURLProtocol.reset() }
+        CodexOAuthAccountURLProtocol.reset()
+
+        let configuration = CodexAuthenticatedHTTPTransport.makeConfiguration()
+        configuration.protocolClasses = [CodexOAuthAccountURLProtocol.self]
+        let transport = CodexAuthenticatedHTTPTransport.makeClient(configuration: configuration)
+
+        let (usageA, usageB) = await CodexAuthenticatedHTTPTransport.$overrideForTesting
+            .withValue(transport) {
+                let usageA = await OpenAIDashboardFetcher.fetchDashboardUsageAPI(
+                    cookieHeader: "session=a",
+                    deadline: nil,
+                    logger: { _ in })
+                let usageB = await OpenAIDashboardFetcher.fetchDashboardUsageAPI(
+                    cookieHeader: "session=b",
+                    deadline: nil,
+                    logger: { _ in })
+                return (usageA, usageB)
+            }
+
+        #expect(usageA?.primaryLimit?.usedPercent == 7)
+        #expect(usageB?.primaryLimit?.usedPercent == 100)
+        let requests = CodexOAuthAccountURLProtocol.recordedRequests
+        #expect(requests.count == 2)
+        #expect(requests.allSatisfy { $0.cachePolicy == .reloadIgnoringLocalCacheData })
+        #expect(requests.map { $0.value(forHTTPHeaderField: "Cookie") } == ["session=a", "session=b"])
+    }
+
+    @MainActor
+    @Test
+    func `dashboard and cookie importer identity calls use isolated transport`() async throws {
+        defer { CodexOAuthAccountURLProtocol.reset() }
+        CodexOAuthAccountURLProtocol.reset()
+
+        let configuration = CodexAuthenticatedHTTPTransport.makeConfiguration()
+        configuration.protocolClasses = [CodexOAuthAccountURLProtocol.self]
+        let transport = CodexAuthenticatedHTTPTransport.makeClient(configuration: configuration)
+        let cookie = try #require(HTTPCookie(properties: [
+            .domain: "chatgpt.com",
+            .path: "/",
+            .name: "session",
+            .value: "a",
+        ]))
+
+        let (dashboardEmail, importerEmail) = try await CodexAuthenticatedHTTPTransport.$overrideForTesting
+            .withValue(transport) {
+                let dashboardEmail = await OpenAIDashboardFetcher.fetchSignedInEmailFromAPI(
+                    cookieHeader: "session=a",
+                    deadline: nil,
+                    logger: { _ in })
+                let importer = OpenAIDashboardBrowserCookieImporter(browserDetection: BrowserDetection(cacheTTL: 0))
+                let importerEmail = try await importer.fetchSignedInEmailFromAPI(
+                    cookies: [cookie],
+                    deadline: nil,
+                    logger: { _ in })
+                return (dashboardEmail, importerEmail)
+            }
+
+        #expect(dashboardEmail == "account-a@example.com")
+        #expect(importerEmail == "account-a@example.com")
+        let requests = CodexOAuthAccountURLProtocol.recordedRequests
+        #expect(requests.count == 2)
+        #expect(requests.allSatisfy { $0.cachePolicy == .reloadIgnoringLocalCacheData })
+        #expect(requests.allSatisfy { $0.url?.path == "/backend-api/me" })
+    }
+    #endif
+
+    @Test
+    func `token refresh request uses isolated cache policy`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.url?.absoluteString == "https://auth.openai.com/oauth/token")
+            #expect(request.httpMethod == "POST")
+            #expect(request.cachePolicy == .reloadIgnoringLocalCacheData)
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Cache-Control": "public, max-age=300"]))
+            return (Data(#"{"access_token":"new-a","refresh_token":"new-r"}"#.utf8), response)
+        }
+        let credentials = CodexOAuthCredentials(
+            accessToken: "old-a",
+            refreshToken: "old-r",
+            idToken: nil,
+            accountId: "account-a",
+            lastRefresh: nil)
+
+        let refreshed = try await CodexAuthenticatedHTTPTransport.$overrideForTesting.withValue(transport) {
+            try await CodexTokenRefresher.refresh(credentials)
+        }
+
+        #expect(refreshed.accessToken == "new-a")
+        #expect(refreshed.refreshToken == "new-r")
+        #expect(await transport.requests().count == 1)
+    }
 }
 
-private actor CodexOAuthAccountCachingTransport: ProviderHTTPTransport {
-    private var recordedRequests: [URLRequest] = []
-    private var cachedResponses: [URL: (Data, URLResponse)] = [:]
+private final class CodexOAuthAccountURLProtocol: URLProtocol {
+    private(set) nonisolated(unsafe) static var recordedRequests: [URLRequest] = []
 
-    func requests() -> [URLRequest] {
-        self.recordedRequests
+    static func reset() {
+        self.recordedRequests = []
     }
 
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        self.recordedRequests.append(request)
-        guard let url = request.url else { throw URLError(.badURL) }
-        if request.cachePolicy != .reloadIgnoringLocalCacheData,
-           let cached = self.cachedResponses[url]
-        {
-            return cached
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.recordedRequests.append(self.request)
+        guard let url = self.request.url else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
         }
 
-        let payload = switch request.value(forHTTPHeaderField: "ChatGPT-Account-Id") {
-        case "account-a":
-            Self.payload(primary: 7, secondary: 9, spark: 2)
-        case "account-b":
-            Self.payload(primary: 100, secondary: 63, spark: 4)
-        default:
-            throw URLError(.userAuthenticationRequired)
+        let accountKey = self.request.value(forHTTPHeaderField: "ChatGPT-Account-Id")
+            ?? self.request.value(forHTTPHeaderField: "Cookie")
+        if self.request.url?.path == "/backend-api/me" {
+            let email = accountKey == "session=a" ? "account-a@example.com" : "account-b@example.com"
+            guard let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Cache-Control": "public, max-age=300"])
+            else {
+                self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+                return
+            }
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .allowed)
+            self.client?.urlProtocol(self, didLoad: Data(#"{"email":"\#(email)"}"#.utf8))
+            self.client?.urlProtocolDidFinishLoading(self)
+            return
         }
-        guard let response = HTTPURLResponse(
-            url: url,
-            statusCode: 200,
-            httpVersion: nil,
-            headerFields: ["Cache-Control": "public, max-age=300"])
+        let payload: String? = switch accountKey {
+        case "account-a", "session=a": Self.payload(primary: 7, secondary: 9, spark: 2)
+        case "account-b", "session=b": Self.payload(primary: 100, secondary: 63, spark: 4)
+        default: nil
+        }
+        guard let payload,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: 200,
+                  httpVersion: nil,
+                  headerFields: ["Cache-Control": "public, max-age=300"])
         else {
-            throw URLError(.badServerResponse)
+            self.client?.urlProtocol(self, didFailWithError: URLError(.userAuthenticationRequired))
+            return
         }
-        let result: (Data, URLResponse) = (Data(payload.utf8), response)
-        if request.cachePolicy != .reloadIgnoringLocalCacheData {
-            self.cachedResponses[url] = result
-        }
-        return result
+
+        self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .allowed)
+        self.client?.urlProtocol(self, didLoad: Data(payload.utf8))
+        self.client?.urlProtocolDidFinishLoading(self)
     }
+
+    override func stopLoading() {}
 
     private static func payload(primary: Int, secondary: Int, spark: Int) -> String {
         """

--- a/Tests/CodexBarTests/CodexOAuthRequestTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthRequestTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct CodexOAuthRequestTests {
+    @Test
+    func `usage requests do not reuse refreshed quota response across accounts`() async throws {
+        let transport = CodexOAuthAccountCachingTransport()
+
+        let refreshed = try await CodexOAuthUsageFetcher.fetchUsage(
+            accessToken: "token-a",
+            accountId: "account-a",
+            env: ["CODEX_HOME": "/tmp/codexbar-oauth-request-test"],
+            session: transport)
+        let depleted = try await CodexOAuthUsageFetcher.fetchUsage(
+            accessToken: "token-b",
+            accountId: "account-b",
+            env: ["CODEX_HOME": "/tmp/codexbar-oauth-request-test"],
+            session: transport)
+
+        #expect(refreshed.rateLimit?.primaryWindow?.usedPercent == 7)
+        #expect(refreshed.rateLimit?.secondaryWindow?.usedPercent == 9)
+        #expect(depleted.rateLimit?.primaryWindow?.usedPercent == 100)
+        #expect(depleted.rateLimit?.secondaryWindow?.usedPercent == 63)
+        #expect(depleted.additionalRateLimits?.first?.rateLimit?.primaryWindow?.usedPercent == 4)
+
+        let requests = await transport.requests()
+        #expect(requests.count == 2)
+        #expect(requests.allSatisfy { $0.cachePolicy == .reloadIgnoringLocalCacheData })
+        #expect(requests.map { $0.value(forHTTPHeaderField: "ChatGPT-Account-Id") } == ["account-a", "account-b"])
+    }
+}
+
+private actor CodexOAuthAccountCachingTransport: ProviderHTTPTransport {
+    private var recordedRequests: [URLRequest] = []
+    private var cachedResponses: [URL: (Data, URLResponse)] = [:]
+
+    func requests() -> [URLRequest] {
+        self.recordedRequests
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        self.recordedRequests.append(request)
+        guard let url = request.url else { throw URLError(.badURL) }
+        if request.cachePolicy != .reloadIgnoringLocalCacheData,
+           let cached = self.cachedResponses[url]
+        {
+            return cached
+        }
+
+        let payload = switch request.value(forHTTPHeaderField: "ChatGPT-Account-Id") {
+        case "account-a":
+            Self.payload(primary: 7, secondary: 9, spark: 2)
+        case "account-b":
+            Self.payload(primary: 100, secondary: 63, spark: 4)
+        default:
+            throw URLError(.userAuthenticationRequired)
+        }
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Cache-Control": "public, max-age=300"])
+        else {
+            throw URLError(.badServerResponse)
+        }
+        let result: (Data, URLResponse) = (Data(payload.utf8), response)
+        if request.cachePolicy != .reloadIgnoringLocalCacheData {
+            self.cachedResponses[url] = result
+        }
+        return result
+    }
+
+    private static func payload(primary: Int, secondary: Int, spark: Int) -> String {
+        """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": \(primary), "reset_at": 1766948068, "limit_window_seconds": 18000
+            },
+            "secondary_window": {
+              "used_percent": \(secondary), "reset_at": 1767407914, "limit_window_seconds": 604800
+            }
+          },
+          "additional_rate_limits": [{
+            "limit_name": "GPT-5.3-Codex-Spark",
+            "rate_limit": {
+              "primary_window": {
+                "used_percent": \(spark), "reset_at": 1766948068, "limit_window_seconds": 18000
+              }
+            }
+          }]
+        }
+        """
+    }
+}

--- a/Tests/CodexBarTests/CodexOpenAIWorkspaceResolverTests.swift
+++ b/Tests/CodexBarTests/CodexOpenAIWorkspaceResolverTests.swift
@@ -1,6 +1,6 @@
-import CodexBarCore
 import Foundation
 import Testing
+@testable import CodexBarCore
 
 @Suite(.serialized)
 struct CodexOpenAIWorkspaceResolverTests {
@@ -51,6 +51,33 @@ struct CodexOpenAIWorkspaceResolverTests {
             == "account-live")
         #expect(CodexOpenAIWorkspaceStubURLProtocol.requests.first?.value(forHTTPHeaderField: "User-Agent")
             == "codex-cli")
+    }
+
+    @Test
+    func `resolver default uses isolated authenticated transport`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.cachePolicy == .reloadIgnoringLocalCacheData)
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Cache-Control": "public, max-age=300"]))
+            return (Data(#"{"items":[{"id":"account-live","name":"Team Alpha"}]}"#.utf8), response)
+        }
+        let credentials = CodexOAuthCredentials(
+            accessToken: "test-a",
+            refreshToken: "test-r",
+            idToken: nil,
+            accountId: "account-live",
+            lastRefresh: nil)
+
+        let identity = try await CodexAuthenticatedHTTPTransport.$overrideForTesting.withValue(transport) {
+            try await CodexOpenAIWorkspaceResolver.resolve(credentials: credentials)
+        }
+
+        #expect(identity?.workspaceLabel == "Team Alpha")
+        #expect(await transport.requests().count == 1)
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexRateLimitResetCreditsTests.swift
+++ b/Tests/CodexBarTests/CodexRateLimitResetCreditsTests.swift
@@ -33,11 +33,12 @@ struct CodexRateLimitResetCreditsTests {
             return (Data(#"{"credits":[],"available_count":0}"#.utf8), response)
         }
 
-        let snapshot = try await CodexOAuthUsageFetcher.fetchRateLimitResetCredits(
-            accessToken: "test-token",
-            accountId: "account-123",
-            env: ["CODEX_HOME": "/tmp/codexbar-reset-credit-request-test"],
-            session: transport)
+        let snapshot = try await CodexAuthenticatedHTTPTransport.$overrideForTesting.withValue(transport) {
+            try await CodexOAuthUsageFetcher.fetchRateLimitResetCredits(
+                accessToken: "test-token",
+                accountId: "account-123",
+                env: ["CODEX_HOME": "/tmp/codexbar-reset-credit-request-test"])
+        }
 
         #expect(snapshot.availableCount == 0)
         #expect(await transport.requests().count == 1)

--- a/Tests/CodexBarTests/CodexRateLimitResetCreditsTests.swift
+++ b/Tests/CodexBarTests/CodexRateLimitResetCreditsTests.swift
@@ -19,6 +19,7 @@ struct CodexRateLimitResetCreditsTests {
             #expect(request.url?.absoluteString == "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")
             #expect(request.httpMethod == "GET")
             #expect(request.timeoutInterval == 4)
+            #expect(request.cachePolicy == .reloadIgnoringLocalCacheData)
             #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
             #expect(request.value(forHTTPHeaderField: "ChatGPT-Account-ID") == "account-123")
             #expect(request.value(forHTTPHeaderField: "OpenAI-Beta") == "codex-1")

--- a/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
@@ -268,6 +268,7 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
         #expect(request.value(forHTTPHeaderField: "Cookie") == "a=b")
         #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
         #expect(request.value(forHTTPHeaderField: "Accept-Language") == "en-US,en;q=0.9")
+        #expect(request.cachePolicy == .reloadIgnoringLocalCacheData)
     }
 
     @Test
@@ -279,6 +280,7 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
         #expect(request.value(forHTTPHeaderField: "Cookie") == "a=b")
         #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
         #expect(request.value(forHTTPHeaderField: "Accept-Language") == "en-US,en;q=0.9")
+        #expect(request.cachePolicy == .reloadIgnoringLocalCacheData)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Isolate every authenticated Codex/OpenAI request from shared URL caches, cookies, and credential storage.
- Route OAuth usage, reset-credit, refresh, workspace, dashboard, and cookie-import identity requests through one redirect-guarded ephemeral transport.
- Add caller-level regressions proving identical cacheable URLs cannot leak one account's quota or identity into another account.
- Preserve the contributor's original account-isolation fix and add the maintainer changelog entry.

## Exact-head validation

Head: `a354051d5ca4930a2854dae3741d80477a630780`

- Focused request/workspace/dashboard/reset-credit suites: 46 tests passed.
- `make check`: passed; SwiftFormat and SwiftLint clean.
- `make test`: all 596 selections in 50 groups passed first attempt; no retries or timeouts.
- Autoreview plus independent final transport/rebase review: clean.
- Signed debug bundle: embedded `a354051d`; Developer ID signature valid; CLI reports CodexBar 0.41.1.
- Isolated packaged-CLI live proof: two synthetic managed accounts shared the same cacheable loopback URLs and still returned distinct 7%/81% usage; the server observed separate credentials and account IDs for both usage and reset-credit requests.
- Live proof used an empty environment, temporary homes, loopback-only fixtures, and disabled Keychain access. No provider, browser-cookie, or ambient credential access.
- Public Model Identifier Gate: PASS. No new dependency.

Fixes #1987
