### PR TITLE
Split provider pane settings into Menu bar and Connection sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Quota warnings: add opt-in predictive pace alerts for Codex and Claude session and weekly limits, with one alert per risk episode. Thanks @vincent-peng!
 
 ### Changed
+- Settings: split provider pane "Settings" sections into "Menu bar" and "Connection" so metric pickers and auth/cookie/source controls are grouped by topic.
 - Settings: reorganize into General, Notifications, Menu Bar, Menu, Advanced, and About panes; merge icon-style, cost-summary, switcher, usage-bar, reset-time, and confetti checkboxes into pickers; consistent sentence-case naming and localized Agent Sessions strings.
 
 ### Fixed

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -104,6 +104,14 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
         return (label: L("Balance"), value: rawPlan)
     }
 
+    private var menuBarSettingsPickers: [ProviderSettingsPickerDescriptor] {
+        self.settingsPickers.filter { $0.placement == .menuBar }
+    }
+
+    private var connectionSettingsPickers: [ProviderSettingsPickerDescriptor] {
+        self.settingsPickers.filter { $0.placement == .connection }
+    }
+
     var body: some View {
         Form {
             Section {
@@ -143,16 +151,26 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
                 }
             }
 
-            if !self.settingsPickers.isEmpty || !self.settingsActions.isEmpty {
+            if !self.menuBarSettingsPickers.isEmpty {
                 Section {
-                    ForEach(self.settingsPickers) { picker in
+                    ForEach(self.menuBarSettingsPickers) { picker in
+                        ProviderSettingsPickerRowView(picker: picker)
+                    }
+                } header: {
+                    Text(L("provider_section_menu_bar"))
+                }
+            }
+
+            if !self.connectionSettingsPickers.isEmpty || !self.settingsActions.isEmpty {
+                Section {
+                    ForEach(self.connectionSettingsPickers) { picker in
                         ProviderSettingsPickerRowView(picker: picker)
                     }
                     ForEach(self.settingsActions) { descriptor in
                         ProviderSettingsActionsRowView(descriptor: descriptor)
                     }
                 } header: {
-                    Text(L("Settings"))
+                    Text(L("provider_section_connection"))
                 }
             }
 

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -587,6 +587,7 @@ struct ProvidersPane: View {
             id: "menuBarMetric",
             title: L("menu_bar_metric_title"),
             subtitle: Self.menuBarMetricPickerSubtitle(for: provider),
+            placement: .menuBar,
             binding: Binding(
                 get: {
                     self.settings

--- a/Sources/CodexBar/Providers/Copilot/CopilotProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Copilot/CopilotProviderImplementation.swift
@@ -113,6 +113,7 @@ struct CopilotProviderImplementation: ProviderImplementation {
                 id: "copilot-icon-secondary-window",
                 title: "Menu bar secondary metric",
                 subtitle: "Choose the second meter shown in the menu bar icon.",
+                placement: .menuBar,
                 dynamicSubtitle: {
                     extraWindows.isEmpty
                         ? "Budget options appear after a refresh finds configured Copilot budgets."

--- a/Sources/CodexBar/Providers/Kiro/KiroProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Kiro/KiroProviderImplementation.swift
@@ -11,6 +11,7 @@ struct KiroProviderImplementation: ProviderImplementation {
                 id: "kiroMenuBarDisplay",
                 title: L("Kiro menu bar value"),
                 subtitle: L("Show or hide Kiro credits, percent, or both next to the menu bar icon."),
+                placement: .menuBar,
                 binding: Binding(
                     get: { context.settings.kiroMenuBarDisplayMode.rawValue },
                     set: { rawValue in

--- a/Sources/CodexBar/Providers/Shared/ProviderSettingsDescriptors.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderSettingsDescriptors.swift
@@ -232,11 +232,17 @@ struct ProviderSettingsOrganizationsDescriptor: Identifiable {
 }
 
 /// Shared picker descriptor rendered in the Providers settings pane.
+enum ProviderSettingsPickerPlacement: Equatable {
+    case menuBar
+    case connection
+}
+
 @MainActor
 struct ProviderSettingsPickerDescriptor: Identifiable {
     let id: String
     let title: String
     let subtitle: String
+    let placement: ProviderSettingsPickerPlacement
     let dynamicSubtitle: (() -> String?)?
     let binding: Binding<String>
     let options: [ProviderSettingsPickerOption]
@@ -249,6 +255,7 @@ struct ProviderSettingsPickerDescriptor: Identifiable {
         id: String,
         title: String,
         subtitle: String,
+        placement: ProviderSettingsPickerPlacement = .connection,
         dynamicSubtitle: (() -> String?)? = nil,
         binding: Binding<String>,
         options: [ProviderSettingsPickerOption],
@@ -260,6 +267,7 @@ struct ProviderSettingsPickerDescriptor: Identifiable {
         self.id = id
         self.title = title
         self.subtitle = subtitle
+        self.placement = placement
         self.dynamicSubtitle = dynamicSubtitle
         self.binding = binding
         self.options = options

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -270,7 +270,8 @@
 "Select the IDE to monitor" = "اختر IDE للمراقبة";
 "Session quota notifications" = "إشعارات حصص الجلسة";
 "Session tokens" = "رموز الجلسة";
-"Settings" = "الإعدادات";
+"provider_section_connection" = "الاتصال";
+"provider_section_menu_bar" = "شريط القوائم";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "عرض أقسام Codex الاعتمادات و Claude الاستخدام الإضافي في القائمة.";
 "Show Debug Settings" = "عرض إعدادات التصحيح";
 "Show all token accounts" = "عرض جميع حسابات الرموز";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -271,7 +271,8 @@
 "Select the IDE to monitor" = "Seleccioneu l'IDE que cal monitorar";
 "Session quota notifications" = "Notificacions de quota de sessió";
 "Session tokens" = "Tokens de sessió";
-"Settings" = "Configuració";
+"provider_section_connection" = "Connexió";
+"provider_section_menu_bar" = "Barra de menús";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Mostreu les seccions de Crèdits de Codex i Ús addicional de Claude al menú.";
 "Show Debug Settings" = "Mostreu la configuració de depuració";
 "Show all token accounts" = "Mostreu tots els comptes amb token";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -266,7 +266,8 @@
 "Select the IDE to monitor" = "Wählen Sie die zu überwachende IDE aus";
 "Session quota notifications" = "Benachrichtigungen über Sitzungskontingente";
 "Session tokens" = "Sitzungstoken";
-"Settings" = "Einstellungen";
+"provider_section_connection" = "Verbindung";
+"provider_section_menu_bar" = "Menüleiste";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Zeigen Sie die Nutzungsabschnitte \"Codex Credits\" und \"Claude Extra\" im Menü an.";
 "Show Debug Settings" = "Debug-Einstellungen anzeigen";
 "Show all token accounts" = "Alle Token-Konten anzeigen";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -270,7 +270,8 @@
 "Select the IDE to monitor" = "Select the IDE to monitor";
 "Session quota notifications" = "Session quota notifications";
 "Session tokens" = "Session tokens";
-"Settings" = "Settings";
+"provider_section_connection" = "Connection";
+"provider_section_menu_bar" = "Menu bar";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Show Codex Credits and Claude Extra usage sections in the menu.";
 "Show Debug Settings" = "Show Debug Settings";
 "Show all token accounts" = "Show all token accounts";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -269,7 +269,8 @@
 "Select the IDE to monitor" = "Selecciona el IDE a monitorizar";
 "Session quota notifications" = "Notificaciones de cuota de sesión";
 "Session tokens" = "Tokens de sesión";
-"Settings" = "Ajustes";
+"provider_section_connection" = "Conexión";
+"provider_section_menu_bar" = "Barra de menús";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Mostrar las secciones de Créditos de Codex y Uso adicional de Claude en el menú.";
 "Show Debug Settings" = "Mostrar ajustes de depuración";
 "Show all token accounts" = "Mostrar todas las cuentas con token";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -270,7 +270,8 @@
 "Select the IDE to monitor" = "IDE را برای مانیتور انتخاب کنید";
 "Session quota notifications" = "اعلان های سهمیه نشست";
 "Session tokens" = "توکن های جلسه";
-"Settings" = "محیط ها";
+"provider_section_connection" = "اتصال";
+"provider_section_menu_bar" = "نوار منو";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "بخش های Codex اعتبارها و Claude استفاده اضافی را در منو نمایش دهید.";
 "Show Debug Settings" = "نمایش تنظیمات اشکال زدایی";
 "Show all token accounts" = "نمایش همه حساب های توکن";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -268,7 +268,8 @@
 "Select the IDE to monitor" = "Sélectionnez l'IDE à surveiller";
 "Session quota notifications" = "Notifications de quota de session";
 "Session tokens" = "Jetons de session";
-"Settings" = "Réglages";
+"provider_section_connection" = "Connexion";
+"provider_section_menu_bar" = "Barre de menus";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Afficher les sections d'utilisation des crédits Codex et de Claude Extra dans le menu.";
 "Show Debug Settings" = "Afficher les paramètres de débogage";
 "Show all token accounts" = "Afficher tous les comptes de jetons";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -268,7 +268,8 @@
 "Select the IDE to monitor" = "Selecciona o IDE que desexas monitorizar";
 "Session quota notifications" = "Notificacións de cota de sesión";
 "Session tokens" = "Tokens de sesión";
-"Settings" = "Axustes";
+"provider_section_connection" = "Conexión";
+"provider_section_menu_bar" = "Barra de menús";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Amosa as seccións de Créditos de Codex e Uso adicional de Claude no menú.";
 "Show Debug Settings" = "Amosar os axustes de depuración";
 "Show all token accounts" = "Amosar todas as contas con token";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -270,7 +270,8 @@
 "Select the IDE to monitor" = "Pilih IDE yang dipantau";
 "Session quota notifications" = "Notifikasi kuota sesi";
 "Session tokens" = "Token sesi";
-"Settings" = "Pengaturan";
+"provider_section_connection" = "Koneksi";
+"provider_section_menu_bar" = "Menu bar";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Tampilkan bagian Kredit Codex dan penggunaan Ekstra Claude di menu.";
 "Show Debug Settings" = "Tampilkan Pengaturan Debug";
 "Show all token accounts" = "Tampilkan semua akun token";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -270,7 +270,8 @@
 "Select the IDE to monitor" = "Seleziona l'IDE da monitorare";
 "Session quota notifications" = "Notifiche quota sessione";
 "Session tokens" = "Token di sessione";
-"Settings" = "Impostazioni";
+"provider_section_connection" = "Connessione";
+"provider_section_menu_bar" = "Barra menu";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Mostra nel menu le sezioni Crediti Codex e Uso extra Claude.";
 "Show Debug Settings" = "Mostra impostazioni debug";
 "Show all token accounts" = "Mostra tutti gli account token";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -268,7 +268,8 @@
 "Select the IDE to monitor" = "監視する IDE を選択";
 "Session quota notifications" = "セッションクォータ通知";
 "Session tokens" = "セッショントークン";
-"Settings" = "設定";
+"provider_section_connection" = "接続";
+"provider_section_menu_bar" = "メニューバー";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Codex クレジットと Claude 追加使用量のセクションをメニューに表示します。";
 "Show Debug Settings" = "デバッグ設定を表示";
 "Show all token accounts" = "すべてのトークンアカウントを表示";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -268,7 +268,8 @@
 "Select the IDE to monitor" = "모니터링할 IDE 선택";
 "Session quota notifications" = "세션 할당량 알림";
 "Session tokens" = "세션 토큰";
-"Settings" = "설정";
+"provider_section_connection" = "연결";
+"provider_section_menu_bar" = "메뉴 막대";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "메뉴에 Codex 크레딧 및 Claude 추가 사용량 섹션을 표시합니다.";
 "Show Debug Settings" = "디버그 설정 표시";
 "Show all token accounts" = "모든 토큰 계정 표시";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -268,7 +268,8 @@
 "Select the IDE to monitor" = "Selecteer de IDE die u wilt monitoren";
 "Session quota notifications" = "Meldingen over sessiequota";
 "Session tokens" = "Sessietokens";
-"Settings" = "Instellingen";
+"provider_section_connection" = "Verbinding";
+"provider_section_menu_bar" = "Menubalk";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Toon Codex Credits en Claude Extra gebruikssecties in het menu.";
 "Show Debug Settings" = "Toon foutopsporingsinstellingen";
 "Show all token accounts" = "Toon alle tokenaccounts";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -270,7 +270,8 @@
 "Select the IDE to monitor" = "Wybierz IDE do monitorowania";
 "Session quota notifications" = "Powiadomienia o limicie sesji";
 "Session tokens" = "Tokeny sesji";
-"Settings" = "Ustawienia";
+"provider_section_connection" = "Połączenie";
+"provider_section_menu_bar" = "Pasek menu";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Pokazuj w menu sekcje Codex Credits i Claude Extra usage.";
 "Show Debug Settings" = "Pokaż ustawienia debugowania";
 "Show all token accounts" = "Pokaż wszystkie konta tokenów";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -268,7 +268,8 @@
 "Select the IDE to monitor" = "Selecione a IDE para monitorar";
 "Session quota notifications" = "Notificações de cota de sessão";
 "Session tokens" = "Tokens de sessão";
-"Settings" = "Ajustes";
+"provider_section_connection" = "Conexão";
+"provider_section_menu_bar" = "Barra de menus";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Mostra as seções de créditos do Codex e uso extra do Claude no menu.";
 "Show Debug Settings" = "Mostrar ajustes de depuração";
 "Show all token accounts" = "Mostrar todas as contas de token";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -270,7 +270,8 @@
 "Select the IDE to monitor" = "Выберите IDE для мониторинга";
 "Session quota notifications" = "Уведомления о квоте сеанса";
 "Session tokens" = "Токены сеанса";
-"Settings" = "Настройки";
+"provider_section_connection" = "Подключение";
+"provider_section_menu_bar" = "Строка меню";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Показывать в меню разделы кредитов Codex и дополнительного использования Claude.";
 "Show Debug Settings" = "Показать настройки отладки";
 "Show all token accounts" = "Показать все токены-аккаунты";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -269,7 +269,8 @@
 "Select the IDE to monitor" = "Välj IDE att övervaka";
 "Session quota notifications" = "Aviseringar för sessionskvot";
 "Session tokens" = "Sessionstoken";
-"Settings" = "Inställningar";
+"provider_section_connection" = "Anslutning";
+"provider_section_menu_bar" = "Menyrad";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Visa avsnitt för Codex-krediter och Claude Extra-användning i menyn.";
 "Show Debug Settings" = "Visa felsökningsinställningar";
 "Show all token accounts" = "Visa alla tokenkonton";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -270,7 +270,8 @@
 "Select the IDE to monitor" = "เลือก IDE ที่จะตรวจสอบ";
 "Session quota notifications" = "การแจ้งเตือนโควต้าเซสชัน";
 "Session tokens" = "โทเค็นเซสชัน";
-"Settings" = "การตั้งค่า";
+"provider_section_connection" = "การเชื่อมต่อ";
+"provider_section_menu_bar" = "แถบเมนู";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "แสดงส่วนเครดิต Codex และการใช้งานเพิ่มเติม Claude ในเมนู";
 "Show Debug Settings" = "แสดงการตั้งค่าการดีบัก";
 "Show all token accounts" = "แสดงบัญชีโทเค็นทั้งหมด";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -270,7 +270,8 @@
 "Select the IDE to monitor" = "İzlenecek IDE'yi seçin";
 "Session quota notifications" = "Oturum kota bildirimleri";
 "Session tokens" = "Oturum jetonları";
-"Settings" = "Ayarlar";
+"provider_section_connection" = "Bağlantı";
+"provider_section_menu_bar" = "Menü çubuğu";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Menüde Codex Kredileri ve Claude Ekstra kullanım bölümlerini göster.";
 "Show Debug Settings" = "Hata Ayıklama Ayarlarını Göster";
 "Show all token accounts" = "Tüm jeton hesaplarını göster";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -268,7 +268,8 @@
 "Select the IDE to monitor" = "Виберіть IDE для моніторингу";
 "Session quota notifications" = "Сповіщення про квоту сеансу";
 "Session tokens" = "Токени сесії";
-"Settings" = "Налаштування";
+"provider_section_connection" = "Підключення";
+"provider_section_menu_bar" = "Рядок меню";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Показати в меню розділи використання кредитів Codex і Claude Extra.";
 "Show Debug Settings" = "Показати налаштування налагодження";
 "Show all token accounts" = "Показати всі облікові записи маркерів";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -268,7 +268,8 @@
 "Select the IDE to monitor" = "Chọn IDE để giám sát";
 "Session quota notifications" = "Thông báo phiên Hạn mức";
 "Session tokens" = "Mã thông báo phiên";
-"Settings" = "Cài đặt";
+"provider_section_connection" = "Kết nối";
+"provider_section_menu_bar" = "Thanh menu";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "Hiển thị Tín dụng Codex và Claude Các phần Mức sử dụng bổ sung trong menu.";
 "Show Debug Settings" = "Hiển thị gỡ lỗi Cài đặt";
 "Show all token accounts" = "Hiển thị tất cả token tài khoản";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -275,7 +275,8 @@
 "Session" = "会话";
 "Session quota notifications" = "会话配额通知";
 "Session tokens" = "会话令牌";
-"Settings" = "设置";
+"provider_section_connection" = "连接";
+"provider_section_menu_bar" = "菜单栏";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "在菜单中显示 Codex 额度和 Claude 额外用量部分。";
 "Show Debug Settings" = "显示调试设置";
 "Show all token accounts" = "显示所有令牌账户";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -277,7 +277,8 @@
 "Session" = "工作階段";
 "Session quota notifications" = "工作階段配額通知";
 "Session tokens" = "工作階段 token";
-"Settings" = "設定";
+"provider_section_connection" = "連線";
+"provider_section_menu_bar" = "選單列";
 "Show Codex Credits and Claude Extra usage sections in the menu." = "在選單中顯示 Codex 額度和 Claude 額外使用量部分。";
 "Show Debug Settings" = "顯示除錯設定";
 "Show all token accounts" = "顯示所有 token 帳號";

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -58,7 +58,8 @@ struct ProviderSettingsDescriptorTests {
         let pickers = CodexProviderImplementation().settingsPickers(context: context)
         let toggles = CodexProviderImplementation().settingsToggles(context: context)
         #expect(pickers.contains(where: { $0.id == "codex-usage-source" }))
-        #expect(pickers.contains(where: { $0.id == "codex-cookie-source" }))
+        let cookiePicker = try #require(pickers.first(where: { $0.id == "codex-cookie-source" }))
+        #expect(cookiePicker.placement == .connection)
         #expect(toggles.contains(where: { $0.id == "codex-historical-tracking" }))
         let sparkToggle = try #require(toggles.first(where: { $0.id == "codex-spark-usage-visible" }))
         #expect(sparkToggle.title == "Show Codex Spark usage")
@@ -112,7 +113,8 @@ struct ProviderSettingsDescriptorTests {
         let context = fixture.settingsContext(provider: .claude)
 
         let pickers = ClaudeProviderImplementation().settingsPickers(context: context)
-        #expect(pickers.contains(where: { $0.id == "claude-usage-source" }))
+        let usagePicker = try #require(pickers.first(where: { $0.id == "claude-usage-source" }))
+        #expect(usagePicker.placement == .connection)
         #expect(pickers.contains(where: { $0.id == "claude-cookie-source" }))
         let toggles = ClaudeProviderImplementation().settingsToggles(context: context)
         #expect(!toggles.contains(where: { $0.id == "claude-peak-hours" }))
@@ -208,6 +210,19 @@ struct ProviderSettingsDescriptorTests {
 
         #expect(pickers.map(\.id) == ["copilot-icon-secondary-window", "copilot-budget-cookie-source"])
         #expect(pickers.first?.title == "Menu bar secondary metric")
+        #expect(pickers.first?.placement == .menuBar)
+        #expect(pickers.last?.placement == .connection)
+    }
+
+    @Test
+    func `kiro menu bar display picker uses the menu bar placement`() throws {
+        let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-kiro-placement")
+        let context = fixture.settingsContext(provider: .kiro)
+
+        let pickers = KiroProviderImplementation().settingsPickers(context: context)
+        let picker = try #require(pickers.first(where: { $0.id == "kiroMenuBarDisplay" }))
+
+        #expect(picker.placement == .menuBar)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -439,6 +439,7 @@ struct ProvidersPaneCoverageTests {
         let picker = pane._test_menuBarMetricPicker(for: .claude)
         let ids = picker?.options.map(\.id) ?? []
         #expect(ids.contains(MenuBarMetricPreference.primaryAndSecondary.rawValue))
+        #expect(picker?.placement == .menuBar)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to #2047. Provider detail panes had a single vague "Settings" section mixing the menu-bar metric picker with connection controls. This splits it into two topical sections:

- **Menu bar** — the shared menu-bar metric picker, Copilot's secondary-metric picker, and Kiro's menu-bar value picker
- **Connection** — usage/auth-source pickers, cookie-source pickers, API-region pickers, the Claude keychain prompt policy, JetBrains IDE selection, and action rows (Google OAuth, Gemini CLI migration)

Implemented via a `placement` field on `ProviderSettingsPickerDescriptor` defaulting to `.connection`, so only the three menu-bar pickers declare a placement and no other provider code changes. A full inventory of all 44 picker IDs confirmed the classification.

Deliberately unchanged: the header-less identity card (a header would duplicate the provider name), "Usage", "Quota warnings", and "Options" — the residual toggles ("Battery Saver", "OpenAI web extras", "Avoid Keychain prompts", …) are genuinely heterogeneous, so a topical header there would mislead.

## Localization

Both new headers translated into all 22 non-English catalogs; the orphaned `"Settings"` key removed everywhere; strict locale parity checks unchanged and green.

## Testing

- `make check` clean (locale parity, SwiftFormat, SwiftLint strict); `make test` full suite green
- New/extended tests: placement assertions for the shared metric picker, Copilot secondary metric, Kiro menu-bar display, and representative connection pickers
