### PR TITLE
Add Cursor and filter widget provider options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Claude: prevent CodexBar's passive CLI probes from starting background Claude Code updates, avoiding repeated partial downloads when a probe exits before an update completes. Thanks @PG2047!
 - Codex cost history: bound malformed session-metadata lines and release read chunks promptly, preventing metadata pre-scans from retaining memory in proportion to oversized JSONL records. Thanks @Yuxin-Qiao!
+- Widgets: add Cursor to configurable and switcher widgets with accurate legacy Requests and current Total, Auto, and API quota labels (#2040). Thanks @Zihao-Qi!
 
 ## 0.42.0 — 2026-07-11
 

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -153,6 +153,10 @@ extension UsageStore {
         }
 
         let primaryTitle: String = {
+            // Legacy request-based Cursor plans track a request quota, not the token-based "Total" pool.
+            if provider == .cursor, snapshot.cursorRequests != nil {
+                return "Requests"
+            }
             if provider == .grok,
                let dyn = GrokProviderDescriptor.primaryLabel(window: snapshot.primary)
             {

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -303,9 +303,7 @@ struct CodexBarSwitcherTimelineProvider: TimelineProvider {
     }
 
     static func supportedProviders(from snapshot: WidgetSnapshot) -> [UsageProvider] {
-        let enabled = snapshot.enabledProviders
-        let providers = enabled.isEmpty ? snapshot.entries.map(\.provider) : enabled
-        let supported = providers.filter { ProviderChoice(provider: $0) != nil }
+        let supported = snapshot.enabledProviders.filter { ProviderChoice(provider: $0) != nil }
         return supported.isEmpty ? [.codex] : supported
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -126,26 +126,6 @@ enum ProviderChoice: String, AppEnum {
         case .zed: return nil // Zed not yet supported in widgets
         }
     }
-
-    static func enabledChoices(from snapshot: WidgetSnapshot?) -> [ProviderChoice] {
-        guard let snapshot else { return Array(allCases) }
-        let enabled = snapshot.enabledProviders.compactMap(Self.init(provider:))
-        return enabled.isEmpty ? [.codex] : enabled
-    }
-}
-
-struct EnabledProviderOptionsProvider: DynamicOptionsProvider {
-    func results() async throws -> [ProviderChoice] {
-        Self.currentChoices()
-    }
-
-    func defaultResult() async -> ProviderChoice? {
-        Self.currentChoices().first
-    }
-
-    static func currentChoices() -> [ProviderChoice] {
-        ProviderChoice.enabledChoices(from: WidgetSnapshotStore.load())
-    }
 }
 
 enum CompactMetric: String, AppEnum {
@@ -166,11 +146,11 @@ struct ProviderSelectionIntent: AppIntent, WidgetConfigurationIntent {
     static let title: LocalizedStringResource = "Provider"
     static let description = IntentDescription("Select the provider to display in the widget.")
 
-    @Parameter(title: "Provider", optionsProvider: EnabledProviderOptionsProvider())
+    @Parameter(title: "Provider", default: .codex)
     var provider: ProviderChoice
 
     init() {
-        self.provider = EnabledProviderOptionsProvider.currentChoices().first ?? .codex
+        self.provider = .codex
     }
 }
 
@@ -198,14 +178,14 @@ struct CompactMetricSelectionIntent: AppIntent, WidgetConfigurationIntent {
     static let title: LocalizedStringResource = "Provider + Metric"
     static let description = IntentDescription("Select the provider and metric to display.")
 
-    @Parameter(title: "Provider", optionsProvider: EnabledProviderOptionsProvider())
+    @Parameter(title: "Provider", default: .codex)
     var provider: ProviderChoice
 
     @Parameter(title: "Metric", default: .credits)
     var metric: CompactMetric
 
     init() {
-        self.provider = EnabledProviderOptionsProvider.currentChoices().first ?? .codex
+        self.provider = .codex
         self.metric = .credits
     }
 }
@@ -303,7 +283,9 @@ struct CodexBarSwitcherTimelineProvider: TimelineProvider {
     }
 
     static func supportedProviders(from snapshot: WidgetSnapshot) -> [UsageProvider] {
-        let supported = snapshot.enabledProviders.filter { ProviderChoice(provider: $0) != nil }
+        let enabled = snapshot.enabledProviders
+        let providers = enabled.isEmpty ? snapshot.entries.map(\.provider) : enabled
+        let supported = providers.filter { ProviderChoice(provider: $0) != nil }
         return supported.isEmpty ? [.codex] : supported
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -10,6 +10,7 @@ enum ProviderChoice: String, AppEnum {
     case alibaba
     case alibabatokenplan
     case antigravity
+    case cursor
     case zai
     case copilot
     case devin
@@ -29,6 +30,7 @@ enum ProviderChoice: String, AppEnum {
         .alibaba: DisplayRepresentation(title: "Alibaba"),
         .alibabatokenplan: DisplayRepresentation(title: "Alibaba Token Plan"),
         .antigravity: DisplayRepresentation(title: "Antigravity"),
+        .cursor: DisplayRepresentation(title: "Cursor"),
         .zai: DisplayRepresentation(title: "z.ai"),
         .copilot: DisplayRepresentation(title: "Copilot"),
         .devin: DisplayRepresentation(title: "Devin"),
@@ -48,6 +50,7 @@ enum ProviderChoice: String, AppEnum {
         case .alibaba: .alibaba
         case .alibabatokenplan: .alibabatokenplan
         case .antigravity: .antigravity
+        case .cursor: .cursor
         case .zai: .zai
         case .copilot: .copilot
         case .devin: .devin
@@ -71,7 +74,7 @@ enum ProviderChoice: String, AppEnum {
         case .alibaba: self = .alibaba
         case .alibabatokenplan: self = .alibabatokenplan
         case .antigravity: self = .antigravity
-        case .cursor: return nil // Cursor not yet supported in widgets
+        case .cursor: self = .cursor
         case .opencode: self = .opencode
         case .opencodego: self = .opencodego
         case .zai: self = .zai
@@ -123,6 +126,26 @@ enum ProviderChoice: String, AppEnum {
         case .zed: return nil // Zed not yet supported in widgets
         }
     }
+
+    static func enabledChoices(from snapshot: WidgetSnapshot?) -> [ProviderChoice] {
+        guard let snapshot else { return Array(allCases) }
+        let enabled = snapshot.enabledProviders.compactMap(Self.init(provider:))
+        return enabled.isEmpty ? [.codex] : enabled
+    }
+}
+
+struct EnabledProviderOptionsProvider: DynamicOptionsProvider {
+    func results() async throws -> [ProviderChoice] {
+        Self.currentChoices()
+    }
+
+    func defaultResult() async -> ProviderChoice? {
+        Self.currentChoices().first
+    }
+
+    static func currentChoices() -> [ProviderChoice] {
+        ProviderChoice.enabledChoices(from: WidgetSnapshotStore.load())
+    }
 }
 
 enum CompactMetric: String, AppEnum {
@@ -143,11 +166,11 @@ struct ProviderSelectionIntent: AppIntent, WidgetConfigurationIntent {
     static let title: LocalizedStringResource = "Provider"
     static let description = IntentDescription("Select the provider to display in the widget.")
 
-    @Parameter(title: "Provider", default: .codex)
+    @Parameter(title: "Provider", optionsProvider: EnabledProviderOptionsProvider())
     var provider: ProviderChoice
 
     init() {
-        self.provider = .codex
+        self.provider = EnabledProviderOptionsProvider.currentChoices().first ?? .codex
     }
 }
 
@@ -175,14 +198,14 @@ struct CompactMetricSelectionIntent: AppIntent, WidgetConfigurationIntent {
     static let title: LocalizedStringResource = "Provider + Metric"
     static let description = IntentDescription("Select the provider and metric to display.")
 
-    @Parameter(title: "Provider", default: .codex)
+    @Parameter(title: "Provider", optionsProvider: EnabledProviderOptionsProvider())
     var provider: ProviderChoice
 
     @Parameter(title: "Metric", default: .credits)
     var metric: CompactMetric
 
     init() {
-        self.provider = .codex
+        self.provider = EnabledProviderOptionsProvider.currentChoices().first ?? .codex
         self.metric = .credits
     }
 }

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -928,6 +928,24 @@ extension CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `supported providers ignore stale entries when every provider is disabled`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .cursor,
+            updatedAt: now,
+            primary: RateWindow(usedPercent: 25, windowMinutes: 43200, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+        let snapshot = WidgetSnapshot(entries: [entry], enabledProviders: [], generatedAt: now)
+
+        #expect(CodexBarSwitcherTimelineProvider.supportedProviders(from: snapshot) == [.codex])
+    }
+
+    @Test
     func `widget token titles disclose stale age for today and history rows`() {
         let entryUpdatedAt = Date()
         let staleToken = WidgetSnapshot.TokenUsageSummary(

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -876,6 +876,58 @@ struct CodexBarWidgetProviderTests {
 
 extension CodexBarWidgetProviderTests {
     @Test
+    func `provider choice supports Cursor`() {
+        #expect(ProviderChoice(provider: .cursor) == .cursor)
+        #expect(ProviderChoice.cursor.provider == .cursor)
+    }
+
+    @Test
+    func `enabled choices keep supported settings providers in order`() {
+        let snapshot = WidgetSnapshot(
+            entries: [],
+            enabledProviders: [.cursor, .chutes, .claude],
+            generatedAt: Date())
+
+        #expect(ProviderChoice.enabledChoices(from: snapshot) == [.cursor, .claude])
+    }
+
+    @Test
+    func `enabled choices expose all supported providers before a snapshot exists`() {
+        let choices = ProviderChoice.enabledChoices(from: nil)
+
+        #expect(choices == Array(ProviderChoice.allCases))
+        #expect(choices.contains(.cursor))
+    }
+
+    @Test
+    func `enabled choices fall back to codex when no enabled provider supports widgets`() {
+        let snapshot = WidgetSnapshot(
+            entries: [],
+            enabledProviders: [.chutes],
+            generatedAt: Date())
+
+        #expect(ProviderChoice.enabledChoices(from: snapshot) == [.codex])
+    }
+
+    @Test
+    func `supported providers keep Cursor when it is the only enabled provider`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .cursor,
+            updatedAt: now,
+            primary: RateWindow(usedPercent: 25, windowMinutes: 43200, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+        let snapshot = WidgetSnapshot(entries: [entry], enabledProviders: [.cursor], generatedAt: now)
+
+        #expect(CodexBarSwitcherTimelineProvider.supportedProviders(from: snapshot) == [.cursor])
+    }
+
+    @Test
     func `widget token titles disclose stale age for today and history rows`() {
         let entryUpdatedAt = Date()
         let staleToken = WidgetSnapshot.TokenUsageSummary(

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -882,34 +882,6 @@ extension CodexBarWidgetProviderTests {
     }
 
     @Test
-    func `enabled choices keep supported settings providers in order`() {
-        let snapshot = WidgetSnapshot(
-            entries: [],
-            enabledProviders: [.cursor, .chutes, .claude],
-            generatedAt: Date())
-
-        #expect(ProviderChoice.enabledChoices(from: snapshot) == [.cursor, .claude])
-    }
-
-    @Test
-    func `enabled choices expose all supported providers before a snapshot exists`() {
-        let choices = ProviderChoice.enabledChoices(from: nil)
-
-        #expect(choices == Array(ProviderChoice.allCases))
-        #expect(choices.contains(.cursor))
-    }
-
-    @Test
-    func `enabled choices fall back to codex when no enabled provider supports widgets`() {
-        let snapshot = WidgetSnapshot(
-            entries: [],
-            enabledProviders: [.chutes],
-            generatedAt: Date())
-
-        #expect(ProviderChoice.enabledChoices(from: snapshot) == [.codex])
-    }
-
-    @Test
     func `supported providers keep Cursor when it is the only enabled provider`() {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let entry = WidgetSnapshot.ProviderEntry(
@@ -925,24 +897,6 @@ extension CodexBarWidgetProviderTests {
         let snapshot = WidgetSnapshot(entries: [entry], enabledProviders: [.cursor], generatedAt: now)
 
         #expect(CodexBarSwitcherTimelineProvider.supportedProviders(from: snapshot) == [.cursor])
-    }
-
-    @Test
-    func `supported providers ignore stale entries when every provider is disabled`() {
-        let now = Date(timeIntervalSince1970: 1_700_000_000)
-        let entry = WidgetSnapshot.ProviderEntry(
-            provider: .cursor,
-            updatedAt: now,
-            primary: RateWindow(usedPercent: 25, windowMinutes: 43200, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            tertiary: nil,
-            creditsRemaining: nil,
-            codeReviewRemainingPercent: nil,
-            tokenUsage: nil,
-            dailyUsage: [])
-        let snapshot = WidgetSnapshot(entries: [entry], enabledProviders: [], generatedAt: now)
-
-        #expect(CodexBarSwitcherTimelineProvider.supportedProviders(from: snapshot) == [.codex])
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -469,4 +469,78 @@ struct UsageStoreWidgetSnapshotTests {
         #expect(entry.tokenUsage?.updatedAt == tokenUpdatedAt)
         #expect(entry.tokenUsage?.isStale(comparedTo: entry.updatedAt) == true)
     }
+
+    @Test
+    func `widget snapshot labels legacy Cursor request quota as Requests`() async throws {
+        let suite = "UsageStoreWidgetSnapshotTests-cursor-requests-label"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 40, windowMinutes: 43200, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                tertiary: nil,
+                cursorRequests: CursorRequestUsage(used: 200, limit: 500),
+                updatedAt: Date()),
+            provider: .cursor)
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        store.persistWidgetSnapshot(reason: "cursor-requests-label-test")
+        await store.widgetSnapshotPersistTask?.value
+
+        let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .cursor })
+        #expect(entry.usageRows?.map(\.id) == ["primary"])
+        #expect(entry.usageRows?.map(\.title) == ["Requests"])
+    }
+
+    @Test
+    func `widget snapshot keeps Cursor Total label for token based plans`() async throws {
+        let suite = "UsageStoreWidgetSnapshotTests-cursor-total-label"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 10, windowMinutes: 43200, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(usedPercent: 20, windowMinutes: 43200, resetsAt: nil, resetDescription: nil),
+                tertiary: RateWindow(usedPercent: 0, windowMinutes: 43200, resetsAt: nil, resetDescription: nil),
+                updatedAt: Date()),
+            provider: .cursor)
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        store.persistWidgetSnapshot(reason: "cursor-total-label-test")
+        await store.widgetSnapshotPersistTask?.value
+
+        let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .cursor })
+        #expect(entry.usageRows?.map(\.title) == ["Total", "Auto", "API"])
+    }
 }

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -31,7 +31,7 @@ read_when:
 
 ## Provider picker support
 The configurable provider widgets currently expose:
-Codex, Claude, Gemini, Alibaba, Antigravity, z.ai, Copilot, MiniMax, Kilo, OpenCode, and OpenCode Go.
+Codex, Claude, Cursor, Gemini, Alibaba, Antigravity, z.ai, Copilot, MiniMax, Kilo, OpenCode, and OpenCode Go.
 
 Providers without a `ProviderChoice` case can still be present in the app snapshot, but they are not selectable from the widget configuration UI yet.
 


### PR DESCRIPTION
## Summary

- add Cursor to the stable provider enum used by configurable and switcher widgets
- preserve existing provider-picker defaults, persisted selections, enabled-provider behavior, and missing-data states
- label legacy Cursor request quotas as `Requests` while current Cursor rows remain `Total`, `Auto`, and `API`
- add focused mapping and snapshot-projection coverage and update widget documentation

Fixes #2040.

## Scope decision

Earlier iterations dynamically filtered every widget configuration picker from enabled providers. The final branch removes that broader compatibility change. This PR now does only the high-certainty Cursor mapping and label work; existing widgets and non-Cursor providers retain current-main behavior.

## Validation

- `swift test --filter CodexBarWidgetProviderTests` — 46 tests passed
- `swift test --filter UsageStoreWidgetSnapshotTests` — 11 tests passed
- `make check` — passed; SwiftLint reported 0 violations
- `make test` — all 601 selections completed; one unrelated group recovered on the built-in retry
- branch-wide autoreview — no findings, confidence 0.91
- exact 0.42.1 app and widget extension — Developer ID signed, strict verification passed, Gatekeeper accepted, app running
- PlugInKit — exact extension from this checkout registered alongside installed versions

## Native proof status

An earlier exact-feature build was exercised in the macOS 27 widget gallery and rendered Cursor with `Total`, `Auto`, and `API` in supported sizes. For this final narrowed head, fresh screenshot/click proof is blocked because the active Peekaboo GUI bridge reports Screen Recording and Accessibility disabled. No fresh screenshot claim is made; the final refactor removes unrelated global filtering and leaves the previously exercised Cursor rendering path unchanged.

Thanks @Zihao-Qi for the contribution.
