### PR TITLE
Default Agent Sessions to off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Quota warnings: add opt-in predictive pace alerts for Codex and Claude session and weekly limits, with one alert per risk episode. Thanks @vincent-peng!
 
 ### Fixed
+- Agent Sessions: keep local and remote session discovery off by default while preserving the General setting for explicit opt-in.
 - Menus: stop completed provider cards and plan-utilization rows from remaining in “Refreshing…” while unrelated provider or token-cost work is still running. Thanks @Yuxin-Qiao!
 - Codex accounts: isolate authenticated OAuth and browser-cookie requests from shared URL caches and cookie stores, preventing one account's cached quota or identity response from appearing under another account and triggering false reset alerts (#1987, #2019). Thanks @harjothkhara!
 - Claude OAuth: honor the app's never-prompt policy in the bundled CLI and defer stale cache cleanup without touching Keychain until access is re-enabled. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -474,7 +474,7 @@ extension SettingsStore {
         let providersSortedAlphabetically = userDefaults.object(
             forKey: "providersSortedAlphabetically") as? Bool ?? false
         let appLanguageRaw = userDefaults.string(forKey: "appLanguage")
-        let agentSessionsEnabled = userDefaults.object(forKey: "agentSessionsEnabled") as? Bool ?? true
+        let agentSessionsEnabled = userDefaults.object(forKey: "agentSessionsEnabled") as? Bool ?? false
         let agentSessionsManualHosts = userDefaults.string(forKey: "agentSessionsManualHosts") ?? ""
         return SettingsDefaultsState(
             refreshFrequency: refreshFrequency,

--- a/Tests/CodexBarTests/AgentSessionMenuDescriptorTests.swift
+++ b/Tests/CodexBarTests/AgentSessionMenuDescriptorTests.swift
@@ -6,6 +6,40 @@ import Testing
 @MainActor
 struct AgentSessionMenuDescriptorTests {
     @Test
+    func `fresh settings omit agent sessions until explicitly enabled`() {
+        let settings = testSettingsStore(suiteName: "AgentSessionMenuDescriptorTests-default-off")
+        settings.statusChecksEnabled = false
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let session = Self.session(id: "local", host: "local-mac", activity: Date())
+
+        let buildDescriptor = {
+            MenuDescriptor.build(
+                provider: .codex,
+                store: store,
+                settings: settings,
+                account: AccountInfo(email: nil, plan: nil),
+                updateReady: false,
+                agentSessionsEnabled: settings.agentSessionsEnabled,
+                localAgentSessions: [session])
+        }
+
+        let disabledEntries = buildDescriptor().sections.flatMap(\.entries)
+        #expect(!Self.containsAgentSessions(in: disabledEntries))
+
+        settings.agentSessionsEnabled = true
+
+        let enabledEntries = buildDescriptor().sections.flatMap(\.entries)
+        #expect(Self.containsAgentSessions(in: enabledEntries))
+        #expect(enabledEntries.contains { entry in
+            guard case .action(_, .focusAgentSession) = entry else { return false }
+            return true
+        })
+    }
+
+    @Test
     func `session section counts groups and renders unreachable hosts`() {
         let now = Date(timeIntervalSince1970: 1000)
         let local = Self.session(id: "local", host: "local-mac", activity: now.addingTimeInterval(-60))
@@ -86,5 +120,12 @@ struct AgentSessionMenuDescriptorTests {
             lastActivityAt: activity,
             transcriptPath: nil,
             host: host)
+    }
+
+    private static func containsAgentSessions(in entries: [MenuDescriptor.Entry]) -> Bool {
+        entries.contains { entry in
+            guard case let .text(title, .headline) = entry else { return false }
+            return title.hasPrefix("Agent Sessions (")
+        }
     }
 }

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -124,6 +124,24 @@ struct SettingsStoreCoverageTests {
     }
 
     @Test
+    func `agent sessions default off and persist explicit opt in`() throws {
+        let suite = "SettingsStoreCoverageTests-agent-sessions"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+
+        let initial = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+        #expect(initial.agentSessionsEnabled == false)
+        #expect(defaults.object(forKey: "agentSessionsEnabled") == nil)
+
+        initial.agentSessionsEnabled = true
+        #expect(defaults.object(forKey: "agentSessionsEnabled") as? Bool == true)
+
+        let reloaded = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+        #expect(reloaded.agentSessionsEnabled)
+    }
+
+    @Test
     func `multi account menu layout persists and bridges legacy show all token accounts`() throws {
         let suite = "SettingsStoreCoverageTests-multi-account-layout"
         let defaults = try #require(UserDefaults(suiteName: suite))


### PR DESCRIPTION
## Summary

- default Agent Sessions to off when the preference has not been set
- preserve explicit opt-in through the existing General setting
- cover fresh-state persistence and menu-section gating with focused tests
- document the behavior change in the changelog

## Verification

- `make check`
- `make test` (598 selections, 50 groups, 0 failures or retries)
- `swift test --no-parallel --filter 'SettingsStoreCoverageTests|AgentSessionMenuDescriptorTests'` after rebasing onto latest `main`
- automated and independent pre-land review: no actionable findings
- Developer ID package launched and relaunched with `agentSessionsEnabled = false`; bundled `sessions --help` remains available

UI accessibility automation could launch CodexBar and open its settings/menu, but those controls did not expose usable accessibility elements, so visual menu extraction was inconclusive. The headless menu-descriptor regression test covers section suppression and explicit enablement.
