### PR TITLE
fix: scope menu refresh state to active providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Quota warnings: add opt-in predictive pace alerts for Codex and Claude session and weekly limits, with one alert per risk episode. Thanks @vincent-peng!
 
 ### Fixed
+- Menus: stop completed provider cards and plan-utilization rows from remaining in “Refreshing…” while unrelated provider or token-cost work is still running. Thanks @Yuxin-Qiao!
 - Codex accounts: isolate authenticated OAuth and browser-cookie requests from shared URL caches and cookie stores, preventing one account's cached quota or identity response from appearing under another account and triggering false reset alerts (#1987, #2019). Thanks @harjothkhara!
 - Claude OAuth: honor the app's never-prompt policy in the bundled CLI and defer stale cache cleanup without touching Keychain until access is re-enabled. Thanks @Yuxin-Qiao!
 - CLI server: retain timed-out route and provider work until it actually exits, preventing repeated requests or config changes from stacking background fetches. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/MenuCardRefreshMonitor.swift
+++ b/Sources/CodexBar/MenuCardRefreshMonitor.swift
@@ -11,9 +11,12 @@ struct MenuCardLiveSubtitle {
 @Observable
 final class MenuCardRefreshMonitor {
     typealias ModelResolver = @MainActor (UsageProvider) -> UsageMenuCardView.Model?
+    typealias ProviderRefreshStateResolver = @MainActor (UsageProvider) -> Bool
 
     private let resolveModel: ModelResolver
-    /// Set while an all-providers refresh is running; it freezes every provider's card.
+    private let isProviderRefreshActive: ProviderRefreshStateResolver
+    /// Set while an all-providers refresh is running; individual cards freeze only while their
+    /// provider has active refresh work.
     private var globalManualRefreshInFlight = false
     /// Providers with an individual manual refresh in flight. Concurrent entries are allowed so
     /// refreshing one provider does not stall or unfreeze another.
@@ -25,8 +28,12 @@ final class MenuCardRefreshMonitor {
         self.globalManualRefreshInFlight || !self.manualRefreshProviders.isEmpty
     }
 
-    init(resolveModel: @escaping ModelResolver) {
+    init(
+        resolveModel: @escaping ModelResolver,
+        isProviderRefreshActive: @escaping ProviderRefreshStateResolver)
+    {
         self.resolveModel = resolveModel
+        self.isProviderRefreshActive = isProviderRefreshActive
     }
 
     func beginManualRefresh(
@@ -60,7 +67,8 @@ final class MenuCardRefreshMonitor {
     }
 
     func isManualRefreshInFlight(for provider: UsageProvider) -> Bool {
-        self.globalManualRefreshInFlight || self.manualRefreshProviders.contains(provider)
+        self.manualRefreshProviders.contains(provider) ||
+            (self.globalManualRefreshInFlight && self.isProviderRefreshActive(provider))
     }
 
     func model(

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -2,6 +2,16 @@ import CodexBarCore
 import Foundation
 
 extension StatusItemController {
+    func makeMenuCardRefreshMonitor() -> MenuCardRefreshMonitor {
+        MenuCardRefreshMonitor(
+            resolveModel: { [weak self] provider in
+                self?.menuCardModel(for: provider)
+            },
+            isProviderRefreshActive: { [weak self] provider in
+                self?.store.refreshingProviders.contains(provider) == true
+            })
+    }
+
     func menuCardModel(
         for provider: UsageProvider?,
         snapshotOverride: UsageSnapshot? = nil,

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -118,9 +118,13 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     let store: UsageStore
     let settings: SettingsStore
     let agentSessions: AgentSessionsStore
-    lazy var menuCardRefreshMonitor = MenuCardRefreshMonitor { [weak self] provider in
-        self?.menuCardModel(for: provider)
-    }
+    lazy var menuCardRefreshMonitor = MenuCardRefreshMonitor(
+        resolveModel: { [weak self] provider in
+            self?.menuCardModel(for: provider)
+        },
+        isProviderRefreshActive: { [weak self] provider in
+            self?.store.refreshingProviders.contains(provider) == true
+        })
 
     let account: AccountInfo
     let updater: UpdaterProviding

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -118,13 +118,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     let store: UsageStore
     let settings: SettingsStore
     let agentSessions: AgentSessionsStore
-    lazy var menuCardRefreshMonitor = MenuCardRefreshMonitor(
-        resolveModel: { [weak self] provider in
-            self?.menuCardModel(for: provider)
-        },
-        isProviderRefreshActive: { [weak self] provider in
-            self?.store.refreshingProviders.contains(provider) == true
-        })
+    lazy var menuCardRefreshMonitor = self.makeMenuCardRefreshMonitor()
 
     let account: AccountInfo
     let updater: UpdaterProviding

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -155,15 +155,13 @@ extension UsageStore {
     }
 
     func shouldShowRefreshingMenuCard(for provider: UsageProvider) -> Bool {
-        let isRefreshing = self.isRefreshing || self.refreshingProviders.contains(provider)
-        return isRefreshing
+        self.refreshingProviders.contains(provider)
             && self.snapshots[provider] == nil
             && self.error(for: provider) == nil
     }
 
     func shouldShowRefreshingMenuCardIndicator(for provider: UsageProvider) -> Bool {
-        let isRefreshing = self.isRefreshing || self.refreshingProviders.contains(provider)
-        return isRefreshing && self.error(for: provider) == nil
+        self.refreshingProviders.contains(provider) && self.error(for: provider) == nil
     }
 
     func shouldHidePlanUtilizationMenuItem(for provider: UsageProvider) -> Bool {

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -339,103 +339,6 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
-    func `global manual refresh only marks active provider cards as refreshing`() {
-        let settings = self.makeSettings()
-        let controller = self.makeController(settings: settings)
-        let monitor = controller.menuCardRefreshMonitor
-        let fallback = MenuCardLiveSubtitle(text: "Idle", style: .info)
-
-        monitor.beginManualRefresh(frozenModels: [:], provider: nil)
-        defer { monitor.endManualRefresh() }
-
-        controller.store.refreshingProviders.insert(.claude)
-        #expect(monitor.isManualRefreshInFlight)
-        #expect(!monitor.isManualRefreshInFlight(for: .codex))
-        #expect(monitor.isManualRefreshInFlight(for: .claude))
-        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
-        #expect(monitor.subtitle(for: .claude, fallback: fallback).style == .loading)
-
-        controller.store.refreshingProviders.remove(.claude)
-        #expect(!monitor.isManualRefreshInFlight(for: .claude))
-        #expect(monitor.subtitle(for: .claude, fallback: fallback).style == .info)
-    }
-
-    @Test
-    func `completed provider cards stop refreshing while another provider is still running`() async {
-        let settings = self.makeSettings()
-        settings.statusChecksEnabled = false
-        settings.costUsageEnabled = false
-        settings.openAIWebAccessEnabled = false
-        settings.codexCookieSource = .off
-        self.enableOnly([.claude, .codex], settings: settings)
-        let controller = self.makeController(settings: settings)
-        let claudeStarted = ManualRefreshGate()
-        let releaseClaude = ManualRefreshGate()
-        let monitor = controller.menuCardRefreshMonitor
-        let fallback = MenuCardLiveSubtitle(text: "Idle", style: .info)
-
-        controller.store._test_providerRefreshOverride = { provider in
-            guard provider == .claude else { return }
-            claudeStarted.resume()
-            await releaseClaude.wait()
-        }
-        defer { controller.store._test_providerRefreshOverride = nil }
-
-        controller.refreshNow()
-        await claudeStarted.wait()
-        for _ in 0..<20 where controller.store.refreshingProviders != [.claude] {
-            await Task.yield()
-        }
-
-        #expect(controller.store.refreshingProviders == [.claude])
-        #expect(!monitor.isManualRefreshInFlight(for: .codex))
-        #expect(monitor.isManualRefreshInFlight(for: .claude))
-        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
-        #expect(monitor.subtitle(for: .claude, fallback: fallback).style == .loading)
-
-        releaseClaude.resume()
-        await controller.manualRefreshTasks[.global]?.value
-    }
-
-    @Test
-    func `token-cost tail does not keep completed provider card refreshing`() async {
-        let settings = self.makeSettings()
-        settings.statusChecksEnabled = false
-        settings.costUsageEnabled = true
-        settings.openAIWebAccessEnabled = false
-        settings.codexCookieSource = .off
-        self.enableOnly([.codex], settings: settings)
-        let controller = self.makeController(settings: settings)
-        let tokenRefreshStarted = ManualRefreshGate()
-        let releaseTokenRefresh = ManualRefreshGate()
-        let monitor = controller.menuCardRefreshMonitor
-        let fallback = MenuCardLiveSubtitle(text: "Idle", style: .info)
-
-        controller.store._test_providerRefreshOverride = { _ in }
-        controller.store._test_tokenUsageRefreshOverride = { _, _ in
-            tokenRefreshStarted.resume()
-            await releaseTokenRefresh.wait()
-        }
-        defer {
-            controller.store._test_providerRefreshOverride = nil
-            controller.store._test_tokenUsageRefreshOverride = nil
-        }
-
-        controller.refreshNow()
-        await tokenRefreshStarted.wait()
-
-        #expect(controller.store.isRefreshing)
-        #expect(controller.store.refreshingProviders.isEmpty)
-        #expect(monitor.isManualRefreshInFlight)
-        #expect(!monitor.isManualRefreshInFlight(for: .codex))
-        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
-
-        releaseTokenRefresh.resume()
-        await controller.manualRefreshTasks[.global]?.value
-        #expect(!monitor.isManualRefreshInFlight)
-    }
-
-    @Test
     func `scoped refresh monitor leaves unrelated providers unchanged`() throws {
         let settings = self.makeSettings()
         let controller = self.makeController(settings: settings)
@@ -1213,6 +1116,104 @@ extension StatusMenuPersistentRefreshTests {
 }
 
 extension StatusMenuPersistentRefreshTests {
+    @Test
+    func `global manual refresh only marks active provider cards as refreshing`() {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        let monitor = controller.menuCardRefreshMonitor
+        let fallback = MenuCardLiveSubtitle(text: "Idle", style: .info)
+
+        monitor.beginManualRefresh(frozenModels: [:], provider: nil)
+        defer { monitor.endManualRefresh() }
+
+        controller.store.refreshingProviders.insert(.claude)
+        #expect(monitor.isManualRefreshInFlight)
+        #expect(!monitor.isManualRefreshInFlight(for: .codex))
+        #expect(monitor.isManualRefreshInFlight(for: .claude))
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
+        #expect(monitor.subtitle(for: .claude, fallback: fallback).style == .loading)
+
+        controller.store.refreshingProviders.remove(.claude)
+        #expect(monitor.isManualRefreshInFlight)
+        #expect(!monitor.isManualRefreshInFlight(for: .claude))
+        #expect(monitor.subtitle(for: .claude, fallback: fallback).style == .info)
+    }
+
+    @Test
+    func `completed provider cards stop refreshing while another provider is still running`() async {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.costUsageEnabled = false
+        settings.openAIWebAccessEnabled = false
+        settings.codexCookieSource = .off
+        self.enableOnly([.claude, .codex], settings: settings)
+        let controller = self.makeController(settings: settings)
+        let claudeStarted = ManualRefreshGate()
+        let releaseClaude = ManualRefreshGate()
+        let monitor = controller.menuCardRefreshMonitor
+        let fallback = MenuCardLiveSubtitle(text: "Idle", style: .info)
+
+        controller.store._test_providerRefreshOverride = { provider in
+            guard provider == .claude else { return }
+            claudeStarted.resume()
+            await releaseClaude.wait()
+        }
+        defer { controller.store._test_providerRefreshOverride = nil }
+
+        controller.refreshNow()
+        await claudeStarted.wait()
+        for _ in 0..<20 where controller.store.refreshingProviders != [.claude] {
+            await Task.yield()
+        }
+
+        #expect(controller.store.refreshingProviders == [.claude])
+        #expect(!monitor.isManualRefreshInFlight(for: .codex))
+        #expect(monitor.isManualRefreshInFlight(for: .claude))
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
+        #expect(monitor.subtitle(for: .claude, fallback: fallback).style == .loading)
+
+        releaseClaude.resume()
+        await controller.manualRefreshTasks[.global]?.value
+    }
+
+    @Test
+    func `token-cost tail does not keep completed provider card refreshing`() async {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.costUsageEnabled = true
+        settings.openAIWebAccessEnabled = false
+        settings.codexCookieSource = .off
+        self.enableOnly([.codex], settings: settings)
+        let controller = self.makeController(settings: settings)
+        let tokenRefreshStarted = ManualRefreshGate()
+        let releaseTokenRefresh = ManualRefreshGate()
+        let monitor = controller.menuCardRefreshMonitor
+        let fallback = MenuCardLiveSubtitle(text: "Idle", style: .info)
+
+        controller.store._test_providerRefreshOverride = { _ in }
+        controller.store._test_tokenUsageRefreshOverride = { _, _ in
+            tokenRefreshStarted.resume()
+            await releaseTokenRefresh.wait()
+        }
+        defer {
+            controller.store._test_providerRefreshOverride = nil
+            controller.store._test_tokenUsageRefreshOverride = nil
+        }
+
+        controller.refreshNow()
+        await tokenRefreshStarted.wait()
+
+        #expect(controller.store.isRefreshing)
+        #expect(controller.store.refreshingProviders.isEmpty)
+        #expect(monitor.isManualRefreshInFlight)
+        #expect(!monitor.isManualRefreshInFlight(for: .codex))
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
+
+        releaseTokenRefresh.resume()
+        await controller.manualRefreshTasks[.global]?.value
+        #expect(!monitor.isManualRefreshInFlight)
+    }
+
     @Test
     func `concurrent manual refreshes keep each provider's frozen card`() throws {
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -302,15 +302,17 @@ struct StatusMenuPersistentRefreshTests {
 
         #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
 
-        controller.store.isRefreshing = true
+        controller.store.refreshingProviders.insert(.codex)
         #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .loading)
 
-        controller.store.isRefreshing = false
+        controller.store.refreshingProviders.remove(.codex)
         monitor.beginManualRefresh(frozenModels: [:], provider: nil)
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
+        controller.store.refreshingProviders.insert(.codex)
         #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .loading)
         monitor.endManualRefresh()
+        controller.store.refreshingProviders.remove(.codex)
 
-        controller.store.isRefreshing = false
         let now = Date()
         controller.store.snapshots[.codex] = UsageSnapshot(
             primary: RateWindow(
@@ -330,7 +332,107 @@ struct StatusMenuPersistentRefreshTests {
         #expect(failure.text == "Refresh failed")
 
         monitor.beginManualRefresh(frozenModels: [:], provider: nil)
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .error)
+        controller.store.refreshingProviders.insert(.codex)
         #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .loading)
+        controller.store.refreshingProviders.remove(.codex)
+    }
+
+    @Test
+    func `global manual refresh only marks active provider cards as refreshing`() {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        let monitor = controller.menuCardRefreshMonitor
+        let fallback = MenuCardLiveSubtitle(text: "Idle", style: .info)
+
+        monitor.beginManualRefresh(frozenModels: [:], provider: nil)
+        defer { monitor.endManualRefresh() }
+
+        controller.store.refreshingProviders.insert(.claude)
+        #expect(monitor.isManualRefreshInFlight)
+        #expect(!monitor.isManualRefreshInFlight(for: .codex))
+        #expect(monitor.isManualRefreshInFlight(for: .claude))
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
+        #expect(monitor.subtitle(for: .claude, fallback: fallback).style == .loading)
+
+        controller.store.refreshingProviders.remove(.claude)
+        #expect(!monitor.isManualRefreshInFlight(for: .claude))
+        #expect(monitor.subtitle(for: .claude, fallback: fallback).style == .info)
+    }
+
+    @Test
+    func `completed provider cards stop refreshing while another provider is still running`() async {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.costUsageEnabled = false
+        settings.openAIWebAccessEnabled = false
+        settings.codexCookieSource = .off
+        self.enableOnly([.claude, .codex], settings: settings)
+        let controller = self.makeController(settings: settings)
+        let claudeStarted = ManualRefreshGate()
+        let releaseClaude = ManualRefreshGate()
+        let monitor = controller.menuCardRefreshMonitor
+        let fallback = MenuCardLiveSubtitle(text: "Idle", style: .info)
+
+        controller.store._test_providerRefreshOverride = { provider in
+            guard provider == .claude else { return }
+            claudeStarted.resume()
+            await releaseClaude.wait()
+        }
+        defer { controller.store._test_providerRefreshOverride = nil }
+
+        controller.refreshNow()
+        await claudeStarted.wait()
+        for _ in 0..<20 where controller.store.refreshingProviders != [.claude] {
+            await Task.yield()
+        }
+
+        #expect(controller.store.refreshingProviders == [.claude])
+        #expect(!monitor.isManualRefreshInFlight(for: .codex))
+        #expect(monitor.isManualRefreshInFlight(for: .claude))
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
+        #expect(monitor.subtitle(for: .claude, fallback: fallback).style == .loading)
+
+        releaseClaude.resume()
+        await controller.manualRefreshTasks[.global]?.value
+    }
+
+    @Test
+    func `token-cost tail does not keep completed provider card refreshing`() async {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.costUsageEnabled = true
+        settings.openAIWebAccessEnabled = false
+        settings.codexCookieSource = .off
+        self.enableOnly([.codex], settings: settings)
+        let controller = self.makeController(settings: settings)
+        let tokenRefreshStarted = ManualRefreshGate()
+        let releaseTokenRefresh = ManualRefreshGate()
+        let monitor = controller.menuCardRefreshMonitor
+        let fallback = MenuCardLiveSubtitle(text: "Idle", style: .info)
+
+        controller.store._test_providerRefreshOverride = { _ in }
+        controller.store._test_tokenUsageRefreshOverride = { _, _ in
+            tokenRefreshStarted.resume()
+            await releaseTokenRefresh.wait()
+        }
+        defer {
+            controller.store._test_providerRefreshOverride = nil
+            controller.store._test_tokenUsageRefreshOverride = nil
+        }
+
+        controller.refreshNow()
+        await tokenRefreshStarted.wait()
+
+        #expect(controller.store.isRefreshing)
+        #expect(controller.store.refreshingProviders.isEmpty)
+        #expect(monitor.isManualRefreshInFlight)
+        #expect(!monitor.isManualRefreshInFlight(for: .codex))
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
+
+        releaseTokenRefresh.resume()
+        await controller.manualRefreshTasks[.global]?.value
+        #expect(!monitor.isManualRefreshInFlight)
     }
 
     @Test
@@ -413,6 +515,7 @@ struct StatusMenuPersistentRefreshTests {
                 updatedAt: now)
             let frozen = try #require(controller.menuCardModel(for: provider))
             controller.menuCardRefreshMonitor.beginManualRefresh(frozenModels: [provider: frozen])
+            controller.store.refreshingProviders.insert(provider)
 
             controller.store.snapshots[provider] = UsageSnapshot(
                 primary: RateWindow(
@@ -430,6 +533,7 @@ struct StatusMenuPersistentRefreshTests {
             #expect(inFlight.metrics.first?.percentLabel == "79% left")
 
             controller.menuCardRefreshMonitor.endManualRefresh()
+            controller.store.refreshingProviders.remove(provider)
             let completed = controller.menuCardRefreshMonitor.model(for: provider, fallback: frozen)
             #expect(completed.metrics.first?.percentLabel == "82% left")
         }
@@ -450,6 +554,8 @@ struct StatusMenuPersistentRefreshTests {
             updatedAt: now)
         let frozen = try #require(controller.menuCardModel(for: .claude))
         controller.menuCardRefreshMonitor.beginManualRefresh(frozenModels: [.claude: frozen])
+        controller.store.refreshingProviders.insert(.claude)
+        defer { controller.store.refreshingProviders.remove(.claude) }
 
         controller.store.snapshots[.claude] = UsageSnapshot(
             primary: RateWindow(
@@ -503,6 +609,8 @@ struct StatusMenuPersistentRefreshTests {
             updatedAt: now)
         let frozen = try #require(controller.menuCardModel(for: .codex))
         controller.menuCardRefreshMonitor.beginManualRefresh(frozenModels: [.codex: frozen])
+        controller.store.refreshingProviders.insert(.codex)
+        defer { controller.store.refreshingProviders.remove(.codex) }
 
         controller.store.snapshots[.codex] = UsageSnapshot(
             primary: nil,
@@ -534,6 +642,8 @@ struct StatusMenuPersistentRefreshTests {
             updatedAt: now)
         let frozen = try #require(controller.menuCardModel(for: .codex))
         controller.menuCardRefreshMonitor.beginManualRefresh(frozenModels: [.codex: frozen])
+        controller.store.refreshingProviders.insert(.codex)
+        defer { controller.store.refreshingProviders.remove(.codex) }
 
         controller.store.snapshots[.codex] = UsageSnapshot(
             primary: nil,
@@ -571,6 +681,8 @@ struct StatusMenuPersistentRefreshTests {
 
         controller.store.snapshots.removeValue(forKey: .claude)
         let fallback = try #require(controller.menuCardModel(for: .claude))
+        controller.store.refreshingProviders.insert(.claude)
+        defer { controller.store.refreshingProviders.remove(.claude) }
         let inFlight = controller.menuCardRefreshMonitor.model(for: .claude, fallback: fallback)
 
         #expect(frozen.metrics.count == 1)
@@ -750,7 +862,10 @@ struct StatusMenuPersistentRefreshTests {
 
         #expect(replacementErrorHeight == errorHeight)
         let fallback = MenuCardLiveSubtitle(text: errorModel.subtitleText, style: errorModel.subtitleStyle)
+        #expect(controller.menuCardRefreshMonitor.subtitle(for: .codex, fallback: fallback).style == .error)
+        controller.store.refreshingProviders.insert(.codex)
         #expect(controller.menuCardRefreshMonitor.subtitle(for: .codex, fallback: fallback).style == .loading)
+        controller.store.refreshingProviders.remove(.codex)
         #expect(retryHeight == errorHeight)
     }
 

--- a/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
@@ -366,6 +366,7 @@ struct StatusMenuSwitcherRefreshTests {
 
         controller.refreshNow()
         #expect(controller.menuCardRefreshMonitor.isManualRefreshInFlight)
+        store.refreshingProviders.insert(.codex)
 
         store._setSnapshotForTesting(
             UsageSnapshot(primary: nil, secondary: nil, updatedAt: now.addingTimeInterval(1)),
@@ -401,6 +402,7 @@ struct StatusMenuSwitcherRefreshTests {
         #expect(inFlight.metrics.first?.percentLabel == "79% left")
 
         gate.resume()
+        store.refreshingProviders.remove(.codex)
         await controller.manualRefreshTasks[.global]?.value
         #expect(!controller.menuCardRefreshMonitor.isManualRefreshInFlight)
         let completed = controller.menuCardRefreshMonitor.model(for: .codex, fallback: emptyFallback)

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -1147,6 +1147,29 @@ extension UsageStorePlanUtilizationTests {
     }
 }
 
+extension UsageStorePlanUtilizationTests {
+    @MainActor
+    @Test
+    func `global refresh tail does not keep completed provider plan card loading`() {
+        let store = Self.makeStore()
+        store._setSnapshotForTesting(nil, provider: .claude)
+        store.isRefreshing = true
+        store.refreshingProviders.insert(.claude)
+
+        #expect(store.shouldShowRefreshingMenuCard(for: .claude))
+        #expect(store.shouldShowRefreshingMenuCardIndicator(for: .claude))
+        #expect(store.shouldHidePlanUtilizationMenuItem(for: .claude))
+
+        store.refreshingProviders.remove(.claude)
+
+        #expect(store.isRefreshing)
+        #expect(store.refreshingProviders.isEmpty)
+        #expect(!store.shouldShowRefreshingMenuCard(for: .claude))
+        #expect(!store.shouldShowRefreshingMenuCardIndicator(for: .claude))
+        #expect(!store.shouldHidePlanUtilizationMenuItem(for: .claude))
+    }
+}
+
 func planEntry(at capturedAt: Date, usedPercent: Double, resetsAt: Date? = nil) -> PlanUtilizationHistoryEntry {
     PlanUtilizationHistoryEntry(capturedAt: capturedAt, usedPercent: usedPercent, resetsAt: resetsAt)
 }


### PR DESCRIPTION
## Summary

- scope global manual-refresh card state to each provider's actual active refresh work
- keep the global task lifecycle for refresh-button de-duplication, while completed providers immediately return to their real subtitle and card model
- stop the plan-utilization card loading/indicator from using the store-wide `isRefreshing` flag

## Root cause

An overview refresh can remain active for token-cost history scans, OpenAI web enrichment, or another provider's request. The previous UI treated that global task as if every provider were still fetching, so completed cards stayed frozen and displayed `Refreshing…`.

## Validation

- `swift test --filter 'StatusMenuPersistentRefreshTests|StatusMenuSwitcherRefreshTests|UsageStorePlanUtilizationTests'`
- `make check`
- `make test` — 598/598 selections, 50/50 groups, zero failures, retries, or timeouts
- structured branch autoreview — clean, no accepted/actionable findings
- signed debug package at exact head `047fcd58d50c75a83122821a28ff0ca5216d3f4b`; Developer ID signature, strict code-sign verification, and Gatekeeper assessment passed
- isolated loopback live QA with Codex and Wayfinder: Codex updated from 12% to 42% while a held Wayfinder request alone retained its prior data and displayed `Refreshing…`; the global Refresh control stayed disabled, a repeated press started no additional requests, and both cards settled after release

The regression coverage includes a real multi-provider refresh where Claude remains active after Codex completes, plus a token-cost tail that keeps the global task alive after the provider refresh has finished. Live QA used synthetic loopback data with Keychain access disabled; no real provider credentials or requests were involved.

## Follow-up

This PR fixes the misleading refresh state only. It intentionally does not decouple the manual token-cost/OpenAI web work from the foreground refresh lifecycle or change provider fallback deadlines.
