### PR TITLE
fix: limit Pi cumulative Ultra token overcount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Codex cost history: bound malformed session-metadata lines and release read chunks promptly, preventing metadata pre-scans from retaining memory in proportion to oversized JSONL records. Thanks @Yuxin-Qiao!
 - Widgets: add Cursor to configurable and switcher widgets with accurate legacy Requests and current Total, Auto, and API quota labels (#2040). Thanks @Zihao-Qi!
 - Menus: return oversized tracked menus to the provider header after a manual refresh without moving background updates, highlighted rows, open submenus, or newer menu/provider sessions (#2046). Thanks @ss251!
+- Codex cost history: reconcile large monotonic Pi usage snapshots only within their narrowest request, message, turn, or task lineage, preventing forked sessions from multiplying cumulative token totals (#2037). Thanks @kiranmagic7!
 
 ## 0.42.0 — 2026-07-11
 

--- a/Sources/CodexBarCore/PiSessionCostScanner.swift
+++ b/Sources/CodexBarCore/PiSessionCostScanner.swift
@@ -46,6 +46,33 @@ enum PiSessionCostScanner {
         let modelName: String
     }
 
+    private struct UsageSample {
+        let sequence: Int
+        let provider: UsageProvider
+        let dayKey: String
+        let modelName: String
+        let lineageKey: String
+        let pricingDate: Date
+        let usage: PiPackedUsage
+
+        func replacingUsage(_ usage: PiPackedUsage) -> UsageSample {
+            UsageSample(
+                sequence: self.sequence,
+                provider: self.provider,
+                dayKey: self.dayKey,
+                modelName: self.modelName,
+                lineageKey: self.lineageKey,
+                pricingDate: self.pricingDate,
+                usage: usage)
+        }
+    }
+
+    private struct UsageSampleGroupKey: Hashable {
+        let providerRawValue: String
+        let modelName: String
+        let lineageKey: String
+    }
+
     private struct ModelsDevPricingContext {
         let catalog: ModelsDevCatalog?
         let cacheRoot: URL?
@@ -61,7 +88,7 @@ enum PiSessionCostScanner {
 
     private static let costScale = 1_000_000_000.0
     /// Bump for Pi-only cost formula changes not represented by the parser or pricing fingerprints.
-    private static let costFormulaVersion = 1
+    private static let costFormulaVersion = 2
     private static let maxLineBytes = 16 * 1024 * 1024
     private static let maxSafeRoundedInt = Double(Int.max) - 1
     private static let sessionStartFilenameRegex = try? NSRegularExpression(
@@ -312,35 +339,6 @@ enum PiSessionCostScanner {
             return
         }
 
-        if !context.forceRescan,
-           let cached,
-           size > cached.size,
-           cached.parsedBytes > 0,
-           cached.parsedBytes <= size
-        {
-            let delta = try self.parsePiSessionFile(
-                fileURL: fileURL,
-                range: context.range,
-                startOffset: cached.parsedBytes,
-                initialModelContext: cached.lastModelContext,
-                pricingContext: context.pricingContext,
-                checkCancellation: context.checkCancellation)
-            if !delta.contributions.isEmpty {
-                self.applyContributions(
-                    daysByProvider: &cache.daysByProvider,
-                    contributions: delta.contributions,
-                    sign: 1)
-            }
-            let merged = self.mergedContributions(existing: cached.contributions, delta: delta.contributions)
-            storeFileUsage(PiSessionFileUsage(
-                mtimeUnixMs: mtimeMs,
-                size: size,
-                parsedBytes: delta.parsedBytes,
-                lastModelContext: delta.lastModelContext,
-                contributions: merged))
-            return
-        }
-
         if let cached {
             self.applyContributions(
                 daysByProvider: &cache.daysByProvider,
@@ -374,6 +372,7 @@ enum PiSessionCostScanner {
         checkCancellation: CostUsageScanner.CancellationCheck? = nil) throws -> ParseResult
     {
         var currentModelContext = initialModelContext
+        var samples: [UsageSample] = []
         var contributions: [String: [String: [String: PiPackedUsage]]] = [:]
 
         func add(provider: UsageProvider, dayKey: String, modelName: String, usage: PiPackedUsage) {
@@ -437,19 +436,32 @@ enum PiSessionCostScanner {
                         guard let identity else { return }
                         guard let date = self.timestampDate(entry: object, message: message) else { return }
                         let dayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: date)
-                        let usage = self.extractUsage(
+                        let usage = self.extractRawUsage(message: message)
+                        let sequence = samples.count
+                        samples.append(UsageSample(
+                            sequence: sequence,
                             provider: identity.provider,
+                            dayKey: dayKey,
                             modelName: identity.modelName,
-                            message: message,
+                            lineageKey: self.lineageKey(entry: object, message: message, fallbackSequence: sequence),
                             pricingDate: date,
-                            pricingContext: pricingContext)
-                        add(provider: identity.provider, dayKey: dayKey, modelName: identity.modelName, usage: usage)
+                            usage: usage))
                     }
                 })
         } catch is CancellationError {
             throw CancellationError()
         } catch {
             parsedBytes = startOffset
+        }
+
+        for sample in self.adjustedUsageSamples(samples) {
+            let usage = self.pricedUsage(
+                provider: sample.provider,
+                modelName: sample.modelName,
+                usage: sample.usage,
+                pricingDate: sample.pricingDate,
+                pricingContext: pricingContext)
+            add(provider: sample.provider, dayKey: sample.dayKey, modelName: sample.modelName, usage: usage)
         }
 
         return ParseResult(
@@ -555,6 +567,37 @@ enum PiSessionCostScanner {
             ?? self.parseTimestampValue(entry["timestamp"])
     }
 
+    private static func lineageKey(
+        entry: [String: Any],
+        message: [String: Any],
+        fallbackSequence: Int) -> String
+    {
+        let keys = [
+            "turnId",
+            "turn_id",
+            "taskId",
+            "task_id",
+            "requestId",
+            "request_id",
+            "messageId",
+            "message_id",
+            "id",
+        ]
+        for key in keys {
+            if let value = (message[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !value.isEmpty
+            {
+                return "\(key):\(value)"
+            }
+            if let value = (entry[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !value.isEmpty
+            {
+                return "\(key):\(value)"
+            }
+        }
+        return "sample:\(fallbackSequence)"
+    }
+
     private static func parseTimestampValue(_ value: Any?) -> Date? {
         if let number = value as? NSNumber {
             let raw = number.doubleValue
@@ -578,13 +621,7 @@ enum PiSessionCostScanner {
         return nil
     }
 
-    private static func extractUsage(
-        provider: UsageProvider,
-        modelName: String,
-        message: [String: Any],
-        pricingDate: Date? = nil,
-        pricingContext: ModelsDevPricingContext? = nil) -> PiPackedUsage
-    {
+    private static func extractRawUsage(message: [String: Any]) -> PiPackedUsage {
         let usage = (message["usage"] as? [String: Any]) ?? [:]
         let input = self.readNonNegativeInt(
             usage["input"]
@@ -624,30 +661,121 @@ enum PiSessionCostScanner {
         let derivedTotal = input + cacheRead + cacheWrite + output
         let totalTokens = max(directTotal, derivedTotal)
 
-        let rawUsage = PiPackedUsage(
+        return PiPackedUsage(
             inputTokens: input,
             cacheReadTokens: cacheRead,
             cacheWriteTokens: cacheWrite,
             outputTokens: output,
             totalTokens: totalTokens)
+    }
+
+    private static func pricedUsage(
+        provider: UsageProvider,
+        modelName: String,
+        usage: PiPackedUsage,
+        pricingDate: Date? = nil,
+        pricingContext: ModelsDevPricingContext? = nil) -> PiPackedUsage
+    {
         // Pi JSONL does not record Anthropic cache retention, so use Pi's persisted default tariff.
         let costUSD = self.computedCostUSD(
             provider: provider,
             modelName: modelName,
-            usage: rawUsage,
+            usage: usage,
             pricingDate: pricingDate,
             pricingContext: pricingContext)
         let costNanos = costUSD.map { Int64(($0 * self.costScale).rounded()) } ?? 0
 
         return PiPackedUsage(
-            inputTokens: rawUsage.inputTokens,
-            cacheReadTokens: rawUsage.cacheReadTokens,
-            cacheWriteTokens: rawUsage.cacheWriteTokens,
-            outputTokens: rawUsage.outputTokens,
-            totalTokens: rawUsage.totalTokens,
+            inputTokens: usage.inputTokens,
+            cacheReadTokens: usage.cacheReadTokens,
+            cacheWriteTokens: usage.cacheWriteTokens,
+            outputTokens: usage.outputTokens,
+            totalTokens: usage.totalTokens,
             costNanos: costNanos,
             costSampleCount: costUSD == nil ? 0 : 1,
             usageSampleCount: 1)
+    }
+
+    private static func adjustedUsageSamples(_ samples: [UsageSample]) -> [UsageSample] {
+        guard samples.count > 1 else { return samples }
+
+        let grouped = Dictionary(grouping: samples) { sample in
+            UsageSampleGroupKey(
+                providerRawValue: sample.provider.rawValue,
+                modelName: sample.modelName,
+                lineageKey: sample.lineageKey)
+        }
+
+        var adjusted: [UsageSample] = []
+        adjusted.reserveCapacity(samples.count)
+
+        for group in grouped.values {
+            let sorted = group.sorted { $0.sequence < $1.sequence }
+            guard self.shouldTreatAsCumulative(sorted) else {
+                adjusted.append(contentsOf: sorted)
+                continue
+            }
+
+            var previous = PiPackedUsage()
+            for sample in sorted {
+                let delta = self.usageDelta(from: previous, to: sample.usage)
+                previous = sample.usage
+                guard !delta.isZero else { continue }
+                adjusted.append(sample.replacingUsage(delta))
+            }
+        }
+
+        return adjusted.sorted { $0.sequence < $1.sequence }
+    }
+
+    private static func shouldTreatAsCumulative(_ samples: [UsageSample]) -> Bool {
+        guard samples.count >= 4 else { return false }
+        let usages = samples.map(\.usage)
+        guard zip(usages, usages.dropFirst()).allSatisfy({ self.isNonDecreasing(previous: $0, current: $1) })
+        else {
+            return false
+        }
+
+        let rawTotal = usages.reduce(0) { partial, usage in
+            self.clampedAdd(partial, self.usageTotal(usage))
+        }
+        guard let final = usages.last.map(self.usageTotal), final > 0 else { return false }
+
+        return Double(rawTotal) >= Double(final) * 3.0
+            && rawTotal - final >= 1_000_000
+    }
+
+    private static func isNonDecreasing(previous: PiPackedUsage, current: PiPackedUsage) -> Bool {
+        current.inputTokens >= previous.inputTokens
+            && current.cacheReadTokens >= previous.cacheReadTokens
+            && current.cacheWriteTokens >= previous.cacheWriteTokens
+            && current.outputTokens >= previous.outputTokens
+            && current.totalTokens >= previous.totalTokens
+    }
+
+    private static func usageDelta(from previous: PiPackedUsage, to current: PiPackedUsage) -> PiPackedUsage {
+        let input = max(0, current.inputTokens - previous.inputTokens)
+        let cacheRead = max(0, current.cacheReadTokens - previous.cacheReadTokens)
+        let cacheWrite = max(0, current.cacheWriteTokens - previous.cacheWriteTokens)
+        let output = max(0, current.outputTokens - previous.outputTokens)
+        let total = max(0, current.totalTokens - previous.totalTokens)
+        return PiPackedUsage(
+            inputTokens: input,
+            cacheReadTokens: cacheRead,
+            cacheWriteTokens: cacheWrite,
+            outputTokens: output,
+            totalTokens: max(total, input + cacheRead + cacheWrite + output))
+    }
+
+    private static func usageTotal(_ usage: PiPackedUsage) -> Int {
+        let derivedTotal = [usage.inputTokens, usage.cacheReadTokens, usage.cacheWriteTokens, usage.outputTokens]
+            .reduce(0, self.clampedAdd)
+        return max(usage.totalTokens, derivedTotal)
+    }
+
+    private static func clampedAdd(_ lhs: Int, _ rhs: Int) -> Int {
+        let added = lhs.addingReportingOverflow(rhs)
+        return added.overflow ? Int.max : added.partialValue
     }
 
     private static func computedCostUSD(

--- a/Sources/CodexBarCore/PiSessionCostScanner.swift
+++ b/Sources/CodexBarCore/PiSessionCostScanner.swift
@@ -262,7 +262,9 @@ enum PiSessionCostScanner {
     }
 
     private static func defaultPiSessionsRoot(options: Options) -> URL {
-        if let override = options.piSessionsRoot { return override }
+        if let override = options.piSessionsRoot {
+            return override
+        }
         return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".pi", isDirectory: true)
             .appendingPathComponent("agent", isDirectory: true)
@@ -572,13 +574,14 @@ enum PiSessionCostScanner {
         message: [String: Any],
         fallbackSequence: Int) -> String
     {
+        // Broader turn and task IDs can span independent requests, so prefer the narrowest stable identity.
         let keys = [
-            "turnId",
-            "turn_id",
             "requestId",
             "request_id",
             "messageId",
             "message_id",
+            "turnId",
+            "turn_id",
             "taskId",
             "task_id",
             "id",

--- a/Sources/CodexBarCore/PiSessionCostScanner.swift
+++ b/Sources/CodexBarCore/PiSessionCostScanner.swift
@@ -575,12 +575,12 @@ enum PiSessionCostScanner {
         let keys = [
             "turnId",
             "turn_id",
-            "taskId",
-            "task_id",
             "requestId",
             "request_id",
             "messageId",
             "message_id",
+            "taskId",
+            "task_id",
             "id",
         ]
         for key in keys {

--- a/Tests/CodexBarTests/PiSessionCostScannerTests.swift
+++ b/Tests/CodexBarTests/PiSessionCostScannerTests.swift
@@ -807,6 +807,159 @@ struct PiSessionCostScannerTests {
 
 extension PiSessionCostScannerTests {
     @Test
+    func `pi scanner deltas cumulative ultra usage samples per lineage`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 7, day: 11)
+        let model = "gpt-5.6-sol"
+
+        func assistant(step: Int) -> [String: Any] {
+            let timestamp = day.addingTimeInterval(TimeInterval(step))
+            let input = step * 1_000_000
+            let cacheRead = step * 100_000
+            let output = step * 1000
+            return [
+                "type": "message",
+                "timestamp": env.isoString(for: timestamp),
+                "message": [
+                    "role": "assistant",
+                    "provider": "openai-codex",
+                    "model": model,
+                    "turnId": "ultra-fork-turn",
+                    "timestamp": Int(timestamp.timeIntervalSince1970 * 1000),
+                    "usage": [
+                        "input": input,
+                        "cacheRead": cacheRead,
+                        "output": output,
+                        "totalTokens": input + cacheRead + output,
+                    ],
+                ],
+            ]
+        }
+
+        _ = try env.writePiSessionFile(
+            relativePath: "2026-07-11T10-00-00-000Z_ultra-cumulative.jsonl",
+            contents: env.jsonl((1...6).map(assistant(step:))))
+
+        let report = PiSessionCostScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: PiSessionCostScanner.Options(
+                piSessionsRoot: env.piSessionsRoot,
+                cacheRoot: env.cacheRoot,
+                refreshMinIntervalSeconds: 0))
+
+        #expect(report.data.count == 1)
+        #expect(report.data.first?.inputTokens == 6_000_000)
+        #expect(report.data.first?.cacheReadTokens == 600_000)
+        #expect(report.data.first?.outputTokens == 6000)
+        #expect(report.data.first?.totalTokens == 6_606_000)
+    }
+
+    @Test
+    func `pi scanner keeps ordinary increasing rows below cumulative guardrail raw`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 7, day: 11)
+
+        func assistant(step: Int) -> [String: Any] {
+            let timestamp = day.addingTimeInterval(TimeInterval(step))
+            let input = step * 100
+            let output = step * 10
+            return [
+                "type": "message",
+                "timestamp": env.isoString(for: timestamp),
+                "message": [
+                    "role": "assistant",
+                    "provider": "openai-codex",
+                    "model": "gpt-5.4",
+                    "turnId": "small-increasing-turn",
+                    "timestamp": Int(timestamp.timeIntervalSince1970 * 1000),
+                    "usage": [
+                        "input": input,
+                        "output": output,
+                        "totalTokens": input + output,
+                    ],
+                ],
+            ]
+        }
+
+        _ = try env.writePiSessionFile(
+            relativePath: "2026-07-11T10-00-00-000Z_small-increasing.jsonl",
+            contents: env.jsonl((1...5).map(assistant(step:))))
+
+        let report = PiSessionCostScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: PiSessionCostScanner.Options(
+                piSessionsRoot: env.piSessionsRoot,
+                cacheRoot: env.cacheRoot,
+                refreshMinIntervalSeconds: 0))
+
+        #expect(report.data.count == 1)
+        #expect(report.data.first?.inputTokens == 1500)
+        #expect(report.data.first?.outputTokens == 150)
+        #expect(report.data.first?.totalTokens == 1650)
+    }
+
+    @Test
+    func `pi scanner keeps rows without lineage raw even when large and monotonic`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 7, day: 11)
+
+        func assistant(step: Int) -> [String: Any] {
+            let timestamp = day.addingTimeInterval(TimeInterval(step))
+            let input = step * 1_000_000
+            let cacheRead = step * 100_000
+            let output = step * 1000
+            return [
+                "type": "message",
+                "timestamp": env.isoString(for: timestamp),
+                "message": [
+                    "role": "assistant",
+                    "provider": "openai-codex",
+                    "model": "gpt-5.6-sol",
+                    "timestamp": Int(timestamp.timeIntervalSince1970 * 1000),
+                    "usage": [
+                        "input": input,
+                        "cacheRead": cacheRead,
+                        "output": output,
+                        "totalTokens": input + cacheRead + output,
+                    ],
+                ],
+            ]
+        }
+
+        _ = try env.writePiSessionFile(
+            relativePath: "2026-07-11T10-00-00-000Z_no-lineage-monotonic.jsonl",
+            contents: env.jsonl((1...6).map(assistant(step:))))
+
+        let report = PiSessionCostScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: PiSessionCostScanner.Options(
+                piSessionsRoot: env.piSessionsRoot,
+                cacheRoot: env.cacheRoot,
+                refreshMinIntervalSeconds: 0))
+
+        #expect(report.data.count == 1)
+        #expect(report.data.first?.inputTokens == 21_000_000)
+        #expect(report.data.first?.cacheReadTokens == 2_100_000)
+        #expect(report.data.first?.outputTokens == 21000)
+        #expect(report.data.first?.totalTokens == 23_121_000)
+    }
+
+    @Test
     func `pi scanner reprices unchanged files when catalog rates change`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }

--- a/Tests/CodexBarTests/PiSessionCostScannerTests.swift
+++ b/Tests/CodexBarTests/PiSessionCostScannerTests.swift
@@ -808,55 +808,10 @@ struct PiSessionCostScannerTests {
 extension PiSessionCostScannerTests {
     @Test
     func `pi scanner deltas cumulative ultra usage samples per lineage`() throws {
-        let env = try CostUsageTestEnvironment()
-        defer { env.cleanup() }
-
-        let day = try env.makeLocalNoon(year: 2026, month: 7, day: 11)
-        let model = "gpt-5.6-sol"
-
-        func assistant(step: Int) -> [String: Any] {
-            let timestamp = day.addingTimeInterval(TimeInterval(step))
-            let input = step * 1_000_000
-            let cacheRead = step * 100_000
-            let output = step * 1000
-            return [
-                "type": "message",
-                "timestamp": env.isoString(for: timestamp),
-                "message": [
-                    "role": "assistant",
-                    "provider": "openai-codex",
-                    "model": model,
-                    "turnId": "ultra-fork-turn",
-                    "timestamp": Int(timestamp.timeIntervalSince1970 * 1000),
-                    "usage": [
-                        "input": input,
-                        "cacheRead": cacheRead,
-                        "output": output,
-                        "totalTokens": input + cacheRead + output,
-                    ],
-                ],
-            ]
-        }
-
-        _ = try env.writePiSessionFile(
+        try self.assertLargeMonotonicPiUsage(
             relativePath: "2026-07-11T10-00-00-000Z_ultra-cumulative.jsonl",
-            contents: env.jsonl((1...6).map(assistant(step:))))
-
-        let report = PiSessionCostScanner.loadDailyReport(
-            provider: .codex,
-            since: day,
-            until: day,
-            now: day,
-            options: PiSessionCostScanner.Options(
-                piSessionsRoot: env.piSessionsRoot,
-                cacheRoot: env.cacheRoot,
-                refreshMinIntervalSeconds: 0))
-
-        #expect(report.data.count == 1)
-        #expect(report.data.first?.inputTokens == 6_000_000)
-        #expect(report.data.first?.cacheReadTokens == 600_000)
-        #expect(report.data.first?.outputTokens == 6000)
-        #expect(report.data.first?.totalTokens == 6_606_000)
+            expected: (6_000_000, 600_000, 6000, 6_606_000),
+            messageFields: { _ in ["turnId": "ultra-fork-turn"] })
     }
 
     @Test
@@ -909,60 +864,40 @@ extension PiSessionCostScannerTests {
     }
 
     @Test
-    func `pi scanner keeps unique requests additive under shared task id`() throws {
-        let env = try CostUsageTestEnvironment()
-        defer { env.cleanup() }
-
-        let day = try env.makeLocalNoon(year: 2026, month: 7, day: 11)
-
-        func assistant(step: Int) -> [String: Any] {
-            let timestamp = day.addingTimeInterval(TimeInterval(step))
-            let input = step * 1_000_000
-            let cacheRead = step * 100_000
-            let output = step * 1000
-            return [
-                "type": "message",
-                "timestamp": env.isoString(for: timestamp),
-                "message": [
-                    "role": "assistant",
-                    "provider": "openai-codex",
-                    "model": "gpt-5.6-sol",
+    func `pi scanner keeps unique requests additive under shared turn and task ids`() throws {
+        try self.assertLargeMonotonicPiUsage(
+            relativePath: "2026-07-11T10-00-00-000Z_shared-task-unique-requests.jsonl",
+            expected: (21_000_000, 2_100_000, 21000, 23_121_000),
+            messageFields: { step in
+                [
+                    "turnId": "shared-pi-turn",
                     "taskId": "shared-pi-task",
                     "requestId": "request-\(step)",
-                    "timestamp": Int(timestamp.timeIntervalSince1970 * 1000),
-                    "usage": [
-                        "input": input,
-                        "cacheRead": cacheRead,
-                        "output": output,
-                        "totalTokens": input + cacheRead + output,
-                    ],
-                ],
-            ]
-        }
+                ]
+            })
+    }
 
-        _ = try env.writePiSessionFile(
-            relativePath: "2026-07-11T10-00-00-000Z_shared-task-unique-requests.jsonl",
-            contents: env.jsonl((1...6).map(assistant(step:))))
-
-        let report = PiSessionCostScanner.loadDailyReport(
-            provider: .codex,
-            since: day,
-            until: day,
-            now: day,
-            options: PiSessionCostScanner.Options(
-                piSessionsRoot: env.piSessionsRoot,
-                cacheRoot: env.cacheRoot,
-                refreshMinIntervalSeconds: 0))
-
-        #expect(report.data.count == 1)
-        #expect(report.data.first?.inputTokens == 21_000_000)
-        #expect(report.data.first?.cacheReadTokens == 2_100_000)
-        #expect(report.data.first?.outputTokens == 21000)
-        #expect(report.data.first?.totalTokens == 23_121_000)
+    @Test
+    func `pi scanner keeps unique event ids additive when usage is large and monotonic`() throws {
+        try self.assertLargeMonotonicPiUsage(
+            relativePath: "2026-07-11T10-00-00-000Z_unique-events-monotonic.jsonl",
+            expected: (21_000_000, 2_100_000, 21000, 23_121_000),
+            entryFields: { step in ["id": "event-\(step)"] })
     }
 
     @Test
     func `pi scanner keeps rows without lineage raw even when large and monotonic`() throws {
+        try self.assertLargeMonotonicPiUsage(
+            relativePath: "2026-07-11T10-00-00-000Z_no-lineage-monotonic.jsonl",
+            expected: (21_000_000, 2_100_000, 21000, 23_121_000))
+    }
+
+    private func assertLargeMonotonicPiUsage(
+        relativePath: String,
+        expected: (input: Int, cacheRead: Int, output: Int, total: Int),
+        entryFields: (Int) -> [String: Any] = { _ in [:] },
+        messageFields: (Int) -> [String: Any] = { _ in [:] }) throws
+    {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }
 
@@ -973,26 +908,30 @@ extension PiSessionCostScannerTests {
             let input = step * 1_000_000
             let cacheRead = step * 100_000
             let output = step * 1000
-            return [
-                "type": "message",
-                "timestamp": env.isoString(for: timestamp),
-                "message": [
-                    "role": "assistant",
-                    "provider": "openai-codex",
-                    "model": "gpt-5.6-sol",
-                    "timestamp": Int(timestamp.timeIntervalSince1970 * 1000),
-                    "usage": [
-                        "input": input,
-                        "cacheRead": cacheRead,
-                        "output": output,
-                        "totalTokens": input + cacheRead + output,
-                    ],
+            var message: [String: Any] = [
+                "role": "assistant",
+                "provider": "openai-codex",
+                "model": "gpt-5.6-sol",
+                "timestamp": Int(timestamp.timeIntervalSince1970 * 1000),
+                "usage": [
+                    "input": input,
+                    "cacheRead": cacheRead,
+                    "output": output,
+                    "totalTokens": input + cacheRead + output,
                 ],
             ]
+            message.merge(messageFields(step)) { _, replacement in replacement }
+            var entry: [String: Any] = [
+                "type": "message",
+                "timestamp": env.isoString(for: timestamp),
+                "message": message,
+            ]
+            entry.merge(entryFields(step)) { _, replacement in replacement }
+            return entry
         }
 
         _ = try env.writePiSessionFile(
-            relativePath: "2026-07-11T10-00-00-000Z_no-lineage-monotonic.jsonl",
+            relativePath: relativePath,
             contents: env.jsonl((1...6).map(assistant(step:))))
 
         let report = PiSessionCostScanner.loadDailyReport(
@@ -1006,10 +945,10 @@ extension PiSessionCostScannerTests {
                 refreshMinIntervalSeconds: 0))
 
         #expect(report.data.count == 1)
-        #expect(report.data.first?.inputTokens == 21_000_000)
-        #expect(report.data.first?.cacheReadTokens == 2_100_000)
-        #expect(report.data.first?.outputTokens == 21000)
-        #expect(report.data.first?.totalTokens == 23_121_000)
+        #expect(report.data.first?.inputTokens == expected.input)
+        #expect(report.data.first?.cacheReadTokens == expected.cacheRead)
+        #expect(report.data.first?.outputTokens == expected.output)
+        #expect(report.data.first?.totalTokens == expected.total)
     }
 
     @Test

--- a/Tests/CodexBarTests/PiSessionCostScannerTests.swift
+++ b/Tests/CodexBarTests/PiSessionCostScannerTests.swift
@@ -909,6 +909,59 @@ extension PiSessionCostScannerTests {
     }
 
     @Test
+    func `pi scanner keeps unique requests additive under shared task id`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 7, day: 11)
+
+        func assistant(step: Int) -> [String: Any] {
+            let timestamp = day.addingTimeInterval(TimeInterval(step))
+            let input = step * 1_000_000
+            let cacheRead = step * 100_000
+            let output = step * 1000
+            return [
+                "type": "message",
+                "timestamp": env.isoString(for: timestamp),
+                "message": [
+                    "role": "assistant",
+                    "provider": "openai-codex",
+                    "model": "gpt-5.6-sol",
+                    "taskId": "shared-pi-task",
+                    "requestId": "request-\(step)",
+                    "timestamp": Int(timestamp.timeIntervalSince1970 * 1000),
+                    "usage": [
+                        "input": input,
+                        "cacheRead": cacheRead,
+                        "output": output,
+                        "totalTokens": input + cacheRead + output,
+                    ],
+                ],
+            ]
+        }
+
+        _ = try env.writePiSessionFile(
+            relativePath: "2026-07-11T10-00-00-000Z_shared-task-unique-requests.jsonl",
+            contents: env.jsonl((1...6).map(assistant(step:))))
+
+        let report = PiSessionCostScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: PiSessionCostScanner.Options(
+                piSessionsRoot: env.piSessionsRoot,
+                cacheRoot: env.cacheRoot,
+                refreshMinIntervalSeconds: 0))
+
+        #expect(report.data.count == 1)
+        #expect(report.data.first?.inputTokens == 21_000_000)
+        #expect(report.data.first?.cacheReadTokens == 2_100_000)
+        #expect(report.data.first?.outputTokens == 21000)
+        #expect(report.data.first?.totalTokens == 23_121_000)
+    }
+
+    @Test
     func `pi scanner keeps rows without lineage raw even when large and monotonic`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }


### PR DESCRIPTION
Fixes #2037.

## Summary
- reparse changed Pi session files so file-level cumulative usage detection stays stable as logs grow
- group Pi assistant usage samples by provider, model, and turn-like lineage, then convert cumulative-looking monotonic sequences into deltas
- prefer request/message IDs before task IDs so a shared task ID cannot collapse independent requests into one cumulative lineage
- keep samples without a lineage raw, and bump the Pi cost formula fingerprint so old overcounted cache entries rebuild

## Tests
- `swift test --filter PiSessionCostScannerTests` - 20 tests passed
- `make check` - passed; existing missing-translation warnings only
- `git diff --check origin/main...HEAD` - clean
- `make test` - not green locally: `AdaptiveRefreshTimerTests` cancels `menu open advances a long idle timer during refresh without postponing an earlier tick` after 30s before reaching the scanner shard; isolated `swift test --skip-build --no-parallel --filter AdaptiveRefreshTimerTests` reproduces the same failure outside this diff

## Risk
Cumulative detection is guarded to large monotonic sequences where the raw sum is at least 3x the final sample and differs by at least 1M tokens. Ordinary small increasing samples, large monotonic samples without a shared lineage, and large rows with unique request IDs under one task ID remain raw/additive.

Review focus: whether the lineage keys cover the current Ultra fork/replay rows without being too broad for ordinary Pi sessions.
