### PR TITLE
Fix bundled ChatGPT Codex CLI discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Claude OAuth: remember an acknowledged CodexBar Keychain explanation for six hours without suppressing macOS authorization or either Keychain opt-out (#1990). Thanks @harjothkhara!
+- Codex accounts: find the Codex CLI bundled with ChatGPT when it is absent from shell PATH, restoring Add Account after the desktop apps merged (#2044). Thanks @sep1107!
 - Claude: prevent CodexBar's passive CLI probes from starting background Claude Code updates, avoiding repeated partial downloads when a probe exits before an update completes. Thanks @PG2047!
 - Codex cost history: bound malformed session-metadata lines and release read chunks promptly, preventing metadata pre-scans from retaining memory in proportion to oversized JSONL records. Thanks @Yuxin-Qiao!
 - Widgets: add Cursor to configurable and switcher widgets with accurate legacy Requests and current Total, Auto, and API quota labels (#2040). Thanks @Zihao-Qi!

--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -6,6 +6,9 @@ import Glibc
 #elseif canImport(Musl)
 import Musl
 #endif
+#if os(macOS)
+import Security
+#endif
 
 public enum PathPurpose: Hashable, Sendable {
     case rpc
@@ -127,12 +130,14 @@ public enum BinaryLocator {
             home: home)
     }
 
-    /// Well-known installation paths for the signed Codex desktop app CLI.
+    /// Well-known installation paths for the signed Codex CLI bundled with current and legacy desktop apps.
     /// Keep these after PATH lookups, but use them as a safe fallback when a PATH shim is blocked.
     static func codexWellKnownPaths(home: String) -> [String] {
         #if os(macOS)
         [
+            "\(home)/Applications/ChatGPT.app/Contents/Resources/codex",
             "\(home)/Applications/Codex.app/Contents/Resources/codex",
+            "/Applications/ChatGPT.app/Contents/Resources/codex",
             "/Applications/Codex.app/Contents/Resources/codex",
         ]
         #else
@@ -370,6 +375,11 @@ public enum BinaryLocator {
 }
 
 public enum CodexLaunchPreflight {
+    struct GatekeeperAssessment {
+        let output: String
+        let exitStatus: Int32
+    }
+
     public static func isLaunchCandidateAllowed(path: String, fileManager: FileManager = .default) -> Bool {
         #if os(macOS)
         self.isLaunchCandidateAllowed(
@@ -377,6 +387,7 @@ public enum CodexLaunchPreflight {
             fileManager: fileManager,
             hasExtendedAttribute: self.hasExtendedAttribute,
             spctlAssessment: { self.spctlAssessment(path: $0) },
+            appSignatureIsTrusted: self.isExpectedOpenAIAppSignature,
             isMachOExecutable: self.isMachOExecutable)
         #else
         _ = path
@@ -386,23 +397,50 @@ public enum CodexLaunchPreflight {
     }
 
     #if os(macOS)
+    // Keep each security boundary injectable so preflight tests never inspect or launch host binaries.
+    // swiftlint:disable:next function_parameter_count
     static func isLaunchCandidateAllowed(
         path: String,
         fileManager: FileManager,
         hasExtendedAttribute: (String, String) -> Bool,
-        spctlAssessment: (String) -> String?,
+        spctlAssessment: (String) -> GatekeeperAssessment?,
+        appSignatureIsTrusted: (String) -> Bool,
         isMachOExecutable: (String) -> Bool) -> Bool
     {
         let realPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
-        let pathsToCheck = [path, realPath] + self.nativeCodexExecutableCandidates(
-            for: realPath,
-            fileManager: fileManager)
+        let sourceAppBundlePath = self.containingAppBundlePath(for: path)
+        let resolvedAppBundlePath = self.containingAppBundlePath(for: realPath)
+        let appBundlePath: String?
+        if let sourceAppBundlePath {
+            let resolvedSourceBundle = URL(fileURLWithPath: sourceAppBundlePath).resolvingSymlinksInPath().path
+            guard resolvedAppBundlePath == resolvedSourceBundle else { return false }
+            appBundlePath = resolvedSourceBundle
+        } else {
+            appBundlePath = resolvedAppBundlePath
+        }
+        let appBundlePaths = [sourceAppBundlePath, appBundlePath].compactMap(\.self)
+        let pathsToCheck = [path, realPath] + appBundlePaths + self
+            .nativeCodexExecutableCandidates(
+                for: realPath,
+                fileManager: fileManager)
 
         for candidate in Set(pathsToCheck) where hasExtendedAttribute(candidate, "com.apple.malware") {
             return false
         }
 
         let hasQuarantine = Set(pathsToCheck).contains { hasExtendedAttribute($0, "com.apple.quarantine") }
+        if let appBundlePath {
+            guard appSignatureIsTrusted(appBundlePath),
+                  let assessment = spctlAssessment(appBundlePath),
+                  assessment.exitStatus == 0,
+                  self.isAcceptedAssessment(assessment.output, path: appBundlePath),
+                  !self.isExplicitlyBlockedAssessment(assessment.output, path: appBundlePath)
+            else {
+                return false
+            }
+            return true
+        }
+
         guard let native = pathsToCheck.first(where: isMachOExecutable) else {
             return !hasQuarantine
         }
@@ -412,7 +450,20 @@ public enum CodexLaunchPreflight {
             return !hasQuarantine
         }
 
-        return !self.isExplicitlyBlockedAssessment(assessment, path: native)
+        return !self.isExplicitlyBlockedAssessment(assessment.output, path: native)
+    }
+
+    private static func containingAppBundlePath(for path: String) -> String? {
+        var candidate = URL(fileURLWithPath: path).standardizedFileURL
+        while candidate.path != "/" {
+            if candidate.pathExtension.caseInsensitiveCompare("app") == .orderedSame {
+                return candidate.path
+            }
+            let parent = candidate.deletingLastPathComponent()
+            guard parent.path != candidate.path else { return nil }
+            candidate = parent
+        }
+        return nil
     }
 
     private static func nativeCodexExecutableCandidates(for path: String, fileManager: FileManager) -> [String] {
@@ -475,7 +526,7 @@ public enum CodexLaunchPreflight {
             bytes == [0xCA, 0xFE, 0xBA, 0xBF]
     }
 
-    private static func spctlAssessment(path: String, timeout: TimeInterval = 2.0) -> String? {
+    private static func spctlAssessment(path: String, timeout: TimeInterval = 2.0) -> GatekeeperAssessment? {
         let spctlPath = "/usr/sbin/spctl"
         guard FileManager.default.isExecutableFile(atPath: spctlPath) else { return nil }
 
@@ -502,7 +553,44 @@ public enum CodexLaunchPreflight {
         }
 
         let data = output.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        return GatekeeperAssessment(output: text, exitStatus: process.terminationStatus)
+    }
+
+    private static func isExpectedOpenAIAppSignature(path: String) -> Bool {
+        let requirementText =
+            "identifier \"com.openai.codex\" and anchor apple generic " +
+            "and certificate leaf[subject.OU] = \"2DC432GLL2\""
+        var staticCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(
+            URL(fileURLWithPath: path) as CFURL,
+            SecCSFlags(),
+            &staticCode) == errSecSuccess,
+            let staticCode
+        else {
+            return false
+        }
+
+        var requirement: SecRequirement?
+        guard SecRequirementCreateWithString(
+            requirementText as CFString,
+            SecCSFlags(),
+            &requirement) == errSecSuccess
+        else {
+            return false
+        }
+
+        // Pin the publisher and bundle identity here; the Gatekeeper assessment below performs full bundle validation.
+        let validationFlags = SecCSFlags(rawValue: kSecCSBasicValidateOnly)
+        return SecStaticCodeCheckValidity(staticCode, validationFlags, requirement) == errSecSuccess
+    }
+
+    private static func isAcceptedAssessment(_ assessment: String, path: String) -> Bool {
+        self.assessmentDiagnosticText(assessment, path: path)
+            .split(whereSeparator: \.isNewline)
+            .first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .localizedCaseInsensitiveCompare("accepted") == .orderedSame
     }
 
     private static func isExplicitlyBlockedAssessment(_ assessment: String, path: String) -> Bool {

--- a/Tests/CodexBarTests/CodexAccountsSettingsSectionTests.swift
+++ b/Tests/CodexBarTests/CodexAccountsSettingsSectionTests.swift
@@ -330,11 +330,15 @@ struct CodexAccountsSettingsSectionTests {
     }
 
     private static func makeUsageStore(settings: SettingsStore) -> UsageStore {
-        UsageStore(
+        let store = UsageStore(
             fetcher: UsageFetcher(environment: [:]),
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings,
             startupBehavior: .testing)
+        // Account-selection tests must never trigger a real provider refresh.
+        store._test_providerRefreshOverride = { _ in }
+        store._test_codexCreditsLoaderOverride = { throw UsageError.noRateLimitsFound }
+        return store
     }
 }
 

--- a/Tests/CodexBarTests/PathBuilderTests.swift
+++ b/Tests/CodexBarTests/PathBuilderTests.swift
@@ -158,6 +158,99 @@ struct PathBuilderTests {
     }
 
     @Test
+    func `resolves codex from bundled ChatGPT app`() {
+        let appPath = "/Applications/ChatGPT.app/Contents/Resources/codex"
+        let fm = MockFileManager(executables: [appPath])
+
+        let resolved = BinaryLocator.resolveCodexBinary(
+            env: ["PATH": "/missing/bin"],
+            loginPATH: nil,
+            commandV: { _, _, _, _ in nil },
+            aliasResolver: { _, _, _, _, _ in nil },
+            launchCandidateFilter: { _, _ in true },
+            fileManager: fm,
+            home: "/Users/test")
+
+        #expect(resolved == appPath)
+    }
+
+    @Test
+    func `resolves codex from user bundled ChatGPT app`() {
+        let appPath = "/Users/test/Applications/ChatGPT.app/Contents/Resources/codex"
+        let fm = MockFileManager(executables: [appPath])
+
+        let resolved = BinaryLocator.resolveCodexBinary(
+            env: ["PATH": "/missing/bin"],
+            loginPATH: nil,
+            commandV: { _, _, _, _ in nil },
+            aliasResolver: { _, _, _, _, _ in nil },
+            launchCandidateFilter: { _, _ in true },
+            fileManager: fm,
+            home: "/Users/test")
+
+        #expect(resolved == appPath)
+    }
+
+    @Test
+    func `prefers bundled ChatGPT app over legacy Codex app within one scope`() {
+        let chatGPTPath = "/Applications/ChatGPT.app/Contents/Resources/codex"
+        let codexPath = "/Applications/Codex.app/Contents/Resources/codex"
+        let fm = MockFileManager(executables: [chatGPTPath, codexPath])
+
+        let resolved = BinaryLocator.resolveCodexBinary(
+            env: ["PATH": "/missing/bin"],
+            loginPATH: nil,
+            commandV: { _, _, _, _ in nil },
+            aliasResolver: { _, _, _, _, _ in nil },
+            launchCandidateFilter: { _, _ in true },
+            fileManager: fm,
+            home: "/Users/test")
+
+        #expect(resolved == chatGPTPath)
+    }
+
+    @Test
+    func `preserves user app precedence over system ChatGPT app`() {
+        let userCodexPath = "/Users/test/Applications/Codex.app/Contents/Resources/codex"
+        let systemChatGPTPath = "/Applications/ChatGPT.app/Contents/Resources/codex"
+        let fm = MockFileManager(executables: [userCodexPath, systemChatGPTPath])
+
+        let resolved = BinaryLocator.resolveCodexBinary(
+            env: ["PATH": "/missing/bin"],
+            loginPATH: nil,
+            commandV: { _, _, _, _ in nil },
+            aliasResolver: { _, _, _, _, _ in nil },
+            launchCandidateFilter: { _, _ in true },
+            fileManager: fm,
+            home: "/Users/test")
+
+        #expect(resolved == userCodexPath)
+    }
+
+    @Test
+    func `skips blocked ChatGPT app and falls back to legacy Codex app`() {
+        let chatGPTPath = "/Users/test/Applications/ChatGPT.app/Contents/Resources/codex"
+        let codexPath = "/Users/test/Applications/Codex.app/Contents/Resources/codex"
+        let fm = MockFileManager(executables: [chatGPTPath, codexPath])
+        var checked: [String] = []
+
+        let resolved = BinaryLocator.resolveCodexBinary(
+            env: ["PATH": "/missing/bin"],
+            loginPATH: nil,
+            commandV: { _, _, _, _ in nil },
+            aliasResolver: { _, _, _, _, _ in nil },
+            launchCandidateFilter: { path, _ in
+                checked.append(path)
+                return path != chatGPTPath
+            },
+            fileManager: fm,
+            home: "/Users/test")
+
+        #expect(resolved == codexPath)
+        #expect(checked == [chatGPTPath, codexPath])
+    }
+
+    @Test
     func `skips blocked codex path and falls back to signed app binary`() {
         let blockedPath = "/usr/local/bin/codex"
         let appPath = "/Applications/Codex.app/Contents/Resources/codex"
@@ -232,7 +325,8 @@ struct PathBuilderTests {
             path: "/Applications/Codex.app/Contents/Resources/codex",
             fileManager: MockFileManager(executables: []),
             hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
-            spctlAssessment: { _ in "accepted\nsource=Notarized Developer ID" },
+            spctlAssessment: { _ in .init(output: "accepted\nsource=Notarized Developer ID", exitStatus: 0) },
+            appSignatureIsTrusted: { _ in true },
             isMachOExecutable: { _ in true })
 
         #expect(allowed)
@@ -247,8 +341,162 @@ struct PathBuilderTests {
             hasExtendedAttribute: { _, name in name == "com.apple.malware" },
             spctlAssessment: { _ in
                 assessed = true
-                return "accepted\nsource=Notarized Developer ID"
+                return .init(output: "accepted\nsource=Notarized Developer ID", exitStatus: 0)
             },
+            appSignatureIsTrusted: { _ in true },
+            isMachOExecutable: { _ in true })
+
+        #expect(!allowed)
+        #expect(!assessed)
+    }
+
+    @Test
+    func `Codex launch preflight validates containing app bundle`() {
+        let executable = "/Applications/ChatGPT.app/Contents/Resources/codex"
+        let bundle = "/Applications/ChatGPT.app"
+        var assessedPaths: [String] = []
+
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: executable,
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { path, name in
+                path == bundle && name == "com.apple.quarantine"
+            },
+            spctlAssessment: { path in
+                assessedPaths.append(path)
+                return .init(output: "\(path): accepted\nsource=Notarized Developer ID", exitStatus: 0)
+            },
+            appSignatureIsTrusted: { path in path == bundle },
+            isMachOExecutable: { path in path == executable })
+
+        #expect(allowed)
+        #expect(assessedPaths == [bundle])
+    }
+
+    @Test
+    func `Codex launch preflight blocks unexpected app signing identity`() {
+        let executable = "/Users/test/Applications/ChatGPT.app/Contents/Resources/codex"
+        let bundle = "/Users/test/Applications/ChatGPT.app"
+        var assessed = false
+
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: executable,
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { _, _ in false },
+            spctlAssessment: { _ in
+                assessed = true
+                return .init(output: "accepted", exitStatus: 0)
+            },
+            appSignatureIsTrusted: { path in
+                #expect(path == bundle)
+                return false
+            },
+            isMachOExecutable: { path in path == executable })
+
+        #expect(!allowed)
+        #expect(!assessed)
+    }
+
+    @Test
+    func `Codex launch preflight blocks rejected containing app bundle`() {
+        let executable = "/Users/test/Applications/ChatGPT.app/Contents/Resources/codex"
+        let bundle = "/Users/test/Applications/ChatGPT.app"
+
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: executable,
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { _, _ in false },
+            spctlAssessment: { path in
+                #expect(path == bundle)
+                return .init(output: "\(path): rejected\nsource=no usable signature", exitStatus: 3)
+            },
+            appSignatureIsTrusted: { _ in true },
+            isMachOExecutable: { path in path == executable })
+
+        #expect(!allowed)
+    }
+
+    @Test
+    func `Codex launch preflight requires successful app bundle assessment`() {
+        let executable = "/Users/test/Applications/ChatGPT.app/Contents/Resources/codex"
+        let bundle = "/Users/test/Applications/ChatGPT.app"
+
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: executable,
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { _, _ in false },
+            spctlAssessment: { path in
+                #expect(path == bundle)
+                return .init(output: "\(path): accepted", exitStatus: 1)
+            },
+            appSignatureIsTrusted: { _ in true },
+            isMachOExecutable: { path in path == executable })
+
+        #expect(!allowed)
+    }
+
+    @Test
+    func `Codex launch preflight rejects indeterminate app assessment`() {
+        let executable = "/Users/test/Applications/ChatGPT.app/Contents/Resources/codex"
+        let bundle = "/Users/test/Applications/ChatGPT.app"
+
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: executable,
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { _, _ in false },
+            spctlAssessment: { path in
+                #expect(path == bundle)
+                return .init(output: "internal code signing error", exitStatus: 0)
+            },
+            appSignatureIsTrusted: { _ in true },
+            isMachOExecutable: { path in path == executable })
+
+        #expect(!allowed)
+    }
+
+    @Test
+    func `Codex launch preflight fails closed when app bundle cannot be assessed`() {
+        let executable = "/Users/test/Applications/ChatGPT.app/Contents/Resources/codex"
+        let bundle = "/Users/test/Applications/ChatGPT.app"
+
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: executable,
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { path, name in
+                path == bundle && name == "com.apple.quarantine"
+            },
+            spctlAssessment: { path in
+                #expect(path == bundle)
+                return nil
+            },
+            appSignatureIsTrusted: { _ in true },
+            isMachOExecutable: { _ in false })
+
+        #expect(!allowed)
+    }
+
+    @Test
+    func `Codex launch preflight blocks app bundled executable symlink escaping the bundle`() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let bundle = root.appendingPathComponent("ChatGPT.app")
+        let resources = bundle.appendingPathComponent("Contents/Resources")
+        let executable = resources.appendingPathComponent("codex")
+        let escapedTarget = root.appendingPathComponent("outside-codex")
+        try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+        try Data().write(to: escapedTarget)
+        try FileManager.default.createSymbolicLink(at: executable, withDestinationURL: escapedTarget)
+        defer { try? FileManager.default.removeItem(at: root) }
+        var assessed = false
+
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: executable.path,
+            fileManager: FileManager.default,
+            hasExtendedAttribute: { _, _ in false },
+            spctlAssessment: { _ in
+                assessed = true
+                return .init(output: "accepted", exitStatus: 0)
+            },
+            appSignatureIsTrusted: { _ in true },
             isMachOExecutable: { _ in true })
 
         #expect(!allowed)
@@ -262,6 +510,7 @@ struct PathBuilderTests {
             fileManager: MockFileManager(executables: []),
             hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
             spctlAssessment: { _ in nil },
+            appSignatureIsTrusted: { _ in true },
             isMachOExecutable: { _ in false })
 
         #expect(!allowed)
@@ -273,7 +522,8 @@ struct PathBuilderTests {
             path: "/Applications/Codex.app/Contents/Resources/codex",
             fileManager: MockFileManager(executables: []),
             hasExtendedAttribute: { _, _ in false },
-            spctlAssessment: { _ in "rejected\nCSSMERR_TP_CERT_REVOKED" },
+            spctlAssessment: { _ in .init(output: "rejected\nCSSMERR_TP_CERT_REVOKED", exitStatus: 3) },
+            appSignatureIsTrusted: { _ in true },
             isMachOExecutable: { _ in true })
 
         #expect(!allowed)
@@ -285,7 +535,8 @@ struct PathBuilderTests {
             path: "/opt/homebrew/bin/codex",
             fileManager: MockFileManager(executables: []),
             hasExtendedAttribute: { _, _ in false },
-            spctlAssessment: { _ in "rejected\nsource=no usable signature" },
+            spctlAssessment: { _ in .init(output: "rejected\nsource=no usable signature", exitStatus: 3) },
+            appSignatureIsTrusted: { _ in true },
             isMachOExecutable: { _ in true })
 
         #expect(!allowed)
@@ -297,7 +548,12 @@ struct PathBuilderTests {
             path: "/opt/homebrew/bin/codex",
             fileManager: MockFileManager(executables: []),
             hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
-            spctlAssessment: { path in "\(path): rejected (the code is valid but does not seem to be an app)" },
+            spctlAssessment: { path in
+                .init(
+                    output: "\(path): rejected (the code is valid but does not seem to be an app)",
+                    exitStatus: 3)
+            },
+            appSignatureIsTrusted: { _ in true },
             isMachOExecutable: { _ in true })
 
         #expect(allowed)
@@ -310,11 +566,14 @@ struct PathBuilderTests {
             fileManager: MockFileManager(executables: []),
             hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
             spctlAssessment: { _ in
-                """
-                rejected (the code is valid but does not seem to be an app)
-                CSSMERR_TP_CERT_REVOKED
-                """
+                .init(
+                    output: """
+                    rejected (the code is valid but does not seem to be an app)
+                    CSSMERR_TP_CERT_REVOKED
+                    """,
+                    exitStatus: 3)
             },
+            appSignatureIsTrusted: { _ in true },
             isMachOExecutable: { _ in true })
 
         #expect(!allowed)
@@ -326,7 +585,10 @@ struct PathBuilderTests {
             path: "/tmp/code is valid but does not seem to be an app/codex",
             fileManager: MockFileManager(executables: []),
             hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
-            spctlAssessment: { path in "\(path): rejected\nsource=no usable signature" },
+            spctlAssessment: { path in
+                .init(output: "\(path): rejected\nsource=no usable signature", exitStatus: 3)
+            },
+            appSignatureIsTrusted: { _ in true },
             isMachOExecutable: { _ in true })
 
         #expect(!allowed)
@@ -338,7 +600,10 @@ struct PathBuilderTests {
             path: "/tmp/x: code is valid but does not seem to be an app/codex",
             fileManager: MockFileManager(executables: []),
             hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
-            spctlAssessment: { path in "\(path): rejected\nsource=no usable signature" },
+            spctlAssessment: { path in
+                .init(output: "\(path): rejected\nsource=no usable signature", exitStatus: 3)
+            },
+            appSignatureIsTrusted: { _ in true },
             isMachOExecutable: { _ in true })
 
         #expect(!allowed)
@@ -351,12 +616,15 @@ struct PathBuilderTests {
             fileManager: MockFileManager(executables: []),
             hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
             spctlAssessment: { path in
-                """
-                \(path): accepted
-                source=revoked quarantine marker
-                origin=malware test fixture
-                """
+                .init(
+                    output: """
+                    \(path): accepted
+                    source=revoked quarantine marker
+                    origin=malware test fixture
+                    """,
+                    exitStatus: 0)
             },
+            appSignatureIsTrusted: { _ in true },
             isMachOExecutable: { _ in true })
 
         #expect(allowed)

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -115,8 +115,11 @@ Example:
 - App-server errors are terminal for the CLI strategy, except when Codex includes a recoverable `wham/usage` JSON body in the error text.
 - If macOS blocks or quarantines the `codex` executable, CodexBar records the launch failure and skips background CLI
   launches for 30 minutes. Use a manual refresh after reinstalling or unblocking `codex` to retry immediately.
-- If managed Codex account login fails after macOS moved `codex` to Trash, first confirm `codex --version` works in
-  Terminal. Check `which -a codex` for stale duplicate installs, then run
+- CodexBar also discovers the Codex CLI bundled with current ChatGPT and legacy Codex desktop apps, even when `codex`
+  is absent from the shell PATH.
+- If managed Codex account login still reports a missing executable, turn on **Show debug settings** in
+  **Settings > Advanced**, then check **Settings > Debug > CLI Paths**. When no Codex binary appears there, confirm
+  `codex --version` works in Terminal, check `which -a codex` for stale duplicate installs, then run
   `npm install -g --include=optional @openai/codex@latest` before retrying Add Account.
 
 ### Codex CLI PTY diagnostics (`/status`)


### PR DESCRIPTION
## Summary

- discover the Codex CLI bundled with the current ChatGPT desktop app when no usable shell-PATH installation exists
- preserve explicit/login/PATH precedence, user-app precedence, and the legacy Codex desktop fallback
- validate the containing app bundle, OpenAI signing identity, Gatekeeper acceptance, and symlink containment before launch
- document the Debug > CLI paths diagnostic and isolate account-settings tests from real provider processes

Fixes #2044

## Verification

- focused path-resolution and account-settings regressions: 59/59 passed
- `make check`
- exact-head full `make test`: 603 selections, 51/51 groups passed first attempt; zero retries, failures, or timeouts
- clean pre-ship autoreview after security hardening
- exact signed debug bundle: embedded commit `54a751c1`; deep strict codesign and Gatekeeper accepted
- isolated live UI: both effective and login-shell PATH limited to `/usr/bin:/bin:/usr/sbin:/sbin`; Debug > CLI paths resolved `/Applications/ChatGPT.app/Contents/Resources/codex`
- source-blind delta validation passed artifact trust, live AX behavior, and production isolation 3/3
- no authentication, browser-cookie, Keychain, or provider-usage probe was exercised; the production CodexBar process remained running unchanged
