### PR TITLE
Menu bar: show reset time when quota runs out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.41.1 — Unreleased
 
 ### Added
-- Menu bar: new "Show reset time when quota runs out" display option — Percent, Pace, and Both modes swap the exhausted value for the time until reset (e.g. ↻ 2h 14m), then flip back after the reset.
+- Menu bar: new "Show reset time when quota runs out" display option — Percent, Pace, and Both modes swap the exhausted value for the time until reset (e.g. ↻ 2h 14m), then flip back after the reset (#2028, #2027). Thanks @brahimhamichan!
 - Agent Sessions: list and focus live local or SSH-discovered Codex and Claude Code sessions from the menu and CLI.
 - Kimi K2: add a Usage Dashboard shortcut to the human-facing legacy credits page. Thanks @joeVenner!
 - Codex: add GPT-5.6 Sol, Terra, and Luna pricing, including long-context, Priority, cache-write, alias, and automatic Pi cache repricing when rates change (#2023). Thanks @0xSMW!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.41.1 — Unreleased
 
 ### Added
+- Menu bar: new "Show reset time when quota runs out" display option — Percent, Pace, and Both modes swap the exhausted value for the time until reset (e.g. ↻ 2h 14m), then flip back after the reset.
 - Agent Sessions: list and focus live local or SSH-discovered Codex and Claude Code sessions from the menu and CLI.
 - Kimi K2: add a Usage Dashboard shortcut to the human-facing legacy credits page. Thanks @joeVenner!
 - Codex: add GPT-5.6 Sol, Terra, and Luna pricing, including long-context, Priority, cache-write, alias, and automatic Pi cache repricing when rates change (#2023). Thanks @0xSMW!

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -143,6 +143,12 @@ enum MenuBarDisplayText {
         now: Date) -> String?
     {
         guard enabled, let window, window.remainingPercent <= 0 else { return nil }
+        // Only replace the percent while the reset is still ahead of us. A snapshot can linger at 0%
+        // with an already-elapsed `resetsAt` (the countdown fires right after reset, or refresh is
+        // manual); rendering "↻ now"/a past clock there would be stale, and since the countdown
+        // scheduler ignores elapsed resets nothing would refresh it back to the percentage. Fall back
+        // to the percent in that window instead of getting stuck on reset text.
+        if let resetsAt = window.resetsAt, resetsAt <= now { return nil }
         return self.resetTimeText(window: window, style: style, now: now)
     }
 

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -85,13 +85,22 @@ enum MenuBarDisplayText {
         now: Date = .init()) -> String?
     {
         if mode != .resetTime,
-           let resetText = self.exhaustedResetText(
-               window: percentWindow,
-               enabled: showsResetTimeWhenExhausted,
-               style: resetTimeDisplayStyle,
-               now: now)
+           showsResetTimeWhenExhausted,
+           let percentWindow,
+           percentWindow.remainingPercent <= 0
         {
-            return resetText
+            if let resetText = self.exhaustedResetText(
+                window: percentWindow,
+                enabled: true,
+                style: resetTimeDisplayStyle,
+                now: now)
+            {
+                return resetText
+            }
+            // Smart mode cannot replace an exhausted percentage unless the reset is concrete, future,
+            // and schedulable. Preserve the quota signal in pace/both modes too; a pace from another
+            // combined lane must not hide that this displayed lane is already exhausted.
+            return self.percentText(window: percentWindow, showUsed: showUsed)
         }
         switch mode {
         case .percent:

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -136,6 +136,12 @@ enum MenuBarDisplayText {
 
     /// Smart-mode replacement: when enabled and the quota is exhausted (0% remaining, regardless of
     /// whether the display shows used or remaining), surface the reset time instead of a dead percent.
+    ///
+    /// Requires a concrete, still-future `resetsAt`. The smart option only replaces the percent when it
+    /// has a reset time it can both render as a live countdown/clock AND hand to the refresh scheduler,
+    /// so the lane keeps ticking and flips back to the percentage once the reset passes. Windows with
+    /// only textual reset metadata (`resetDescription`, no `resetsAt`) or an already-elapsed reset can't
+    /// be scheduled, so they keep showing the percent instead of freezing on stale reset text.
     private static func exhaustedResetText(
         window: RateWindow?,
         enabled: Bool,
@@ -143,12 +149,7 @@ enum MenuBarDisplayText {
         now: Date) -> String?
     {
         guard enabled, let window, window.remainingPercent <= 0 else { return nil }
-        // Only replace the percent while the reset is still ahead of us. A snapshot can linger at 0%
-        // with an already-elapsed `resetsAt` (the countdown fires right after reset, or refresh is
-        // manual); rendering "↻ now"/a past clock there would be stale, and since the countdown
-        // scheduler ignores elapsed resets nothing would refresh it back to the percentage. Fall back
-        // to the percent in that window instead of getting stuck on reset text.
-        if let resetsAt = window.resetsAt, resetsAt <= now { return nil }
+        guard let resetsAt = window.resetsAt, resetsAt > now else { return nil }
         return self.resetTimeText(window: window, style: style, now: now)
     }
 

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -21,19 +21,52 @@ enum MenuBarDisplayText {
     static func combinedSessionWeeklyPercentText(
         sessionWindow: RateWindow?,
         weeklyWindow: RateWindow?,
-        showUsed: Bool)
+        showUsed: Bool,
+        resetTimeDisplayStyle: ResetTimeDisplayStyle = .countdown,
+        showsResetTimeWhenExhausted: Bool = false,
+        now: Date = .init())
         -> String?
     {
         var parts: [String] = []
         if let sessionWindow,
-           let session = self.percentText(window: sessionWindow, showUsed: showUsed)
+           let session = self.laneValueText(
+               window: sessionWindow,
+               showUsed: showUsed,
+               resetTimeDisplayStyle: resetTimeDisplayStyle,
+               showsResetTimeWhenExhausted: showsResetTimeWhenExhausted,
+               now: now)
         {
             parts.append("\(self.sessionWindowLabel(window: sessionWindow)) \(session)")
         }
-        if let weekly = self.percentText(window: weeklyWindow, showUsed: showUsed) {
+        if let weeklyWindow,
+           let weekly = self.laneValueText(
+               window: weeklyWindow,
+               showUsed: showUsed,
+               resetTimeDisplayStyle: resetTimeDisplayStyle,
+               showsResetTimeWhenExhausted: showsResetTimeWhenExhausted,
+               now: now)
+        {
             parts.append("W \(weekly)")
         }
         return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private static func laneValueText(
+        window: RateWindow,
+        showUsed: Bool,
+        resetTimeDisplayStyle: ResetTimeDisplayStyle,
+        showsResetTimeWhenExhausted: Bool,
+        now: Date) -> String?
+    {
+        if let resetText = self.exhaustedResetText(
+            window: window,
+            enabled: showsResetTimeWhenExhausted,
+            style: resetTimeDisplayStyle,
+            now: now)
+        {
+            return resetText
+        }
+        return self.percentText(window: window, showUsed: showUsed)
     }
 
     private static func sessionWindowLabel(window: RateWindow) -> String {
@@ -48,8 +81,18 @@ enum MenuBarDisplayText {
         pace: UsagePace? = nil,
         showUsed: Bool,
         resetTimeDisplayStyle: ResetTimeDisplayStyle = .countdown,
+        showsResetTimeWhenExhausted: Bool = false,
         now: Date = .init()) -> String?
     {
+        if mode != .resetTime,
+           let resetText = self.exhaustedResetText(
+               window: percentWindow,
+               enabled: showsResetTimeWhenExhausted,
+               style: resetTimeDisplayStyle,
+               now: now)
+        {
+            return resetText
+        }
         switch mode {
         case .percent:
             return self.percentText(window: percentWindow, showUsed: showUsed)
@@ -65,20 +108,42 @@ enum MenuBarDisplayText {
             return "\(percent) · \(paceText)"
         case .resetTime:
             guard let percentWindow else { return nil }
-            if let resetsAt = percentWindow.resetsAt {
-                let description = switch resetTimeDisplayStyle {
-                case .countdown:
-                    UsageFormatter.resetCountdownDescription(from: resetsAt, now: now)
-                case .absolute:
-                    UsageFormatter.resetDescription(from: resetsAt, now: now)
-                }
-                return "↻ \(description)"
-            }
-            if let resetDescription = self.resetMetadataText(percentWindow.resetDescription) {
-                return "↻ \(resetDescription)"
-            }
-            return self.percentText(window: percentWindow, showUsed: showUsed)
+            return self.resetTimeText(window: percentWindow, style: resetTimeDisplayStyle, now: now)
+                ?? self.percentText(window: percentWindow, showUsed: showUsed)
         }
+    }
+
+    /// "↻ …" reset text for a window, or nil when it carries no usable reset metadata.
+    static func resetTimeText(
+        window: RateWindow,
+        style: ResetTimeDisplayStyle,
+        now: Date) -> String?
+    {
+        if let resetsAt = window.resetsAt {
+            let description = switch style {
+            case .countdown:
+                UsageFormatter.resetCountdownDescription(from: resetsAt, now: now)
+            case .absolute:
+                UsageFormatter.resetDescription(from: resetsAt, now: now)
+            }
+            return "↻ \(description)"
+        }
+        if let resetDescription = self.resetMetadataText(window.resetDescription) {
+            return "↻ \(resetDescription)"
+        }
+        return nil
+    }
+
+    /// Smart-mode replacement: when enabled and the quota is exhausted (0% remaining, regardless of
+    /// whether the display shows used or remaining), surface the reset time instead of a dead percent.
+    private static func exhaustedResetText(
+        window: RateWindow?,
+        enabled: Bool,
+        style: ResetTimeDisplayStyle,
+        now: Date) -> String?
+    {
+        guard enabled, let window, window.remainingPercent <= 0 else { return nil }
+        return self.resetTimeText(window: window, style: style, now: now)
     }
 
     private static func resetMetadataText(_ description: String?) -> String? {

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -53,6 +53,15 @@ struct DisplayPane: View {
                         Text(mode.label)
                     })
                     .disabled(!self.settings.menuBarShowsBrandIconWithPercent)
+
+                Toggle(isOn: self.$settings.menuBarShowsResetTimeWhenExhausted) {
+                    SettingsRowLabel(
+                        L("menu_bar_reset_when_exhausted_title"),
+                        subtitle: L("menu_bar_reset_when_exhausted_subtitle"))
+                }
+                .disabled(
+                    !self.settings.menuBarShowsBrandIconWithPercent
+                        || self.settings.menuBarDisplayMode == .resetTime)
             } header: {
                 Text(L("section_menu_bar"))
             }

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -668,6 +668,8 @@
 "display_mode_pace_desc" = "مؤشر السرعة (مثلا +5%)";
 "display_mode_both_desc" = "أظهر كل من النسبة المئوية والسرعة (مثلا 45% · +5%)";
 "display_mode_reset_time_desc" = "عرض وقت إعادة الضبط للمقياس المحدد (مثلا ↻ 3:56 مساء)";
+"menu_bar_reset_when_exhausted_title" = "عرض وقت إعادة التعيين عند نفاد الحصة";
+"menu_bar_reset_when_exhausted_subtitle" = "عند تبقّي 0%، اعرض الوقت حتى إعادة التعيين بدلًا من النسبة المئوية";
 
 /* Provider status */
 "status_operational" = "التشغيل";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -652,6 +652,8 @@
 "display_mode_pace_desc" = "Mostreu l'indicador de ritme (p. ex. +5%)";
 "display_mode_both_desc" = "Mostreu el percentatge i el ritme (p. ex. 45% · +5%)";
 "display_mode_reset_time_desc" = "Mostreu l'hora de reinici de la mètrica seleccionada (p. ex. ↻ 3:56 PM)";
+"menu_bar_reset_when_exhausted_title" = "Mostra l'hora de restabliment quan s'esgoti la quota";
+"menu_bar_reset_when_exhausted_subtitle" = "Amb un 0% restant, mostra el temps fins al restabliment en lloc del percentatge";
 
 /* Provider status */
 "status_operational" = "Operatiu";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -665,6 +665,8 @@
 "display_mode_pace_desc" = "Tempoanzeige anzeigen (z. B. +5%)";
 "display_mode_both_desc" = "Zeigen Sie sowohl Prozentsatz als auch Tempo an (z. B. 45 % · +5 %)";
 "display_mode_reset_time_desc" = "Zurücksetzungszeit der ausgewählten Metrik anzeigen (z. B. ↻ 15:56)";
+"menu_bar_reset_when_exhausted_title" = "Zurücksetzungszeit anzeigen, wenn das Kontingent aufgebraucht ist";
+"menu_bar_reset_when_exhausted_subtitle" = "Bei 0 % Rest die Zeit bis zur Zurücksetzung statt des Prozentwerts anzeigen";
 
 /* Provider status */
 "status_operational" = "Betriebsbereit";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -668,6 +668,8 @@
 "display_mode_pace_desc" = "Show pace indicator (e.g. +5%)";
 "display_mode_both_desc" = "Show both percentage and pace (e.g. 45% · +5%)";
 "display_mode_reset_time_desc" = "Show the reset time for the selected metric (e.g. ↻ 3:56 PM)";
+"menu_bar_reset_when_exhausted_title" = "Show reset time when quota runs out";
+"menu_bar_reset_when_exhausted_subtitle" = "At 0% remaining, show the time until reset instead of the percentage";
 
 /* Provider status */
 "status_operational" = "Operational";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -660,6 +660,8 @@
 "display_mode_pace_desc" = "Mostrar el indicador de ritmo (p. ej. +5 %)";
 "display_mode_both_desc" = "Mostrar porcentaje y ritmo (p. ej. 45 % · +5 %)";
 "display_mode_reset_time_desc" = "Mostrar el tiempo de restablecimiento de la métrica seleccionada (p. ej. ↻ 3:56 PM)";
+"menu_bar_reset_when_exhausted_title" = "Mostrar la hora de restablecimiento cuando se agote la cuota";
+"menu_bar_reset_when_exhausted_subtitle" = "Con un 0% restante, muestra el tiempo hasta el restablecimiento en lugar del porcentaje";
 
 /* Provider status */
 "status_operational" = "Operativo";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -668,6 +668,8 @@
 "display_mode_pace_desc" = "نمایش شاخص سرعت (مثلا +5%)";
 "display_mode_both_desc" = "هم درصد و هم سرعت را نشان دهید (مثلا 45% · +5%)";
 "display_mode_reset_time_desc" = "زمان بازنشانی متریک انتخاب شده را نشان دهید (مثلا ↻ ساعت ۳:۵۶ بعدازظهر)";
+"menu_bar_reset_when_exhausted_title" = "نمایش زمان بازنشانی هنگام اتمام سهمیه";
+"menu_bar_reset_when_exhausted_subtitle" = "در ۰٪ باقی‌مانده، به‌جای درصد، زمان تا بازنشانی نمایش داده می‌شود";
 
 /* Provider status */
 "status_operational" = "عملیاتی";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -667,6 +667,8 @@
 "display_mode_pace_desc" = "Afficher l'indicateur d'allure (par exemple +5 %)";
 "display_mode_both_desc" = "Afficher à la fois le pourcentage et le rythme (par exemple 45 % · +5 %)";
 "display_mode_reset_time_desc" = "Afficher l'heure de réinitialisation de la métrique sélectionnée (par exemple ↻ 15:56)";
+"menu_bar_reset_when_exhausted_title" = "Afficher l'heure de réinitialisation quand le quota est épuisé";
+"menu_bar_reset_when_exhausted_subtitle" = "À 0 % restant, affiche le temps avant réinitialisation au lieu du pourcentage";
 
 /* Provider status */
 "status_operational" = "Opérationnel";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -645,6 +645,8 @@
 "display_mode_pace_desc" = "Amosa o indicador de ritmo (ex. +5 %)";
 "display_mode_both_desc" = "Amosa a porcentaxe e o ritmo (ex. 45 % · +5 %)";
 "display_mode_reset_time_desc" = "Amosa o tempo de restablecemento da métrica seleccionada (p. ex. ↻ 15:56)";
+"menu_bar_reset_when_exhausted_title" = "Mostrar a hora de restablecemento cando se esgote a cota";
+"menu_bar_reset_when_exhausted_subtitle" = "Cun 0% restante, mostra o tempo ata o restablecemento en lugar da porcentaxe";
 
 /* Provider status */
 "status_operational" = "Operativo";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -670,6 +670,8 @@
 "display_mode_pace_desc" = "Tampilkan indikator pace (mis. +5%)";
 "display_mode_both_desc" = "Tampilkan persentase dan pace (mis. 45% · +5%)";
 "display_mode_reset_time_desc" = "Tampilkan waktu reset untuk metrik yang dipilih (mis. ↻ 3:56 PM)";
+"menu_bar_reset_when_exhausted_title" = "Tampilkan waktu reset saat kuota habis";
+"menu_bar_reset_when_exhausted_subtitle" = "Saat tersisa 0%, tampilkan waktu hingga reset alih-alih persentase";
 
 /* Provider status */
 "status_operational" = "Operasional";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -670,6 +670,8 @@
 "display_mode_pace_desc" = "Mostra indicatore andamento (es. +5%)";
 "display_mode_both_desc" = "Mostra percentuale e andamento (es. 45% · +5%)";
 "display_mode_reset_time_desc" = "Mostra l'ora di reimpostazione per la metrica selezionata (es. ↻ 15:56)";
+"menu_bar_reset_when_exhausted_title" = "Mostra l'ora di ripristino quando la quota si esaurisce";
+"menu_bar_reset_when_exhausted_subtitle" = "Allo 0% rimanente, mostra il tempo al ripristino invece della percentuale";
 
 /* Provider status */
 "status_operational" = "Operativo";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -664,6 +664,8 @@
 "display_mode_pace_desc" = "ペースインジケータを表示（例: +5%）";
 "display_mode_both_desc" = "パーセンテージとペースの両方を表示（例: 45% · +5%）";
 "display_mode_reset_time_desc" = "選択した指標のリセット時刻を表示（例: ↻ 15:56）";
+"menu_bar_reset_when_exhausted_title" = "クォータを使い切ったらリセット時刻を表示";
+"menu_bar_reset_when_exhausted_subtitle" = "残り0%のとき、パーセントの代わりにリセットまでの時間を表示します";
 
 /* Provider status */
 "status_operational" = "正常稼働中";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -646,6 +646,8 @@
 "display_mode_pace_desc" = "사용 속도 표시기 표시(예: +5%)";
 "display_mode_both_desc" = "백분율과 사용 속도 모두 표시(예: 45% · +5%)";
 "display_mode_reset_time_desc" = "선택한 지표의 재설정 시간 표시(예: ↻ 오후 3:56)";
+"menu_bar_reset_when_exhausted_title" = "할당량 소진 시 재설정 시간 표시";
+"menu_bar_reset_when_exhausted_subtitle" = "남은 양이 0%일 때 백분율 대신 재설정까지의 시간을 표시합니다";
 "status_operational" = "정상 작동";
 "status_degraded" = "성능 저하";
 "status_partial_outage" = "부분 장애";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -667,6 +667,8 @@
 "display_mode_pace_desc" = "Toon tempo-indicator (bijv. +5%)";
 "display_mode_both_desc" = "Toon zowel percentage als tempo (bijvoorbeeld 45% · +5%)";
 "display_mode_reset_time_desc" = "Toon de resettijd voor de geselecteerde metriek (bijvoorbeeld ↻ 15:56)";
+"menu_bar_reset_when_exhausted_title" = "Toon resettijd wanneer het quotum op is";
+"menu_bar_reset_when_exhausted_subtitle" = "Bij 0% resterend wordt de tijd tot de reset getoond in plaats van het percentage";
 
 /* Provider status */
 "status_operational" = "Operationeel";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -670,6 +670,8 @@
 "display_mode_pace_desc" = "Pokaż wskaźnik tempa (np. +5%)";
 "display_mode_both_desc" = "Pokaż jednocześnie procent i tempo (np. 45% · +5%)";
 "display_mode_reset_time_desc" = "Pokaż godzinę resetu dla wybranej metryki (np. ↻ 15:56)";
+"menu_bar_reset_when_exhausted_title" = "Pokaż czas resetu, gdy limit się wyczerpie";
+"menu_bar_reset_when_exhausted_subtitle" = "Przy 0% pozostałych pokazuje czas do resetu zamiast wartości procentowej";
 
 /* Provider status */
 "status_operational" = "Operacyjne";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -664,6 +664,8 @@
 "display_mode_pace_desc" = "Mostra o indicador de ritmo (ex.: +5%)";
 "display_mode_both_desc" = "Mostra porcentagem e ritmo (ex.: 45% · +5%)";
 "display_mode_reset_time_desc" = "Mostra o tempo de redefinição da métrica selecionada (ex.: ↻ 3:56 PM)";
+"menu_bar_reset_when_exhausted_title" = "Mostrar horário de redefinição quando a cota acabar";
+"menu_bar_reset_when_exhausted_subtitle" = "Com 0% restante, mostra o tempo até a redefinição em vez da porcentagem";
 
 /* Provider status */
 "status_operational" = "Operacional";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -668,6 +668,8 @@
 "display_mode_pace_desc" = "Показывать индикатор темпа (например, +5%)";
 "display_mode_both_desc" = "Показывать и процент, и темп (например, 45% · +5%)";
 "display_mode_reset_time_desc" = "Показывать время сброса для выбранного показателя (например, ↻ 15:56).";
+"menu_bar_reset_when_exhausted_title" = "Показывать время сброса, когда квота исчерпана";
+"menu_bar_reset_when_exhausted_subtitle" = "При 0% остатка показывает время до сброса вместо процента";
 
 /* Provider status */
 "status_operational" = "Работает";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -666,6 +666,8 @@
 "display_mode_pace_desc" = "Visa taktindikator (t.ex. +5 %)";
 "display_mode_both_desc" = "Visa både procent och takt (t.ex. 45 % · +5 %)";
 "display_mode_reset_time_desc" = "Visa återställningstiden för valt mått (t.ex. ↻ 3:56 PM)";
+"menu_bar_reset_when_exhausted_title" = "Visa återställningstid när kvoten tar slut";
+"menu_bar_reset_when_exhausted_subtitle" = "Vid 0 % kvar visas tiden till återställning i stället för procenttalet";
 
 /* Provider status */
 "status_operational" = "Fungerar normalt";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -668,6 +668,8 @@
 "display_mode_pace_desc" = "แสดงตัวบ่งชี้อัตราการก้าว (เช่น +5%)";
 "display_mode_both_desc" = "แสดงทั้งเปอร์เซ็นต์และความเร็ว (เช่น 45% · +5%)";
 "display_mode_reset_time_desc" = "แสดงเวลารีเซ็ตสําหรับเมตริกที่เลือก (เช่น ↻ 15:56 น.)";
+"menu_bar_reset_when_exhausted_title" = "แสดงเวลารีเซ็ตเมื่อโควตาหมด";
+"menu_bar_reset_when_exhausted_subtitle" = "เมื่อเหลือ 0% จะแสดงเวลาจนถึงการรีเซ็ตแทนเปอร์เซ็นต์";
 
 /* Provider status */
 "status_operational" = "การดําเนินงาน";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1127,6 +1127,8 @@
 "Request quota: %@ / %@" = "İstek kotası: %@ / %@";
 "display_mode_reset_time" = "Sıfırlama zamanı";
 "display_mode_reset_time_desc" = "Seçilen metrik için sıfırlama zamanını göster (örn. ↻ 15:56)";
+"menu_bar_reset_when_exhausted_title" = "Kota bittiğinde sıfırlama zamanını göster";
+"menu_bar_reset_when_exhausted_subtitle" = "%0 kaldığında yüzde yerine sıfırlamaya kalan süreyi gösterir";
 "terminal_app_title" = "Varsayılan Terminal";
 "terminal_app_subtitle" = "Terminali Aç eyleminde kullanılan terminal";
 "language_arabic" = "العربية";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -667,6 +667,8 @@
 "display_mode_pace_desc" = "Показати індикатор темпу (наприклад, +5%)";
 "display_mode_both_desc" = "Показати відсоток і темп (наприклад, 45% · +5%)";
 "display_mode_reset_time_desc" = "Показувати час скидання для вибраного показника (наприклад, ↻ 15:56)";
+"menu_bar_reset_when_exhausted_title" = "Показувати час скидання, коли квоту вичерпано";
+"menu_bar_reset_when_exhausted_subtitle" = "За залишку 0% показує час до скидання замість відсотка";
 
 /* Provider status */
 "status_operational" = "Працює";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -663,6 +663,8 @@
 "display_mode_pace_desc" = "Hiển thị chỉ báo tốc độ (ví dụ: +5%)";
 "display_mode_both_desc" = "Hiển thị cả phần trăm và tốc độ (ví dụ: 45% · +5%)";
 "display_mode_reset_time_desc" = "Hiển thị thời gian đặt lại của chỉ số đã chọn (ví dụ: ↻ 15:56)";
+"menu_bar_reset_when_exhausted_title" = "Hiển thị thời gian đặt lại khi hết hạn mức";
+"menu_bar_reset_when_exhausted_subtitle" = "Khi còn 0%, hiển thị thời gian đến lúc đặt lại thay vì phần trăm";
 
 /* Provider status */
 "status_operational" = "Hoạt động";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -638,6 +638,8 @@
 "display_mode_pace_desc" = "显示进度指示器（例如 +5%）";
 "display_mode_both_desc" = "同时显示百分比和进度（例如 45% · +5%）";
 "display_mode_reset_time_desc" = "显示所选指标的重置时间（例如 ↻ 3:56 PM）";
+"menu_bar_reset_when_exhausted_title" = "配额用尽时显示重置时间";
+"menu_bar_reset_when_exhausted_subtitle" = "剩余 0% 时，显示距重置的时间而非百分比";
 "status_operational" = "正常运行";
 "status_degraded" = "性能下降";
 "status_partial_outage" = "部分中断";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -656,6 +656,8 @@
 "display_mode_pace_desc" = "顯示進度指示器（例如 +5%）";
 "display_mode_both_desc" = "同時顯示百分比和進度（例如 45% · +5%）";
 "display_mode_reset_time_desc" = "顯示所選指標的重置時間（例如 ↻ 3:56 PM）";
+"menu_bar_reset_when_exhausted_title" = "配額用盡時顯示重設時間";
+"menu_bar_reset_when_exhausted_subtitle" = "剩餘 0% 時，顯示距重設的時間而非百分比";
 "status_operational" = "運作正常";
 "status_degraded" = "效能下降";
 "status_partial_outage" = "部分服務中斷";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -299,6 +299,14 @@ extension SettingsStore {
         set { self.menuBarDisplayModeRaw = newValue.rawValue }
     }
 
+    var menuBarShowsResetTimeWhenExhausted: Bool {
+        get { self.defaultsState.menuBarShowsResetTimeWhenExhausted }
+        set {
+            self.defaultsState.menuBarShowsResetTimeWhenExhausted = newValue
+            self.userDefaults.set(newValue, forKey: "menuBarShowsResetTimeWhenExhausted")
+        }
+    }
+
     private var kiroMenuBarDisplayModeRaw: String? {
         get { self.defaultsState.kiroMenuBarDisplayModeRaw }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -29,6 +29,7 @@ extension SettingsStore {
         _ = self.menuBarHidesCritters
         _ = self.menuBarShowsHighestUsage
         _ = self.menuBarDisplayMode
+        _ = self.menuBarShowsResetTimeWhenExhausted
         _ = self.kiroMenuBarDisplayMode
         _ = self.historicalTrackingEnabled
         _ = self.multiAccountMenuLayout

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -413,6 +413,8 @@ extension SettingsStore {
         let menuBarHidesCritters = userDefaults.object(forKey: "menuBarHidesCritters") as? Bool ?? false
         let menuBarDisplayModeRaw = userDefaults.string(forKey: "menuBarDisplayMode")
             ?? MenuBarDisplayMode.percent.rawValue
+        let menuBarShowsResetTimeWhenExhausted = userDefaults.object(
+            forKey: "menuBarShowsResetTimeWhenExhausted") as? Bool ?? false
         let kiroMenuBarDisplayModeRaw = userDefaults.string(forKey: "kiroMenuBarDisplayMode")
             ?? KiroMenuBarDisplayMode.automatic.rawValue
         let historicalTrackingEnabled = userDefaults.object(forKey: "historicalTrackingEnabled") as? Bool ?? false
@@ -503,6 +505,7 @@ extension SettingsStore {
             menuBarShowsBrandIconWithPercent: menuBarShowsBrandIconWithPercent,
             menuBarHidesCritters: menuBarHidesCritters,
             menuBarDisplayModeRaw: menuBarDisplayModeRaw,
+            menuBarShowsResetTimeWhenExhausted: menuBarShowsResetTimeWhenExhausted,
             kiroMenuBarDisplayModeRaw: kiroMenuBarDisplayModeRaw,
             historicalTrackingEnabled: historicalTrackingEnabled,
             multiAccountMenuLayoutRaw: multiAccountMenuLayoutRaw,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -29,6 +29,7 @@ struct SettingsDefaultsState {
     var menuBarShowsBrandIconWithPercent: Bool
     var menuBarHidesCritters: Bool
     var menuBarDisplayModeRaw: String?
+    var menuBarShowsResetTimeWhenExhausted: Bool
     var kiroMenuBarDisplayModeRaw: String?
     var historicalTrackingEnabled: Bool
     var multiAccountMenuLayoutRaw: String

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -1113,9 +1113,12 @@ extension StatusItemController {
         let snapshot = self.store.snapshot(for: provider)
         let mode = self.settings.menuBarDisplayMode
 
-        // The combined Session + Weekly percent metric renders each exhausted lane's reset text
-        // independently, so collect both lanes' reset dates (elapsed ones are dropped downstream).
-        if mode == .percent {
+        // Combined Session + Weekly metric: percent mode renders each exhausted lane's reset text, and
+        // pace/both surface an exhausted lane through `combinedDisplayPercentWindow`. Collect every
+        // exhausted lane so the scheduler always covers whichever lane the display actually shows — an
+        // extra boundary for a lane that isn't currently displayed just triggers a harmless recompute.
+        // Reset-time mode shows a single window, handled below.
+        if mode != .resetTime {
             let projection = self.store.codexConsumerProjectionIfNeeded(
                 for: provider,
                 surface: .menuBar,

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -846,7 +846,10 @@ extension StatusItemController {
             if let combinedText = MenuBarDisplayText.combinedSessionWeeklyPercentText(
                 sessionWindow: combinedLanes.session,
                 weeklyWindow: combinedLanes.weekly,
-                showUsed: self.settings.usageBarsShowUsed)
+                showUsed: self.settings.usageBarsShowUsed,
+                resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
+                showsResetTimeWhenExhausted: self.settings.menuBarShowsResetTimeWhenExhausted,
+                now: now)
             {
                 return combinedText
             }
@@ -861,7 +864,10 @@ extension StatusItemController {
             mode: mode,
             percentWindow: displayPercentWindow,
             pace: pace,
-            showUsed: self.settings.usageBarsShowUsed)
+            showUsed: self.settings.usageBarsShowUsed,
+            resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
+            showsResetTimeWhenExhausted: self.settings.menuBarShowsResetTimeWhenExhausted,
+            now: now)
     }
 
     nonisolated static func deepSeekBalanceDisplayText(snapshot: UsageSnapshot?) -> String? {

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -1105,32 +1105,39 @@ extension StatusItemController {
     }
 
     /// Reset dates for every lane whose menu-bar text is currently rendered as a reset time, so the
-    /// countdown scheduler can refresh each of them. Reset-time mode drives a single window, but the
-    /// smart "reset time when exhausted" option can surface reset text for BOTH combined session/weekly
-    /// lanes at once (percent mode) — schedule against every exhausted lane rather than only the single
-    /// icon-metric window, otherwise a lane that resets later can freeze once the earlier one elapses.
+    /// countdown scheduler can refresh each of them. Reset-time mode drives a single window. The smart
+    /// "reset time when exhausted" option can surface BOTH combined session/weekly lanes in percent mode,
+    /// while pace/both render the one lane chosen by `combinedDisplayPercentWindow` — mirror that presentation
+    /// here rather than scheduling whichever lane happened to drive the icon.
     func menuBarDisplayedResetDates(for provider: UsageProvider, now: Date) -> [Date] {
         let snapshot = self.store.snapshot(for: provider)
         let mode = self.settings.menuBarDisplayMode
 
-        // Combined Session + Weekly metric: percent mode renders each exhausted lane's reset text, and
-        // pace/both surface an exhausted lane through `combinedDisplayPercentWindow`. Collect every
-        // exhausted lane so the scheduler always covers whichever lane the display actually shows — an
-        // extra boundary for a lane that isn't currently displayed just triggers a harmless recompute.
-        // Reset-time mode shows a single window, handled below.
-        if mode != .resetTime {
-            let projection = self.store.codexConsumerProjectionIfNeeded(
-                for: provider,
-                surface: .menuBar,
-                snapshotOverride: snapshot,
-                now: now)
-            if let lanes = self.combinedSessionWeeklyLanes(
-                for: provider, snapshot: snapshot, projection: projection)
-            {
+        let projection = self.store.codexConsumerProjectionIfNeeded(
+            for: provider,
+            surface: .menuBar,
+            snapshotOverride: snapshot,
+            now: now)
+        if let lanes = self.combinedSessionWeeklyLanes(
+            for: provider, snapshot: snapshot, projection: projection)
+        {
+            switch mode {
+            case .percent:
+                // Percent renders both lanes independently, so schedule every exhausted reset.
                 return [lanes.session, lanes.weekly]
                     .compactMap(\.self)
                     .filter { $0.remainingPercent <= 0 }
                     .compactMap(\.resetsAt)
+            case .pace, .both:
+                // Pace/both render one usage lane alongside the weekly pace. Use that exact lane rather
+                // than `menuBarMetricWindow`, whose tie-breaking can select the other exhausted window.
+                let window = Self.combinedDisplayPercentWindow(
+                    lanes: lanes,
+                    fallback: self.menuBarMetricWindow(for: provider, snapshot: snapshot, now: now))
+                guard let window, window.remainingPercent <= 0 else { return [] }
+                return window.resetsAt.map { [$0] } ?? []
+            case .resetTime:
+                break
             }
         }
 

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -1104,6 +1104,40 @@ extension StatusItemController {
         return (session, weekly)
     }
 
+    /// Reset dates for every lane whose menu-bar text is currently rendered as a reset time, so the
+    /// countdown scheduler can refresh each of them. Reset-time mode drives a single window, but the
+    /// smart "reset time when exhausted" option can surface reset text for BOTH combined session/weekly
+    /// lanes at once (percent mode) — schedule against every exhausted lane rather than only the single
+    /// icon-metric window, otherwise a lane that resets later can freeze once the earlier one elapses.
+    func menuBarDisplayedResetDates(for provider: UsageProvider, now: Date) -> [Date] {
+        let snapshot = self.store.snapshot(for: provider)
+        let mode = self.settings.menuBarDisplayMode
+
+        // The combined Session + Weekly percent metric renders each exhausted lane's reset text
+        // independently, so collect both lanes' reset dates (elapsed ones are dropped downstream).
+        if mode == .percent {
+            let projection = self.store.codexConsumerProjectionIfNeeded(
+                for: provider,
+                surface: .menuBar,
+                snapshotOverride: snapshot,
+                now: now)
+            if let lanes = self.combinedSessionWeeklyLanes(
+                for: provider, snapshot: snapshot, projection: projection)
+            {
+                return [lanes.session, lanes.weekly]
+                    .compactMap(\.self)
+                    .filter { $0.remainingPercent <= 0 }
+                    .compactMap(\.resetsAt)
+            }
+        }
+
+        guard let window = self.menuBarMetricWindow(for: provider, snapshot: snapshot, now: now)
+        else { return [] }
+        // Outside reset-time mode the reset text is only visible once the quota is exhausted.
+        if mode != .resetTime, window.remainingPercent > 0 { return [] }
+        return window.resetsAt.map { [$0] } ?? []
+    }
+
     /// The combined metric's session (5h) lane. Codex resolves it through the consumer projection; other
     /// providers classify by window cadence. A 5-hour lane the provider only synthesized to stand in for an
     /// absent session — Claude web's null `five_hour` placeholder, flagged at the boundary — is dropped so a

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -1119,7 +1119,8 @@ extension StatusItemController {
             snapshotOverride: snapshot,
             now: now)
         if let lanes = self.combinedSessionWeeklyLanes(
-            for: provider, snapshot: snapshot, projection: projection)
+            for: provider, snapshot: snapshot, projection: projection),
+            lanes.session != nil || lanes.weekly != nil
         {
             switch mode {
             case .percent:

--- a/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
@@ -10,15 +10,19 @@ extension StatusItemController {
 
         var delays: [TimeInterval] = []
         let providers = self.menuBarRefreshProviders()
+        let displayMode = self.settings.menuBarDisplayMode
         if self.settings.menuBarShowsBrandIconWithPercent,
-           self.settings.menuBarDisplayMode == .resetTime,
-           self.settings.resetTimeDisplayStyle == .countdown
+           self.settings.resetTimeDisplayStyle == .countdown,
+           displayMode == .resetTime || self.settings.menuBarShowsResetTimeWhenExhausted
         {
-            let resetDates = providers.compactMap { provider in
-                self.menuBarMetricWindow(
+            let resetDates = providers.compactMap { provider -> Date? in
+                guard let window = self.menuBarMetricWindow(
                     for: provider,
                     snapshot: self.store.snapshot(for: provider),
-                    now: now)?.resetsAt
+                    now: now) else { return nil }
+                // Outside reset-time mode the countdown is only visible once the quota is exhausted.
+                if displayMode != .resetTime, window.remainingPercent > 0 { return nil }
+                return window.resetsAt
             }
             if let delay = Self.menuBarCountdownRefreshDelay(resetDates: resetDates, now: now) {
                 delays.append(delay)

--- a/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
@@ -11,21 +11,43 @@ extension StatusItemController {
         var delays: [TimeInterval] = []
         let providers = self.menuBarRefreshProviders()
         let displayMode = self.settings.menuBarDisplayMode
-        if self.settings.menuBarShowsBrandIconWithPercent,
-           self.settings.resetTimeDisplayStyle == .countdown,
-           displayMode == .resetTime || self.settings.menuBarShowsResetTimeWhenExhausted
-        {
-            let resetDates = providers.compactMap { provider -> Date? in
+        let smartExhaustedActive = self.settings.menuBarShowsBrandIconWithPercent
+            && self.settings.menuBarShowsResetTimeWhenExhausted
+            && displayMode != .resetTime
+
+        /// Reset dates for the windows whose menu-bar text is currently driven by reset timing: every
+        /// window in reset-time mode, or just the exhausted ones when the smart option is showing the
+        /// reset time in place of a 0% value.
+        func resetDrivenResetDates() -> [Date] {
+            providers.compactMap { provider -> Date? in
                 guard let window = self.menuBarMetricWindow(
                     for: provider,
                     snapshot: self.store.snapshot(for: provider),
                     now: now) else { return nil }
-                // Outside reset-time mode the countdown is only visible once the quota is exhausted.
+                // Outside reset-time mode the reset text is only visible once the quota is exhausted.
                 if displayMode != .resetTime, window.remainingPercent > 0 { return nil }
                 return window.resetsAt
             }
-            if let delay = Self.menuBarCountdownRefreshDelay(resetDates: resetDates, now: now) {
+        }
+
+        if self.settings.menuBarShowsBrandIconWithPercent,
+           self.settings.resetTimeDisplayStyle == .countdown,
+           displayMode == .resetTime || smartExhaustedActive
+        {
+            // Countdown text ticks every minute; refresh on each displayed-minute boundary (the last of
+            // which lands at the reset, flipping a smart-exhausted lane back to the percentage).
+            if let delay = Self.menuBarCountdownRefreshDelay(resetDates: resetDrivenResetDates(), now: now) {
                 delays.append(delay)
+            }
+        } else if smartExhaustedActive, self.settings.resetTimeDisplayStyle == .absolute {
+            // Absolute clocks don't tick, so the per-minute scheduler above is skipped — but a smart
+            // exhausted lane still needs one refresh at the reset boundary to fall back to the percentage
+            // once the reset passes (otherwise a slow/manual provider refresh leaves a stale past clock).
+            for resetsAt in resetDrivenResetDates() {
+                let remaining = resetsAt.timeIntervalSince(now)
+                if remaining > 0 {
+                    delays.append(remaining + Self.menuBarCountdownRefreshEpsilon)
+                }
             }
         }
 

--- a/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
@@ -31,14 +31,11 @@ extension StatusItemController {
                 delays.append(delay)
             }
         } else if smartExhaustedActive, self.settings.resetTimeDisplayStyle == .absolute {
-            // Absolute clocks don't tick, so the per-minute scheduler above is skipped — but a smart
-            // exhausted lane still needs one refresh at the reset boundary to fall back to the percentage
-            // once the reset passes (otherwise a slow/manual provider refresh leaves a stale past clock).
-            for resetsAt in resetDrivenResetDates() {
-                let remaining = resetsAt.timeIntervalSince(now)
-                if remaining > 0 {
-                    delays.append(remaining + Self.menuBarCountdownRefreshEpsilon)
-                }
+            // Absolute clocks don't tick each minute, but their human-friendly date label can change at
+            // local midnight (for example, "tomorrow" becomes a same-day time). Wake at that boundary or
+            // the reset itself, whichever comes first; the next icon update schedules any later boundary.
+            if let delay = Self.menuBarAbsoluteRefreshDelay(resetDates: resetDrivenResetDates(), now: now) {
+                delays.append(delay)
             }
         }
 
@@ -80,6 +77,23 @@ extension StatusItemController {
         }.min()
     }
 
+    nonisolated static func menuBarAbsoluteRefreshDelay(
+        resetDates: [Date],
+        now: Date,
+        calendar: Calendar = .current)
+        -> TimeInterval?
+    {
+        guard let nextDayStart = calendar.dateInterval(of: .day, for: now)?.end else { return nil }
+
+        return resetDates.compactMap { resetDate -> TimeInterval? in
+            guard resetDate > now else { return nil }
+            let nextTextChange = min(resetDate, nextDayStart)
+            return max(
+                self.menuBarCountdownRefreshEpsilon,
+                nextTextChange.timeIntervalSince(now) + self.menuBarCountdownRefreshEpsilon)
+        }.min()
+    }
+
     private func menuBarRefreshProviders() -> [UsageProvider] {
         if self.shouldMergeIcons {
             return [self.primaryProviderForUnifiedIcon()]
@@ -88,8 +102,12 @@ extension StatusItemController {
     }
 
     private func menuBarObservesCodexReset(providers: [UsageProvider]) -> Bool {
-        if providers.contains(.codex) { return true }
-        guard self.shouldMergeIcons, self.settings.menuBarShowsHighestUsage else { return false }
+        if providers.contains(.codex) {
+            return true
+        }
+        guard self.shouldMergeIcons, self.settings.menuBarShowsHighestUsage else {
+            return false
+        }
         let activeProviders = self.store.enabledProvidersForDisplay()
         return self.settings.resolvedMergedOverviewProviders(
             activeProviders: activeProviders,

--- a/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
@@ -15,19 +15,10 @@ extension StatusItemController {
             && self.settings.menuBarShowsResetTimeWhenExhausted
             && displayMode != .resetTime
 
-        /// Reset dates for the windows whose menu-bar text is currently driven by reset timing: every
-        /// window in reset-time mode, or just the exhausted ones when the smart option is showing the
-        /// reset time in place of a 0% value.
+        /// Reset dates for every lane whose menu-bar text is currently a reset time — including both
+        /// combined session/weekly lanes when the smart option surfaces reset text for each of them.
         func resetDrivenResetDates() -> [Date] {
-            providers.compactMap { provider -> Date? in
-                guard let window = self.menuBarMetricWindow(
-                    for: provider,
-                    snapshot: self.store.snapshot(for: provider),
-                    now: now) else { return nil }
-                // Outside reset-time mode the reset text is only visible once the quota is exhausted.
-                if displayMode != .resetTime, window.remainingPercent > 0 { return nil }
-                return window.resetsAt
-            }
+            providers.flatMap { self.menuBarDisplayedResetDates(for: $0, now: now) }
         }
 
         if self.settings.menuBarShowsBrandIconWithPercent,

--- a/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
@@ -30,7 +30,10 @@ extension StatusItemController {
             if let delay = Self.menuBarCountdownRefreshDelay(resetDates: resetDrivenResetDates(), now: now) {
                 delays.append(delay)
             }
-        } else if smartExhaustedActive, self.settings.resetTimeDisplayStyle == .absolute {
+        } else if self.settings.menuBarShowsBrandIconWithPercent,
+                  self.settings.resetTimeDisplayStyle == .absolute,
+                  displayMode == .resetTime || smartExhaustedActive
+        {
             // Absolute clocks don't tick each minute, but their human-friendly date label can change at
             // local midnight (for example, "tomorrow" becomes a same-day time). Wake at that boundary or
             // the reset itself, whichever comes first; the next icon update schedules any later boundary.
@@ -112,6 +115,31 @@ extension StatusItemController {
         return self.settings.resolvedMergedOverviewProviders(
             activeProviders: activeProviders,
             maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit).contains(.codex)
+    }
+
+    func observeMenuBarTimeEnvironmentChanges() {
+        for name in [
+            Notification.Name.NSSystemClockDidChange,
+            .NSSystemTimeZoneDidChange,
+            .NSCalendarDayChanged,
+        ] {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(self.handleMenuBarTimeEnvironmentDidChange),
+                name: name,
+                object: nil)
+        }
+    }
+
+    @objc nonisolated func handleMenuBarTimeEnvironmentDidChange() {
+        Task { @MainActor [weak self] in
+            guard let self, !self.hasPreparedForAppShutdown else { return }
+            self.handleMenuBarTimeEnvironmentChange()
+        }
+    }
+
+    func handleMenuBarTimeEnvironmentChange() {
+        self.updateIcons()
     }
 
     #if DEBUG

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -455,6 +455,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             selector: #selector(self.handleScreenParametersDidChange(_:)),
             name: NSApplication.didChangeScreenParametersNotification,
             object: nil)
+        self.observeMenuBarTimeEnvironmentChanges()
     }
 
     convenience init(

--- a/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
+++ b/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
@@ -33,6 +33,45 @@ struct MenuBarCountdownRefreshTests {
     }
 
     @Test
+    func `absolute refresh observes local midnight before the reset`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 7,
+            day: 10,
+            hour: 23,
+            minute: 59)))
+        let reset = try #require(calendar.date(byAdding: .hour, value: 2, to: now))
+
+        let delay = StatusItemController.menuBarAbsoluteRefreshDelay(
+            resetDates: [reset],
+            now: now,
+            calendar: calendar)
+
+        #expect(abs((delay ?? 0) - 60.05) < 0.001)
+    }
+
+    @Test
+    func `absolute refresh observes midnight after a skipped day start`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Santiago"))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2024,
+            month: 9,
+            day: 8,
+            hour: 23)))
+        let reset = try #require(calendar.date(byAdding: .hour, value: 3, to: now))
+
+        let delay = StatusItemController.menuBarAbsoluteRefreshDelay(
+            resetDates: [reset],
+            now: now,
+            calendar: calendar)
+
+        #expect(abs((delay ?? 0) - 3600.05) < 0.001)
+    }
+
+    @Test
     func `status item schedules countdown and exhausted lane refreshes`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "MenuBarCountdownRefreshTests-scheduling"),
@@ -228,65 +267,77 @@ struct MenuBarCountdownRefreshTests {
         #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
     }
 
-    @Test(arguments: [MenuBarDisplayMode.percent, .both, .pace])
-    func `combined metric schedules both exhausted session and weekly lanes`(_ mode: MenuBarDisplayMode) {
-        // Isolated defaults: enabling the smart option must not leak into `.standard`.
-        let settings = testSettingsStore(suiteName: "MenuBarCountdownRefreshTests-combined-lanes")
-        settings.statusChecksEnabled = false
-        settings.refreshFrequency = .manual
-        settings.menuBarShowsBrandIconWithPercent = true
-        settings.menuBarDisplayMode = mode
-        settings.menuBarShowsResetTimeWhenExhausted = true
-        settings.resetTimesShowAbsolute = false
-        settings.mergeIcons = false
-        settings.selectedMenuProvider = .claude
-        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
-        if let metadata = ProviderRegistry.shared.metadata[.claude] {
-            settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+    @Test(arguments: [MenuBarDisplayMode.percent, .pace, .both])
+    func `combined metric schedules every displayed exhausted reset lane`(mode: MenuBarDisplayMode) {
+        for usesAbsoluteClock in [false, true] {
+            // Isolated defaults: enabling the smart option must not leak into `.standard`.
+            let settings = testSettingsStore(
+                suiteName: "MenuBarCountdownRefreshTests-combined-lanes-\(mode.rawValue)-\(usesAbsoluteClock)")
+            settings.statusChecksEnabled = false
+            settings.refreshFrequency = .manual
+            settings.menuBarShowsBrandIconWithPercent = true
+            settings.menuBarDisplayMode = mode
+            settings.menuBarShowsResetTimeWhenExhausted = true
+            settings.resetTimesShowAbsolute = usesAbsoluteClock
+            settings.mergeIcons = false
+            settings.selectedMenuProvider = .claude
+            settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+            if let metadata = ProviderRegistry.shared.metadata[.claude] {
+                settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+            }
+
+            let fetcher = UsageFetcher()
+            let store = UsageStore(
+                fetcher: fetcher,
+                browserDetection: BrowserDetection(cacheTTL: 0),
+                settings: settings)
+            let now = Date()
+            // Both combined lanes exhausted: the session (5h) reset has already elapsed, the weekly (7d)
+            // reset is still ahead. The scheduler must consider the weekly lane, not just the icon-metric
+            // lane, so the still-displayed weekly countdown or absolute clock reaches its reset boundary.
+            let sessionReset = now.addingTimeInterval(-60)
+            let weeklyReset = now.addingTimeInterval(3600)
+            store._setSnapshotForTesting(
+                UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: 100,
+                        windowMinutes: 300,
+                        resetsAt: sessionReset,
+                        resetDescription: nil),
+                    secondary: RateWindow(
+                        usedPercent: 100,
+                        windowMinutes: 10080,
+                        resetsAt: weeklyReset,
+                        resetDescription: nil),
+                    updatedAt: now),
+                provider: .claude)
+
+            let controller = StatusItemController(
+                store: store,
+                settings: settings,
+                account: fetcher.loadAccountInfo(),
+                updater: DisabledUpdaterController(),
+                preferencesSelection: PreferencesSelection(),
+                statusBar: .system)
+            controller.updateIcons()
+
+            let dates = controller.menuBarDisplayedResetDates(for: .claude, now: now)
+            switch mode {
+            case .percent:
+                // Percent displays both lane values independently.
+                #expect(dates == [sessionReset, weeklyReset])
+            case .pace, .both:
+                // Pace/both surface the exhausted weekly lane, not the session lane that wins the 100/100
+                // icon-metric tie.
+                #expect(dates == [weeklyReset])
+            case .resetTime:
+                Issue.record("reset-time mode is not an argument for this smart-reset test")
+            }
+            // The future weekly boundary stays scheduled for countdown and absolute-clock styles even
+            // though the session lane elapsed.
+            #expect(controller._test_isMenuBarCountdownRefreshScheduled())
+            controller.releaseStatusItemsForTesting()
         }
-
-        let fetcher = UsageFetcher()
-        let store = UsageStore(
-            fetcher: fetcher,
-            browserDetection: BrowserDetection(cacheTTL: 0),
-            settings: settings)
-        let now = Date()
-        // Both combined lanes exhausted: the session (5h) reset has already elapsed, the weekly (7d)
-        // reset is still ahead. The scheduler must consider the weekly lane, not just the icon-metric
-        // lane, so the still-displayed weekly countdown keeps refreshing.
-        let sessionReset = now.addingTimeInterval(-60)
-        let weeklyReset = now.addingTimeInterval(3600)
-        store._setSnapshotForTesting(
-            UsageSnapshot(
-                primary: RateWindow(
-                    usedPercent: 100,
-                    windowMinutes: 300,
-                    resetsAt: sessionReset,
-                    resetDescription: nil),
-                secondary: RateWindow(
-                    usedPercent: 100,
-                    windowMinutes: 10080,
-                    resetsAt: weeklyReset,
-                    resetDescription: nil),
-                updatedAt: now),
-            provider: .claude)
-
-        let controller = StatusItemController(
-            store: store,
-            settings: settings,
-            account: fetcher.loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: .system)
-        defer { controller.releaseStatusItemsForTesting() }
-
-        controller.updateIcons()
-
-        let dates = controller.menuBarDisplayedResetDates(for: .claude, now: now)
-        #expect(dates.contains(sessionReset))
-        #expect(dates.contains(weeklyReset))
-        // The future weekly boundary must keep a refresh scheduled even though the session lane elapsed.
-        #expect(controller._test_isMenuBarCountdownRefreshScheduled())
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
+++ b/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
@@ -153,6 +153,83 @@ struct MenuBarCountdownRefreshTests {
     }
 
     @Test
+    func `absolute clock smart mode schedules the exhausted reset boundary`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "MenuBarCountdownRefreshTests-absolute-smart"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.menuBarShowsBrandIconWithPercent = true
+        settings.menuBarDisplayMode = .percent
+        settings.menuBarShowsResetTimeWhenExhausted = true
+        // Absolute clock style: the per-minute countdown scheduler is skipped, but a smart-exhausted
+        // lane still needs a boundary refresh so it falls back to the percentage once the reset passes.
+        settings.resetTimesShowAbsolute = true
+        if let metadata = ProviderRegistry.shared.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: metadata, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let now = Date()
+
+        // Exhausted lane with a future reset → schedule a boundary refresh even in absolute mode.
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 100,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(90),
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now),
+            provider: .codex)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        #expect(controller._test_isMenuBarCountdownRefreshScheduled())
+
+        // Elapsed reset → nothing to schedule (the lane already falls back to the percentage).
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 100,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(-1),
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now),
+            provider: .codex)
+        controller.updateIcons()
+        #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+
+        // Healthy quota → smart replacement inactive, so no boundary refresh.
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 40,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(90),
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now),
+            provider: .codex)
+        controller.updateIcons()
+        #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+    }
+
+    @Test
     func `merged highest usage observes reset for noncurrent Codex candidate`() throws {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "MenuBarCountdownRefreshTests-merged-highest"),

--- a/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
+++ b/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
@@ -228,14 +228,14 @@ struct MenuBarCountdownRefreshTests {
         #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
     }
 
-    @Test
-    func `combined metric schedules both exhausted session and weekly lanes`() {
+    @Test(arguments: [MenuBarDisplayMode.percent, .both, .pace])
+    func `combined metric schedules both exhausted session and weekly lanes`(_ mode: MenuBarDisplayMode) {
         // Isolated defaults: enabling the smart option must not leak into `.standard`.
         let settings = testSettingsStore(suiteName: "MenuBarCountdownRefreshTests-combined-lanes")
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.menuBarShowsBrandIconWithPercent = true
-        settings.menuBarDisplayMode = .percent
+        settings.menuBarDisplayMode = mode
         settings.menuBarShowsResetTimeWhenExhausted = true
         settings.resetTimesShowAbsolute = false
         settings.mergeIcons = false

--- a/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
+++ b/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
@@ -115,7 +115,12 @@ struct MenuBarCountdownRefreshTests {
 
         settings.resetTimesShowAbsolute = true
         controller.updateIcons()
+        #expect(controller._test_isMenuBarCountdownRefreshScheduled())
+
+        settings.menuBarShowsBrandIconWithPercent = false
+        controller.updateIcons()
         #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+        settings.menuBarShowsBrandIconWithPercent = true
 
         let now = Date()
         store._setSnapshotForTesting(
@@ -150,7 +155,9 @@ struct MenuBarCountdownRefreshTests {
                 updatedAt: now),
             provider: .codex)
         controller.updateIcons()
-        #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+        // The elapsed weekly cap falls out of the projection; absolute reset-time mode now observes the
+        // still-future session reset instead of leaving its label stale.
+        #expect(controller._test_isMenuBarCountdownRefreshScheduled())
 
         store._setSnapshotForTesting(
             UsageSnapshot(
@@ -338,6 +345,97 @@ struct MenuBarCountdownRefreshTests {
             #expect(controller._test_isMenuBarCountdownRefreshScheduled())
             controller.releaseStatusItemsForTesting()
         }
+    }
+
+    @Test
+    func `combined metric falls through to a nonstandard exhausted fallback lane`() {
+        let settings = testSettingsStore(suiteName: "MenuBarCountdownRefreshTests-combined-fallback")
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.menuBarShowsBrandIconWithPercent = true
+        settings.menuBarDisplayMode = .percent
+        settings.menuBarShowsResetTimeWhenExhausted = true
+        settings.resetTimesShowAbsolute = false
+        settings.mergeIcons = false
+        settings.selectedMenuProvider = .claude
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+        if let metadata = ProviderRegistry.shared.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let now = Date()
+        let reset = now.addingTimeInterval(3600)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: 60,
+                resetsAt: reset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        #expect(controller.menuBarDisplayText(for: .claude, snapshot: snapshot, now: now) == "↻ in 1h")
+        #expect(controller.menuBarDisplayedResetDates(for: .claude, now: now) == [reset])
+        #expect(controller._test_isMenuBarCountdownRefreshScheduled())
+    }
+
+    @Test
+    func `time environment change reschedules an absolute reset label`() {
+        let settings = testSettingsStore(suiteName: "MenuBarCountdownRefreshTests-time-environment")
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.menuBarShowsBrandIconWithPercent = true
+        settings.menuBarDisplayMode = .resetTime
+        settings.resetTimesShowAbsolute = true
+        if let metadata = ProviderRegistry.shared.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: metadata, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+        let now = Date()
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 42,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(3600),
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now),
+            provider: .codex)
+
+        controller.handleMenuBarTimeEnvironmentChange()
+
+        #expect(controller._test_isMenuBarCountdownRefreshScheduled())
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
+++ b/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
@@ -154,10 +154,9 @@ struct MenuBarCountdownRefreshTests {
 
     @Test
     func `absolute clock smart mode schedules the exhausted reset boundary`() {
-        let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: "MenuBarCountdownRefreshTests-absolute-smart"),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+        // Isolated defaults: this test enables the smart option, which must not leak into `.standard`
+        // and flip other suites' exhausted-lane expectations.
+        let settings = testSettingsStore(suiteName: "MenuBarCountdownRefreshTests-absolute-smart")
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.menuBarShowsBrandIconWithPercent = true
@@ -227,6 +226,67 @@ struct MenuBarCountdownRefreshTests {
             provider: .codex)
         controller.updateIcons()
         #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+    }
+
+    @Test
+    func `combined metric schedules both exhausted session and weekly lanes`() {
+        // Isolated defaults: enabling the smart option must not leak into `.standard`.
+        let settings = testSettingsStore(suiteName: "MenuBarCountdownRefreshTests-combined-lanes")
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.menuBarShowsBrandIconWithPercent = true
+        settings.menuBarDisplayMode = .percent
+        settings.menuBarShowsResetTimeWhenExhausted = true
+        settings.resetTimesShowAbsolute = false
+        settings.mergeIcons = false
+        settings.selectedMenuProvider = .claude
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+        if let metadata = ProviderRegistry.shared.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let now = Date()
+        // Both combined lanes exhausted: the session (5h) reset has already elapsed, the weekly (7d)
+        // reset is still ahead. The scheduler must consider the weekly lane, not just the icon-metric
+        // lane, so the still-displayed weekly countdown keeps refreshing.
+        let sessionReset = now.addingTimeInterval(-60)
+        let weeklyReset = now.addingTimeInterval(3600)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 100,
+                    windowMinutes: 300,
+                    resetsAt: sessionReset,
+                    resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 100,
+                    windowMinutes: 10080,
+                    resetsAt: weeklyReset,
+                    resetDescription: nil),
+                updatedAt: now),
+            provider: .claude)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.updateIcons()
+
+        let dates = controller.menuBarDisplayedResetDates(for: .claude, now: now)
+        #expect(dates.contains(sessionReset))
+        #expect(dates.contains(weeklyReset))
+        // The future weekly boundary must keep a refresh scheduled even though the session lane elapsed.
+        #expect(controller._test_isMenuBarCountdownRefreshScheduled())
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
+++ b/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
@@ -233,6 +233,31 @@ struct MenuBarResetTimeDisplayTests {
     }
 
     @Test
+    func `smart reset ignores textual reset metadata without a concrete reset time`() {
+        // Provider supplies only a textual resetDescription (no resetsAt). The smart option can't hand
+        // that to the refresh scheduler, so it keeps the percent rather than freezing on "↻ in 2h".
+        let window = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: "in 2h")
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .percent,
+            percentWindow: window,
+            showUsed: false,
+            showsResetTimeWhenExhausted: true)
+
+        #expect(text == "0%")
+        // Reset-time mode still surfaces the textual metadata (unchanged behavior).
+        let resetTimeText = MenuBarDisplayText.displayText(
+            mode: .resetTime,
+            percentWindow: window,
+            showUsed: false)
+        #expect(resetTimeText == "↻ in 2h")
+    }
+
+    @Test
     func `smart reset falls back to percent without reset metadata`() {
         let window = RateWindow(
             usedPercent: 100,

--- a/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
+++ b/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
@@ -133,4 +133,143 @@ struct MenuBarResetTimeDisplayTests {
 
         #expect(text == "58%")
     }
+
+    @Test(arguments: [MenuBarDisplayMode.percent, .pace, .both])
+    func `smart reset shows countdown when the quota is exhausted`(_ mode: MenuBarDisplayMode) {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let window = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 300,
+            resetsAt: now.addingTimeInterval(2 * 3600 + 15 * 60),
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: mode,
+            percentWindow: window,
+            showUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            showsResetTimeWhenExhausted: true,
+            now: now)
+
+        #expect(text == "↻ in 2h 15m")
+    }
+
+    @Test
+    func `smart reset honors the absolute clock preference`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let resetsAt = now.addingTimeInterval(2 * 3600)
+        let window = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 300,
+            resetsAt: resetsAt,
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .percent,
+            percentWindow: window,
+            showUsed: false,
+            resetTimeDisplayStyle: .absolute,
+            showsResetTimeWhenExhausted: true,
+            now: now)
+
+        #expect(text == "↻ \(UsageFormatter.resetDescription(from: resetsAt, now: now))")
+    }
+
+    @Test
+    func `smart reset leaves a non-exhausted quota untouched`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let window = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 300,
+            resetsAt: now.addingTimeInterval(3600),
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .percent,
+            percentWindow: window,
+            showUsed: false,
+            showsResetTimeWhenExhausted: true,
+            now: now)
+
+        #expect(text == "58%")
+    }
+
+    @Test
+    func `smart reset disabled keeps the exhausted percent`() {
+        let window = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 300,
+            resetsAt: Date(timeIntervalSince1970: 1_800_000_000),
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .percent,
+            percentWindow: window,
+            showUsed: false)
+
+        #expect(text == "0%")
+    }
+
+    @Test
+    func `smart reset falls back to percent without reset metadata`() {
+        let window = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .percent,
+            percentWindow: window,
+            showUsed: false,
+            showsResetTimeWhenExhausted: true)
+
+        #expect(text == "0%")
+    }
+
+    @Test
+    func `smart reset does not alter reset time mode`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let resetsAt = now.addingTimeInterval(3600)
+        let window = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 300,
+            resetsAt: resetsAt,
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .resetTime,
+            percentWindow: window,
+            showUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            showsResetTimeWhenExhausted: true,
+            now: now)
+
+        #expect(text == "↻ in 1h")
+    }
+
+    @Test
+    func `smart reset replaces only the exhausted lane in combined text`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let session = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 300,
+            resetsAt: now.addingTimeInterval(2 * 3600 + 15 * 60),
+            resetDescription: nil)
+        let weekly = RateWindow(
+            usedPercent: 55,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(3 * 86400),
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.combinedSessionWeeklyPercentText(
+            sessionWindow: session,
+            weeklyWindow: weekly,
+            showUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            showsResetTimeWhenExhausted: true,
+            now: now)
+
+        #expect(text == "5h ↻ in 2h 15m · W 45%")
+    }
 }

--- a/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
+++ b/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
@@ -211,6 +211,28 @@ struct MenuBarResetTimeDisplayTests {
     }
 
     @Test
+    func `smart reset falls back to percent once the reset has elapsed`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        // Exhausted window whose reset moment is already in the past (e.g. snapshot lingering at 100%
+        // before the next provider refresh). Showing "↻ now" here would be stale and could stick.
+        let window = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 300,
+            resetsAt: now.addingTimeInterval(-60),
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .percent,
+            percentWindow: window,
+            showUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            showsResetTimeWhenExhausted: true,
+            now: now)
+
+        #expect(text == "0%")
+    }
+
+    @Test
     func `smart reset falls back to percent without reset metadata`() {
         let window = RateWindow(
             usedPercent: 100,

--- a/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
+++ b/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
@@ -274,6 +274,33 @@ struct MenuBarResetTimeDisplayTests {
         #expect(text == "0%")
     }
 
+    @Test(arguments: [MenuBarDisplayMode.pace, .both])
+    func `smart reset keeps exhausted percent when pace exists but reset is unusable`(_ mode: MenuBarDisplayMode) {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let window = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 300,
+            resetsAt: now.addingTimeInterval(-60),
+            resetDescription: nil)
+        let pace = UsagePace(
+            stage: .ahead,
+            deltaPercent: 12,
+            expectedUsedPercent: 40,
+            actualUsedPercent: 52,
+            etaSeconds: nil,
+            willLastToReset: true)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: mode,
+            percentWindow: window,
+            pace: pace,
+            showUsed: false,
+            showsResetTimeWhenExhausted: true,
+            now: now)
+
+        #expect(text == "0%")
+    }
+
     @Test
     func `smart reset does not alter reset time mode`() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)

--- a/Tests/CodexBarTests/MenuBarSmartResetIntegrationTests.swift
+++ b/Tests/CodexBarTests/MenuBarSmartResetIntegrationTests.swift
@@ -1,0 +1,63 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct MenuBarSmartResetIntegrationTests {
+    @Test(arguments: [MenuBarDisplayMode.pace, .both])
+    func `combined smart reset keeps exhausted session percent without a reset`(mode: MenuBarDisplayMode) {
+        let settings = testSettingsStore(
+            suiteName: "MenuBarSmartResetIntegrationTests-combined-fallback-\(mode.rawValue)")
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarShowsBrandIconWithPercent = true
+        settings.menuBarDisplayMode = mode
+        settings.menuBarShowsResetTimeWhenExhausted = true
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
+
+        if let metadata = ProviderRegistry.shared.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 50,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        // Weekly pace remains available, but it must not hide that the displayed session is exhausted.
+        // Without a concrete future session reset there is no reset text or timer to surface instead.
+        #expect(controller.menuBarDisplayText(for: .claude, snapshot: snapshot, now: now) == "0%")
+        #expect(controller.menuBarDisplayedResetDates(for: .claude, now: now).isEmpty)
+        #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+    }
+}

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -127,6 +127,29 @@ struct SettingsStoreTests {
     }
 
     @Test
+    func `exhausted reset time display defaults off and persists`() throws {
+        let suite = "SettingsStoreTests-exhausted-reset-time"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(store.menuBarShowsResetTimeWhenExhausted == false)
+        store.menuBarShowsResetTimeWhenExhausted = true
+
+        let reloaded = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        #expect(reloaded.menuBarShowsResetTimeWhenExhausted == true)
+    }
+
+    @Test
     func `weekly confetti setting defaults off and persists`() throws {
         let suite = "SettingsStoreTests-weekly-confetti"
         let defaultsA = try #require(UserDefaults(suiteName: suite))

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -1208,6 +1208,7 @@ struct StatusItemAnimationTests {
         settings.mergeIcons = true
         settings.selectedMenuProvider = .claude
         settings.menuBarDisplayMode = .both
+        settings.menuBarShowsResetTimeWhenExhausted = false
         settings.usageBarsShowUsed = false
         settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
 
@@ -1380,6 +1381,7 @@ struct StatusItemAnimationTests {
         settings.mergeIcons = true
         settings.selectedMenuProvider = .claude
         settings.menuBarDisplayMode = .both
+        settings.menuBarShowsResetTimeWhenExhausted = false
         settings.usageBarsShowUsed = false
         settings.setMenuBarMetricPreference(.primaryAndSecondary, for: .claude)
 


### PR DESCRIPTION
Closes #2028

## Summary

Adds a default-off Display setting, **Show reset time when quota runs out**, for brand-icon menu bar text. In Percent, Pace, and Both modes, an exhausted quota can show its reset countdown or clock instead of a dead percentage. The value returns to percentage display after the reset.

The setting remains separate from Display mode so it composes with the existing used/remaining and countdown/absolute-clock preferences.

## Details

- Triggers from `remainingPercent <= 0`, independent of the used/remaining presentation preference.
- Requires a concrete, future reset date. Missing, textual-only, or elapsed reset metadata keeps the exhausted percentage visible instead of showing stale text.
- Percent mode handles combined session and weekly lanes independently. Pace and Both use the same displayed lane for rendering and refresh scheduling.
- Countdown labels update at displayed-minute boundaries. Absolute labels update at reset and local-day boundaries.
- System clock, time-zone, and calendar-day changes rerender and reschedule absolute labels.
- Refresh work is armed only while brand-percentage text is visible.
- The setting persists, is disabled when percentage display is off or Display mode is already Reset time, and is localized across all app locales.

## Verification

- Exact head: `29cc66858f278a9eafd1cc1946a93c456ebe0499`
- `make check` — clean; SwiftFormat, SwiftLint, locales, package/signing scripts, parser hash
- `make test` — 597/597 selections, 50/50 groups, first pass, zero retries or timeouts
- Focused reset display, scheduler, settings, and combined-lane tests — green
- Structured autoreview and two independent source reviews — clean
- Developer-ID-signed debug package — exact embedded commit, Gatekeeper accepted, CLI 0.41.1
- Isolated packaged QA — Keychain disabled; loopback-only usage/reset requests; no unexpected requests; setting enablement and persistence verified across relaunch

No dependencies added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
