### PR TITLE
fix(claude): preserve future reset occurrences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 - Ollama: validate API keys against an authenticated endpoint instead of the public model catalog while preserving refresh cancellation. Thanks @joeVenner!
-- Claude CLI: resolve yearless and time-only reset timestamps to their nearest occurrence so stale data cannot appear nearly a day or year away. Thanks @fanwenlin!
+- Claude CLI: resolve yearless and time-only reset timestamps against their quota window and exact calendar occurrence, keeping recently stale resets current without moving future, leap-day, or repeated-hour resets into the past. Thanks @fanwenlin!
 - Catalan: complete current strings, align instructional voice, and enforce catalog parity. Thanks @pmontp19!
 - Quota warnings: use compact per-window threshold editors that save on focus loss, Return, or window close while preserving provider inheritance. Thanks @Zihao-Qi!
 - Display settings: keep display mode, work days, multi-account layout, and cost summary selectors interactive on macOS 27. Thanks @jordanschwartz-js!

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -467,7 +467,9 @@ extension ClaudeStatusProbe {
                 window: RateWindow(
                     usedPercent: usedPercent,
                     windowMinutes: 7 * 24 * 60,
-                    resetsAt: self.parseResetDate(from: resetDescription),
+                    resetsAt: self.parseResetDate(
+                        from: resetDescription,
+                        expectedWindow: 7 * 24 * 60 * 60),
                     resetDescription: resetDescription))
         }
     }
@@ -819,79 +821,173 @@ extension ClaudeStatusProbe {
         return cleaned
     }
 
-    /// Attempts to parse a Claude reset string into a Date, using the current year and handling optional timezones.
+    /// Parses a Claude reset string as its next calendar occurrence in any explicit timezone.
     public static func parseResetDate(from text: String?, now: Date = .init()) -> Date? {
+        self.parseResetDate(from: text, now: now, expectedWindow: nil)
+    }
+
+    /// Quota surfaces may accept a recently stale occurrence when the next occurrence cannot belong to that window.
+    package static func parseResetDate(
+        from text: String?,
+        now: Date = .init(),
+        expectedWindow: TimeInterval?) -> Date?
+    {
         guard let normalized = self.normalizeResetInput(text) else { return nil }
         let (raw, timeZone) = normalized
 
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = timeZone ?? TimeZone.current
-        formatter.defaultDate = now
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = formatter.timeZone
+        // Parse yearless Feb 29 independently of the current year, then resolve validated calendar occurrences.
+        formatter.defaultDate = calendar.date(from: DateComponents(year: 2000, month: 1, day: 1))
 
         if let date = self.parseDate(raw, formats: Self.resetDateTimeWithMinutes, formatter: formatter) {
-            var comps = calendar.dateComponents([.month, .day, .hour, .minute], from: date)
-            comps.year = calendar.component(.year, from: now)
-            comps.second = 0
-            return self.nearestOccurrence(
-                calendar.date(from: comps),
-                adjusting: .year,
+            let comps = calendar.dateComponents([.month, .day, .hour, .minute], from: date)
+            return self.resolveOccurrence(
+                self.yearlyOccurrences(for: comps, now: now, calendar: calendar),
                 now: now,
-                calendar: calendar)
+                expectedWindow: expectedWindow)
         }
         if let date = self.parseDate(raw, formats: Self.resetDateTimeHourOnly, formatter: formatter) {
-            var comps = calendar.dateComponents([.month, .day, .hour], from: date)
-            comps.year = calendar.component(.year, from: now)
-            comps.minute = 0
-            comps.second = 0
-            return self.nearestOccurrence(
-                calendar.date(from: comps),
-                adjusting: .year,
+            let comps = calendar.dateComponents([.month, .day, .hour], from: date)
+            return self.resolveOccurrence(
+                self.yearlyOccurrences(for: comps, now: now, calendar: calendar),
                 now: now,
-                calendar: calendar)
+                expectedWindow: expectedWindow)
         }
 
         if let time = self.parseDate(raw, formats: Self.resetTimeWithMinutes, formatter: formatter) {
             let comps = calendar.dateComponents([.hour, .minute], from: time)
-            guard let anchored = calendar.date(
-                bySettingHour: comps.hour ?? 0,
-                minute: comps.minute ?? 0,
-                second: 0,
-                of: now) else { return nil }
-            return self.nearestOccurrence(anchored, adjusting: .day, now: now, calendar: calendar)
+            return self.resolveOccurrence(
+                self.dailyOccurrences(for: comps, now: now, calendar: calendar),
+                now: now,
+                expectedWindow: expectedWindow)
         }
 
         guard let time = self.parseDate(raw, formats: Self.resetTimeHourOnly, formatter: formatter) else { return nil }
         let comps = calendar.dateComponents([.hour], from: time)
-        guard let anchored = calendar.date(
-            bySettingHour: comps.hour ?? 0,
-            minute: 0,
-            second: 0,
-            of: now) else { return nil }
-        return self.nearestOccurrence(anchored, adjusting: .day, now: now, calendar: calendar)
+        return self.resolveOccurrence(
+            self.dailyOccurrences(for: comps, now: now, calendar: calendar),
+            now: now,
+            expectedWindow: expectedWindow)
     }
 
-    /// Yearless and time-only resets describe nearby quota boundaries, not distant calendar events.
-    private static func nearestOccurrence(
-        _ date: Date?,
-        adjusting component: Calendar.Component,
+    private static func resolveOccurrence(
+        _ candidates: [Date],
         now: Date,
-        calendar: Calendar) -> Date?
+        expectedWindow: TimeInterval?) -> Date?
     {
-        guard let date else { return nil }
-        let candidates = (-1...1).compactMap { offset in
-            calendar.date(byAdding: component, value: offset, to: date)
+        let sortedCandidates = candidates.sorted()
+        guard let future = sortedCandidates.first(where: { $0 >= now }) else { return sortedCandidates.last }
+        guard let expectedWindow else { return future }
+
+        let horizon = max(0, expectedWindow)
+        let past = sortedCandidates.last(where: { $0 < now })
+        let pastIsPlausible = past.map { now.timeIntervalSince($0) <= horizon } ?? false
+        let futureIsPlausible = future.timeIntervalSince(now) <= horizon
+        return pastIsPlausible && !futureIsPlausible ? past : future
+    }
+
+    private static func yearlyOccurrences(
+        for components: DateComponents,
+        now: Date,
+        calendar: Calendar) -> [Date]
+    {
+        guard let month = components.month,
+              let day = components.day,
+              let hour = components.hour
+        else { return [] }
+        let currentYear = calendar.component(.year, from: now)
+        // Eight years covers the Gregorian century gap between leap days (for example, 2096 to 2104).
+        return ((currentYear - 8)...(currentYear + 8)).flatMap { year in
+            self.exactLocalOccurrences(
+                DateComponents(
+                    timeZone: calendar.timeZone,
+                    year: year,
+                    month: month,
+                    day: day,
+                    hour: hour,
+                    minute: components.minute ?? 0,
+                    second: 0),
+                calendar: calendar)
         }
-        return candidates.min { lhs, rhs in
-            let lhsDistance = abs(lhs.timeIntervalSince(now))
-            let rhsDistance = abs(rhs.timeIntervalSince(now))
-            if lhsDistance != rhsDistance {
-                return lhsDistance < rhsDistance
-            }
-            return lhs >= now && rhs < now
+    }
+
+    private static func dailyOccurrences(
+        for components: DateComponents,
+        now: Date,
+        calendar: Calendar) -> [Date]
+    {
+        guard let hour = components.hour else { return [] }
+        let startOfToday = calendar.startOfDay(for: now)
+        return (-1...1).flatMap { offset -> [Date] in
+            guard let day = calendar.date(byAdding: .day, value: offset, to: startOfToday) else { return [] }
+            let dayComponents = calendar.dateComponents([.year, .month, .day], from: day)
+            guard let year = dayComponents.year,
+                  let month = dayComponents.month,
+                  let dayOfMonth = dayComponents.day
+            else { return [] }
+            return self.exactLocalOccurrences(
+                DateComponents(
+                    timeZone: calendar.timeZone,
+                    year: year,
+                    month: month,
+                    day: dayOfMonth,
+                    hour: hour,
+                    minute: components.minute ?? 0,
+                    second: 0),
+                calendar: calendar)
         }
+    }
+
+    /// Returns both instants when a local wall time repeats during a daylight-saving transition.
+    private static func exactLocalOccurrences(
+        _ target: DateComponents,
+        calendar: Calendar) -> [Date]
+    {
+        guard let year = target.year,
+              let month = target.month,
+              let day = target.day,
+              let hour = target.hour,
+              let minute = target.minute
+        else { return [] }
+        guard let firstApproximation = calendar.date(from: target) else { return [] }
+        let approximationComponents = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: firstApproximation)
+        guard approximationComponents.year == year,
+              approximationComponents.month == month,
+              approximationComponents.day == day,
+              approximationComponents.hour == hour,
+              approximationComponents.minute == minute,
+              approximationComponents.second == 0
+        else { return [] }
+        let startOfDay = calendar.startOfDay(for: firstApproximation)
+        guard let searchStart = calendar.date(byAdding: .second, value: -1, to: startOfDay) else { return [] }
+
+        var results: [Date] = []
+        for policy in [Calendar.RepeatedTimePolicy.first, .last] {
+            guard let date = calendar.nextDate(
+                after: searchStart,
+                matching: target,
+                matchingPolicy: .strict,
+                repeatedTimePolicy: policy,
+                direction: .forward)
+            else { continue }
+            let resolved = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+            guard resolved.year == year,
+                  resolved.month == month,
+                  resolved.day == day,
+                  resolved.hour == hour,
+                  resolved.minute == minute,
+                  resolved.second == 0,
+                  !results.contains(date)
+            else { continue }
+            results.append(date)
+        }
+        return results
     }
 
     private static let resetTimeWithMinutes = ["h:mma", "h:mm a", "HH:mm", "H:mm"]

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -1341,7 +1341,9 @@ extension ClaudeUsageFetcher {
             return RateWindow(
                 usedPercent: used,
                 windowMinutes: windowMinutes,
-                resetsAt: ClaudeStatusProbe.parseResetDate(from: resetClean),
+                resetsAt: ClaudeStatusProbe.parseResetDate(
+                    from: resetClean,
+                    expectedWindow: TimeInterval(windowMinutes * 60)),
                 resetDescription: resetClean)
         }
 

--- a/Tests/CodexBarTests/ClaudeResetOccurrenceTests.swift
+++ b/Tests/CodexBarTests/ClaudeResetOccurrenceTests.swift
@@ -1,0 +1,77 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct ClaudeResetOccurrenceTests {
+    @Test
+    func `parser preserves both repeated daylight saving times`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/New_York"))
+        let startOfDay = try #require(calendar.date(from: DateComponents(
+            year: 2026, month: 11, day: 1, hour: 0)))
+        let searchStart = try #require(calendar.date(byAdding: .second, value: -1, to: startOfDay))
+        let matching = DateComponents(hour: 1, minute: 30, second: 0)
+        let first = try #require(calendar.nextDate(
+            after: searchStart,
+            matching: matching,
+            matchingPolicy: .strict,
+            repeatedTimePolicy: .first,
+            direction: .forward))
+        let second = try #require(calendar.nextDate(
+            after: searchStart,
+            matching: matching,
+            matchingPolicy: .strict,
+            repeatedTimePolicy: .last,
+            direction: .forward))
+        let tomorrow = try #require(calendar.date(from: DateComponents(
+            year: 2026, month: 11, day: 2, hour: 1, minute: 30)))
+
+        let timeOnlyCases = [
+            (now: first.addingTimeInterval(-60), expected: first),
+            (now: first.addingTimeInterval(30 * 60), expected: second),
+            (now: second.addingTimeInterval(60), expected: tomorrow),
+        ]
+        for item in timeOnlyCases {
+            let parsed = ClaudeStatusProbe.parseResetDate(
+                from: "Resets 1:30am (America/New_York)",
+                now: item.now)
+            #expect(parsed == item.expected)
+        }
+
+        let betweenOccurrences = first.addingTimeInterval(30 * 60)
+        #expect(ClaudeStatusProbe.parseResetDate(
+            from: "Resets Nov 1, 1:30am (America/New_York)",
+            now: betweenOccurrences) == second)
+        #expect(ClaudeStatusProbe.parseResetDate(
+            from: "Resets Nov 1, 1:30am (America/New_York)",
+            now: second.addingTimeInterval(60),
+            expectedWindow: 7 * 24 * 60 * 60) == second)
+    }
+
+    @Test
+    func `parser searches across leap years`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+        let leapReset = try #require(calendar.date(from: DateComponents(
+            year: 2028, month: 2, day: 29, hour: 9)))
+        let futureCases = [
+            DateComponents(year: 2025, month: 1, day: 1),
+            DateComponents(year: 2024, month: 3, day: 1),
+        ]
+        for nowComponents in futureCases {
+            let now = try #require(calendar.date(from: nowComponents))
+            #expect(ClaudeStatusProbe.parseResetDate(
+                from: "Resets Feb 29, 9am (UTC)",
+                now: now) == leapReset)
+        }
+
+        let currentLeapReset = try #require(calendar.date(from: DateComponents(
+            year: 2024, month: 2, day: 29, hour: 9)))
+        let shortlyAfter = try #require(calendar.date(from: DateComponents(
+            year: 2024, month: 2, day: 29, hour: 10)))
+        #expect(ClaudeStatusProbe.parseResetDate(
+            from: "Resets Feb 29, 9am (UTC)",
+            now: shortlyAfter,
+            expectedWindow: 7 * 24 * 60 * 60) == currentLeapReset)
+    }
+}

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -630,14 +630,22 @@ struct StatusProbeTests {
     }
 
     @Test
-    func `chooses nearest claude reset time across adjacent days`() throws {
+    func `uses the five hour window to resolve stale claude reset times`() throws {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
         let cases: [(now: DateComponents, text: String, expected: DateComponents)] = [
             (
+                DateComponents(year: 2026, month: 7, day: 9, hour: 15),
+                "Resets 3pm (UTC)",
+                DateComponents(year: 2026, month: 7, day: 9, hour: 15)),
+            (
                 DateComponents(year: 2026, month: 7, day: 9, hour: 15, minute: 5),
                 "Resets 3pm (UTC)",
                 DateComponents(year: 2026, month: 7, day: 9, hour: 15, minute: 0)),
+            (
+                DateComponents(year: 2026, month: 7, day: 9, hour: 20),
+                "Resets 3pm (UTC)",
+                DateComponents(year: 2026, month: 7, day: 9, hour: 15)),
             (
                 DateComponents(year: 2026, month: 7, day: 9, hour: 23, minute: 59),
                 "Resets 12:01am (UTC)",
@@ -650,8 +658,11 @@ struct StatusProbeTests {
 
         for item in cases {
             let now = try #require(calendar.date(from: item.now))
-            let parsed = ClaudeStatusProbe.parseResetDate(from: item.text, now: now)
-            #expect(parsed == calendar.date(from: item.expected), "Failed nearest-day resolution: \(item.text)")
+            let parsed = ClaudeStatusProbe.parseResetDate(
+                from: item.text,
+                now: now,
+                expectedWindow: 5 * 60 * 60)
+            #expect(parsed == calendar.date(from: item.expected), "Failed session-window resolution: \(item.text)")
         }
     }
 
@@ -672,7 +683,7 @@ struct StatusProbeTests {
     }
 
     @Test
-    func `chooses nearest claude reset date across adjacent years`() throws {
+    func `uses the weekly window to resolve stale claude reset dates`() throws {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
         let cases: [(now: DateComponents, text: String, expected: DateComponents)] = [
@@ -700,8 +711,37 @@ struct StatusProbeTests {
 
         for item in cases {
             let now = try #require(calendar.date(from: item.now))
+            let parsed = ClaudeStatusProbe.parseResetDate(
+                from: item.text,
+                now: now,
+                expectedWindow: 7 * 24 * 60 * 60)
+            #expect(parsed == calendar.date(from: item.expected), "Failed weekly-window resolution: \(item.text)")
+        }
+    }
+
+    @Test
+    func `public claude reset parser remains forward looking`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+        let cases: [(now: DateComponents, text: String, expected: DateComponents)] = [
+            (
+                DateComponents(year: 2026, month: 7, day: 9, hour: 8),
+                "Resets 9pm (UTC)",
+                DateComponents(year: 2026, month: 7, day: 9, hour: 21)),
+            (
+                DateComponents(year: 2026, month: 7, day: 9, hour: 20),
+                "Resets 1pm (UTC)",
+                DateComponents(year: 2026, month: 7, day: 10, hour: 13)),
+            (
+                DateComponents(year: 2026, month: 7, day: 9, hour: 12),
+                "Resets Jul 1, 9am (UTC)",
+                DateComponents(year: 2027, month: 7, day: 1, hour: 9)),
+        ]
+
+        for item in cases {
+            let now = try #require(calendar.date(from: item.now))
             let parsed = ClaudeStatusProbe.parseResetDate(from: item.text, now: now)
-            #expect(parsed == calendar.date(from: item.expected), "Failed nearest-year resolution: \(item.text)")
+            #expect(parsed == calendar.date(from: item.expected), "Failed future resolution: \(item.text)")
         }
     }
 
@@ -712,7 +752,10 @@ struct StatusProbeTests {
         let now = try #require(calendar.date(from: DateComponents(
             year: 2026, month: 7, day: 9, hour: 15, minute: 5, second: 0)))
         let resetText = "Resets Jul 9, 3:00pm (UTC)"
-        let resetDate = try #require(ClaudeStatusProbe.parseResetDate(from: resetText, now: now))
+        let resetDate = try #require(ClaudeStatusProbe.parseResetDate(
+            from: resetText,
+            now: now,
+            expectedWindow: 5 * 60 * 60))
         let window = RateWindow(
             usedPercent: 73,
             windowMinutes: 5 * 60,
@@ -738,7 +781,8 @@ struct StatusProbeTests {
         let parsedTimeOnly = ClaudeStatusProbe.parseResetDate(from: "Resets 1pm (UTC)", now: now)
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
-        let expected = try #require(calendar.date(bySettingHour: 13, minute: 0, second: 0, of: now))
+        let sameDay = try #require(calendar.date(bySettingHour: 13, minute: 0, second: 0, of: now))
+        let expected = try #require(calendar.date(byAdding: .day, value: 1, to: sameDay))
         #expect(parsedTimeOnly == expected)
 
         let parsedDateTime = ClaudeStatusProbe.parseResetDate(from: "Resets Dec 9, 9am", now: now)


### PR DESCRIPTION
## Summary

Follow-up to #2008. Choosing the nearest yearless/time-only occurrence fixed stale reset text, but could reinterpret a valid later reset as yesterday or last year.

- preserve the public parser's forward-looking contract;
- let quota callers accept a recent past occurrence only when it fits the known 5-hour or 7-day window and the future occurrence cannot;
- generate exact timezone-local candidates, including both repeated daylight-saving instants and validated leap-day years;
- keep scoped weekly rows on the same 7-day rule;
- retain contributor credit in the changelog.

## Proof

- `swift test --no-parallel --filter 'ClaudeResetOccurrenceTests|StatusProbeTests'` — pass.
- `make check` — pass; SwiftFormat and SwiftLint clean.
- `make test` — all 50 local shards pass.
- Independent caller/calendar review — clean after adding DST and leap-day coverage.
- Developer ID-signed debug bundle at exact commit `27bf30e9`; app/helper strict code-sign verification and Gatekeeper assessment pass.
- Packaged CLI with an isolated fake Claude executable — 2/2 scenarios pass: recent session/weekly resets remain past, while a later session reset and an out-of-window yearless weekly date remain future.
- Fixture isolation — disposable home/config, explicit CLI source, Keychain access suppressed, no browser, real provider credential, or external network use; child cleanup verified.
- Public Model Identifier Gate — PASS. Dependencies unchanged.

Refs #2008.
