### PR TITLE
ci: reduce macOS Swift tests to two shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard-index: [0, 1, 2, 3]
-        shard-count: [4]
+        shard-index: [0, 1]
+        shard-count: [2]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Two shards amortize SwiftPM's per-shard discovery/cold build.
+        # Each shard remains within the 50-minute Swift Test timeout.
         shard-index: [0, 1]
         shard-count: [2]
     steps:

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -97,6 +97,27 @@ run_harness() {
     --swift-command-arg=fake-swift
 }
 
+python3 - "${ROOT_DIR}/.github/workflows/ci.yml" <<'PY'
+import pathlib
+import re
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text()
+job_match = re.search(r"(?ms)^  swift-test-macos:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:|\Z)", workflow)
+if not job_match:
+    raise SystemExit("swift-test-macos job not found in CI workflow")
+
+job = job_match.group("body")
+if not re.search(r"(?m)^\s+shard-index:\s+\[0,\s*1\]\s*$", job):
+    raise SystemExit("swift-test-macos must run exactly two shard indexes: [0, 1]")
+if not re.search(r"(?m)^\s+shard-count:\s+\[2\]\s*$", job):
+    raise SystemExit("swift-test-macos shard-count must be [2]")
+if "CODEXBAR_TEST_SHARD_INDEX=${{ matrix.shard-index }}" not in job:
+    raise SystemExit("swift-test-macos must pass matrix.shard-index to Scripts/test.sh")
+if "CODEXBAR_TEST_SHARD_COUNT=${{ matrix.shard-count }}" not in job:
+    raise SystemExit("swift-test-macos must pass matrix.shard-count to Scripts/test.sh")
+PY
+
 reset_case retry
 export FAKE_SWIFT_MODE=group_fail_once
 run_harness --group-size 4 --timeout 10 > "${TEMP_DIR}/retry.log"


### PR DESCRIPTION
## Summary

- reduce the macOS Swift test matrix from four shards to two
- keep the existing group size, skip-build execution, strict hosted failure handling, timeout isolation, and macOS change gate unchanged
- add a workflow-contract regression proving both matrix values still reach `Scripts/test.sh`
- document why two shards are intentional: amortize SwiftPM discovery/cold-build cost while preserving the 50-minute per-step timeout margin

## Why

After #2026, each macOS shard performs one discovery/cold build and then runs selected groups with `--skip-build`. Discovery became the dominant fixed cost, so four shards repeat that work four times.

The two-shard experiment at `22589eda1e31a543eee73d687e9d848b1d642c96` completed every discovered selection with no failures, retries, or timeouts:

- coverage: 595/595 selections, split 299 + 296; 149/149 groups, split 75 + 74
- macOS runner consumption: 54m57s total across 36m50s and 18m07s jobs
- immediate post-#2026 four-shard baseline: 64m17s total runner time (about 14.5% more)
- slowest Swift Test step: 34m24s, below the existing 50-minute step timeout

Wall-clock latency is intentionally not claimed as improved: one experimental shard queued for about 73 minutes, making the roughly 91-minute workflow latency runner-capacity-confounded. The supported benefit is lower total runner consumption with complete coverage and adequate per-shard timeout margin.

## Validation

- exact candidate: `4c2b7c1e2ff22f9f777731574835a17321932051`
- `bash Scripts/test_swift_test_sharding.sh` — passed
- `make check` — passed; zero SwiftFormat/SwiftLint violations
- `make test` — 598/598 selections, 50/50 groups, zero failures, retries, or timeouts
- structured autoreview — clean; no accepted/actionable findings
- exact-head hosted CI: both two-shard macOS jobs must complete green and account for every discovered selection

## Merge criteria

- both exact-head macOS shards pass within the existing 50-minute Swift Test / 60-minute job limits
- both shard summaries together cover every discovered selection with no duplicates, omissions, failures, retries, or timeouts
- lint, Linux builds, aggregate gate, and security pass
