### PR TITLE
docs: add Azure OpenAI provider details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Codex: add a provider option to hide Spark quota rows without hiding credits or other extra usage (#2013). Thanks @intellectronica!
 - Wayfinder: add opt-in local gateway health, routing, savings, and latency usage with configurable loopback URL support. Thanks @tcballard!
 - Claude CLI: surface model-scoped weekly limits alongside all-model usage without duplicating matching web limits. Thanks @janpollak!
-- Documentation: add detailed setup and troubleshooting references for Perplexity, Mistral, and Qoder. Thanks @kiranmagic7!
+- Documentation: add detailed setup and troubleshooting references for Azure OpenAI, Perplexity, Mistral, and Qoder. Thanks @kiranmagic7!
 - Quota warnings: add opt-in predictive pace alerts for Codex and Claude session and weekly limits, with one alert per risk episode. Thanks @vincent-peng!
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ See [CLI configuration](docs/cli-configuration.md) for the full flow.
 
 - [Codex](docs/codex.md) — OAuth API or local Codex CLI, plus optional OpenAI web dashboard extras.
 - [OpenAI](docs/openai.md) — Admin API key usage/cost graphs with legacy credit-balance fallback.
+- [Azure OpenAI](docs/azure-openai.md) — API key, endpoint, and deployment validation probe.
 - [Claude](docs/claude.md) — OAuth API, browser cookies, or CLI PTY fallback; session and weekly usage where available.
 - [Cursor](docs/cursor.md) — Browser session cookies for plan + usage + billing resets.
 - [OpenCode](docs/opencode.md) — Browser cookies for workspace subscription usage.
@@ -106,6 +107,7 @@ See [CLI configuration](docs/cli-configuration.md) for the full flow.
 - [Warp](docs/warp.md) — API token for GraphQL request limits and monthly credits.
 - [ElevenLabs](docs/elevenlabs.md) — API key for character credits and voice slot usage.
 - [OpenRouter](docs/openrouter.md) — API token for credit-based usage tracking across multiple AI providers.
+- [CrossModel](docs/crossmodel.md) — API key wallet balance with daily, weekly, and monthly spend.
 - [Windsurf](docs/windsurf.md) — Browser localStorage session import or local SQLite cache for plan usage.
 - [Zed](docs/zed.md) — Zed editor Keychain session for plan, edit-prediction quota, billing cycle, and overdue invoices.
 - [Perplexity](docs/perplexity.md) — Account usage credits from Perplexity usage data.

--- a/docs/azure-openai.md
+++ b/docs/azure-openai.md
@@ -1,0 +1,101 @@
+---
+summary: "Azure OpenAI provider: API key, endpoint, and deployment validation probe."
+read_when:
+  - Debugging Azure OpenAI provider setup
+  - Updating Azure OpenAI endpoint or deployment validation
+  - Explaining Azure OpenAI environment variables
+---
+
+# Azure OpenAI provider
+
+CodexBar's Azure OpenAI provider validates that a configured deployment is reachable. It does not read Azure spend,
+quota history, or token usage history.
+
+## Authentication
+
+Azure OpenAI requires three values:
+
+1. API key
+2. Resource endpoint
+3. Deployment name
+
+Settings -> Providers -> Azure OpenAI stores those values in the shared CodexBar config. The same values can also be
+provided with environment variables:
+
+```bash
+export AZURE_OPENAI_API_KEY="..."
+export AZURE_OPENAI_ENDPOINT="https://resource.openai.azure.com"
+export AZURE_OPENAI_DEPLOYMENT_NAME="chat-prod"
+```
+
+You can store the API key through the CLI:
+
+```bash
+printf '%s' "$AZURE_OPENAI_API_KEY" | codexbar config set-api-key --provider azure-openai --stdin
+```
+
+The endpoint and deployment are stored as `enterpriseHost` and `workspaceID` in the `azureopenai` provider config:
+
+```json
+{
+  "id": "azureopenai",
+  "apiKey": "<AZURE_OPENAI_API_KEY>",
+  "enterpriseHost": "https://resource.openai.azure.com",
+  "workspaceID": "chat-prod"
+}
+```
+
+## Data source
+
+CodexBar sends a minimal chat-completions request to validate the deployment:
+
+```http
+POST https://resource.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=2024-10-21
+api-key: <api key>
+Accept: application/json
+Content-Type: application/json
+```
+
+The request body contains one `ping` message and `max_tokens: 1`. A successful response is parsed only for the returned
+`model` field so the menu can show deployment detail.
+
+Set `AZURE_OPENAI_API_VERSION` to override the API version. When it is set to `v1`, CodexBar uses Azure's
+OpenAI-compatible v1 path and includes the deployment name as the request `model`:
+
+```http
+POST https://resource.openai.azure.com/openai/v1/chat/completions
+```
+
+## Endpoint handling
+
+`AZURE_OPENAI_ENDPOINT` and the configured endpoint field must be HTTPS URLs, or bare hosts that can be normalized to
+HTTPS. CodexBar rejects explicit `http://` endpoints, user info, and encoded host-delimiter tricks before attaching the
+`api-key` header.
+
+Endpoint paths are preserved. If the endpoint already ends with `/openai` or `/openai/v1`, CodexBar avoids duplicating
+those path components when building the validation URL.
+
+## Display
+
+- The provider uses the `api` source label.
+- The menu shows the Azure OpenAI resource host as organization context.
+- The primary detail line shows `Deployment: <name>` and includes `Model: <model>` when the validation response returns
+  one.
+- The menu bar usage meter does not show spend, quota, or reset history because the provider only performs deployment
+  validation.
+
+## CLI usage
+
+```bash
+codexbar usage --provider azure-openai
+codexbar usage --provider azureopenai
+codexbar usage --provider aoai
+```
+
+## Key files
+
+- `Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIProviderDescriptor.swift`
+- `Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift`
+- `Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift`
+- `Sources/CodexBar/Providers/AzureOpenAI/AzureOpenAIProviderImplementation.swift`
+- `Tests/CodexBarTests/AzureOpenAIUsageFetcherTests.swift`

--- a/docs/azure-openai.md
+++ b/docs/azure-openai.md
@@ -56,11 +56,12 @@ Accept: application/json
 Content-Type: application/json
 ```
 
-The request body contains one `ping` message and `max_tokens: 1`. A successful response is parsed only for the returned
-`model` field so the menu can show deployment detail.
+For dated API versions, the request body contains one `ping` message and `max_tokens: 1`. A successful response is
+parsed only for the returned `model` field so the menu can show deployment detail.
 
 Set `AZURE_OPENAI_API_VERSION` to override the API version. When it is set to `v1`, CodexBar uses Azure's
-OpenAI-compatible v1 path and includes the deployment name as the request `model`:
+OpenAI-compatible v1 path, includes the deployment name as the request `model`, and uses
+`max_completion_tokens: 1`:
 
 ```http
 POST https://resource.openai.azure.com/openai/v1/chat/completions
@@ -72,12 +73,16 @@ POST https://resource.openai.azure.com/openai/v1/chat/completions
 HTTPS. CodexBar rejects explicit `http://` endpoints, user info, and encoded host-delimiter tricks before attaching the
 `api-key` header.
 
-Endpoint paths are preserved. If the endpoint already ends with `/openai` or `/openai/v1`, CodexBar avoids duplicating
-those path components when building the validation URL.
+Endpoint paths are preserved. CodexBar avoids duplicating a trailing `/openai` for dated API versions or a trailing
+`/openai/v1` for the v1 API when building the validation URL.
+
+Each refresh with complete, valid configuration sends this real inference request and can consume billable input and
+output tokens for the configured deployment.
 
 ## Display
 
-- The provider uses the `api` source label.
+- Settings shows the provider's static `api` label before a fetch. After a successful fetch, Settings' Source row and
+  the CLI report `deployment`.
 - The menu shows the Azure OpenAI resource host as organization context.
 - The primary detail line shows `Deployment: <name>` and includes `Model: <model>` when the validation response returns
   one.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -100,6 +100,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Validates the configured deployment with a minimal chat-completions request; it does not expose Azure spend or quota history.
 - Use `AZURE_OPENAI_API_VERSION` to override the API version. Set it to `v1` for Azure's OpenAI-compatible v1 API path.
 - Status: Azure status page link.
+- Details: `docs/azure-openai.md`.
 
 ## Claude
 - Admin API: `sk-ant-admin...` key in Settings/config, token accounts, or `ANTHROPIC_ADMIN_KEY`.


### PR DESCRIPTION
## Purpose

Document the Azure OpenAI provider details page and wire it into the existing provider documentation.

## Summary

- Adds `docs/azure-openai.md` with setup, request paths, endpoint validation, display behavior, CLI aliases, and key source files.
- Documents the distinct dated-API and v1 payload fields and mode-specific path normalization.
- Makes the billing boundary explicit: a refresh with valid configuration performs a real minimal inference request.
- Distinguishes the static Settings label from the post-fetch Source label used in Settings and CLI output.
- Links the details page from `docs/providers.md` and adds missing Azure OpenAI and CrossModel README entries.
- Extends the existing documentation changelog credit to include Azure OpenAI. Thanks @kiranmagic7!

## Verification

- Exact head: `58e1f1cf5e370fd8924a49f26b49727be09c838d`
- Documentation links: 164 local links, clean
- Generated `docs/llms.txt`: current
- Azure OpenAI focused tests: 10/10 across 3 suites
- `make check`: clean
- `make test`: 597/597 selections across 50/50 groups, first pass; zero failures, retries, or timeouts
- Exact full-branch source review: clean
- Structured autoreview of the maintainer correction delta: clean

No real Azure request was made: this is documentation-only, and the documented validation call can consume billable tokens. No dependencies added.
