### PR TITLE
perf: avoid reflecting nested cost history projects on submenu open

### DIFF
--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -764,6 +764,75 @@ struct CostHistoryChartMenuView: View {
 }
 
 extension CostHistoryChartMenuView {
+    struct RenderFingerprint: Equatable {
+        let currencyCode: String
+        let historyDays: Int
+        let windowLabel: String?
+        let totalCostBitPattern: UInt64?
+        let daily: [DailyEntry]
+        let projects: [VisibleProjectFingerprint]
+    }
+
+    struct VisibleProjectFingerprint: Equatable {
+        let name: String
+        let path: String?
+        let totalTokens: Int?
+        let totalCostBitPattern: UInt64?
+        let visibleSourceCount: Int
+        let sources: [VisibleSourceFingerprint]
+    }
+
+    struct VisibleSourceFingerprint: Equatable {
+        let name: String
+        let path: String?
+        let totalTokens: Int?
+        let totalCostBitPattern: UInt64?
+    }
+
+    static func renderFingerprint(from snapshot: CostUsageTokenSnapshot) -> RenderFingerprint {
+        self.makeRenderFingerprint(RenderFingerprintInputs(
+            currencyCode: snapshot.currencyCode,
+            historyDays: snapshot.historyDays,
+            windowLabel: snapshot.historyLabel,
+            totalCostUSD: snapshot.last30DaysCostUSD,
+            daily: snapshot.daily,
+            projects: snapshot.projects))
+    }
+
+    private struct RenderFingerprintInputs {
+        let currencyCode: String
+        let historyDays: Int
+        let windowLabel: String?
+        let totalCostUSD: Double?
+        let daily: [DailyEntry]
+        let projects: [CostUsageProjectBreakdown]
+    }
+
+    private static func makeRenderFingerprint(_ inputs: RenderFingerprintInputs) -> RenderFingerprint {
+        RenderFingerprint(
+            currencyCode: inputs.currencyCode,
+            historyDays: inputs.historyDays,
+            windowLabel: inputs.windowLabel,
+            totalCostBitPattern: inputs.totalCostUSD.map(\.bitPattern),
+            daily: inputs.daily,
+            projects: Array(inputs.projects.prefix(self.maxVisibleProjectRows)).map { project in
+                let visibleSources = self.visibleProjectSources(project)
+                return VisibleProjectFingerprint(
+                    name: project.name,
+                    path: project.path,
+                    totalTokens: project.totalTokens,
+                    totalCostBitPattern: project.totalCostUSD.map(\.bitPattern),
+                    visibleSourceCount: visibleSources.count,
+                    sources: Array(visibleSources.prefix(self.maxVisibleProjectSourceRows)).map { source in
+                        VisibleSourceFingerprint(
+                            name: source.name,
+                            path: source.path,
+                            totalTokens: source.totalTokens,
+                            totalCostBitPattern: source.totalCostUSD.map(\.bitPattern))
+                    })
+            })
+    }
+
     static func _defaultSelectedDateKeyForTesting(provider: UsageProvider, daily: [DailyEntry]) -> String? {
         self.defaultSelectedDateKey(model: self.makeModel(provider: provider, daily: daily))
     }

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -3,6 +3,26 @@ import CodexBarCore
 import QuartzCore
 import SwiftUI
 
+enum HostedSubviewContentFingerprint: Equatable {
+    case text(String)
+    case costHistory(CostHistoryChartMenuView.RenderFingerprint)
+}
+
+struct HostedSubviewRenderSignature: Equatable {
+    let chartID: String
+    let providerRawValue: String?
+    let widthBitPattern: UInt64
+    let content: HostedSubviewContentFingerprint
+}
+
+final class HostedSubviewRenderSignatureBox: NSObject {
+    let signature: HostedSubviewRenderSignature
+
+    init(_ signature: HostedSubviewRenderSignature) {
+        self.signature = signature
+    }
+}
+
 extension StatusItemController {
     private struct HostedSubviewIdentity {
         let chartID: String
@@ -153,7 +173,7 @@ extension StatusItemController {
             return
         }
         let signature = self.hostedSubviewRenderSignature(identity: identity, width: width)
-        if self.hostedSubviewRenderSignatures.object(forKey: menu) as String? == signature {
+        if self.hostedSubviewRenderSignatures.object(forKey: menu)?.signature == signature {
             if identity.chartID == Self.zaiHourlyUsageChartID {
                 self.refreshHostedSubviewHeights(in: menu)
             }
@@ -210,7 +230,9 @@ extension StatusItemController {
                 chartID: identity.chartID,
                 providerRawValue: identity.provider?.rawValue ?? identity.providerRawValue)
         }
-        self.hostedSubviewRenderSignatures.setObject(signature as NSString, forKey: menu)
+        self.hostedSubviewRenderSignatures.setObject(
+            HostedSubviewRenderSignatureBox(signature),
+            forKey: menu)
     }
 
     private func hostedSubviewIdentity(for menu: NSMenu)
@@ -240,51 +262,51 @@ extension StatusItemController {
         width: CGFloat)
     {
         let signature = self.hostedSubviewRenderSignature(identity: identity, width: width)
-        self.hostedSubviewRenderSignatures.setObject(signature as NSString, forKey: menu)
+        self.hostedSubviewRenderSignatures.setObject(
+            HostedSubviewRenderSignatureBox(signature),
+            forKey: menu)
     }
 
     private func hostedSubviewRenderSignature(
         identity: HostedSubviewIdentity,
-        width: CGFloat) -> String
+        width: CGFloat) -> HostedSubviewRenderSignature
     {
-        let contentSignature: String = switch identity.chartID {
+        let contentSignature: HostedSubviewContentFingerprint = switch identity.chartID {
         case Self.usageBreakdownChartID:
-            Self.dashboardBreakdownReadinessSignature(
+            .text(Self.dashboardBreakdownReadinessSignature(
                 OpenAIDashboardDailyBreakdown.removingSkillUsageServices(
-                    from: self.store.openAIDashboard?.usageBreakdown ?? []))
+                    from: self.store.openAIDashboard?.usageBreakdown ?? [])))
         case Self.creditsHistoryChartID:
-            Self.dashboardBreakdownReadinessSignature(self.store.openAIDashboard?.dailyBreakdown ?? [])
+            .text(Self.dashboardBreakdownReadinessSignature(self.store.openAIDashboard?.dailyBreakdown ?? []))
         case Self.costHistoryChartID:
-            identity.provider.map(self.costHistoryRenderSignature(for:)) ?? "missing-provider"
+            if let provider = identity.provider {
+                self.costHistoryRenderFingerprint(for: provider)
+            } else {
+                .text("missing-provider")
+            }
         case Self.usageHistoryChartID:
-            identity.provider.map(self.usageHistoryRenderSignature(for:)) ?? "missing-provider"
+            .text(identity.provider.map(self.usageHistoryRenderSignature(for:)) ?? "missing-provider")
         case Self.storageBreakdownID:
-            identity.provider.map(self.storageBreakdownRenderSignature(for:)) ?? "missing-provider"
+            .text(identity.provider.map(self.storageBreakdownRenderSignature(for:)) ?? "missing-provider")
         case Self.statusComponentsID:
-            identity.provider.map(self.statusComponentsRenderSignature(for:)) ?? "missing-provider"
+            .text(identity.provider.map(self.statusComponentsRenderSignature(for:)) ?? "missing-provider")
         case Self.zaiHourlyUsageChartID:
-            identity.provider.map(self.zaiHourlyUsageRenderSignature(for:)) ?? "missing-provider"
+            .text(identity.provider.map(self.zaiHourlyUsageRenderSignature(for:)) ?? "missing-provider")
         default:
-            "unknown"
+            .text("unknown")
         }
-        return [
-            identity.chartID,
-            identity.providerRawValue ?? "",
-            String(Double(width).bitPattern, radix: 16),
-            contentSignature,
-        ].joined(separator: "|")
+        return HostedSubviewRenderSignature(
+            chartID: identity.chartID,
+            providerRawValue: identity.providerRawValue,
+            widthBitPattern: Double(width).bitPattern,
+            content: contentSignature)
     }
 
-    private func costHistoryRenderSignature(for provider: UsageProvider) -> String {
-        guard let snapshot = self.tokenSnapshotForCostHistorySubmenu(provider: provider) else { return "none" }
-        return [
-            snapshot.currencyCode,
-            "\(snapshot.historyDays)",
-            snapshot.historyLabel ?? "",
-            snapshot.last30DaysCostUSD.map { String($0.bitPattern, radix: 16) } ?? "nil",
-            String(reflecting: snapshot.daily),
-            String(reflecting: snapshot.projects),
-        ].joined(separator: "|")
+    private func costHistoryRenderFingerprint(for provider: UsageProvider) -> HostedSubviewContentFingerprint {
+        guard let snapshot = self.tokenSnapshotForCostHistorySubmenu(provider: provider) else {
+            return .text("none")
+        }
+        return .costHistory(CostHistoryChartMenuView.renderFingerprint(from: snapshot))
     }
 
     private func usageHistoryRenderSignature(for provider: UsageProvider) -> String {
@@ -626,3 +648,16 @@ extension StatusItemController {
         return true
     }
 }
+
+#if DEBUG
+extension StatusItemController {
+    func _hostedSubviewRenderSignatureForTesting(menu: NSMenu, width: CGFloat) -> HostedSubviewRenderSignature? {
+        guard let identity = self.hostedSubviewIdentity(for: menu) else { return nil }
+        return self.hostedSubviewRenderSignature(identity: identity, width: width)
+    }
+
+    func _storedHostedSubviewRenderSignatureForTesting(menu: NSMenu) -> HostedSubviewRenderSignature? {
+        self.hostedSubviewRenderSignatures.object(forKey: menu)?.signature
+    }
+}
+#endif

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -139,7 +139,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var menuProviders: [ObjectIdentifier: UsageProvider] = [:]
     var menuSession = MenuSessionCoordinator<ObjectIdentifier>()
     var menuReadinessSignatures: [ObjectIdentifier: String] = [:]
-    let hostedSubviewRenderSignatures = NSMapTable<NSMenu, NSString>.weakToStrongObjects()
+    let hostedSubviewRenderSignatures = NSMapTable<NSMenu, HostedSubviewRenderSignatureBox>.weakToStrongObjects()
     /// Persistent Refresh rows are weakly tracked so their enabled state can change during menu tracking.
     let persistentRefreshItems = NSHashTable<NSMenuItem>.weakObjects()
     var menuCardHeightCache: [MenuCardHeightCacheKey: CGFloat] = [:]

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import Testing
 @testable import CodexBar
 
+@MainActor
 struct CostHistoryChartMenuViewTests {
     @Test
     @MainActor
@@ -286,6 +287,187 @@ struct CostHistoryChartMenuViewTests {
         #expect(CostHistoryChartMenuView.visibleProjectSources(differing).compactMap(\.path) == ["/tmp/worktree"])
     }
 
+    @Test
+    @MainActor
+    func `render fingerprint is stable for identical snapshots`() {
+        let snapshot = Self.makeSnapshot(dailyCost: 1.23, projectCount: 5)
+        let first = CostHistoryChartMenuView.renderFingerprint(from: snapshot)
+        let second = CostHistoryChartMenuView.renderFingerprint(from: snapshot)
+
+        #expect(first == second)
+        #expect(first.projects.count == 5)
+        #expect(first.projects.allSatisfy { $0.sources.count <= 2 })
+    }
+
+    @Test
+    @MainActor
+    func `render fingerprint changes when daily cost changes`() {
+        let before = CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(dailyCost: 1.0))
+        let after = CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(dailyCost: 2.0))
+
+        #expect(before != after)
+    }
+
+    @Test
+    @MainActor
+    func `render fingerprint changes for total currency history window and label`() {
+        let base = Self.makeSnapshot(dailyCost: 1.0)
+        #expect(
+            CostHistoryChartMenuView.renderFingerprint(from: base)
+                != CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(
+                    dailyCost: 1.0,
+                    totalCostUSD: 9.99)))
+        #expect(
+            CostHistoryChartMenuView.renderFingerprint(from: base)
+                != CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(
+                    dailyCost: 1.0,
+                    currencyCode: "EUR")))
+        #expect(
+            CostHistoryChartMenuView.renderFingerprint(from: base)
+                != CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(
+                    dailyCost: 1.0,
+                    historyDays: 7)))
+        #expect(
+            CostHistoryChartMenuView.renderFingerprint(from: base)
+                != CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(
+                    dailyCost: 1.0,
+                    historyLabel: "Last week")))
+    }
+
+    @Test
+    @MainActor
+    func `render fingerprint tracks daily token request and model breakdown fields`() {
+        let baseDaily = [Self.entry(date: "2026-06-07", modelCount: 1)]
+        let base = Self.fingerprint(dailyCost: 1.0, daily: baseDaily, projects: [])
+
+        var changedTokens = baseDaily
+        changedTokens[0] = CostUsageDailyReport.Entry(
+            date: "2026-06-07",
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 999,
+            costUSD: 1,
+            modelsUsed: ["model-0"],
+            modelBreakdowns: changedTokens[0].modelBreakdowns)
+        #expect(base != Self.fingerprint(dailyCost: 1.0, daily: changedTokens, projects: []))
+
+        var changedRequests = baseDaily
+        changedRequests[0] = CostUsageDailyReport.Entry(
+            date: "2026-06-07",
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+            requestCount: 42,
+            costUSD: 1,
+            modelsUsed: ["model-0"],
+            modelBreakdowns: changedRequests[0].modelBreakdowns)
+        #expect(base != Self.fingerprint(dailyCost: 1.0, daily: changedRequests, projects: []))
+
+        let changedModel = [
+            Self.entry(date: "2026-06-07", modelCount: 1, modelNamePrefix: "other"),
+        ]
+        #expect(base != Self.fingerprint(dailyCost: 1.0, daily: changedModel, projects: []))
+
+        let changedMode = [
+            Self.entry(date: "2026-06-07", modelCount: 1, hasModeDetails: true),
+        ]
+        #expect(base != Self.fingerprint(dailyCost: 1.0, daily: changedMode, projects: []))
+
+        let reorderedDaily = [
+            Self.entry(date: "2026-06-08", modelCount: 1),
+            Self.entry(date: "2026-06-07", modelCount: 1),
+        ]
+        #expect(base != Self.fingerprint(dailyCost: 1.0, daily: reorderedDaily, projects: []))
+    }
+
+    @Test
+    @MainActor
+    func `render fingerprint tracks visible project and source fields only`() {
+        let daily = [Self.entry(date: "2026-06-07", modelCount: 1)]
+        let projects = Self.makeProjects(count: 6, sourcesPerProject: 3)
+        let base = Self.fingerprint(totalCostUSD: 6.0, daily: daily, projects: projects)
+
+        var sixthProjectNestedDaily = projects
+        sixthProjectNestedDaily[5] = Self.makeProject(
+            index: 5,
+            sourceCount: 3,
+            nestedDailyCost: 99.0)
+        #expect(base == Self.fingerprint(totalCostUSD: 6.0, daily: daily, projects: sixthProjectNestedDaily))
+
+        var topProjectNestedDaily = projects
+        topProjectNestedDaily[0] = Self.makeProject(
+            index: 0,
+            sourceCount: 3,
+            nestedDailyCost: 99.0)
+        #expect(base == Self.fingerprint(totalCostUSD: 6.0, daily: daily, projects: topProjectNestedDaily))
+
+        var renamedTopProject = projects
+        renamedTopProject[0] = Self.makeProject(index: 0, sourceCount: 3, nameSuffix: "-renamed")
+        #expect(base != Self.fingerprint(totalCostUSD: 6.0, daily: daily, projects: renamedTopProject))
+
+        var changedTopProjectPath = projects
+        changedTopProjectPath[0] = Self.makeProject(index: 0, sourceCount: 3, pathSuffix: "-renamed")
+        #expect(base != Self.fingerprint(totalCostUSD: 6.0, daily: daily, projects: changedTopProjectPath))
+
+        var changedTopProjectTotals = projects
+        changedTopProjectTotals[0] = Self.makeProject(index: 0, sourceCount: 3, totalCostUSD: 42.0, totalTokens: 9999)
+        #expect(base != Self.fingerprint(totalCostUSD: 6.0, daily: daily, projects: changedTopProjectTotals))
+
+        var reorderedProjects = Array(projects.reversed())
+        #expect(base != Self.fingerprint(totalCostUSD: 6.0, daily: daily, projects: reorderedProjects))
+
+        var promotedHiddenProject = projects
+        let promoted = Self.makeProject(
+            index: 5,
+            sourceCount: 3,
+            totalCostUSD: 1000.0)
+        promotedHiddenProject.remove(at: 5)
+        promotedHiddenProject.insert(promoted, at: 0)
+        #expect(base != Self.fingerprint(totalCostUSD: 6.0, daily: daily, projects: promotedHiddenProject))
+    }
+
+    @Test
+    @MainActor
+    func `render fingerprint tracks source visibility and overflow count`() {
+        let daily = [Self.entry(date: "2026-06-07", modelCount: 1)]
+        let twoSources = [
+            Self.makeProject(index: 0, sourceCount: 2),
+        ]
+        let threeSources = [
+            Self.makeProject(index: 0, sourceCount: 3),
+        ]
+        let base = Self.fingerprint(dailyCost: 1.0, daily: daily, projects: twoSources)
+
+        #expect(base != Self.fingerprint(dailyCost: 1.0, daily: daily, projects: threeSources))
+
+        var thirdSourceRenamed = threeSources
+        thirdSourceRenamed[0] = Self.makeProject(index: 0, sourceCount: 3, renameThirdSource: true)
+        #expect(Self.fingerprint(dailyCost: 1.0, daily: daily, projects: threeSources)
+            == Self.fingerprint(dailyCost: 1.0, daily: daily, projects: thirdSourceRenamed))
+
+        var firstSourceRenamed = twoSources
+        firstSourceRenamed[0] = Self.makeProject(index: 0, sourceCount: 2, renameFirstSource: true)
+        #expect(base != Self.fingerprint(dailyCost: 1.0, daily: daily, projects: firstSourceRenamed))
+
+        var firstSourceTotals = twoSources
+        firstSourceTotals[0] = Self.makeProject(
+            index: 0,
+            sourceCount: 2,
+            firstSourceCostUSD: 9.99,
+            firstSourceTokens: 8888)
+        #expect(base != Self.fingerprint(dailyCost: 1.0, daily: daily, projects: firstSourceTotals))
+
+        let hiddenSingleSource = [
+            Self.project(path: "/tmp/main", sourcePath: "/tmp/main"),
+        ]
+        let visibleSingleSource = [
+            Self.project(path: "/tmp/main", sourcePath: "/tmp/worktree"),
+        ]
+        #expect(
+            Self.fingerprint(dailyCost: 1.0, daily: daily, projects: hiddenSingleSource)
+                != Self.fingerprint(dailyCost: 1.0, daily: daily, projects: visibleSingleSource))
+    }
+
     private static func project(path: String, sourcePath: String) -> CostUsageProjectBreakdown {
         CostUsageProjectBreakdown(
             name: "Project",
@@ -320,7 +502,8 @@ struct CostHistoryChartMenuViewTests {
     private static func entry(
         date: String,
         modelCount: Int,
-        hasModeDetails: Bool = false) -> CostUsageDailyReport.Entry
+        hasModeDetails: Bool = false,
+        modelNamePrefix: String = "model") -> CostUsageDailyReport.Entry
     {
         CostUsageDailyReport.Entry(
             date: date,
@@ -328,15 +511,133 @@ struct CostHistoryChartMenuViewTests {
             outputTokens: 50,
             totalTokens: 150,
             costUSD: 1,
-            modelsUsed: modelCount > 0 ? (0..<modelCount).map { "model-\($0)" } : nil,
+            modelsUsed: modelCount > 0 ? (0..<modelCount).map { "\(modelNamePrefix)-\($0)" } : nil,
             modelBreakdowns: modelCount > 0
                 ? (0..<modelCount).map {
                     CostUsageDailyReport.ModelBreakdown(
-                        modelName: "model-\($0)",
+                        modelName: "\(modelNamePrefix)-\($0)",
                         costUSD: Double($0 + 1),
                         totalTokens: ($0 + 1) * 100,
                         standardCostUSD: hasModeDetails ? Double($0 + 1) * 0.75 : nil)
                 }
                 : nil)
+    }
+
+    private static func makeSnapshot(
+        dailyCost: Double = 1.0,
+        projectCount: Int = 0,
+        totalCostUSD: Double? = nil,
+        currencyCode: String = "USD",
+        historyDays: Int = 30,
+        historyLabel: String? = nil,
+        daily: [CostUsageDailyReport.Entry]? = nil,
+        projects: [CostUsageProjectBreakdown]? = nil) -> CostUsageTokenSnapshot
+    {
+        CostUsageTokenSnapshot(
+            sessionTokens: 123,
+            sessionCostUSD: 0.12,
+            last30DaysTokens: 123,
+            last30DaysCostUSD: totalCostUSD ?? dailyCost,
+            currencyCode: currencyCode,
+            historyDays: historyDays,
+            historyLabel: historyLabel,
+            daily: daily ?? [
+                CostUsageDailyReport.Entry(
+                    date: "2025-12-23",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 123,
+                    costUSD: dailyCost,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            projects: projects ?? self.makeProjects(count: projectCount, sourcesPerProject: 1),
+            updatedAt: Date())
+    }
+
+    private static func fingerprint(
+        dailyCost: Double = 1.0,
+        totalCostUSD: Double? = nil,
+        currencyCode: String = "USD",
+        historyDays: Int = 30,
+        historyLabel: String? = nil,
+        daily: [CostUsageDailyReport.Entry]? = nil,
+        projects: [CostUsageProjectBreakdown]? = nil) -> CostHistoryChartMenuView.RenderFingerprint
+    {
+        CostHistoryChartMenuView.renderFingerprint(from: self.makeSnapshot(
+            dailyCost: dailyCost,
+            totalCostUSD: totalCostUSD,
+            currencyCode: currencyCode,
+            historyDays: historyDays,
+            historyLabel: historyLabel,
+            daily: daily,
+            projects: projects))
+    }
+
+    private static func makeProjects(count: Int, sourcesPerProject: Int) -> [CostUsageProjectBreakdown] {
+        (0..<count).map { Self.makeProject(index: $0, sourceCount: sourcesPerProject) }
+    }
+
+    private static func makeProject(
+        index: Int,
+        sourceCount: Int,
+        totalCostUSD: Double = 1.0,
+        totalTokens: Int? = nil,
+        nestedDailyCost: Double = 0.01,
+        nameSuffix: String = "",
+        pathSuffix: String = "",
+        renameThirdSource: Bool = false,
+        renameFirstSource: Bool = false,
+        firstSourceCostUSD: Double? = nil,
+        firstSourceTokens: Int? = nil) -> CostUsageProjectBreakdown
+    {
+        let nestedDaily = [
+            CostUsageDailyReport.Entry(
+                date: "2025-12-23",
+                inputTokens: 1,
+                outputTokens: 1,
+                totalTokens: 10,
+                costUSD: nestedDailyCost,
+                modelsUsed: ["nested"],
+                modelBreakdowns: [
+                    CostUsageDailyReport.ModelBreakdown(
+                        modelName: "nested-model",
+                        costUSD: nestedDailyCost,
+                        totalTokens: 10),
+                ]),
+        ]
+        let sources = (0..<sourceCount).map { sourceIndex in
+            CostUsageProjectSourceBreakdown(
+                name: {
+                    if renameThirdSource, sourceIndex == 2 { return "Renamed Source" }
+                    if renameFirstSource, sourceIndex == 0 { return "Renamed Source" }
+                    return "Source-\(sourceIndex)"
+                }(),
+                path: "/tmp/project-\(index)\(pathSuffix)/source-\(sourceIndex)",
+                totalTokens: sourceIndex == 0 ? (firstSourceTokens ?? 10 + sourceIndex) : 10 + sourceIndex,
+                totalCostUSD: sourceIndex == 0
+                    ? (firstSourceCostUSD ?? totalCostUSD / Double(sourceCount))
+                    : totalCostUSD / Double(sourceCount),
+                daily: nestedDaily,
+                modelBreakdowns: [
+                    CostUsageDailyReport.ModelBreakdown(
+                        modelName: "source-model",
+                        costUSD: nestedDailyCost,
+                        totalTokens: 10),
+                ])
+        }
+        return CostUsageProjectBreakdown(
+            name: "Project-\(index)\(nameSuffix)",
+            path: "/tmp/project-\(index)\(pathSuffix)",
+            totalTokens: totalTokens ?? 100 + index,
+            totalCostUSD: totalCostUSD + Double(index),
+            daily: nestedDaily,
+            modelBreakdowns: [
+                CostUsageDailyReport.ModelBreakdown(
+                    modelName: "project-model",
+                    costUSD: nestedDailyCost,
+                    totalTokens: 10),
+            ],
+            sources: sources)
     }
 }

--- a/Tests/CodexBarTests/StatusMenuCodexCostHistoryRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCodexCostHistoryRefreshTests.swift
@@ -1,0 +1,274 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuCodexCostHistoryRefreshTests {
+    @Test
+    func `codex cost history preserves identity when hidden project nested data changes`() throws {
+        try self.assertCodexCostHistoryPreservesIdentity(
+            mutate: { snapshot in
+                var projects = snapshot.projects
+                guard projects.count > 5 else { return snapshot }
+                projects[5] = Self.makeCodexProject(
+                    index: 5,
+                    sourceCount: 1,
+                    nestedDailyCost: 99.0)
+                return Self.copySnapshot(snapshot, projects: projects)
+            })
+    }
+
+    @Test
+    func `codex cost history preserves identity when visible project nested data changes`() throws {
+        try self.assertCodexCostHistoryPreservesIdentity(
+            mutate: { snapshot in
+                var projects = snapshot.projects
+                guard !projects.isEmpty else { return snapshot }
+                projects[0] = Self.makeCodexProject(
+                    index: 0,
+                    sourceCount: 1,
+                    nestedDailyCost: 99.0)
+                return Self.copySnapshot(snapshot, projects: projects)
+            })
+    }
+
+    @Test
+    func `codex cost history rebuilds when daily cost changes`() throws {
+        try self.assertCodexCostHistoryRebuilds(
+            mutate: { snapshot in
+                Self.copySnapshot(snapshot, dailyCost: 9.87)
+            })
+    }
+
+    @Test
+    func `hydrated codex cost history stores the same fingerprint as refresh`() throws {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering }
+
+        let settings = Self.makeSettings()
+        settings.costUsageEnabled = true
+        Self.enableOnly(settings, provider: .codex)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setTokenSnapshotForTesting(Self.makeCodexCostSnapshot(), provider: .codex)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let width = StatusItemController.menuCardBaseWidth
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.costHistoryChartID,
+            provider: .codex,
+            width: width)
+        controller.menuWillOpen(submenu)
+
+        let stored = try #require(controller._storedHostedSubviewRenderSignatureForTesting(menu: submenu))
+        let recomputed = try #require(controller._hostedSubviewRenderSignatureForTesting(menu: submenu, width: width))
+        #expect(stored == recomputed)
+
+        controller.refreshHostedSubviewMenu(submenu)
+        #expect(controller._storedHostedSubviewRenderSignatureForTesting(menu: submenu) == recomputed)
+    }
+
+    private func assertCodexCostHistoryPreservesIdentity(
+        mutate: (CostUsageTokenSnapshot) -> CostUsageTokenSnapshot) throws
+    {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering }
+
+        let settings = Self.makeSettings()
+        settings.costUsageEnabled = true
+        Self.enableOnly(settings, provider: .codex)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setTokenSnapshotForTesting(Self.makeCodexCostSnapshot(), provider: .codex)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.costHistoryChartID,
+            provider: .codex,
+            width: StatusItemController.menuCardBaseWidth)
+        controller.menuWillOpen(submenu)
+
+        let hydratedView = try #require(submenu.items.first?.view)
+        store._setTokenSnapshotForTesting(mutate(Self.makeCodexCostSnapshot()), provider: .codex)
+        controller.refreshHostedSubviewMenu(submenu)
+
+        #expect(submenu.items.first?.view === hydratedView)
+    }
+
+    private func assertCodexCostHistoryRebuilds(
+        mutate: (CostUsageTokenSnapshot) -> CostUsageTokenSnapshot) throws
+    {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering }
+
+        let settings = Self.makeSettings()
+        settings.costUsageEnabled = true
+        Self.enableOnly(settings, provider: .codex)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setTokenSnapshotForTesting(Self.makeCodexCostSnapshot(), provider: .codex)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.costHistoryChartID,
+            provider: .codex,
+            width: StatusItemController.menuCardBaseWidth)
+        controller.menuWillOpen(submenu)
+
+        let hydratedView = try #require(submenu.items.first?.view)
+        store._setTokenSnapshotForTesting(mutate(Self.makeCodexCostSnapshot()), provider: .codex)
+        controller.refreshHostedSubviewMenu(submenu)
+
+        #expect(submenu.items.first?.view !== hydratedView)
+    }
+
+    private static func makeSettings() -> SettingsStore {
+        let suite = "StatusMenuCodexCostHistoryRefreshTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    private static func enableOnly(_ settings: SettingsStore, provider enabledProvider: UsageProvider) {
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == enabledProvider)
+        }
+    }
+
+    private static func makeCodexCostSnapshot(
+        dailyCost: Double = 1.23,
+        projectCount: Int = 6) -> CostUsageTokenSnapshot
+    {
+        CostUsageTokenSnapshot(
+            sessionTokens: 123,
+            sessionCostUSD: 0.12,
+            last30DaysTokens: 123,
+            last30DaysCostUSD: dailyCost,
+            daily: [
+                CostUsageDailyReport.Entry(
+                    date: "2025-12-23",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 123,
+                    costUSD: dailyCost,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            projects: (0..<projectCount).map { Self.makeCodexProject(index: $0, sourceCount: 1) },
+            updatedAt: Date())
+    }
+
+    private static func copySnapshot(
+        _ snapshot: CostUsageTokenSnapshot,
+        dailyCost: Double? = nil,
+        projects: [CostUsageProjectBreakdown]? = nil) -> CostUsageTokenSnapshot
+    {
+        let daily = snapshot.daily.map { entry in
+            CostUsageDailyReport.Entry(
+                date: entry.date,
+                inputTokens: entry.inputTokens,
+                outputTokens: entry.outputTokens,
+                totalTokens: entry.totalTokens,
+                costUSD: dailyCost ?? entry.costUSD,
+                modelsUsed: entry.modelsUsed,
+                modelBreakdowns: entry.modelBreakdowns)
+        }
+        return CostUsageTokenSnapshot(
+            sessionTokens: snapshot.sessionTokens,
+            sessionCostUSD: snapshot.sessionCostUSD,
+            last30DaysTokens: snapshot.last30DaysTokens,
+            last30DaysCostUSD: dailyCost ?? snapshot.last30DaysCostUSD,
+            currencyCode: snapshot.currencyCode,
+            historyDays: snapshot.historyDays,
+            historyLabel: snapshot.historyLabel,
+            daily: daily,
+            projects: projects ?? snapshot.projects,
+            updatedAt: snapshot.updatedAt)
+    }
+
+    private static func makeCodexProject(
+        index: Int,
+        sourceCount: Int,
+        nestedDailyCost: Double = 0.01) -> CostUsageProjectBreakdown
+    {
+        let nestedDaily = [
+            CostUsageDailyReport.Entry(
+                date: "2025-12-23",
+                inputTokens: 1,
+                outputTokens: 1,
+                totalTokens: 10,
+                costUSD: nestedDailyCost,
+                modelsUsed: ["nested"],
+                modelBreakdowns: [
+                    CostUsageDailyReport.ModelBreakdown(
+                        modelName: "nested-model",
+                        costUSD: nestedDailyCost,
+                        totalTokens: 10),
+                ]),
+        ]
+        return CostUsageProjectBreakdown(
+            name: "Project-\(index)",
+            path: "/tmp/project-\(index)",
+            totalTokens: 100 + index,
+            totalCostUSD: 1.0 + Double(index),
+            daily: nestedDaily,
+            modelBreakdowns: [
+                CostUsageDailyReport.ModelBreakdown(
+                    modelName: "project-model",
+                    costUSD: nestedDailyCost,
+                    totalTokens: 10),
+            ],
+            sources: (0..<sourceCount).map { sourceIndex in
+                CostUsageProjectSourceBreakdown(
+                    name: "Source-\(sourceIndex)",
+                    path: "/tmp/project-\(index)/source-\(sourceIndex)",
+                    totalTokens: 10 + sourceIndex,
+                    totalCostUSD: 0.5,
+                    daily: nestedDaily,
+                    modelBreakdowns: [
+                        CostUsageDailyReport.ModelBreakdown(
+                            modelName: "source-model",
+                            costUSD: nestedDailyCost,
+                            totalTokens: 10),
+                    ])
+            })
+    }
+}


### PR DESCRIPTION
## Summary
- Cost History’s hosted-submenu signature recursively reflected each project and source, including their full daily and model-breakdown histories, on the main-thread menu-open path. Project rollups made this scale with data that the submenu never renders.
- Replace the reflective signature with a typed visible-content fingerprint bounded to the global daily chart, five displayed projects, and two displayed sources per project.
- Follow-up to #1384; regression amplified by project rollups added in #1884.

## Test plan
- [x] `swift test --filter CostHistoryChartMenuViewTests`
- [x] `swift test --filter StatusMenuHostedSubmenuRefreshTests`
- [x] `swift test --filter StatusMenuCodexCostHistoryRefreshTests`
- [x] `swift build -c release`
- [x] `make check`
- [x] `make test`

## Performance evidence
Release, 30 samples after warm-up, 30 days / 4 models / 1 source per project (`swift run -c release --package-path /tmp/CostBench CostBench <projects> 1`):

| Projects | Reflection median | Reflection P95 | Fingerprint median | Fingerprint P95 |
|---:|---:|---:|---:|---:|
| 5 | 2.19 ms | 3.75 ms | 0.001 ms | 0.003 ms |
| 20 | 4.49 ms | 4.96 ms | 0.001 ms | 0.003 ms |

Audit baseline on upstream main (same workload): 5 projects 18.29 ms / 20.26 ms P95; 20 projects 61.23 ms / 64.39 ms P95; visible projection ~0.06–0.07 ms median.

## Risk
Main risk is an incomplete fingerprint masking a visible update. The implementation keeps the full bounded global daily array and tests every project/source field that the view renders. Project/source nested daily data is intentionally excluded because it is not displayed.

Made with [Cursor](https://cursor.com)