### PR TITLE
Fix stranded menu scroll after a manual refresh clears a provider error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Claude: prevent CodexBar's passive CLI probes from starting background Claude Code updates, avoiding repeated partial downloads when a probe exits before an update completes. Thanks @PG2047!
 - Codex cost history: bound malformed session-metadata lines and release read chunks promptly, preventing metadata pre-scans from retaining memory in proportion to oversized JSONL records. Thanks @Yuxin-Qiao!
 - Widgets: add Cursor to configurable and switcher widgets with accurate legacy Requests and current Total, Auto, and API quota labels (#2040). Thanks @Zihao-Qi!
+- Menus: return oversized tracked menus to the provider header after a manual refresh without moving background updates, highlighted rows, open submenus, or newer menu/provider sessions (#2046). Thanks @ss251!
 
 ## 0.42.0 — 2026-07-11
 

--- a/Sources/CodexBar/MenuSessionCoordinator.swift
+++ b/Sources/CodexBar/MenuSessionCoordinator.swift
@@ -12,6 +12,7 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
     private(set) var renderedVersions: [MenuID: Int] = [:]
     private(set) var deferredUntilNextOpen: Set<MenuID> = []
     private(set) var parentRebuildsDeferredDuringTracking: Set<MenuID> = []
+    private(set) var pendingViewportRestores: Set<MenuID> = []
 
     @discardableResult
     mutating func invalidate(
@@ -92,16 +93,29 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
         self.parentRebuildsDeferredDuringTracking.contains(menuID)
     }
 
+    /// One-shot viewport restore armed by a completed user-initiated manual refresh and
+    /// consumed when that refresh's open-menu rebuild lands.
+    mutating func armViewportRestore(_ menuID: MenuID) {
+        self.pendingViewportRestores.insert(menuID)
+    }
+
+    @discardableResult
+    mutating func consumeViewportRestore(_ menuID: MenuID) -> Bool {
+        self.pendingViewportRestores.remove(menuID) != nil
+    }
+
     mutating func removeMenu(_ menuID: MenuID) {
         self.renderedVersions.removeValue(forKey: menuID)
         self.deferredUntilNextOpen.remove(menuID)
         self.parentRebuildsDeferredDuringTracking.remove(menuID)
+        self.pendingViewportRestores.remove(menuID)
     }
 
     mutating func clearMenuTracking() {
         self.renderedVersions.removeAll(keepingCapacity: false)
         self.deferredUntilNextOpen.removeAll(keepingCapacity: false)
         self.parentRebuildsDeferredDuringTracking.removeAll(keepingCapacity: false)
+        self.pendingViewportRestores.removeAll(keepingCapacity: false)
     }
 
     #if DEBUG

--- a/Sources/CodexBar/MenuSessionCoordinator.swift
+++ b/Sources/CodexBar/MenuSessionCoordinator.swift
@@ -12,7 +12,8 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
     private(set) var renderedVersions: [MenuID: Int] = [:]
     private(set) var deferredUntilNextOpen: Set<MenuID> = []
     private(set) var parentRebuildsDeferredDuringTracking: Set<MenuID> = []
-    private(set) var pendingViewportRestores: Set<MenuID> = []
+    private var nextViewportRestoreToken = 0
+    private(set) var pendingViewportRestores: [MenuID: Int] = [:]
 
     @discardableResult
     mutating func invalidate(
@@ -93,22 +94,34 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
         self.parentRebuildsDeferredDuringTracking.contains(menuID)
     }
 
-    /// One-shot viewport restore armed by a completed user-initiated manual refresh and
-    /// consumed when that refresh's open-menu rebuild lands.
-    mutating func armViewportRestore(_ menuID: MenuID) {
-        self.pendingViewportRestores.insert(menuID)
+    /// One-shot viewport restore tied to the menu-tracking session that started a manual refresh.
+    @discardableResult
+    mutating func armViewportRestore(_ menuID: MenuID) -> Int {
+        self.nextViewportRestoreToken &+= 1
+        self.pendingViewportRestores[menuID] = self.nextViewportRestoreToken
+        return self.nextViewportRestoreToken
+    }
+
+    func isCurrentViewportRestore(_ token: Int, for menuID: MenuID) -> Bool {
+        self.pendingViewportRestores[menuID] == token
     }
 
     @discardableResult
-    mutating func consumeViewportRestore(_ menuID: MenuID) -> Bool {
-        self.pendingViewportRestores.remove(menuID) != nil
+    mutating func consumeViewportRestore(_ menuID: MenuID, token: Int) -> Bool {
+        guard self.isCurrentViewportRestore(token, for: menuID) else { return false }
+        self.pendingViewportRestores.removeValue(forKey: menuID)
+        return true
+    }
+
+    mutating func cancelViewportRestore(_ menuID: MenuID) {
+        self.pendingViewportRestores.removeValue(forKey: menuID)
     }
 
     mutating func removeMenu(_ menuID: MenuID) {
         self.renderedVersions.removeValue(forKey: menuID)
         self.deferredUntilNextOpen.remove(menuID)
         self.parentRebuildsDeferredDuringTracking.remove(menuID)
-        self.pendingViewportRestores.remove(menuID)
+        self.cancelViewportRestore(menuID)
     }
 
     mutating func clearMenuTracking() {

--- a/Sources/CodexBar/MenuSessionCoordinator.swift
+++ b/Sources/CodexBar/MenuSessionCoordinator.swift
@@ -12,9 +12,9 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
     private(set) var renderedVersions: [MenuID: Int] = [:]
     private(set) var deferredUntilNextOpen: Set<MenuID> = []
     private(set) var parentRebuildsDeferredDuringTracking: Set<MenuID> = []
-    private var nextMenuInteractionToken = 0
-    private(set) var menuInteractionTokens: [MenuID: Int] = [:]
-    private var nextViewportRestoreToken = 0
+    private var nextMenuInteractionGeneration = 0
+    private(set) var menuInteractionGenerations: [MenuID: Int] = [:]
+    private var nextViewportRestoreGeneration = 0
     private(set) var pendingViewportRestores: [MenuID: Int] = [:]
 
     @discardableResult
@@ -99,48 +99,48 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
     /// Identifies one concrete open/close lifetime even when AppKit reuses the same menu object.
     @discardableResult
     mutating func beginTrackingSession(_ menuID: MenuID) -> Int {
-        self.replaceMenuInteractionToken(for: menuID)
+        self.replaceMenuInteractionGeneration(for: menuID)
     }
 
-    func menuInteractionToken(for menuID: MenuID) -> Int? {
-        self.menuInteractionTokens[menuID]
+    func menuInteractionGeneration(for menuID: MenuID) -> Int? {
+        self.menuInteractionGenerations[menuID]
     }
 
-    func isCurrentMenuInteraction(_ token: Int, for menuID: MenuID) -> Bool {
-        self.menuInteractionTokens[menuID] == token
+    func isCurrentMenuInteraction(_ generation: Int, for menuID: MenuID) -> Bool {
+        self.menuInteractionGenerations[menuID] == generation
     }
 
     @discardableResult
     mutating func advanceMenuInteraction(for menuID: MenuID) -> Int? {
-        guard self.menuInteractionTokens[menuID] != nil else { return nil }
-        return self.replaceMenuInteractionToken(for: menuID)
+        guard self.menuInteractionGenerations[menuID] != nil else { return nil }
+        return self.replaceMenuInteractionGeneration(for: menuID)
     }
 
-    private mutating func replaceMenuInteractionToken(for menuID: MenuID) -> Int {
-        self.nextMenuInteractionToken &+= 1
-        self.menuInteractionTokens[menuID] = self.nextMenuInteractionToken
-        return self.nextMenuInteractionToken
+    private mutating func replaceMenuInteractionGeneration(for menuID: MenuID) -> Int {
+        self.nextMenuInteractionGeneration &+= 1
+        self.menuInteractionGenerations[menuID] = self.nextMenuInteractionGeneration
+        return self.nextMenuInteractionGeneration
     }
 
     mutating func endTrackingSession(_ menuID: MenuID) {
-        self.menuInteractionTokens.removeValue(forKey: menuID)
+        self.menuInteractionGenerations.removeValue(forKey: menuID)
     }
 
     /// One-shot viewport restore tied to the menu-tracking session that started a manual refresh.
     @discardableResult
     mutating func armViewportRestore(_ menuID: MenuID) -> Int {
-        self.nextViewportRestoreToken &+= 1
-        self.pendingViewportRestores[menuID] = self.nextViewportRestoreToken
-        return self.nextViewportRestoreToken
+        self.nextViewportRestoreGeneration &+= 1
+        self.pendingViewportRestores[menuID] = self.nextViewportRestoreGeneration
+        return self.nextViewportRestoreGeneration
     }
 
-    func isCurrentViewportRestore(_ token: Int, for menuID: MenuID) -> Bool {
-        self.pendingViewportRestores[menuID] == token
+    func isCurrentViewportRestore(_ generation: Int, for menuID: MenuID) -> Bool {
+        self.pendingViewportRestores[menuID] == generation
     }
 
     @discardableResult
-    mutating func consumeViewportRestore(_ menuID: MenuID, token: Int) -> Bool {
-        guard self.isCurrentViewportRestore(token, for: menuID) else { return false }
+    mutating func consumeViewportRestore(_ menuID: MenuID, generation: Int) -> Bool {
+        guard self.isCurrentViewportRestore(generation, for: menuID) else { return false }
         self.pendingViewportRestores.removeValue(forKey: menuID)
         return true
     }
@@ -161,7 +161,7 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
         self.renderedVersions.removeAll(keepingCapacity: false)
         self.deferredUntilNextOpen.removeAll(keepingCapacity: false)
         self.parentRebuildsDeferredDuringTracking.removeAll(keepingCapacity: false)
-        self.menuInteractionTokens.removeAll(keepingCapacity: false)
+        self.menuInteractionGenerations.removeAll(keepingCapacity: false)
         self.pendingViewportRestores.removeAll(keepingCapacity: false)
     }
 

--- a/Sources/CodexBar/MenuSessionCoordinator.swift
+++ b/Sources/CodexBar/MenuSessionCoordinator.swift
@@ -12,6 +12,8 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
     private(set) var renderedVersions: [MenuID: Int] = [:]
     private(set) var deferredUntilNextOpen: Set<MenuID> = []
     private(set) var parentRebuildsDeferredDuringTracking: Set<MenuID> = []
+    private var nextMenuInteractionToken = 0
+    private(set) var menuInteractionTokens: [MenuID: Int] = [:]
     private var nextViewportRestoreToken = 0
     private(set) var pendingViewportRestores: [MenuID: Int] = [:]
 
@@ -94,6 +96,36 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
         self.parentRebuildsDeferredDuringTracking.contains(menuID)
     }
 
+    /// Identifies one concrete open/close lifetime even when AppKit reuses the same menu object.
+    @discardableResult
+    mutating func beginTrackingSession(_ menuID: MenuID) -> Int {
+        self.replaceMenuInteractionToken(for: menuID)
+    }
+
+    func menuInteractionToken(for menuID: MenuID) -> Int? {
+        self.menuInteractionTokens[menuID]
+    }
+
+    func isCurrentMenuInteraction(_ token: Int, for menuID: MenuID) -> Bool {
+        self.menuInteractionTokens[menuID] == token
+    }
+
+    @discardableResult
+    mutating func advanceMenuInteraction(for menuID: MenuID) -> Int? {
+        guard self.menuInteractionTokens[menuID] != nil else { return nil }
+        return self.replaceMenuInteractionToken(for: menuID)
+    }
+
+    private mutating func replaceMenuInteractionToken(for menuID: MenuID) -> Int {
+        self.nextMenuInteractionToken &+= 1
+        self.menuInteractionTokens[menuID] = self.nextMenuInteractionToken
+        return self.nextMenuInteractionToken
+    }
+
+    mutating func endTrackingSession(_ menuID: MenuID) {
+        self.menuInteractionTokens.removeValue(forKey: menuID)
+    }
+
     /// One-shot viewport restore tied to the menu-tracking session that started a manual refresh.
     @discardableResult
     mutating func armViewportRestore(_ menuID: MenuID) -> Int {
@@ -121,6 +153,7 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
         self.renderedVersions.removeValue(forKey: menuID)
         self.deferredUntilNextOpen.remove(menuID)
         self.parentRebuildsDeferredDuringTracking.remove(menuID)
+        self.endTrackingSession(menuID)
         self.cancelViewportRestore(menuID)
     }
 
@@ -128,6 +161,7 @@ struct MenuSessionCoordinator<MenuID: Hashable> {
         self.renderedVersions.removeAll(keepingCapacity: false)
         self.deferredUntilNextOpen.removeAll(keepingCapacity: false)
         self.parentRebuildsDeferredDuringTracking.removeAll(keepingCapacity: false)
+        self.menuInteractionTokens.removeAll(keepingCapacity: false)
         self.pendingViewportRestores.removeAll(keepingCapacity: false)
     }
 

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -135,7 +135,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         self.startManualRefresh(
             for: nil,
             originatingMenuID: nil,
-            originatingMenuInteractionToken: nil)
+            originatingMenuInteractionGeneration: nil)
     }
 
     @objc func refreshMenuItem(_ sender: NSMenuItem) {
@@ -144,18 +144,18 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
 
     func refreshMenuProviderNow(in menu: NSMenu?) {
         let originatingMenuID = menu.map(ObjectIdentifier.init)
-        let originatingMenuInteractionToken = originatingMenuID.flatMap {
-            self.menuSession.menuInteractionToken(for: $0)
+        let originatingMenuInteractionGeneration = originatingMenuID.flatMap {
+            self.menuSession.menuInteractionGeneration(for: $0)
         }
         self.startManualRefresh(
             for: self.manualRefreshProvider(for: menu),
             originatingMenuID: originatingMenuID,
-            originatingMenuInteractionToken: originatingMenuInteractionToken)
+            originatingMenuInteractionGeneration: originatingMenuInteractionGeneration)
     }
 
     private func refreshMenuProviderNow(
         menuID: ObjectIdentifier,
-        originatingMenuInteractionToken: Int)
+        originatingMenuInteractionGeneration: Int)
     {
         let menu = self.openMenus[menuID] ?? self.mergedMenu.flatMap {
             ObjectIdentifier($0) == menuID ? $0 : nil
@@ -164,13 +164,13 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         self.startManualRefresh(
             for: provider,
             originatingMenuID: menuID,
-            originatingMenuInteractionToken: originatingMenuInteractionToken)
+            originatingMenuInteractionGeneration: originatingMenuInteractionGeneration)
     }
 
     private func startManualRefresh(
         for provider: UsageProvider?,
         originatingMenuID: ObjectIdentifier?,
-        originatingMenuInteractionToken: Int?)
+        originatingMenuInteractionGeneration: Int?)
     {
         let scope: ManualRefreshScope = provider.map(ManualRefreshScope.provider) ?? .global
         let scopedRefreshInFlight = provider.map { self.store.refreshingProviders.contains($0) }
@@ -191,7 +191,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         let frozenModels = self.frozenManualRefreshMenuCardModels()
         let viewportRestoreRequests = self.armManualRefreshViewportRestoreRequests(
             originatingMenuID: originatingMenuID,
-            originatingMenuInteractionToken: originatingMenuInteractionToken)
+            originatingMenuInteractionGeneration: originatingMenuInteractionGeneration)
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
             var completed = false
@@ -266,21 +266,21 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     func performPersistentRefreshAction(in menuID: ObjectIdentifier) {
-        guard let menuInteractionToken = self.menuSession.menuInteractionToken(for: menuID) else { return }
+        guard let menuInteractionGeneration = self.menuSession.menuInteractionGeneration(for: menuID) else { return }
         self.performPersistentRefreshAction(
             in: menuID,
-            menuInteractionToken: menuInteractionToken)
+            menuInteractionGeneration: menuInteractionGeneration)
     }
 
     nonisolated func performPersistentRefreshAction(
         in menuID: ObjectIdentifier,
-        menuInteractionToken: Int)
+        menuInteractionGeneration: Int)
     {
         Task { @MainActor [weak self] in
             guard let self else { return }
             self.refreshMenuProviderNow(
                 menuID: menuID,
-                originatingMenuInteractionToken: menuInteractionToken)
+                originatingMenuInteractionGeneration: menuInteractionGeneration)
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -183,6 +183,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
                 self.manualRefreshTasks[scope] = nil
                 self.menuCardRefreshMonitor.endManualRefresh(for: provider)
                 self.updatePersistentRefreshItemsEnabled()
+                self.armMenuViewportRestoreAfterManualRefresh()
                 self.prepareAttachedClosedMenusIfNeeded()
             }
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -132,7 +132,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     @objc func refreshNow() {
-        self.startManualRefresh(for: nil)
+        self.startManualRefresh(for: nil, originatingMenuID: nil)
     }
 
     @objc func refreshMenuItem(_ sender: NSMenuItem) {
@@ -140,11 +140,12 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     func refreshMenuProviderNow(in menu: NSMenu?) {
+        let originatingMenuID = menu.map(ObjectIdentifier.init)
         guard let provider = self.manualRefreshProvider(for: menu) else {
-            self.startManualRefresh(for: nil)
+            self.startManualRefresh(for: nil, originatingMenuID: originatingMenuID)
             return
         }
-        self.startManualRefresh(for: provider)
+        self.startManualRefresh(for: provider, originatingMenuID: originatingMenuID)
     }
 
     private func refreshMenuProviderNow(menuID: ObjectIdentifier) {
@@ -153,13 +154,16 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         } else if let mergedMenu = self.mergedMenu, ObjectIdentifier(mergedMenu) == menuID {
             self.refreshMenuProviderNow(in: mergedMenu)
         } else if let provider = self.menuProviders[menuID] {
-            self.startManualRefresh(for: provider)
+            self.startManualRefresh(for: provider, originatingMenuID: menuID)
         } else {
-            self.startManualRefresh(for: nil)
+            self.startManualRefresh(for: nil, originatingMenuID: menuID)
         }
     }
 
-    private func startManualRefresh(for provider: UsageProvider?) {
+    private func startManualRefresh(
+        for provider: UsageProvider?,
+        originatingMenuID: ObjectIdentifier?)
+    {
         let scope: ManualRefreshScope = provider.map(ManualRefreshScope.provider) ?? .global
         let scopedRefreshInFlight = provider.map { self.store.refreshingProviders.contains($0) }
             ?? !self.store.refreshingProviders.isEmpty
@@ -177,13 +181,21 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         else { return }
 
         let frozenModels = self.frozenManualRefreshMenuCardModels()
+        let viewportRestoreRequests = self.armManualRefreshViewportRestoreRequests(
+            originatingMenuID: originatingMenuID)
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
+            var completed = false
             defer {
                 self.manualRefreshTasks[scope] = nil
                 self.menuCardRefreshMonitor.endManualRefresh(for: provider)
                 self.updatePersistentRefreshItemsEnabled()
-                self.armMenuViewportRestoreAfterManualRefresh()
+                if completed {
+                    self.scheduleCompletedManualRefreshViewportRestore(viewportRestoreRequests)
+                } else {
+                    self.cancelManualRefreshViewportRestoreRequests(viewportRestoreRequests)
+                }
+                self.completeParentMenuRebuildAfterHostedSubviewCloseIfNeeded()
                 self.prepareAttachedClosedMenusIfNeeded()
             }
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
@@ -191,6 +203,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             if let operation = self._test_manualRefreshOperation {
                 await operation()
                 guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+                completed = true
                 return
             }
             #endif
@@ -205,6 +218,8 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
                     refreshOpenMenusWhenComplete: true,
                     interaction: .userInitiated)
             }
+            guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+            completed = true
         }
         self.manualRefreshTasks[scope] = task
         self.menuCardRefreshMonitor.beginManualRefresh(frozenModels: frozenModels, provider: provider)

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -132,7 +132,10 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     @objc func refreshNow() {
-        self.startManualRefresh(for: nil, originatingMenuID: nil)
+        self.startManualRefresh(
+            for: nil,
+            originatingMenuID: nil,
+            originatingMenuInteractionToken: nil)
     }
 
     @objc func refreshMenuItem(_ sender: NSMenuItem) {
@@ -141,28 +144,33 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
 
     func refreshMenuProviderNow(in menu: NSMenu?) {
         let originatingMenuID = menu.map(ObjectIdentifier.init)
-        guard let provider = self.manualRefreshProvider(for: menu) else {
-            self.startManualRefresh(for: nil, originatingMenuID: originatingMenuID)
-            return
+        let originatingMenuInteractionToken = originatingMenuID.flatMap {
+            self.menuSession.menuInteractionToken(for: $0)
         }
-        self.startManualRefresh(for: provider, originatingMenuID: originatingMenuID)
+        self.startManualRefresh(
+            for: self.manualRefreshProvider(for: menu),
+            originatingMenuID: originatingMenuID,
+            originatingMenuInteractionToken: originatingMenuInteractionToken)
     }
 
-    private func refreshMenuProviderNow(menuID: ObjectIdentifier) {
-        if let menu = self.openMenus[menuID] {
-            self.refreshMenuProviderNow(in: menu)
-        } else if let mergedMenu = self.mergedMenu, ObjectIdentifier(mergedMenu) == menuID {
-            self.refreshMenuProviderNow(in: mergedMenu)
-        } else if let provider = self.menuProviders[menuID] {
-            self.startManualRefresh(for: provider, originatingMenuID: menuID)
-        } else {
-            self.startManualRefresh(for: nil, originatingMenuID: menuID)
+    private func refreshMenuProviderNow(
+        menuID: ObjectIdentifier,
+        originatingMenuInteractionToken: Int)
+    {
+        let menu = self.openMenus[menuID] ?? self.mergedMenu.flatMap {
+            ObjectIdentifier($0) == menuID ? $0 : nil
         }
+        let provider = menu.flatMap { self.manualRefreshProvider(for: $0) } ?? self.menuProviders[menuID]
+        self.startManualRefresh(
+            for: provider,
+            originatingMenuID: menuID,
+            originatingMenuInteractionToken: originatingMenuInteractionToken)
     }
 
     private func startManualRefresh(
         for provider: UsageProvider?,
-        originatingMenuID: ObjectIdentifier?)
+        originatingMenuID: ObjectIdentifier?,
+        originatingMenuInteractionToken: Int?)
     {
         let scope: ManualRefreshScope = provider.map(ManualRefreshScope.provider) ?? .global
         let scopedRefreshInFlight = provider.map { self.store.refreshingProviders.contains($0) }
@@ -182,7 +190,8 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
 
         let frozenModels = self.frozenManualRefreshMenuCardModels()
         let viewportRestoreRequests = self.armManualRefreshViewportRestoreRequests(
-            originatingMenuID: originatingMenuID)
+            originatingMenuID: originatingMenuID,
+            originatingMenuInteractionToken: originatingMenuInteractionToken)
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
             var completed = false
@@ -256,10 +265,22 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         return models
     }
 
-    nonisolated func performPersistentRefreshAction(in menuID: ObjectIdentifier) {
+    func performPersistentRefreshAction(in menuID: ObjectIdentifier) {
+        guard let menuInteractionToken = self.menuSession.menuInteractionToken(for: menuID) else { return }
+        self.performPersistentRefreshAction(
+            in: menuID,
+            menuInteractionToken: menuInteractionToken)
+    }
+
+    nonisolated func performPersistentRefreshAction(
+        in menuID: ObjectIdentifier,
+        menuInteractionToken: Int)
+    {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            self.refreshMenuProviderNow(menuID: menuID)
+            self.refreshMenuProviderNow(
+                menuID: menuID,
+                originatingMenuInteractionToken: menuInteractionToken)
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+ClaudeSwapMenu.swift
+++ b/Sources/CodexBar/StatusItemController+ClaudeSwapMenu.swift
@@ -58,7 +58,7 @@ extension StatusItemController {
         let accountID = account.id
         return { [weak self, weak menu] in
             guard let self else { return }
-            self.advanceMenuContentSelection(for: menu)
+            self.advanceMenuInteraction(for: menu)
             self.store.switchClaudeSwapAccount(accountID)
         }
     }

--- a/Sources/CodexBar/StatusItemController+ClaudeSwapMenu.swift
+++ b/Sources/CodexBar/StatusItemController+ClaudeSwapMenu.swift
@@ -2,7 +2,11 @@ import AppKit
 import CodexBarCore
 
 extension StatusItemController {
-    func addClaudeSwapMenuCards(to menu: NSMenu, context: MenuCardContext) {
+    func addClaudeSwapMenuCards(
+        to menu: NSMenu,
+        captureMenu: NSMenu,
+        context: MenuCardContext)
+    {
         let cardRows = self.store.claudeSwapAccountSnapshots.compactMap { account ->
             (account: ProviderAccountUsageSnapshot, model: UsageMenuCardView.Model)? in
             guard let model = self.menuCardModel(
@@ -30,22 +34,32 @@ extension StatusItemController {
             context: context,
             planAction: { [weak self] index in
                 guard cardRows.indices.contains(index) else { return nil }
-                return self?.claudeSwapAccountSwitchAction(cardRows[index].account)
+                return self?.claudeSwapAccountSwitchAction(cardRows[index].account, menu: captureMenu)
             })
     }
 
     private func claudeSwapAccountActionLabel(_ account: ProviderAccountUsageSnapshot) -> String? {
-        if account.isActive { return L("Active") }
-        if self.store.claudeSwapTransientState.switchingAccountID == account.id { return L("Loading…") }
+        if account.isActive {
+            return L("Active")
+        }
+        if self.store.claudeSwapTransientState.switchingAccountID == account.id {
+            return L("Loading…")
+        }
         guard self.store.claudeSwapTransientState.task == nil, account.canActivate else { return nil }
         return L("Switch Account...")
     }
 
-    private func claudeSwapAccountSwitchAction(_ account: ProviderAccountUsageSnapshot) -> (() -> Void)? {
+    private func claudeSwapAccountSwitchAction(
+        _ account: ProviderAccountUsageSnapshot,
+        menu: NSMenu)
+        -> (() -> Void)?
+    {
         guard self.store.claudeSwapTransientState.task == nil, account.canActivate else { return nil }
         let accountID = account.id
-        return { [weak self] in
-            self?.store.switchClaudeSwapAccount(accountID)
+        return { [weak self, weak menu] in
+            guard let self else { return }
+            self.advanceMenuContentSelection(for: menu)
+            self.store.switchClaudeSwapAccount(accountID)
         }
     }
 }

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -10,6 +10,27 @@ extension StatusItemController {
         let providerRawValue: String?
     }
 
+    func refreshHostedSubviewHeights(in menu: NSMenu) {
+        let width = self.renderedMenuWidth(for: menu)
+
+        for item in menu.items {
+            guard let view = item.view else { continue }
+            let height = self.hostedSubviewFittingHeight(for: view, width: width)
+            view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))
+        }
+    }
+
+    /// Measures the natural height of a hosted submenu view at the given width using the live
+    /// view that will actually be displayed. Hosted chart items used to spin up a second,
+    /// throwaway `NSHostingController` purely to size the chart even though every build path
+    /// immediately re-measures the live view via `fittingSize`; that extra SwiftUI hierarchy was
+    /// pure overhead on a popup-menu hot path, so callers now size the displayed view directly.
+    func hostedSubviewFittingHeight(for view: NSView, width: CGFloat) -> CGFloat {
+        view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: 1))
+        view.layoutSubtreeIfNeeded()
+        return view.fittingSize.height
+    }
+
     func isHostedSubviewMenu(_ menu: NSMenu) -> Bool {
         let ids: Set = [
             Self.usageBreakdownChartID,

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -7,12 +7,6 @@ import SwiftUI
 // MARK: - NSMenu construction
 
 extension StatusItemController {
-    var fallbackProvider: UsageProvider? {
-        // Intentionally uses availability-filtered list: fallback activates when no provider
-        // can actually work, ensuring at least a codex icon is always visible.
-        self.store.enabledProviders().isEmpty ? .codex : nil
-    }
-
     static let menuCardBaseWidth: CGFloat = 310
     private static let maxOverviewProviders = SettingsStore.mergedOverviewProviderLimit
     static let overviewRowIdentifierPrefix = "overviewRow-"
@@ -57,10 +51,6 @@ extension StatusItemController {
         }
     }
 
-    func isPersistentRefreshItem(_ item: NSMenuItem) -> Bool {
-        item.representedObject as? String == Self.persistentRefreshMenuItemID
-    }
-
     func makeMenu() -> NSMenu {
         guard self.shouldMergeIcons else {
             return self.makeMenu(for: nil)
@@ -87,6 +77,8 @@ extension StatusItemController {
 
         self.cancelDeferredMenuInteractionRefreshTask()
         self.cancelClosedMenuRebuild(menu)
+
+        self.beginMenuTrackingSession(for: menu)
 
         // Track whether this is the root menu opening (no menus were open). Only the root open rebuilds
         // all content from current data, so the readiness baseline is re-anchored only here — re-anchoring
@@ -172,6 +164,8 @@ extension StatusItemController {
     func forgetClosedMenu(_ menu: NSMenu) {
         let key = ObjectIdentifier(menu)
         let wasMergedMenu = menu === self.mergedMenu
+
+        self.endMenuTrackingSession(for: menu)
 
         if key == self.providerSwitcherShortcutMenuID {
             self.removeProviderSwitcherShortcutMonitor()
@@ -613,7 +607,7 @@ extension StatusItemController {
         menu.addItem(item)
     }
 
-    private func addMenuCards(to menu: NSMenu, context: MenuCardContext) -> Bool {
+    private func addMenuCards(to menu: NSMenu, context: MenuCardContext, captureMenu: NSMenu? = nil) -> Bool {
         if let codexAccountDisplay = context.codexAccountDisplay, codexAccountDisplay.showAll {
             self.addStackedCodexMenuCards(codexAccountDisplay, to: menu, context: context)
             return false
@@ -625,7 +619,7 @@ extension StatusItemController {
             provider: context.currentProvider,
             accountCount: self.store.claudeSwapAccountSnapshots.count)
         {
-            self.addClaudeSwapMenuCards(to: menu, context: context)
+            self.addClaudeSwapMenuCards(to: menu, captureMenu: captureMenu ?? menu, context: context)
             return false
         }
 
@@ -776,7 +770,7 @@ extension StatusItemController {
                 menu.addItem(.separator())
             }
         } else {
-            let addedOpenAIWebItems = self.addMenuCards(to: menu, context: context)
+            let addedOpenAIWebItems = self.addMenuCards(to: menu, context: context, captureMenu: captureMenu)
             self.addOpenAIWebItemsIfNeeded(
                 to: menu,
                 currentProvider: context.currentProvider,
@@ -1023,6 +1017,7 @@ extension StatusItemController {
                 guard let self, let menu else { return nil }
                 guard display.accounts.indices.contains(index) else { return nil }
                 let selectedAccount = display.accounts[index]
+                self.advanceMenuContentSelection(for: menu)
                 self.settings.setActiveTokenAccountIndex(index, for: display.provider)
                 self.store.activateCachedTokenAccountSnapshot(
                     provider: display.provider,
@@ -1066,6 +1061,7 @@ extension StatusItemController {
     @discardableResult
     private func handleCodexVisibleAccountSelection(_ account: CodexVisibleAccount, menu: NSMenu?) -> Bool {
         let visibleAccountID = account.id
+        self.advanceMenuContentSelection(for: menu)
         self.settings.selectDisplayedCodexVisibleAccount(account)
         if self.store.prepareCodexAccountScopedRefreshIfNeeded(), let menu {
             self.deferSwitcherMenuRebuildIfStillVisible(menu, provider: .codex)
@@ -1091,7 +1087,9 @@ extension StatusItemController {
 
     func resolvedMenuProvider(enabledProviders: [UsageProvider]? = nil) -> UsageProvider? {
         let enabled = enabledProviders ?? self.store.enabledProvidersForDisplay()
-        if enabled.isEmpty { return .codex }
+        if enabled.isEmpty {
+            return .codex
+        }
         if let selected = self.selectedMenuProvider, enabled.contains(selected) {
             return selected
         }
@@ -1164,7 +1162,9 @@ extension StatusItemController {
                 refreshingProviders: self.store.refreshingProviders,
                 staleProviders: Set(visibleProviders.filter { self.store.isStale(provider: $0) }),
                 missingProviders: Set(visibleProviders.filter { !self.store.hasSatisfiedUsageFetch(for: $0) })))
-            if plan.refreshCodexDashboard { self.deferOpenAIDashboardRefreshUntilMenuCloses(reason: "refresh all") }
+            if plan.refreshCodexDashboard {
+                self.deferOpenAIDashboardRefreshUntilMenuCloses(reason: "refresh all")
+            }
             let retryProviders = plan.providers
             guard !retryProviders.isEmpty else {
                 self.clearSatisfiedDeferredMenuInteractionRefreshes(
@@ -1639,27 +1639,6 @@ extension StatusItemController {
             guard let id = item.representedObject as? String else { return false }
             return ids.contains(id)
         }
-    }
-
-    func refreshHostedSubviewHeights(in menu: NSMenu) {
-        let width = self.renderedMenuWidth(for: menu)
-
-        for item in menu.items {
-            guard let view = item.view else { continue }
-            let height = self.hostedSubviewFittingHeight(for: view, width: width)
-            view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))
-        }
-    }
-
-    /// Measures the natural height of a hosted submenu view at the given width using the live
-    /// view that will actually be displayed. Hosted chart items used to spin up a second,
-    /// throwaway `NSHostingController` purely to size the chart even though every build path
-    /// immediately re-measures the live view via `fittingSize`; that extra SwiftUI hierarchy was
-    /// pure overhead on a popup-menu hot path, so callers now size the displayed view directly.
-    func hostedSubviewFittingHeight(for view: NSView, width: CGFloat) -> CGFloat {
-        view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: 1))
-        view.layoutSubtreeIfNeeded()
-        return view.fittingSize.height
     }
 
     @objc func menuCardNoOp(_ sender: NSMenuItem) {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1017,7 +1017,7 @@ extension StatusItemController {
                 guard let self, let menu else { return nil }
                 guard display.accounts.indices.contains(index) else { return nil }
                 let selectedAccount = display.accounts[index]
-                self.advanceMenuContentSelection(for: menu)
+                self.advanceMenuInteraction(for: menu)
                 self.settings.setActiveTokenAccountIndex(index, for: display.provider)
                 self.store.activateCachedTokenAccountSnapshot(
                     provider: display.provider,
@@ -1061,7 +1061,7 @@ extension StatusItemController {
     @discardableResult
     private func handleCodexVisibleAccountSelection(_ account: CodexVisibleAccount, menu: NSMenu?) -> Bool {
         let visibleAccountID = account.id
-        self.advanceMenuContentSelection(for: menu)
+        self.advanceMenuInteraction(for: menu)
         self.settings.selectDisplayedCodexVisibleAccount(account)
         if self.store.prepareCodexAccountScopedRefreshIfNeeded(), let menu {
             self.deferSwitcherMenuRebuildIfStillVisible(menu, provider: .codex)

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -7,6 +7,12 @@ import SwiftUI
 // MARK: - NSMenu construction
 
 extension StatusItemController {
+    var fallbackProvider: UsageProvider? {
+        // Intentionally uses availability-filtered list: fallback activates when no provider
+        // can actually work, ensuring at least a codex icon is always visible.
+        self.store.enabledProviders().isEmpty ? .codex : nil
+    }
+
     static let menuCardBaseWidth: CGFloat = 310
     private static let maxOverviewProviders = SettingsStore.mergedOverviewProviderLimit
     static let overviewRowIdentifierPrefix = "overviewRow-"

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -2,6 +2,28 @@ import AppKit
 import CodexBarCore
 
 extension StatusItemController {
+    func beginMenuTrackingSession(for menu: NSMenu) {
+        if menu.supermenu != nil, !self.isHostedSubviewMenu(menu) {
+            self.advanceMenuContentSelection(for: self.rootMenu(for: menu))
+        }
+        let menuID = ObjectIdentifier(menu)
+        let token = self.menuSession.beginTrackingSession(menuID)
+        (menu as? StatusItemMenu)?.menuInteractionToken = token
+    }
+
+    func endMenuTrackingSession(for menu: NSMenu) {
+        (menu as? StatusItemMenu)?.menuInteractionToken = nil
+        self.menuSession.endTrackingSession(ObjectIdentifier(menu))
+    }
+
+    private func rootMenu(for menu: NSMenu) -> NSMenu {
+        var root = menu
+        while let parent = root.supermenu {
+            root = parent
+        }
+        return root
+    }
+
     private static let defaultClosedMenuPreparationDelay: Duration = .milliseconds(350)
 
     var isMenuRefreshEnabled: Bool {
@@ -379,6 +401,10 @@ extension StatusItemController {
 
     func hasOpenHostedSubviewMenu() -> Bool {
         self.openMenus.values.contains { self.isHostedSubviewMenu($0) }
+    }
+
+    func hasOpenNonHostedChildMenu() -> Bool {
+        self.openMenus.values.contains { $0.supermenu != nil && !self.isHostedSubviewMenu($0) }
     }
 
     func refreshOpenMenuIfStillVisible(_ menu: NSMenu, provider: UsageProvider?) {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -7,12 +7,12 @@ extension StatusItemController {
             self.advanceMenuContentSelection(for: self.rootMenu(for: menu))
         }
         let menuID = ObjectIdentifier(menu)
-        let token = self.menuSession.beginTrackingSession(menuID)
-        (menu as? StatusItemMenu)?.menuInteractionToken = token
+        let generation = self.menuSession.beginTrackingSession(menuID)
+        (menu as? StatusItemMenu)?.menuInteractionGeneration = generation
     }
 
     func endMenuTrackingSession(for menu: NSMenu) {
-        (menu as? StatusItemMenu)?.menuInteractionToken = nil
+        (menu as? StatusItemMenu)?.menuInteractionGeneration = nil
         self.menuSession.endTrackingSession(ObjectIdentifier(menu))
     }
 

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -131,7 +131,7 @@ extension StatusItemController {
         self.openMenuRebuildRequests.cancel(for: key)
         self.openMenuRebuildsClosingHostedSubviewMenus.remove(key)
         self.pendingMenuBaselineResyncs.remove(key)
-        self.menuSession.consumeViewportRestore(key)
+        self.cancelManualRefreshViewportRestore(for: key)
     }
 
     func clearMenuHighlight(_ key: ObjectIdentifier) {
@@ -411,7 +411,7 @@ extension StatusItemController {
             self.markMenuFresh(menu)
             self.menuSession.clearParentRebuildDeferral(key)
             self.applyIcon(phase: nil)
-            self.consumePendingMenuViewportRestore(for: menu)
+            self.scheduleDeferredManualRefreshViewportRestoreAfterRebuild(for: menu)
         }
         #if DEBUG
         self._test_openMenuRebuildObserver?(menu)

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -4,7 +4,7 @@ import CodexBarCore
 extension StatusItemController {
     func beginMenuTrackingSession(for menu: NSMenu) {
         if menu.supermenu != nil, !self.isHostedSubviewMenu(menu) {
-            self.advanceMenuContentSelection(for: self.rootMenu(for: menu))
+            self.advanceMenuInteraction(for: self.rootMenu(for: menu))
         }
         let menuID = ObjectIdentifier(menu)
         let generation = self.menuSession.beginTrackingSession(menuID)

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -131,6 +131,7 @@ extension StatusItemController {
         self.openMenuRebuildRequests.cancel(for: key)
         self.openMenuRebuildsClosingHostedSubviewMenus.remove(key)
         self.pendingMenuBaselineResyncs.remove(key)
+        self.menuSession.consumeViewportRestore(key)
     }
 
     func clearMenuHighlight(_ key: ObjectIdentifier) {
@@ -410,6 +411,7 @@ extension StatusItemController {
             self.markMenuFresh(menu)
             self.menuSession.clearParentRebuildDeferral(key)
             self.applyIcon(phase: nil)
+            self.consumePendingMenuViewportRestore(for: menu)
         }
         #if DEBUG
         self._test_openMenuRebuildObserver?(menu)

--- a/Sources/CodexBar/StatusItemController+MenuTypes.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTypes.swift
@@ -2,6 +2,14 @@ import AppKit
 import CodexBarCore
 import SwiftUI
 
+extension StatusItemController {
+    var fallbackProvider: UsageProvider? {
+        // Intentionally uses availability-filtered list: fallback activates when no provider
+        // can actually work, ensuring at least a codex icon is always visible.
+        self.store.enabledProviders().isEmpty ? .codex : nil
+    }
+}
+
 extension ProviderSwitcherSelection {
     var provider: UsageProvider? {
         switch self {

--- a/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
+++ b/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
@@ -2,6 +2,7 @@ import AppKit
 
 struct ManualRefreshViewportRestoreRequest {
     let token: Int
+    let menuInteractionToken: Int
     let switcherSelection: ProviderSwitcherSelection?
 }
 
@@ -22,7 +23,8 @@ extension StatusItemController {
     /// before refreshing so a close and reopen cannot transfer the restore to a new tracking
     /// session. Background refreshes never enter this path and therefore never move the viewport.
     func armManualRefreshViewportRestoreRequests(
-        originatingMenuID: ObjectIdentifier?)
+        originatingMenuID: ObjectIdentifier?,
+        originatingMenuInteractionToken: Int?)
         -> [ObjectIdentifier: ManualRefreshViewportRestoreRequest]
     {
         let candidates: [(ObjectIdentifier, NSMenu)]
@@ -35,9 +37,17 @@ extension StatusItemController {
 
         var requests: [ObjectIdentifier: ManualRefreshViewportRestoreRequest] = [:]
         for (key, menu) in candidates where menu.supermenu == nil && !self.isHostedSubviewMenu(menu) {
+            guard let menuInteractionToken = self.menuSession.menuInteractionToken(for: key) else { continue }
+            if key == originatingMenuID,
+               let originatingMenuInteractionToken,
+               menuInteractionToken != originatingMenuInteractionToken
+            {
+                continue
+            }
             self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
             requests[key] = ManualRefreshViewportRestoreRequest(
                 token: self.menuSession.armViewportRestore(key),
+                menuInteractionToken: menuInteractionToken,
                 switcherSelection: self.viewportRestoreSwitcherSelection(for: menu))
         }
         return requests
@@ -50,7 +60,10 @@ extension StatusItemController {
         _ requests: [ObjectIdentifier: ManualRefreshViewportRestoreRequest])
     {
         for (key, request) in requests {
-            guard self.menuSession.isCurrentViewportRestore(request.token, for: key) else { continue }
+            guard self.isCurrentManualRefreshViewportRestoreContext(request, for: key) else {
+                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                continue
+            }
             guard !self.hasPreparedForAppShutdown,
                   let menu = self.openMenus[key],
                   ObjectIdentifier(menu) == key,
@@ -59,6 +72,10 @@ extension StatusItemController {
                   request.switcherSelection == self.viewportRestoreSwitcherSelection(for: menu),
                   self.menuNeedsRefresh(menu)
             else {
+                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                continue
+            }
+            guard !self.hasOpenNonHostedChildMenu() else {
                 self.cancelManualRefreshViewportRestoreRequest(request, for: key)
                 continue
             }
@@ -82,9 +99,10 @@ extension StatusItemController {
         let key = ObjectIdentifier(menu)
         guard let request = self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
         else { return }
-        guard self.menuSession.isCurrentViewportRestore(request.token, for: key),
+        guard self.isCurrentManualRefreshViewportRestoreContext(request, for: key),
               !self.hasPreparedForAppShutdown,
               self.openMenus[key] === menu,
+              !self.hasOpenNonHostedChildMenu(),
               !self.hasOpenHostedSubviewMenu(),
               !self.isNativeMenuItemHighlighted(in: menu),
               request.switcherSelection == self.viewportRestoreSwitcherSelection(for: menu)
@@ -102,12 +120,19 @@ extension StatusItemController {
         let key = ObjectIdentifier(menu)
         let operation: @MainActor () -> Void = { [weak self, weak menu] in
             guard let self else { return }
-            guard self.menuSession.isCurrentViewportRestore(request.token, for: key) else { return }
+            guard self.isCurrentManualRefreshViewportRestoreContext(request, for: key) else {
+                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                return
+            }
             guard !self.hasPreparedForAppShutdown,
                   let menu,
                   self.openMenus[key] === menu,
                   request.switcherSelection == self.viewportRestoreSwitcherSelection(for: menu)
             else {
+                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                return
+            }
+            guard !self.hasOpenNonHostedChildMenu() else {
                 self.cancelManualRefreshViewportRestoreRequest(request, for: key)
                 return
             }
@@ -173,6 +198,24 @@ extension StatusItemController {
             return .overview
         }
         return .provider(self.resolvedMenuProvider() ?? .codex)
+    }
+
+    private func isCurrentManualRefreshViewportRestoreContext(
+        _ request: ManualRefreshViewportRestoreRequest,
+        for key: ObjectIdentifier)
+        -> Bool
+    {
+        self.menuSession.isCurrentViewportRestore(request.token, for: key) &&
+            self.menuSession.isCurrentMenuInteraction(request.menuInteractionToken, for: key)
+    }
+
+    func advanceMenuContentSelection(for menu: NSMenu?) {
+        guard let menu else { return }
+        let key = ObjectIdentifier(menu)
+        guard self.openMenus[key] === menu,
+              let token = self.menuSession.advanceMenuInteraction(for: key)
+        else { return }
+        (menu as? StatusItemMenu)?.menuInteractionToken = token
     }
 
     func restoreMenuViewportToTop(_ menu: NSMenu) {

--- a/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
+++ b/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
@@ -86,7 +86,7 @@ extension StatusItemController {
                 self.manualRefreshViewportRestoreState.deferredUntilRebuild[key] = request
                 continue
             }
-            guard !self.isNativeMenuItemHighlighted(in: menu) else {
+            guard !self.hasMenuItemHighlightedForViewportRestore(in: menu) else {
                 self.cancelManualRefreshViewportRestoreRequest(request, for: key)
                 continue
             }
@@ -104,7 +104,7 @@ extension StatusItemController {
               self.openMenus[key] === menu,
               !self.hasOpenNonHostedChildMenu(),
               !self.hasOpenHostedSubviewMenu(),
-              !self.isNativeMenuItemHighlighted(in: menu),
+              !self.hasMenuItemHighlightedForViewportRestore(in: menu),
               request.switcherSelection == self.viewportRestoreSwitcherSelection(for: menu)
         else {
             self.cancelManualRefreshViewportRestoreRequest(request, for: key)
@@ -151,7 +151,7 @@ extension StatusItemController {
                 self.manualRefreshViewportRestoreState.deferredUntilRebuild[key] = request
                 return
             }
-            guard !self.isNativeMenuItemHighlighted(in: menu) else {
+            guard !self.hasMenuItemHighlightedForViewportRestore(in: menu) else {
                 self.cancelManualRefreshViewportRestoreRequest(request, for: key)
                 return
             }
@@ -207,6 +207,12 @@ extension StatusItemController {
     {
         self.menuSession.isCurrentViewportRestore(request.generation, for: key) &&
             self.menuSession.isCurrentMenuInteraction(request.menuInteractionGeneration, for: key)
+    }
+
+    private func hasMenuItemHighlightedForViewportRestore(in menu: NSMenu) -> Bool {
+        let key = ObjectIdentifier(menu)
+        guard let item = self.highlightedMenuItems[key], item.menu === menu else { return false }
+        return item.isEnabled
     }
 
     func advanceMenuContentSelection(for menu: NSMenu?) {

--- a/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
+++ b/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
@@ -215,7 +215,7 @@ extension StatusItemController {
         return item.isEnabled
     }
 
-    func advanceMenuContentSelection(for menu: NSMenu?) {
+    func advanceMenuInteraction(for menu: NSMenu?) {
         guard let menu else { return }
         let key = ObjectIdentifier(menu)
         guard self.openMenus[key] === menu,

--- a/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
+++ b/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
@@ -1,41 +1,183 @@
 import AppKit
 
-extension StatusItemController {
-    #if DEBUG
-    static var _test_menuViewportRestoreObserver: (@MainActor (NSMenu) -> Void)?
-    #endif
+struct ManualRefreshViewportRestoreRequest {
+    let token: Int
+    let switcherSelection: ProviderSwitcherSelection?
+}
 
+@MainActor
+final class ManualRefreshViewportRestoreState {
+    var deferredUntilRebuild: [ObjectIdentifier: ManualRefreshViewportRestoreRequest] = [:]
+    #if DEBUG
+    var testOperation: (@MainActor () async -> Void)?
+    var testObserver: (@MainActor (NSMenu) -> Void)?
+    var testScheduler: ((@escaping @MainActor () -> Void) -> Void)?
+    #endif
+}
+
+extension StatusItemController {
     /// A user-initiated manual refresh reconciles the tracked menu in place, and the row
-    /// heights it changes (a recovered provider-error banner collapsing is the largest jump)
-    /// can leave AppKit's private menu scrolling anchored mid-list with no way back to the
-    /// top short of closing and reopening the menu. Arm a one-shot viewport restore for the
-    /// open menus the refresh will rebuild; the restore runs when that rebuild lands.
-    /// Background data ticks never arm this, so they cannot yank a viewport the user is
-    /// reading.
-    func armMenuViewportRestoreAfterManualRefresh() {
-        for (key, menu) in self.openMenus {
-            guard !self.isHostedSubviewMenu(menu) else { continue }
-            guard self.menuNeedsRefresh(menu) else { continue }
-            self.menuSession.armViewportRestore(key)
+    /// geometry and AppKit scroll state it changes can leave the private menu viewport anchored
+    /// mid-list with no way back to the top short of closing and reopening the menu. Arm a token
+    /// before refreshing so a close and reopen cannot transfer the restore to a new tracking
+    /// session. Background refreshes never enter this path and therefore never move the viewport.
+    func armManualRefreshViewportRestoreRequests(
+        originatingMenuID: ObjectIdentifier?)
+        -> [ObjectIdentifier: ManualRefreshViewportRestoreRequest]
+    {
+        let candidates: [(ObjectIdentifier, NSMenu)]
+        if let originatingMenuID {
+            guard let menu = self.openMenus[originatingMenuID] else { return [:] }
+            candidates = [(originatingMenuID, menu)]
+        } else {
+            candidates = Array(self.openMenus)
+        }
+
+        var requests: [ObjectIdentifier: ManualRefreshViewportRestoreRequest] = [:]
+        for (key, menu) in candidates where menu.supermenu == nil && !self.isHostedSubviewMenu(menu) {
+            self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
+            requests[key] = ManualRefreshViewportRestoreRequest(
+                token: self.menuSession.armViewportRestore(key),
+                switcherSelection: self.viewportRestoreSwitcherSelection(for: menu))
+        }
+        return requests
+    }
+
+    /// A completed manual refresh updates live card content without rebuilding the tracked
+    /// parent menu. Restore on AppKit's tracking run loop after that live layout settles. The
+    /// exact token prevents an older completion from consuming a newer refresh or menu session.
+    func scheduleCompletedManualRefreshViewportRestore(
+        _ requests: [ObjectIdentifier: ManualRefreshViewportRestoreRequest])
+    {
+        for (key, request) in requests {
+            guard self.menuSession.isCurrentViewportRestore(request.token, for: key) else { continue }
+            guard !self.hasPreparedForAppShutdown,
+                  let menu = self.openMenus[key],
+                  ObjectIdentifier(menu) == key,
+                  menu.supermenu == nil,
+                  !self.isHostedSubviewMenu(menu),
+                  request.switcherSelection == self.viewportRestoreSwitcherSelection(for: menu),
+                  self.menuNeedsRefresh(menu)
+            else {
+                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                continue
+            }
+            if self.hasOpenHostedSubviewMenu() ||
+                self.parentMenuRebuildPendingAfterHostedSubviewClose ||
+                self.openMenuRebuildRequests.tokens[key] != nil
+            {
+                self.manualRefreshViewportRestoreState.deferredUntilRebuild[key] = request
+                continue
+            }
+            guard !self.isNativeMenuItemHighlighted(in: menu) else {
+                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                continue
+            }
+
+            self.scheduleManualRefreshViewportRestore(request, for: menu)
         }
     }
 
-    /// Consumes a pending restore after `populateMenu` has reconciled the open menu. The
-    /// scroll repair runs on the next main-actor turn so AppKit's own relayout of the
-    /// table-backed menu settles first; the restore is a no-op when the menu is not
-    /// scrolled or no longer open.
-    func consumePendingMenuViewportRestore(for menu: NSMenu) {
-        guard self.menuSession.consumeViewportRestore(ObjectIdentifier(menu)) else { return }
-        Task { @MainActor [weak self, weak menu] in
-            guard let self, let menu else { return }
-            guard self.openMenus[ObjectIdentifier(menu)] != nil else { return }
+    func scheduleDeferredManualRefreshViewportRestoreAfterRebuild(for menu: NSMenu) {
+        let key = ObjectIdentifier(menu)
+        guard let request = self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
+        else { return }
+        guard self.menuSession.isCurrentViewportRestore(request.token, for: key),
+              !self.hasPreparedForAppShutdown,
+              self.openMenus[key] === menu,
+              !self.hasOpenHostedSubviewMenu(),
+              !self.isNativeMenuItemHighlighted(in: menu),
+              request.switcherSelection == self.viewportRestoreSwitcherSelection(for: menu)
+        else {
+            self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+            return
+        }
+        self.scheduleManualRefreshViewportRestore(request, for: menu)
+    }
+
+    private func scheduleManualRefreshViewportRestore(
+        _ request: ManualRefreshViewportRestoreRequest,
+        for menu: NSMenu)
+    {
+        let key = ObjectIdentifier(menu)
+        let operation: @MainActor () -> Void = { [weak self, weak menu] in
+            guard let self else { return }
+            guard self.menuSession.isCurrentViewportRestore(request.token, for: key) else { return }
+            guard !self.hasPreparedForAppShutdown,
+                  let menu,
+                  self.openMenus[key] === menu,
+                  request.switcherSelection == self.viewportRestoreSwitcherSelection(for: menu)
+            else {
+                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                return
+            }
+            let menuIsDirty = self.menuNeedsRefresh(menu)
+            let parentRebuildPending = self.openMenuRebuildRequests.tokens[key] != nil ||
+                (self.parentMenuRebuildPendingAfterHostedSubviewClose && menuIsDirty)
+            if self.hasOpenHostedSubviewMenu() {
+                guard menuIsDirty || parentRebuildPending else {
+                    self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                    return
+                }
+                self.manualRefreshViewportRestoreState.deferredUntilRebuild[key] = request
+                return
+            }
+            if parentRebuildPending {
+                self.manualRefreshViewportRestoreState.deferredUntilRebuild[key] = request
+                return
+            }
+            guard !self.isNativeMenuItemHighlighted(in: menu) else {
+                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                return
+            }
+            guard self.menuSession.consumeViewportRestore(key, token: request.token) else { return }
             self.restoreMenuViewportToTop(menu)
         }
+        #if DEBUG
+        if let scheduler = self._test_menuViewportRestoreScheduler {
+            scheduler(operation)
+        } else {
+            ProviderSwitcherTrackingRunLoopScheduler.schedule(operation)
+        }
+        #else
+        ProviderSwitcherTrackingRunLoopScheduler.schedule(operation)
+        #endif
+    }
+
+    func cancelManualRefreshViewportRestore(for key: ObjectIdentifier) {
+        self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
+        self.menuSession.cancelViewportRestore(key)
+    }
+
+    private func cancelManualRefreshViewportRestoreRequest(
+        _ request: ManualRefreshViewportRestoreRequest,
+        for key: ObjectIdentifier)
+    {
+        if self.manualRefreshViewportRestoreState.deferredUntilRebuild[key]?.token == request.token {
+            self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
+        }
+        self.menuSession.consumeViewportRestore(key, token: request.token)
+    }
+
+    func cancelManualRefreshViewportRestoreRequests(
+        _ requests: [ObjectIdentifier: ManualRefreshViewportRestoreRequest])
+    {
+        for (key, request) in requests {
+            self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+        }
+    }
+
+    private func viewportRestoreSwitcherSelection(for menu: NSMenu) -> ProviderSwitcherSelection? {
+        guard self.shouldMergeIcons, menu === self.mergedMenu else { return nil }
+        if self.isMergedOverviewSelected(in: menu) {
+            return .overview
+        }
+        return .provider(self.resolvedMenuProvider() ?? .codex)
     }
 
     func restoreMenuViewportToTop(_ menu: NSMenu) {
         #if DEBUG
-        if let observer = Self._test_menuViewportRestoreObserver {
+        if let observer = self._test_menuViewportRestoreObserver {
             observer(menu)
             return
         }

--- a/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
+++ b/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
@@ -6,9 +6,337 @@ struct ManualRefreshViewportRestoreRequest {
     let switcherSelection: ProviderSwitcherSelection?
 }
 
+struct MenuViewportGeometry: Equatable {
+    let documentID: ObjectIdentifier
+    let clipID: ObjectIdentifier
+    let documentSize: CGSize
+    let documentIsFlipped: Bool
+    let clipSize: CGSize
+    let clipOrigin: CGPoint
+}
+
+enum MenuViewportGeometryTransition: Equatable {
+    case unchanged
+    case layout
+    case movement
+}
+
+private struct MenuViewportOriginRange {
+    private(set) var minimumX: CGFloat
+    private(set) var maximumX: CGFloat
+    private(set) var minimumY: CGFloat
+    private(set) var maximumY: CGFloat
+
+    init(baseline: CGPoint, current: CGPoint) {
+        self.minimumX = min(baseline.x, current.x)
+        self.maximumX = max(baseline.x, current.x)
+        self.minimumY = min(baseline.y, current.y)
+        self.maximumY = max(baseline.y, current.y)
+    }
+
+    mutating func include(_ origin: CGPoint) {
+        self.minimumX = min(self.minimumX, origin.x)
+        self.maximumX = max(self.maximumX, origin.x)
+        self.minimumY = min(self.minimumY, origin.y)
+        self.maximumY = max(self.maximumY, origin.y)
+    }
+
+    func exceeds(_ tolerance: CGFloat) -> Bool {
+        self.maximumX - self.minimumX > tolerance || self.maximumY - self.minimumY > tolerance
+    }
+}
+
+@MainActor
+final class ManualRefreshViewportMovementTracker: NSObject {
+    private weak var scrollView: NSScrollView?
+    private weak var clipView: NSClipView?
+    private weak var documentView: NSView?
+    private let originalPostsBoundsChangedNotifications: Bool
+    private let originalClipPostsFrameChangedNotifications: Bool
+    private let originalDocumentPostsFrameChangedNotifications: Bool
+    private var baselineGeometry: MenuViewportGeometry?
+    private var pendingOriginRange: MenuViewportOriginRange?
+    private var afterSettleOperations: [@MainActor () -> Void] = []
+    private var settleScheduled = false
+    private var permitsPostLayoutTopCorrection = false
+    private var isActive = true
+    private(set) var observedMovement = false
+
+    init(scrollView: NSScrollView) {
+        let clipView = scrollView.contentView
+        let documentView = scrollView.documentView
+        self.scrollView = scrollView
+        self.clipView = clipView
+        self.documentView = documentView
+        self.originalPostsBoundsChangedNotifications = clipView.postsBoundsChangedNotifications
+        self.originalClipPostsFrameChangedNotifications = clipView.postsFrameChangedNotifications
+        self.originalDocumentPostsFrameChangedNotifications = documentView?.postsFrameChangedNotifications ?? false
+        self.baselineGeometry = nil
+        self.pendingOriginRange = nil
+        super.init()
+        clipView.postsBoundsChangedNotifications = true
+        clipView.postsFrameChangedNotifications = true
+        documentView?.postsFrameChangedNotifications = true
+        self.baselineGeometry = StatusItemController.menuViewportGeometry(in: scrollView)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.viewportGeometryDidChange(_:)),
+            name: NSView.boundsDidChangeNotification,
+            object: clipView)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.viewportGeometryDidChange(_:)),
+            name: NSView.frameDidChangeNotification,
+            object: clipView)
+        if let documentView {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(self.viewportGeometryDidChange(_:)),
+                name: NSView.frameDidChangeNotification,
+                object: documentView)
+        }
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    func stop() {
+        guard self.isActive else { return }
+        self.isActive = false
+        self.clipView?.postsBoundsChangedNotifications = self.originalPostsBoundsChangedNotifications
+        self.clipView?.postsFrameChangedNotifications = self.originalClipPostsFrameChangedNotifications
+        self.documentView?.postsFrameChangedNotifications = self.originalDocumentPostsFrameChangedNotifications
+        self.settleScheduled = false
+        self.permitsPostLayoutTopCorrection = false
+        self.pendingOriginRange = nil
+        self.afterSettleOperations.removeAll(keepingCapacity: false)
+        self.documentView = nil
+        self.clipView = nil
+        self.scrollView = nil
+    }
+
+    func isTracking(_ scrollView: NSScrollView) -> Bool {
+        self.scrollView === scrollView &&
+            self.clipView === scrollView.contentView &&
+            self.documentView === scrollView.documentView
+    }
+
+    /// Make settled refresh geometry the baseline for the short completion-to-delivery window.
+    /// Callers must enter through `afterPendingGeometrySettles` so stale AppKit geometry is never sampled.
+    func rebaseAfterRefreshLayout() {
+        guard !self.observedMovement, let scrollView = self.scrollView else { return }
+        self.baselineGeometry = StatusItemController.menuViewportGeometry(in: scrollView)
+        self.pendingOriginRange = nil
+    }
+
+    func afterPendingGeometrySettles(_ operation: @escaping @MainActor () -> Void) {
+        guard self.isActive else { return }
+        guard self.settleScheduled else {
+            operation()
+            return
+        }
+        self.afterSettleOperations.append(operation)
+    }
+
+    func settlePendingGeometryChanges() {
+        self.settleScheduled = false
+        if self.isActive,
+           !self.observedMovement,
+           let scrollView = self.scrollView,
+           let current = StatusItemController.menuViewportGeometry(in: scrollView)
+        {
+            if let baselineGeometry = self.baselineGeometry {
+                let pendingMovement = self.pendingOriginRange?.exceeds(1) == true
+                switch StatusItemController.menuViewportGeometryTransition(from: baselineGeometry, to: current) {
+                case .unchanged:
+                    if pendingMovement {
+                        if self.consumePostLayoutTopCorrectionIfNeeded(current) {
+                            self.baselineGeometry = current
+                        } else {
+                            self.observedMovement = true
+                        }
+                    }
+                // Otherwise keep the original baseline so fractional scroll deltas accumulate.
+                case .layout:
+                    self.baselineGeometry = current
+                    // AppKit can publish the new document frame one run-loop pass before its
+                    // automatic reset to the menu's top. Only that no-op restore target is safe
+                    // to absorb; an arbitrary next origin is newer user movement.
+                    self.permitsPostLayoutTopCorrection = !pendingMovement
+                case .movement:
+                    if self.consumePostLayoutTopCorrectionIfNeeded(current) {
+                        self.baselineGeometry = current
+                    } else {
+                        self.observedMovement = true
+                    }
+                }
+            } else {
+                self.baselineGeometry = current
+            }
+            self.pendingOriginRange = nil
+        }
+        let operations = self.afterSettleOperations
+        self.afterSettleOperations.removeAll(keepingCapacity: false)
+        for operation in operations where self.isActive {
+            operation()
+        }
+    }
+
+    private func consumePostLayoutTopCorrectionIfNeeded(_ geometry: MenuViewportGeometry) -> Bool {
+        guard self.permitsPostLayoutTopCorrection else { return false }
+        self.permitsPostLayoutTopCorrection = false
+        return StatusItemController.menuViewportGeometryIsAtTop(geometry)
+    }
+
+    @objc private func viewportGeometryDidChange(_: Notification) {
+        guard self.isActive, !self.observedMovement else { return }
+        if let origin = self.scrollView?.contentView.bounds.origin {
+            if self.pendingOriginRange == nil {
+                self.pendingOriginRange = MenuViewportOriginRange(
+                    baseline: self.baselineGeometry?.clipOrigin ?? origin,
+                    current: origin)
+            } else {
+                self.pendingOriginRange?.include(origin)
+            }
+        }
+        guard !self.settleScheduled else { return }
+        self.settleScheduled = true
+        ProviderSwitcherTrackingRunLoopScheduler.schedule { [weak self] in
+            self?.settlePendingGeometryChanges()
+        }
+    }
+}
+
+private struct ManualRefreshViewportMovementTracking {
+    let generation: Int
+    let tracker: ManualRefreshViewportMovementTracker
+}
+
 @MainActor
 final class ManualRefreshViewportRestoreState {
     var deferredUntilRebuild: [ObjectIdentifier: ManualRefreshViewportRestoreRequest] = [:]
+    private var movementTrackers: [ObjectIdentifier: ManualRefreshViewportMovementTracking] = [:]
+
+    func startMovementTracking(
+        for key: ObjectIdentifier,
+        generation: Int,
+        scrollView: NSScrollView)
+    {
+        self.stopMovementTracking(for: key)
+        self.movementTrackers[key] = ManualRefreshViewportMovementTracking(
+            generation: generation,
+            tracker: ManualRefreshViewportMovementTracker(scrollView: scrollView))
+    }
+
+    func prepareForCompletedRefreshLayout(
+        for key: ObjectIdentifier,
+        generation: Int,
+        scrollView: NSScrollView,
+        completion: @escaping @MainActor () -> Void)
+    {
+        self.prepareMovementTracking(
+            for: key,
+            generation: generation,
+            scrollView: scrollView,
+            rebaseAfterLayout: true,
+            completion: completion)
+    }
+
+    func prepareForDelivery(
+        for key: ObjectIdentifier,
+        generation: Int,
+        scrollView: NSScrollView,
+        completion: @escaping @MainActor () -> Void)
+    {
+        self.prepareMovementTracking(
+            for: key,
+            generation: generation,
+            scrollView: scrollView,
+            rebaseAfterLayout: false,
+            completion: completion)
+    }
+
+    func afterMovementSettles(
+        for key: ObjectIdentifier,
+        generation: Int,
+        operation: @escaping @MainActor () -> Void)
+    {
+        guard let tracking = self.movementTrackers[key], tracking.generation == generation else {
+            operation()
+            return
+        }
+        let tracker = tracking.tracker
+        tracker.afterPendingGeometrySettles { [weak self, weak tracker] in
+            guard let self,
+                  let tracker,
+                  let current = self.movementTrackers[key],
+                  current.generation == generation,
+                  current.tracker === tracker
+            else { return }
+            operation()
+        }
+    }
+
+    func observedMovement(for key: ObjectIdentifier, generation: Int) -> Bool {
+        guard let tracking = self.movementTrackers[key], tracking.generation == generation else { return false }
+        return tracking.tracker.observedMovement
+    }
+
+    func stopMovementTracking(for key: ObjectIdentifier, generation: Int? = nil) {
+        guard let tracking = self.movementTrackers[key],
+              generation == nil || tracking.generation == generation
+        else { return }
+        tracking.tracker.stop()
+        self.movementTrackers.removeValue(forKey: key)
+    }
+
+    func stopAllMovementTracking() {
+        for tracking in self.movementTrackers.values {
+            tracking.tracker.stop()
+        }
+        self.movementTrackers.removeAll(keepingCapacity: false)
+    }
+
+    private func prepareMovementTracking(
+        for key: ObjectIdentifier,
+        generation: Int,
+        scrollView: NSScrollView,
+        rebaseAfterLayout: Bool,
+        completion: @escaping @MainActor () -> Void)
+    {
+        guard let tracking = self.movementTrackers[key] else {
+            self.startMovementTracking(for: key, generation: generation, scrollView: scrollView)
+            completion()
+            return
+        }
+        guard tracking.generation == generation else {
+            // A newer overlapping provider refresh owns this menu's tracker. Let the caller's
+            // context check discard the stale completion without erasing newer movement.
+            completion()
+            return
+        }
+        let tracker = tracking.tracker
+        tracker.afterPendingGeometrySettles { [weak self, weak tracker] in
+            guard let self,
+                  let tracker,
+                  let current = self.movementTrackers[key],
+                  current.generation == generation,
+                  current.tracker === tracker
+            else { return }
+            if !tracker.observedMovement {
+                if tracker.isTracking(scrollView) {
+                    if rebaseAfterLayout {
+                        tracker.rebaseAfterRefreshLayout()
+                    }
+                } else {
+                    self.startMovementTracking(for: key, generation: generation, scrollView: scrollView)
+                }
+            }
+            completion()
+        }
+    }
+
     #if DEBUG
     var testOperation: (@MainActor () async -> Void)?
     var testObserver: (@MainActor (NSMenu) -> Void)?
@@ -45,8 +373,15 @@ extension StatusItemController {
                 continue
             }
             self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
+            let generation = self.menuSession.armViewportRestore(key)
+            if let scrollView = Self.attachedMenuScrollView(in: menu) {
+                self.manualRefreshViewportRestoreState.startMovementTracking(
+                    for: key,
+                    generation: generation,
+                    scrollView: scrollView)
+            }
             requests[key] = ManualRefreshViewportRestoreRequest(
-                generation: self.menuSession.armViewportRestore(key),
+                generation: generation,
                 menuInteractionGeneration: menuInteractionGeneration,
                 switcherSelection: self.viewportRestoreSwitcherSelection(for: menu))
         }
@@ -60,51 +395,110 @@ extension StatusItemController {
         _ requests: [ObjectIdentifier: ManualRefreshViewportRestoreRequest])
     {
         for (key, request) in requests {
-            guard self.isCurrentManualRefreshViewportRestoreContext(request, for: key) else {
-                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
-                continue
-            }
-            guard !self.hasPreparedForAppShutdown,
-                  let menu = self.openMenus[key],
-                  ObjectIdentifier(menu) == key,
-                  menu.supermenu == nil,
-                  !self.isHostedSubviewMenu(menu),
-                  request.switcherSelection == self.viewportRestoreSwitcherSelection(for: menu),
-                  self.menuNeedsRefresh(menu)
+            guard self.isCurrentManualRefreshViewportRestoreContext(request, for: key),
+                  let menu = self.openMenus[key]
             else {
                 self.cancelManualRefreshViewportRestoreRequest(request, for: key)
                 continue
             }
-            guard !self.hasOpenNonHostedChildMenu() else {
-                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
-                continue
+            let completion: @MainActor () -> Void = { [weak self, weak menu] in
+                guard let self else { return }
+                guard let menu else {
+                    self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                    return
+                }
+                self.continueSchedulingCompletedManualRefreshViewportRestore(
+                    request,
+                    for: key,
+                    menu: menu)
             }
-            if self.hasOpenHostedSubviewMenu() ||
-                self.parentMenuRebuildPendingAfterHostedSubviewClose ||
-                self.openMenuRebuildRequests.tokens[key] != nil
-            {
-                self.manualRefreshViewportRestoreState.deferredUntilRebuild[key] = request
-                continue
+            if let scrollView = Self.attachedMenuScrollView(in: menu) {
+                self.manualRefreshViewportRestoreState.prepareForCompletedRefreshLayout(
+                    for: key,
+                    generation: request.generation,
+                    scrollView: scrollView,
+                    completion: completion)
+            } else {
+                completion()
             }
-            guard !self.hasMenuItemHighlightedForViewportRestore(in: menu) else {
-                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
-                continue
-            }
-
-            self.scheduleManualRefreshViewportRestore(request, for: menu)
         }
+    }
+
+    private func continueSchedulingCompletedManualRefreshViewportRestore(
+        _ request: ManualRefreshViewportRestoreRequest,
+        for key: ObjectIdentifier,
+        menu: NSMenu)
+    {
+        guard self.isCurrentManualRefreshViewportRestoreContext(request, for: key),
+              !self.hasPreparedForAppShutdown,
+              self.openMenus[key] === menu,
+              ObjectIdentifier(menu) == key,
+              menu.supermenu == nil,
+              !self.isHostedSubviewMenu(menu),
+              request.switcherSelection == self.viewportRestoreSwitcherSelection(for: menu),
+              self.menuNeedsRefresh(menu),
+              !self.manualRefreshViewportRestoreState.observedMovement(
+                  for: key,
+                  generation: request.generation),
+              !self.hasOpenNonHostedChildMenu()
+        else {
+            self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+            return
+        }
+        if self.hasOpenHostedSubviewMenu() ||
+            self.parentMenuRebuildPendingAfterHostedSubviewClose ||
+            self.openMenuRebuildRequests.tokens[key] != nil
+        {
+            self.manualRefreshViewportRestoreState.deferredUntilRebuild[key] = request
+            return
+        }
+        guard !self.hasMenuItemHighlightedForViewportRestore(in: menu) else {
+            self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+            return
+        }
+        self.scheduleManualRefreshViewportRestore(request, for: menu)
     }
 
     func scheduleDeferredManualRefreshViewportRestoreAfterRebuild(for menu: NSMenu) {
         let key = ObjectIdentifier(menu)
         guard let request = self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
         else { return }
+        let completion: @MainActor () -> Void = { [weak self, weak menu] in
+            guard let self else { return }
+            guard let menu else {
+                self.cancelManualRefreshViewportRestoreRequest(request, for: key)
+                return
+            }
+            self.continueSchedulingDeferredManualRefreshViewportRestore(
+                request,
+                for: key,
+                menu: menu)
+        }
+        if let scrollView = Self.attachedMenuScrollView(in: menu) {
+            self.manualRefreshViewportRestoreState.prepareForDelivery(
+                for: key,
+                generation: request.generation,
+                scrollView: scrollView,
+                completion: completion)
+        } else {
+            completion()
+        }
+    }
+
+    private func continueSchedulingDeferredManualRefreshViewportRestore(
+        _ request: ManualRefreshViewportRestoreRequest,
+        for key: ObjectIdentifier,
+        menu: NSMenu)
+    {
         guard self.isCurrentManualRefreshViewportRestoreContext(request, for: key),
               !self.hasPreparedForAppShutdown,
               self.openMenus[key] === menu,
               !self.hasOpenNonHostedChildMenu(),
               !self.hasOpenHostedSubviewMenu(),
               !self.hasMenuItemHighlightedForViewportRestore(in: menu),
+              !self.manualRefreshViewportRestoreState.observedMovement(
+                  for: key,
+                  generation: request.generation),
               request.switcherSelection == self.viewportRestoreSwitcherSelection(for: menu)
         else {
             self.cancelManualRefreshViewportRestoreRequest(request, for: key)
@@ -118,7 +512,7 @@ extension StatusItemController {
         for menu: NSMenu)
     {
         let key = ObjectIdentifier(menu)
-        let operation: @MainActor () -> Void = { [weak self, weak menu] in
+        let delivery: @MainActor () -> Void = { [weak self, weak menu] in
             guard let self else { return }
             guard self.isCurrentManualRefreshViewportRestoreContext(request, for: key) else {
                 self.cancelManualRefreshViewportRestoreRequest(request, for: key)
@@ -151,12 +545,25 @@ extension StatusItemController {
                 self.manualRefreshViewportRestoreState.deferredUntilRebuild[key] = request
                 return
             }
-            guard !self.hasMenuItemHighlightedForViewportRestore(in: menu) else {
+            guard !self.hasMenuItemHighlightedForViewportRestore(in: menu),
+                  !self.manualRefreshViewportRestoreState.observedMovement(
+                      for: key,
+                      generation: request.generation)
+            else {
                 self.cancelManualRefreshViewportRestoreRequest(request, for: key)
                 return
             }
             guard self.menuSession.consumeViewportRestore(key, generation: request.generation) else { return }
+            self.manualRefreshViewportRestoreState.stopMovementTracking(
+                for: key,
+                generation: request.generation)
             self.restoreMenuViewportToTop(menu)
+        }
+        let operation: @MainActor () -> Void = { [weak self] in
+            self?.manualRefreshViewportRestoreState.afterMovementSettles(
+                for: key,
+                generation: request.generation,
+                operation: delivery)
         }
         #if DEBUG
         if let scheduler = self._test_menuViewportRestoreScheduler {
@@ -171,6 +578,7 @@ extension StatusItemController {
 
     func cancelManualRefreshViewportRestore(for key: ObjectIdentifier) {
         self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
+        self.manualRefreshViewportRestoreState.stopMovementTracking(for: key)
         self.menuSession.cancelViewportRestore(key)
     }
 
@@ -181,6 +589,9 @@ extension StatusItemController {
         if self.manualRefreshViewportRestoreState.deferredUntilRebuild[key]?.generation == request.generation {
             self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
         }
+        self.manualRefreshViewportRestoreState.stopMovementTracking(
+            for: key,
+            generation: request.generation)
         self.menuSession.consumeViewportRestore(key, generation: request.generation)
     }
 
@@ -257,6 +668,50 @@ extension StatusItemController {
             }
         }
         return nil
+    }
+
+    static func menuViewportGeometry(in scrollView: NSScrollView) -> MenuViewportGeometry? {
+        guard let documentView = scrollView.documentView else { return nil }
+        let clipView = scrollView.contentView
+        return MenuViewportGeometry(
+            documentID: ObjectIdentifier(documentView),
+            clipID: ObjectIdentifier(clipView),
+            documentSize: documentView.frame.size,
+            documentIsFlipped: documentView.isFlipped,
+            clipSize: clipView.bounds.size,
+            clipOrigin: clipView.bounds.origin)
+    }
+
+    /// Bounds notifications can arrive before AppKit exposes updated row geometry. Compare only
+    /// coalesced, settled samples: any geometry change is layout; stable geometry exposes scrolling.
+    static func menuViewportGeometryTransition(
+        from previous: MenuViewportGeometry,
+        to current: MenuViewportGeometry,
+        movementTolerance: CGFloat = 1)
+        -> MenuViewportGeometryTransition
+    {
+        // AppKit can publish an origin reset before exposing a row-size change. A mixed batch is
+        // therefore irreducibly ambiguous: treat it as layout, then catch repeating edge-scroll
+        // ticks against the new stable geometry on the next batch.
+        guard previous.documentID == current.documentID,
+              previous.clipID == current.clipID,
+              previous.documentSize == current.documentSize,
+              previous.documentIsFlipped == current.documentIsFlipped,
+              previous.clipSize == current.clipSize
+        else { return .layout }
+        let moved = abs(current.clipOrigin.x - previous.clipOrigin.x) > movementTolerance ||
+            abs(current.clipOrigin.y - previous.clipOrigin.y) > movementTolerance
+        return moved ? .movement : .unchanged
+    }
+
+    static func menuViewportGeometryIsAtTop(
+        _ geometry: MenuViewportGeometry,
+        tolerance: CGFloat = 1)
+        -> Bool
+    {
+        let maximumOffset = max(0, geometry.documentSize.height - geometry.clipSize.height)
+        let topOffset = geometry.documentIsFlipped ? 0 : maximumOffset
+        return abs(geometry.clipOrigin.y - topOffset) <= tolerance
     }
 
     /// Returns the offset that shows the top of the menu content, or nil when the menu is

--- a/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
+++ b/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
@@ -1,8 +1,8 @@
 import AppKit
 
 struct ManualRefreshViewportRestoreRequest {
-    let token: Int
-    let menuInteractionToken: Int
+    let generation: Int
+    let menuInteractionGeneration: Int
     let switcherSelection: ProviderSwitcherSelection?
 }
 
@@ -24,7 +24,7 @@ extension StatusItemController {
     /// session. Background refreshes never enter this path and therefore never move the viewport.
     func armManualRefreshViewportRestoreRequests(
         originatingMenuID: ObjectIdentifier?,
-        originatingMenuInteractionToken: Int?)
+        originatingMenuInteractionGeneration: Int?)
         -> [ObjectIdentifier: ManualRefreshViewportRestoreRequest]
     {
         let candidates: [(ObjectIdentifier, NSMenu)]
@@ -37,17 +37,17 @@ extension StatusItemController {
 
         var requests: [ObjectIdentifier: ManualRefreshViewportRestoreRequest] = [:]
         for (key, menu) in candidates where menu.supermenu == nil && !self.isHostedSubviewMenu(menu) {
-            guard let menuInteractionToken = self.menuSession.menuInteractionToken(for: key) else { continue }
+            guard let menuInteractionGeneration = self.menuSession.menuInteractionGeneration(for: key) else { continue }
             if key == originatingMenuID,
-               let originatingMenuInteractionToken,
-               menuInteractionToken != originatingMenuInteractionToken
+               let originatingMenuInteractionGeneration,
+               menuInteractionGeneration != originatingMenuInteractionGeneration
             {
                 continue
             }
             self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
             requests[key] = ManualRefreshViewportRestoreRequest(
-                token: self.menuSession.armViewportRestore(key),
-                menuInteractionToken: menuInteractionToken,
+                generation: self.menuSession.armViewportRestore(key),
+                menuInteractionGeneration: menuInteractionGeneration,
                 switcherSelection: self.viewportRestoreSwitcherSelection(for: menu))
         }
         return requests
@@ -155,7 +155,7 @@ extension StatusItemController {
                 self.cancelManualRefreshViewportRestoreRequest(request, for: key)
                 return
             }
-            guard self.menuSession.consumeViewportRestore(key, token: request.token) else { return }
+            guard self.menuSession.consumeViewportRestore(key, generation: request.generation) else { return }
             self.restoreMenuViewportToTop(menu)
         }
         #if DEBUG
@@ -178,10 +178,10 @@ extension StatusItemController {
         _ request: ManualRefreshViewportRestoreRequest,
         for key: ObjectIdentifier)
     {
-        if self.manualRefreshViewportRestoreState.deferredUntilRebuild[key]?.token == request.token {
+        if self.manualRefreshViewportRestoreState.deferredUntilRebuild[key]?.generation == request.generation {
             self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeValue(forKey: key)
         }
-        self.menuSession.consumeViewportRestore(key, token: request.token)
+        self.menuSession.consumeViewportRestore(key, generation: request.generation)
     }
 
     func cancelManualRefreshViewportRestoreRequests(
@@ -205,17 +205,17 @@ extension StatusItemController {
         for key: ObjectIdentifier)
         -> Bool
     {
-        self.menuSession.isCurrentViewportRestore(request.token, for: key) &&
-            self.menuSession.isCurrentMenuInteraction(request.menuInteractionToken, for: key)
+        self.menuSession.isCurrentViewportRestore(request.generation, for: key) &&
+            self.menuSession.isCurrentMenuInteraction(request.menuInteractionGeneration, for: key)
     }
 
     func advanceMenuContentSelection(for menu: NSMenu?) {
         guard let menu else { return }
         let key = ObjectIdentifier(menu)
         guard self.openMenus[key] === menu,
-              let token = self.menuSession.advanceMenuInteraction(for: key)
+              let generation = self.menuSession.advanceMenuInteraction(for: key)
         else { return }
-        (menu as? StatusItemMenu)?.menuInteractionToken = token
+        (menu as? StatusItemMenu)?.menuInteractionGeneration = generation
     }
 
     func restoreMenuViewportToTop(_ menu: NSMenu) {

--- a/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
+++ b/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
@@ -1,0 +1,84 @@
+import AppKit
+
+extension StatusItemController {
+    #if DEBUG
+    static var _test_menuViewportRestoreObserver: (@MainActor (NSMenu) -> Void)?
+    #endif
+
+    /// A user-initiated manual refresh reconciles the tracked menu in place, and the row
+    /// heights it changes (a recovered provider-error banner collapsing is the largest jump)
+    /// can leave AppKit's private menu scrolling anchored mid-list with no way back to the
+    /// top short of closing and reopening the menu. Arm a one-shot viewport restore for the
+    /// open menus the refresh will rebuild; the restore runs when that rebuild lands.
+    /// Background data ticks never arm this, so they cannot yank a viewport the user is
+    /// reading.
+    func armMenuViewportRestoreAfterManualRefresh() {
+        for (key, menu) in self.openMenus {
+            guard !self.isHostedSubviewMenu(menu) else { continue }
+            guard self.menuNeedsRefresh(menu) else { continue }
+            self.menuSession.armViewportRestore(key)
+        }
+    }
+
+    /// Consumes a pending restore after `populateMenu` has reconciled the open menu. The
+    /// scroll repair runs on the next main-actor turn so AppKit's own relayout of the
+    /// table-backed menu settles first; the restore is a no-op when the menu is not
+    /// scrolled or no longer open.
+    func consumePendingMenuViewportRestore(for menu: NSMenu) {
+        guard self.menuSession.consumeViewportRestore(ObjectIdentifier(menu)) else { return }
+        Task { @MainActor [weak self, weak menu] in
+            guard let self, let menu else { return }
+            guard self.openMenus[ObjectIdentifier(menu)] != nil else { return }
+            self.restoreMenuViewportToTop(menu)
+        }
+    }
+
+    func restoreMenuViewportToTop(_ menu: NSMenu) {
+        #if DEBUG
+        if let observer = Self._test_menuViewportRestoreObserver {
+            observer(menu)
+            return
+        }
+        #endif
+        guard let scrollView = Self.attachedMenuScrollView(in: menu),
+              let documentView = scrollView.documentView
+        else { return }
+        let clipView = scrollView.contentView
+        guard let target = Self.menuViewportTopOffset(
+            documentIsFlipped: documentView.isFlipped,
+            documentHeight: documentView.frame.height,
+            clipHeight: clipView.bounds.height,
+            currentOffset: clipView.documentVisibleRect.origin.y)
+        else { return }
+        self.performMenuMutationWithoutAnimation {
+            clipView.scroll(to: NSPoint(x: clipView.documentVisibleRect.origin.x, y: target))
+            scrollView.reflectScrolledClipView(clipView)
+        }
+    }
+
+    /// The view-based menu (`NSMenuScrollView` → `NSClipView` → table representation)
+    /// recycles row views once they scroll offscreen, so the shared scroll view must be
+    /// resolved through whichever item view is currently attached to the menu window.
+    static func attachedMenuScrollView(in menu: NSMenu) -> NSScrollView? {
+        for item in menu.items {
+            if let scrollView = item.view?.enclosingScrollView {
+                return scrollView
+            }
+        }
+        return nil
+    }
+
+    /// Returns the offset that shows the top of the menu content, or nil when the menu is
+    /// not scrollable or the viewport is already there.
+    static func menuViewportTopOffset(
+        documentIsFlipped: Bool,
+        documentHeight: CGFloat,
+        clipHeight: CGFloat,
+        currentOffset: CGFloat) -> CGFloat?
+    {
+        guard clipHeight > 0, documentHeight - clipHeight > 0.5 else { return nil }
+        let top: CGFloat = documentIsFlipped ? 0 : documentHeight - clipHeight
+        guard abs(currentOffset - top) > 0.5 else { return nil }
+        return top
+    }
+}

--- a/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
@@ -10,6 +10,10 @@ extension StatusItemController {
             }
             guard let menu = item.menu else { continue }
             let enabled = !self.isRefreshActionInFlight(for: menu)
+            if !enabled, self.highlightedMenuItems[ObjectIdentifier(menu)] === item {
+                (item.view as? MenuCardHighlighting)?.setHighlighted(false)
+                self.highlightedMenuItems.removeValue(forKey: ObjectIdentifier(menu))
+            }
             item.isEnabled = enabled
             (item.view as? PersistentRefreshMenuView)?.setEnabled(enabled)
         }

--- a/Sources/CodexBar/StatusItemController+PersistentRefreshMenuItem.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentRefreshMenuItem.swift
@@ -1,6 +1,10 @@
 import AppKit
 
 extension StatusItemController {
+    func isPersistentRefreshItem(_ item: NSMenuItem) -> Bool {
+        item.representedObject as? String == Self.persistentRefreshMenuItemID
+    }
+
     func makePersistentRefreshItem(title: String, menu: NSMenu, width: CGFloat) -> NSMenuItem {
         let shortcutText = self.shortcut(for: .refresh).map(Self.shortcutDisplayLabel)
         let metrics = PersistentRefreshRowMetrics.defaults
@@ -10,7 +14,11 @@ extension StatusItemController {
             shortcutText: shortcutText,
             onClick: { [weak self, weak menu] in
                 guard let self, let menu else { return }
-                self.performPersistentRefreshAction(in: ObjectIdentifier(menu))
+                if let menu = menu as? StatusItemMenu {
+                    menu.requestPersistentRefreshAction()
+                } else {
+                    self.performPersistentRefreshAction(in: ObjectIdentifier(menu))
+                }
             })
         let enabled = !self.isRefreshActionInFlight(for: menu)
         view.setEnabled(enabled)
@@ -30,11 +38,21 @@ extension StatusItemController {
         for shortcut: (key: String, modifiers: NSEvent.ModifierFlags)) -> String
     {
         var label = ""
-        if shortcut.modifiers.contains(.control) { label += "^" }
-        if shortcut.modifiers.contains(.option) { label += "⌥" }
-        if shortcut.modifiers.contains(.shift) { label += "⇧" }
-        if shortcut.modifiers.contains(.command) { label += "⌘" }
-        if !label.isEmpty { label += " " }
+        if shortcut.modifiers.contains(.control) {
+            label += "^"
+        }
+        if shortcut.modifiers.contains(.option) {
+            label += "⌥"
+        }
+        if shortcut.modifiers.contains(.shift) {
+            label += "⇧"
+        }
+        if shortcut.modifiers.contains(.command) {
+            label += "⌘"
+        }
+        if !label.isEmpty {
+            label += " "
+        }
         return label + shortcut.key.uppercased()
     }
 }

--- a/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
@@ -9,7 +9,7 @@ extension StatusItemController {
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
         #endif
-        self.advanceMenuContentSelection(for: self.mergedMenu)
+        self.advanceMenuInteraction(for: self.mergedMenu)
         self.invalidateMenus(refreshOpenMenus: refreshOpenMenus)
         if deferRendering {
             self.scheduleProviderSelectionUIRefresh()

--- a/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
@@ -9,6 +9,7 @@ extension StatusItemController {
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
         #endif
+        self.advanceMenuContentSelection(for: self.mergedMenu)
         self.invalidateMenus(refreshOpenMenus: refreshOpenMenus)
         if deferRendering {
             self.scheduleProviderSelectionUIRefresh()
@@ -90,7 +91,9 @@ extension StatusItemController {
     }
 
     private func navigationResolvedProvider(enabledProviders: [UsageProvider]) -> UsageProvider? {
-        if enabledProviders.isEmpty { return .codex }
+        if enabledProviders.isEmpty {
+            return .codex
+        }
         if let selected = self.selectedMenuProvider, enabledProviders.contains(selected) {
             return selected
         }

--- a/Sources/CodexBar/StatusItemController+ProviderSwitcher.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderSwitcher.swift
@@ -239,9 +239,10 @@ extension StatusItemController {
 
         self.removeProviderSwitcherShortcutMonitor()
         self.resetOverviewScrollAccumulation()
-        let eventMask: NSEvent.EventTypeMask = hasProviderSwitcher
-            ? [.keyDown, .keyUp, .scrollWheel]
-            : [.keyDown, .keyUp]
+        // Every tracked menu observes wheel events so a manual scroll made after Refresh
+        // invalidates that refresh's pending viewport restore. Unhandled wheel events remain
+        // queued for AppKit's native menu scroller.
+        let eventMask: NSEvent.EventTypeMask = [.keyDown, .keyUp, .scrollWheel]
         let monitor = ProviderSwitcherShortcutEventMonitor(
             events: eventMask)
         { [weak self, weak menu] event in
@@ -268,6 +269,9 @@ extension StatusItemController {
 
     @discardableResult
     func handleMenuTrackingShortcutEvent(_ event: NSEvent, menu: NSMenu) -> Bool {
+        if event.type == .scrollWheel {
+            self.advanceMenuInteraction(for: menu)
+        }
         if StatusItemMenu.isPersistentRefreshShortcut(for: event),
            menu.items.contains(where: self.isPersistentRefreshItem)
         {

--- a/Sources/CodexBar/StatusItemController+ProviderSwitcher.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderSwitcher.swift
@@ -42,7 +42,9 @@ final class ProviderSwitcherEventPeekGate {
         }
         // CoreGraphics does not count key autorepeat events. Keep peeking while a key is
         // held so repeated provider-navigation events are still handled.
-        if !self.heldKeyCodes.isEmpty { return true }
+        if !self.heldKeyCodes.isEmpty {
+            return true
+        }
         return self.emptyPeekBudget > 0
     }
 
@@ -269,7 +271,11 @@ extension StatusItemController {
         if StatusItemMenu.isPersistentRefreshShortcut(for: event),
            menu.items.contains(where: self.isPersistentRefreshItem)
         {
-            self.performPersistentRefreshAction(in: ObjectIdentifier(menu))
+            if let menu = menu as? StatusItemMenu {
+                menu.requestPersistentRefreshAction()
+            } else {
+                self.performPersistentRefreshAction(in: ObjectIdentifier(menu))
+            }
             return true
         }
         guard menu.items.first?.view is ProviderSwitcherView else { return false }

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -80,6 +80,7 @@ extension StatusItemController {
         self.openMenuRebuildRequests.cancelAll()
         self.openMenuRebuildsClosingHostedSubviewMenus.removeAll(keepingCapacity: false)
         self.menuSession.clearMenuTracking()
+        self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeAll(keepingCapacity: false)
         self.openMenus.removeAll(keepingCapacity: false)
         self.highlightedMenuItems.removeAll(keepingCapacity: false)
         self.nativeHighlightDeferredMenuRebuilds.removeAll(keepingCapacity: false)

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -81,6 +81,7 @@ extension StatusItemController {
         self.openMenuRebuildsClosingHostedSubviewMenus.removeAll(keepingCapacity: false)
         self.menuSession.clearMenuTracking()
         self.manualRefreshViewportRestoreState.deferredUntilRebuild.removeAll(keepingCapacity: false)
+        self.manualRefreshViewportRestoreState.stopAllMovementTracking()
         self.openMenus.removeAll(keepingCapacity: false)
         self.highlightedMenuItems.removeAll(keepingCapacity: false)
         self.nativeHighlightDeferredMenuRebuilds.removeAll(keepingCapacity: false)

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -207,8 +207,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var _test_providerSwitcherMenuRebuildDebounceNanoseconds: UInt64?
     var _test_codexAmbientLoginRunnerOverride:
         (@MainActor (TimeInterval) async -> CodexLoginRunner.Result)?
-    var _test_manualRefreshOperation: (@MainActor () async -> Void)?
     #endif
+    var manualRefreshViewportRestoreState = ManualRefreshViewportRestoreState()
     var blinkTask: Task<Void, Never>?
     var menuBarCountdownRefreshTask: Task<Void, Never>?
     var loginTask: Task<Void, Never>? {
@@ -812,12 +812,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.updateBlinkingState()
     }
 
-    var fallbackProvider: UsageProvider? {
-        // Intentionally uses availability-filtered list: fallback activates when no provider
-        // can actually work, ensuring at least a codex icon is always visible.
-        self.store.enabledProviders().isEmpty ? .codex : nil
-    }
-
     func isEnabled(_ provider: UsageProvider) -> Bool {
         self.store.isEnabled(provider)
     }
@@ -948,6 +942,21 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
 #if DEBUG
 extension StatusItemController {
+    var _test_manualRefreshOperation: (@MainActor () async -> Void)? {
+        get { self.manualRefreshViewportRestoreState.testOperation }
+        set { self.manualRefreshViewportRestoreState.testOperation = newValue }
+    }
+
+    var _test_menuViewportRestoreObserver: (@MainActor (NSMenu) -> Void)? {
+        get { self.manualRefreshViewportRestoreState.testObserver }
+        set { self.manualRefreshViewportRestoreState.testObserver = newValue }
+    }
+
+    var _test_menuViewportRestoreScheduler: ((@escaping @MainActor () -> Void) -> Void)? {
+        get { self.manualRefreshViewportRestoreState.testScheduler }
+        set { self.manualRefreshViewportRestoreState.testScheduler = newValue }
+    }
+
     var menuContentVersion: Int {
         get { self.menuSession.contentVersion }
         set { self.menuSession.replaceContentVersionForTesting(newValue) }

--- a/Sources/CodexBar/StatusItemMenu.swift
+++ b/Sources/CodexBar/StatusItemMenu.swift
@@ -8,7 +8,7 @@ enum StatusItemMenuProviderNavigationDirection {
 protocol StatusItemMenuPersistentActionDelegate: AnyObject {
     func performPersistentRefreshAction(
         in menuID: ObjectIdentifier,
-        menuInteractionToken: Int)
+        menuInteractionGeneration: Int)
     func performPersistentSettingsAction()
     func performPersistentQuitAction()
     func performProviderNavigation(_ direction: StatusItemMenuProviderNavigationDirection)
@@ -16,13 +16,13 @@ protocol StatusItemMenuPersistentActionDelegate: AnyObject {
 
 final class StatusItemMenu: NSMenu {
     weak var persistentActionDelegate: StatusItemMenuPersistentActionDelegate?
-    var menuInteractionToken: Int?
+    var menuInteractionGeneration: Int?
 
     func requestPersistentRefreshAction() {
-        guard let menuInteractionToken else { return }
+        guard let menuInteractionGeneration else { return }
         self.persistentActionDelegate?.performPersistentRefreshAction(
             in: ObjectIdentifier(self),
-            menuInteractionToken: menuInteractionToken)
+            menuInteractionGeneration: menuInteractionGeneration)
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {

--- a/Sources/CodexBar/StatusItemMenu.swift
+++ b/Sources/CodexBar/StatusItemMenu.swift
@@ -6,7 +6,9 @@ enum StatusItemMenuProviderNavigationDirection {
 }
 
 protocol StatusItemMenuPersistentActionDelegate: AnyObject {
-    func performPersistentRefreshAction(in menuID: ObjectIdentifier)
+    func performPersistentRefreshAction(
+        in menuID: ObjectIdentifier,
+        menuInteractionToken: Int)
     func performPersistentSettingsAction()
     func performPersistentQuitAction()
     func performProviderNavigation(_ direction: StatusItemMenuProviderNavigationDirection)
@@ -14,12 +16,20 @@ protocol StatusItemMenuPersistentActionDelegate: AnyObject {
 
 final class StatusItemMenu: NSMenu {
     weak var persistentActionDelegate: StatusItemMenuPersistentActionDelegate?
+    var menuInteractionToken: Int?
+
+    func requestPersistentRefreshAction() {
+        guard let menuInteractionToken else { return }
+        self.persistentActionDelegate?.performPersistentRefreshAction(
+            in: ObjectIdentifier(self),
+            menuInteractionToken: menuInteractionToken)
+    }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         if let action = Self.persistentAction(for: event) {
             switch action {
             case .refresh:
-                self.persistentActionDelegate?.performPersistentRefreshAction(in: ObjectIdentifier(self))
+                self.requestPersistentRefreshAction()
             case .settings:
                 self.persistentActionDelegate?.performPersistentSettingsAction()
             case .quit:

--- a/Tests/CodexBarTests/MenuSessionCoordinatorTests.swift
+++ b/Tests/CodexBarTests/MenuSessionCoordinatorTests.swift
@@ -64,13 +64,40 @@ struct MenuSessionCoordinatorTests {
         coordinator.markFresh(menu)
         coordinator.deferUntilNextOpen(menu)
         coordinator.deferParentRebuild(menu)
+        _ = coordinator.beginTrackingSession(menu)
         _ = coordinator.armViewportRestore(menu)
         coordinator.removeMenu(menu)
 
         #expect(coordinator.renderedVersion(for: menu) == nil)
         #expect(!coordinator.isDeferredUntilNextOpen(menu))
         #expect(!coordinator.isParentRebuildDeferred(menu))
+        #expect(coordinator.menuInteractionToken(for: menu) == nil)
         #expect(coordinator.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `reopening a persistent menu replaces its tracking session token`() {
+        var coordinator = MenuSessionCoordinator<String>()
+
+        let closedSession = coordinator.beginTrackingSession("menu")
+        coordinator.endTrackingSession("menu")
+        let reopenedSession = coordinator.beginTrackingSession("menu")
+
+        #expect(closedSession != reopenedSession)
+        #expect(!coordinator.isCurrentMenuInteraction(closedSession, for: "menu"))
+        #expect(coordinator.isCurrentMenuInteraction(reopenedSession, for: "menu"))
+    }
+
+    @Test
+    func `menu interaction token advances within one tracking session`() throws {
+        var coordinator = MenuSessionCoordinator<String>()
+        let initial = coordinator.beginTrackingSession("menu")
+
+        let advanced = coordinator.advanceMenuInteraction(for: "menu")
+        let replacement = try #require(advanced)
+
+        #expect(!coordinator.isCurrentMenuInteraction(initial, for: "menu"))
+        #expect(coordinator.isCurrentMenuInteraction(replacement, for: "menu"))
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuSessionCoordinatorTests.swift
+++ b/Tests/CodexBarTests/MenuSessionCoordinatorTests.swift
@@ -64,11 +64,29 @@ struct MenuSessionCoordinatorTests {
         coordinator.markFresh(menu)
         coordinator.deferUntilNextOpen(menu)
         coordinator.deferParentRebuild(menu)
+        _ = coordinator.armViewportRestore(menu)
         coordinator.removeMenu(menu)
 
         #expect(coordinator.renderedVersion(for: menu) == nil)
         #expect(!coordinator.isDeferredUntilNextOpen(menu))
         #expect(!coordinator.isParentRebuildDeferred(menu))
+        #expect(coordinator.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `replacement viewport restore token rejects stale completion`() {
+        var coordinator = MenuSessionCoordinator<String>()
+
+        let stale = coordinator.armViewportRestore("menu")
+        let current = coordinator.armViewportRestore("menu")
+
+        #expect(!coordinator.isCurrentViewportRestore(stale, for: "menu"))
+        let staleConsumed = coordinator.consumeViewportRestore("menu", token: stale)
+        #expect(!staleConsumed)
+        #expect(coordinator.isCurrentViewportRestore(current, for: "menu"))
+        let currentConsumed = coordinator.consumeViewportRestore("menu", token: current)
+        #expect(currentConsumed)
+        #expect(coordinator.pendingViewportRestores.isEmpty)
     }
 }
 

--- a/Tests/CodexBarTests/MenuSessionCoordinatorTests.swift
+++ b/Tests/CodexBarTests/MenuSessionCoordinatorTests.swift
@@ -71,7 +71,7 @@ struct MenuSessionCoordinatorTests {
         #expect(coordinator.renderedVersion(for: menu) == nil)
         #expect(!coordinator.isDeferredUntilNextOpen(menu))
         #expect(!coordinator.isParentRebuildDeferred(menu))
-        #expect(coordinator.menuInteractionToken(for: menu) == nil)
+        #expect(coordinator.menuInteractionGeneration(for: menu) == nil)
         #expect(coordinator.pendingViewportRestores.isEmpty)
     }
 
@@ -108,10 +108,10 @@ struct MenuSessionCoordinatorTests {
         let current = coordinator.armViewportRestore("menu")
 
         #expect(!coordinator.isCurrentViewportRestore(stale, for: "menu"))
-        let staleConsumed = coordinator.consumeViewportRestore("menu", token: stale)
+        let staleConsumed = coordinator.consumeViewportRestore("menu", generation: stale)
         #expect(!staleConsumed)
         #expect(coordinator.isCurrentViewportRestore(current, for: "menu"))
-        let currentConsumed = coordinator.consumeViewportRestore("menu", token: current)
+        let currentConsumed = coordinator.consumeViewportRestore("menu", generation: current)
         #expect(currentConsumed)
         #expect(coordinator.pendingViewportRestores.isEmpty)
     }

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -771,21 +771,22 @@ extension StatusMenuTests {
         controller.openMenus[submenuKey] = submenu
         controller.menuRefreshEnabledOverrideForTesting = true
 
-        var rebuildCount = 0
-        controller._test_openMenuRebuildObserver = { _ in
-            rebuildCount += 1
+        var rootRebuildCount = 0
+        controller._test_openMenuRebuildObserver = { rebuiltMenu in
+            guard rebuiltMenu === menu else { return }
+            rootRebuildCount += 1
         }
         defer { controller._test_openMenuRebuildObserver = nil }
 
         controller.deferSwitcherMenuRebuildIfStillVisible(menu, provider: .codex)
         controller.refreshOpenMenuIfStillVisible(menu, provider: .codex)
 
-        for _ in 0..<20 where rebuildCount == 0 {
+        for _ in 0..<20 where rootRebuildCount == 0 {
             await Task.yield()
         }
 
         #expect(controller.openMenus[submenuKey] == nil)
-        #expect(rebuildCount == 1)
+        #expect(rootRebuildCount == 1)
         #expect(controller.menuVersions[menuKey] == controller.menuContentVersion)
     }
 

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -7,18 +7,18 @@ import Testing
 private final class RefreshShortcutRecorder: StatusItemMenuPersistentActionDelegate {
     var refreshCount = 0
     var refreshMenuIDs: [ObjectIdentifier] = []
-    var refreshMenuInteractionTokens: [Int] = []
+    var refreshMenuInteractionGenerations: [Int] = []
     var settingsCount = 0
     var quitCount = 0
     var navigationDirections: [StatusItemMenuProviderNavigationDirection] = []
 
     func performPersistentRefreshAction(
         in menuID: ObjectIdentifier,
-        menuInteractionToken: Int)
+        menuInteractionGeneration: Int)
     {
         self.refreshCount += 1
         self.refreshMenuIDs.append(menuID)
-        self.refreshMenuInteractionTokens.append(menuInteractionToken)
+        self.refreshMenuInteractionGenerations.append(menuInteractionGeneration)
     }
 
     func performPersistentSettingsAction() {
@@ -1029,7 +1029,7 @@ extension StatusMenuPersistentRefreshTests {
         let menu = StatusItemMenu()
         let recorder = RefreshShortcutRecorder()
         menu.persistentActionDelegate = recorder
-        menu.menuInteractionToken = 42
+        menu.menuInteractionGeneration = 42
 
         #expect(try menu.performKeyEquivalent(with: self.keyEvent("r", keyCode: 15)) == true)
         #expect(try menu.performKeyEquivalent(with: self.keyEvent(",", keyCode: 43)) == true)
@@ -1037,7 +1037,7 @@ extension StatusMenuPersistentRefreshTests {
 
         #expect(recorder.refreshCount == 1)
         #expect(recorder.refreshMenuIDs == [ObjectIdentifier(menu)])
-        #expect(recorder.refreshMenuInteractionTokens == [42])
+        #expect(recorder.refreshMenuInteractionGenerations == [42])
         #expect(recorder.settingsCount == 1)
         #expect(recorder.quitCount == 1)
     }

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -7,13 +7,18 @@ import Testing
 private final class RefreshShortcutRecorder: StatusItemMenuPersistentActionDelegate {
     var refreshCount = 0
     var refreshMenuIDs: [ObjectIdentifier] = []
+    var refreshMenuInteractionTokens: [Int] = []
     var settingsCount = 0
     var quitCount = 0
     var navigationDirections: [StatusItemMenuProviderNavigationDirection] = []
 
-    func performPersistentRefreshAction(in menuID: ObjectIdentifier) {
+    func performPersistentRefreshAction(
+        in menuID: ObjectIdentifier,
+        menuInteractionToken: Int)
+    {
         self.refreshCount += 1
         self.refreshMenuIDs.append(menuID)
+        self.refreshMenuInteractionTokens.append(menuInteractionToken)
     }
 
     func performPersistentSettingsAction() {
@@ -869,7 +874,8 @@ extension StatusMenuPersistentRefreshTests {
         controller._test_manualRefreshOperation = { await mouseGate.wait() }
         let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
         #expect(controller.isPersistentRefreshItem(refreshItem))
-        controller.performPersistentRefreshAction(in: ObjectIdentifier(menu))
+        let refreshView = try #require(refreshItem.view as? PersistentRefreshMenuView)
+        #expect(refreshView.accessibilityPerformPress())
         for _ in 0..<20 where controller.manualRefreshTasks[.provider(.claude)] == nil {
             await Task.yield()
         }
@@ -1023,6 +1029,7 @@ extension StatusMenuPersistentRefreshTests {
         let menu = StatusItemMenu()
         let recorder = RefreshShortcutRecorder()
         menu.persistentActionDelegate = recorder
+        menu.menuInteractionToken = 42
 
         #expect(try menu.performKeyEquivalent(with: self.keyEvent("r", keyCode: 15)) == true)
         #expect(try menu.performKeyEquivalent(with: self.keyEvent(",", keyCode: 43)) == true)
@@ -1030,6 +1037,7 @@ extension StatusMenuPersistentRefreshTests {
 
         #expect(recorder.refreshCount == 1)
         #expect(recorder.refreshMenuIDs == [ObjectIdentifier(menu)])
+        #expect(recorder.refreshMenuInteractionTokens == [42])
         #expect(recorder.settingsCount == 1)
         #expect(recorder.quitCount == 1)
     }

--- a/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
+++ b/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
@@ -595,7 +595,7 @@ struct StatusMenuViewportRestoreTests {
         let menu = try #require(controller.makeMenu(for: .codex) as? StatusItemMenu)
         controller.providerMenus[.codex] = menu
         controller.menuWillOpen(menu)
-        let closedSession = try #require(menu.menuInteractionToken)
+        let closedSession = try #require(menu.menuInteractionGeneration)
 
         let gate = ViewportRefreshGate()
         var scheduledCount = 0
@@ -611,7 +611,7 @@ struct StatusMenuViewportRestoreTests {
         controller.menuDidClose(menu)
         controller.menuWillOpen(menu)
         defer { controller.menuDidClose(menu) }
-        let reopenedSession = try #require(menu.menuInteractionToken)
+        let reopenedSession = try #require(menu.menuInteractionGeneration)
         #expect(reopenedSession != closedSession)
 
         for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
@@ -698,14 +698,14 @@ extension StatusMenuViewportRestoreTests {
             await Task.yield()
         }
         let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
-        let refreshInteraction = try #require(controller.menuSession.menuInteractionToken(for: rootID))
+        let refreshInteraction = try #require(controller.menuSession.menuInteractionGeneration(for: rootID))
 
         let submenu = NSMenu()
         let submenuItem = NSMenuItem(title: "Submenu", action: nil, keyEquivalent: "")
         submenuItem.submenu = submenu
         rootMenu.addItem(submenuItem)
         controller.menuWillOpen(submenu)
-        #expect(controller.menuSession.menuInteractionToken(for: rootID) != refreshInteraction)
+        #expect(controller.menuSession.menuInteractionGeneration(for: rootID) != refreshInteraction)
         controller.menuDidClose(submenu)
 
         gate.resume()
@@ -831,11 +831,12 @@ extension StatusMenuViewportRestoreTests {
         await task.value
         #expect(scheduled.count == 1)
 
-        let initialGeneration = try #require(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)))
+        let initialGeneration = try #require(controller.menuSession
+            .menuInteractionGeneration(for: ObjectIdentifier(menu)))
         controller.selectOverviewProvider(.codex, menu: menu)
         controller.selectOverviewProvider(.claude, menu: menu)
         #expect(settings.selectedMenuProvider == .claude)
-        #expect(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)) == initialGeneration + 2)
+        #expect(controller.menuSession.menuInteractionGeneration(for: ObjectIdentifier(menu)) == initialGeneration + 2)
 
         scheduled.removeFirst()()
 
@@ -871,10 +872,11 @@ extension StatusMenuViewportRestoreTests {
         }
 
         menu.requestPersistentRefreshAction()
-        let actionGeneration = try #require(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)))
+        let actionGeneration = try #require(controller.menuSession
+            .menuInteractionGeneration(for: ObjectIdentifier(menu)))
         controller.selectOverviewProvider(.codex, menu: menu)
         controller.selectOverviewProvider(.claude, menu: menu)
-        #expect(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)) == actionGeneration + 2)
+        #expect(controller.menuSession.menuInteractionGeneration(for: ObjectIdentifier(menu)) == actionGeneration + 2)
 
         for _ in 0..<20 where controller.manualRefreshTasks[.provider(.claude)] == nil {
             await Task.yield()
@@ -922,14 +924,15 @@ extension StatusMenuViewportRestoreTests {
             await Task.yield()
         }
         let task = try #require(controller.manualRefreshTasks[.provider(.copilot)])
-        let initialToken = try #require(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)))
+        let initialGeneration = try #require(controller.menuSession
+            .menuInteractionGeneration(for: ObjectIdentifier(menu)))
 
         let secondaryRefresh = try #require(switcher._test_select(index: 1))
         secondaryRefresh.cancel()
         let primaryRefresh = try #require(switcher._test_select(index: 0))
         primaryRefresh.cancel()
         #expect(settings.tokenAccountsData(for: .copilot)?.clampedActiveIndex() == 0)
-        #expect(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)) == initialToken + 2)
+        #expect(controller.menuSession.menuInteractionGeneration(for: ObjectIdentifier(menu)) == initialGeneration + 2)
 
         gate.resume()
         await task.value

--- a/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
+++ b/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
@@ -1,0 +1,207 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuViewportRestoreTests {
+    private func makeSettings() -> SettingsStore {
+        testSettingsStore(suiteName: "StatusMenuViewportRestoreTests")
+    }
+
+    private func makeController(settings: SettingsStore) -> StatusItemController {
+        let environment = Self.isolatedEnvironment()
+        let fetcher = UsageFetcher(environment: environment)
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: environment)
+        return StatusItemController(
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+    }
+
+    private static func isolatedEnvironment() -> [String: String] {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        return [
+            "HOME": root.path,
+            "CODEX_HOME": root.appendingPathComponent(".codex", isDirectory: true).path,
+            "XDG_CONFIG_HOME": root.appendingPathComponent(".config", isDirectory: true).path,
+        ]
+    }
+
+    @Test
+    func `viewport top offset is nil when the menu content fits the clip`() {
+        #expect(StatusItemController.menuViewportTopOffset(
+            documentIsFlipped: true,
+            documentHeight: 500,
+            clipHeight: 500,
+            currentOffset: 0) == nil)
+        #expect(StatusItemController.menuViewportTopOffset(
+            documentIsFlipped: true,
+            documentHeight: 400,
+            clipHeight: 500,
+            currentOffset: 0) == nil)
+        #expect(StatusItemController.menuViewportTopOffset(
+            documentIsFlipped: true,
+            documentHeight: 400,
+            clipHeight: 0,
+            currentOffset: 0) == nil)
+    }
+
+    @Test
+    func `viewport top offset is nil when the viewport already shows the top`() {
+        #expect(StatusItemController.menuViewportTopOffset(
+            documentIsFlipped: true,
+            documentHeight: 1700,
+            clipHeight: 950,
+            currentOffset: 0) == nil)
+        #expect(StatusItemController.menuViewportTopOffset(
+            documentIsFlipped: false,
+            documentHeight: 1700,
+            clipHeight: 950,
+            currentOffset: 750) == nil)
+    }
+
+    @Test
+    func `viewport top offset targets the content top for a scrolled menu`() {
+        #expect(StatusItemController.menuViewportTopOffset(
+            documentIsFlipped: true,
+            documentHeight: 1700,
+            clipHeight: 950,
+            currentOffset: 750) == 0)
+        #expect(StatusItemController.menuViewportTopOffset(
+            documentIsFlipped: false,
+            documentHeight: 1700,
+            clipHeight: 950,
+            currentOffset: 0) == 750)
+    }
+
+    @Test
+    func `completed manual refresh arms a restore for the open dirty menu`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+        #expect(controller.openMenus[ObjectIdentifier(menu)] === menu)
+
+        controller._test_manualRefreshOperation = {
+            // Stand-in for the store mutations of a real refresh: content is newer
+            // than what the open menu rendered.
+            controller.menuContentVersion += 1
+        }
+        controller.refreshNow()
+        for _ in 0..<20 where controller.manualRefreshTasks[.global] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.global])
+        await task.value
+
+        #expect(controller.menuSession.pendingViewportRestores.contains(ObjectIdentifier(menu)))
+    }
+
+    @Test
+    func `completed manual refresh does not arm a restore for a clean menu`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+        controller.markMenuFresh(menu)
+
+        controller._test_manualRefreshOperation = {}
+        controller.refreshNow()
+        for _ in 0..<20 where controller.manualRefreshTasks[.global] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.global])
+        await task.value
+
+        #expect(!controller.menuSession.pendingViewportRestores.contains(ObjectIdentifier(menu)))
+    }
+
+    @Test
+    func `landed open-menu rebuild consumes the pending restore exactly once`() async {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+        #expect(controller.openMenus[ObjectIdentifier(menu)] === menu)
+
+        var restoredMenus: [ObjectIdentifier] = []
+        StatusItemController._test_menuViewportRestoreObserver = { restoredMenus.append(ObjectIdentifier($0)) }
+        defer { StatusItemController._test_menuViewportRestoreObserver = nil }
+
+        controller.menuSession.armViewportRestore(ObjectIdentifier(menu))
+        controller.rebuildOpenMenuIfStillVisible(menu, provider: .codex)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+        for _ in 0..<20 where restoredMenus.isEmpty {
+            await Task.yield()
+        }
+        #expect(restoredMenus == [ObjectIdentifier(menu)])
+
+        // A follow-up rebuild without a pending restore must leave the viewport alone.
+        controller.rebuildOpenMenuIfStillVisible(menu, provider: .codex)
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+        #expect(restoredMenus == [ObjectIdentifier(menu)])
+    }
+
+    @Test
+    func `closing the menu clears its pending restore`() {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        controller.menuSession.armViewportRestore(ObjectIdentifier(menu))
+        controller.menuDidClose(menu)
+
+        #expect(!controller.menuSession.pendingViewportRestores.contains(ObjectIdentifier(menu)))
+    }
+
+    @Test
+    func `viewport restore is a safe no-op without an attached menu window`() {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        // Menu items exist but no view is hosted in a menu window, so the private
+        // scroll view cannot be resolved and the restore must bail out quietly.
+        #expect(StatusItemController.attachedMenuScrollView(in: menu) == nil)
+        controller.restoreMenuViewportToTop(menu)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
+++ b/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
@@ -639,6 +639,79 @@ struct StatusMenuViewportRestoreTests {
     }
 
     @Test
+    func `scroll during refresh invalidates parent viewport restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        let gate = ViewportRefreshGate()
+        var scheduledCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        let initialGeneration = try #require(controller.menuSession
+            .menuInteractionGeneration(for: ObjectIdentifier(menu)))
+
+        let scroll = try self.scrollEvent()
+        #expect(!controller.handleMenuTrackingShortcutEvent(scroll, menu: menu))
+        #expect(controller.menuSession.menuInteractionGeneration(for: ObjectIdentifier(menu)) == initialGeneration + 1)
+
+        gate.resume()
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `scroll before delivery invalidates parent viewport restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+        #expect(scheduled.count == 1)
+
+        let scroll = try self.scrollEvent()
+        #expect(!controller.handleMenuTrackingShortcutEvent(scroll, menu: menu))
+        scheduled.removeFirst()()
+
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
     func `non-manual invalidation never schedules a viewport restore`() {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
@@ -1119,6 +1192,17 @@ extension StatusMenuViewportRestoreTests {
             charactersIgnoringModifiers: characters,
             isARepeat: false,
             keyCode: keyCode))
+    }
+
+    private func scrollEvent() throws -> NSEvent {
+        let event = CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 1,
+            wheel1: 30,
+            wheel2: 0,
+            wheel3: 0)
+        return try #require(event.flatMap(NSEvent.init(cgEvent:)))
     }
 
     private func enableOnly(_ providers: Set<UsageProvider>, settings: SettingsStore) {

--- a/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
+++ b/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
@@ -4,6 +4,31 @@ import Testing
 @testable import CodexBar
 
 @MainActor
+private final class ViewportRefreshGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func wait() async {
+        if self.isOpen {
+            self.isOpen = false
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func resume() {
+        if let continuation = self.continuation {
+            continuation.resume()
+            self.continuation = nil
+        } else {
+            self.isOpen = true
+        }
+    }
+}
+
+@MainActor
 @Suite(.serialized)
 struct StatusMenuViewportRestoreTests {
     private func makeSettings() -> SettingsStore {
@@ -87,47 +112,499 @@ struct StatusMenuViewportRestoreTests {
     }
 
     @Test
-    func `completed manual refresh arms a restore for the open dirty menu`() async throws {
+    func `manual refresh restores originating dirty menu without rebuilding tracked parent`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
 
         let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
         controller.menuRefreshEnabledOverrideForTesting = true
         let menu = controller.makeMenu(for: .codex)
         controller.menuWillOpen(menu)
         defer { controller.menuDidClose(menu) }
-        #expect(controller.openMenus[ObjectIdentifier(menu)] === menu)
+        let menuID = ObjectIdentifier(menu)
 
-        controller._test_manualRefreshOperation = {
-            // Stand-in for the store mutations of a real refresh: content is newer
-            // than what the open menu rendered.
-            controller.menuContentVersion += 1
+        var restoredMenus: [ObjectIdentifier] = []
+        var rebuildCount = 0
+        controller._test_menuViewportRestoreObserver = { restoredMenus.append(ObjectIdentifier($0)) }
+        controller._test_openMenuRebuildObserver = { rebuiltMenu in
+            if rebuiltMenu === menu {
+                rebuildCount += 1
+            }
         }
-        controller.refreshNow()
-        for _ in 0..<20 where controller.manualRefreshTasks[.global] == nil {
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        #expect(try controller.handleMenuTrackingShortcutEvent(self.keyEvent("r", keyCode: 15), menu: menu))
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
             await Task.yield()
         }
-        let task = try #require(controller.manualRefreshTasks[.global])
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
         await task.value
 
-        #expect(controller.menuSession.pendingViewportRestores.contains(ObjectIdentifier(menu)))
+        #expect(controller.menuNeedsRefresh(menu))
+        #expect(controller.menuSession.isParentRebuildDeferred(menuID))
+        #expect(rebuildCount == 0)
+
+        self.runLoop(mode: CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
+
+        #expect(restoredMenus == [menuID])
+        self.runLoop(mode: .defaultMode)
+        #expect(restoredMenus == [menuID])
+        #expect(rebuildCount == 0)
+        #expect(controller.menuNeedsRefresh(menu))
+        #expect(controller.menuSession.isParentRebuildDeferred(menuID))
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
     }
 
     @Test
-    func `completed manual refresh does not arm a restore for a clean menu`() async throws {
+    func `completed manual refresh clears its request when the menu stayed clean`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
 
         let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
         controller.menuRefreshEnabledOverrideForTesting = true
         let menu = controller.makeMenu(for: .codex)
         controller.menuWillOpen(menu)
         defer { controller.menuDidClose(menu) }
         controller.markMenuFresh(menu)
 
+        var scheduledCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
         controller._test_manualRefreshOperation = {}
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `provider refresh restores only its originating open menu`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let claudeMenu = controller.makeMenu(for: .claude)
+        let codexMenu = controller.makeMenu(for: .codex)
+        controller.providerMenus[.claude] = claudeMenu
+        controller.providerMenus[.codex] = codexMenu
+        controller.menuWillOpen(claudeMenu)
+        controller.menuWillOpen(codexMenu)
+        defer {
+            controller.menuDidClose(codexMenu)
+            controller.menuDidClose(claudeMenu)
+        }
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoredMenus: [ObjectIdentifier] = []
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { restoredMenus.append(ObjectIdentifier($0)) }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: claudeMenu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.claude)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.claude)])
+        await task.value
+
+        #expect(scheduled.count == 1)
+        scheduled.removeFirst()()
+
+        #expect(restoredMenus == [ObjectIdentifier(claudeMenu)])
+        #expect(controller.menuNeedsRefresh(codexMenu))
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `closing and reopening during refresh cannot transfer restore to new tracking session`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        let gate = ViewportRefreshGate()
+        var scheduledCount = 0
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        #expect(!controller.menuSession.pendingViewportRestores.isEmpty)
+
+        controller.menuDidClose(menu)
+        controller.menuWillOpen(menu)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+
+        gate.resume()
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `closing after completion invalidates scheduled restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+        #expect(scheduled.count == 1)
+
+        controller.menuDidClose(menu)
+        scheduled.removeFirst()()
+
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `open hosted submenu blocks parent viewport restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.usageBreakdownChartID)
+        controller.openMenus[ObjectIdentifier(submenu)] = submenu
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        var rebuildCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_openMenuRebuildObserver = { rebuiltMenu in
+            if rebuiltMenu === menu {
+                rebuildCount += 1
+            }
+        }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+
+        #expect(scheduled.isEmpty)
+        #expect(restoreCount == 0)
+        #expect(!controller.menuSession.pendingViewportRestores.isEmpty)
+        #expect(controller.manualRefreshViewportRestoreState.deferredUntilRebuild.count == 1)
+
+        controller.menuDidClose(submenu)
+        for _ in 0..<20 where scheduled.isEmpty {
+            await Task.yield()
+        }
+        #expect(rebuildCount == 1)
+        #expect(scheduled.count == 1)
+        scheduled.removeFirst()()
+
+        #expect(restoreCount == 1)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+        #expect(controller.manualRefreshViewportRestoreState.deferredUntilRebuild.isEmpty)
+    }
+
+    @Test
+    func `hosted submenu opening before delivery invalidates parent viewport restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        var rebuildCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_openMenuRebuildObserver = { rebuiltMenu in
+            if rebuiltMenu === menu {
+                rebuildCount += 1
+            }
+        }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+        #expect(scheduled.count == 1)
+
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.usageBreakdownChartID)
+        controller.openMenus[ObjectIdentifier(submenu)] = submenu
+        scheduled.removeFirst()()
+
+        #expect(restoreCount == 0)
+        #expect(!controller.menuSession.pendingViewportRestores.isEmpty)
+        #expect(controller.manualRefreshViewportRestoreState.deferredUntilRebuild.count == 1)
+
+        controller.menuDidClose(submenu)
+        for _ in 0..<20 where scheduled.isEmpty {
+            await Task.yield()
+        }
+        #expect(rebuildCount == 1)
+        #expect(scheduled.count == 1)
+        scheduled.removeFirst()()
+
+        #expect(restoreCount == 1)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+        #expect(controller.manualRefreshViewportRestoreState.deferredUntilRebuild.isEmpty)
+    }
+
+    @Test
+    func `fresh parent does not defer old restore when hosted submenu opens before delivery`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+        #expect(scheduled.count == 1)
+
+        controller.rebuildOpenMenuIfStillVisible(menu, provider: .codex)
+        #expect(!controller.menuNeedsRefresh(menu))
+        controller.parentMenuRebuildPendingAfterHostedSubviewClose = true
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.usageBreakdownChartID)
+        controller.openMenus[ObjectIdentifier(submenu)] = submenu
+        scheduled.removeFirst()()
+
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+        #expect(controller.manualRefreshViewportRestoreState.deferredUntilRebuild.isEmpty)
+    }
+
+    @Test
+    func `native highlight blocks parent viewport restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        let settingsItem = try #require(menu.items.first { $0.title == "Settings..." })
+        controller.menu(menu, willHighlight: settingsItem)
+
+        var scheduledCount = 0
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `native highlight before delivery invalidates parent viewport restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+        #expect(scheduled.count == 1)
+
+        let settingsItem = try #require(menu.items.first { $0.title == "Settings..." })
+        controller.menu(menu, willHighlight: settingsItem)
+        scheduled.removeFirst()()
+
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `non-manual invalidation never schedules a viewport restore`() {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        var scheduledCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller.refreshOpenMenusAfterExplicitStoreAction()
+
+        #expect(controller.menuNeedsRefresh(menu))
+        #expect(scheduledCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `closed origin cannot transfer restore to another open menu before task starts`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let claudeMenu = controller.makeMenu(for: .claude)
+        let codexMenu = controller.makeMenu(for: .codex)
+        controller.providerMenus[.claude] = claudeMenu
+        controller.providerMenus[.codex] = codexMenu
+        controller.menuWillOpen(claudeMenu)
+
+        var scheduledCount = 0
+        var restoreCount = 0
+        let gate = ViewportRefreshGate()
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+
+        controller.performPersistentRefreshAction(in: ObjectIdentifier(claudeMenu))
+        controller.menuDidClose(claudeMenu)
+        controller.menuWillOpen(codexMenu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.claude)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.claude)])
+        gate.resume()
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `global manual refresh ignores tracked non-root submenu`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let rootMenu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(rootMenu)
+        let submenu = NSMenu()
+        let submenuItem = NSMenuItem(title: "Submenu", action: nil, keyEquivalent: "")
+        submenuItem.submenu = submenu
+        rootMenu.addItem(submenuItem)
+        controller.openMenus[ObjectIdentifier(submenu)] = submenu
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoredMenus: [ObjectIdentifier] = []
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { restoredMenus.append(ObjectIdentifier($0)) }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
         controller.refreshNow()
         for _ in 0..<20 where controller.manualRefreshTasks[.global] == nil {
             await Task.yield()
@@ -135,57 +612,78 @@ struct StatusMenuViewportRestoreTests {
         let task = try #require(controller.manualRefreshTasks[.global])
         await task.value
 
-        #expect(!controller.menuSession.pendingViewportRestores.contains(ObjectIdentifier(menu)))
-    }
-
-    @Test
-    func `landed open-menu rebuild consumes the pending restore exactly once`() async {
-        let settings = self.makeSettings()
-        settings.refreshFrequency = .manual
-        settings.mergeIcons = false
-
-        let controller = self.makeController(settings: settings)
-        controller.menuRefreshEnabledOverrideForTesting = true
-        let menu = controller.makeMenu(for: .codex)
-        controller.menuWillOpen(menu)
-        defer { controller.menuDidClose(menu) }
-        #expect(controller.openMenus[ObjectIdentifier(menu)] === menu)
-
-        var restoredMenus: [ObjectIdentifier] = []
-        StatusItemController._test_menuViewportRestoreObserver = { restoredMenus.append(ObjectIdentifier($0)) }
-        defer { StatusItemController._test_menuViewportRestoreObserver = nil }
-
-        controller.menuSession.armViewportRestore(ObjectIdentifier(menu))
-        controller.rebuildOpenMenuIfStillVisible(menu, provider: .codex)
+        #expect(scheduled.count == 1)
+        scheduled.removeFirst()()
+        #expect(restoredMenus == [ObjectIdentifier(rootMenu)])
         #expect(controller.menuSession.pendingViewportRestores.isEmpty)
-        for _ in 0..<20 where restoredMenus.isEmpty {
-            await Task.yield()
-        }
-        #expect(restoredMenus == [ObjectIdentifier(menu)])
-
-        // A follow-up rebuild without a pending restore must leave the viewport alone.
-        controller.rebuildOpenMenuIfStillVisible(menu, provider: .codex)
-        for _ in 0..<20 {
-            await Task.yield()
-        }
-        #expect(restoredMenus == [ObjectIdentifier(menu)])
     }
 
     @Test
-    func `closing the menu clears its pending restore`() {
+    func `merged selection change discards originating refresh restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnly([.claude, .codex], settings: settings)
+        settings.selectedMenuProvider = .claude
+        settings.mergedMenuLastSelectedWasOverview = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.menuWillOpen(menu)
+
+        let gate = ViewportRefreshGate()
+        var scheduledCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.claude)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.claude)])
+
+        settings.selectedMenuProvider = .codex
+        gate.resume()
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `cancelled manual refresh clears restore request without scheduling`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
 
         let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
         controller.menuRefreshEnabledOverrideForTesting = true
         let menu = controller.makeMenu(for: .codex)
         controller.menuWillOpen(menu)
 
-        controller.menuSession.armViewportRestore(ObjectIdentifier(menu))
-        controller.menuDidClose(menu)
+        let gate = ViewportRefreshGate()
+        var scheduledCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_manualRefreshOperation = { await gate.wait() }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        #expect(!controller.menuSession.pendingViewportRestores.isEmpty)
 
-        #expect(!controller.menuSession.pendingViewportRestores.contains(ObjectIdentifier(menu)))
+        task.cancel()
+        gate.resume()
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
     }
 
     @Test
@@ -195,6 +693,7 @@ struct StatusMenuViewportRestoreTests {
         settings.mergeIcons = false
 
         let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
         let menu = controller.makeMenu(for: .codex)
         controller.menuWillOpen(menu)
         defer { controller.menuDidClose(menu) }
@@ -203,5 +702,30 @@ struct StatusMenuViewportRestoreTests {
         // scroll view cannot be resolved and the restore must bail out quietly.
         #expect(StatusItemController.attachedMenuScrollView(in: menu) == nil)
         controller.restoreMenuViewportToTop(menu)
+    }
+
+    private func keyEvent(_ characters: String, keyCode: UInt16) throws -> NSEvent {
+        try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode))
+    }
+
+    private func enableOnly(_ providers: Set<UsageProvider>, settings: SettingsStore) {
+        for provider in UsageProvider.allCases {
+            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: providers.contains(provider))
+        }
+    }
+
+    private func runLoop(mode: CFRunLoopMode) {
+        CFRunLoopRunInMode(mode, 0.1, true)
     }
 }

--- a/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
+++ b/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
@@ -897,8 +897,8 @@ extension StatusMenuViewportRestoreTests {
         settings.multiAccountMenuLayout = .segmented
         settings.statusChecksEnabled = false
         self.enableOnly([.copilot], settings: settings)
-        settings.addTokenAccount(provider: .copilot, label: "Primary", token: "test-primary")
-        settings.addTokenAccount(provider: .copilot, label: "Secondary", token: "test-secondary")
+        settings.addTokenAccount(provider: .copilot, label: "Primary", token: "a")
+        settings.addTokenAccount(provider: .copilot, label: "Secondary", token: "b")
         settings.setActiveTokenAccountIndex(0, for: .copilot)
 
         let controller = self.makeController(settings: settings)

--- a/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
+++ b/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
@@ -28,6 +28,12 @@ private final class ViewportRefreshGate {
     }
 }
 
+private final class FlippedViewportDocumentView: NSView {
+    override var isFlipped: Bool {
+        true
+    }
+}
+
 @MainActor
 @Suite(.serialized)
 struct StatusMenuViewportRestoreTests {
@@ -110,6 +116,194 @@ struct StatusMenuViewportRestoreTests {
             clipHeight: 950,
             currentOffset: 0) == 750)
     }
+}
+
+extension StatusMenuViewportRestoreTests {
+    @Test
+    func `settled viewport geometry distinguishes layout from movement`() {
+        let document = NSView()
+        let clipView = NSClipView()
+        let initial = MenuViewportGeometry(
+            documentID: ObjectIdentifier(document),
+            clipID: ObjectIdentifier(clipView),
+            documentSize: CGSize(width: 200, height: 600),
+            documentIsFlipped: false,
+            clipSize: CGSize(width: 200, height: 100),
+            clipOrigin: CGPoint(x: 0, y: 200))
+
+        #expect(StatusItemController.menuViewportGeometryTransition(
+            from: initial,
+            to: MenuViewportGeometry(
+                documentID: ObjectIdentifier(document),
+                clipID: initial.clipID,
+                documentSize: initial.documentSize,
+                documentIsFlipped: false,
+                clipSize: initial.clipSize,
+                clipOrigin: CGPoint(x: 0, y: 200.5))) == .unchanged)
+        #expect(StatusItemController.menuViewportGeometryTransition(
+            from: initial,
+            to: MenuViewportGeometry(
+                documentID: ObjectIdentifier(document),
+                clipID: initial.clipID,
+                documentSize: initial.documentSize,
+                documentIsFlipped: false,
+                clipSize: initial.clipSize,
+                clipOrigin: CGPoint(x: 0, y: 210))) == .movement)
+        #expect(StatusItemController.menuViewportGeometryTransition(
+            from: initial,
+            to: MenuViewportGeometry(
+                documentID: ObjectIdentifier(document),
+                clipID: initial.clipID,
+                documentSize: CGSize(width: 200, height: 500),
+                documentIsFlipped: false,
+                clipSize: initial.clipSize,
+                clipOrigin: .zero)) == .layout)
+    }
+
+    @Test
+    func `viewport movement tracker settles layout then accumulates fractional scrolling`() {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        let documentView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 500))
+        scrollView.documentView = documentView
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 100))
+        let originalBoundsNotifications = scrollView.contentView.postsBoundsChangedNotifications
+        let originalClipFrameNotifications = scrollView.contentView.postsFrameChangedNotifications
+        let originalDocumentFrameNotifications = documentView.postsFrameChangedNotifications
+
+        let tracker = ManualRefreshViewportMovementTracker(scrollView: scrollView)
+        #expect(scrollView.contentView.postsBoundsChangedNotifications)
+        #expect(scrollView.contentView.postsFrameChangedNotifications)
+        #expect(documentView.postsFrameChangedNotifications)
+
+        // AppKit can publish the origin reset before exposing the new document height. The
+        // coalesced sample must see the settled geometry and classify the batch as layout.
+        scrollView.contentView.scroll(to: .zero)
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView)
+        documentView.frame.size.height = 600
+        tracker.settlePendingGeometryChanges()
+        #expect(!tracker.observedMovement)
+
+        for offset in [0.4, 0.8] {
+            scrollView.contentView.scroll(to: NSPoint(x: 0, y: offset))
+            tracker.settlePendingGeometryChanges()
+            #expect(!tracker.observedMovement)
+        }
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 1.2))
+        tracker.settlePendingGeometryChanges()
+        #expect(tracker.observedMovement)
+
+        tracker.stop()
+        #expect(scrollView.contentView.postsBoundsChangedNotifications == originalBoundsNotifications)
+        #expect(scrollView.contentView.postsFrameChangedNotifications == originalClipFrameNotifications)
+        #expect(documentView.postsFrameChangedNotifications == originalDocumentFrameNotifications)
+    }
+
+    @Test
+    func `refresh completion waits for settled AppKit geometry before rebasing`() {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        let documentView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 500))
+        scrollView.documentView = documentView
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 100))
+
+        let tracker = ManualRefreshViewportMovementTracker(scrollView: scrollView)
+        defer { tracker.stop() }
+
+        // macOS 27 can publish this reset while the document still reports its old height.
+        scrollView.contentView.scroll(to: .zero)
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView)
+        var completionRan = false
+        tracker.afterPendingGeometrySettles {
+            tracker.rebaseAfterRefreshLayout()
+            completionRan = true
+        }
+        #expect(!completionRan)
+
+        documentView.frame.size.height = 600
+        self.runLoop(mode: CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
+
+        #expect(completionRan)
+        #expect(!tracker.observedMovement)
+    }
+
+    @Test
+    func `viewport tracker absorbs a delayed origin correction after layout settles`() {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        let documentView = FlippedViewportDocumentView(frame: NSRect(x: 0, y: 0, width: 200, height: 500))
+        scrollView.documentView = documentView
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 100))
+
+        let tracker = ManualRefreshViewportMovementTracker(scrollView: scrollView)
+        defer { tracker.stop() }
+
+        documentView.frame.size.height = 600
+        self.runLoop(mode: CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
+        #expect(!tracker.observedMovement)
+
+        // AppKit may correct the origin on the following pass, after geometry already settled.
+        scrollView.contentView.scroll(to: .zero)
+        self.runLoop(mode: CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
+        #expect(!tracker.observedMovement)
+
+        // A further stable-geometry edge tick is user movement and remains sticky.
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 20))
+        self.runLoop(mode: CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
+        #expect(tracker.observedMovement)
+    }
+
+    @Test
+    func `viewport observer records move away and return within one settled batch`() {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        let documentView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 500))
+        scrollView.documentView = documentView
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 100))
+
+        let tracker = ManualRefreshViewportMovementTracker(scrollView: scrollView)
+        defer { tracker.stop() }
+
+        for offset in [120.0, 100.0] {
+            scrollView.contentView.scroll(to: NSPoint(x: 0, y: offset))
+            NotificationCenter.default.post(
+                name: NSView.boundsDidChangeNotification,
+                object: scrollView.contentView)
+        }
+        self.runLoop(mode: CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
+
+        #expect(tracker.observedMovement)
+    }
+
+    @Test
+    func `stale completion preserves movement owned by a newer refresh`() {
+        let menu = NSMenu()
+        let key = ObjectIdentifier(menu)
+        let newerScrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        newerScrollView.documentView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 500))
+        newerScrollView.contentView.scroll(to: NSPoint(x: 0, y: 100))
+        let staleScrollView = NSScrollView(frame: newerScrollView.frame)
+        staleScrollView.documentView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 500))
+
+        let state = ManualRefreshViewportRestoreState()
+        defer { state.stopAllMovementTracking() }
+        state.startMovementTracking(for: key, generation: 2, scrollView: newerScrollView)
+        newerScrollView.contentView.scroll(to: NSPoint(x: 0, y: 120))
+        self.runLoop(mode: CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
+        #expect(state.observedMovement(for: key, generation: 2))
+
+        var completionCount = 0
+        state.prepareForCompletedRefreshLayout(
+            for: key,
+            generation: 1,
+            scrollView: staleScrollView)
+        {
+            completionCount += 1
+        }
+
+        #expect(completionCount == 1)
+        #expect(state.observedMovement(for: key, generation: 2))
+    }
 
     @Test
     func `manual refresh restores originating dirty menu without rebuilding tracked parent`() async throws {
@@ -183,6 +377,44 @@ struct StatusMenuViewportRestoreTests {
         await task.value
 
         #expect(scheduledCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `viewport becoming attachable during refresh schedules one restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        #expect(StatusItemController.attachedMenuScrollView(in: menu) == nil)
+
+        let gate = ViewportRefreshGate()
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        _ = self.attachScrollableViewport(to: menu)
+
+        gate.resume()
+        await task.value
+
+        #expect(scheduled.count == 1)
+        scheduled.removeFirst()()
+        #expect(restoreCount == 1)
         #expect(controller.menuSession.pendingViewportRestores.isEmpty)
     }
 
@@ -639,6 +871,41 @@ struct StatusMenuViewportRestoreTests {
     }
 
     @Test
+    func `clip movement during refresh invalidates parent viewport restore without a wheel event`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        let scrollView = self.attachScrollableViewport(to: menu)
+
+        let gate = ViewportRefreshGate()
+        var scheduledCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 120))
+        gate.resume()
+        await task.value
+        self.runLoop(mode: CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
+
+        #expect(scheduledCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
     func `scroll during refresh invalidates parent viewport restore`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
@@ -673,6 +940,42 @@ struct StatusMenuViewportRestoreTests {
         await task.value
 
         #expect(scheduledCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `clip movement before delivery invalidates parent viewport restore without a wheel event`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        let scrollView = self.attachScrollableViewport(to: menu)
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+        #expect(scheduled.count == 1)
+
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 120))
+        scheduled.removeFirst()()
+        self.runLoop(mode: CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
+
+        #expect(restoreCount == 0)
         #expect(controller.menuSession.pendingViewportRestores.isEmpty)
     }
 
@@ -1203,6 +1506,20 @@ extension StatusMenuViewportRestoreTests {
             wheel2: 0,
             wheel3: 0)
         return try #require(event.flatMap(NSEvent.init(cgEvent:)))
+    }
+
+    private func attachScrollableViewport(to menu: NSMenu) -> NSScrollView {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        let documentView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 500))
+        let hostedItemView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 20))
+        let item = NSMenuItem()
+        item.view = hostedItemView
+        menu.addItem(item)
+        scrollView.documentView = documentView
+        documentView.addSubview(hostedItemView)
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 100))
+        #expect(StatusItemController.attachedMenuScrollView(in: menu) === scrollView)
+        return scrollView
     }
 
     private func enableOnly(_ providers: Set<UsageProvider>, settings: SettingsStore) {

--- a/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
+++ b/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
@@ -522,6 +522,123 @@ struct StatusMenuViewportRestoreTests {
     }
 
     @Test
+    func `custom highlight blocks parent viewport restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        let overviewItem = NSMenuItem()
+        overviewItem.view = NSView()
+        overviewItem.isEnabled = true
+        menu.addItem(overviewItem)
+        controller.menu(menu, willHighlight: overviewItem)
+
+        var scheduledCount = 0
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            controller.menuSession.invalidate(allowsStaleContent: false, requiresRebuild: true)
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `custom highlight before delivery invalidates parent viewport restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
+        #expect(scheduled.count == 1)
+
+        let overviewItem = NSMenuItem()
+        overviewItem.view = NSView()
+        overviewItem.isEnabled = true
+        menu.addItem(overviewItem)
+        controller.menu(menu, willHighlight: overviewItem)
+        scheduled.removeFirst()()
+
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `refresh row highlight clears while its action is in flight`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        let refreshItem = try #require(menu.items.first(where: controller.isPersistentRefreshItem))
+        let refreshView = try #require(refreshItem.view as? PersistentRefreshMenuView)
+        controller.menu(menu, willHighlight: refreshItem)
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        let gate = ViewportRefreshGate()
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+
+        #expect(refreshView.accessibilityPerformPress())
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] == nil)
+        #expect(!refreshItem.isEnabled)
+
+        gate.resume()
+        await task.value
+        #expect(refreshItem.isEnabled)
+        #expect(scheduled.count == 1)
+
+        scheduled.removeFirst()()
+        #expect(restoreCount == 1)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
     func `non-manual invalidation never schedules a viewport restore`() {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
+++ b/Tests/CodexBarTests/StatusMenuViewportRestoreTests.swift
@@ -270,7 +270,7 @@ struct StatusMenuViewportRestoreTests {
     }
 
     @Test
-    func `closing after completion invalidates scheduled restore`() async throws {
+    func `closing and reopening after completion invalidates scheduled restore`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
@@ -297,6 +297,8 @@ struct StatusMenuViewportRestoreTests {
         #expect(scheduled.count == 1)
 
         controller.menuDidClose(menu)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
         scheduled.removeFirst()()
 
         #expect(restoreCount == 0)
@@ -582,7 +584,54 @@ struct StatusMenuViewportRestoreTests {
     }
 
     @Test
-    func `global manual refresh ignores tracked non-root submenu`() async throws {
+    func `queued refresh cannot arm restore for a reopened persistent menu`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = try #require(controller.makeMenu(for: .codex) as? StatusItemMenu)
+        controller.providerMenus[.codex] = menu
+        controller.menuWillOpen(menu)
+        let closedSession = try #require(menu.menuInteractionToken)
+
+        let gate = ViewportRefreshGate()
+        var scheduledCount = 0
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+
+        menu.requestPersistentRefreshAction()
+        controller.menuDidClose(menu)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+        let reopenedSession = try #require(menu.menuInteractionToken)
+        #expect(reopenedSession != closedSession)
+
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+
+        gate.resume()
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+}
+
+extension StatusMenuViewportRestoreTests {
+    @Test
+    func `open non-hosted child menu blocks global viewport restore`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
@@ -596,12 +645,16 @@ struct StatusMenuViewportRestoreTests {
         let submenuItem = NSMenuItem(title: "Submenu", action: nil, keyEquivalent: "")
         submenuItem.submenu = submenu
         rootMenu.addItem(submenuItem)
-        controller.openMenus[ObjectIdentifier(submenu)] = submenu
+        controller.menuWillOpen(submenu)
+        defer {
+            controller.menuDidClose(submenu)
+            controller.menuDidClose(rootMenu)
+        }
 
-        var scheduled: [@MainActor () -> Void] = []
-        var restoredMenus: [ObjectIdentifier] = []
-        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
-        controller._test_menuViewportRestoreObserver = { restoredMenus.append(ObjectIdentifier($0)) }
+        var scheduledCount = 0
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
         controller._test_manualRefreshOperation = {
             controller.refreshOpenMenusAfterExplicitStoreAction()
         }
@@ -612,9 +665,94 @@ struct StatusMenuViewportRestoreTests {
         let task = try #require(controller.manualRefreshTasks[.global])
         await task.value
 
+        #expect(scheduledCount == 0)
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `opening and closing non-hosted child during refresh invalidates parent restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let rootMenu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(rootMenu)
+        defer { controller.menuDidClose(rootMenu) }
+        let rootID = ObjectIdentifier(rootMenu)
+
+        let gate = ViewportRefreshGate()
+        var scheduledCount = 0
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: rootMenu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        let refreshInteraction = try #require(controller.menuSession.menuInteractionToken(for: rootID))
+
+        let submenu = NSMenu()
+        let submenuItem = NSMenuItem(title: "Submenu", action: nil, keyEquivalent: "")
+        submenuItem.submenu = submenu
+        rootMenu.addItem(submenuItem)
+        controller.menuWillOpen(submenu)
+        #expect(controller.menuSession.menuInteractionToken(for: rootID) != refreshInteraction)
+        controller.menuDidClose(submenu)
+
+        gate.resume()
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `non-hosted child opening before delivery invalidates parent restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let rootMenu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(rootMenu)
+        defer { controller.menuDidClose(rootMenu) }
+
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: rootMenu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.codex)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.codex)])
+        await task.value
         #expect(scheduled.count == 1)
+
+        let submenu = NSMenu()
+        let submenuItem = NSMenuItem(title: "Submenu", action: nil, keyEquivalent: "")
+        submenuItem.submenu = submenu
+        rootMenu.addItem(submenuItem)
+        controller.menuWillOpen(submenu)
+        defer { controller.menuDidClose(submenu) }
         scheduled.removeFirst()()
-        #expect(restoredMenus == [ObjectIdentifier(rootMenu)])
+
+        #expect(restoreCount == 0)
         #expect(controller.menuSession.pendingViewportRestores.isEmpty)
     }
 
@@ -648,6 +786,151 @@ struct StatusMenuViewportRestoreTests {
         let task = try #require(controller.manualRefreshTasks[.provider(.claude)])
 
         settings.selectedMenuProvider = .codex
+        gate.resume()
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `merged selection ABA discards originating refresh restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnly([.claude, .codex], settings: settings)
+        settings.mergedOverviewSelectedProviders = []
+        settings.selectedMenuProvider = .claude
+        settings.mergedMenuLastSelectedWasOverview = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        controller._test_providerSwitcherMenuRebuildDebounceNanoseconds = UInt64.max
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        let gate = ViewportRefreshGate()
+        var scheduled: [@MainActor () -> Void] = []
+        var restoreCount = 0
+        controller._test_menuViewportRestoreScheduler = { scheduled.append($0) }
+        controller._test_menuViewportRestoreObserver = { _ in restoreCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.claude)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.claude)])
+
+        gate.resume()
+        await task.value
+        #expect(scheduled.count == 1)
+
+        let initialGeneration = try #require(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)))
+        controller.selectOverviewProvider(.codex, menu: menu)
+        controller.selectOverviewProvider(.claude, menu: menu)
+        #expect(settings.selectedMenuProvider == .claude)
+        #expect(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)) == initialGeneration + 2)
+
+        scheduled.removeFirst()()
+
+        #expect(restoreCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `queued refresh captures menu interaction before its task starts`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnly([.claude, .codex], settings: settings)
+        settings.mergedOverviewSelectedProviders = []
+        settings.selectedMenuProvider = .claude
+        settings.mergedMenuLastSelectedWasOverview = false
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        controller._test_providerSwitcherMenuRebuildDebounceNanoseconds = UInt64.max
+        let menu = try #require(controller.makeMenu() as? StatusItemMenu)
+        controller.mergedMenu = menu
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        let gate = ViewportRefreshGate()
+        var scheduledCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+
+        menu.requestPersistentRefreshAction()
+        let actionGeneration = try #require(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)))
+        controller.selectOverviewProvider(.codex, menu: menu)
+        controller.selectOverviewProvider(.claude, menu: menu)
+        #expect(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)) == actionGeneration + 2)
+
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.claude)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.claude)])
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+
+        gate.resume()
+        await task.value
+
+        #expect(scheduledCount == 0)
+        #expect(controller.menuSession.pendingViewportRestores.isEmpty)
+    }
+
+    @Test
+    func `account selection ABA discards originating refresh restore`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.multiAccountMenuLayout = .segmented
+        settings.statusChecksEnabled = false
+        self.enableOnly([.copilot], settings: settings)
+        settings.addTokenAccount(provider: .copilot, label: "Primary", token: "test-primary")
+        settings.addTokenAccount(provider: .copilot, label: "Secondary", token: "test-secondary")
+        settings.setActiveTokenAccountIndex(0, for: .copilot)
+
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+        controller._test_providerSwitcherMenuRebuildDebounceNanoseconds = UInt64.max
+        let menu = controller.makeMenu(for: .copilot)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+        let switcher = try #require(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
+
+        let gate = ViewportRefreshGate()
+        var scheduledCount = 0
+        controller._test_menuViewportRestoreScheduler = { _ in scheduledCount += 1 }
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.refreshOpenMenusAfterExplicitStoreAction()
+        }
+        controller.refreshMenuProviderNow(in: menu)
+        for _ in 0..<20 where controller.manualRefreshTasks[.provider(.copilot)] == nil {
+            await Task.yield()
+        }
+        let task = try #require(controller.manualRefreshTasks[.provider(.copilot)])
+        let initialToken = try #require(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)))
+
+        let secondaryRefresh = try #require(switcher._test_select(index: 1))
+        secondaryRefresh.cancel()
+        let primaryRefresh = try #require(switcher._test_select(index: 0))
+        primaryRefresh.cancel()
+        #expect(settings.tokenAccountsData(for: .copilot)?.clampedActiveIndex() == 0)
+        #expect(controller.menuSession.menuInteractionToken(for: ObjectIdentifier(menu)) == initialToken + 2)
+
         gate.resume()
         await task.value
 


### PR DESCRIPTION
Fixes #2046.

## Summary

An explicit refresh can collapse a multi-line provider error while an oversized AppKit menu is being tracked, leaving the viewport stranded below the provider header. This change:

- Arms a one-shot restore only for persistent Refresh/Command-R and scopes it to the initiating menu, tracking session, interaction generation, provider/account selection, and refresh generation.
- Waits for clip/document geometry to settle through the existing event-tracking-aware scheduler, distinguishing AppKit layout corrections from deliberate viewport movement.
- Cancels restoration after scrolling, highlighting or selection changes, child or hosted submenu activity, provider/account switches, close/reopen, cancellation, shutdown, or replacement by a newer refresh.
- Leaves background refreshes untouched and restores observer state during teardown.

The implementation integrates the manual-refresh, menu-session, switcher/submenu, interaction, and shutdown paths. It adds 39 focused viewport tests, adjacent lifecycle coverage, a deterministic root-menu assertion for asynchronous submenu cleanup, and a changelog entry thanking @ss251.

## Verification

- `make check`
- `swift test --filter 'StatusMenu(ViewportRestore|OpenRefresh|PersistentRefresh|SwitcherTracking)Tests'` — 114 tests across 4 suites passed.
- `swift test --filter StatusMenuViewportRestoreTests` — 39 tests passed.
- Hosted-submenu cleanup regression — 30/30 isolated repetitions passed.
- `CODEXBAR_TEST_RETRY_NON_TIMEOUT_FAILURES=0 make test` — 602 selections; all 51 groups passed first attempt with no retries, timeouts, or failures.
- Isolated release build passed.
- Autoreview reported no actionable findings; the final test-only race hardening was independently reviewed.
- A signed debug bundle from the exact candidate passed strict deep signature verification and Gatekeeper assessment. In an isolated deterministic failure-to-success run, one Command-R produced one provider invocation; the same native popup remained open, the error cleared, fresh-update state appeared, and the provider header returned into view without close/reopen.

No authenticated-provider behavior is claimed; live proof used deterministic local responses with credential access disabled. No dependencies changed.
