### PR TITLE
Disable Claude updater in passive probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Settings: split provider pane "Settings" sections into "Menu bar" and "Connection" so metric pickers and auth/cookie/source controls are grouped by topic.
 
+### Fixed
+- Claude: prevent CodexBar's passive CLI probes from starting background Claude Code updates, avoiding repeated partial downloads when a probe exits before an update completes. Thanks @PG2047!
+
 ## 0.42.0 — 2026-07-11
 
 ### Added

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
@@ -174,7 +174,9 @@ actor ClaudeCLISession {
                 buffer.append(newData)
                 lastOutputAt = Date()
                 Self.appendScanText(newData: newData, scanTailText: &scanTailText, utf8Carry: &utf8Carry)
-                if scanTailText.count > 8192 { scanTailText = String(scanTailText.suffix(8192)) }
+                if scanTailText.count > 8192 {
+                    scanTailText = String(scanTailText.suffix(8192))
+                }
                 normalizedScan = Self.normalizedNeedle(TextParsing.stripANSICodes(scanTailText))
 
                 let scanData = scanBuffer.append(newData)
@@ -221,7 +223,9 @@ actor ClaudeCLISession {
                 let settleDeadline = Date().addingTimeInterval(settle)
                 while Date() < settleDeadline {
                     let newData = self.readChunk()
-                    if !newData.isEmpty { buffer.append(newData) }
+                    if !newData.isEmpty {
+                        buffer.append(newData)
+                    }
                     try await Task.sleep(nanoseconds: 50_000_000)
                 }
             }
@@ -475,7 +479,9 @@ actor ClaudeCLISession {
                     retries = 0
                     continue
                 }
-                if written == 0 { break }
+                if written == 0 {
+                    break
+                }
 
                 let err = errno
                 if err == EINTR || err == EAGAIN || err == EWOULDBLOCK {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
@@ -353,7 +353,10 @@ actor ClaudeCLISession {
     }
 
     static func launchEnvironment(baseEnv: [String: String] = ProcessInfo.processInfo.environment) -> [String: String] {
-        self.scrubbedClaudeEnvironment(from: TTYCommandRunner.enrichedEnvironment(baseEnv: baseEnv))
+        var env = self.scrubbedClaudeEnvironment(from: TTYCommandRunner.enrichedEnvironment(baseEnv: baseEnv))
+        // Passive status and auth probes must not mutate or update the user's Claude CLI installation.
+        env["DISABLE_AUTOUPDATER"] = "1"
+        return env
     }
 
     private static func scrubbedClaudeEnvironment(from base: [String: String]) -> [String: String] {

--- a/Tests/CodexBarTests/ClaudeDirectUsageFallbackTests.swift
+++ b/Tests/CodexBarTests/ClaudeDirectUsageFallbackTests.swift
@@ -50,6 +50,8 @@ struct ClaudeDirectUsageFallbackTests {
         let invocations = log.contents()
         #expect(invocations.contains("pty-usage"))
         #expect(invocations.contains("direct-usage"))
+        #expect(invocations.contains("pty-auto-updater-disabled"))
+        #expect(invocations.contains("direct-auto-updater-disabled"))
         #expect(!invocations.contains("pty-secret-env"))
         #expect(!invocations.contains("direct-secret-env"))
     }
@@ -87,6 +89,9 @@ struct ClaudeDirectUsageFallbackTests {
         try self.makeClaudeCLI(name: "claude-direct-fallback", logURL: logURL, scriptBody: """
         if [ "$1" = "/usage" ]; then
           printf 'direct-usage\\n' >> "$LOG_FILE"
+          if [ "$DISABLE_AUTOUPDATER" = "1" ]; then
+            printf 'direct-auto-updater-disabled\\n' >> "$LOG_FILE"
+          fi
           if [ -n "$CODEXBAR_CLAUDE_OAUTH_TOKEN" ] ||
              [ -n "$CODEXBAR_CLAUDE_OAUTH_SCOPES" ] ||
              [ -n "$ANTHROPIC_ADMIN_KEY" ]; then
@@ -99,6 +104,9 @@ struct ClaudeDirectUsageFallbackTests {
           case "$line" in
             *"/usage"*)
               printf 'pty-usage\\n' >> "$LOG_FILE"
+              if [ "$DISABLE_AUTOUPDATER" = "1" ]; then
+                printf 'pty-auto-updater-disabled\\n' >> "$LOG_FILE"
+              fi
               if [ -n "$CODEXBAR_CLAUDE_OAUTH_TOKEN" ] ||
                  [ -n "$CODEXBAR_CLAUDE_OAUTH_SCOPES" ] ||
                  [ -n "$ANTHROPIC_ADMIN_KEY" ]; then

--- a/Tests/CodexBarTests/ClaudeDirectUsageFallbackTests.swift
+++ b/Tests/CodexBarTests/ClaudeDirectUsageFallbackTests.swift
@@ -19,6 +19,19 @@ struct ClaudeDirectUsageFallbackTests {
     }
 
     @Test
+    func `passive claude probes always disable the cli auto updater`() {
+        let environment = ClaudeCLISession.launchEnvironment(baseEnv: [
+            "DISABLE_AUTOUPDATER": "0",
+            ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
+            "ANTHROPIC_API_KEY": "api-token",
+        ])
+
+        #expect(environment["DISABLE_AUTOUPDATER"] == "1")
+        #expect(environment[ClaudeOAuthCredentialsStore.environmentTokenKey] == nil)
+        #expect(environment["ANTHROPIC_API_KEY"] == nil)
+    }
+
+    @Test
     func `cli source falls back to direct usage when pty usage fails to load`() async throws {
         let cliLogURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("claude-direct-fallback-log-\(UUID().uuidString).txt")


### PR DESCRIPTION
## Summary

- force `DISABLE_AUTOUPDATER=1` in the environment used by CodexBar-owned passive Claude CLI probes
- cover both the PTY probe path and direct usage fallback with focused regression assertions

Closes #2052.

## Incident evidence

Full sanitized report: [#2052 - Background Claude probes can trigger repeated CLI auto-update downloads](https://github.com/steipete/CodexBar/issues/2052)

| Window | Download from `downloads.claude.ai` | Upload | Unique Claude CLI PIDs | Connections |
| --- | ---: | ---: | ---: | ---: |
| Day 1 (partial) | 21.836 GiB | 0.266 MiB | 257 | 264 |
| Day 2 | 49.137 GiB | 0.512 MiB | 495 | 511 |
| Day 3 (through uninstall) | 19.584 GiB | 0.235 MiB | 225 | 233 |

Total observed download was **90.557 GiB**. The issue includes the sanitized process tree, five-minute/short-retry cadence, failed version artifacts, and an exact live-counter check: one connection's event-delta sum and controller total both equaled `82,807,053` bytes. Removing CodexBar stopped new matching connections.

## Root cause

CodexBar launches Claude CLI to collect status/usage and to touch the CLI-owned OAuth path. Claude Code performs update checks on startup and can download a new release in the background. Because the probe has a bounded lifetime, it can exit before that download completes; a later scheduled refresh then starts another CLI process and another partial download.

The incident documented in #2052 reached 49.137 GiB from `downloads.claude.ai` in one day. Current `main` scrubs credentials from the child environment but does not disable the updater.

## Behavior

`ClaudeCLISession.launchEnvironment` now overrides `DISABLE_AUTOUPDATER` to `1`. This is scoped to CodexBar's child processes and does not modify the user's Claude settings or prevent manual updates outside CodexBar.

The shared environment covers:

- PTY status and OAuth touch probes
- direct `/usage` fallback
- CLI auth-status checks

## Validation

- `git diff --check` passed
- `./Scripts/lint.sh lint-macos` passed
- SwiftFormat 0.61.1 reported `0/1350 files require formatting`
- focused test assertions exercise the PTY and direct fallback child environments

Full local `swift test --filter ClaudeDirectUsageFallbackTests` could not run on this machine because only Command Line Tools are installed; the `KeyboardShortcuts` dependency requires the full Xcode `PreviewsMacros` plugin. `make check` completed repository, packaging, documentation-link, locale, and shell checks before the local Node 22 module-mode check rejected `docs/site.js`. SwiftLint likewise requires full Xcode's `sourcekitdInProc`. These are local toolchain constraints rather than failures in the changed files; the upstream macOS CI should provide the complete validation environment.

## Privacy

The linked incident report contains only sanitized byte totals, process relationships, cadence, and file sizes. It omits usernames, machine names, IP addresses, proxy routes, account identifiers, and OAuth material.