### PR TITLE
Fix stale native menu hover highlight geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 - Menus: stop completed provider cards and plan-utilization rows from remaining in “Refreshing…” while unrelated provider or token-cost work is still running. Thanks @Yuxin-Qiao!
+- Menu: keep native hover highlights aligned by deferring geometry-changing open-menu rebuilds until the pointer leaves the row.
 - Codex accounts: isolate authenticated OAuth and browser-cookie requests from shared URL caches and cookie stores, preventing one account's cached quota or identity response from appearing under another account and triggering false reset alerts (#1987, #2019). Thanks @harjothkhara!
 - Claude OAuth: honor the app's never-prompt policy in the bundled CLI and defer stale cache cleanup without touching Keychain until access is re-enabled. Thanks @Yuxin-Qiao!
 - CLI server: retain timed-out route and provider work until it actually exits, preventing repeated requests or config changes from stacking background fetches. Thanks @Yuxin-Qiao!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixed
 - Menus: stop completed provider cards and plan-utilization rows from remaining in “Refreshing…” while unrelated provider or token-cost work is still running. Thanks @Yuxin-Qiao!
-- Menu: keep native hover highlights aligned by deferring geometry-changing open-menu rebuilds until the pointer leaves the row.
+- Menu: keep native hover highlights aligned by deferring geometry-changing open-menu rebuilds until the pointer leaves the row. Thanks @Zihao-Qi!
 - Codex accounts: isolate authenticated OAuth and browser-cookie requests from shared URL caches and cookie stores, preventing one account's cached quota or identity response from appearing under another account and triggering false reset alerts (#1987, #2019). Thanks @harjothkhara!
 - Claude OAuth: honor the app's never-prompt policy in the bundled CLI and defer stale cache cleanup without touching Keychain until access is re-enabled. Thanks @Yuxin-Qiao!
 - CLI server: retain timed-out route and provider work until it actually exits, preventing repeated requests or config changes from stacking background fetches. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -202,6 +202,7 @@ extension StatusItemController {
         let key = ObjectIdentifier(menu)
         let previous = self.highlightedMenuItems[key]
         guard previous !== item else { return }
+        let previousWasNative = self.isNativeMenuItemHighlighted(in: menu)
 
         if let previous {
             (previous.view as? MenuCardHighlighting)?.setHighlighted(false)
@@ -215,6 +216,10 @@ extension StatusItemController {
             (item.view as? MenuCardHighlighting)?.setHighlighted(true)
         } else {
             self.highlightedMenuItems.removeValue(forKey: key)
+        }
+
+        if previousWasNative, !self.isNativeMenuItemHighlighted(in: menu) {
+            self.resumeMenuRebuildDeferredForNativeHighlightIfNeeded(menu)
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -344,8 +344,14 @@ extension StatusItemController {
         if request.shouldCloseHostedSubviewMenus {
             self.closeHostedSubviewMenusForParentSwitch()
         }
-        self.rebuildOpenMenuIfStillVisible(menu, provider: request.provider)
-        if request.resyncReadinessBaselineAfterRebuild, !self.menuNeedsRefresh(menu) {
+        self.rebuildOpenMenuIfStillVisible(
+            menu,
+            provider: request.provider,
+            resyncReadinessBaselineAfterRebuild: request.resyncReadinessBaselineAfterRebuild)
+        let shouldResyncReadinessBaseline = request.resyncReadinessBaselineAfterRebuild ||
+            self.nativeHighlightDeferredMenuBaselineResyncs.contains(key)
+        if shouldResyncReadinessBaseline, !self.menuNeedsRefresh(menu) {
+            self.nativeHighlightDeferredMenuBaselineResyncs.remove(key)
             self.resyncMenuAdjunctReadinessBaseline()
         }
     }

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -8,7 +8,6 @@ extension StatusItemController {
     private struct ScheduledOpenMenuRebuild {
         let provider: UsageProvider?
         let shouldCloseHostedSubviewMenus: Bool
-        let resyncReadinessBaselineAfterRebuild: Bool
         let beforeRebuild: (@MainActor () -> Bool)?
     }
 
@@ -279,7 +278,6 @@ extension StatusItemController {
                 request: ScheduledOpenMenuRebuild(
                     provider: provider,
                     shouldCloseHostedSubviewMenus: true,
-                    resyncReadinessBaselineAfterRebuild: false,
                     beforeRebuild: beforeRebuild))
         }
     }
@@ -293,6 +291,9 @@ extension StatusItemController {
         beforeRebuild: (@MainActor () -> Bool)? = nil)
     {
         let key = ObjectIdentifier(menu)
+        if resyncReadinessBaselineAfterRebuild {
+            self.pendingMenuBaselineResyncs.insert(key)
+        }
         if closeHostedSubviewMenusBeforeRebuild {
             self.openMenuRebuildsClosingHostedSubviewMenus.insert(key)
         }
@@ -321,7 +322,6 @@ extension StatusItemController {
                 request: ScheduledOpenMenuRebuild(
                     provider: provider,
                     shouldCloseHostedSubviewMenus: shouldCloseHostedSubviewMenus,
-                    resyncReadinessBaselineAfterRebuild: resyncReadinessBaselineAfterRebuild,
                     beforeRebuild: beforeRebuild))
         }
     }
@@ -344,14 +344,9 @@ extension StatusItemController {
         if request.shouldCloseHostedSubviewMenus {
             self.closeHostedSubviewMenusForParentSwitch()
         }
-        self.rebuildOpenMenuIfStillVisible(
-            menu,
-            provider: request.provider,
-            resyncReadinessBaselineAfterRebuild: request.resyncReadinessBaselineAfterRebuild)
-        let shouldResyncReadinessBaseline = request.resyncReadinessBaselineAfterRebuild ||
-            self.nativeHighlightDeferredMenuBaselineResyncs.contains(key)
-        if shouldResyncReadinessBaseline, !self.menuNeedsRefresh(menu) {
-            self.nativeHighlightDeferredMenuBaselineResyncs.remove(key)
+        self.rebuildOpenMenuIfStillVisible(menu, provider: request.provider)
+        if self.pendingMenuBaselineResyncs.contains(key), !self.menuNeedsRefresh(menu) {
+            self.pendingMenuBaselineResyncs.remove(key)
             self.resyncMenuAdjunctReadinessBaseline()
         }
     }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -130,6 +130,7 @@ extension StatusItemController {
         self.openMenuRebuildTasks.removeValue(forKey: key)?.cancel()
         self.openMenuRebuildRequests.cancel(for: key)
         self.openMenuRebuildsClosingHostedSubviewMenus.remove(key)
+        self.pendingMenuBaselineResyncs.remove(key)
     }
 
     func clearMenuHighlight(_ key: ObjectIdentifier) {
@@ -137,7 +138,6 @@ extension StatusItemController {
             (highlightedView as? MenuCardHighlighting)?.setHighlighted(false)
         }
         self.nativeHighlightDeferredMenuRebuilds.remove(key)
-        self.nativeHighlightDeferredMenuBaselineResyncs.remove(key)
     }
 
     func removeMenuLifecycleState(_ key: ObjectIdentifier) {
@@ -393,26 +393,24 @@ extension StatusItemController {
             allowStaleContentDuringDataRefresh: true)
     }
 
-    func rebuildOpenMenuIfStillVisible(
-        _ menu: NSMenu,
-        provider: UsageProvider?,
-        resyncReadinessBaselineAfterRebuild: Bool = false)
-    {
+    func rebuildOpenMenuIfStillVisible(_ menu: NSMenu, provider: UsageProvider?) {
         let key = ObjectIdentifier(menu)
         guard self.openMenus[key] != nil else { return }
-        guard self.isHostedSubviewMenu(menu) || !self.hasOpenHostedSubviewMenu() else { return }
+        let isHostedSubviewMenu = self.isHostedSubviewMenu(menu)
+        guard isHostedSubviewMenu || !self.hasOpenHostedSubviewMenu() else { return }
         guard !self.isNativeMenuItemHighlighted(in: menu) else {
             self.nativeHighlightDeferredMenuRebuilds.insert(key)
-            if resyncReadinessBaselineAfterRebuild {
-                self.nativeHighlightDeferredMenuBaselineResyncs.insert(key)
-            }
             return
         }
         self.nativeHighlightDeferredMenuRebuilds.remove(key)
-        self.populateMenu(menu, provider: provider)
-        self.markMenuFresh(menu)
-        self.menuSession.clearParentRebuildDeferral(key)
-        self.applyIcon(phase: nil)
+        if isHostedSubviewMenu {
+            self.refreshHostedSubviewMenu(menu)
+        } else {
+            self.populateMenu(menu, provider: provider)
+            self.markMenuFresh(menu)
+            self.menuSession.clearParentRebuildDeferral(key)
+            self.applyIcon(phase: nil)
+        }
         #if DEBUG
         self._test_openMenuRebuildObserver?(menu)
         #endif
@@ -427,17 +425,24 @@ extension StatusItemController {
     func resumeMenuRebuildDeferredForNativeHighlightIfNeeded(_ menu: NSMenu) {
         let key = ObjectIdentifier(menu)
         guard self.nativeHighlightDeferredMenuRebuilds.contains(key) else { return }
-        guard self.openMenus[key] === menu, self.menuNeedsRefresh(menu) else {
+        guard self.openMenus[key] === menu else {
             self.nativeHighlightDeferredMenuRebuilds.remove(key)
-            self.nativeHighlightDeferredMenuBaselineResyncs.remove(key)
+            self.pendingMenuBaselineResyncs.remove(key)
             return
         }
-        guard !self.hasOpenHostedSubviewMenu() else { return }
+        let isHostedSubviewMenu = self.isHostedSubviewMenu(menu)
+        guard isHostedSubviewMenu || self.menuNeedsRefresh(menu) else {
+            self.nativeHighlightDeferredMenuRebuilds.remove(key)
+            if self.pendingMenuBaselineResyncs.remove(key) != nil {
+                self.resyncMenuAdjunctReadinessBaseline()
+            }
+            return
+        }
+        guard isHostedSubviewMenu || !self.hasOpenHostedSubviewMenu() else { return }
         self.nativeHighlightDeferredMenuRebuilds.remove(key)
         self.scheduleOpenMenuRebuildIfStillVisible(
             menu,
-            provider: self.menuProvider(for: menu),
-            resyncReadinessBaselineAfterRebuild: self.nativeHighlightDeferredMenuBaselineResyncs.contains(key))
+            provider: self.menuProvider(for: menu))
     }
 
     func refreshOpenMenusIfNeeded() {
@@ -521,7 +526,7 @@ extension StatusItemController {
         hasOpenHostedSubviewMenu: Bool)
     {
         if self.isHostedSubviewMenu(menu) {
-            self.refreshHostedSubviewMenu(menu)
+            self.scheduleOpenMenuRebuildIfStillVisible(menu, provider: self.menuProvider(for: menu))
             return
         }
         guard allowsParentRebuild else { return }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -136,6 +136,7 @@ extension StatusItemController {
         if let highlightedView = self.highlightedMenuItems.removeValue(forKey: key)?.view {
             (highlightedView as? MenuCardHighlighting)?.setHighlighted(false)
         }
+        self.nativeHighlightDeferredMenuRebuilds.remove(key)
     }
 
     func removeMenuLifecycleState(_ key: ObjectIdentifier) {
@@ -395,6 +396,11 @@ extension StatusItemController {
         let key = ObjectIdentifier(menu)
         guard self.openMenus[key] != nil else { return }
         guard self.isHostedSubviewMenu(menu) || !self.hasOpenHostedSubviewMenu() else { return }
+        guard !self.isNativeMenuItemHighlighted(in: menu) else {
+            self.nativeHighlightDeferredMenuRebuilds.insert(key)
+            return
+        }
+        self.nativeHighlightDeferredMenuRebuilds.remove(key)
         self.populateMenu(menu, provider: provider)
         self.markMenuFresh(menu)
         self.menuSession.clearParentRebuildDeferral(key)
@@ -402,6 +408,20 @@ extension StatusItemController {
         #if DEBUG
         self._test_openMenuRebuildObserver?(menu)
         #endif
+    }
+
+    func isNativeMenuItemHighlighted(in menu: NSMenu) -> Bool {
+        let key = ObjectIdentifier(menu)
+        guard let item = self.highlightedMenuItems[key], item.menu === menu else { return false }
+        return item.isEnabled && item.view == nil
+    }
+
+    func resumeMenuRebuildDeferredForNativeHighlightIfNeeded(_ menu: NSMenu) {
+        let key = ObjectIdentifier(menu)
+        guard self.nativeHighlightDeferredMenuRebuilds.remove(key) != nil else { return }
+        guard self.openMenus[key] === menu, self.menuNeedsRefresh(menu) else { return }
+        guard !self.hasOpenHostedSubviewMenu() else { return }
+        self.scheduleOpenMenuRebuildIfStillVisible(menu, provider: self.menuProvider(for: menu))
     }
 
     func refreshOpenMenusIfNeeded() {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -457,6 +457,21 @@ extension StatusItemController {
         }
         self.parentMenuRebuildPendingAfterHostedSubviewClose = false
         self.refreshOpenMenusIfNeeded(allowsParentRebuild: true)
+        self.resumeParentMenuRebuildsDeferredForNativeHighlightAfterHostedSubviewClose()
+    }
+
+    private func resumeParentMenuRebuildsDeferredForNativeHighlightAfterHostedSubviewClose() {
+        guard !self.hasOpenHostedSubviewMenu() else { return }
+        let deferredParents = self.openMenus.values.filter { menu in
+            let key = ObjectIdentifier(menu)
+            return !self.isHostedSubviewMenu(menu) &&
+                self.nativeHighlightDeferredMenuRebuilds[key] != nil
+        }
+        // Schedule the saved explicit request after the generic dirty-menu pass, even when the native
+        // highlight is still active. The scheduled rebuild will defer again, preserving its provider.
+        for menu in deferredParents {
+            self.resumeMenuRebuildDeferredForNativeHighlightIfNeeded(menu)
+        }
     }
 
     func completeParentMenuRebuildAfterHostedSubviewCloseIfNeeded() {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -137,6 +137,7 @@ extension StatusItemController {
             (highlightedView as? MenuCardHighlighting)?.setHighlighted(false)
         }
         self.nativeHighlightDeferredMenuRebuilds.remove(key)
+        self.nativeHighlightDeferredMenuBaselineResyncs.remove(key)
     }
 
     func removeMenuLifecycleState(_ key: ObjectIdentifier) {
@@ -392,12 +393,19 @@ extension StatusItemController {
             allowStaleContentDuringDataRefresh: true)
     }
 
-    func rebuildOpenMenuIfStillVisible(_ menu: NSMenu, provider: UsageProvider?) {
+    func rebuildOpenMenuIfStillVisible(
+        _ menu: NSMenu,
+        provider: UsageProvider?,
+        resyncReadinessBaselineAfterRebuild: Bool = false)
+    {
         let key = ObjectIdentifier(menu)
         guard self.openMenus[key] != nil else { return }
         guard self.isHostedSubviewMenu(menu) || !self.hasOpenHostedSubviewMenu() else { return }
         guard !self.isNativeMenuItemHighlighted(in: menu) else {
             self.nativeHighlightDeferredMenuRebuilds.insert(key)
+            if resyncReadinessBaselineAfterRebuild {
+                self.nativeHighlightDeferredMenuBaselineResyncs.insert(key)
+            }
             return
         }
         self.nativeHighlightDeferredMenuRebuilds.remove(key)
@@ -418,10 +426,18 @@ extension StatusItemController {
 
     func resumeMenuRebuildDeferredForNativeHighlightIfNeeded(_ menu: NSMenu) {
         let key = ObjectIdentifier(menu)
-        guard self.nativeHighlightDeferredMenuRebuilds.remove(key) != nil else { return }
-        guard self.openMenus[key] === menu, self.menuNeedsRefresh(menu) else { return }
+        guard self.nativeHighlightDeferredMenuRebuilds.contains(key) else { return }
+        guard self.openMenus[key] === menu, self.menuNeedsRefresh(menu) else {
+            self.nativeHighlightDeferredMenuRebuilds.remove(key)
+            self.nativeHighlightDeferredMenuBaselineResyncs.remove(key)
+            return
+        }
         guard !self.hasOpenHostedSubviewMenu() else { return }
-        self.scheduleOpenMenuRebuildIfStillVisible(menu, provider: self.menuProvider(for: menu))
+        self.nativeHighlightDeferredMenuRebuilds.remove(key)
+        self.scheduleOpenMenuRebuildIfStillVisible(
+            menu,
+            provider: self.menuProvider(for: menu),
+            resyncReadinessBaselineAfterRebuild: self.nativeHighlightDeferredMenuBaselineResyncs.contains(key))
     }
 
     func refreshOpenMenusIfNeeded() {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -137,7 +137,7 @@ extension StatusItemController {
         if let highlightedView = self.highlightedMenuItems.removeValue(forKey: key)?.view {
             (highlightedView as? MenuCardHighlighting)?.setHighlighted(false)
         }
-        self.nativeHighlightDeferredMenuRebuilds.remove(key)
+        self.nativeHighlightDeferredMenuRebuilds.removeValue(forKey: key)
     }
 
     func removeMenuLifecycleState(_ key: ObjectIdentifier) {
@@ -399,10 +399,10 @@ extension StatusItemController {
         let isHostedSubviewMenu = self.isHostedSubviewMenu(menu)
         guard isHostedSubviewMenu || !self.hasOpenHostedSubviewMenu() else { return }
         guard !self.isNativeMenuItemHighlighted(in: menu) else {
-            self.nativeHighlightDeferredMenuRebuilds.insert(key)
+            self.nativeHighlightDeferredMenuRebuilds[key] = NativeHighlightDeferredMenuRebuild(provider: provider)
             return
         }
-        self.nativeHighlightDeferredMenuRebuilds.remove(key)
+        self.nativeHighlightDeferredMenuRebuilds.removeValue(forKey: key)
         if isHostedSubviewMenu {
             self.refreshHostedSubviewMenu(menu)
         } else {
@@ -424,25 +424,18 @@ extension StatusItemController {
 
     func resumeMenuRebuildDeferredForNativeHighlightIfNeeded(_ menu: NSMenu) {
         let key = ObjectIdentifier(menu)
-        guard self.nativeHighlightDeferredMenuRebuilds.contains(key) else { return }
+        guard let deferredRebuild = self.nativeHighlightDeferredMenuRebuilds[key] else { return }
         guard self.openMenus[key] === menu else {
-            self.nativeHighlightDeferredMenuRebuilds.remove(key)
+            self.nativeHighlightDeferredMenuRebuilds.removeValue(forKey: key)
             self.pendingMenuBaselineResyncs.remove(key)
             return
         }
         let isHostedSubviewMenu = self.isHostedSubviewMenu(menu)
-        guard isHostedSubviewMenu || self.menuNeedsRefresh(menu) else {
-            self.nativeHighlightDeferredMenuRebuilds.remove(key)
-            if self.pendingMenuBaselineResyncs.remove(key) != nil {
-                self.resyncMenuAdjunctReadinessBaseline()
-            }
-            return
-        }
         guard isHostedSubviewMenu || !self.hasOpenHostedSubviewMenu() else { return }
-        self.nativeHighlightDeferredMenuRebuilds.remove(key)
+        self.nativeHighlightDeferredMenuRebuilds.removeValue(forKey: key)
         self.scheduleOpenMenuRebuildIfStillVisible(
             menu,
-            provider: self.menuProvider(for: menu))
+            provider: deferredRebuild.provider)
     }
 
     func refreshOpenMenusIfNeeded() {

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -81,7 +81,7 @@ extension StatusItemController {
         self.openMenus.removeAll(keepingCapacity: false)
         self.highlightedMenuItems.removeAll(keepingCapacity: false)
         self.nativeHighlightDeferredMenuRebuilds.removeAll(keepingCapacity: false)
-        self.nativeHighlightDeferredMenuBaselineResyncs.removeAll(keepingCapacity: false)
+        self.pendingMenuBaselineResyncs.removeAll(keepingCapacity: false)
         self.menuCardHeightCache.removeAll(keepingCapacity: false)
         self.measuredStandardMenuWidthCache.removeAll(keepingCapacity: false)
         self.mergedSwitcherContentCaches.removeAll(keepingCapacity: false)

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -81,6 +81,7 @@ extension StatusItemController {
         self.openMenus.removeAll(keepingCapacity: false)
         self.highlightedMenuItems.removeAll(keepingCapacity: false)
         self.nativeHighlightDeferredMenuRebuilds.removeAll(keepingCapacity: false)
+        self.nativeHighlightDeferredMenuBaselineResyncs.removeAll(keepingCapacity: false)
         self.menuCardHeightCache.removeAll(keepingCapacity: false)
         self.measuredStandardMenuWidthCache.removeAll(keepingCapacity: false)
         self.mergedSwitcherContentCaches.removeAll(keepingCapacity: false)

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -80,6 +80,7 @@ extension StatusItemController {
         self.menuSession.clearMenuTracking()
         self.openMenus.removeAll(keepingCapacity: false)
         self.highlightedMenuItems.removeAll(keepingCapacity: false)
+        self.nativeHighlightDeferredMenuRebuilds.removeAll(keepingCapacity: false)
         self.menuCardHeightCache.removeAll(keepingCapacity: false)
         self.measuredStandardMenuWidthCache.removeAll(keepingCapacity: false)
         self.mergedSwitcherContentCaches.removeAll(keepingCapacity: false)

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -33,6 +33,10 @@ extension StatusItemControlling {
     func prepareForAppShutdown() {}
 }
 
+struct NativeHighlightDeferredMenuRebuild {
+    let provider: UsageProvider?
+}
+
 @MainActor
 final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControlling {
     // Disable SwiftUI menu cards + menu refresh work in tests to avoid swiftpm-testing-helper crashes.
@@ -169,7 +173,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var deferredMenuInteractionRefreshTask: Task<Void, Never>?
     var highlightedMenuItems: [ObjectIdentifier: NSMenuItem] = [:]
     /// Open-menu rebuilds paused so AppKit's native selection background cannot retain stale geometry.
-    var nativeHighlightDeferredMenuRebuilds: Set<ObjectIdentifier> = []
+    var nativeHighlightDeferredMenuRebuilds: [ObjectIdentifier: NativeHighlightDeferredMenuRebuild] = [:]
     /// Baseline resync intent survives rebuild coalescing and any native-row or hosted-submenu deferral.
     var pendingMenuBaselineResyncs: Set<ObjectIdentifier> = []
     var providerSwitcherShortcutEventMonitor: ProviderSwitcherShortcutEventMonitor?

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -170,6 +170,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var highlightedMenuItems: [ObjectIdentifier: NSMenuItem] = [:]
     /// Open-menu rebuilds paused so AppKit's native selection background cannot retain stale geometry.
     var nativeHighlightDeferredMenuRebuilds: Set<ObjectIdentifier> = []
+    var nativeHighlightDeferredMenuBaselineResyncs: Set<ObjectIdentifier> = []
     var providerSwitcherShortcutEventMonitor: ProviderSwitcherShortcutEventMonitor?
     var providerSwitcherShortcutMenuID: ObjectIdentifier?
     var providerSwitcherPointerInteractionMenuID: ObjectIdentifier?

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -168,6 +168,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var deferredOpenAIDashboardRefreshReason: String?
     var deferredMenuInteractionRefreshTask: Task<Void, Never>?
     var highlightedMenuItems: [ObjectIdentifier: NSMenuItem] = [:]
+    /// Open-menu rebuilds paused so AppKit's native selection background cannot retain stale geometry.
+    var nativeHighlightDeferredMenuRebuilds: Set<ObjectIdentifier> = []
     var providerSwitcherShortcutEventMonitor: ProviderSwitcherShortcutEventMonitor?
     var providerSwitcherShortcutMenuID: ObjectIdentifier?
     var providerSwitcherPointerInteractionMenuID: ObjectIdentifier?

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -170,7 +170,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var highlightedMenuItems: [ObjectIdentifier: NSMenuItem] = [:]
     /// Open-menu rebuilds paused so AppKit's native selection background cannot retain stale geometry.
     var nativeHighlightDeferredMenuRebuilds: Set<ObjectIdentifier> = []
-    var nativeHighlightDeferredMenuBaselineResyncs: Set<ObjectIdentifier> = []
+    /// Baseline resync intent survives rebuild coalescing and any native-row or hosted-submenu deferral.
+    var pendingMenuBaselineResyncs: Set<ObjectIdentifier> = []
     var providerSwitcherShortcutEventMonitor: ProviderSwitcherShortcutEventMonitor?
     var providerSwitcherShortcutMenuID: ObjectIdentifier?
     var providerSwitcherPointerInteractionMenuID: ObjectIdentifier?

--- a/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
@@ -43,6 +43,8 @@ struct StatusItemControllerShutdownTests {
         controller.menuRefreshTasks[key] = Task { try? await Task.sleep(for: .seconds(30)) }
         controller.menuReadinessSignatures[key] = "readiness"
         controller.menuIdentitySignatures[key] = "identity"
+        controller.nativeHighlightDeferredMenuRebuilds.insert(key)
+        controller.pendingMenuBaselineResyncs.insert(key)
 
         #expect(controller.openMenus[key] === menu)
         #expect(controller.mergedMenu != nil)
@@ -56,6 +58,8 @@ struct StatusItemControllerShutdownTests {
         #expect(controller.menuRefreshTasks.isEmpty)
         #expect(controller.menuReadinessSignatures.isEmpty)
         #expect(controller.menuIdentitySignatures.isEmpty)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds.isEmpty)
+        #expect(controller.pendingMenuBaselineResyncs.isEmpty)
         #expect(controller.providerSwitcherShortcutEventMonitor == nil)
         #expect(controller.statusItem.menu == nil)
         #expect(controller.statusItems.isEmpty)

--- a/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
@@ -43,7 +43,7 @@ struct StatusItemControllerShutdownTests {
         controller.menuRefreshTasks[key] = Task { try? await Task.sleep(for: .seconds(30)) }
         controller.menuReadinessSignatures[key] = "readiness"
         controller.menuIdentitySignatures[key] = "identity"
-        controller.nativeHighlightDeferredMenuRebuilds.insert(key)
+        controller.nativeHighlightDeferredMenuRebuilds[key] = .init(provider: .codex)
         controller.pendingMenuBaselineResyncs.insert(key)
 
         #expect(controller.openMenus[key] === menu)

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -148,7 +148,7 @@ struct StatusItemControllerSplitLifecycleTests {
             _ = controller.openMenuRebuildRequests.replaceRequest(for: key)
             controller.openMenuRebuildsClosingHostedSubviewMenus.insert(key)
             controller.highlightedMenuItems[key] = NSMenuItem(title: "Highlighted", action: nil, keyEquivalent: "")
-            controller.nativeHighlightDeferredMenuRebuilds.insert(key)
+            controller.nativeHighlightDeferredMenuRebuilds[key] = .init(provider: .codex)
             controller.pendingMenuBaselineResyncs.insert(key)
         }
 
@@ -170,7 +170,7 @@ struct StatusItemControllerSplitLifecycleTests {
             #expect(controller.openMenuRebuildRequests.tokens[key] == nil)
             #expect(!controller.openMenuRebuildsClosingHostedSubviewMenus.contains(key))
             #expect(controller.highlightedMenuItems[key] == nil)
-            #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+            #expect(controller.nativeHighlightDeferredMenuRebuilds[key] == nil)
             #expect(!controller.pendingMenuBaselineResyncs.contains(key))
         }
     }

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -149,6 +149,7 @@ struct StatusItemControllerSplitLifecycleTests {
             controller.openMenuRebuildsClosingHostedSubviewMenus.insert(key)
             controller.highlightedMenuItems[key] = NSMenuItem(title: "Highlighted", action: nil, keyEquivalent: "")
             controller.nativeHighlightDeferredMenuRebuilds.insert(key)
+            controller.nativeHighlightDeferredMenuBaselineResyncs.insert(key)
         }
 
         settings.mergeIcons = true
@@ -170,6 +171,7 @@ struct StatusItemControllerSplitLifecycleTests {
             #expect(!controller.openMenuRebuildsClosingHostedSubviewMenus.contains(key))
             #expect(controller.highlightedMenuItems[key] == nil)
             #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+            #expect(!controller.nativeHighlightDeferredMenuBaselineResyncs.contains(key))
         }
     }
 

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -149,7 +149,7 @@ struct StatusItemControllerSplitLifecycleTests {
             controller.openMenuRebuildsClosingHostedSubviewMenus.insert(key)
             controller.highlightedMenuItems[key] = NSMenuItem(title: "Highlighted", action: nil, keyEquivalent: "")
             controller.nativeHighlightDeferredMenuRebuilds.insert(key)
-            controller.nativeHighlightDeferredMenuBaselineResyncs.insert(key)
+            controller.pendingMenuBaselineResyncs.insert(key)
         }
 
         settings.mergeIcons = true
@@ -171,7 +171,7 @@ struct StatusItemControllerSplitLifecycleTests {
             #expect(!controller.openMenuRebuildsClosingHostedSubviewMenus.contains(key))
             #expect(controller.highlightedMenuItems[key] == nil)
             #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
-            #expect(!controller.nativeHighlightDeferredMenuBaselineResyncs.contains(key))
+            #expect(!controller.pendingMenuBaselineResyncs.contains(key))
         }
     }
 

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -148,6 +148,7 @@ struct StatusItemControllerSplitLifecycleTests {
             _ = controller.openMenuRebuildRequests.replaceRequest(for: key)
             controller.openMenuRebuildsClosingHostedSubviewMenus.insert(key)
             controller.highlightedMenuItems[key] = NSMenuItem(title: "Highlighted", action: nil, keyEquivalent: "")
+            controller.nativeHighlightDeferredMenuRebuilds.insert(key)
         }
 
         settings.mergeIcons = true
@@ -168,6 +169,7 @@ struct StatusItemControllerSplitLifecycleTests {
             #expect(controller.openMenuRebuildRequests.tokens[key] == nil)
             #expect(!controller.openMenuRebuildsClosingHostedSubviewMenus.contains(key))
             #expect(controller.highlightedMenuItems[key] == nil)
+            #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
         }
     }
 

--- a/Tests/CodexBarTests/StatusMenuHighlightTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHighlightTests.swift
@@ -54,7 +54,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `native highlight defers open menu rebuild until pointer leaves native rows`() async {
+    func `native highlight preserves coalesced baseline resync until pointer leaves native rows`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -96,13 +96,14 @@ extension StatusMenuTests {
             menu,
             provider: .codex,
             resyncReadinessBaselineAfterRebuild: true)
+        controller.scheduleOpenMenuRebuildIfStillVisible(menu, provider: .codex)
         for _ in 0..<20 where !controller.nativeHighlightDeferredMenuRebuilds.contains(key) {
             await Task.yield()
         }
 
         #expect(rebuildCount == 0)
         #expect(controller.nativeHighlightDeferredMenuRebuilds.contains(key))
-        #expect(controller.nativeHighlightDeferredMenuBaselineResyncs.contains(key))
+        #expect(controller.pendingMenuBaselineResyncs.contains(key))
         #expect(controller.menuNeedsRefresh(menu))
 
         controller.menu(menu, willHighlight: cost)
@@ -119,9 +120,192 @@ extension StatusMenuTests {
 
         #expect(rebuildCount == 1)
         #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
-        #expect(!controller.nativeHighlightDeferredMenuBaselineResyncs.contains(key))
+        #expect(!controller.pendingMenuBaselineResyncs.contains(key))
         #expect(!controller.menuNeedsRefresh(menu))
         #expect(controller.lastMenuAdjunctReadinessSignature == controller.menuAdjunctReadinessSignature())
+    }
+
+    @Test
+    func `hosted submenu close preserves pending parent baseline resync`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let parent = controller.makeMenu()
+        controller.populateMenu(parent, provider: .codex)
+        controller.markMenuFresh(parent)
+        let parentKey = ObjectIdentifier(parent)
+        controller.openMenus[parentKey] = parent
+        defer { controller.menuDidClose(parent) }
+
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.costHistoryChartID,
+            provider: .codex)
+        let submenuKey = ObjectIdentifier(submenu)
+        controller.openMenus[submenuKey] = submenu
+
+        controller.lastMenuAdjunctReadinessSignature = "stale-baseline"
+        controller.menuSession.invalidate(allowsStaleContent: false, requiresRebuild: true)
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { menu in
+            if menu === parent { rebuildCount += 1 }
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        controller.scheduleOpenMenuRebuildIfStillVisible(
+            parent,
+            provider: .codex,
+            resyncReadinessBaselineAfterRebuild: true)
+        for _ in 0..<20 where controller.openMenuRebuildTasks[parentKey] != nil {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 0)
+        #expect(controller.pendingMenuBaselineResyncs.contains(parentKey))
+        #expect(controller.menuNeedsRefresh(parent))
+
+        controller.menuDidClose(submenu)
+        for _ in 0..<40 where rebuildCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus[submenuKey] == nil)
+        #expect(rebuildCount == 1)
+        #expect(!controller.pendingMenuBaselineResyncs.contains(parentKey))
+        #expect(!controller.menuNeedsRefresh(parent))
+        #expect(controller.lastMenuAdjunctReadinessSignature == controller.menuAdjunctReadinessSignature())
+    }
+
+    @Test
+    func `menu close clears native highlight deferral and pending baseline resync`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        let key = ObjectIdentifier(menu)
+        controller.openMenus[key] = menu
+        let nativeItem = NSMenuItem(title: "Settings", action: nil, keyEquivalent: "")
+        nativeItem.isEnabled = true
+        menu.addItem(nativeItem)
+        controller.menu(menu, willHighlight: nativeItem)
+        controller.menuSession.invalidate(allowsStaleContent: false, requiresRebuild: true)
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in rebuildCount += 1 }
+        defer { controller._test_openMenuRebuildObserver = nil }
+        controller.scheduleOpenMenuRebuildIfStillVisible(
+            menu,
+            provider: .codex,
+            resyncReadinessBaselineAfterRebuild: true)
+        for _ in 0..<20 where !controller.nativeHighlightDeferredMenuRebuilds.contains(key) {
+            await Task.yield()
+        }
+
+        #expect(controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.pendingMenuBaselineResyncs.contains(key))
+        controller.menuDidClose(menu)
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 0)
+        #expect(controller.openMenus[key] == nil)
+        #expect(controller.highlightedMenuItems[key] == nil)
+        #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(!controller.pendingMenuBaselineResyncs.contains(key))
+        #expect(controller.openMenuRebuildTasks[key] == nil)
+        #expect(controller.openMenuRebuildRequests.tokens[key] == nil)
+    }
+
+    @Test
+    func `hosted native highlight defers signature changing refresh until pointer leaves`() async throws {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = true
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let submenu = NSMenu()
+        #expect(controller.appendStatusComponentsItem(
+            to: submenu,
+            provider: .codex,
+            width: StatusItemController.menuCardBaseWidth))
+        let key = ObjectIdentifier(submenu)
+        controller.openMenus[key] = submenu
+        defer { controller.menuDidClose(submenu) }
+        let originalLink = try #require(submenu.items.last)
+        #expect(originalLink.title == L("Open Status Page"))
+        #expect(originalLink.view == nil)
+        #expect(originalLink.isEnabled)
+        controller.menu(submenu, willHighlight: originalLink)
+
+        store.statusComponents[.codex] = [
+            ProviderStatusComponent(
+                id: "api",
+                name: "API",
+                indicator: .none,
+                status: "operational"),
+        ]
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { menu in
+            if menu === submenu { rebuildCount += 1 }
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        controller.refreshOpenMenusAllowingParentRebuild()
+        for _ in 0..<20 where !controller.nativeHighlightDeferredMenuRebuilds.contains(key) {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 0)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(submenu.items.count == 1)
+        #expect(submenu.items.first === originalLink)
+
+        controller.menu(submenu, willHighlight: nil)
+        for _ in 0..<20 where rebuildCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 1)
+        #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(submenu.items.count == 3)
+        #expect(submenu.items.last !== originalLink)
+        #expect(submenu.items.last?.title == L("Open Status Page"))
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuHighlightTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHighlightTests.swift
@@ -97,12 +97,12 @@ extension StatusMenuTests {
             provider: .codex,
             resyncReadinessBaselineAfterRebuild: true)
         controller.scheduleOpenMenuRebuildIfStillVisible(menu, provider: .codex)
-        for _ in 0..<20 where !controller.nativeHighlightDeferredMenuRebuilds.contains(key) {
+        for _ in 0..<20 where controller.nativeHighlightDeferredMenuRebuilds[key] == nil {
             await Task.yield()
         }
 
         #expect(rebuildCount == 0)
-        #expect(controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[key] != nil)
         #expect(controller.pendingMenuBaselineResyncs.contains(key))
         #expect(controller.menuNeedsRefresh(menu))
 
@@ -111,7 +111,7 @@ extension StatusMenuTests {
             await Task.yield()
         }
         #expect(rebuildCount == 0)
-        #expect(controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[key] != nil)
 
         controller.menu(menu, willHighlight: nil)
         for _ in 0..<20 where rebuildCount == 0 {
@@ -119,10 +119,62 @@ extension StatusMenuTests {
         }
 
         #expect(rebuildCount == 1)
-        #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[key] == nil)
         #expect(!controller.pendingMenuBaselineResyncs.contains(key))
         #expect(!controller.menuNeedsRefresh(menu))
         #expect(controller.lastMenuAdjunctReadinessSignature == controller.menuAdjunctReadinessSignature())
+    }
+
+    @Test
+    func `native highlight preserves explicit rebuild even when menu is already fresh`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        controller.openMenus[key] = menu
+        defer { controller.menuDidClose(menu) }
+
+        let nativeItem = NSMenuItem(title: "Plan Usage", action: nil, keyEquivalent: "")
+        nativeItem.isEnabled = true
+        menu.addItem(nativeItem)
+        controller.menu(menu, willHighlight: nativeItem)
+        #expect(!controller.menuNeedsRefresh(menu))
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in rebuildCount += 1 }
+        defer { controller._test_openMenuRebuildObserver = nil }
+        controller.scheduleOpenMenuRebuildIfStillVisible(menu, provider: .claude)
+        for _ in 0..<20 where controller.nativeHighlightDeferredMenuRebuilds[key] == nil {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 0)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[key]?.provider == .claude)
+        #expect(!controller.menuNeedsRefresh(menu))
+
+        controller.menu(menu, willHighlight: nil)
+        for _ in 0..<20 where rebuildCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 1)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[key] == nil)
+        #expect(!controller.menuNeedsRefresh(menu))
     }
 
     @Test
@@ -221,11 +273,11 @@ extension StatusMenuTests {
             menu,
             provider: .codex,
             resyncReadinessBaselineAfterRebuild: true)
-        for _ in 0..<20 where !controller.nativeHighlightDeferredMenuRebuilds.contains(key) {
+        for _ in 0..<20 where controller.nativeHighlightDeferredMenuRebuilds[key] == nil {
             await Task.yield()
         }
 
-        #expect(controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[key] != nil)
         #expect(controller.pendingMenuBaselineResyncs.contains(key))
         controller.menuDidClose(menu)
         for _ in 0..<10 {
@@ -235,7 +287,7 @@ extension StatusMenuTests {
         #expect(rebuildCount == 0)
         #expect(controller.openMenus[key] == nil)
         #expect(controller.highlightedMenuItems[key] == nil)
-        #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[key] == nil)
         #expect(!controller.pendingMenuBaselineResyncs.contains(key))
         #expect(controller.openMenuRebuildTasks[key] == nil)
         #expect(controller.openMenuRebuildRequests.tokens[key] == nil)
@@ -287,12 +339,12 @@ extension StatusMenuTests {
         defer { controller._test_openMenuRebuildObserver = nil }
 
         controller.refreshOpenMenusAllowingParentRebuild()
-        for _ in 0..<20 where !controller.nativeHighlightDeferredMenuRebuilds.contains(key) {
+        for _ in 0..<20 where controller.nativeHighlightDeferredMenuRebuilds[key] == nil {
             await Task.yield()
         }
 
         #expect(rebuildCount == 0)
-        #expect(controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[key] != nil)
         #expect(submenu.items.count == 1)
         #expect(submenu.items.first === originalLink)
 
@@ -302,7 +354,7 @@ extension StatusMenuTests {
         }
 
         #expect(rebuildCount == 1)
-        #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[key] == nil)
         #expect(submenu.items.count == 3)
         #expect(submenu.items.last !== originalLink)
         #expect(submenu.items.last?.title == L("Open Status Page"))
@@ -344,7 +396,7 @@ extension StatusMenuTests {
         controller.rebuildOpenMenuIfStillVisible(menu, provider: .codex)
 
         #expect(rebuildCount == 1)
-        #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[key] == nil)
         #expect(!controller.menuNeedsRefresh(menu))
     }
 }

--- a/Tests/CodexBarTests/StatusMenuHighlightTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHighlightTests.swift
@@ -52,4 +52,105 @@ extension StatusMenuTests {
         #expect(secondView.states == [true])
         #expect(thirdView.states.isEmpty)
     }
+
+    @Test
+    func `native highlight defers open menu rebuild until pointer leaves native rows`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+        let key = ObjectIdentifier(menu)
+        controller.cancelMenuWork(key)
+        controller.openMenus[key] = menu
+        let planUsage = NSMenuItem(title: "Plan Usage", action: nil, keyEquivalent: "")
+        planUsage.isEnabled = true
+        let cost = NSMenuItem(title: "Cost", action: nil, keyEquivalent: "")
+        cost.isEnabled = true
+        menu.addItem(planUsage)
+        menu.addItem(cost)
+
+        controller.menu(menu, willHighlight: planUsage)
+        #expect(controller.highlightedMenuItems[key] === planUsage)
+        #expect(controller.isNativeMenuItemHighlighted(in: menu))
+        controller.menuSession.invalidate(allowsStaleContent: false, requiresRebuild: true)
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in rebuildCount += 1 }
+        defer { controller._test_openMenuRebuildObserver = nil }
+        controller.rebuildOpenMenuIfStillVisible(menu, provider: .codex)
+
+        #expect(rebuildCount == 0)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.menuNeedsRefresh(menu))
+
+        controller.menu(menu, willHighlight: cost)
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+        #expect(rebuildCount == 0)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+
+        controller.menu(menu, willHighlight: nil)
+        for _ in 0..<20 where rebuildCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 1)
+        #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(!controller.menuNeedsRefresh(menu))
+    }
+
+    @Test
+    func `custom highlight does not defer open menu rebuild`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+        let key = ObjectIdentifier(menu)
+        controller.cancelMenuWork(key)
+        controller.openMenus[key] = menu
+        let customItem = NSMenuItem()
+        customItem.view = HighlightProbeView()
+        customItem.isEnabled = true
+        menu.addItem(customItem)
+        controller.menu(menu, willHighlight: customItem)
+        controller.menuSession.invalidate(allowsStaleContent: false, requiresRebuild: true)
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in rebuildCount += 1 }
+        defer { controller._test_openMenuRebuildObserver = nil }
+        controller.rebuildOpenMenuIfStillVisible(menu, provider: .codex)
+
+        #expect(rebuildCount == 1)
+        #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(!controller.menuNeedsRefresh(menu))
+    }
 }

--- a/Tests/CodexBarTests/StatusMenuHighlightTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHighlightTests.swift
@@ -86,15 +86,23 @@ extension StatusMenuTests {
         controller.menu(menu, willHighlight: planUsage)
         #expect(controller.highlightedMenuItems[key] === planUsage)
         #expect(controller.isNativeMenuItemHighlighted(in: menu))
+        controller.lastMenuAdjunctReadinessSignature = "stale-baseline"
         controller.menuSession.invalidate(allowsStaleContent: false, requiresRebuild: true)
 
         var rebuildCount = 0
         controller._test_openMenuRebuildObserver = { _ in rebuildCount += 1 }
         defer { controller._test_openMenuRebuildObserver = nil }
-        controller.rebuildOpenMenuIfStillVisible(menu, provider: .codex)
+        controller.scheduleOpenMenuRebuildIfStillVisible(
+            menu,
+            provider: .codex,
+            resyncReadinessBaselineAfterRebuild: true)
+        for _ in 0..<20 where !controller.nativeHighlightDeferredMenuRebuilds.contains(key) {
+            await Task.yield()
+        }
 
         #expect(rebuildCount == 0)
         #expect(controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(controller.nativeHighlightDeferredMenuBaselineResyncs.contains(key))
         #expect(controller.menuNeedsRefresh(menu))
 
         controller.menu(menu, willHighlight: cost)
@@ -111,7 +119,9 @@ extension StatusMenuTests {
 
         #expect(rebuildCount == 1)
         #expect(!controller.nativeHighlightDeferredMenuRebuilds.contains(key))
+        #expect(!controller.nativeHighlightDeferredMenuBaselineResyncs.contains(key))
         #expect(!controller.menuNeedsRefresh(menu))
+        #expect(controller.lastMenuAdjunctReadinessSignature == controller.menuAdjunctReadinessSignature())
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuHighlightTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHighlightTests.swift
@@ -178,6 +178,145 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `hosted submenu close resumes deferred explicit rebuild on fresh parent`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let parent = controller.makeMenu()
+        controller.populateMenu(parent, provider: .codex)
+        controller.markMenuFresh(parent)
+        let parentKey = ObjectIdentifier(parent)
+        controller.openMenus[parentKey] = parent
+        defer { controller.menuDidClose(parent) }
+
+        let nativeItem = NSMenuItem(title: "Plan Usage", action: nil, keyEquivalent: "")
+        nativeItem.isEnabled = true
+        parent.addItem(nativeItem)
+        controller.menu(parent, willHighlight: nativeItem)
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { menu in
+            if menu === parent {
+                rebuildCount += 1
+            }
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+        controller.scheduleOpenMenuRebuildIfStillVisible(parent, provider: .claude)
+        for _ in 0..<20 where controller.nativeHighlightDeferredMenuRebuilds[parentKey] == nil {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 0)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[parentKey]?.provider == .claude)
+        #expect(!controller.menuNeedsRefresh(parent))
+
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.costHistoryChartID,
+            provider: .codex)
+        let submenuKey = ObjectIdentifier(submenu)
+        controller.openMenus[submenuKey] = submenu
+        controller.menu(parent, willHighlight: nil)
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 0)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[parentKey]?.provider == .claude)
+        #expect(!controller.menuNeedsRefresh(parent))
+
+        controller.menuDidClose(submenu)
+        for _ in 0..<40 where rebuildCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus[submenuKey] == nil)
+        #expect(rebuildCount == 1)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[parentKey] == nil)
+        #expect(!controller.menuNeedsRefresh(parent))
+    }
+
+    @Test
+    func `hosted submenu close keeps explicit rebuild ahead of dirty parent refresh`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let parent = controller.makeMenu()
+        controller.populateMenu(parent, provider: .codex)
+        controller.markMenuFresh(parent)
+        let parentKey = ObjectIdentifier(parent)
+        controller.openMenus[parentKey] = parent
+        defer { controller.menuDidClose(parent) }
+
+        let nativeItem = NSMenuItem(title: "Plan Usage", action: nil, keyEquivalent: "")
+        nativeItem.isEnabled = true
+        parent.addItem(nativeItem)
+        controller.menu(parent, willHighlight: nativeItem)
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { menu in
+            if menu === parent {
+                rebuildCount += 1
+            }
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+        controller.scheduleOpenMenuRebuildIfStillVisible(parent, provider: .claude)
+        for _ in 0..<20 where controller.nativeHighlightDeferredMenuRebuilds[parentKey] == nil {
+            await Task.yield()
+        }
+
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.costHistoryChartID,
+            provider: .codex)
+        controller.openMenus[ObjectIdentifier(submenu)] = submenu
+        controller.menuSession.invalidate(allowsStaleContent: false, requiresRebuild: true)
+        #expect(controller.menuNeedsRefresh(parent))
+
+        controller.menuDidClose(submenu)
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 0)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[parentKey]?.provider == .claude)
+        #expect(controller.menuNeedsRefresh(parent))
+
+        controller.menu(parent, willHighlight: nil)
+        for _ in 0..<40 where rebuildCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 1)
+        #expect(controller.nativeHighlightDeferredMenuRebuilds[parentKey] == nil)
+        #expect(!controller.menuNeedsRefresh(parent))
+    }
+
+    @Test
     func `hosted submenu close preserves pending parent baseline resync`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
@@ -212,7 +351,9 @@ extension StatusMenuTests {
         controller.menuSession.invalidate(allowsStaleContent: false, requiresRebuild: true)
         var rebuildCount = 0
         controller._test_openMenuRebuildObserver = { menu in
-            if menu === parent { rebuildCount += 1 }
+            if menu === parent {
+                rebuildCount += 1
+            }
         }
         defer { controller._test_openMenuRebuildObserver = nil }
 
@@ -334,7 +475,9 @@ extension StatusMenuTests {
         ]
         var rebuildCount = 0
         controller._test_openMenuRebuildObserver = { menu in
-            if menu === submenu { rebuildCount += 1 }
+            if menu === submenu {
+                rebuildCount += 1
+            }
         }
         defer { controller._test_openMenuRebuildObserver = nil }
 


### PR DESCRIPTION
## Summary

- Defer geometry-changing root and hosted-submenu rebuilds while AppKit is highlighting a native row.
- Preserve the exact provider request and sticky readiness-baseline resync across scheduler replacement, native-highlight deferral, and an open hosted child.
- Keep that saved explicit provider authoritative when a dirty parent resumes after its hosted child closes.
- Resume one coalesced rebuild when the pointer leaves native rows; discard it cleanly when tracking closes.
- Add focused lifecycle, coalescing, fresh-menu, and hosted Status Page regressions.

## Problem

When usage or status content refreshed while hovering native rows such as Plan Usage, Cost, or Open Status Page, AppKit could keep drawing the selection background using the old row geometry while the menu was rebuilt underneath it. This occasionally left the blue hover highlight over a different part of the menu.

## Fix

Track the complete deferred rebuild request per open menu. Rebuild requests keep fetching and updating provider state, but any geometry-changing root or hosted-submenu mutation waits while a native item is highlighted. Coalesced requests retain readiness-baseline resync intent, and lifecycle cleanup removes deferred work when the menu closes.

## Impact

Only visible menu layout mutation is briefly deferred while the pointer remains over a native row. Provider fetching, status items, widgets, and background updates continue normally.

## Verification

Exact candidate: `94ccb89a96f426444e76d79d790c674ea1a9df7b`

- Focused menu/lifecycle coverage: 187/187 tests across 3 suites passed, including both hosted-child close orders and the dirty-parent provider-precedence race.
- `make check`: passed.
- `make test`: 598/598 selections, 50/50 groups, zero failures, retries, or timeouts.
- Full-branch review plus final two-file autoreview: clean.
- Current `main` integration: clean merge tree after #2039.
- Hosted CI/security: exact-head run `29115867481` passed changes, lint, Linux arm64/x64, both macOS shards, aggregate, and GitGuardian checks.

Package verification used a Developer ID-signed normal exact-commit bundle. The controlled UI mutation used a separate strict-valid exact debug bundle with debug-only `get-task-allow`. Runtime used isolated home/config state, denied network and provider subprocess execution, and enabled both Keychain gates. A file-gated in-memory fixture recorded the real AppKit highlight state before mutation:

- Root: `Plan Usage` was a native highlighted row; root rebuild count stayed flat while highlighted, then increased exactly once after the pointer left. The menu stayed open with stable row geometry.
- Hosted Status Page submenu: `Open Status Page` was a native highlighted row; the API-only submenu remained unchanged while highlighted, then rebuilt exactly once after pointer exit and showed the added Dashboard row.
- Close while deferred: no late rebuild fired; reopening populated the new layout through the normal open path.
- Hosted-child provider race: the child closed with the dirty parent still natively highlighted and an explicit Claude rebuild saved. The callback re-deferred Claude while highlighted; after pointer exit exactly one rebuild ran, cleared the deferred state, marked the parent fresh, and visibly replaced the Codex placeholder with Claude actions. The generic Codex request never ran.

Local screenshots were retained as QA artifacts and were not uploaded.

## Screenshot before

<img width="310" height="341" alt="Screenshot 2026-07-09 at 22 44 33" src="https://github.com/user-attachments/assets/39bca214-87f9-47a3-8cb7-f360ccd949b2" />
