### PR TITLE
fix: cool down Claude keychain pre-alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Settings: split provider pane "Settings" sections into "Menu bar" and "Connection" so metric pickers and auth/cookie/source controls are grouped by topic.
 
 ### Fixed
+- Claude OAuth: remember an acknowledged CodexBar Keychain explanation for six hours without suppressing macOS authorization or either Keychain opt-out (#1990). Thanks @harjothkhara!
 - Claude: prevent CodexBar's passive CLI probes from starting background Claude Code updates, avoiding repeated partial downloads when a probe exits before an update completes. Thanks @PG2047!
 - Codex cost history: bound malformed session-metadata lines and release read chunks promptly, preventing metadata pre-scans from retaining memory in proportion to oversized JSONL records. Thanks @Yuxin-Qiao!
 - Widgets: add Cursor to configurable and switcher widgets with accurate legacy Requests and current Total, Auto, and API quota labels (#2040). Thanks @Zihao-Qi!

--- a/Sources/CodexBarCore/KeychainAccessPreflight.swift
+++ b/Sources/CodexBarCore/KeychainAccessPreflight.swift
@@ -45,12 +45,15 @@ public enum KeychainPromptHandler {
     @TaskLocal private static var taskHandlerStore: HandlerStore?
     public nonisolated(unsafe) static var handler: ((KeychainPromptContext) -> Void)?
 
-    public static func notify(_ context: KeychainPromptContext) {
+    @discardableResult
+    public static func notify(_ context: KeychainPromptContext) -> Bool {
         if let taskHandlerStore {
             taskHandlerStore.handler(context)
-            return
+            return true
         }
-        self.handler?(context)
+        guard let handler else { return false }
+        handler(context)
+        return true
     }
 
     #if DEBUG

--- a/Sources/CodexBarCore/KeychainAccessPreflight.swift
+++ b/Sources/CodexBarCore/KeychainAccessPreflight.swift
@@ -45,8 +45,12 @@ public enum KeychainPromptHandler {
     @TaskLocal private static var taskHandlerStore: HandlerStore?
     public nonisolated(unsafe) static var handler: ((KeychainPromptContext) -> Void)?
 
+    public static func notify(_ context: KeychainPromptContext) {
+        _ = self.notifyIfHandled(context)
+    }
+
     @discardableResult
-    public static func notify(_ context: KeychainPromptContext) -> Bool {
+    static func notifyIfHandled(_ context: KeychainPromptContext) -> Bool {
         if let taskHandlerStore {
             taskHandlerStore.handler(context)
             return true

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+TestingOverrides.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+TestingOverrides.swift
@@ -105,15 +105,21 @@ extension ClaudeOAuthCredentialsStore {
 
     static func withIsolatedMemoryCacheForTesting<T>(operation: () throws -> T) rethrows -> T {
         let store = MemoryCacheStore()
-        return try self.$taskMemoryCacheStoreOverride.withValue(store) {
-            try operation()
+        let preAlertStore = ClaudeOAuthKeychainPreAlertGate.StateStore()
+        return try ClaudeOAuthKeychainPreAlertGate.withStateStoreOverrideForTesting(preAlertStore) {
+            try self.$taskMemoryCacheStoreOverride.withValue(store) {
+                try operation()
+            }
         }
     }
 
     static func withIsolatedMemoryCacheForTesting<T>(operation: () async throws -> T) async rethrows -> T {
         let store = MemoryCacheStore()
-        return try await self.$taskMemoryCacheStoreOverride.withValue(store) {
-            try await operation()
+        let preAlertStore = ClaudeOAuthKeychainPreAlertGate.StateStore()
+        return try await ClaudeOAuthKeychainPreAlertGate.withStateStoreOverrideForTesting(preAlertStore) {
+            try await self.$taskMemoryCacheStoreOverride.withValue(store) {
+                try await operation()
+            }
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -422,15 +422,14 @@ public enum ClaudeOAuthCredentialsStore {
                     guard fallbackDecision.allowed else { return nil }
                 }
 
-                if ClaudeOAuthCredentialsStore.shouldNotifyClaudeKeychainPreAlert(),
-                   ClaudeOAuthKeychainPreAlertGate.beginPresentation()
-                {
-                    let wasPresented = KeychainPromptHandler.notify(
-                        KeychainPromptContext(
-                            kind: .claudeOAuth,
-                            service: ClaudeOAuthCredentialsStore.claudeKeychainService,
-                            account: nil))
-                    ClaudeOAuthKeychainPreAlertGate.finishPresentation(wasPresented: wasPresented)
+                if ClaudeOAuthCredentialsStore.shouldNotifyClaudeKeychainPreAlert() {
+                    ClaudeOAuthKeychainPreAlertGate.presentIfNeeded {
+                        KeychainPromptHandler.notify(
+                            KeychainPromptContext(
+                                kind: .claudeOAuth,
+                                service: ClaudeOAuthCredentialsStore.claudeKeychainService,
+                                account: nil))
+                    }
                 }
                 let keychainData: Data = if shouldPreferSecurityCLIKeychainRead {
                     try ClaudeOAuthCredentialsStore.loadFromClaudeKeychainUsingSecurityFramework(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -424,7 +424,7 @@ public enum ClaudeOAuthCredentialsStore {
 
                 if ClaudeOAuthCredentialsStore.shouldNotifyClaudeKeychainPreAlert() {
                     ClaudeOAuthKeychainPreAlertGate.presentIfNeeded {
-                        KeychainPromptHandler.notify(
+                        KeychainPromptHandler.notifyIfHandled(
                             KeychainPromptContext(
                                 kind: .claudeOAuth,
                                 service: ClaudeOAuthCredentialsStore.claudeKeychainService,

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -422,12 +422,15 @@ public enum ClaudeOAuthCredentialsStore {
                     guard fallbackDecision.allowed else { return nil }
                 }
 
-                if ClaudeOAuthCredentialsStore.shouldNotifyClaudeKeychainPreAlert() {
-                    KeychainPromptHandler.notify(
+                if ClaudeOAuthCredentialsStore.shouldNotifyClaudeKeychainPreAlert(),
+                   ClaudeOAuthKeychainPreAlertGate.beginPresentation()
+                {
+                    let wasPresented = KeychainPromptHandler.notify(
                         KeychainPromptContext(
                             kind: .claudeOAuth,
                             service: ClaudeOAuthCredentialsStore.claudeKeychainService,
                             account: nil))
+                    ClaudeOAuthKeychainPreAlertGate.finishPresentation(wasPresented: wasPresented)
                 }
                 let keychainData: Data = if shouldPreferSecurityCLIKeychainRead {
                     try ClaudeOAuthCredentialsStore.loadFromClaudeKeychainUsingSecurityFramework(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainPreAlertGate.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainPreAlertGate.swift
@@ -4,7 +4,7 @@ import Foundation
 import os.lock
 
 enum ClaudeOAuthKeychainPreAlertGate {
-    private struct State {
+    fileprivate struct State {
         var loaded = false
         var acknowledgedUntil: Date?
         var presentationInFlight = false
@@ -16,56 +16,53 @@ enum ClaudeOAuthKeychainPreAlertGate {
 
     #if DEBUG
     final class StateStore: @unchecked Sendable {
-        var acknowledgedUntil: Date?
-        var presentationInFlight = false
+        fileprivate let lock = OSAllocatedUnfairLock<State>(initialState: State(loaded: true))
     }
 
     @TaskLocal private static var taskStateStoreOverrideForTesting: StateStore?
     #endif
 
-    /// Reserves presentation so concurrent credential reads cannot show duplicate explanatory alerts.
-    static func beginPresentation(now: Date = Date()) -> Bool {
+    /// Presents at most one explanatory alert and starts the cooldown only when it reaches a handler.
+    @discardableResult
+    static func presentIfNeeded(
+        now: Date = Date(),
+        completedAt: Date? = nil,
+        present: () -> Bool) -> Bool
+    {
+        guard self.beginPresentation(now: now) else { return false }
+        let wasPresented = present()
+        self.finishPresentation(wasPresented: wasPresented, now: completedAt ?? Date())
+        return wasPresented
+    }
+
+    private static func beginPresentation(now: Date) -> Bool {
         #if DEBUG
         if let store = self.taskStateStoreOverrideForTesting {
-            guard !store.presentationInFlight else { return false }
-            if let acknowledgedUntil = store.acknowledgedUntil, acknowledgedUntil > now {
-                return false
+            return store.lock.withLock { state in
+                self.reservePresentation(state: &state, now: now)
             }
-            store.acknowledgedUntil = nil
-            store.presentationInFlight = true
-            return true
         }
         #endif
         return self.lock.withLock { state in
             self.loadIfNeeded(&state)
-            guard !state.presentationInFlight else { return false }
-            if let acknowledgedUntil = state.acknowledgedUntil, acknowledgedUntil > now {
-                return false
-            }
-            state.acknowledgedUntil = nil
-            state.presentationInFlight = true
+            guard self.reservePresentation(state: &state, now: now) else { return false }
             self.persist(state)
             return true
         }
     }
 
-    /// Completes a reservation. Only a prompt that reached an installed handler starts the cooldown.
-    static func finishPresentation(wasPresented: Bool, now: Date = Date()) {
+    private static func finishPresentation(wasPresented: Bool, now: Date) {
         #if DEBUG
         if let store = self.taskStateStoreOverrideForTesting {
-            store.presentationInFlight = false
-            if wasPresented {
-                store.acknowledgedUntil = now.addingTimeInterval(self.cooldownInterval)
+            store.lock.withLock { state in
+                self.completePresentation(state: &state, wasPresented: wasPresented, now: now)
             }
             return
         }
         #endif
         self.lock.withLock { state in
             self.loadIfNeeded(&state)
-            state.presentationInFlight = false
-            if wasPresented {
-                state.acknowledgedUntil = now.addingTimeInterval(self.cooldownInterval)
-            }
+            self.completePresentation(state: &state, wasPresented: wasPresented, now: now)
             self.persist(state)
         }
     }
@@ -111,6 +108,23 @@ enum ClaudeOAuthKeychainPreAlertGate {
         }
     }
 
+    private static func reservePresentation(state: inout State, now: Date) -> Bool {
+        guard !state.presentationInFlight else { return false }
+        if let acknowledgedUntil = state.acknowledgedUntil, acknowledgedUntil > now {
+            return false
+        }
+        state.acknowledgedUntil = nil
+        state.presentationInFlight = true
+        return true
+    }
+
+    private static func completePresentation(state: inout State, wasPresented: Bool, now: Date) {
+        state.presentationInFlight = false
+        if wasPresented {
+            state.acknowledgedUntil = now.addingTimeInterval(self.cooldownInterval)
+        }
+    }
+
     private static func persist(_ state: State) {
         if let acknowledgedUntil = state.acknowledgedUntil {
             UserDefaults.standard.set(acknowledgedUntil.timeIntervalSince1970, forKey: self.defaultsKey)
@@ -127,11 +141,14 @@ enum ClaudeOAuthKeychainPreAlertGate {
     final class StateStore: @unchecked Sendable {}
     #endif
 
-    static func beginPresentation(now _: Date = Date()) -> Bool {
+    @discardableResult
+    static func presentIfNeeded(
+        now _: Date = Date(),
+        completedAt _: Date? = nil,
+        present _: () -> Bool) -> Bool
+    {
         false
     }
-
-    static func finishPresentation(wasPresented _: Bool, now _: Date = Date()) {}
 
     #if DEBUG
     static func withStateStoreOverrideForTesting<T>(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainPreAlertGate.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainPreAlertGate.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+#if os(macOS)
+import os.lock
+
+enum ClaudeOAuthKeychainPreAlertGate {
+    private struct State {
+        var loaded = false
+        var acknowledgedUntil: Date?
+        var presentationInFlight = false
+    }
+
+    private static let lock = OSAllocatedUnfairLock<State>(initialState: State())
+    private static let defaultsKey = "claudeOAuthKeychainPreAlertAcknowledgedUntilV1"
+    static let cooldownInterval: TimeInterval = 60 * 60 * 6
+
+    #if DEBUG
+    final class StateStore: @unchecked Sendable {
+        var acknowledgedUntil: Date?
+        var presentationInFlight = false
+    }
+
+    @TaskLocal private static var taskStateStoreOverrideForTesting: StateStore?
+    #endif
+
+    /// Reserves presentation so concurrent credential reads cannot show duplicate explanatory alerts.
+    static func beginPresentation(now: Date = Date()) -> Bool {
+        #if DEBUG
+        if let store = self.taskStateStoreOverrideForTesting {
+            guard !store.presentationInFlight else { return false }
+            if let acknowledgedUntil = store.acknowledgedUntil, acknowledgedUntil > now {
+                return false
+            }
+            store.acknowledgedUntil = nil
+            store.presentationInFlight = true
+            return true
+        }
+        #endif
+        return self.lock.withLock { state in
+            self.loadIfNeeded(&state)
+            guard !state.presentationInFlight else { return false }
+            if let acknowledgedUntil = state.acknowledgedUntil, acknowledgedUntil > now {
+                return false
+            }
+            state.acknowledgedUntil = nil
+            state.presentationInFlight = true
+            self.persist(state)
+            return true
+        }
+    }
+
+    /// Completes a reservation. Only a prompt that reached an installed handler starts the cooldown.
+    static func finishPresentation(wasPresented: Bool, now: Date = Date()) {
+        #if DEBUG
+        if let store = self.taskStateStoreOverrideForTesting {
+            store.presentationInFlight = false
+            if wasPresented {
+                store.acknowledgedUntil = now.addingTimeInterval(self.cooldownInterval)
+            }
+            return
+        }
+        #endif
+        self.lock.withLock { state in
+            self.loadIfNeeded(&state)
+            state.presentationInFlight = false
+            if wasPresented {
+                state.acknowledgedUntil = now.addingTimeInterval(self.cooldownInterval)
+            }
+            self.persist(state)
+        }
+    }
+
+    #if DEBUG
+    static func withStateStoreOverrideForTesting<T>(
+        _ store: StateStore?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$taskStateStoreOverrideForTesting.withValue(store) {
+            try operation()
+        }
+    }
+
+    static func withStateStoreOverrideForTesting<T>(
+        _ store: StateStore?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskStateStoreOverrideForTesting.withValue(store) {
+            try await operation()
+        }
+    }
+
+    static func resetForTesting() {
+        self.lock.withLock { state in
+            state = State(loaded: true)
+            UserDefaults.standard.removeObject(forKey: self.defaultsKey)
+        }
+    }
+
+    static func resetInMemoryForTesting() {
+        self.lock.withLock { state in
+            state = State()
+        }
+    }
+    #endif
+
+    private static func loadIfNeeded(_ state: inout State) {
+        guard !state.loaded else { return }
+        state.loaded = true
+        if let raw = UserDefaults.standard.object(forKey: self.defaultsKey) as? Double {
+            state.acknowledgedUntil = Date(timeIntervalSince1970: raw)
+        }
+    }
+
+    private static func persist(_ state: State) {
+        if let acknowledgedUntil = state.acknowledgedUntil {
+            UserDefaults.standard.set(acknowledgedUntil.timeIntervalSince1970, forKey: self.defaultsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: self.defaultsKey)
+        }
+    }
+}
+#else
+enum ClaudeOAuthKeychainPreAlertGate {
+    static let cooldownInterval: TimeInterval = 60 * 60 * 6
+
+    #if DEBUG
+    final class StateStore: @unchecked Sendable {}
+    #endif
+
+    static func beginPresentation(now _: Date = Date()) -> Bool {
+        false
+    }
+
+    static func finishPresentation(wasPresented _: Bool, now _: Date = Date()) {}
+
+    #if DEBUG
+    static func withStateStoreOverrideForTesting<T>(
+        _: StateStore?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try operation()
+    }
+
+    static func withStateStoreOverrideForTesting<T>(
+        _: StateStore?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await operation()
+    }
+    #endif
+}
+#endif

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStorePromptPolicyTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStorePromptPolicyTests.swift
@@ -4,6 +4,12 @@ import Testing
 
 @Suite(.serialized)
 struct ClaudeOAuthCredentialsStorePromptPolicyTests {
+    @Test
+    func `keychain prompt notify preserves its void function signature`() {
+        let notify: (KeychainPromptContext) -> Void = KeychainPromptHandler.notify
+        _ = notify
+    }
+
     private func makeCredentialsData(accessToken: String, expiresAt: Date, refreshToken: String? = nil) -> Data {
         let millis = Int(expiresAt.timeIntervalSince1970 * 1000)
         let refreshField: String = {

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStorePromptPolicyTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStorePromptPolicyTests.swift
@@ -127,7 +127,7 @@ struct ClaudeOAuthCredentialsStorePromptPolicyTests {
     }
 
     @Test
-    func `user initiated claude keychain read shows pre alert even when preflight allows`() throws {
+    func `user initiated claude keychain reads respect pre alert acknowledgement cooldown`() throws {
         let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
         try KeychainCacheStore.withServiceOverrideForTesting(service) {
             try KeychainAccessGate.withTaskOverrideForTesting(false) {
@@ -158,7 +158,7 @@ struct ClaudeOAuthCredentialsStorePromptPolicyTests {
                         let promptHandler: (KeychainPromptContext) -> Void = { _ in
                             preAlertHits += 1
                         }
-                        let creds = try KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting(
+                        let credentials = try KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting(
                             preflightOverride,
                             operation: {
                                 try KeychainPromptHandler.withHandlerForTesting(promptHandler, operation: {
@@ -170,17 +170,23 @@ struct ClaudeOAuthCredentialsStorePromptPolicyTests {
                                                 data: keychainData,
                                                 fingerprint: nil)
                                             {
-                                                try ClaudeOAuthCredentialsStore.load(
+                                                let first = try ClaudeOAuthCredentialsStore.load(
                                                     environment: [:],
                                                     allowKeychainPrompt: true)
+                                                ClaudeOAuthCredentialsStore.invalidateCache()
+                                                let second = try ClaudeOAuthCredentialsStore.load(
+                                                    environment: [:],
+                                                    allowKeychainPrompt: true)
+                                                return (first, second)
                                             }
                                         }
                                     }
                                 })
                             })
 
-                        #expect(creds.accessToken == "keychain-token")
-                        #expect(preAlertHits >= 1)
+                        #expect(credentials.0.accessToken == "keychain-token")
+                        #expect(credentials.1.accessToken == "keychain-token")
+                        #expect(preAlertHits == 1)
                     }
                 }
             }
@@ -241,9 +247,7 @@ struct ClaudeOAuthCredentialsStorePromptPolicyTests {
                             })
 
                         #expect(creds.accessToken == "keychain-token")
-                        // TODO: tighten this to `== 1` once keychain pre-alert delivery is deduplicated/scoped.
-                        // This path can currently emit more than one pre-alert during a single load attempt.
-                        #expect(preAlertHits >= 1)
+                        #expect(preAlertHits == 1)
                     }
                 }
             }
@@ -304,9 +308,7 @@ struct ClaudeOAuthCredentialsStorePromptPolicyTests {
                             })
 
                         #expect(creds.accessToken == "keychain-token")
-                        // TODO: tighten this to `== 1` once keychain pre-alert delivery is deduplicated/scoped.
-                        // This path can currently emit more than one pre-alert during a single load attempt.
-                        #expect(preAlertHits >= 1)
+                        #expect(preAlertHits == 1)
                     }
                 }
             }
@@ -434,7 +436,7 @@ struct ClaudeOAuthCredentialsStorePromptPolicyTests {
                             })
 
                         #expect(creds.accessToken == "fallback-token")
-                        #expect(preAlertHits >= 1)
+                        #expect(preAlertHits == 1)
                     }
                 }
             }
@@ -725,7 +727,7 @@ struct ClaudeOAuthCredentialsStorePromptPolicyTests {
                             })
 
                         #expect(creds.accessToken == "fallback-token")
-                        #expect(preAlertHits >= 1)
+                        #expect(preAlertHits == 1)
                     }
                 }
             }

--- a/Tests/CodexBarTests/ClaudeOAuthKeychainPreAlertGateTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthKeychainPreAlertGateTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if os(macOS)
+@Suite(.serialized)
+struct ClaudeOAuthKeychainPreAlertGateTests {
+    @Test
+    func `acknowledgement suppresses repeated presentation until cooldown expires`() {
+        let store = ClaudeOAuthKeychainPreAlertGate.StateStore()
+        ClaudeOAuthKeychainPreAlertGate.withStateStoreOverrideForTesting(store) {
+            let now = Date(timeIntervalSince1970: 1000)
+            #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now))
+            ClaudeOAuthKeychainPreAlertGate.finishPresentation(wasPresented: true, now: now)
+
+            #expect(
+                ClaudeOAuthKeychainPreAlertGate.beginPresentation(
+                    now: now.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval - 1)) == false)
+            #expect(
+                ClaudeOAuthKeychainPreAlertGate.beginPresentation(
+                    now: now.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval + 1)))
+        }
+    }
+
+    @Test
+    func `missing prompt handler does not consume acknowledgement cooldown`() {
+        let store = ClaudeOAuthKeychainPreAlertGate.StateStore()
+        ClaudeOAuthKeychainPreAlertGate.withStateStoreOverrideForTesting(store) {
+            let now = Date(timeIntervalSince1970: 2000)
+            #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now))
+            ClaudeOAuthKeychainPreAlertGate.finishPresentation(wasPresented: false, now: now)
+            #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now))
+        }
+    }
+
+    @Test
+    func `duplicate while presentation is in flight is suppressed`() {
+        let store = ClaudeOAuthKeychainPreAlertGate.StateStore()
+        ClaudeOAuthKeychainPreAlertGate.withStateStoreOverrideForTesting(store) {
+            let now = Date(timeIntervalSince1970: 3000)
+            #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now))
+            #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now) == false)
+            ClaudeOAuthKeychainPreAlertGate.finishPresentation(wasPresented: true, now: now)
+        }
+    }
+
+    @Test
+    func `acknowledgement persists across in memory reset`() {
+        ClaudeOAuthKeychainPreAlertGate.resetForTesting()
+        defer { ClaudeOAuthKeychainPreAlertGate.resetForTesting() }
+
+        let now = Date(timeIntervalSince1970: 4000)
+        #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now))
+        ClaudeOAuthKeychainPreAlertGate.finishPresentation(wasPresented: true, now: now)
+        ClaudeOAuthKeychainPreAlertGate.resetInMemoryForTesting()
+
+        #expect(
+            ClaudeOAuthKeychainPreAlertGate.beginPresentation(
+                now: now.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval - 1)) == false)
+    }
+}
+#endif

--- a/Tests/CodexBarTests/ClaudeOAuthKeychainPreAlertGateTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthKeychainPreAlertGateTests.swift
@@ -10,15 +10,40 @@ struct ClaudeOAuthKeychainPreAlertGateTests {
         let store = ClaudeOAuthKeychainPreAlertGate.StateStore()
         ClaudeOAuthKeychainPreAlertGate.withStateStoreOverrideForTesting(store) {
             let now = Date(timeIntervalSince1970: 1000)
-            #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now))
-            ClaudeOAuthKeychainPreAlertGate.finishPresentation(wasPresented: true, now: now)
+            #expect(ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(now: now, completedAt: now) { true })
 
             #expect(
-                ClaudeOAuthKeychainPreAlertGate.beginPresentation(
-                    now: now.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval - 1)) == false)
+                ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(
+                    now: now.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval - 1),
+                    completedAt: now,
+                    present: { true }) == false)
             #expect(
-                ClaudeOAuthKeychainPreAlertGate.beginPresentation(
-                    now: now.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval + 1)))
+                ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(
+                    now: now.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval + 1),
+                    completedAt: now,
+                    present: { true }))
+        }
+    }
+
+    @Test
+    func `cooldown starts when presentation completes`() {
+        let store = ClaudeOAuthKeychainPreAlertGate.StateStore()
+        ClaudeOAuthKeychainPreAlertGate.withStateStoreOverrideForTesting(store) {
+            let startedAt = Date(timeIntervalSince1970: 1000)
+            let completedAt = Date(timeIntervalSince1970: 2000)
+            #expect(ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(
+                now: startedAt,
+                completedAt: completedAt,
+                present: { true }))
+
+            #expect(ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(
+                now: startedAt.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval + 1),
+                completedAt: completedAt,
+                present: { true }) == false)
+            #expect(ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(
+                now: completedAt.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval + 1),
+                completedAt: completedAt,
+                present: { true }))
         }
     }
 
@@ -27,9 +52,8 @@ struct ClaudeOAuthKeychainPreAlertGateTests {
         let store = ClaudeOAuthKeychainPreAlertGate.StateStore()
         ClaudeOAuthKeychainPreAlertGate.withStateStoreOverrideForTesting(store) {
             let now = Date(timeIntervalSince1970: 2000)
-            #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now))
-            ClaudeOAuthKeychainPreAlertGate.finishPresentation(wasPresented: false, now: now)
-            #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now))
+            #expect(ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(now: now, completedAt: now) { false } == false)
+            #expect(ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(now: now, completedAt: now) { true })
         }
     }
 
@@ -38,9 +62,18 @@ struct ClaudeOAuthKeychainPreAlertGateTests {
         let store = ClaudeOAuthKeychainPreAlertGate.StateStore()
         ClaudeOAuthKeychainPreAlertGate.withStateStoreOverrideForTesting(store) {
             let now = Date(timeIntervalSince1970: 3000)
-            #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now))
-            #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now) == false)
-            ClaudeOAuthKeychainPreAlertGate.finishPresentation(wasPresented: true, now: now)
+            var nestedPresentationRan = false
+            var nestedResult: Bool?
+            let outerResult = ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(now: now, completedAt: now) {
+                nestedResult = ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(now: now) {
+                    nestedPresentationRan = true
+                    return true
+                }
+                return true
+            }
+            #expect(outerResult)
+            #expect(nestedResult == false)
+            #expect(nestedPresentationRan == false)
         }
     }
 
@@ -50,13 +83,14 @@ struct ClaudeOAuthKeychainPreAlertGateTests {
         defer { ClaudeOAuthKeychainPreAlertGate.resetForTesting() }
 
         let now = Date(timeIntervalSince1970: 4000)
-        #expect(ClaudeOAuthKeychainPreAlertGate.beginPresentation(now: now))
-        ClaudeOAuthKeychainPreAlertGate.finishPresentation(wasPresented: true, now: now)
+        #expect(ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(now: now, completedAt: now) { true })
         ClaudeOAuthKeychainPreAlertGate.resetInMemoryForTesting()
 
         #expect(
-            ClaudeOAuthKeychainPreAlertGate.beginPresentation(
-                now: now.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval - 1)) == false)
+            ClaudeOAuthKeychainPreAlertGate.presentIfNeeded(
+                now: now.addingTimeInterval(ClaudeOAuthKeychainPreAlertGate.cooldownInterval - 1),
+                completedAt: now,
+                present: { true }) == false)
     }
 }
 #endif

--- a/docs/keychain-prompts.md
+++ b/docs/keychain-prompts.md
@@ -20,6 +20,10 @@ Before a Keychain read that may require interaction, CodexBar shows an explanati
 **Learn More** opens this page without dismissing that explanation or starting the macOS prompt. Choose **OK** only
 when you are ready to continue, or use the opt-out below.
 
+After you acknowledge the Claude OAuth explanation, CodexBar does not repeat that explanation for six hours. This
+cooldown only applies to CodexBar's explanatory alert: macOS can still show its own Keychain authorization prompt,
+and the Claude **Never prompt** and global **Disable Keychain access** settings remain in effect.
+
 ## If the prompt appears after uninstalling CodexBar
 
 Deleting `CodexBar.app` prevents a new process from launching from that bundle, but it does not terminate a process


### PR DESCRIPTION
## Summary

- Suppress repeated CodexBar Claude OAuth explanatory alerts for six hours after the alert is shown and acknowledged.
- Reserve an in-flight presentation so concurrent credential reads cannot display duplicates, and do not consume the cooldown when no prompt handler is installed.
- Add gate and prompt-policy regressions, plus document the behavior.

## Product and security boundary

This PR chooses a persisted six-hour acknowledgement cooldown for maintainer review. The cooldown applies only to the CodexBar explanation. The subsequent Security.framework read is unchanged, macOS may still show its authorization prompt, and Claude Never prompt plus global Disable Keychain access remain authoritative.

No live Keychain UI validation was run, per AGENTS.md.

## Validation

- swift build --target CodexBarCore: passed
- swift build -c release --target CodexBarCore: passed
- SwiftFormat on touched files: passed
- Portable repository checks: passed
- Full Swift tests and SwiftLint are unavailable in this Command Line Tools environment because Apple macro and sourcekitd frameworks are missing; CI is the authoritative full run
- PR #2011 addresses a separate periodic Keychain prompt loop and explicitly leaves #1990’s manual-refresh pre-alert UX unchanged, so it does not supersede this PR.
- A synthetic merge of #2011 and this PR completed without conflicts, and `swift build --target CodexBarCore` passed on the combined tree.
- This uses a separate acknowledgement gate because `ClaudeOAuthKeychainAccessGate` controls actual Keychain access, while this cooldown suppresses only CodexBar’s explanatory pre-alert.
- Six hours prevents repeated interruptions during an active work session while allowing the explanation to reappear on a later retry.
- Codex assisted with implementation, tests, and compatibility analysis

Fixes #1990