### PR TITLE
ci: batch macOS test selections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
         run: |
           CODEXBAR_TEST_GROUP_SIZE=4 \
             CODEXBAR_TEST_SUITE_TIMEOUT=120 \
+            CODEXBAR_TEST_RETRY_NON_TIMEOUT_FAILURES=0 \
             CODEXBAR_TEST_SHARD_INDEX=${{ matrix.shard-index }} \
             CODEXBAR_TEST_SHARD_COUNT=${{ matrix.shard-count }} \
             ./Scripts/test.sh
@@ -141,12 +142,13 @@ jobs:
           RUNS_LINT_MACOS: ${{ matrix.shard-index == 0 }}
         run: |
           set -euo pipefail
+          display_shard_index=$((SHARD_INDEX + 1))
           xcode_version="$(/usr/bin/xcodebuild -version 2>/dev/null | tr '\n' ' ' || true)"
           {
             printf '### macOS Swift shard\n\n'
             printf '| Field | Value |\n'
             printf '| --- | --- |\n'
-            printf '| Shard | `%s / %s` |\n' "$SHARD_INDEX" "$SHARD_COUNT"
+            printf '| Shard | `%s / %s` |\n' "$display_shard_index" "$SHARD_COUNT"
             printf '| Runner | `%s` |\n' "${RUNNER_NAME:-unknown}"
             printf '| Xcode | `%s` |\n' "${xcode_version:-unknown}"
             printf '| Runs lint-macos | `%s` |\n' "$RUNS_LINT_MACOS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,10 @@ jobs:
         run: ./Scripts/lint.sh lint-macos
 
       - name: Swift Test
-        # Intel cold builds can spend ~26 minutes compiling the full test target before isolated suites start.
+        # Keep small batches to reduce SwiftPM process overhead without returning to one aggregate run.
         timeout-minutes: 50
         run: |
-          CODEXBAR_TEST_GROUP_SIZE=1 \
+          CODEXBAR_TEST_GROUP_SIZE=4 \
             CODEXBAR_TEST_SUITE_TIMEOUT=120 \
             CODEXBAR_TEST_SHARD_INDEX=${{ matrix.shard-index }} \
             CODEXBAR_TEST_SHARD_COUNT=${{ matrix.shard-count }} \

--- a/Scripts/ci_swift_test_by_suite.py
+++ b/Scripts/ci_swift_test_by_suite.py
@@ -208,7 +208,7 @@ def filter_for(suites: list[TestSelection]) -> str:
 
 def run_group(suites: list[TestSelection], timeout: int, swift_command: list[str]) -> int:
     return run_command(
-        [*swift_command, "test", "--no-parallel", "--filter", filter_for(suites)],
+        [*swift_command, "test", "--skip-build", "--no-parallel", "--filter", filter_for(suites)],
         timeout=timeout,
     )
 

--- a/Scripts/ci_swift_test_by_suite.py
+++ b/Scripts/ci_swift_test_by_suite.py
@@ -23,7 +23,8 @@ class TestSelection:
 
 @dataclass
 class RunStats:
-    selected_tests: int = 0
+    discovered_selections: int = 0
+    selected_selections: int = 0
     selected_groups: int = 0
     group_size: int = 0
     shard_index: int | None = None
@@ -31,12 +32,12 @@ class RunStats:
     discovery_seconds: float = 0
     execution_seconds: float = 0
     total_seconds: float = 0
-    successful_groups: int = 0
-    failed_groups: int = 0
-    retried_groups: int = 0
+    first_pass_successful_groups: int = 0
+    first_pass_failed_groups: int = 0
+    full_group_retries: int = 0
     timed_out_groups: int = 0
     recovered_groups: int = 0
-    retried_suites: int = 0
+    isolated_selection_retries: int = 0
 
     def summary_rows(self) -> list[tuple[str, str]]:
         shard = "none"
@@ -45,14 +46,15 @@ class RunStats:
         return [
             ("Shard", shard),
             ("Group size", str(self.group_size)),
-            ("Selected tests", str(self.selected_tests)),
+            ("Discovered selections", str(self.discovered_selections)),
+            ("Selected selections", str(self.selected_selections)),
             ("Selected groups", str(self.selected_groups)),
-            ("Successful groups", str(self.successful_groups)),
-            ("Failed groups", str(self.failed_groups)),
-            ("Retried groups", str(self.retried_groups)),
+            ("First-pass successful groups", str(self.first_pass_successful_groups)),
+            ("First-pass failed groups", str(self.first_pass_failed_groups)),
+            ("Full-group retries", str(self.full_group_retries)),
             ("Recovered groups", str(self.recovered_groups)),
             ("Timed out groups", str(self.timed_out_groups)),
-            ("Retried suites", str(self.retried_suites)),
+            ("Isolated selection retries", str(self.isolated_selection_retries)),
             ("Discovery seconds", f"{self.discovery_seconds:.1f}"),
             ("Execution seconds", f"{self.execution_seconds:.1f}"),
             ("Total seconds", f"{self.total_seconds:.1f}"),
@@ -66,6 +68,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--limit-groups", type=int)
     parser.add_argument("--shard-index", type=int)
     parser.add_argument("--shard-count", type=int)
+    parser.add_argument(
+        "--no-retry-non-timeout-failures",
+        action="store_false",
+        dest="retry_non_timeout_failures",
+        help="fail immediately when a group exits without timing out",
+    )
     parser.add_argument("--list-only", action="store_true")
     parser.add_argument("--swift-command", default="swift")
     parser.add_argument("--swift-command-arg", action="append", default=[])
@@ -205,6 +213,22 @@ def run_group(suites: list[TestSelection], timeout: int, swift_command: list[str
     )
 
 
+def retry_selections_individually(
+    suites: list[TestSelection],
+    timeout: int,
+    swift_command: list[str],
+    stats: RunStats,
+) -> int:
+    for suite in suites:
+        stats.isolated_selection_retries += 1
+        print(f"::group::Swift test retry {suite.name}", flush=True)
+        retry_result = run_group([suite], timeout, swift_command)
+        print("::endgroup::", flush=True)
+        if retry_result != 0:
+            return retry_result
+    return 0
+
+
 def main() -> int:
     total_started = time.monotonic()
     args = parse_args()
@@ -221,9 +245,11 @@ def main() -> int:
     result = 0
     try:
         discovery_started = time.monotonic()
-        suites = prioritized_suites(filtered_suites_for_environment(swift_test_list(swift_command)))
-        stats.discovery_seconds = time.monotonic() - discovery_started
-        stats.selected_tests = len(suites)
+        try:
+            suites = prioritized_suites(filtered_suites_for_environment(swift_test_list(swift_command)))
+        finally:
+            stats.discovery_seconds = time.monotonic() - discovery_started
+        stats.discovered_selections = len(suites)
 
         suite_groups = list(chunks(suites, args.group_size))
         try:
@@ -234,12 +260,17 @@ def main() -> int:
             return result
         if args.limit_groups is not None:
             suite_groups = suite_groups[: args.limit_groups]
+        stats.selected_selections = sum(len(group) for group in suite_groups)
         stats.selected_groups = len(suite_groups)
 
         shard_suffix = ""
         if args.shard_index is not None and args.shard_count is not None:
             shard_suffix = f" in shard {args.shard_index + 1}/{args.shard_count}"
-        print(f"Discovered {len(suites)} test selections; running {len(suite_groups)} groups{shard_suffix}", flush=True)
+        print(
+            f"Discovered {len(suites)} test selections; running {stats.selected_selections} selections "
+            f"in {len(suite_groups)} groups{shard_suffix}",
+            flush=True,
+        )
         if args.list_only:
             for group in suite_groups:
                 for suite in group:
@@ -253,41 +284,48 @@ def main() -> int:
         execution_started = time.monotonic()
         for group_index, group in enumerate(suite_groups, start=1):
             print(
-                f"::group::Swift test shard {group_index}/{len(suite_groups)} "
+                f"::group::Swift test group {group_index}/{len(suite_groups)} "
                 f"({len(group)} selections)",
                 flush=True,
             )
             group_result = run_group(group, args.timeout, swift_command)
             print("::endgroup::", flush=True)
             if group_result == 0:
-                stats.successful_groups += 1
+                stats.first_pass_successful_groups += 1
                 continue
 
-            stats.failed_groups += 1
+            stats.first_pass_failed_groups += 1
+            group_timed_out = group_result == 124
+            if group_timed_out:
+                stats.timed_out_groups += 1
             if len(group) == 1:
                 result = group_result
                 return result
 
             if group_result != 124:
-                stats.retried_groups += 1
-                print(f"Shard {group_index} failed with exit code {group_result}; retrying shard once", flush=True)
+                if not args.retry_non_timeout_failures:
+                    result = group_result
+                    return result
+
+                stats.full_group_retries += 1
+                print(f"Group {group_index} failed with exit code {group_result}; retrying group once", flush=True)
                 retry_result = run_group(group, args.timeout, swift_command)
                 if retry_result == 0:
                     stats.recovered_groups += 1
                     continue
-                result = retry_result
-                return result
-
-            stats.timed_out_groups += 1
-            print(f"Shard {group_index} timed out; retrying suites one at a time", flush=True)
-            for suite in group:
-                stats.retried_suites += 1
-                print(f"::group::Swift test retry {suite.name}", flush=True)
-                retry_result = run_group([suite], args.timeout, swift_command)
-                print("::endgroup::", flush=True)
-                if retry_result != 0:
+                if retry_result != 124:
                     result = retry_result
                     return result
+                group_timed_out = True
+                stats.timed_out_groups += 1
+
+            print(f"Group {group_index} timed out; retrying selections one at a time", flush=True)
+            retry_result = retry_selections_individually(group, args.timeout, swift_command, stats)
+            if retry_result != 0:
+                result = retry_result
+                return result
+            if group_timed_out:
+                stats.recovered_groups += 1
 
         return result
     finally:

--- a/Scripts/ci_swift_test_by_suite.py
+++ b/Scripts/ci_swift_test_by_suite.py
@@ -9,6 +9,7 @@ import re
 import signal
 import subprocess
 import sys
+import time
 from collections.abc import Iterable
 from dataclasses import dataclass
 
@@ -18,6 +19,44 @@ class TestSelection:
     name: str
     filter_pattern: str
     suite_name: str | None = None
+
+
+@dataclass
+class RunStats:
+    selected_tests: int = 0
+    selected_groups: int = 0
+    group_size: int = 0
+    shard_index: int | None = None
+    shard_count: int | None = None
+    discovery_seconds: float = 0
+    execution_seconds: float = 0
+    total_seconds: float = 0
+    successful_groups: int = 0
+    failed_groups: int = 0
+    retried_groups: int = 0
+    timed_out_groups: int = 0
+    recovered_groups: int = 0
+    retried_suites: int = 0
+
+    def summary_rows(self) -> list[tuple[str, str]]:
+        shard = "none"
+        if self.shard_index is not None and self.shard_count is not None:
+            shard = f"{self.shard_index + 1}/{self.shard_count}"
+        return [
+            ("Shard", shard),
+            ("Group size", str(self.group_size)),
+            ("Selected tests", str(self.selected_tests)),
+            ("Selected groups", str(self.selected_groups)),
+            ("Successful groups", str(self.successful_groups)),
+            ("Failed groups", str(self.failed_groups)),
+            ("Retried groups", str(self.retried_groups)),
+            ("Recovered groups", str(self.recovered_groups)),
+            ("Timed out groups", str(self.timed_out_groups)),
+            ("Retried suites", str(self.retried_suites)),
+            ("Discovery seconds", f"{self.discovery_seconds:.1f}"),
+            ("Execution seconds", f"{self.execution_seconds:.1f}"),
+            ("Total seconds", f"{self.total_seconds:.1f}"),
+        ]
 
 
 def parse_args() -> argparse.Namespace:
@@ -97,6 +136,27 @@ def swift_test_list(swift_command: list[str]) -> list[TestSelection]:
     return sorted(selections, key=lambda selection: selection.name)
 
 
+def append_github_summary(stats: RunStats) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    with open(summary_path, "a", encoding="utf-8") as summary:
+        summary.write("### macOS Swift test timing\n\n")
+        summary.write("| Field | Value |\n")
+        summary.write("| --- | --- |\n")
+        for field, value in stats.summary_rows():
+            safe_value = value.replace("|", "\\|")
+            summary.write(f"| {field} | `{safe_value}` |\n")
+        summary.write("\n")
+
+
+def print_timing_summary(stats: RunStats) -> None:
+    print("Swift test timing summary:", flush=True)
+    for field, value in stats.summary_rows():
+        print(f"- {field}: {value}", flush=True)
+
+
 def chunks(items: list[TestSelection], size: int) -> Iterable[list[TestSelection]]:
     for index in range(0, len(items), size):
         yield items[index : index + size]
@@ -146,65 +206,97 @@ def run_group(suites: list[TestSelection], timeout: int, swift_command: list[str
 
 
 def main() -> int:
+    total_started = time.monotonic()
     args = parse_args()
+    stats = RunStats(
+        group_size=args.group_size,
+        shard_index=args.shard_index,
+        shard_count=args.shard_count,
+    )
     if args.group_size < 1:
         print("--group-size must be positive", file=sys.stderr)
         return 2
 
     swift_command = [args.swift_command, *args.swift_command_arg]
-    suites = prioritized_suites(filtered_suites_for_environment(swift_test_list(swift_command)))
-    suite_groups = list(chunks(suites, args.group_size))
+    result = 0
     try:
-        suite_groups = shard_groups(suite_groups, args.shard_index, args.shard_count)
-    except ValueError as error:
-        print(str(error), file=sys.stderr)
-        return 2
-    if args.limit_groups is not None:
-        suite_groups = suite_groups[: args.limit_groups]
+        discovery_started = time.monotonic()
+        suites = prioritized_suites(filtered_suites_for_environment(swift_test_list(swift_command)))
+        stats.discovery_seconds = time.monotonic() - discovery_started
+        stats.selected_tests = len(suites)
 
-    shard_suffix = ""
-    if args.shard_index is not None and args.shard_count is not None:
-        shard_suffix = f" in shard {args.shard_index + 1}/{args.shard_count}"
-    print(f"Discovered {len(suites)} test selections; running {len(suite_groups)} groups{shard_suffix}", flush=True)
-    if args.list_only:
-        for group in suite_groups:
-            for suite in group:
-                print(suite.name)
-        return 0
-
-    if not suite_groups:
-        print("No test groups selected.", flush=True)
-        return 0
-
-    for group_index, group in enumerate(suite_groups, start=1):
-        print(
-            f"::group::Swift test shard {group_index}/{len(suite_groups)} "
-            f"({len(group)} selections)",
-            flush=True,
-        )
-        result = run_group(group, args.timeout, swift_command)
-        print("::endgroup::", flush=True)
-        if result == 0:
-            continue
-        if len(group) == 1:
+        suite_groups = list(chunks(suites, args.group_size))
+        try:
+            suite_groups = shard_groups(suite_groups, args.shard_index, args.shard_count)
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            result = 2
             return result
+        if args.limit_groups is not None:
+            suite_groups = suite_groups[: args.limit_groups]
+        stats.selected_groups = len(suite_groups)
 
-        if result != 124:
-            print(f"Shard {group_index} failed with exit code {result}; retrying shard once", flush=True)
-            retry_result = run_group(group, args.timeout, swift_command)
-            if retry_result == 0:
-                continue
-            return retry_result
+        shard_suffix = ""
+        if args.shard_index is not None and args.shard_count is not None:
+            shard_suffix = f" in shard {args.shard_index + 1}/{args.shard_count}"
+        print(f"Discovered {len(suites)} test selections; running {len(suite_groups)} groups{shard_suffix}", flush=True)
+        if args.list_only:
+            for group in suite_groups:
+                for suite in group:
+                    print(suite.name)
+            return 0
 
-        print(f"Shard {group_index} timed out; retrying suites one at a time", flush=True)
-        for suite in group:
-            print(f"::group::Swift test retry {suite.name}", flush=True)
-            retry_result = run_group([suite], args.timeout, swift_command)
+        if not suite_groups:
+            print("No test groups selected.", flush=True)
+            return 0
+
+        execution_started = time.monotonic()
+        for group_index, group in enumerate(suite_groups, start=1):
+            print(
+                f"::group::Swift test shard {group_index}/{len(suite_groups)} "
+                f"({len(group)} selections)",
+                flush=True,
+            )
+            group_result = run_group(group, args.timeout, swift_command)
             print("::endgroup::", flush=True)
-            if retry_result != 0:
-                return retry_result
+            if group_result == 0:
+                stats.successful_groups += 1
+                continue
 
-    return 0
+            stats.failed_groups += 1
+            if len(group) == 1:
+                result = group_result
+                return result
+
+            if group_result != 124:
+                stats.retried_groups += 1
+                print(f"Shard {group_index} failed with exit code {group_result}; retrying shard once", flush=True)
+                retry_result = run_group(group, args.timeout, swift_command)
+                if retry_result == 0:
+                    stats.recovered_groups += 1
+                    continue
+                result = retry_result
+                return result
+
+            stats.timed_out_groups += 1
+            print(f"Shard {group_index} timed out; retrying suites one at a time", flush=True)
+            for suite in group:
+                stats.retried_suites += 1
+                print(f"::group::Swift test retry {suite.name}", flush=True)
+                retry_result = run_group([suite], args.timeout, swift_command)
+                print("::endgroup::", flush=True)
+                if retry_result != 0:
+                    result = retry_result
+                    return result
+
+        return result
+    finally:
+        stats.total_seconds = time.monotonic() - total_started
+        if "execution_started" in locals():
+            stats.execution_seconds = time.monotonic() - execution_started
+        if not args.list_only:
+            print_timing_summary(stats)
+            append_github_summary(stats)
 
 
 if __name__ == "__main__":

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GROUP_SIZE="${CODEXBAR_TEST_GROUP_SIZE:-12}"
 SUITE_TIMEOUT="${CODEXBAR_TEST_SUITE_TIMEOUT:-180}"
+RETRY_NON_TIMEOUT_FAILURES="${CODEXBAR_TEST_RETRY_NON_TIMEOUT_FAILURES:-1}"
 
 cd "${ROOT_DIR}"
 
@@ -18,6 +19,15 @@ ARGS=(
   --group-size "${GROUP_SIZE}"
   --timeout "${SUITE_TIMEOUT}"
 )
+
+case "${RETRY_NON_TIMEOUT_FAILURES}" in
+  0) ARGS+=(--no-retry-non-timeout-failures) ;;
+  1) ;;
+  *)
+    echo "CODEXBAR_TEST_RETRY_NON_TIMEOUT_FAILURES must be 0 or 1" >&2
+    exit 2
+    ;;
+esac
 
 if [[ -n "${CODEXBAR_TEST_SHARD_INDEX:-}" || -n "${CODEXBAR_TEST_SHARD_COUNT:-}" ]]; then
   ARGS+=(

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -33,6 +33,7 @@ fi
 EOF
 
 export FAKE_SWIFT_LOG="${TEMP_DIR}/swift.log"
+export GITHUB_STEP_SUMMARY="${TEMP_DIR}/step-summary.md"
 
 python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
   --group-size 4 \
@@ -43,6 +44,9 @@ python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
   --swift-command-arg=fake-swift \
   >"${TEMP_DIR}/retry.log"
 grep -Fq "failed with exit code 1; retrying shard once" "${TEMP_DIR}/retry.log"
+grep -Fq "Swift test timing summary:" "${TEMP_DIR}/retry.log"
+grep -Fq "| Group size | \`4\` |" "${GITHUB_STEP_SUMMARY}"
+grep -Fq "| Retried groups | \`1\` |" "${GITHUB_STEP_SUMMARY}"
 grep -Fq "CodexBarTests\\.Alpha" "${FAKE_SWIFT_LOG}"
 grep -Fq "CodexBarTests\\.Beta" "${FAKE_SWIFT_LOG}"
 grep -Fq "CodexBarTests\\..*top\\ level\\ works" "${FAKE_SWIFT_LOG}"

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 
 printf '%s\n' "$*" >> "${FAKE_SWIFT_LOG}"
 if [[ "$*" == "test list" ]]; then
-  if [[ "${FAKE_SWIFT_LIST_FAIL:-0}" == "1" ]]; then
+  if [[ "${FAKE_SWIFT_MODE:-success}" == "list_fail" ]]; then
+    sleep 0.25
     printf 'test-list stdout marker\n'
     printf 'test-list stderr marker\n' >&2
     exit 42
@@ -20,105 +21,196 @@ if [[ "$*" == "test list" ]]; then
     "CodexBarTests.Alpha/test_one()" \
     "CodexBarTests.Alpha/test_two(argument:)" \
     "CodexBarTests.Beta/test_two" \
+    "CodexBarTests.Gamma/test_three" \
+    "CodexBarTests.Delta/test_four" \
+    "CodexBarTests.Epsilon/test_five" \
+    "CodexBarTests.Zeta/test_six" \
+    "CodexBarTests.Eta/test_seven" \
+    "CodexBarTests.Theta/test_eight" \
     'CodexBarTests.`top level works`()' \
     'CodexBarTests.`top/level slash works`()'
   exit 0
 fi
+
+is_group=0
 if [[ "$*" == *"|"* ]]; then
-  group_runs="$(grep -c '|' "${FAKE_SWIFT_LOG}")"
-  if [[ "${FAKE_SWIFT_GROUP_ALWAYS_FAIL:-0}" == "1" || "${group_runs}" -eq 1 ]]; then
-    exit 1
-  fi
+  is_group=1
 fi
+
+next_group_attempt() {
+  local attempt=0
+  if [[ -f "${FAKE_SWIFT_STATE}" ]]; then
+    read -r attempt < "${FAKE_SWIFT_STATE}"
+  fi
+  attempt=$((attempt + 1))
+  printf '%s\n' "${attempt}" > "${FAKE_SWIFT_STATE}"
+  printf '%s\n' "${attempt}"
+}
+
+case "${FAKE_SWIFT_MODE:-success}" in
+  group_fail_once)
+    if [[ "${is_group}" == "1" && "$(next_group_attempt)" == "1" ]]; then
+      exit 1
+    fi
+    ;;
+  group_always_fail)
+    if [[ "${is_group}" == "1" ]]; then
+      exit 1
+    fi
+    ;;
+  group_timeout)
+    if [[ "${is_group}" == "1" ]]; then
+      sleep 2
+    fi
+    ;;
+  singleton_timeout)
+    if [[ "${is_group}" == "0" ]]; then
+      sleep 2
+    fi
+    ;;
+  group_fail_then_timeout)
+    if [[ "${is_group}" == "1" ]]; then
+      attempt="$(next_group_attempt)"
+      if [[ "${attempt}" == "1" ]]; then
+        exit 1
+      fi
+      sleep 2
+    fi
+    ;;
+esac
 EOF
 
-export FAKE_SWIFT_LOG="${TEMP_DIR}/swift.log"
-export GITHUB_STEP_SUMMARY="${TEMP_DIR}/step-summary.md"
+reset_case() {
+  local name="$1"
+  export FAKE_SWIFT_LOG="${TEMP_DIR}/${name}-swift.log"
+  export FAKE_SWIFT_STATE="${TEMP_DIR}/${name}-state"
+  export GITHUB_STEP_SUMMARY="${TEMP_DIR}/${name}-summary.md"
+  rm -f "${FAKE_SWIFT_LOG}" "${FAKE_SWIFT_STATE}" "${GITHUB_STEP_SUMMARY}"
+}
 
-python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
-  --group-size 4 \
-  --timeout 10 \
-  --swift-command /bin/bash \
-  --swift-command-arg=-c \
-  --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
-  --swift-command-arg=fake-swift \
-  >"${TEMP_DIR}/retry.log"
-grep -Fq "failed with exit code 1; retrying shard once" "${TEMP_DIR}/retry.log"
+run_harness() {
+  python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
+    "$@" \
+    --swift-command /bin/bash \
+    --swift-command-arg=-c \
+    --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
+    --swift-command-arg=fake-swift
+}
+
+reset_case retry
+export FAKE_SWIFT_MODE=group_fail_once
+run_harness --group-size 4 --timeout 10 > "${TEMP_DIR}/retry.log"
+grep -Fq "failed with exit code 1; retrying group once" "${TEMP_DIR}/retry.log"
 grep -Fq "Swift test timing summary:" "${TEMP_DIR}/retry.log"
-grep -Fq "| Group size | \`4\` |" "${GITHUB_STEP_SUMMARY}"
-grep -Fq "| Retried groups | \`1\` |" "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Discovered selections | `10` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Selected selections | `10` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Selected groups | `3` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| First-pass successful groups | `2` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| First-pass failed groups | `1` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Full-group retries | `1` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Recovered groups | `1` |' "${GITHUB_STEP_SUMMARY}"
 grep -Fq "CodexBarTests\\.Alpha" "${FAKE_SWIFT_LOG}"
 grep -Fq "CodexBarTests\\.Beta" "${FAKE_SWIFT_LOG}"
 grep -Fq "CodexBarTests\\..*top\\ level\\ works" "${FAKE_SWIFT_LOG}"
 grep -Fq "CodexBarTests\\..*top/level\\ slash\\ works" "${FAKE_SWIFT_LOG}"
-[[ "$(wc -l < "${FAKE_SWIFT_LOG}")" -eq 3 ]]
+[[ "$(wc -l < "${FAKE_SWIFT_LOG}")" -eq 5 ]]
 
-python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
-  --group-size 1 \
-  --timeout 10 \
-  --shard-index 0 \
-  --shard-count 2 \
-  --list-only \
-  --swift-command /bin/bash \
-  --swift-command-arg=-c \
-  --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
-  --swift-command-arg=fake-swift \
-  >"${TEMP_DIR}/shard-0.log"
+reset_case strict
+export FAKE_SWIFT_MODE=group_fail_once
+set +e
+CODEXBAR_TEST_GROUP_SIZE=4 \
+  CODEXBAR_TEST_SUITE_TIMEOUT=10 \
+  CODEXBAR_TEST_RETRY_NON_TIMEOUT_FAILURES=0 \
+  "${ROOT_DIR}/Scripts/test.sh" \
+    --limit-groups 1 \
+    --swift-command /bin/bash \
+    --swift-command-arg=-c \
+    --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
+    --swift-command-arg=fake-swift \
+    > "${TEMP_DIR}/strict.log" 2>&1
+strict_status=$?
+set -e
+[[ "${strict_status}" -eq 1 ]]
+grep -Fq '| First-pass failed groups | `1` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Full-group retries | `0` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Isolated selection retries | `0` |' "${GITHUB_STEP_SUMMARY}"
+[[ "$(wc -l < "${FAKE_SWIFT_LOG}")" -eq 2 ]]
 
-python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
-  --group-size 1 \
-  --timeout 10 \
-  --shard-index 1 \
-  --shard-count 2 \
-  --list-only \
-  --swift-command /bin/bash \
-  --swift-command-arg=-c \
-  --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
-  --swift-command-arg=fake-swift \
-  >"${TEMP_DIR}/shard-1.log"
+reset_case shard-0
+export FAKE_SWIFT_MODE=success
+run_harness --group-size 4 --timeout 10 --shard-index 0 --shard-count 2 > "${TEMP_DIR}/shard-0.log"
+grep -Fq '| Shard | `1/2` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Selected selections | `6` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Selected groups | `2` |' "${GITHUB_STEP_SUMMARY}"
 
-cat "${TEMP_DIR}/shard-0.log" "${TEMP_DIR}/shard-1.log" \
+reset_case shard-1
+run_harness --group-size 4 --timeout 10 --shard-index 1 --shard-count 2 > "${TEMP_DIR}/shard-1.log"
+grep -Fq '| Shard | `2/2` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Selected selections | `4` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Selected groups | `1` |' "${GITHUB_STEP_SUMMARY}"
+
+reset_case shard-list-0
+run_harness --group-size 4 --timeout 10 --shard-index 0 --shard-count 2 --list-only \
+  > "${TEMP_DIR}/shard-list-0.log"
+reset_case shard-list-1
+run_harness --group-size 4 --timeout 10 --shard-index 1 --shard-count 2 --list-only \
+  > "${TEMP_DIR}/shard-list-1.log"
+cat "${TEMP_DIR}/shard-list-0.log" "${TEMP_DIR}/shard-list-1.log" \
   | grep -v '^Discovered ' \
-  | sort >"${TEMP_DIR}/shards-combined.log"
-python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
-  --group-size 1 \
-  --timeout 10 \
-  --list-only \
-  --swift-command /bin/bash \
-  --swift-command-arg=-c \
-  --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
-  --swift-command-arg=fake-swift \
+  | sort > "${TEMP_DIR}/shards-combined.log"
+reset_case shard-list-all
+run_harness --group-size 4 --timeout 10 --list-only \
   | grep -v '^Discovered ' \
-  | sort >"${TEMP_DIR}/shards-expected.log"
+  | sort > "${TEMP_DIR}/shards-expected.log"
 diff -u "${TEMP_DIR}/shards-expected.log" "${TEMP_DIR}/shards-combined.log"
 
-if FAKE_SWIFT_GROUP_ALWAYS_FAIL=1 \
-  python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
-    --group-size 4 \
-    --timeout 10 \
-    --swift-command /bin/bash \
-    --swift-command-arg=-c \
-    --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
-    --swift-command-arg=fake-swift \
-    >"${TEMP_DIR}/failure.log" 2>&1; then
-  echo "ERROR: Repeated shard failure was masked." >&2
-  exit 1
-fi
+reset_case group-timeout
+export FAKE_SWIFT_MODE=group_timeout
+run_harness --group-size 4 --limit-groups 1 --timeout 1 > "${TEMP_DIR}/group-timeout.log"
+grep -Fq "timed out; retrying selections one at a time" "${TEMP_DIR}/group-timeout.log"
+grep -Fq '| Timed out groups | `1` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Recovered groups | `1` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Isolated selection retries | `4` |' "${GITHUB_STEP_SUMMARY}"
 
-if FAKE_SWIFT_LIST_FAIL=1 \
-  python3 "${ROOT_DIR}/Scripts/ci_swift_test_by_suite.py" \
-    --group-size 1 \
-    --timeout 10 \
-    --list-only \
-    --swift-command /bin/bash \
-    --swift-command-arg=-c \
-    --swift-command-arg="${FAKE_SWIFT_SCRIPT}" \
-    --swift-command-arg=fake-swift \
-    >"${TEMP_DIR}/list-failure.log" 2>&1; then
-  echo "ERROR: Failed test discovery was masked." >&2
-  exit 1
-fi
+reset_case singleton-timeout
+export FAKE_SWIFT_MODE=singleton_timeout
+set +e
+run_harness --group-size 1 --limit-groups 1 --timeout 1 > "${TEMP_DIR}/singleton-timeout.log" 2>&1
+singleton_timeout_status=$?
+set -e
+[[ "${singleton_timeout_status}" -eq 124 ]]
+grep -Fq '| Timed out groups | `1` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Recovered groups | `0` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Isolated selection retries | `0` |' "${GITHUB_STEP_SUMMARY}"
+
+reset_case retry-timeout
+export FAKE_SWIFT_MODE=group_fail_then_timeout
+run_harness --group-size 4 --limit-groups 1 --timeout 1 > "${TEMP_DIR}/retry-timeout.log"
+grep -Fq '| Full-group retries | `1` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Timed out groups | `1` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Recovered groups | `1` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Isolated selection retries | `4` |' "${GITHUB_STEP_SUMMARY}"
+
+reset_case repeated-failure
+export FAKE_SWIFT_MODE=group_always_fail
+set +e
+run_harness --group-size 4 --limit-groups 1 --timeout 10 > "${TEMP_DIR}/failure.log" 2>&1
+failure_status=$?
+set -e
+[[ "${failure_status}" -eq 1 ]]
+grep -Fq '| Full-group retries | `1` |' "${GITHUB_STEP_SUMMARY}"
+grep -Fq '| Recovered groups | `0` |' "${GITHUB_STEP_SUMMARY}"
+
+reset_case list-failure
+export FAKE_SWIFT_MODE=list_fail
+set +e
+run_harness --group-size 1 --timeout 10 > "${TEMP_DIR}/list-failure.log" 2>&1
+list_failure_status=$?
+set -e
+[[ "${list_failure_status}" -ne 0 ]]
 grep -Fq "test-list stdout marker" "${TEMP_DIR}/list-failure.log"
 grep -Fq "test-list stderr marker" "${TEMP_DIR}/list-failure.log"
+grep -Eq -- '- Discovery seconds: 0\.[1-9]' "${TEMP_DIR}/list-failure.log"
+grep -Fq '| Discovered selections | `0` |' "${GITHUB_STEP_SUMMARY}"
 
 echo "Swift test sharding tests passed."

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -109,6 +109,7 @@ grep -Fq '| First-pass successful groups | `2` |' "${GITHUB_STEP_SUMMARY}"
 grep -Fq '| First-pass failed groups | `1` |' "${GITHUB_STEP_SUMMARY}"
 grep -Fq '| Full-group retries | `1` |' "${GITHUB_STEP_SUMMARY}"
 grep -Fq '| Recovered groups | `1` |' "${GITHUB_STEP_SUMMARY}"
+[[ "$(grep -c '^test --skip-build --no-parallel' "${FAKE_SWIFT_LOG}")" -eq 4 ]]
 grep -Fq "CodexBarTests\\.Alpha" "${FAKE_SWIFT_LOG}"
 grep -Fq "CodexBarTests\\.Beta" "${FAKE_SWIFT_LOG}"
 grep -Fq "CodexBarTests\\..*top\\ level\\ works" "${FAKE_SWIFT_LOG}"


### PR DESCRIPTION
## Summary

- Batch macOS Swift test selections in groups of four while preserving the existing four-way hosted shard split.
- Build test targets once during `swift test list`, then run each selected group with `--skip-build` and `--no-parallel`.
- Keep the historical local retry for non-timeout failures, but make hosted CI fail immediately so a real test failure cannot retry green.
- Isolate timed-out batches one selection at a time and report accurate discovery, selected-selection, first-pass, retry, recovery, timeout, and timing metrics.

## Correctness contract

- Selection counts are computed after sharding and `--limit-groups`.
- Hosted non-timeout failures preserve their first exit code without a retry.
- Singleton timeouts report one timed-out group and exit 124.
- Batched timeouts retry individual selections and report recovery only when every isolated selection passes.
- A local non-timeout retry that then times out falls through to the same isolated-selection path.
- Operator summaries use one-based shard labels consistently.

## Observed performance

The contributor's first hosted group-size-four run passed all checks. Its macOS Swift Test steps took approximately 13m22s to 18m17s despite runner queueing. The final candidate also removes repeated SwiftPM build planning after discovery; exact-head hosted timing is tracked by the per-shard summaries added here.

## Exact-head proof

Head: `85a0924e7a7851e0dbcfed6ded9f9ee75187f906`

- `DEVELOPER_DIR=/Applications/Xcode-26.6.app/Contents/Developer make check`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.app/Contents/Developer make test`: 594/594 selections, 50/50 groups, zero first-pass failures, retries, recoveries, or timeouts
- Real strict group-size-four run: 4/4 selected selections passed through `--skip-build`
- `bash Scripts/test_swift_test_sharding.sh`: strict hosted failure, local retry, shard completeness/counts, singleton timeout, timeout recovery, retry-to-timeout isolation, skip-build, and discovery-timing cases passed
- Final branch autoreview: clean, no accepted/actionable findings
- Public Model Identifier Gate: PASS; no model-bearing public data in this CI-only diff
- Dependency freshness: N/A; no dependencies changed

Exact-head hosted CI/security is running.
