### PR TITLE
Fix explicit-year Claude reset parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Token costs: coalesce bounded pricing-catalog refreshes when a newly observed model is still unpriced, preserving its exact usage until pricing arrives. Thanks @iam-brain!
 - Cost history: keep model breakdown menus steady while hovering, preserve compact rows, and make overflowing histories scrollable. Thanks @iam-brain!
 - Ollama: validate API keys against an authenticated endpoint instead of the public model catalog while preserving refresh cancellation. Thanks @joeVenner!
+- Claude CLI: recognize explicit-year reset timestamps while preserving their stated year and exact local DST occurrence, keeping countdowns, pace, and reset scheduling available.
 - Claude CLI: resolve yearless and time-only reset timestamps against their quota window and exact calendar occurrence, keeping recently stale resets current without moving future, leap-day, or repeated-hour resets into the past. Thanks @fanwenlin!
 - Catalan: complete current strings, align instructional voice, and enforce catalog parity. Thanks @pmontp19!
 - Kimi K2: report missing, blank, or rejected API keys clearly and trim surrounding whitespace before requests. Thanks @joeVenner!

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -821,7 +821,8 @@ extension ClaudeStatusProbe {
         return cleaned
     }
 
-    /// Parses a Claude reset string as its next calendar occurrence in any explicit timezone.
+    /// Parses explicit-year resets at their stated occurrence; recurring forms resolve forward in any explicit
+    /// timezone.
     public static func parseResetDate(from text: String?, now: Date = .init()) -> Date? {
         self.parseResetDate(from: text, now: now, expectedWindow: nil)
     }
@@ -843,6 +844,12 @@ extension ClaudeStatusProbe {
         // Parse yearless Feb 29 independently of the current year, then resolve validated calendar occurrences.
         formatter.defaultDate = calendar.date(from: DateComponents(year: 2000, month: 1, day: 1))
 
+        if let date = self.parseDate(raw, formats: Self.resetDateTimeWithExplicitYear, formatter: formatter) {
+            return self.resolveOccurrence(
+                self.explicitOccurrences(for: date, calendar: calendar),
+                now: now,
+                expectedWindow: expectedWindow)
+        }
         if let date = self.parseDate(raw, formats: Self.resetDateTimeWithMinutes, formatter: formatter) {
             let comps = calendar.dateComponents([.month, .day, .hour, .minute], from: date)
             return self.resolveOccurrence(
@@ -872,6 +879,26 @@ extension ClaudeStatusProbe {
             self.dailyOccurrences(for: comps, now: now, calendar: calendar),
             now: now,
             expectedWindow: expectedWindow)
+    }
+
+    private static func explicitOccurrences(for date: Date, calendar: Calendar) -> [Date] {
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+        guard let year = components.year,
+              let month = components.month,
+              let day = components.day,
+              let hour = components.hour,
+              let minute = components.minute
+        else { return [] }
+        return self.exactLocalOccurrences(
+            DateComponents(
+                timeZone: calendar.timeZone,
+                year: year,
+                month: month,
+                day: day,
+                hour: hour,
+                minute: minute,
+                second: 0),
+            calendar: calendar)
     }
 
     private static func resolveOccurrence(
@@ -992,6 +1019,27 @@ extension ClaudeStatusProbe {
 
     private static let resetTimeWithMinutes = ["h:mma", "h:mm a", "HH:mm", "H:mm"]
     private static let resetTimeHourOnly = ["ha", "h a"]
+
+    private static let resetDateTimeWithExplicitYear = [
+        "MMM d, yyyy, h:mma",
+        "MMM d, yyyy, h:mm a",
+        "MMM d, yyyy, HH:mm",
+        "MMM d, yyyy h:mma",
+        "MMM d, yyyy h:mm a",
+        "MMM d, yyyy HH:mm",
+        "MMM d yyyy h:mma",
+        "MMM d yyyy h:mm a",
+        "MMM d yyyy HH:mm",
+        "MMM d, yyyy, ha",
+        "MMM d, yyyy, h a",
+        "MMM d, yyyy, HH",
+        "MMM d, yyyy ha",
+        "MMM d, yyyy h a",
+        "MMM d, yyyy HH",
+        "MMM d yyyy ha",
+        "MMM d yyyy h a",
+        "MMM d yyyy HH",
+    ]
 
     private static let resetDateTimeWithMinutes = [
         "MMM d, h:mma",

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -712,11 +712,15 @@ extension ClaudeUsageFetcher {
     // MARK: - Parsing helpers
 
     public static func parse(json: Data) -> ClaudeUsageSnapshot? {
-        guard let output = String(data: json, encoding: .utf8) else { return nil }
-        return try? Self.parse(output: output)
+        self.parse(json: json, now: .init())
     }
 
-    private static func parse(output: String) throws -> ClaudeUsageSnapshot {
+    package static func parse(json: Data, now: Date) -> ClaudeUsageSnapshot? {
+        guard let output = String(data: json, encoding: .utf8) else { return nil }
+        return try? Self.parse(output: output, now: now)
+    }
+
+    private static func parse(output: String, now: Date) throws -> ClaudeUsageSnapshot {
         guard
             let data = output.data(using: .utf8),
             let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -745,7 +749,10 @@ extension ClaudeUsageFetcher {
             return RateWindow(
                 usedPercent: pct,
                 windowMinutes: windowMinutes,
-                resetsAt: Self.parseReset(text: resetText),
+                resetsAt: ClaudeStatusProbe.parseResetDate(
+                    from: resetText,
+                    now: now,
+                    expectedWindow: TimeInterval(windowMinutes * 60)),
                 resetDescription: resetText)
         }
 
@@ -767,53 +774,23 @@ extension ClaudeUsageFetcher {
         let org = (rawOrg?.isEmpty ?? true) ? nil : rawOrg
         let loginMethod = (obj["login_method"] as? String)?.trimmingCharacters(
             in: .whitespacesAndNewlines)
-        let opusWindow: RateWindow? = {
-            let candidates = firstWindowDict([
+        let opusWindow = makeWindow(
+            firstWindowDict([
                 "week_sonnet",
                 "week_sonnet_only",
                 "week_opus",
-            ])
-            guard let opus = candidates else { return nil }
-            let pct = (opus["pct_used"] as? NSNumber)?.doubleValue ?? 0
-            let resets = opus["resets"] as? String
-            return RateWindow(
-                usedPercent: pct,
-                windowMinutes: Self.weeklyWindowMinutes,
-                resetsAt: Self.parseReset(text: resets),
-                resetDescription: resets)
-        }()
+            ]),
+            windowMinutes: Self.weeklyWindowMinutes)
         return ClaudeUsageSnapshot(
             primary: session,
             secondary: weekAll,
             opus: opusWindow,
             providerCost: nil,
-            updatedAt: Date(),
+            updatedAt: now,
             accountEmail: email,
             accountOrganization: org,
             loginMethod: loginMethod,
             rawText: output)
-    }
-
-    private static func parseReset(text: String?) -> Date? {
-        guard let text, !text.isEmpty else { return nil }
-        let parts = text.split(separator: "(")
-        let timePart = parts.first?.trimmingCharacters(in: .whitespaces)
-        let tzPart =
-            parts.count > 1
-                ? parts[1].replacingOccurrences(of: ")", with: "").trimmingCharacters(in: .whitespaces)
-                : nil
-        let tz = tzPart.flatMap(TimeZone.init(identifier:))
-        let formats = ["ha", "h:mma", "MMM d 'at' ha", "MMM d 'at' h:mma"]
-        for format in formats {
-            let df = DateFormatter()
-            df.locale = Locale(identifier: "en_US_POSIX")
-            df.timeZone = tz ?? TimeZone.current
-            df.dateFormat = format
-            if let t = timePart, let date = df.date(from: t) {
-                return date
-            }
-        }
-        return nil
     }
 
     // MARK: - Public API
@@ -1329,7 +1306,10 @@ extension ClaudeUsageFetcher {
         return try Self.makeSnapshot(from: snap)
     }
 
-    private static func makeSnapshot(from snap: ClaudeStatusSnapshot) throws -> ClaudeUsageSnapshot {
+    private static func makeSnapshot(
+        from snap: ClaudeStatusSnapshot,
+        now: Date = .init()) throws -> ClaudeUsageSnapshot
+    {
         guard let sessionPctLeft = snap.sessionPercentLeft else {
             throw ClaudeUsageError.parseFailed("missing session data")
         }
@@ -1343,6 +1323,7 @@ extension ClaudeUsageFetcher {
                 windowMinutes: windowMinutes,
                 resetsAt: ClaudeStatusProbe.parseResetDate(
                     from: resetClean,
+                    now: now,
                     expectedWindow: TimeInterval(windowMinutes * 60)),
                 resetDescription: resetClean)
         }
@@ -1366,7 +1347,7 @@ extension ClaudeUsageFetcher {
             opus: opus,
             extraRateWindows: snap.extraRateWindows,
             providerCost: nil,
-            updatedAt: Date(),
+            updatedAt: now,
             accountEmail: snap.accountEmail,
             accountOrganization: snap.accountOrganization,
             loginMethod: snap.loginMethod,

--- a/Tests/CodexBarTests/ClaudeResetJSONParserTests.swift
+++ b/Tests/CodexBarTests/ClaudeResetJSONParserTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeResetJSONParserTests {
+    @Test
+    func `usage JSON parser applies quota horizons from one clock`() throws {
+        let reset = "Jul 9 at 6am (UTC)"
+        let json = """
+        {
+          "ok": true,
+          "session_5h": { "pct_used": 1, "resets": "\(reset)" },
+          "week_all_models": { "pct_used": 2, "resets": "\(reset)" },
+          "week_sonnet": { "pct_used": 3, "resets": "\(reset)" }
+        }
+        """
+        let now = try Self.isoDate("2026-07-09T12:00:00Z")
+        let snapshot = try #require(ClaudeUsageFetcher.parse(json: Data(json.utf8), now: now))
+        let futureReset = try Self.isoDate("2027-07-09T06:00:00Z")
+        let recentReset = try Self.isoDate("2026-07-09T06:00:00Z")
+
+        #expect(snapshot.primary.resetsAt == futureReset)
+        #expect(snapshot.secondary?.resetsAt == recentReset)
+        #expect(snapshot.opus?.resetsAt == recentReset)
+        #expect(snapshot.updatedAt == now)
+    }
+
+    @Test
+    func `usage JSON parser supports explicit years and preserves malformed reset text`() throws {
+        let explicitReset = "Jan 2, 2026, 10:59pm (Europe/Helsinki)"
+        let malformedReset = "after the next billing sync"
+        let json = """
+        {
+          "ok": true,
+          "session_5h": { "pct_used": 1, "resets": "\(explicitReset)" },
+          "week_all_models": { "pct_used": 2, "resets": "\(malformedReset)" }
+        }
+        """
+        let now = try Self.isoDate("2025-01-01T00:00:00Z")
+        let snapshot = try #require(ClaudeUsageFetcher.parse(
+            json: Data(json.utf8),
+            now: now))
+        let expectedReset = try Self.isoDate("2026-01-02T20:59:00Z")
+
+        #expect(snapshot.primary.resetsAt == expectedReset)
+        #expect(snapshot.primary.resetDescription == explicitReset)
+        #expect(snapshot.secondary?.resetsAt == nil)
+        #expect(snapshot.secondary?.resetDescription == malformedReset)
+    }
+
+    private static func isoDate(_ text: String) throws -> Date {
+        let formatter = ISO8601DateFormatter()
+        return try #require(formatter.date(from: text))
+    }
+}

--- a/Tests/CodexBarTests/ClaudeResetOccurrenceTests.swift
+++ b/Tests/CodexBarTests/ClaudeResetOccurrenceTests.swift
@@ -46,6 +46,12 @@ struct ClaudeResetOccurrenceTests {
             from: "Resets Nov 1, 1:30am (America/New_York)",
             now: second.addingTimeInterval(60),
             expectedWindow: 7 * 24 * 60 * 60) == second)
+        #expect(ClaudeStatusProbe.parseResetDate(
+            from: "Resets Nov 1, 2026, 1:30am (America/New_York)",
+            now: betweenOccurrences) == second)
+        #expect(ClaudeStatusProbe.parseResetDate(
+            from: "Resets Nov 1, 2026, 1:30am (America/New_York)",
+            now: second.addingTimeInterval(60)) == second)
     }
 
     @Test
@@ -73,5 +79,44 @@ struct ClaudeResetOccurrenceTests {
             from: "Resets Feb 29, 9am (UTC)",
             now: shortlyAfter,
             expectedWindow: 7 * 24 * 60 * 60) == currentLeapReset)
+    }
+
+    @Test
+    func `parser keeps explicit years authoritative across supported time forms`() throws {
+        let now = try Self.isoDate("2025-01-01T00:00:00Z")
+        let cases = [
+            (
+                text: "Resets Jan 2, 2026, 10:59pm (Europe/Helsinki)",
+                expected: "2026-01-02T20:59:00Z"),
+            (text: "Resets Jan 2 2026 10pm (UTC)", expected: "2026-01-02T22:00:00Z"),
+            (text: "Resets Jan 2, 2026, 22:15 (UTC)", expected: "2026-01-02T22:15:00Z"),
+            (text: "Resets Jan 2, 2026, 22 (UTC)", expected: "2026-01-02T22:00:00Z"),
+        ]
+
+        for item in cases {
+            let expected = try Self.isoDate(item.expected)
+            #expect(ClaudeStatusProbe.parseResetDate(
+                from: item.text,
+                now: now) == expected)
+        }
+
+        let afterStatedYear = try Self.isoDate("2027-01-01T00:00:00Z")
+        let statedReset = try Self.isoDate(cases[0].expected)
+        #expect(ClaudeStatusProbe.parseResetDate(
+            from: cases[0].text,
+            now: afterStatedYear) == statedReset)
+    }
+
+    @Test
+    func `parser rejects nonexistent explicit local time`() throws {
+        let now = try Self.isoDate("2026-01-01T00:00:00Z")
+        #expect(ClaudeStatusProbe.parseResetDate(
+            from: "Resets Mar 8, 2026, 2:30am (America/New_York)",
+            now: now) == nil)
+    }
+
+    private static func isoDate(_ text: String) throws -> Date {
+        let formatter = ISO8601DateFormatter()
+        return try #require(formatter.date(from: text))
     }
 }


### PR DESCRIPTION
## Summary

- Parse explicit-year Claude reset timestamps before recurring yearless/time-only forms, preserving the stated year and exact local DST occurrence.
- Keep recurring resets on the existing forward/5-hour/7-day occurrence policy; reject nonexistent local wall times and retain raw text when parsing fails.
- Route the public JSON fixture parser through the canonical reset parser with one injected clock, then remove its duplicate formatter path.
- Add focused explicit-year, DST, malformed-input, and caller-horizon regressions plus an Unreleased changelog entry.

## Why

An existing Claude CLI fixture contains `Resets Jan 2, 2026, 10:59pm (Europe/Helsinki)`. CodexBar preserved that text but returned no structured reset date because the canonical parser only accepted yearless forms. That removed countdown, pace, warning, and reset-scheduling behavior from an otherwise valid quota window. The public JSON helper also anchored partial reset dates to year 2000 through a separate formatter.

This is a focused follow-up to #2022. Explicit years are authoritative and never become annual recurrences; existing yearless/time-only behavior remains unchanged.

## Verification

Exact candidate: `becac52c39183fee8f0c351c0561b3e94bf41c46`

- Focused reset/fixture tests: 261 passed, including the real explicit-year punctuation, 12-hour/hour-only/24-hour forms, past stated years, repeated DST, nonexistent spring-forward time, malformed raw fallback, and 5-hour versus 7-day caller wiring.
- `make check`: passed; SwiftFormat and SwiftLint report zero violations.
- `make test`: 599/599 selections and 50/50 groups passed with zero failures, retries, or timeouts.
- Independent review: clean after aligning the public parser documentation with authoritative explicit-year behavior.
- `autoreview --mode branch --base origin/main`: clean; no accepted/actionable findings.
- Signed packaged/source-blind CLI proof: all 7/7 contract clauses passed. The exact Developer-ID debug artifact was Gatekeeper-accepted; explicit 2030/2020 resets stayed exact, malformed tertiary text stayed unstructured, and identical six-hour-old yearless text resolved forward for the session lane but backward for the weekly lane. Fresh final runs used disposable state, dual Keychain denial, and network/securityd/real-home denial; an initial login-shell PATH escape was detected, rejected, and eliminated before both reruns passed.
- Exact-head CI: [run 29104479860](https://github.com/steipete/CodexBar/actions/runs/29104479860) passed both macOS shards, both Linux builds, lint, aggregate, change detection, and GitGuardian.
- Current-main composition: clean virtual merge with `e0ee6a04` (#2035), producing tree `069be2ea` with the exact five-file +171/-41 delta. The only overlap is independent changelog additions; all four runtime/test blobs are byte-identical to the proven candidate. GitHub's cached merge ref still uses the older base, so this is reported separately as current-main merge-tree proof.
- ClawSweeper repeatedly acquired and expired infrastructure leases without producing a review or finding; GitHub reports no review threads or inline comments.

No provider login, browser session, real Claude request, or Keychain access is required for this parser-only change.

Public Model Identifier Gate: **PASS** (model-free diff and fixtures).

Dependency freshness: **N/A** (no dependency changes).
