### PR TITLE
Style settings section footers as leading-aligned footnote captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Settings: split provider pane "Settings" sections into "Menu bar" and "Connection" so metric pickers and auth/cookie/source controls are grouped by topic.
 
 ### Fixed
+- Settings: render section footer captions (Advanced keychain note, refresh hints, quota-warning and provider subtitles) leading-aligned in footnote size instead of the trailing-aligned body text macOS gives bare form footers.
 - Claude: prevent CodexBar's passive CLI probes from starting background Claude Code updates, avoiding repeated partial downloads when a probe exits before an update completes. Thanks @PG2047!
 - Codex cost history: bound malformed session-metadata lines and release read chunks promptly, preventing metadata pre-scans from retaining memory in proportion to oversized JSONL records. Thanks @Yuxin-Qiao!
 - Widgets: add Cursor to configurable and switcher widgets with accurate legacy Requests and current Total, Auto, and API quota labels (#2040). Thanks @Zihao-Qi!

--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -29,7 +29,7 @@ struct AdvancedPane: View {
                 Text(L("section_command_line"))
             } footer: {
                 if let status = self.cliStatus {
-                    Text(status)
+                    SettingsSectionFooter(status)
                 }
             }
 
@@ -46,7 +46,7 @@ struct AdvancedPane: View {
             } header: {
                 Text(L("section_privacy"))
             } footer: {
-                Text(L("keychain_access_caption"))
+                SettingsSectionFooter(L("keychain_access_caption"))
             }
 
             Section {

--- a/Sources/CodexBar/PreferencesComponents.swift
+++ b/Sources/CodexBar/PreferencesComponents.swift
@@ -48,6 +48,32 @@ struct SettingsRowLabel: View {
     }
 }
 
+/// Section footer for grouped forms. macOS renders bare footer text trailing-aligned
+/// at body size, which reads badly for long captions; this pins it leading at footnote
+/// size in secondary color, matching System Settings captions.
+struct SettingsSectionFooter<Content: View>: View {
+    private let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        self.content
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+extension SettingsSectionFooter where Content == Text {
+    init(_ text: String) {
+        self.init { Text(text) }
+    }
+}
+
 @MainActor
 struct OpenMenuShortcutRecorder: NSViewRepresentable {
     static let preferredWidth: CGFloat = 170

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -130,7 +130,7 @@ struct GeneralPane: View {
                 Text(L("section_refreshing"))
             } footer: {
                 if self.settings.refreshFrequency == .manual {
-                    Text(L("manual_refresh_hint"))
+                    SettingsSectionFooter(L("manual_refresh_hint"))
                 }
             }
 

--- a/Sources/CodexBar/PreferencesMenuPane.swift
+++ b/Sources/CodexBar/PreferencesMenuPane.swift
@@ -80,7 +80,7 @@ struct MenuPane: View {
             } header: {
                 Text(L("section_agent_sessions"))
             } footer: {
-                Text(L("agent_sessions_footer"))
+                SettingsSectionFooter(L("agent_sessions_footer"))
             }
         }
         .formStyle(.grouped)
@@ -121,10 +121,12 @@ struct CostSummarySettingsSection: View {
             Text(L("section_cost_summary"))
         } footer: {
             if self.settings.costUsageEnabled {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(L("cost_auto_refresh_info"))
-                    self.costStatusLine(provider: .claude)
-                    self.costStatusLine(provider: .codex)
+                SettingsSectionFooter {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(L("cost_auto_refresh_info"))
+                        self.costStatusLine(provider: .claude)
+                        self.costStatusLine(provider: .codex)
+                    }
                 }
             }
         }

--- a/Sources/CodexBar/PreferencesProviderSettingsRows.swift
+++ b/Sources/CodexBar/PreferencesProviderSettingsRows.swift
@@ -165,12 +165,14 @@ struct ProviderSettingsFieldRowView: View {
         let trimmedSubtitle = self.field.subtitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let footer = (self.field.footerText?.isEmpty == false) ? self.field.footerText : nil
         if !trimmedSubtitle.isEmpty || footer != nil {
-            VStack(alignment: .leading, spacing: 3) {
-                if !trimmedSubtitle.isEmpty {
-                    Text(L(trimmedSubtitle))
-                }
-                if let footer {
-                    Text(L(footer))
+            SettingsSectionFooter {
+                VStack(alignment: .leading, spacing: 3) {
+                    if !trimmedSubtitle.isEmpty {
+                        Text(L(trimmedSubtitle))
+                    }
+                    if let footer {
+                        Text(L(footer))
+                    }
                 }
             }
         }
@@ -401,7 +403,7 @@ struct ProviderSettingsTokenAccountsRowView: View {
             Text(L(self.descriptor.title))
         } footer: {
             if !self.descriptor.subtitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                Text(L(self.descriptor.subtitle))
+                SettingsSectionFooter(L(self.descriptor.subtitle))
             }
         }
     }
@@ -612,7 +614,7 @@ struct ProviderSettingsOrganizationsRowView: View {
             if let subtitle = self.descriptor.subtitle,
                !subtitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             {
-                Text(L(subtitle))
+                SettingsSectionFooter(L(subtitle))
             }
         }
     }

--- a/Sources/CodexBar/QuotaWarningSettingsViews.swift
+++ b/Sources/CodexBar/QuotaWarningSettingsViews.swift
@@ -75,7 +75,7 @@ struct ProviderQuotaWarningSettingsView: View {
         } header: {
             Text(L("quota_warnings_title"))
         } footer: {
-            Text(self.footerText)
+            SettingsSectionFooter(self.footerText)
         }
         .background(FocusResigningBackground())
     }


### PR DESCRIPTION
## Summary

macOS grouped `Form` renders bare section-footer `Text` at body size with trailing alignment. Short one-liners get away with it, but the Advanced pane's four-sentence keychain caption rendered as a large, ragged, right-aligned paragraph.

This adds a shared `SettingsSectionFooter` component (footnote size, secondary color, leading-aligned, full-width) and applies it to every plain-text section footer:

- Advanced: keychain caption + Install CLI status
- General: manual refresh hint
- Menu: agent-sessions footer + cost summary status block
- Quota warnings footer
- Provider settings rows: field/actions/accounts section subtitles

The About pane's centered copyright footer is intentionally left as is.

## Commands run

- `swift build`
- `make check` (SwiftFormat + SwiftLint, 0 violations)
- `make test` (full sharded suite, exit 0)
- Rendered `AdvancedPane` via `NSHostingView` snapshot to verify the caption now reads as a System Settings-style leading footnote caption.
- Codex autoreview: clean, no actionable findings.
