### PR TITLE
feat(codex): add Spark usage visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Agent Sessions: list and focus live local or SSH-discovered Codex and Claude Code sessions from the menu and CLI.
+- Codex: add a provider option to hide Spark quota rows without hiding credits or other extra usage (#2013). Thanks @intellectronica!
 - Wayfinder: add opt-in local gateway health, routing, savings, and latency usage with configurable loopback URL support. Thanks @tcballard!
 - Claude CLI: surface model-scoped weekly limits alongside all-model usage without duplicating matching web limits. Thanks @janpollak!
 - Documentation: add detailed setup and troubleshooting references for Perplexity, Mistral, and Qoder. Thanks @kiranmagic7!

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -538,7 +538,12 @@ extension UsageMenuCardView.Model {
         if input.provider == .copilot, !input.copilotBudgetExtrasEnabled {
             return []
         }
-        return extraRateWindows.map { namedWindow in
+        let visibleRateWindows = if input.provider == .codex, !input.codexSparkUsageVisible {
+            extraRateWindows.filter { !Self.isCodexSparkRateWindow($0) }
+        } else {
+            extraRateWindows
+        }
+        return visibleRateWindows.map { namedWindow in
             let paceDetail = Self.extraRateWindowPaceDetail(
                 provider: input.provider,
                 window: namedWindow.window,
@@ -570,6 +575,11 @@ extension UsageMenuCardView.Model {
                 pacePercent: usageKnown ? paceDetail?.pacePercent : nil,
                 paceOnTop: paceDetail?.paceOnTop ?? true)
         }
+    }
+
+    private static func isCodexSparkRateWindow(_ namedWindow: NamedRateWindow) -> Bool {
+        namedWindow.id == CodexAdditionalRateLimitMapper.sparkWindowID ||
+            namedWindow.id == CodexAdditionalRateLimitMapper.sparkWeeklyWindowID
     }
 
     private static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"

--- a/Sources/CodexBar/MenuCardView+ModelInput.swift
+++ b/Sources/CodexBar/MenuCardView+ModelInput.swift
@@ -26,6 +26,7 @@ extension UsageMenuCardView.Model {
         let tokenCostMenuSectionEnabled: Bool
         let costComparisonPeriodsEnabled: Bool
         let showOptionalCreditsAndExtraUsage: Bool
+        let codexSparkUsageVisible: Bool
         let copilotBudgetExtrasEnabled: Bool
         let sourceLabel: String?
         let kiloAutoMode: Bool
@@ -60,6 +61,7 @@ extension UsageMenuCardView.Model {
             tokenCostMenuSectionEnabled: Bool? = nil,
             costComparisonPeriodsEnabled: Bool = false,
             showOptionalCreditsAndExtraUsage: Bool,
+            codexSparkUsageVisible: Bool = true,
             copilotBudgetExtrasEnabled: Bool = false,
             sourceLabel: String? = nil,
             kiloAutoMode: Bool = false,
@@ -93,6 +95,7 @@ extension UsageMenuCardView.Model {
             self.tokenCostMenuSectionEnabled = tokenCostMenuSectionEnabled ?? tokenCostUsageEnabled
             self.costComparisonPeriodsEnabled = costComparisonPeriodsEnabled
             self.showOptionalCreditsAndExtraUsage = showOptionalCreditsAndExtraUsage
+            self.codexSparkUsageVisible = codexSparkUsageVisible
             self.copilotBudgetExtrasEnabled = copilotBudgetExtrasEnabled
             self.sourceLabel = sourceLabel
             self.kiloAutoMode = kiloAutoMode

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -688,6 +688,7 @@ struct ProvidersPane: View {
             // available cost data in their Usage section.
             tokenCostMenuSectionEnabled: self.settings.isCostUsageEffectivelyEnabled(for: provider),
             showOptionalCreditsAndExtraUsage: self.settings.showOptionalCreditsAndExtraUsage,
+            codexSparkUsageVisible: self.settings.codexSparkUsageVisible,
             copilotBudgetExtrasEnabled: self.settings.copilotBudgetExtrasEnabled,
             hidePersonalInfo: self.settings.hidePersonalInfo,
             weeklyPace: weeklyPace,

--- a/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
@@ -84,6 +84,21 @@ struct CodexProviderImplementation: ProviderImplementation {
                 onAppDidBecomeActive: nil,
                 onAppearWhenEnabled: nil),
             ProviderSettingsToggleDescriptor(
+                id: "codex-spark-usage-visible",
+                title: "Show Codex Spark usage",
+                subtitle: [
+                    "Shows Codex Spark quota rows in the menu and provider preview.",
+                    "Requires optional credits and extra usage in Display settings.",
+                ].joined(separator: " "),
+                binding: context.boolBinding(\.codexSparkUsageVisible),
+                statusText: nil,
+                actions: [],
+                isVisible: nil,
+                isEnabled: { context.settings.showOptionalCreditsAndExtraUsage },
+                onChange: nil,
+                onAppDidBecomeActive: nil,
+                onAppearWhenEnabled: nil),
+            ProviderSettingsToggleDescriptor(
                 id: "codex-openai-web-extras",
                 title: "OpenAI web extras",
                 subtitle: [

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1162,3 +1162,5 @@
 "section_diagnostics" = "التشخيصات";
 "section_updates" = "التحديثات";
 "section_links" = "روابط";
+"Show Codex Spark usage" = "عرض استخدام Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "يعرض صفوف حصة Codex Spark في القائمة ومعاينة المزوّد. يتطلب تفعيل «عرض الاعتمادات + الاستخدام الإضافي» في إعدادات العرض.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1161,3 +1161,5 @@
 "section_diagnostics" = "Diagnòstics";
 "section_updates" = "Actualitzacions";
 "section_links" = "Enllaços";
+"Show Codex Spark usage" = "Mostreu l'ús de Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Mostreu les files de quota de Codex Spark al menú i a la previsualització del proveïdor. Cal activar «Mostreu crèdits + ús addicional» a la configuració de Pantalla.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1155,3 +1155,5 @@
 "section_diagnostics" = "Diagnose";
 "section_updates" = "Updates";
 "section_links" = "Links";
+"Show Codex Spark usage" = "Codex-Spark-Nutzung anzeigen";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Zeigt die Codex-Spark-Kontingentzeilen im Menü und in der Anbietervorschau an. Erfordert, dass „Credits + zusätzliche Nutzung anzeigen“ in den Anzeigeeinstellungen aktiviert ist.";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1162,3 +1162,5 @@
 "section_diagnostics" = "Diagnostics";
 "section_updates" = "Updates";
 "section_links" = "Links";
+"Show Codex Spark usage" = "Show Codex Spark usage";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1016,3 +1016,5 @@
 "section_diagnostics" = "Diagnósticos";
 "section_updates" = "Actualizaciones";
 "section_links" = "Enlaces";
+"Show Codex Spark usage" = "Mostrar el uso de Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Muestra las filas de cuota de Codex Spark en el menú y en la vista previa del proveedor. Requiere activar «Mostrar créditos + uso adicional» en los ajustes de Pantalla.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1162,3 +1162,5 @@
 "section_diagnostics" = "عیب‌یابی";
 "section_updates" = "به‌روزرسانی‌ها";
 "section_links" = "پیوندها";
+"Show Codex Spark usage" = "نمایش استفاده از Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "ردیف‌های سهمیه Codex Spark را در منو و پیش‌نمایش ارائه‌دهنده نمایش می‌دهد. لازم است «نمایش اعتبارها + استفاده اضافی» در تنظیمات نمایش فعال باشد.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1155,3 +1155,5 @@
 "section_diagnostics" = "Diagnostics";
 "section_updates" = "Mises à jour";
 "section_links" = "Liens";
+"Show Codex Spark usage" = "Afficher l’utilisation de Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Affiche les lignes de quota Codex Spark dans le menu et l’aperçu du fournisseur. Nécessite d’activer « Afficher les crédits + utilisation supplémentaire » dans les réglages Affichage.";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1157,3 +1157,5 @@
 "usage_percent_suffix_used" = "usado";
 "z.ai API token not found. Set apiKey in ~/.codexbar/config.json or Z_AI_API_KEY." = "Non se atopou o token da API de z.ai. Define apiKey en ~/.codexbar/config.json ou Z_AI_API_KEY.";
 "≈ %d%% run-out risk" = "≈ %d%% de risco de esgotamento";
+"Show Codex Spark usage" = "Amosar o uso de Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Amosa as filas de cota de Codex Spark no menú e na previsualización do provedor. Require activar «Amosar créditos + uso adicional» nos axustes de Pantalla.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1161,3 +1161,5 @@
 "section_diagnostics" = "Diagnostik";
 "section_updates" = "Pembaruan";
 "section_links" = "Tautan";
+"Show Codex Spark usage" = "Tampilkan penggunaan Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Menampilkan baris kuota Codex Spark di menu dan pratinjau penyedia. Mengharuskan “Tampilkan kredit + penggunaan ekstra” diaktifkan di pengaturan Tampilan.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1161,3 +1161,5 @@
 "section_diagnostics" = "Diagnostica";
 "section_updates" = "Aggiornamenti";
 "section_links" = "Link";
+"Show Codex Spark usage" = "Mostra l’utilizzo di Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Mostra le righe della quota Codex Spark nel menu e nell’anteprima del provider. Richiede di attivare «Mostra crediti + uso extra» nelle impostazioni Aspetto.";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1156,3 +1156,5 @@
 "section_diagnostics" = "診断";
 "section_updates" = "アップデート";
 "section_links" = "リンク";
+"Show Codex Spark usage" = "Codex Spark の使用量を表示";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "メニューとプロバイダのプレビューに Codex Spark のクォータ行を表示します。表示設定で「クレジットと追加使用量を表示」を有効にする必要があります。";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1124,3 +1124,5 @@
 "section_diagnostics" = "진단";
 "section_updates" = "업데이트";
 "section_links" = "링크";
+"Show Codex Spark usage" = "Codex Spark 사용량 표시";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "메뉴와 공급자 미리보기에 Codex Spark 할당량 행을 표시합니다. 표시 설정에서 ‘크레딧 + 추가 사용량 표시’를 활성화해야 합니다.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1155,3 +1155,5 @@
 "section_diagnostics" = "Diagnostiek";
 "section_updates" = "Updates";
 "section_links" = "Links";
+"Show Codex Spark usage" = "Codex Spark-gebruik tonen";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Toont Codex Spark-quotumregels in het menu en de voorvertoning van de provider. Vereist dat ‘Toon credits + extra gebruik’ is ingeschakeld in de instellingen voor Weergave.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1161,3 +1161,5 @@
 "section_diagnostics" = "Diagnostyka";
 "section_updates" = "Aktualizacje";
 "section_links" = "Linki";
+"Show Codex Spark usage" = "Pokaż użycie Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Pokazuje wiersze limitu Codex Spark w menu i podglądzie dostawcy. Wymaga włączenia opcji „Pokaż kredyty + dodatkowe użycie” w ustawieniach Wyświetlanie.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1156,3 +1156,5 @@
 "section_diagnostics" = "Diagnósticos";
 "section_updates" = "Atualizações";
 "section_links" = "Links";
+"Show Codex Spark usage" = "Mostrar uso do Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Mostra as linhas de cota do Codex Spark no menu e na prévia do provedor. Requer ativar “Mostrar créditos + uso extra” nos ajustes de Exibição.";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1162,3 +1162,5 @@
 "section_diagnostics" = "Диагностика";
 "section_updates" = "Обновления";
 "section_links" = "Ссылки";
+"Show Codex Spark usage" = "Показывать использование Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Показывает строки квот Codex Spark в меню и предварительном просмотре провайдера. Требует включить «Показывать кредиты и доп. использование» в настройках «Отображение».";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1154,3 +1154,5 @@
 "section_diagnostics" = "Diagnostik";
 "section_updates" = "Uppdateringar";
 "section_links" = "Länkar";
+"Show Codex Spark usage" = "Visa Codex Spark-användning";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Visar kvotrader för Codex Spark i menyn och i förhandsvisningen för leverantören. Kräver att ”Visa krediter och extra användning” är aktiverat under Visning i Inställningar.";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1162,3 +1162,5 @@
 "section_diagnostics" = "การวินิจฉัย";
 "section_updates" = "อัปเดต";
 "section_links" = "ลิงก์";
+"Show Codex Spark usage" = "แสดงการใช้งาน Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "แสดงแถวโควตา Codex Spark ในเมนูและตัวอย่างผู้ให้บริการ ต้องเปิดใช้ “แสดงเครดิต + การใช้งานเพิ่มเติม” ในการตั้งค่าการแสดงผล";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1159,3 +1159,5 @@
 "section_diagnostics" = "Tanılama";
 "section_updates" = "Güncellemeler";
 "section_links" = "Bağlantılar";
+"Show Codex Spark usage" = "Codex Spark kullanımını göster";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Codex Spark kota satırlarını menüde ve sağlayıcı önizlemesinde gösterir. Görünüm ayarlarında “Krediler + ekstra kullanımı göster” seçeneğinin etkin olmasını gerektirir.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1155,3 +1155,5 @@
 "section_diagnostics" = "Діагностика";
 "section_updates" = "Оновлення";
 "section_links" = "Посилання";
+"Show Codex Spark usage" = "Показати використання Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Показує рядки квоти Codex Spark у меню та попередньому перегляді провайдера. Потрібно ввімкнути «Показати кредити + додаткове використання» в налаштуваннях «Відображення».";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1156,3 +1156,5 @@
 "section_diagnostics" = "Chẩn đoán";
 "section_updates" = "Cập nhật";
 "section_links" = "Liên kết";
+"Show Codex Spark usage" = "Hiển thị mức sử dụng Codex Spark";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Hiển thị các hàng hạn mức Codex Spark trong menu và bản xem trước của nhà cung cấp. Yêu cầu bật “Hiển thị tín dụng + mức sử dụng bổ sung” trong phần cài đặt Hiển thị.";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1132,3 +1132,5 @@
 "section_diagnostics" = "诊断";
 "section_updates" = "更新";
 "section_links" = "链接";
+"Show Codex Spark usage" = "显示 Codex Spark 用量";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "在菜单和提供商预览中显示 Codex Spark 配额行。需要在“显示”设置中启用“显示额度 + 额外用量”。";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1191,3 +1191,5 @@
 "section_diagnostics" = "診斷";
 "section_updates" = "更新";
 "section_links" = "連結";
+"Show Codex Spark usage" = "顯示 Codex Spark 使用量";
+"Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "在選單和提供者預覽中顯示 Codex Spark 配額列。需要在「顯示」設定中啟用「顯示額度 + 額外使用量」。";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -513,6 +513,14 @@ extension SettingsStore {
         }
     }
 
+    var codexSparkUsageVisible: Bool {
+        get { self.defaultsState.codexSparkUsageVisible }
+        set {
+            self.defaultsState.codexSparkUsageVisible = newValue
+            self.userDefaults.set(newValue, forKey: "codexSparkUsageVisible")
+        }
+    }
+
     var openAIWebAccessEnabled: Bool {
         get { self.defaultsState.openAIWebAccessEnabled }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -48,6 +48,7 @@ extension SettingsStore {
         _ = self.claudeWebExtrasEnabled
         _ = self.copilotBudgetExtrasEnabled
         _ = self.showOptionalCreditsAndExtraUsage
+        _ = self.codexSparkUsageVisible
         _ = self.openAIWebAccessEnabled
         _ = self.openAIWebBatterySaverEnabled
         _ = self.providerStorageFootprintsEnabled

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -440,6 +440,11 @@ extension SettingsStore {
         if Self.isRunningTests, creditsExtrasDefault == nil {
             userDefaults.set(true, forKey: "showOptionalCreditsAndExtraUsage")
         }
+        let codexSparkUsageVisibleDefault = userDefaults.object(forKey: "codexSparkUsageVisible") as? Bool
+        let codexSparkUsageVisible = codexSparkUsageVisibleDefault ?? true
+        if Self.isRunningTests, codexSparkUsageVisibleDefault == nil {
+            userDefaults.set(true, forKey: "codexSparkUsageVisible")
+        }
         let openAIWebAccessDefault = userDefaults.object(forKey: "openAIWebAccessEnabled") as? Bool
         let openAIWebAccessEnabled = openAIWebAccessDefault ?? false
         if Self.isRunningTests, openAIWebAccessDefault == nil {
@@ -517,6 +522,7 @@ extension SettingsStore {
             claudeOAuthKeychainReadStrategyRaw: claudeOAuthKeychainReadStrategyRaw,
             claudeWebExtrasEnabledRaw: claudeWebExtrasEnabledRaw,
             showOptionalCreditsAndExtraUsage: showOptionalCreditsAndExtraUsage,
+            codexSparkUsageVisible: codexSparkUsageVisible,
             openAIWebAccessEnabled: openAIWebAccessEnabled,
             openAIWebBatterySaverEnabled: openAIWebBatterySaverEnabled,
             providerStorageFootprintsEnabled: providerStorageFootprintsEnabled,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -48,6 +48,7 @@ struct SettingsDefaultsState {
     var claudeOAuthKeychainReadStrategyRaw: String?
     var claudeWebExtrasEnabledRaw: Bool
     var showOptionalCreditsAndExtraUsage: Bool
+    var codexSparkUsageVisible: Bool
     var openAIWebAccessEnabled: Bool
     var openAIWebBatterySaverEnabled: Bool
     var providerStorageFootprintsEnabled: Bool

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -122,6 +122,7 @@ extension StatusItemController {
                 self.settings.costSummaryShowsSubmenu(for: target),
             costComparisonPeriodsEnabled: self.settings.costComparisonPeriodsEnabled,
             showOptionalCreditsAndExtraUsage: self.settings.showOptionalCreditsAndExtraUsage,
+            codexSparkUsageVisible: self.settings.codexSparkUsageVisible,
             copilotBudgetExtrasEnabled: self.settings.copilotBudgetExtrasEnabled,
             sourceLabel: sourceLabel,
             kiloAutoMode: kiloAutoMode,

--- a/Sources/CodexBarCore/Providers/Codex/CodexAdditionalRateLimitMapper.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexAdditionalRateLimitMapper.swift
@@ -7,11 +7,11 @@ import Foundation
 /// weekly Codex windows, so we surface them through `UsageSnapshot.extraRateWindows` rather than the core
 /// primary/secondary lanes. When the field is absent the mapper returns an empty list and the snapshot is
 /// unchanged.
-enum CodexAdditionalRateLimitMapper {
+package enum CodexAdditionalRateLimitMapper {
     /// Stable ids/titles for GPT-5.3-Codex-Spark limits so SwiftUI identity stays constant even if the API
     /// label wording shifts. Keep the original 5-hour id for compatibility with the first Spark implementation.
-    static let sparkWindowID = "codex-spark"
-    static let sparkWeeklyWindowID = "codex-spark-weekly"
+    package static let sparkWindowID = "codex-spark"
+    package static let sparkWeeklyWindowID = "codex-spark-weekly"
     static let sparkWindowTitle = "Codex Spark 5-hour"
     static let sparkWeeklyWindowTitle = "Codex Spark Weekly"
 

--- a/Tests/CodexBarTests/MenuCardModelCodexProjectionTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelCodexProjectionTests.swift
@@ -757,9 +757,11 @@ struct MenuCardModelCodexProjectionTests {
 
         #expect(model.creditsText == nil)
     }
+}
 
+struct MenuCardModelCodexSparkVisibilityTests {
     @Test
-    func `hides codex spark extra metric when showOptionalCreditsAndExtraUsage is false`() throws {
+    func `codex spark visibility hides only spark metrics`() throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let metadata = try #require(ProviderDefaults.metadata[.codex])
         let identity = ProviderIdentitySnapshot(
@@ -796,6 +798,14 @@ struct MenuCardModelCodexProjectionTests {
                         windowMinutes: 10080,
                         resetsAt: now.addingTimeInterval(6 * 24 * 60 * 60),
                         resetDescription: nil)),
+                NamedRateWindow(
+                    id: "codex-other-limit",
+                    title: "Other Codex limit",
+                    window: RateWindow(
+                        usedPercent: 25,
+                        windowMinutes: 1440,
+                        resetsAt: now.addingTimeInterval(12 * 60 * 60),
+                        resetDescription: nil)),
             ],
             updatedAt: now,
             identity: identity)
@@ -804,7 +814,7 @@ struct MenuCardModelCodexProjectionTests {
             context: CodexConsumerProjection.Context(
                 snapshot: snapshot,
                 rawUsageError: nil,
-                liveCredits: nil,
+                liveCredits: CreditsSnapshot(remaining: 12, events: [], updatedAt: now),
                 rawCreditsError: nil,
                 liveDashboard: nil,
                 rawDashboardError: nil,
@@ -817,7 +827,36 @@ struct MenuCardModelCodexProjectionTests {
             metadata: metadata,
             snapshot: snapshot,
             codexProjection: projection,
-            credits: nil,
+            credits: CreditsSnapshot(remaining: 12, events: [], updatedAt: now),
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "user@example.com", plan: "Pro"),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            codexSparkUsageVisible: false,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(!model.metrics.contains { $0.id == "codex-spark" })
+        #expect(!model.metrics.contains { $0.id == "codex-spark-weekly" })
+        #expect(model.metrics.contains { $0.id == "primary" })
+        #expect(model.metrics.contains { $0.id == "secondary" })
+        #expect(model.metrics.contains { $0.id == "codex-other-limit" })
+        #expect(model.creditsText != nil)
+
+        let globalOffModel = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: snapshot,
+            codexProjection: projection,
+            credits: CreditsSnapshot(remaining: 12, events: [], updatedAt: now),
             creditsError: nil,
             dashboard: nil,
             dashboardError: nil,
@@ -830,12 +869,13 @@ struct MenuCardModelCodexProjectionTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: false,
             showOptionalCreditsAndExtraUsage: false,
+            codexSparkUsageVisible: true,
             hidePersonalInfo: false,
             now: now))
 
-        #expect(!model.metrics.contains { $0.id == "codex-spark" })
-        #expect(!model.metrics.contains { $0.id == "codex-spark-weekly" })
-        #expect(model.metrics.contains { $0.id == "primary" })
-        #expect(model.metrics.contains { $0.id == "secondary" })
+        #expect(!globalOffModel.metrics.contains { $0.id == "codex-spark" })
+        #expect(!globalOffModel.metrics.contains { $0.id == "codex-spark-weekly" })
+        #expect(!globalOffModel.metrics.contains { $0.id == "codex-other-limit" })
+        #expect(globalOffModel.creditsText == nil)
     }
 }

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -60,6 +60,17 @@ struct ProviderSettingsDescriptorTests {
         #expect(pickers.contains(where: { $0.id == "codex-usage-source" }))
         #expect(pickers.contains(where: { $0.id == "codex-cookie-source" }))
         #expect(toggles.contains(where: { $0.id == "codex-historical-tracking" }))
+        let sparkToggle = try #require(toggles.first(where: { $0.id == "codex-spark-usage-visible" }))
+        #expect(sparkToggle.title == "Show Codex Spark usage")
+        #expect(sparkToggle.subtitle.contains("menu and provider preview"))
+        #expect(sparkToggle.binding.wrappedValue)
+        #expect(sparkToggle.isEnabled?() == true)
+
+        sparkToggle.binding.wrappedValue = false
+        #expect(fixture.settings.codexSparkUsageVisible == false)
+
+        fixture.settings.showOptionalCreditsAndExtraUsage = false
+        #expect(sparkToggle.isEnabled?() == false)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -183,6 +183,51 @@ struct ProvidersPaneCoverageTests {
     }
 
     @Test
+    func `codex provider preview follows spark visibility`() {
+        let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-codex-spark-preview")
+        let store = Self.makeUsageStore(settings: settings)
+        let now = Date()
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 30,
+                    windowMinutes: 10080,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                extraRateWindows: [
+                    NamedRateWindow(
+                        id: CodexAdditionalRateLimitMapper.sparkWindowID,
+                        title: "Codex Spark 5-hour",
+                        window: RateWindow(
+                            usedPercent: 40,
+                            windowMinutes: 300,
+                            resetsAt: now.addingTimeInterval(1800),
+                            resetDescription: nil)),
+                    NamedRateWindow(
+                        id: "codex-other-limit",
+                        title: "Other Codex limit",
+                        window: RateWindow(
+                            usedPercent: 30,
+                            windowMinutes: 1440,
+                            resetsAt: now.addingTimeInterval(3600),
+                            resetDescription: nil)),
+                ],
+                updatedAt: now),
+            provider: .codex)
+        let pane = ProvidersPane(settings: settings, store: store)
+
+        #expect(pane._test_menuCardModel(for: .codex).metrics.contains {
+            $0.id == CodexAdditionalRateLimitMapper.sparkWindowID
+        })
+
+        settings.codexSparkUsageVisible = false
+        let hiddenModel = pane._test_menuCardModel(for: .codex)
+        #expect(!hiddenModel.metrics.contains { $0.id == CodexAdditionalRateLimitMapper.sparkWindowID })
+        #expect(hiddenModel.metrics.contains { $0.id == "codex-other-limit" })
+    }
+
+    @Test
     func `open router menu bar metric picker shows only automatic and primary`() {
         Self.withEnglishLocalization {
             let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-openrouter-picker")

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -1283,6 +1283,39 @@ struct SettingsStoreTests {
     }
 
     @Test
+    func `codex spark usage visibility defaults on persists and refreshes only menus`() async throws {
+        let suite = "SettingsStoreTests-codex-spark-usage-visible"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(store.codexSparkUsageVisible)
+        let backgroundRevision = store.backgroundWorkSettingsRevision
+        let menuDidChange = ObservationFlag()
+        withObservationTracking {
+            _ = store.menuObservationToken
+        } onChange: {
+            menuDidChange.set()
+        }
+        store.codexSparkUsageVisible = false
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(store.backgroundWorkSettingsRevision == backgroundRevision)
+        #expect(menuDidChange.get())
+
+        let reloaded = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        #expect(reloaded.codexSparkUsageVisible == false)
+    }
+
+    @Test
     func `menu observation token updates on defaults change`() async throws {
         let suite = "SettingsStoreTests-observation-defaults"
         let defaults = try #require(UserDefaults(suiteName: suite))

--- a/Tests/CodexBarTests/StatusMenuUsageDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusMenuUsageDisplayTests.swift
@@ -1,4 +1,5 @@
 import CodexBarCore
+import Foundation
 import Testing
 @testable import CodexBar
 
@@ -27,5 +28,60 @@ extension StatusMenuTests {
         let usedMetric = try #require(controller.menuCardModel(for: .codex)?.metrics.first { $0.id == "primary" })
         #expect(usedMetric.percent == 22)
         #expect(usedMetric.percentStyle.rawValue == "used")
+    }
+
+    @Test
+    func `status menu card follows codex spark visibility`() throws {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let now = Date()
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 22,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(1800),
+                    resetDescription: nil),
+                secondary: nil,
+                tertiary: nil,
+                extraRateWindows: [
+                    NamedRateWindow(
+                        id: CodexAdditionalRateLimitMapper.sparkWindowID,
+                        title: "Codex Spark 5-hour",
+                        window: RateWindow(
+                            usedPercent: 40,
+                            windowMinutes: 300,
+                            resetsAt: now.addingTimeInterval(1800),
+                            resetDescription: nil)),
+                    NamedRateWindow(
+                        id: "codex-other-limit",
+                        title: "Other Codex limit",
+                        window: RateWindow(
+                            usedPercent: 30,
+                            windowMinutes: 1440,
+                            resetsAt: now.addingTimeInterval(3600),
+                            resetDescription: nil)),
+                ],
+                updatedAt: now),
+            provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        #expect(controller.menuCardModel(for: .codex)?.metrics.contains {
+            $0.id == CodexAdditionalRateLimitMapper.sparkWindowID
+        } == true)
+
+        settings.codexSparkUsageVisible = false
+        let hiddenModel = try #require(controller.menuCardModel(for: .codex))
+        #expect(!hiddenModel.metrics.contains { $0.id == CodexAdditionalRateLimitMapper.sparkWindowID })
+        #expect(hiddenModel.metrics.contains { $0.id == "codex-other-limit" })
     }
 }

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -646,6 +646,7 @@ struct UsageStoreCoverageTests {
         settings.usageBarsShowUsed = true
         settings.mergeIcons = true
         settings.randomBlinkEnabled = true
+        settings.codexSparkUsageVisible.toggle()
         settings.debugLoadingPattern = .pulse
         settings.setProviderOrder(Array(settings.orderedProviders().reversed()))
         try? await Task.sleep(nanoseconds: 50_000_000)
@@ -715,13 +716,16 @@ struct UsageStoreCoverageTests {
         settings.usageBarsShowUsed = true
         settings.mergeIcons = true
         settings.randomBlinkEnabled = true
+        settings.codexSparkUsageVisible.toggle()
         settings.debugLoadingPattern = .pulse
         settings.setProviderOrder(Array(settings.orderedProviders().reversed()))
         try? await Task.sleep(nanoseconds: 50_000_000)
         #expect(refreshedProviders.isEmpty)
 
         settings.codexUsageDataSource = .cli
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        for _ in 0..<20 where !refreshedProviders.contains(.codex) {
+            try? await Task.sleep(nanoseconds: 25_000_000)
+        }
         #expect(refreshedProviders.contains(.codex))
     }
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -38,8 +38,10 @@ Usage source picker:
   nearing-expiry notifications. CodexBar does not redeem or modify reset credits.
 - `rate_limit.primary_window` / `secondary_window` map to the session/weekly lanes.
 - `additional_rate_limits[]` (model-specific limits such as GPT-5.3-Codex-Spark) map to named
-  `UsageSnapshot.extraRateWindows` entries (Spark uses a stable `codex-spark` id / `Codex Spark` title).
-  When the field is absent, the snapshot is unchanged.
+  `UsageSnapshot.extraRateWindows` entries. Spark uses stable `codex-spark` / `codex-spark-weekly` ids and
+  `Codex Spark 5-hour` / `Codex Spark Weekly` titles. When the field is absent, the snapshot is unchanged.
+- Preferences → Providers → Codex → Show Codex Spark usage hides only the Spark rows in menus and the provider
+  preview. It does not change fetching, history, notifications, widgets, credits, or other extra limits.
 
 ### Advanced profile-home accounts
 - Managed Codex accounts remain the default multi-account path.


### PR DESCRIPTION
## Summary

- add a default-on Codex provider setting to hide only Spark quota rows
- keep Session, Weekly, Credits, fetching, history, notifications, widgets, and menu-bar metrics unchanged
- make the global optional-usage setting the master gate and explain that dependency in Settings
- localize the new setting in all 23 app catalogs and document the behavior

## Verification

- `make check`
- `make test` (all 50 shards)
- focused settings, projection, menu, preview, and refresh-isolation regression suites
- independent exact-diff code/design review: clean
- exact signed debug bundle at `c9102c2d`: Developer ID team Y5PE65HELJ; Gatekeeper accepted
- loopback-only live UI proof with Keychain disabled: default-on showed Session, Weekly, both Spark rows, and Credits; toggling off removed only Spark; the choice persisted after Settings reopen and app relaunch; the global master gate disabled the provider control; restoring both controls restored both rows
- Public Model Identifier Gate: PASS
- dependencies unchanged

Closes #2013
