### PR TITLE
fix: confirm Codex weekly reset snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixed
 - Gemini: recover expired Workspace and education OAuth sessions when current CLI packages omit `oauth2.js`, with explicit credential and install-path discovery fallbacks. Thanks @Yuxin-Qiao!
-- Codex: require weekly reset-boundary advancement before celebrating quota resets, while keeping same-email workspace accounts isolated. Thanks @Yuxin-Qiao!
+- Codex accounts: confirm apparent weekly resets before publishing them and isolate reset detection by stable account ownership, preventing transient full gauges and confetti across same-email workspaces (#2054). Thanks @Yuxin-Qiao!
 - Settings: render section footer captions (Advanced keychain note, refresh hints, quota-warning and provider subtitles) leading-aligned in footnote size instead of the trailing-aligned body text macOS gives bare form footers.
 - Claude OAuth: remember an acknowledged CodexBar Keychain explanation for six hours without suppressing macOS authorization or either Keychain opt-out (#1990). Thanks @harjothkhara!
 - Codex accounts: find the Codex CLI bundled with ChatGPT when it is absent from shell PATH, restoring Add Account after the desktop apps merged (#2044). Thanks @sep1107!

--- a/Sources/CodexBar/CodexAccountUsageSnapshotStore.swift
+++ b/Sources/CodexBar/CodexAccountUsageSnapshotStore.swift
@@ -37,27 +37,15 @@ struct FileCodexAccountUsageSnapshotStore: CodexAccountUsageSnapshotStoring, @un
         }
 
         func matches(_ account: CodexVisibleAccount) -> Bool {
-            guard self.normalizedEmail == CodexIdentityResolver.normalizeEmail(account.email) else {
+            guard let normalizedEmail = self.normalizedEmail,
+                  normalizedEmail == CodexIdentityResolver.normalizeEmail(account.email),
+                  let workspaceAccountID = self.workspaceAccountID,
+                  workspaceAccountID == CodexOpenAIWorkspaceResolver.normalizeWorkspaceAccountID(
+                      account.workspaceAccountID)
+            else {
                 return false
             }
-
-            let currentWorkspaceAccountID = CodexOpenAIWorkspaceResolver.normalizeWorkspaceAccountID(
-                account.workspaceAccountID)
-            if self.workspaceAccountID != nil || currentWorkspaceAccountID != nil {
-                return self.workspaceAccountID == currentWorkspaceAccountID
-            }
-
-            let currentAuthFingerprint = CodexAuthFingerprint.normalize(account.authFingerprint)
-            if self.authFingerprint != nil || currentAuthFingerprint != nil {
-                return self.authFingerprint == currentAuthFingerprint
-            }
-
-            if self.storedAccountID != nil || account.storedAccountID != nil {
-                return self.storedAccountID == account.storedAccountID
-            }
-
-            guard let selectionSource else { return true }
-            return selectionSource == account.selectionSource
+            return true
         }
     }
 
@@ -83,14 +71,10 @@ struct FileCodexAccountUsageSnapshotStore: CodexAccountUsageSnapshotStoring, @un
         let accountsByID = Dictionary(uniqueKeysWithValues: accounts.map { ($0.id, $0) })
         return payload.records.compactMap { record in
             guard let account = accountsByID[record.id] else { return nil }
-            guard record.accountIdentity?.matches(account)
-                ?? Self.canHydrateLegacyRecord(record, account: account)
-            else {
-                return nil
-            }
+            guard record.accountIdentity?.matches(account) == true else { return nil }
             return CodexAccountUsageSnapshot(
                 account: account,
-                snapshot: record.snapshot,
+                snapshot: Self.relabelSnapshot(record.snapshot, for: account),
                 error: record.error,
                 sourceLabel: record.sourceLabel)
         }
@@ -99,10 +83,12 @@ struct FileCodexAccountUsageSnapshotStore: CodexAccountUsageSnapshotStoring, @un
     func store(_ snapshots: [CodexAccountUsageSnapshot]) {
         let payload = Payload(
             version: Self.currentVersion,
-            records: snapshots.map { snapshot in
-                Record(
+            records: snapshots.compactMap { snapshot in
+                let identity = AccountIdentity(account: snapshot.account)
+                guard identity.normalizedEmail != nil, identity.workspaceAccountID != nil else { return nil }
+                return Record(
                     id: snapshot.id,
-                    accountIdentity: AccountIdentity(account: snapshot.account),
+                    accountIdentity: identity,
                     snapshot: snapshot.snapshot,
                     error: snapshot.error,
                     sourceLabel: snapshot.sourceLabel)
@@ -125,15 +111,16 @@ struct FileCodexAccountUsageSnapshotStore: CodexAccountUsageSnapshotStoring, @un
         }
     }
 
-    private static func canHydrateLegacyRecord(_ record: Record, account: CodexVisibleAccount) -> Bool {
-        guard record.accountIdentity == nil else { return false }
-        let normalizedID = CodexIdentityResolver.normalizeEmail(record.id)
-        let normalizedEmail = CodexIdentityResolver.normalizeEmail(account.email)
-        let isEmailOnlyVisibleID = normalizedID == normalizedEmail
-        guard isEmailOnlyVisibleID else { return true }
-        return CodexOpenAIWorkspaceResolver.normalizeWorkspaceAccountID(account.workspaceAccountID) == nil &&
-            account.storedAccountID == nil &&
-            CodexAuthFingerprint.normalize(account.authFingerprint) == nil
+    private static func relabelSnapshot(_ snapshot: UsageSnapshot?, for account: CodexVisibleAccount)
+        -> UsageSnapshot?
+    {
+        guard let snapshot else { return nil }
+        let identity = snapshot.identity(for: .codex)
+        return snapshot.withIdentity(ProviderIdentitySnapshot(
+            providerID: .codex,
+            accountEmail: account.email,
+            accountOrganization: identity?.accountOrganization,
+            loginMethod: identity?.loginMethod ?? account.workspaceLabel))
     }
 
     static func defaultURL() -> URL {

--- a/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
@@ -320,6 +320,10 @@ struct CodexConsumerProjection {
         self.rateWindowsByLane[lane]
     }
 
+    static func sourceRateWindow(for lane: RateLane, snapshot: UsageSnapshot?) -> RateWindow? {
+        self.rateWindowsByLane(snapshot: snapshot)[lane]
+    }
+
     func menuBarSelectableRateWindow(for lane: RateLane) -> RateWindow? {
         guard let window = self.rateWindow(for: lane) else { return nil }
         guard window.remainingPercent <= 0,

--- a/Sources/CodexBar/Providers/Codex/CodexLimitResetOwnerKey.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexLimitResetOwnerKey.swift
@@ -1,0 +1,42 @@
+import CodexBarCore
+import CryptoKit
+import Foundation
+
+struct CodexLimitResetOwnerKey: Equatable, Hashable, Sendable {
+    let rawValue: String
+
+    init?(identity: CodexIdentity, accountEmail: String?) {
+        guard case let .providerAccount(id) = identity,
+              let normalizedID = CodexOpenAIWorkspaceResolver.normalizeWorkspaceAccountID(id),
+              let normalizedEmail = CodexIdentityResolver.normalizeEmail(accountEmail)
+        else {
+            return nil
+        }
+        let input = "codex-limit-reset-owner:v2\0\(normalizedID)\0\(normalizedEmail)"
+        let digest = SHA256.hash(data: Data(input.utf8))
+        self.rawValue = digest.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+extension UsageStore {
+    func codexLimitResetOwnerKey(
+        expectedGuard: CodexAccountScopedRefreshGuard,
+        visibleAccounts _: [CodexVisibleAccount]) -> CodexLimitResetOwnerKey?
+    {
+        CodexLimitResetOwnerKey(
+            identity: expectedGuard.identity,
+            accountEmail: expectedGuard.accountKey)
+    }
+
+    func codexLimitResetOwnerKey(
+        forVisibleAccount account: CodexVisibleAccount,
+        visibleAccounts _: [CodexVisibleAccount]) -> CodexLimitResetOwnerKey?
+    {
+        guard let workspaceAccountID = CodexOpenAIWorkspaceResolver.normalizeWorkspaceAccountID(
+            account.workspaceAccountID)
+        else { return nil }
+        return CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: workspaceAccountID),
+            accountEmail: account.email)
+    }
+}

--- a/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
@@ -1,0 +1,184 @@
+import CodexBarCore
+import Foundation
+
+struct CodexWeeklyResetConfirmation: Sendable {
+    enum InitialDecision: Equatable, Sendable {
+        case publishInitial
+        case requiresConfirmation
+        case preservePrevious
+    }
+
+    enum ConfirmationDecision: Equatable, Sendable {
+        case publishConfirmation
+        case preservePrevious
+    }
+
+    private static let resetEquivalenceToleranceSeconds: TimeInterval = 2 * 60
+    private static let resetThreshold = 1.0
+
+    static func initialDecision(
+        previous: UsageSnapshot?,
+        initial: UsageSnapshot) -> InitialDecision
+    {
+        guard self.isFinite(initial.updatedAt) else { return .preservePrevious }
+        guard let previous else {
+            guard let initialWeekly = CodexConsumerProjection.sourceRateWindow(
+                for: .weekly,
+                snapshot: initial)
+            else {
+                return .publishInitial
+            }
+            return self.initialDecisionWithoutWeeklyBaseline(
+                initialWeekly: initialWeekly,
+                capturedAt: initial.updatedAt)
+        }
+        guard Self.isFinite(previous.updatedAt), initial.updatedAt > previous.updatedAt else {
+            return .preservePrevious
+        }
+
+        guard let previousWeekly = CodexConsumerProjection.sourceRateWindow(
+            for: .weekly,
+            snapshot: previous)
+        else {
+            guard let initialWeekly = CodexConsumerProjection.sourceRateWindow(
+                for: .weekly,
+                snapshot: initial)
+            else {
+                return .publishInitial
+            }
+            return self.initialDecisionWithoutWeeklyBaseline(
+                initialWeekly: initialWeekly,
+                capturedAt: initial.updatedAt)
+        }
+        guard previousWeekly.usedPercent.isFinite else {
+            return .preservePrevious
+        }
+        // A source can legitimately omit the weekly lane and rely on the existing
+        // reset-window backfill path. Only gate an explicit weekly observation.
+        guard let initialWeekly = CodexConsumerProjection.sourceRateWindow(
+            for: .weekly,
+            snapshot: initial)
+        else {
+            return .preservePrevious
+        }
+        guard initialWeekly.usedPercent.isFinite else { return .preservePrevious }
+        let previousBoundary = Self.finiteResetBoundary(previousWeekly)
+        let initialBoundary = Self.finiteResetBoundary(initialWeekly)
+        if initialWeekly.resetsAt != nil,
+           Self.validResetBoundary(initialWeekly, capturedAt: initial.updatedAt) == nil
+        {
+            return .preservePrevious
+        }
+        if let previousBoundary, let initialBoundary,
+           initialBoundary.timeIntervalSince(previousBoundary) < -Self.resetEquivalenceToleranceSeconds
+        {
+            return .preservePrevious
+        }
+
+        guard previousWeekly.usedPercent > Self.resetThreshold,
+              initialWeekly.usedPercent <= Self.resetThreshold
+        else {
+            return .publishInitial
+        }
+        guard Self.validResetBoundary(initialWeekly, capturedAt: initial.updatedAt) != nil else {
+            return .preservePrevious
+        }
+        return .requiresConfirmation
+    }
+
+    static func confirmationDecision(
+        previous: UsageSnapshot?,
+        initial: UsageSnapshot,
+        confirmation: UsageSnapshot) -> ConfirmationDecision
+    {
+        guard previous.map({ self.isFinite($0.updatedAt) }) ?? true,
+              self.isFinite(initial.updatedAt),
+              self.isFinite(confirmation.updatedAt),
+              confirmation.updatedAt > initial.updatedAt,
+              let initialWeekly = CodexConsumerProjection.sourceRateWindow(
+                  for: .weekly,
+                  snapshot: initial),
+              let confirmationWeekly = CodexConsumerProjection.sourceRateWindow(
+                  for: .weekly,
+                  snapshot: confirmation),
+              initialWeekly.usedPercent.isFinite,
+              confirmationWeekly.usedPercent.isFinite
+        else {
+            return .preservePrevious
+        }
+        let previousWeekly = CodexConsumerProjection.sourceRateWindow(
+            for: .weekly,
+            snapshot: previous)
+        guard previousWeekly?.usedPercent.isFinite ?? true else { return .preservePrevious }
+        let previousBoundary = previousWeekly.flatMap(Self.finiteResetBoundary)
+        let confirmationBoundary = Self.finiteResetBoundary(confirmationWeekly)
+        if confirmationWeekly.resetsAt != nil,
+           Self.validResetBoundary(confirmationWeekly, capturedAt: confirmation.updatedAt) == nil
+        {
+            return .preservePrevious
+        }
+        if let previousBoundary, let confirmationBoundary,
+           confirmationBoundary.timeIntervalSince(previousBoundary) < -Self.resetEquivalenceToleranceSeconds
+        {
+            return .preservePrevious
+        }
+
+        if confirmationWeekly.usedPercent > Self.resetThreshold {
+            return .publishConfirmation
+        }
+
+        guard initialWeekly.usedPercent <= Self.resetThreshold,
+              let initialBoundary = Self.validResetBoundary(initialWeekly, capturedAt: initial.updatedAt),
+              let confirmationBoundary = Self.validResetBoundary(
+                  confirmationWeekly,
+                  capturedAt: confirmation.updatedAt),
+              abs(initialBoundary.timeIntervalSince(confirmationBoundary))
+              < Self.resetEquivalenceToleranceSeconds
+        else {
+            return .preservePrevious
+        }
+        if let previous,
+           let previousWeekly,
+           let previousBoundary = Self.validResetBoundary(
+               previousWeekly,
+               capturedAt: previous.updatedAt)
+        {
+            guard initialBoundary.timeIntervalSince(previousBoundary) >= Self.resetEquivalenceToleranceSeconds,
+                  confirmationBoundary.timeIntervalSince(previousBoundary) >= Self.resetEquivalenceToleranceSeconds
+            else {
+                return .preservePrevious
+            }
+        }
+        return .publishConfirmation
+    }
+
+    private static func initialDecisionWithoutWeeklyBaseline(
+        initialWeekly: RateWindow,
+        capturedAt: Date) -> InitialDecision
+    {
+        guard initialWeekly.usedPercent.isFinite else { return .preservePrevious }
+        if initialWeekly.resetsAt != nil,
+           self.validResetBoundary(initialWeekly, capturedAt: capturedAt) == nil
+        {
+            return .preservePrevious
+        }
+        guard initialWeekly.usedPercent <= self.resetThreshold else { return .publishInitial }
+        return self.validResetBoundary(initialWeekly, capturedAt: capturedAt) == nil
+            ? .preservePrevious
+            : .requiresConfirmation
+    }
+
+    private static func finiteResetBoundary(_ window: RateWindow) -> Date? {
+        guard let boundary = window.resetsAt, isFinite(boundary) else { return nil }
+        return boundary
+    }
+
+    private static func validResetBoundary(_ window: RateWindow, capturedAt: Date) -> Date? {
+        guard let boundary = self.finiteResetBoundary(window), boundary > capturedAt else { return nil }
+        return boundary
+    }
+
+    private static func isFinite(_ date: Date) -> Bool {
+        date.timeIntervalSinceReferenceDate.isFinite
+    }
+}

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -23,7 +23,7 @@ struct CodexAccountScopedRefreshGuard: Equatable {
     {
         self.source = source
         self.identity = identity
-        self.accountKey = accountKey
+        self.accountKey = CodexIdentityResolver.normalizeEmail(accountKey)
         self.authFingerprint = CodexAuthFingerprint.normalize(authFingerprint)
     }
 }
@@ -68,27 +68,22 @@ extension UsageStore {
     }
 
     @discardableResult
-    func prepareCodexAccountScopedRefreshIfNeeded() -> Bool {
-        let currentGuard = self.freshCodexAccountScopedRefreshGuard(
+    func prepareCodexAccountScopedRefreshIfNeeded(
+        forceInvalidation: Bool = false,
+        currentGuardOverride: CodexAccountScopedRefreshGuard? = nil) -> Bool
+    {
+        let currentGuard = currentGuardOverride ?? self.freshCodexAccountScopedRefreshGuard(
             preferCurrentSnapshot: false,
             allowLastKnownLiveFallback: false)
         let previousGuard = self.lastCodexAccountScopedRefreshGuard
         self.lastCodexAccountScopedRefreshGuard = currentGuard
 
-        guard let previousGuard,
-              !Self.codexScopedRefreshGuardsMatchAccount(previousGuard, currentGuard)
-        else { return false }
+        let accountChanged = previousGuard.map {
+            !Self.codexScopedRefreshGuardsMatchAccount($0, currentGuard)
+        } ?? false
+        guard forceInvalidation || accountChanged else { return false }
 
-        self.snapshots.removeValue(forKey: .codex)
-        self.errors[.codex] = nil
-        self.lastSourceLabels.removeValue(forKey: .codex)
-        self.lastFetchAttempts.removeValue(forKey: .codex)
-        self.accountSnapshots.removeValue(forKey: .codex)
-        self.codexAccountSnapshots = []
-        self.failureGates[.codex]?.reset()
-        self.lastKnownSessionRemaining.removeValue(forKey: .codex)
-        self.lastKnownSessionWindowSource.removeValue(forKey: .codex)
-        self.lastKnownResetSnapshots.removeValue(forKey: .codex)
+        self.clearCodexPublishedUsageState()
 
         self.credits = nil
         self.lastCreditsError = nil
@@ -101,6 +96,56 @@ extension UsageStore {
 
         self.persistWidgetSnapshot(reason: "codex-account-invalidate")
         return true
+    }
+
+    func clearCodexPublishedUsageState() {
+        self.snapshots.removeValue(forKey: .codex)
+        self.errors[.codex] = nil
+        self.lastSourceLabels.removeValue(forKey: .codex)
+        self.lastFetchAttempts.removeValue(forKey: .codex)
+        self.accountSnapshots.removeValue(forKey: .codex)
+        // Visible-account rows carry their own owner and are reconciled against the current projection.
+        // Clearing selected-account state must not discard valid sibling rows.
+        self.failureGates[.codex]?.reset()
+        self.lastKnownSessionRemaining.removeValue(forKey: .codex)
+        self.lastKnownSessionWindowSource.removeValue(forKey: .codex)
+        self.lastKnownResetSnapshots.removeValue(forKey: .codex)
+        self.lastCodexUsagePublicationGuard = nil
+    }
+
+    @discardableResult
+    func reconcileCodexPublishedUsageOwner(
+        with currentGuard: CodexAccountScopedRefreshGuard,
+        persistWidgetSnapshot: Bool = true) -> Bool
+    {
+        let hasPublishedUsageState = self.snapshots[.codex] != nil ||
+            self.lastKnownResetSnapshots[.codex] != nil ||
+            self.errors[.codex] != nil ||
+            self.lastSourceLabels[.codex] != nil ||
+            self.lastFetchAttempts[.codex] != nil
+        guard hasPublishedUsageState else { return false }
+        guard self.lastCodexUsagePublicationGuard.map({
+            Self.codexScopedRefreshGuardsMatchAccount($0, currentGuard)
+        }) == true
+        else {
+            self.clearCodexPublishedUsageState()
+            if persistWidgetSnapshot {
+                self.persistWidgetSnapshot(reason: "codex-account-invalidate")
+            }
+            return true
+        }
+        return false
+    }
+
+    func reconcileCodexAccountStateForUsageOwner(_ currentGuard: CodexAccountScopedRefreshGuard) {
+        let clearedUsage = self.reconcileCodexPublishedUsageOwner(
+            with: currentGuard,
+            persistWidgetSnapshot: false)
+        let invalidatedAccountState = self.prepareCodexAccountScopedRefreshIfNeeded(
+            currentGuardOverride: currentGuard)
+        if clearedUsage, !invalidatedAccountState {
+            self.persistWidgetSnapshot(reason: "codex-account-invalidate")
+        }
     }
 
     func seedCodexAccountScopedRefreshGuard(
@@ -196,13 +241,12 @@ extension UsageStore {
             currentGuard: currentGuard)
 
         if expectedGuard.identity != .unresolved {
-            guard currentGuard.identity == expectedGuard.identity else { return false }
+            guard Self.codexGuardIdentityAndEmailMatch(currentGuard, expectedGuard) else { return false }
+            guard resultMatchesCurrentAccountKey else { return false }
             if fingerprintsAllowApply {
-                guard case .managedAccount = currentGuard.source else { return true }
-                return resultMatchesCurrentAccountKey
+                return true
             }
             guard canProveNilToCurrentAuth else { return false }
-            guard resultMatchesCurrentAccountKey else { return false }
             return resultIdentity == currentGuard.identity ||
                 (resultAccountKey != nil && resultAccountKey == currentGuard.accountKey)
         }
@@ -215,7 +259,9 @@ extension UsageStore {
         switch currentGuard.source {
         case .liveSystem:
             guard resultIdentity != .unresolved else { return false }
-            if fingerprintsAllowApply { return true }
+            if fingerprintsAllowApply {
+                return true
+            }
             guard canProveNilToCurrentAuth else { return false }
             guard let currentAccountKey = currentGuard.accountKey else { return true }
             return resultAccountKey == currentAccountKey
@@ -232,7 +278,7 @@ extension UsageStore {
         guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
-            return currentGuard.identity == expectedGuard.identity
+            return Self.codexGuardIdentityAndEmailMatch(currentGuard, expectedGuard)
         }
 
         return currentGuard.identity == .unresolved
@@ -245,7 +291,7 @@ extension UsageStore {
         guard currentGuard.source == expectedGuard.source else { return nil }
         guard Self.codexGuardAuthFingerprintAllowsUsageApply(currentGuard, expectedGuard) else { return nil }
         guard expectedGuard.identity != .unresolved else { return nil }
-        guard currentGuard.identity == expectedGuard.identity else { return nil }
+        guard Self.codexGuardIdentityAndEmailMatch(currentGuard, expectedGuard) else { return nil }
         return currentGuard
     }
 
@@ -258,7 +304,7 @@ extension UsageStore {
         guard currentGuard.source == expectedGuard.source else { return false }
         guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
         guard expectedGuard.identity != .unresolved else { return false }
-        return currentGuard.identity == expectedGuard.identity
+        return Self.codexGuardIdentityAndEmailMatch(currentGuard, expectedGuard)
     }
 
     func shouldApplyOpenAIDashboardRefreshGuard(
@@ -271,7 +317,7 @@ extension UsageStore {
         guard Self.codexGuardAuthFingerprintAllowsUsageApply(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
-            return currentGuard.identity == expectedGuard.identity
+            return Self.codexGuardIdentityAndEmailMatch(currentGuard, expectedGuard)
         }
 
         guard case .liveSystem = expectedGuard.source else { return false }
@@ -292,7 +338,7 @@ extension UsageStore {
         guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
-            return currentGuard.identity == expectedGuard.identity
+            return Self.codexGuardIdentityAndEmailMatch(currentGuard, expectedGuard)
         }
 
         guard case .liveSystem = expectedGuard.source else { return false }
@@ -312,9 +358,11 @@ extension UsageStore {
         guard currentGuard.source == expectedGuard.source else { return false }
 
         if expectedGuard.identity != .unresolved {
-            guard currentGuard.identity == expectedGuard.identity else { return false }
-            return Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) ||
-                Self.codexGuardAuthFingerprintAllowsSameProviderAccount(currentGuard, expectedGuard)
+            if Self.codexGuardIdentityAndEmailMatch(currentGuard, expectedGuard) {
+                return Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) ||
+                    Self.codexGuardAuthFingerprintAllowsUsageApply(currentGuard, expectedGuard)
+            }
+            return Self.codexGuardAuthFingerprintAllowsProviderTransitionCleanup(currentGuard, expectedGuard)
         }
 
         guard case .liveSystem = expectedGuard.source else { return false }
@@ -416,20 +464,26 @@ extension UsageStore {
         let lhsFingerprint = CodexAuthFingerprint.normalize(lhs.authFingerprint)
         let rhsFingerprint = CodexAuthFingerprint.normalize(rhs.authFingerprint)
         guard lhsFingerprint != nil, rhsFingerprint != nil else { return false }
-        guard case .providerAccount = rhs.identity, lhs.identity == rhs.identity else { return false }
+        guard case .providerAccount = rhs.identity,
+              self.codexGuardIdentityAndEmailMatch(lhs, rhs)
+        else { return false }
         guard case .liveSystem = lhs.source else { return true }
-        return lhs.accountKey != nil && lhs.accountKey == rhs.accountKey
+        return true
     }
 
-    private nonisolated static func codexGuardAuthFingerprintAllowsSameProviderAccount(
+    private nonisolated static func codexGuardAuthFingerprintAllowsProviderTransitionCleanup(
         _ lhs: CodexAccountScopedRefreshGuard,
         _ rhs: CodexAccountScopedRefreshGuard) -> Bool
     {
         let lhsFingerprint = CodexAuthFingerprint.normalize(lhs.authFingerprint)
         let rhsFingerprint = CodexAuthFingerprint.normalize(rhs.authFingerprint)
-        guard lhsFingerprint != nil, rhsFingerprint != nil else { return false }
+        guard let lhsFingerprint, let rhsFingerprint, lhsFingerprint != rhsFingerprint else { return false }
         guard case .providerAccount = rhs.identity else { return false }
-        return lhs.identity == rhs.identity
+        guard lhs.identity == rhs.identity else { return false }
+        guard let lhsEmail = CodexIdentityResolver.normalizeEmail(lhs.accountKey),
+              let rhsEmail = CodexIdentityResolver.normalizeEmail(rhs.accountKey)
+        else { return false }
+        return lhsEmail != rhsEmail
     }
 
     nonisolated static func codexScopedRefreshGuardsMatchAccount(
@@ -437,14 +491,29 @@ extension UsageStore {
         _ rhs: CodexAccountScopedRefreshGuard) -> Bool
     {
         guard lhs.source == rhs.source else { return false }
-        if lhs == rhs { return true }
+        if lhs == rhs {
+            guard case .providerAccount = lhs.identity else { return true }
+            return self.codexGuardIdentityAndEmailMatch(lhs, rhs)
+        }
         guard lhs.identity != .unresolved,
-              lhs.identity == rhs.identity,
+              self.codexGuardIdentityAndEmailMatch(lhs, rhs),
               lhs.accountKey == rhs.accountKey
         else {
             return false
         }
         return self.codexGuardAuthFingerprintAllowsUsageApply(lhs, rhs)
+    }
+
+    private nonisolated static func codexGuardIdentityAndEmailMatch(
+        _ lhs: CodexAccountScopedRefreshGuard,
+        _ rhs: CodexAccountScopedRefreshGuard) -> Bool
+    {
+        guard lhs.identity == rhs.identity else { return false }
+        guard case .providerAccount = lhs.identity else { return true }
+        guard let lhsEmail = CodexIdentityResolver.normalizeEmail(lhs.accountKey),
+              let rhsEmail = CodexIdentityResolver.normalizeEmail(rhs.accountKey)
+        else { return false }
+        return lhsEmail == rhsEmail
     }
 
     private nonisolated static func codexUsageResultAccountKeyMatchesCurrentGuard(

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
@@ -97,6 +97,7 @@ extension UsageStore {
             guard !Task.isCancelled else { return }
             guard let applyGuard = self.codexScopedNonUsageSuccessApplyGuard(
                 expectedGuard: expectedGuard) else { return }
+            self.reconcileCodexPublishedUsageOwner(with: applyGuard)
             await MainActor.run {
                 self.credits = credits
                 self.lastCreditsError = nil
@@ -128,6 +129,7 @@ extension UsageStore {
             let message = error.localizedDescription
             if message.localizedCaseInsensitiveContains("data not available yet") {
                 guard self.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard) else { return }
+                self.reconcileCodexPublishedUsageOwner(with: expectedGuard)
                 await MainActor.run {
                     if let cached = self.lastCreditsSnapshot,
                        self.lastCreditsSnapshotAccountKey == expectedGuard.accountKey
@@ -145,6 +147,7 @@ extension UsageStore {
             }
 
             guard self.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard) else { return }
+            self.reconcileCodexPublishedUsageOwner(with: expectedGuard)
             await MainActor.run {
                 self.creditsFailureStreak += 1
                 if let cached = self.lastCreditsSnapshot,
@@ -194,7 +197,9 @@ extension UsageStore {
         let deadline = Date().addingTimeInterval(Self.codexSnapshotWaitTimeoutSeconds)
 
         while Date() < deadline {
-            if Task.isCancelled { return nil }
+            if Task.isCancelled {
+                return nil
+            }
             if let snapshot = await MainActor.run(body: { self.snapshots[.codex] }),
                snapshot.updatedAt >= minimumUpdatedAt
             {
@@ -211,7 +216,9 @@ extension UsageStore {
         let refreshStartDeadline = Date().addingTimeInterval(Self.codexRefreshStartGraceSeconds)
 
         while Date() < deadline {
-            if Task.isCancelled { return nil }
+            if Task.isCancelled {
+                return nil
+            }
             let state = await MainActor.run {
                 (
                     snapshot: self.snapshots[.codex],

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexWeeklyResetConfirmation.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexWeeklyResetConfirmation.swift
@@ -1,0 +1,90 @@
+import CodexBarCore
+
+extension UsageStore {
+    typealias CodexWeeklyConfirmationFetch = @Sendable () async -> ProviderFetchOutcome
+
+    nonisolated static func codexOutcomeAdmittedForPublication(
+        initialOutcome: ProviderFetchOutcome,
+        previousSnapshot: UsageSnapshot?,
+        missingWindowBackfillSnapshot: UsageSnapshot?,
+        fetchConfirmation: @escaping CodexWeeklyConfirmationFetch) async -> ProviderFetchOutcome?
+    {
+        guard case let .success(rawInitialResult) = initialOutcome.result else { return initialOutcome }
+        let rawInitialSnapshot = rawInitialResult.usage.scoped(to: .codex)
+        let publicationBaseline = [previousSnapshot, missingWindowBackfillSnapshot]
+            .compactMap(\.self)
+            .max { $0.updatedAt < $1.updatedAt }
+        let publicationInitialOutcome = if let missingWindowBackfillSnapshot {
+            initialOutcome.replacingUsage(Self.codexBackfillingResetWindows(
+                rawInitialSnapshot,
+                from: missingWindowBackfillSnapshot))
+        } else {
+            initialOutcome
+        }
+
+        if CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: rawInitialSnapshot) == nil {
+            guard rawInitialSnapshot.updatedAt.timeIntervalSinceReferenceDate.isFinite,
+                  previousSnapshot.map({
+                      $0.updatedAt.timeIntervalSinceReferenceDate.isFinite &&
+                          rawInitialSnapshot.updatedAt > $0.updatedAt
+                  }) ?? true,
+                  missingWindowBackfillSnapshot.map({
+                      $0.updatedAt.timeIntervalSinceReferenceDate.isFinite &&
+                          rawInitialSnapshot.updatedAt >= $0.updatedAt
+                  }) ?? true
+            else {
+                return nil
+            }
+            if CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: publicationBaseline) != nil,
+               case let .success(publicationResult) = publicationInitialOutcome.result,
+               CodexConsumerProjection.sourceRateWindow(
+                   for: .weekly,
+                   snapshot: publicationResult.usage.scoped(to: .codex)) == nil
+            {
+                return nil
+            }
+            return publicationInitialOutcome
+        }
+
+        switch CodexWeeklyResetConfirmation.initialDecision(
+            previous: publicationBaseline,
+            initial: rawInitialSnapshot)
+        {
+        case .publishInitial:
+            return publicationInitialOutcome
+        case .preservePrevious:
+            return nil
+        case .requiresConfirmation:
+            break
+        }
+
+        guard !Task.isCancelled else { return nil }
+        let confirmationOutcome = await fetchConfirmation()
+        guard !Task.isCancelled,
+              case let .success(confirmationResult) = confirmationOutcome.result
+        else {
+            return nil
+        }
+        let confirmationSnapshot = confirmationResult.usage.scoped(to: .codex)
+        guard CodexIdentityResolver.normalizeEmail(rawInitialSnapshot.accountEmail(for: .codex)) ==
+            CodexIdentityResolver.normalizeEmail(confirmationSnapshot.accountEmail(for: .codex))
+        else {
+            return nil
+        }
+        switch CodexWeeklyResetConfirmation.confirmationDecision(
+            previous: publicationBaseline,
+            initial: rawInitialSnapshot,
+            confirmation: confirmationSnapshot)
+        {
+        case .publishConfirmation:
+            if let missingWindowBackfillSnapshot {
+                return confirmationOutcome.replacingUsage(Self.codexBackfillingResetWindows(
+                    confirmationSnapshot,
+                    from: missingWindowBackfillSnapshot))
+            }
+            return confirmationOutcome
+        case .preservePrevious:
+            return nil
+        }
+    }
+}

--- a/Sources/CodexBar/StatusItemController+AccountMenuDisplay.swift
+++ b/Sources/CodexBar/StatusItemController+AccountMenuDisplay.swift
@@ -116,11 +116,12 @@ extension StatusItemController {
     }
 
     private func codexAccountSnapshots(matching accounts: [CodexVisibleAccount]) -> [CodexAccountUsageSnapshot] {
-        var snapshotsByID: [String: CodexAccountUsageSnapshot] = [:]
-        for snapshot in self.store.codexAccountSnapshots {
-            snapshotsByID[snapshot.id] = snapshot
+        accounts.compactMap { account in
+            self.store.codexAccountSnapshots.first { snapshot in
+                snapshot.id == account.id &&
+                    UsageStore.codexPriorSnapshotAccountMatches(snapshot.account, account: account)
+            }
         }
-        return accounts.compactMap { snapshotsByID[$0.id] }
     }
 
     func stableCodexAccountMenuDisplay(

--- a/Sources/CodexBar/UsageStore+CodexResetCredits.swift
+++ b/Sources/CodexBar/UsageStore+CodexResetCredits.swift
@@ -107,7 +107,7 @@ extension UsageStore {
 }
 
 extension ProviderFetchOutcome {
-    fileprivate func replacingUsage(_ usage: UsageSnapshot) -> ProviderFetchOutcome {
+    func replacingUsage(_ usage: UsageSnapshot) -> ProviderFetchOutcome {
         guard case let .success(result) = self.result else { return self }
         return ProviderFetchOutcome(
             result: .success(ProviderFetchResult(

--- a/Sources/CodexBar/UsageStore+LimitResetIdentity.swift
+++ b/Sources/CodexBar/UsageStore+LimitResetIdentity.swift
@@ -1,79 +1,32 @@
 import CodexBarCore
-import Foundation
 
 extension UsageStore {
-    func activeCodexVisibleAccountForLimitResetDetection() -> CodexVisibleAccount? {
-        let projection = self.settings.codexVisibleAccountProjection
-        guard let activeID = projection.activeVisibleAccountID else { return nil }
-        return projection.visibleAccounts.first { $0.id == activeID }
-    }
-
     func limitResetAccountIdentifier(
         provider: UsageProvider,
         account: ProviderTokenAccount?,
         snapshot: UsageSnapshot,
         accountKey: String?,
-        codexVisibleAccount: CodexVisibleAccount?) -> String
+        codexLimitResetOwnerKey: CodexLimitResetOwnerKey?) -> String?
     {
+        if provider == .codex {
+            return codexLimitResetOwnerKey?.rawValue
+        }
         let identity = snapshot.identity(for: provider)
-        if let account {
-            return account.id.uuidString.lowercased()
-        }
-        if provider == .codex,
-           let codexIdentifier = self.codexLimitResetDetectorAccountIdentifier(
-               snapshot: snapshot,
-               accountKey: accountKey,
-               visibleAccount: codexVisibleAccount)
-        {
-            return codexIdentifier
-        }
-        return accountKey
+        return account?.id.uuidString.lowercased()
+            ?? accountKey
             ?? identity?.accountEmail
             ?? identity?.accountOrganization
             ?? provider.rawValue
     }
 
-    func codexLimitResetDetectorAccountIdentifier(
-        snapshot: UsageSnapshot,
-        accountKey: String?,
-        visibleAccount: CodexVisibleAccount?) -> String?
+    func limitResetAccountLabel(
+        provider: UsageProvider,
+        account: ProviderTokenAccount?,
+        snapshot: UsageSnapshot) -> String?
     {
-        let ownership = if let visibleAccount {
-            self.codexOwnershipContext(forVisibleAccount: visibleAccount)
-        } else {
-            self.codexOwnershipContext(snapshot: snapshot, includeDashboardFallback: false)
-        }
-        if let canonicalKey = ownership.canonicalKey,
-           CodexHistoryOwnership.isCanonicalProviderAccountKey(canonicalKey)
-        {
-            return canonicalKey
-        }
-
-        if let visibleAccount,
-           let accountKey = ownership.canonicalKey ?? accountKey,
-           let workspaceDiscriminator = Self.codexLimitResetWorkspaceDiscriminator(visibleAccount)
-        {
-            return Self.sha256Hex(
-                "codex:limit-reset:\(accountKey):workspace:\(workspaceDiscriminator)")
-        }
-
-        return ownership.canonicalKey ?? accountKey
-    }
-
-    private nonisolated static func codexLimitResetWorkspaceDiscriminator(
-        _ account: CodexVisibleAccount) -> String?
-    {
-        if let storedAccountID = account.storedAccountID {
-            return "managed:\(storedAccountID.uuidString.lowercased())"
-        }
-        if case let .profileHome(path) = account.selectionSource {
-            return "profile:\(path)"
-        }
-        let workspaceLabel = account.workspaceLabel?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if let workspaceLabel, !workspaceLabel.isEmpty {
-            return "workspace-label:\(workspaceLabel.lowercased())"
-        }
-        return CodexAuthFingerprint.normalize(account.authFingerprint).map { "auth:\($0)" }
+        let identity = snapshot.identity(for: provider)
+        return account?.label
+            ?? identity?.accountEmail
+            ?? identity?.accountOrganization
     }
 }

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -140,6 +140,9 @@ extension UsageStore {
         }
 
         let attachedAccountEmail = self.codexDashboardAttachmentEmail(from: authority.input)
+        self.reconcileCodexPublishedUsageOwner(with: self.freshCodexAccountScopedRefreshGuard(
+            preferCurrentSnapshot: true,
+            allowLastKnownLiveFallback: false))
 
         await self.applyOpenAIDashboardAuthorityDecision(
             authority.decision,
@@ -255,12 +258,16 @@ extension UsageStore {
             if decision.allowedEffects.contains(.usageBackfill),
                allowCodexUsageBackfill,
                self.snapshots[.codex] == nil,
-               let usage = dashboard.toUsageSnapshot(provider: .codex, accountEmail: attachedAccountEmail)
+               let usage = dashboard.toUsageSnapshot(provider: .codex, accountEmail: attachedAccountEmail),
+               CodexWeeklyResetConfirmation.initialDecision(previous: nil, initial: usage) == .publishInitial
             {
                 self.snapshots[.codex] = usage
                 self.errors[.codex] = nil
                 self.failureGates[.codex]?.recordSuccess()
                 self.lastSourceLabels[.codex] = "openai-web"
+                self.lastCodexUsagePublicationGuard = self.currentCodexAccountScopedRefreshGuard(
+                    preferCurrentSnapshot: true,
+                    allowLastKnownLiveFallback: false)
             }
 
             if decision.allowedEffects.contains(.creditsAttachment),
@@ -336,15 +343,7 @@ extension UsageStore {
 
     private func clearDashboardDerivedCodexUsageIfNeeded() {
         guard self.lastSourceLabels[.codex] == "openai-web" else { return }
-        self.snapshots.removeValue(forKey: .codex)
-        self.errors[.codex] = nil
-        self.lastSourceLabels.removeValue(forKey: .codex)
-        self.lastFetchAttempts.removeValue(forKey: .codex)
-        self.accountSnapshots.removeValue(forKey: .codex)
-        self.codexAccountSnapshots = []
-        self.failureGates[.codex]?.reset()
-        self.lastKnownSessionRemaining.removeValue(forKey: .codex)
-        self.lastKnownSessionWindowSource.removeValue(forKey: .codex)
+        self.clearCodexPublishedUsageState()
     }
 
     private func clearDashboardDerivedCreditsIfNeeded() {
@@ -358,9 +357,17 @@ extension UsageStore {
     }
 
     private func clearDashboardRefreshGuardSeedIfNeeded() {
-        self.lastCodexAccountScopedRefreshGuard = self.currentCodexAccountScopedRefreshGuard(
+        let currentGuard = self.currentCodexAccountScopedRefreshGuard(
             preferCurrentSnapshot: false,
             allowLastKnownLiveFallback: false)
+        if self.snapshots[.codex] != nil,
+           self.lastCodexUsagePublicationGuard.map({
+               !Self.codexScopedRefreshGuardsMatchAccount($0, currentGuard)
+           }) ?? true
+        {
+            self.clearCodexPublishedUsageState()
+        }
+        self.lastCodexAccountScopedRefreshGuard = currentGuard
     }
 
     private func openAIDashboardPolicyFailureMessage(
@@ -900,7 +907,9 @@ extension UsageStore {
 
             if allowLastKnownLiveFallback {
                 let lastKnown = self.lastKnownLiveSystemCodexEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
-                if let lastKnown, !lastKnown.isEmpty { return lastKnown }
+                if let lastKnown, !lastKnown.isEmpty {
+                    return lastKnown
+                }
             }
             return nil
         case .managedAccount:
@@ -1254,7 +1263,9 @@ extension UsageStore {
                 } else {
                     found
                         .sorted { lhs, rhs in
-                            if lhs.sourceLabel == rhs.sourceLabel { return lhs.email < rhs.email }
+                            if lhs.sourceLabel == rhs.sourceLabel {
+                                return lhs.email < rhs.email
+                            }
                             return lhs.sourceLabel < rhs.sourceLabel
                         }
                         .map { "\($0.sourceLabel): \($0.email)" }
@@ -1382,7 +1393,9 @@ extension UsageStore {
 
             guard allowLastKnownLiveFallback else { return nil }
             let lastKnown = self.lastKnownLiveSystemCodexEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let lastKnown, !lastKnown.isEmpty { return lastKnown }
+            if let lastKnown, !lastKnown.isEmpty {
+                return lastKnown
+            }
             return nil
         case .managedAccount:
             if self.openAIWebManagedTargetStoreIsUnreadable() {
@@ -1391,12 +1404,16 @@ extension UsageStore {
 
             let managed = self.currentManagedCodexRuntimeEmail()?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            if let managed, !managed.isEmpty { return managed }
+            if let managed, !managed.isEmpty {
+                return managed
+            }
             return nil
         case let .profileHome(path):
             let profile = self.currentProfileCodexRuntimeEmail(path: path)?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            if let profile, !profile.isEmpty { return profile }
+            if let profile, !profile.isEmpty {
+                return profile
+            }
             return nil
         }
     }
@@ -1427,7 +1444,9 @@ extension UsageStore {
     }
 
     nonisolated static func shouldSkipOpenAIWebRefresh(_ context: OpenAIWebRefreshGateContext) -> Bool {
-        if context.force || context.accountDidChange { return false }
+        if context.force || context.accountDidChange {
+            return false
+        }
         if let lastAttemptAt = context.lastAttemptAt,
            context.now.timeIntervalSince(lastAttemptAt) < context.refreshInterval
         {
@@ -1443,7 +1462,9 @@ extension UsageStore {
     }
 
     nonisolated static func shouldSkipOpenAIWebEmptyHistoryRetry(_ context: OpenAIWebRefreshGateContext) -> Bool {
-        if context.force || context.accountDidChange { return false }
+        if context.force || context.accountDidChange {
+            return false
+        }
         guard let lastAttemptAt = context.lastAttemptAt,
               context.now.timeIntervalSince(lastAttemptAt) < context.refreshInterval
         else { return false }

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -78,7 +78,7 @@ extension UsageStore {
         let snapshot: UsageSnapshot
         let accountKey: String?
         let capturedAt: Date
-        let codexVisibleAccount: CodexVisibleAccount?
+        let codexLimitResetOwnerKey: CodexLimitResetOwnerKey?
     }
 
     private struct LimitResetObservation {
@@ -183,7 +183,7 @@ extension UsageStore {
         isClaudeOAuthSample: Bool = false,
         shouldUpdatePreferredAccountKey: Bool = true,
         shouldAdoptUnscopedHistory: Bool = true,
-        codexVisibleAccount: CodexVisibleAccount? = nil,
+        codexLimitResetOwnerKey: CodexLimitResetOwnerKey? = nil,
         now: Date = Date())
         async
     {
@@ -213,18 +213,13 @@ extension UsageStore {
             // Persisting without a high-entropy owner would merge unrelated OAuth accounts into `unscoped`.
             return
         }
-        let effectiveCodexVisibleAccount: CodexVisibleAccount? = if provider == .codex {
-            codexVisibleAccount ?? self.activeCodexVisibleAccountForLimitResetDetection()
-        } else {
-            nil
-        }
         let detectorContext = LimitResetDetectionContext(
             provider: provider,
             account: account,
             snapshot: snapshot,
             accountKey: detectorAccountKey,
             capturedAt: now,
-            codexVisibleAccount: effectiveCodexVisibleAccount)
+            codexLimitResetOwnerKey: codexLimitResetOwnerKey)
         await MainActor.run {
             self.postLimitResetCelebrationsIfNeeded(
                 context: detectorContext,
@@ -474,12 +469,15 @@ extension UsageStore {
     {
         guard let observation else { return }
 
-        let accountIdentifier = self.limitResetAccountIdentifier(
+        guard let accountIdentifier = self.limitResetAccountIdentifier(
             provider: context.provider,
             account: context.account,
             snapshot: context.snapshot,
             accountKey: context.accountKey,
-            codexVisibleAccount: context.codexVisibleAccount)
+            codexLimitResetOwnerKey: context.codexLimitResetOwnerKey)
+        else {
+            return
+        }
         let detectorKey = Self.limitResetDetectorStateKey(
             provider: context.provider,
             accountIdentifier: accountIdentifier)
@@ -878,17 +876,6 @@ extension UsageStore {
 
     private func shouldDeferClaudePlanUtilizationHistory(provider: UsageProvider) -> Bool {
         provider == .claude && self.shouldHidePlanUtilizationMenuItem(for: .claude)
-    }
-
-    private func limitResetAccountLabel(
-        provider: UsageProvider,
-        account: ProviderTokenAccount?,
-        snapshot: UsageSnapshot) -> String?
-    {
-        let identity = snapshot.identity(for: provider)
-        return account?.label
-            ?? identity?.accountEmail
-            ?? identity?.accountOrganization
     }
 
     private nonisolated static func limitResetDetectorStateKey(

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -5,8 +5,16 @@ extension UsageStore {
     private struct ProviderRefreshOutcomeContext {
         let generation: UInt64
         let codexExpectedGuard: CodexAccountScopedRefreshGuard?
+        let codexLimitResetOwnerKey: CodexLimitResetOwnerKey?
         let claudeOAuthHistoryPersistentRefHash: String?
         let claudeOAuthActiveAccountObservation: ClaudeOAuthActiveAccountObservation
+    }
+
+    private struct CodexRefreshPublicationPreparation {
+        let expectedGuard: CodexAccountScopedRefreshGuard
+        let limitResetOwnerKey: CodexLimitResetOwnerKey?
+        let previousSnapshot: UsageSnapshot?
+        let missingWindowBackfillSnapshot: UsageSnapshot?
     }
 
     static func commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
@@ -128,6 +136,64 @@ extension UsageStore {
             generation: generation)
     }
 
+    private func prepareCodexRefreshPublication() -> CodexRefreshPublicationPreparation {
+        let previousGuard = self.lastCodexUsagePublicationGuard
+        let expectedGuard = self.freshCodexAccountScopedRefreshGuard()
+        let hydrationCandidates = self.codexAccountSnapshots
+        let projection = self.settings.codexVisibleAccountProjection
+        let visibleAccounts = projection.visibleAccounts
+        let ownerKey = self.codexLimitResetOwnerKey(
+            expectedGuard: expectedGuard,
+            visibleAccounts: visibleAccounts)
+        let previousOwnerKey = previousGuard.flatMap {
+            CodexLimitResetOwnerKey(identity: $0.identity, accountEmail: $0.accountKey)
+        }
+        let ownerMatchesPrevious = ownerKey != nil && ownerKey == previousOwnerKey
+        self.reconcileCodexAccountStateForUsageOwner(expectedGuard)
+
+        let hydratedPrior: CodexAccountUsageSnapshot? = {
+            guard let ownerKey, let activeVisibleAccountID = projection.activeVisibleAccountID else { return nil }
+            let matches = hydrationCandidates.filter { row in
+                row.snapshot != nil &&
+                    row.id == activeVisibleAccountID &&
+                    self.codexLimitResetOwnerKey(
+                        forVisibleAccount: row.account,
+                        visibleAccounts: visibleAccounts) == ownerKey
+            }
+            guard matches.count == 1 else { return nil }
+            return matches[0]
+        }()
+        if self.snapshots[.codex] == nil,
+           let hydratedPrior,
+           let hydratedSnapshot = hydratedPrior.snapshot
+        {
+            self.snapshots[.codex] = hydratedSnapshot
+            self.lastKnownResetSnapshots[.codex] = hydratedSnapshot
+            self.errors[.codex] = hydratedPrior.error
+            self.lastSourceLabels[.codex] = hydratedPrior.sourceLabel
+            self.lastCodexUsagePublicationGuard = expectedGuard
+            self.lastCodexAccountScopedRefreshGuard = expectedGuard
+        }
+
+        var trustedCandidates = ownerMatchesPrevious
+            ? [self.snapshots[.codex], self.lastKnownResetSnapshots[.codex]].compactMap(\.self)
+            : []
+        if let hydratedSnapshot = hydratedPrior?.snapshot {
+            trustedCandidates.append(hydratedSnapshot)
+        }
+        let weeklyCandidates = trustedCandidates.filter {
+            CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: $0) != nil
+        }
+        let previousSnapshot = (weeklyCandidates.isEmpty ? trustedCandidates : weeklyCandidates)
+            .max { $0.updatedAt < $1.updatedAt }
+        let missingWindowBackfillSnapshot = Self.codexMergedResetBackfillSnapshot(trustedCandidates)
+        return CodexRefreshPublicationPreparation(
+            expectedGuard: expectedGuard,
+            limitResetOwnerKey: ownerKey,
+            previousSnapshot: previousSnapshot,
+            missingWindowBackfillSnapshot: missingWindowBackfillSnapshot)
+    }
+
     private func refreshProviderNow(
         _ provider: UsageProvider,
         allowDisabled: Bool,
@@ -136,7 +202,9 @@ extension UsageStore {
         self.prepareRefreshState(for: provider)
         guard let spec = await self.providerRefreshSpec(provider) else { return }
         guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
-        let codexExpectedGuard = provider == .codex ? self.freshCodexAccountScopedRefreshGuard() : nil
+        let codexPreparation = provider == .codex ? self.prepareCodexRefreshPublication() : nil
+        let codexExpectedGuard = codexPreparation?.expectedGuard
+        let codexLimitResetOwnerKey = codexPreparation?.limitResetOwnerKey
 
         if !spec.isEnabled(), !allowDisabled {
             await self.clearDisabledProviderRefreshState(provider)
@@ -183,20 +251,64 @@ extension UsageStore {
         let fetchContext = self.makeFetchContext(provider: provider, override: nil)
         let descriptor = spec.descriptor
         let codexResetCreditsFetcher = self.codexResetCreditsFetcher()
+        let previousCodexSnapshot = codexPreparation?.previousSnapshot
+        let codexMissingWindowBackfillSnapshot = codexPreparation?.missingWindowBackfillSnapshot
+        let fetchOutcome: @Sendable () async -> ProviderFetchOutcome = {
+            let outcome = await descriptor.fetchOutcome(context: fetchContext)
+            guard provider == .codex else { return outcome }
+            return await Self.attachingCodexResetCreditsIfNeeded(
+                to: outcome,
+                env: fetchContext.env,
+                fetcher: codexResetCreditsFetcher)
+        }
         // Keep provider fetch work off MainActor so slow keychain/process reads don't stall menu/UI responsiveness.
-        let outcome = await withTaskGroup(
+        let initialOutcome = await withTaskGroup(
             of: ProviderFetchOutcome.self,
             returning: ProviderFetchOutcome.self)
         { group in
-            group.addTask {
-                let outcome = await descriptor.fetchOutcome(context: fetchContext)
-                guard provider == .codex else { return outcome }
-                return await Self.attachingCodexResetCreditsIfNeeded(
-                    to: outcome,
-                    env: fetchContext.env,
-                    fetcher: codexResetCreditsFetcher)
-            }
+            group.addTask(operation: fetchOutcome)
             return await group.next()!
+        }
+        let outcome: ProviderFetchOutcome
+        if provider == .codex {
+            if case let .success(result) = initialOutcome.result,
+               let codexExpectedGuard,
+               !self.shouldApplyCodexUsageResult(
+                   expectedGuard: codexExpectedGuard,
+                   usage: result.usage.scoped(to: .codex))
+            {
+                self.retireCodexStateIfRefreshOwnerChanged(
+                    expectedGuard: codexExpectedGuard,
+                    generation: generation)
+                return
+            }
+            guard let admittedOutcome = await Self.codexOutcomeAdmittedForPublication(
+                initialOutcome: initialOutcome,
+                previousSnapshot: previousCodexSnapshot,
+                missingWindowBackfillSnapshot: codexMissingWindowBackfillSnapshot,
+                fetchConfirmation: fetchOutcome)
+            else {
+                if let codexExpectedGuard {
+                    self.retireCodexStateIfRefreshOwnerChanged(
+                        expectedGuard: codexExpectedGuard,
+                        generation: generation)
+                }
+                return
+            }
+            if case let .success(result) = admittedOutcome.result,
+               let codexExpectedGuard,
+               !self.shouldApplyCodexUsageResult(
+                   expectedGuard: codexExpectedGuard,
+                   usage: result.usage.scoped(to: .codex))
+            {
+                self.retireCodexStateIfRefreshOwnerChanged(
+                    expectedGuard: codexExpectedGuard,
+                    generation: generation)
+                return
+            }
+            outcome = admittedOutcome
+        } else {
+            outcome = initialOutcome
         }
         let claudeHistoryAccountState = provider == .claude
             ? await Self.captureClaudeHistoryAccountState()
@@ -236,6 +348,7 @@ extension UsageStore {
             context: ProviderRefreshOutcomeContext(
                 generation: generation,
                 codexExpectedGuard: codexExpectedGuard,
+                codexLimitResetOwnerKey: codexLimitResetOwnerKey,
                 claudeOAuthHistoryPersistentRefHash: claudeOAuthHistoryPersistentRefHash,
                 claudeOAuthActiveAccountObservation: claudeOAuthActiveAccountObservation))
     }
@@ -245,26 +358,43 @@ extension UsageStore {
         outcome: ProviderFetchOutcome,
         context: ProviderRefreshOutcomeContext) async
     {
-        await MainActor.run {
-            self.lastFetchAttempts[provider] = outcome.attempts
-        }
-
         switch outcome.result {
         case let .success(result):
-            let scoped = result.usage.scoped(to: provider)
+            let rawScoped = result.usage.scoped(to: provider)
             if provider == .codex,
                let codexExpectedGuard = context.codexExpectedGuard,
-               !self.shouldApplyCodexUsageResult(expectedGuard: codexExpectedGuard, usage: scoped)
+               !self.shouldApplyCodexUsageResult(expectedGuard: codexExpectedGuard, usage: rawScoped)
             {
+                self.retireCodexStateIfRefreshOwnerChanged(
+                    expectedGuard: codexExpectedGuard,
+                    generation: context.generation)
                 return
             }
+            let scoped = Self.codexUsageWithExpectedEmailIfMissing(
+                provider: provider,
+                usage: rawScoped,
+                expectedGuard: context.codexExpectedGuard)
             let backfilled = await MainActor.run { () -> UsageSnapshot? in
                 guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else {
                     return nil
                 }
-                let resetBackfillSource = provider == .codex
-                    ? self.codexLastKnownResetSnapshot(matching: context.codexExpectedGuard)
-                    : self.lastKnownResetSnapshots[provider]
+                if provider == .codex,
+                   let codexExpectedGuard = context.codexExpectedGuard,
+                   !self.shouldApplyCodexUsageResult(expectedGuard: codexExpectedGuard, usage: rawScoped)
+                {
+                    self.retireCodexStateIfRefreshOwnerChanged(
+                        expectedGuard: codexExpectedGuard,
+                        generation: context.generation)
+                    return nil
+                }
+                self.lastFetchAttempts[provider] = outcome.attempts
+                let resetBackfillSource = if provider == .codex {
+                    context.codexLimitResetOwnerKey == nil
+                        ? nil
+                        : self.codexLastKnownResetSnapshot(matching: context.codexExpectedGuard)
+                } else {
+                    self.lastKnownResetSnapshots[provider]
+                }
                 let stabilized = Self.commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
                     current: scoped,
                     previous: self.snapshots[provider])
@@ -306,6 +436,12 @@ extension UsageStore {
                 if provider == .codex {
                     self.rememberLiveSystemCodexEmailIfNeeded(scoped.accountEmail(for: .codex))
                     self.seedCodexAccountScopedRefreshGuard(accountEmail: scoped.accountEmail(for: .codex))
+                    self.lastCodexUsagePublicationGuard = self.lastCodexAccountScopedRefreshGuard
+                    self.persistSingleCodexAccountSnapshot(
+                        backfilled,
+                        sourceLabel: result.sourceLabel,
+                        expectedGuard: context.codexExpectedGuard,
+                        expectedOwnerKey: context.codexLimitResetOwnerKey)
                 }
                 return backfilled
             }
@@ -336,7 +472,8 @@ extension UsageStore {
                         || (result.claudeOAuthKeychainPersistentRefHash != nil
                             && claudeOAuthPersistentRefHash == nil)),
                 claudeOAuthActiveAccountObservation: context.claudeOAuthActiveAccountObservation,
-                isClaudeOAuthSample: isClaudeOAuthSample)
+                isClaudeOAuthSample: isClaudeOAuthSample,
+                codexLimitResetOwnerKey: context.codexLimitResetOwnerKey)
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             if let runtime = self.providerRuntimes[provider] {
                 let context = ProviderRuntimeContext(
@@ -347,21 +484,114 @@ extension UsageStore {
                 self.recordCodexHistoricalSampleIfNeeded(snapshot: backfilled)
             }
         case let .failure(error):
-            // Credential-change cleanup already ran above; cancellation is now safe to suppress.
-            guard !Self.errorIsCancellation(error) else { return }
             if provider == .codex,
                let codexExpectedGuard = context.codexExpectedGuard,
                !self.shouldApplyCodexScopedFailure(expectedGuard: codexExpectedGuard)
             {
+                self.retireCodexStateIfRefreshOwnerChanged(
+                    expectedGuard: codexExpectedGuard,
+                    generation: context.generation)
                 return
             }
+            // Credential-change cleanup already ran above; cancellation is now safe to suppress.
+            guard !Self.errorIsCancellation(error) else { return }
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
+            self.bindCodexFailurePublicationOwner(
+                provider: provider,
+                expectedGuard: context.codexExpectedGuard)
+            self.lastFetchAttempts[provider] = outcome.attempts
             self.recordStartupConnectivityRetryableFailure(error)
             await self.handleProviderFetchFailure(
                 provider: provider,
                 error: error,
                 generation: context.generation)
         }
+    }
+
+    private func bindCodexFailurePublicationOwner(
+        provider: UsageProvider,
+        expectedGuard: CodexAccountScopedRefreshGuard?)
+    {
+        guard provider == .codex, let expectedGuard else { return }
+        self.lastCodexUsagePublicationGuard = expectedGuard
+    }
+
+    private func retireCodexStateIfRefreshOwnerChanged(
+        expectedGuard: CodexAccountScopedRefreshGuard,
+        generation: UInt64)
+    {
+        guard self.isCurrentProviderRefreshGeneration(.codex, generation: generation) else { return }
+        let currentGuard = self.freshCodexAccountScopedRefreshGuard()
+        guard !Self.codexScopedRefreshGuardsMatchAccount(expectedGuard, currentGuard) else { return }
+        self.reconcileCodexAccountStateForUsageOwner(currentGuard)
+    }
+
+    private nonisolated static func codexUsageWithExpectedEmailIfMissing(
+        provider: UsageProvider,
+        usage: UsageSnapshot,
+        expectedGuard: CodexAccountScopedRefreshGuard?) -> UsageSnapshot
+    {
+        guard provider == .codex,
+              CodexIdentityResolver.normalizeEmail(usage.accountEmail(for: .codex)) == nil,
+              let accountEmail = CodexIdentityResolver.normalizeEmail(expectedGuard?.accountKey)
+        else {
+            return usage
+        }
+        let identity = usage.identity(for: .codex)
+        return usage.withIdentity(ProviderIdentitySnapshot(
+            providerID: .codex,
+            accountEmail: accountEmail,
+            accountOrganization: identity?.accountOrganization,
+            loginMethod: identity?.loginMethod))
+    }
+
+    private func persistSingleCodexAccountSnapshot(
+        _ snapshot: UsageSnapshot,
+        sourceLabel: String,
+        expectedGuard: CodexAccountScopedRefreshGuard?,
+        expectedOwnerKey: CodexLimitResetOwnerKey?)
+    {
+        guard let expectedGuard,
+              let expectedOwnerKey
+        else { return }
+
+        let currentGuard = self.freshCodexAccountScopedRefreshGuard()
+        guard Self.codexScopedRefreshGuardsMatchAccount(expectedGuard, currentGuard),
+              let currentOwnerKey = CodexLimitResetOwnerKey(
+                  identity: currentGuard.identity,
+                  accountEmail: currentGuard.accountKey),
+              currentOwnerKey == expectedOwnerKey
+        else { return }
+
+        let visibleAccounts = self.freshCodexVisibleAccountsForSnapshotHydration()
+        let activeMatches = visibleAccounts.filter {
+            $0.isActive &&
+                $0.selectionSource == currentGuard.source &&
+                CodexIdentityResolver.normalizeEmail($0.email) == currentGuard.accountKey
+        }
+        guard activeMatches.count == 1,
+              let account = activeMatches.first,
+              let snapshotEmail = CodexIdentityResolver.normalizeEmail(snapshot.accountEmail(for: .codex)),
+              snapshotEmail == CodexIdentityResolver.normalizeEmail(currentGuard.accountKey),
+              snapshotEmail == CodexIdentityResolver.normalizeEmail(account.email),
+              self.codexLimitResetOwnerKey(
+                  forVisibleAccount: account,
+                  visibleAccounts: visibleAccounts) == currentOwnerKey
+        else { return }
+
+        let identity = snapshot.identity(for: .codex)
+        let relabeled = snapshot.withIdentity(ProviderIdentitySnapshot(
+            providerID: .codex,
+            accountEmail: account.email,
+            accountOrganization: identity?.accountOrganization,
+            loginMethod: identity?.loginMethod ?? account.workspaceLabel))
+        let currentSnapshots = [CodexAccountUsageSnapshot(
+            account: account,
+            snapshot: relabeled,
+            error: nil,
+            sourceLabel: sourceLabel)]
+        self.codexAccountSnapshots = currentSnapshots
+        self.codexAccountUsageSnapshotStore?.store(currentSnapshots)
     }
 
     private func clearDisabledProviderRefreshState(_ provider: UsageProvider) async {
@@ -376,6 +606,7 @@ extension UsageStore {
             self.accountSnapshots.removeValue(forKey: provider)
             if provider == .codex {
                 self.codexAccountSnapshots = []
+                self.lastCodexUsagePublicationGuard = nil
             }
             if provider == .kilo {
                 self.kiloScopeSnapshots = []
@@ -711,8 +942,12 @@ extension UsageStore {
 
     private static func shouldPreservePriorSnapshot(after error: Error, hadPriorData: Bool) -> Bool {
         guard hadPriorData else { return false }
-        if error is CancellationError { return true }
-        if self.isPreservableNetworkTransportError(error) { return true }
+        if error is CancellationError {
+            return true
+        }
+        if self.isPreservableNetworkTransportError(error) {
+            return true
+        }
 
         let message = error.localizedDescription.lowercased()
         return message.contains("timed out") ||
@@ -746,7 +981,9 @@ extension UsageStore {
     }
 
     static func isStartupConnectivityRetryableError(_ error: Error) -> Bool {
-        if error is CancellationError { return false }
+        if error is CancellationError {
+            return false
+        }
 
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain {
@@ -774,7 +1011,9 @@ extension UsageStore {
     }
 
     private static func isClaudeUsageProbeTimeout(_ error: Error) -> Bool {
-        if case ClaudeStatusProbeError.timedOut = error { return true }
+        if case ClaudeStatusProbeError.timedOut = error {
+            return true
+        }
         return error.localizedDescription == ClaudeStatusProbeError.timedOut.localizedDescription
     }
 
@@ -783,7 +1022,9 @@ extension UsageStore {
     }
 
     private static func isClaudeWebSessionRefreshFailure(_ error: Error) -> Bool {
-        if case ClaudeWebAPIFetcher.FetchError.unauthorized = error { return true }
+        if case ClaudeWebAPIFetcher.FetchError.unauthorized = error {
+            return true
+        }
         return error.localizedDescription == ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription
     }
 

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -69,7 +69,18 @@ private struct TokenAccountFetchResult {
 private struct CodexAccountFetchResult {
     let index: Int
     let account: CodexVisibleAccount
-    let outcome: ProviderFetchOutcome
+    let outcome: ProviderFetchOutcome?
+    let limitResetOwnerKey: CodexLimitResetOwnerKey?
+}
+
+private struct CodexAccountFetchRequest {
+    let index: Int
+    let account: CodexVisibleAccount
+    let previousSnapshot: UsageSnapshot?
+    let missingWindowBackfillSnapshot: UsageSnapshot?
+    let limitResetOwnerKey: CodexLimitResetOwnerKey?
+    let descriptor: ProviderDescriptor
+    let context: ProviderFetchContext
 }
 
 private struct CodexManagedVisibleAccountRuntimeState {
@@ -79,8 +90,6 @@ private struct CodexManagedVisibleAccountRuntimeState {
 
 extension UsageStore {
     static let tokenAccountMenuSnapshotLimit = 6
-    private static let codexSessionWindowMinutes = 5 * 60
-    private static let codexWeeklyWindowMinutes = 7 * 24 * 60
 
     func freshCodexVisibleAccountsForSnapshotHydration() -> [CodexVisibleAccount] {
         self.freshCodexVisibleAccountProjectionForAccountRefresh().visibleAccounts
@@ -121,30 +130,44 @@ extension UsageStore {
         let originalVisibleAccount = originalVisibleAccountID.flatMap { id in
             accounts.first { $0.id == id }
         }
-        let priorByAccountID = Dictionary(uniqueKeysWithValues: self.codexAccountSnapshots.map { ($0.id, $0) })
+        let priorSnapshots = self.codexAccountSnapshots
         var snapshots: [CodexAccountUsageSnapshot] = []
         var selectedOutcome: ProviderFetchOutcome?
         var selectedAccount: CodexVisibleAccount?
         var selectedSnapshot: UsageSnapshot?
         var selectedSourceLabel: String?
-        var sawAnyNonCancellationOutcome = false
+        var selectedLimitResetOwnerKey: CodexLimitResetOwnerKey?
 
-        let results = await self.fetchCodexVisibleAccountOutcomes(accounts)
+        let results = await self.fetchCodexVisibleAccountOutcomes(
+            accounts,
+            allVisibleAccounts: projection.visibleAccounts,
+            priorSnapshots: priorSnapshots,
+            activeVisibleAccountID: originalVisibleAccountID)
         for result in results {
             let account = result.account
-            let outcome = result.outcome
-            let isCancellation = Self.outcomeIsCancellation(outcome)
-            if !isCancellation {
-                sawAnyNonCancellationOutcome = true
+            let priorSnapshot = Self.codexPriorAccountSnapshot(
+                matching: account,
+                in: priorSnapshots)
+            guard let outcome = result.outcome else {
+                if let priorSnapshot {
+                    snapshots.append(priorSnapshot)
+                }
+                if account.id == originalVisibleAccountID {
+                    selectedAccount = account
+                    selectedLimitResetOwnerKey = result.limitResetOwnerKey
+                }
+                continue
             }
             let resolved = self.resolveCodexAccountOutcome(
                 outcome,
                 account: account,
-                priorSnapshot: priorByAccountID[account.id],
-                resetBackfillSnapshots: self.codexResetBackfillSnapshots(
-                    for: account,
-                    priorSnapshot: priorByAccountID[account.id],
-                    activeVisibleAccountID: originalVisibleAccountID))
+                priorSnapshot: priorSnapshot,
+                resetBackfillSnapshots: result.limitResetOwnerKey == nil
+                    ? []
+                    : self.codexResetBackfillSnapshots(
+                        for: account,
+                        priorSnapshot: priorSnapshot,
+                        activeVisibleAccountID: originalVisibleAccountID))
             if let snapshot = resolved.snapshot {
                 snapshots.append(snapshot)
             }
@@ -153,6 +176,7 @@ extension UsageStore {
                 selectedAccount = account
                 selectedSnapshot = resolved.usage
                 selectedSourceLabel = resolved.sourceLabel
+                selectedLimitResetOwnerKey = result.limitResetOwnerKey
             }
         }
 
@@ -176,21 +200,32 @@ extension UsageStore {
                 error: snapshot.error,
                 sourceLabel: snapshot.sourceLabel)
         }
-        let shouldPreservePriorState = !sawAnyNonCancellationOutcome &&
-            currentSnapshots.allSatisfy { $0.snapshot == nil }
-        if !shouldPreservePriorState {
-            self.codexAccountSnapshots = currentSnapshots
-            self.codexAccountUsageSnapshotStore?.store(currentSnapshots)
-        }
+        self.codexAccountSnapshots = currentSnapshots
+        self.codexAccountUsageSnapshotStore?.store(currentSnapshots)
 
         let selectionStillMatches = self.codexVisibleSelectionStillMatches(
             originalVisibleAccountID: originalVisibleAccountID,
             originalSelectionSource: originalSelectionSource,
             originalAccount: originalVisibleAccount,
             currentProjection: currentProjection)
-        guard let selectedOutcome, let selectedAccount else { return }
+        guard let selectedOutcome, let selectedAccount else {
+            if selectionStillMatches,
+               let selectedID = currentProjection.activeVisibleAccountID,
+               let preserved = currentSnapshots.first(where: { $0.id == selectedID }),
+               let snapshot = preserved.snapshot
+            {
+                self.snapshots[.codex] = snapshot
+                self.lastKnownResetSnapshots[.codex] = snapshot
+                let publicationGuard = Self.codexScopedRefreshGuard(for: preserved.account)
+                self.lastCodexUsagePublicationGuard = publicationGuard
+                self.lastCodexAccountScopedRefreshGuard = publicationGuard
+            } else if !selectionStillMatches {
+                self.reconcileCodexAccountStateForUsageOwner(self.freshCodexAccountScopedRefreshGuard())
+            }
+            return
+        }
         guard selectionStillMatches else {
-            _ = self.prepareCodexAccountScopedRefreshIfNeeded()
+            self.reconcileCodexAccountStateForUsageOwner(self.freshCodexAccountScopedRefreshGuard())
             return
         }
 
@@ -217,10 +252,11 @@ extension UsageStore {
                     account: currentSelectedAccount,
                     snapshot: currentSelectedSnapshot,
                     sourceLabel: selectedSourceLabel,
+                    limitResetOwnerKey: selectedLimitResetOwnerKey,
                     generation: generation)
             }
         } else {
-            _ = self.prepareCodexAccountScopedRefreshIfNeeded()
+            self.reconcileCodexAccountStateForUsageOwner(self.freshCodexAccountScopedRefreshGuard())
         }
     }
 
@@ -238,7 +274,11 @@ extension UsageStore {
         if currentProjection.activeVisibleAccountID == originalVisibleAccountID,
            currentSelectionSource == originalSelectionSource
         {
-            return true
+            guard let originalAccount else { return true }
+            guard let currentActiveAccount else { return false }
+            return Self.codexVisibleAccountMatchesCurrentProjection(
+                originalAccount,
+                account: currentActiveAccount)
         }
         guard let originalAccount, let currentActiveAccount, currentSelectionSource == originalSelectionSource else {
             return false
@@ -359,8 +399,12 @@ extension UsageStore {
     {
         guard prior.selectionSource == account.selectionSource else { return false }
 
-        let priorEmail = CodexIdentityResolver.normalizeEmail(prior.email)
-        let accountEmail = CodexIdentityResolver.normalizeEmail(account.email)
+        guard let priorEmail = CodexIdentityResolver.normalizeEmail(prior.email),
+              let accountEmail = CodexIdentityResolver.normalizeEmail(account.email),
+              priorEmail == accountEmail
+        else {
+            return false
+        }
 
         let priorWorkspaceID = self.normalizedCodexVisibleAccountText(prior.workspaceAccountID)
             .map(CodexOpenAIWorkspaceIdentity.normalizeWorkspaceAccountID)
@@ -371,20 +415,7 @@ extension UsageStore {
             if !allowProviderAccountAuthFingerprintMismatch {
                 guard self.codexVisibleAccountAuthFingerprintMatches(prior, account: account) else { return false }
             }
-            switch account.selectionSource {
-            case .managedAccount:
-                if !self.codexVisibleAccountAuthFingerprintMatches(prior, account: account) {
-                    return priorEmail != nil && priorEmail == accountEmail
-                }
-                return true
-            case .liveSystem:
-                return priorEmail != nil && priorEmail == accountEmail
-            case .profileHome:
-                if !allowProviderAccountAuthFingerprintMismatch {
-                    guard self.codexVisibleAccountAuthFingerprintMatches(prior, account: account) else { return false }
-                }
-                return priorEmail != nil && priorEmail == accountEmail
-            }
+            return true
         }
 
         let priorAuthFingerprint = CodexAuthFingerprint.normalize(prior.authFingerprint)
@@ -393,7 +424,7 @@ extension UsageStore {
             guard priorAuthFingerprint == accountAuthFingerprint else { return false }
         }
 
-        return priorEmail != nil && priorEmail == accountEmail
+        return true
     }
 
     private static func codexVisibleAccountAuthFingerprintMatches(
@@ -505,6 +536,19 @@ extension UsageStore {
         return false
     }
 
+    private nonisolated static func codexUsageOutcomeMatchesVisibleAccount(
+        _ outcome: ProviderFetchOutcome,
+        account: CodexVisibleAccount) -> Bool
+    {
+        guard case let .success(result) = outcome.result else { return true }
+        guard let resultEmail = CodexIdentityResolver.normalizeEmail(
+            result.usage.scoped(to: .codex).accountEmail(for: .codex))
+        else {
+            return true
+        }
+        return resultEmail == CodexIdentityResolver.normalizeEmail(account.email)
+    }
+
     nonisolated static func errorIsCancellation(_ error: any Error) -> Bool {
         if error is CancellationError {
             return true
@@ -525,7 +569,9 @@ extension UsageStore {
         selected: ProviderTokenAccount?) -> [ProviderTokenAccount]
     {
         let limit = Self.tokenAccountMenuSnapshotLimit
-        if accounts.count <= limit { return accounts }
+        if accounts.count <= limit {
+            return accounts
+        }
         var limited = Array(accounts.prefix(limit))
         if let selected, !limited.contains(where: { $0.id == selected.id }) {
             limited.removeLast()
@@ -544,7 +590,9 @@ extension UsageStore {
             snapshots: snapshots,
             activeVisibleAccountID: activeVisibleAccountID)
         let limit = Self.tokenAccountMenuSnapshotLimit
-        if accounts.count <= limit { return accounts }
+        if accounts.count <= limit {
+            return accounts
+        }
         var limited = Array(accounts.prefix(limit))
         if let activeVisibleAccountID,
            let active = accounts.first(where: { $0.id == activeVisibleAccountID }),
@@ -615,23 +663,42 @@ extension UsageStore {
         }
     }
 
-    private func fetchCodexVisibleAccountOutcomes(_ accounts: [CodexVisibleAccount]) async
+    private func fetchCodexVisibleAccountOutcomes(
+        _ accounts: [CodexVisibleAccount],
+        allVisibleAccounts: [CodexVisibleAccount],
+        priorSnapshots: [CodexAccountUsageSnapshot],
+        activeVisibleAccountID: String?) async
     -> [CodexAccountFetchResult] {
         let resetCreditsFetcher = self.codexResetCreditsFetcher()
-        let requests: [(
-            index: Int,
-            account: CodexVisibleAccount,
-            descriptor: ProviderDescriptor,
-            context: ProviderFetchContext)] =
-            accounts.enumerated().map { index, account in
-                let descriptor = self.providerSpecs[.codex]?.descriptor ?? ProviderDescriptorRegistry
-                    .descriptor(for: .codex)
-                let context = self.makeFetchContext(
-                    provider: .codex,
-                    override: nil,
-                    codexActiveSourceOverride: account.selectionSource)
-                return (index, account, descriptor, context)
-            }
+        let requests: [CodexAccountFetchRequest] = accounts.enumerated().map { index, account in
+            let descriptor = self.providerSpecs[.codex]?.descriptor ?? ProviderDescriptorRegistry
+                .descriptor(for: .codex)
+            let context = self.makeFetchContext(
+                provider: .codex,
+                override: nil,
+                codexActiveSourceOverride: account.selectionSource)
+            let limitResetOwnerKey = self.codexLimitResetOwnerKey(
+                forVisibleAccount: account,
+                visibleAccounts: allVisibleAccounts)
+            let priorSnapshot = Self.codexPriorAccountSnapshot(
+                matching: account,
+                in: priorSnapshots)
+            let trustedBackfillSnapshots = limitResetOwnerKey == nil
+                ? []
+                : self.codexResetBackfillSnapshots(
+                    for: account,
+                    priorSnapshot: priorSnapshot,
+                    activeVisibleAccountID: activeVisibleAccountID)
+            let missingWindowBackfillSnapshot = Self.codexMergedResetBackfillSnapshot(trustedBackfillSnapshots)
+            return CodexAccountFetchRequest(
+                index: index,
+                account: account,
+                previousSnapshot: limitResetOwnerKey == nil ? nil : priorSnapshot?.snapshot,
+                missingWindowBackfillSnapshot: missingWindowBackfillSnapshot,
+                limitResetOwnerKey: limitResetOwnerKey,
+                descriptor: descriptor,
+                context: context)
+        }
 
         return await withTaskGroup(
             of: CodexAccountFetchResult.self,
@@ -639,15 +706,37 @@ extension UsageStore {
         { group in
             for request in requests {
                 group.addTask {
-                    let baseOutcome = await request.descriptor.fetchOutcome(context: request.context)
-                    let outcome = await Self.attachingCodexResetCreditsIfNeeded(
-                        to: baseOutcome,
-                        env: request.context.env,
-                        fetcher: resetCreditsFetcher)
+                    let fetchOutcome: CodexWeeklyConfirmationFetch = {
+                        let baseOutcome = await request.descriptor.fetchOutcome(context: request.context)
+                        return await Self.attachingCodexResetCreditsIfNeeded(
+                            to: baseOutcome,
+                            env: request.context.env,
+                            fetcher: resetCreditsFetcher)
+                    }
+                    let initialOutcome = await fetchOutcome()
+                    let outcome: ProviderFetchOutcome? = if Self.codexUsageOutcomeMatchesVisibleAccount(
+                        initialOutcome,
+                        account: request.account)
+                    {
+                        if let admitted = await Self.codexOutcomeAdmittedForPublication(
+                            initialOutcome: initialOutcome,
+                            previousSnapshot: request.previousSnapshot,
+                            missingWindowBackfillSnapshot: request.missingWindowBackfillSnapshot,
+                            fetchConfirmation: fetchOutcome),
+                            Self.codexUsageOutcomeMatchesVisibleAccount(admitted, account: request.account)
+                        {
+                            admitted
+                        } else {
+                            nil
+                        }
+                    } else {
+                        nil
+                    }
                     return CodexAccountFetchResult(
                         index: request.index,
                         account: request.account,
-                        outcome: outcome)
+                        outcome: outcome,
+                        limitResetOwnerKey: request.limitResetOwnerKey)
                 }
             }
 
@@ -745,11 +834,6 @@ extension UsageStore {
         let sourceLabel: String?
     }
 
-    private struct CodexResetBackfillWindowCandidate {
-        let window: RateWindow
-        let capturedAt: Date
-    }
-
     func tokenAccountErrorMessage(_ error: any Error) -> String? {
         guard !Self.errorIsCancellation(error) else { return nil }
         let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -780,59 +864,15 @@ extension UsageStore {
         {
             snapshots.append(lastKnown)
         }
-        if account.id != activeVisibleAccountID || self.codexCanUseHistoricalResetBackfill(for: account),
-           let history = self.codexPlanHistoryResetBackfillSnapshot(for: account)
-        {
-            snapshots.append(history)
-        }
+        // Plan history remains display-only: its legacy provider and email keys cannot prove
+        // the composite publication owner required for quota state.
         return snapshots
-    }
-
-    private func codexCanUseHistoricalResetBackfill(for account: CodexVisibleAccount) -> Bool {
-        let authFingerprint = CodexAuthFingerprint.normalize(account.authFingerprint)
-        let workspaceAccountID = Self.normalizedCodexVisibleAccountText(account.workspaceAccountID)
-            .map(CodexOpenAIWorkspaceIdentity.normalizeWorkspaceAccountID)
-        guard authFingerprint != nil, workspaceAccountID == nil else { return true }
-        return Self.codexScopedGuard(self.lastCodexAccountScopedRefreshGuard, matches: account)
-    }
-
-    private func codexPlanHistoryResetBackfillSnapshot(for account: CodexVisibleAccount) -> UsageSnapshot? {
-        let histories = self.codexPlanUtilizationHistories(forVisibleAccount: account)
-        guard !histories.isEmpty
-        else {
-            return nil
-        }
-
-        let now = Date()
-        let primaryCandidate = Self.codexResetBackfillWindowCandidate(
-            from: histories,
-            name: .session,
-            windowMinutes: Self.codexSessionWindowMinutes,
-            now: now)
-        let secondaryCandidate = Self.codexResetBackfillWindowCandidate(
-            from: histories,
-            name: .weekly,
-            windowMinutes: Self.codexWeeklyWindowMinutes,
-            now: now)
-        let primary = primaryCandidate?.window
-        let secondary = secondaryCandidate?.window
-        guard primary != nil || secondary != nil else { return nil }
-
-        return UsageSnapshot(
-            primary: primary,
-            secondary: secondary,
-            updatedAt: [primaryCandidate?.capturedAt, secondaryCandidate?.capturedAt].compactMap(\.self).max() ?? now,
-            identity: ProviderIdentitySnapshot(
-                providerID: .codex,
-                accountEmail: account.email,
-                accountOrganization: nil,
-                loginMethod: account.workspaceLabel))
     }
 
     private func codexLastKnownResetSnapshot(for account: CodexVisibleAccount) -> UsageSnapshot? {
         guard let snapshot = self.lastKnownResetSnapshots[.codex],
               Self.codexVisibleAccountEmailMatches(snapshot: snapshot, account: account),
-              Self.codexScopedGuard(self.lastCodexAccountScopedRefreshGuard, matches: account)
+              Self.codexScopedGuard(self.lastCodexUsagePublicationGuard, matches: account)
         else {
             return nil
         }
@@ -841,7 +881,7 @@ extension UsageStore {
 
     func codexLastKnownResetSnapshot(matching guardValue: CodexAccountScopedRefreshGuard?) -> UsageSnapshot? {
         guard let guardValue,
-              let lastGuard = self.lastCodexAccountScopedRefreshGuard,
+              let lastGuard = self.lastCodexUsagePublicationGuard,
               Self.codexScopedRefreshGuardAllowsResetBackfill(lastGuard, matching: guardValue)
         else {
             return nil
@@ -863,7 +903,7 @@ extension UsageStore {
         return true
     }
 
-    private nonisolated static func codexPriorSnapshotAccountMatches(
+    nonisolated static func codexPriorSnapshotAccountMatches(
         _ prior: CodexVisibleAccount,
         account: CodexVisibleAccount) -> Bool
     {
@@ -901,6 +941,22 @@ extension UsageStore {
 
         guard prior.id != prior.email, account.id != account.email else { return false }
         return prior.id == account.id
+    }
+
+    private nonisolated static func codexPriorAccountSnapshot(
+        matching account: CodexVisibleAccount,
+        in snapshots: [CodexAccountUsageSnapshot]) -> CodexAccountUsageSnapshot?
+    {
+        if let exact = snapshots.first(where: { $0.id == account.id }),
+           self.codexPriorSnapshotAccountMatches(exact.account, account: account)
+        {
+            return exact
+        }
+        let matches = snapshots.filter {
+            self.codexPriorSnapshotAccountMatches($0.account, account: account)
+        }
+        guard matches.count == 1 else { return nil }
+        return matches[0]
     }
 
     private nonisolated static func codexScopedGuard(
@@ -953,59 +1009,34 @@ extension UsageStore {
         return trimmed
     }
 
-    private nonisolated static func codexResetBackfillWindowCandidate(
-        from histories: [PlanUtilizationSeriesHistory],
-        name: PlanUtilizationSeriesName,
-        windowMinutes: Int,
-        now: Date) -> CodexResetBackfillWindowCandidate?
-    {
-        let candidate = histories.lazy
-            .filter { $0.name == name && name.canonicalWindowMinutes($0.windowMinutes) == windowMinutes }
-            .flatMap { history in
-                history.entries.map { entry in
-                    (capturedAt: entry.capturedAt, usedPercent: entry.usedPercent, resetsAt: entry.resetsAt)
-                }
-            }
-            .filter { $0.resetsAt.map { $0 > now } ?? false }
-            .max { lhs, rhs in
-                if lhs.capturedAt != rhs.capturedAt {
-                    return lhs.capturedAt < rhs.capturedAt
-                }
-                return (lhs.resetsAt ?? .distantPast) < (rhs.resetsAt ?? .distantPast)
-            }
-
-        guard let candidate, let resetsAt = candidate.resetsAt else { return nil }
-        return CodexResetBackfillWindowCandidate(
-            window: RateWindow(
-                usedPercent: candidate.usedPercent,
-                windowMinutes: windowMinutes,
-                resetsAt: resetsAt,
-                resetDescription: nil),
-            capturedAt: candidate.capturedAt)
-    }
-
-    private nonisolated static func codexBackfillingResetWindows(
+    nonisolated static func codexBackfillingResetWindows(
         _ snapshot: UsageSnapshot,
         from cached: UsageSnapshot) -> UsageSnapshot
     {
-        let primary = self.codexBackfillingResetWindow(snapshot.primary, from: cached.primary)
-        let secondary = self.codexBackfillingResetWindow(snapshot.secondary, from: cached.secondary)
+        let primary = self.codexBackfillingResetWindow(
+            CodexConsumerProjection.sourceRateWindow(for: .session, snapshot: snapshot),
+            from: CodexConsumerProjection.sourceRateWindow(for: .session, snapshot: cached))
+        let secondary = self.codexBackfillingResetWindow(
+            CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: snapshot),
+            from: CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: cached))
         guard primary != snapshot.primary || secondary != snapshot.secondary else { return snapshot }
         return snapshot.with(primary: primary, secondary: secondary)
     }
 
-    private nonisolated static func codexMergedResetBackfillSnapshot(
+    nonisolated static func codexMergedResetBackfillSnapshot(
         _ snapshots: [UsageSnapshot],
         now: Date = Date()) -> UsageSnapshot?
     {
         let primary = self.codexPreferredResetBackfillWindow(
             snapshots.enumerated().compactMap { index, snapshot in
-                snapshot.primary.map { (window: $0, updatedAt: snapshot.updatedAt, priority: index) }
+                CodexConsumerProjection.sourceRateWindow(for: .session, snapshot: snapshot)
+                    .map { (window: $0, updatedAt: snapshot.updatedAt, priority: index) }
             },
             now: now)
         let secondary = self.codexPreferredResetBackfillWindow(
             snapshots.enumerated().compactMap { index, snapshot in
-                snapshot.secondary.map { (window: $0, updatedAt: snapshot.updatedAt, priority: index) }
+                CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: snapshot)
+                    .map { (window: $0, updatedAt: snapshot.updatedAt, priority: index) }
             },
             now: now)
         guard primary != nil || secondary != nil else { return nil }
@@ -1122,6 +1153,14 @@ extension UsageStore {
         switch outcome.result {
         case let .success(result):
             let scoped = result.usage.scoped(to: .codex)
+            if let resultEmail = CodexIdentityResolver.normalizeEmail(scoped.accountEmail(for: .codex)),
+               resultEmail != CodexIdentityResolver.normalizeEmail(account.email)
+            {
+                return ResolvedCodexAccountOutcome(
+                    snapshot: priorSnapshot,
+                    usage: nil,
+                    sourceLabel: priorSnapshot?.sourceLabel)
+            }
             let labeled = self.applyCodexVisibleAccountLabel(scoped, account: account)
             let backfilled = Self.codexMergedResetBackfillSnapshot(resetBackfillSnapshots)
                 .map { Self.codexBackfillingResetWindows(labeled, from: $0) } ?? labeled
@@ -1189,18 +1228,21 @@ extension UsageStore {
         account: CodexVisibleAccount,
         snapshot: UsageSnapshot?,
         sourceLabel: String?,
+        limitResetOwnerKey: CodexLimitResetOwnerKey?,
         generation: UInt64? = nil) async
     {
         guard self.isCurrentProviderRefreshGeneration(.codex, generation: generation) else { return }
-        self.lastFetchAttempts[.codex] = outcome.attempts
         switch outcome.result {
         case .success:
             guard let snapshot else { return }
+            self.lastFetchAttempts[.codex] = outcome.attempts
             self.handleCodexResetCreditNotifications(snapshot: snapshot)
             self.handleSessionQuotaTransition(provider: .codex, snapshot: snapshot)
             self.handlePredictivePaceWarningTransitions(provider: .codex, snapshot: snapshot)
             self.lastKnownResetSnapshots[.codex] = snapshot
-            self.lastCodexAccountScopedRefreshGuard = Self.codexScopedRefreshGuard(for: account)
+            let publicationGuard = Self.codexScopedRefreshGuard(for: account)
+            self.lastCodexUsagePublicationGuard = publicationGuard
+            self.lastCodexAccountScopedRefreshGuard = publicationGuard
             self.snapshots[.codex] = snapshot
             if let sourceLabel {
                 self.lastSourceLabels[.codex] = sourceLabel
@@ -1212,7 +1254,7 @@ extension UsageStore {
             await self.recordPlanUtilizationHistorySample(
                 provider: .codex,
                 snapshot: snapshot,
-                codexVisibleAccount: account)
+                codexLimitResetOwnerKey: limitResetOwnerKey)
             guard self.isCurrentProviderRefreshGeneration(.codex, generation: generation) else { return }
             self.recordCodexHistoricalSampleIfNeeded(snapshot: snapshot)
         case let .failure(error):
@@ -1220,6 +1262,10 @@ extension UsageStore {
                 self.errors[.codex] = nil
                 return
             }
+            let publicationGuard = Self.codexScopedRefreshGuard(for: account)
+            self.lastCodexUsagePublicationGuard = publicationGuard
+            self.lastCodexAccountScopedRefreshGuard = publicationGuard
+            self.lastFetchAttempts[.codex] = outcome.attempts
             let hadPriorData = self.snapshots[.codex] != nil
             let shouldSurface =
                 self.failureGates[.codex]?

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -218,6 +218,7 @@ final class UsageStore {
     @ObservationIgnored var lastOpenAIDashboardCookieImportAttemptAt: Date?
     @ObservationIgnored var lastOpenAIDashboardCookieImportEmail: String?
     @ObservationIgnored var lastCodexAccountScopedRefreshGuard: CodexAccountScopedRefreshGuard?
+    @ObservationIgnored var lastCodexUsagePublicationGuard: CodexAccountScopedRefreshGuard?
     @ObservationIgnored var lastKnownLiveSystemCodexEmail: String?
     @ObservationIgnored var openAIWebAccountDidChange: Bool = false
     @ObservationIgnored var creditsRefreshTask: Task<Void, Never>?

--- a/Sources/CodexBarCore/Providers/Codex/CodexVisibleAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexVisibleAccountProjection.swift
@@ -105,17 +105,24 @@ extension CodexVisibleAccountProjection {
 
         for storedAccount in snapshot.storedAccounts {
             let normalizedEmail = snapshot.runtimeEmail(for: storedAccount)
+            let runtimeIdentity = snapshot.runtimeIdentity(for: storedAccount)
+            let runtimeWorkspaceAccountID: String? = switch runtimeIdentity {
+            case let .providerAccount(id):
+                ManagedCodexAccount.normalizeWorkspaceAccountID(id)
+            case .emailOnly, .unresolved:
+                nil
+            }
             drafts.append(VisibleAccountDraft(
                 email: normalizedEmail,
                 workspaceLabel: Self.normalizeWorkspaceLabel(storedAccount.workspaceLabel),
-                workspaceAccountID: storedAccount.workspaceAccountID,
+                workspaceAccountID: storedAccount.workspaceAccountID ?? runtimeWorkspaceAccountID,
                 authFingerprint: storedAccount.authFingerprint,
                 storedAccountID: storedAccount.id,
                 selectionSource: .managedAccount(id: storedAccount.id),
                 isLive: false,
                 canReauthenticate: true,
                 canRemove: true,
-                identity: snapshot.runtimeIdentity(for: storedAccount)))
+                identity: runtimeIdentity))
         }
 
         if let liveSystemAccount = snapshot.liveSystemAccount {

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -63,7 +63,9 @@ extension CodexAccountScopedRefreshTests {
             identity: .providerAccount(id: "acct-alpha"))
         let store = self.makeUsageStore(settings: settings)
         let resetsAt = Date().addingTimeInterval(45 * 60)
-        store.lastCodexAccountScopedRefreshGuard = store.freshCodexAccountScopedRefreshGuard()
+        let publicationGuard = store.freshCodexAccountScopedRefreshGuard()
+        store.lastCodexUsagePublicationGuard = publicationGuard
+        store.lastCodexAccountScopedRefreshGuard = publicationGuard
         store.lastKnownResetSnapshots[.codex] = UsageSnapshot(
             primary: RateWindow(
                 usedPercent: 10,
@@ -1382,7 +1384,12 @@ extension CodexAccountScopedRefreshTests {
         await refreshTask.value
 
         #expect(store.snapshots[.codex]?.primary?.usedPercent == 25)
+        #expect(store.snapshots[.codex]?.accountEmail(for: .codex) == "email-less-managed@example.com")
         #expect(store.errors[.codex] == nil)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "email-less-managed@example.com")
+        #expect(store.codexAccountSnapshots.first?.account.email == "email-less-managed@example.com")
+        #expect(store.codexAccountSnapshots.first?.snapshot?.accountEmail(for: .codex) ==
+            "email-less-managed@example.com")
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexAccountCompositeGuardTests.swift
+++ b/Tests/CodexBarTests/CodexAccountCompositeGuardTests.swift
@@ -1,0 +1,145 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `shared workspace rejects stale member results without fingerprints`() {
+        self.assertSharedWorkspaceMemberSwitchRejectsStaleResults(
+            suite: "CodexAccountScopedRefreshTests-shared-workspace-nil-fingerprint",
+            authFingerprint: nil)
+    }
+
+    @Test
+    func `shared workspace rejects stale member results with stable fingerprints`() {
+        self.assertSharedWorkspaceMemberSwitchRejectsStaleResults(
+            suite: "CodexAccountScopedRefreshTests-shared-workspace-stable-fingerprint",
+            authFingerprint: "stable-auth")
+    }
+
+    @Test
+    func `provider identity without email fails every scoped guard closed`() {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-provider-identity-missing-email")
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = self.providerAccount(
+            email: "   ",
+            authFingerprint: nil,
+            workspaceLabel: "Workspace")
+
+        let store = self.makeUsageStore(settings: settings)
+        let expectedGuard = CodexAccountScopedRefreshGuard(
+            source: .liveSystem,
+            identity: .providerAccount(id: "shared-workspace"),
+            accountKey: nil,
+            authFingerprint: nil)
+
+        self.expectEveryScopedGuardRejects(
+            store: store,
+            expectedGuard: expectedGuard,
+            staleEmail: nil)
+        #expect(!UsageStore.codexScopedRefreshGuardsMatchAccount(expectedGuard, expectedGuard))
+    }
+
+    @Test
+    func `same member auth rotation keeps success admission policy`() {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-same-member-auth-rotation")
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = self.providerAccount(
+            email: "Member@Example.com",
+            authFingerprint: "old-auth",
+            workspaceLabel: "Old label")
+
+        let store = self.makeUsageStore(settings: settings)
+        let expectedGuard = store.freshCodexAccountScopedRefreshGuard()
+
+        settings._test_liveSystemCodexAccount = self.providerAccount(
+            email: " member@example.com ",
+            authFingerprint: "new-auth",
+            workspaceLabel: "New label")
+
+        let usage = self.codexSnapshot(email: "member@example.com", usedPercent: 25)
+        #expect(store.shouldApplyCodexUsageResult(expectedGuard: expectedGuard, usage: usage))
+        #expect(store.shouldApplyCodexScopedNonUsageResult(expectedGuard: expectedGuard))
+        #expect(store.shouldApplyOpenAIDashboardRefreshGuard(
+            expectedGuard: expectedGuard,
+            routingTargetEmail: "member@example.com"))
+        #expect(store.shouldApplyOpenAIDashboardPolicyResult(
+            expectedGuard: expectedGuard,
+            routingTargetEmail: "member@example.com"))
+        #expect(!store.shouldApplyCodexScopedFailure(expectedGuard: expectedGuard))
+        #expect(!store.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard))
+        #expect(!store.shouldApplyOpenAIWebNonSuccessResult(
+            expectedGuard: expectedGuard,
+            routingTargetEmail: "member@example.com"))
+    }
+
+    private func assertSharedWorkspaceMemberSwitchRejectsStaleResults(
+        suite: String,
+        authFingerprint: String?)
+    {
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = self.providerAccount(
+            email: "alpha@example.com",
+            authFingerprint: authFingerprint,
+            workspaceLabel: "Alpha")
+
+        let store = self.makeUsageStore(settings: settings)
+        let expectedGuard = store.freshCodexAccountScopedRefreshGuard()
+        #expect(expectedGuard.identity == .providerAccount(id: "shared-workspace"))
+        #expect(expectedGuard.accountKey == "alpha@example.com")
+
+        settings._test_liveSystemCodexAccount = self.providerAccount(
+            email: "beta@example.com",
+            authFingerprint: authFingerprint,
+            workspaceLabel: "Beta")
+
+        self.expectEveryScopedGuardRejects(
+            store: store,
+            expectedGuard: expectedGuard,
+            staleEmail: "alpha@example.com")
+        #expect(!UsageStore.codexScopedRefreshGuardsMatchAccount(
+            expectedGuard,
+            store.freshCodexAccountScopedRefreshGuard()))
+    }
+
+    private func expectEveryScopedGuardRejects(
+        store: UsageStore,
+        expectedGuard: CodexAccountScopedRefreshGuard,
+        staleEmail: String?)
+    {
+        let usage = self.codexSnapshot(email: staleEmail ?? "", usedPercent: 25)
+        #expect(!store.shouldApplyCodexUsageResult(expectedGuard: expectedGuard, usage: usage))
+        #expect(!store.shouldApplyCodexScopedFailure(expectedGuard: expectedGuard))
+        #expect(!store.shouldApplyCodexScopedNonUsageResult(expectedGuard: expectedGuard))
+        #expect(!store.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard))
+        #expect(!store.shouldApplyOpenAIDashboardRefreshGuard(
+            expectedGuard: expectedGuard,
+            routingTargetEmail: staleEmail))
+        #expect(!store.shouldApplyOpenAIWebNonSuccessResult(
+            expectedGuard: expectedGuard,
+            routingTargetEmail: staleEmail))
+        #expect(!store.shouldApplyOpenAIDashboardPolicyResult(
+            expectedGuard: expectedGuard,
+            routingTargetEmail: staleEmail))
+    }
+
+    private func providerAccount(
+        email: String,
+        authFingerprint: String?,
+        workspaceLabel: String) -> ObservedSystemCodexAccount
+    {
+        ObservedSystemCodexAccount(
+            email: email,
+            workspaceLabel: workspaceLabel,
+            workspaceAccountID: "shared-workspace",
+            authFingerprint: authFingerprint,
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "shared-workspace"))
+    }
+}

--- a/Tests/CodexBarTests/CodexAccountEmailOnlyHistoryBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountEmailOnlyHistoryBackfillTests.swift
@@ -6,7 +6,7 @@ import Testing
 @MainActor
 extension CodexAccountScopedRefreshTests {
     @Test
-    func `backfills non active email only codex row from own history`() async throws {
+    func `email only plan history never backfills quota publication`() async throws {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountVisibleHistoryBackfillTests-non-active-email-history")
         settings.refreshFrequency = .manual
@@ -107,14 +107,13 @@ extension CodexAccountScopedRefreshTests {
             $0.account.email == "sibling-email-history@example.com"
         }?.snapshot)
         #expect(siblingSnapshot.primary?.usedPercent == 6)
-        #expect(siblingSnapshot.primary?.windowMinutes == 300)
-        #expect(siblingSnapshot.primary?.resetsAt == sessionReset)
-        #expect(siblingSnapshot.secondary?.usedPercent == 36)
-        #expect(siblingSnapshot.secondary?.resetsAt == weeklyReset)
+        #expect(siblingSnapshot.primary?.windowMinutes == 0)
+        #expect(siblingSnapshot.primary?.resetsAt == nil)
+        #expect(siblingSnapshot.secondary == nil)
         let persistedSibling = try #require(snapshotStore.storedSnapshots.first {
             $0.account.email == "sibling-email-history@example.com"
         }?.snapshot)
-        #expect(persistedSibling.primary?.resetsAt == sessionReset)
-        #expect(persistedSibling.secondary?.resetsAt == weeklyReset)
+        #expect(persistedSibling.primary?.resetsAt == nil)
+        #expect(persistedSibling.secondary == nil)
     }
 }

--- a/Tests/CodexBarTests/CodexAccountMenuDisplaySnapshotTests.swift
+++ b/Tests/CodexBarTests/CodexAccountMenuDisplaySnapshotTests.swift
@@ -134,6 +134,83 @@ struct CodexAccountMenuDisplaySnapshotTests {
     }
 
     @Test
+    func `stacked menu matches runtime enriched snapshot for legacy managed workspace`() throws {
+        let settings = self.makeSettings()
+        settings.multiAccountMenuLayout = .stacked
+        let legacyID = UUID()
+        let siblingID = UUID()
+        let legacy = ManagedCodexAccount(
+            id: legacyID,
+            email: "legacy@example.com",
+            workspaceAccountID: nil,
+            managedHomePath: "/tmp/legacy",
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        let sibling = ManagedCodexAccount(
+            id: siblingID,
+            email: "sibling@example.com",
+            workspaceAccountID: "account-sibling",
+            managedHomePath: "/tmp/sibling",
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        let snapshot = CodexAccountReconciliationSnapshot(
+            storedAccounts: [legacy, sibling],
+            activeStoredAccount: legacy,
+            liveSystemAccount: nil,
+            matchingStoredAccountForLiveSystemAccount: nil,
+            activeSource: .managedAccount(id: legacyID),
+            hasUnreadableAddedAccountStore: false,
+            storedAccountRuntimeIdentities: [
+                legacyID: .providerAccount(id: " Account-Runtime "),
+                siblingID: .providerAccount(id: "account-sibling"),
+            ])
+        let projection = CodexVisibleAccountProjection.make(from: snapshot)
+        let legacyProjected = try #require(projection.visibleAccounts.first {
+            $0.selectionSource == .managedAccount(id: legacyID)
+        })
+        let siblingProjected = try #require(projection.visibleAccounts.first {
+            $0.selectionSource == .managedAccount(id: siblingID)
+        })
+        let runtimeEnrichedLegacy = CodexVisibleAccount(
+            id: legacyProjected.id,
+            email: legacyProjected.email,
+            workspaceLabel: legacyProjected.workspaceLabel,
+            workspaceAccountID: "account-runtime",
+            authFingerprint: legacyProjected.authFingerprint,
+            storedAccountID: legacyProjected.storedAccountID,
+            selectionSource: legacyProjected.selectionSource,
+            isActive: legacyProjected.isActive,
+            isLive: legacyProjected.isLive,
+            canReauthenticate: legacyProjected.canReauthenticate,
+            canRemove: legacyProjected.canRemove)
+
+        settings.codexActiveSource = .managedAccount(id: legacyID)
+        settings.cachedCodexAccountMenuProjection = self.cachedProjection(snapshot: snapshot, loadedAt: Date())
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        store.codexAccountSnapshots = [runtimeEnrichedLegacy, siblingProjected].map {
+            CodexAccountUsageSnapshot(account: $0, snapshot: nil, error: nil, sourceLabel: "test")
+        }
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let display = try #require(controller.codexAccountMenuDisplay(for: .codex))
+
+        #expect(legacyProjected.workspaceAccountID == "account-runtime")
+        #expect(display.snapshots.map(\.id).sorted() == [legacyProjected.id, siblingProjected.id].sorted())
+    }
+
+    @Test
     func `stale menu projection returns immediately then refreshes concurrently`() async {
         let settings = self.makeSettings()
         let staleSnapshot = self.liveSnapshot(email: "before@example.com")

--- a/Tests/CodexBarTests/CodexAccountRefreshProjectionTests.swift
+++ b/Tests/CodexBarTests/CodexAccountRefreshProjectionTests.swift
@@ -54,7 +54,9 @@ extension CodexAccountScopedRefreshTests {
         await store.refreshProvider(.codex, allowDisabled: true)
 
         #expect(store.snapshots[.codex]?.primary?.usedPercent == 42)
-        #expect(store.codexAccountSnapshots.isEmpty)
+        #expect(store.codexAccountSnapshots.count == 1)
+        #expect(store.codexAccountSnapshots.first?.account.email == "live-collapse@example.com")
+        #expect(store.codexAccountSnapshots.first?.snapshot?.primary?.usedPercent == 42)
     }
 
     @Test
@@ -156,7 +158,7 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
-    func `startup snapshot hydration refreshes managed auth fingerprint from disk`() throws {
+    func `startup snapshot hydration refreshes managed auth fingerprint with composite disk owner`() throws {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-startup-managed-auth-hydration")
         settings.refreshFrequency = .manual
@@ -168,7 +170,8 @@ extension CodexAccountScopedRefreshTests {
         try Self.writeCodexAuthFile(
             homeURL: managedHome,
             email: "managed-startup@example.com",
-            plan: "Pro")
+            plan: "Pro",
+            accountId: "acct-managed-startup")
         let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
         let managedAccount = ManagedCodexAccount(
             id: accountID,
@@ -193,11 +196,13 @@ extension CodexAccountScopedRefreshTests {
         let staleAccount = try #require(settings.codexVisibleAccountProjection.visibleAccounts
             .first { $0.storedAccountID == accountID })
         #expect(staleAccount.authFingerprint == oldFingerprint)
+        #expect(staleAccount.workspaceAccountID == "acct-managed-startup")
 
         try Self.writeCodexAuthFile(
             homeURL: managedHome,
             email: "managed-startup@example.com",
-            plan: "Team")
+            plan: "Team",
+            accountId: "acct-managed-startup")
         let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
         #expect(newFingerprint != oldFingerprint)
 
@@ -221,7 +226,7 @@ extension CodexAccountScopedRefreshTests {
                 error: nil,
                 sourceLabel: "cached"),
         ])
-        #expect(snapshotStore.load(for: [staleAccount]).isEmpty)
+        #expect(snapshotStore.load(for: [staleAccount]).count == 1)
 
         let store = UsageStore(
             fetcher: UsageFetcher(environment: [:]),
@@ -235,5 +240,43 @@ extension CodexAccountScopedRefreshTests {
         #expect(hydrated.id == freshAccount.id)
         #expect(hydrated.account.authFingerprint == newFingerprint)
         #expect(hydrated.snapshot?.primary?.usedPercent == 64)
+    }
+
+    @Test
+    func `snapshot hydration never crosses members of the same provider workspace`() {
+        let snapshotURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-provider-member-isolation-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: snapshotURL) }
+
+        let priorAccount = CodexVisibleAccount(
+            id: "shared-row-id",
+            email: "first-member@example.com",
+            workspaceAccountID: "workspace-shared-by-members",
+            storedAccountID: nil,
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: false,
+            canRemove: false)
+        let otherMember = CodexVisibleAccount(
+            id: "shared-row-id",
+            email: "second-member@example.com",
+            workspaceAccountID: "workspace-shared-by-members",
+            storedAccountID: nil,
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: false,
+            canRemove: false)
+        let snapshotStore = FileCodexAccountUsageSnapshotStore(fileURL: snapshotURL)
+        snapshotStore.store([
+            CodexAccountUsageSnapshot(
+                account: priorAccount,
+                snapshot: self.codexSnapshot(email: priorAccount.email, usedPercent: 64),
+                error: nil,
+                sourceLabel: "cached"),
+        ])
+
+        #expect(snapshotStore.load(for: [otherMember]).isEmpty)
     }
 }

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
@@ -90,8 +90,15 @@ extension CodexAccountScopedRefreshTests {
     }
 
     func liveAccount(email: String, identity: CodexIdentity = .unresolved) -> ObservedSystemCodexAccount {
-        ObservedSystemCodexAccount(
+        let workspaceAccountID: String? = switch identity {
+        case let .providerAccount(id):
+            id
+        case .emailOnly, .unresolved:
+            nil
+        }
+        return ObservedSystemCodexAccount(
             email: email,
+            workspaceAccountID: workspaceAccountID,
             codexHomePath: "/Users/test/.codex",
             observedAt: Date(),
             identity: identity)
@@ -426,6 +433,194 @@ actor BlockingCodexFetchStrategy {
     func resume(with result: Result<UsageSnapshot, Error>) {
         self.waiters.forEach { $0.resume(returning: result) }
         self.waiters.removeAll()
+    }
+}
+
+struct SequencedCodexSnapshotLoadStep: Sendable {
+    let result: Result<UsageSnapshot, TestRefreshError>
+    let isGated: Bool
+
+    static func success(_ snapshot: UsageSnapshot, gated: Bool = false) -> Self {
+        Self(result: .success(snapshot), isGated: gated)
+    }
+
+    static func failure(_ message: String, gated: Bool = false) -> Self {
+        Self(result: .failure(TestRefreshError(message: message)), isGated: gated)
+    }
+}
+
+actor SequencedCodexSnapshotLoader {
+    private let steps: [SequencedCodexSnapshotLoadStep]
+    private var completedCallCount = 0
+    private var startedCallCount = 0
+    private var releasedCalls: Set<Int> = []
+    private var gateWaiters: [Int: CheckedContinuation<Void, Never>] = [:]
+
+    init(steps: [SequencedCodexSnapshotLoadStep]) {
+        self.steps = steps
+    }
+
+    var callCount: Int {
+        self.startedCallCount
+    }
+
+    func load() async throws -> UsageSnapshot {
+        let call = self.startedCallCount + 1
+        self.startedCallCount = call
+
+        guard self.steps.indices.contains(call - 1) else {
+            throw TestRefreshError(message: "Unexpected Codex fetch call \(call)")
+        }
+        let step = self.steps[call - 1]
+        if step.isGated, !self.releasedCalls.contains(call) {
+            await withCheckedContinuation { continuation in
+                self.gateWaiters[call] = continuation
+            }
+        }
+        self.completedCallCount += 1
+        return try step.result.get()
+    }
+
+    @discardableResult
+    func waitUntilCallCount(_ count: Int, timeout: Duration = .seconds(5)) async -> Bool {
+        let startedAt = ContinuousClock.now
+        while self.startedCallCount < count {
+            guard startedAt.duration(to: .now) < timeout else { return false }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return true
+    }
+
+    func release(call: Int) {
+        self.releasedCalls.insert(call)
+        self.gateWaiters.removeValue(forKey: call)?.resume()
+    }
+
+    @discardableResult
+    func waitUntilCompletedCallCount(_ count: Int, timeout: Duration = .seconds(5)) async -> Bool {
+        let startedAt = ContinuousClock.now
+        while self.completedCallCount < count {
+            guard startedAt.duration(to: .now) < timeout else { return false }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return true
+    }
+}
+
+extension CodexAccountScopedRefreshTests {
+    func codexWeeklySnapshot(
+        email: String,
+        weeklyUsedPercent: Double?,
+        weeklyReset: Date?,
+        updatedAt: Date,
+        sessionUsedPercent: Double = 25) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: sessionUsedPercent,
+                windowMinutes: 300,
+                resetsAt: updatedAt.addingTimeInterval(4 * 60 * 60),
+                resetDescription: nil),
+            secondary: weeklyUsedPercent.map {
+                RateWindow(
+                    usedPercent: $0,
+                    windowMinutes: 10080,
+                    resetsAt: weeklyReset,
+                    resetDescription: nil)
+            },
+            updatedAt: updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: email,
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+    }
+
+    func makeCodexWeeklyPublicationStore(
+        settings: SettingsStore,
+        suite: String,
+        snapshotStore: (any CodexAccountUsageSnapshotStoring)? = nil) -> UsageStore
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-weekly-publication-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let environment = [
+            "HOME": root.path,
+            "CODEX_HOME": root.appendingPathComponent(".codex", isDirectory: true).path,
+            "XDG_CONFIG_HOME": root.appendingPathComponent(".config", isDirectory: true).path,
+            "CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS": "1",
+        ]
+        settings._test_codexReconciliationEnvironment = environment
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: environment),
+            browserDetection: BrowserDetection(homeDirectory: root.path, cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: testPlanUtilizationHistoryStore(suiteName: suite),
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing,
+            environmentBase: environment)
+        store._test_codexResetCreditsFetcherOverride = { _ in nil }
+        return store
+    }
+
+    func makeManagedCodexWeeklyPublicationAccount(
+        id: UUID,
+        email: String,
+        workspaceID: String,
+        workspaceLabel: String,
+        homeURL: URL) throws -> ManagedCodexAccount
+    {
+        try Self.writeCodexAuthFile(
+            homeURL: homeURL,
+            email: email,
+            plan: "Pro",
+            accountId: workspaceID)
+        let fingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: homeURL.path))
+        return ManagedCodexAccount(
+            id: id,
+            email: email,
+            providerAccountID: workspaceID,
+            workspaceLabel: workspaceLabel,
+            workspaceAccountID: workspaceID,
+            authFingerprint: fingerprint,
+            managedHomePath: homeURL.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+    }
+
+    func seedCodexWeeklyPublicationState(
+        store: UsageStore,
+        settings: SettingsStore,
+        snapshot: UsageSnapshot,
+        error: String? = "prior error") async -> Int
+    {
+        store.snapshots[.codex] = snapshot
+        store.lastKnownResetSnapshots[.codex] = snapshot
+        store.lastSourceLabels[.codex] = "prior-source"
+        if let error {
+            store.errors[.codex] = error
+        } else {
+            store.errors.removeValue(forKey: .codex)
+        }
+        store.lastFetchAttempts[.codex] = [ProviderFetchAttempt(
+            strategyID: "prior-strategy",
+            kind: .cli,
+            wasAvailable: true,
+            errorDescription: "prior diagnostic")]
+
+        let guardValue = store.currentCodexAccountScopedRefreshGuard(preferCurrentSnapshot: false)
+        store.lastCodexUsagePublicationGuard = guardValue
+        store.lastCodexAccountScopedRefreshGuard = guardValue
+        let ownerKey = store.codexLimitResetOwnerKey(
+            expectedGuard: guardValue,
+            visibleAccounts: settings.codexVisibleAccountProjection.visibleAccounts)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: snapshot,
+            codexLimitResetOwnerKey: ownerKey,
+            now: snapshot.updatedAt)
+        return store.planUtilizationHistoryRevision
     }
 }
 

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
@@ -141,6 +141,9 @@ struct CodexAccountScopedRefreshTests {
         settings._test_liveSystemCodexAccount = self.liveAccount(email: "beta@example.com")
         let freshSnapshot = self.codexSnapshot(email: "beta@example.com", usedPercent: 5)
         store._setSnapshotForTesting(freshSnapshot, provider: .codex)
+        let betaGuard = store.freshCodexAccountScopedRefreshGuard()
+        store.lastCodexUsagePublicationGuard = betaGuard
+        store.lastCodexAccountScopedRefreshGuard = betaGuard
         await blocker.resume(with: .failure(TestRefreshError(message: "stale failure")))
         await refreshTask.value
 
@@ -379,6 +382,12 @@ struct CodexAccountScopedRefreshTests {
             self.codexSnapshot(email: "trusted@example.com", usedPercent: 12),
             provider: .codex)
         store.lastSourceLabels[.codex] = "codex-cli"
+        let trustedGuard = CodexAccountScopedRefreshGuard(
+            source: .liveSystem,
+            identity: .emailOnly(normalizedEmail: "trusted@example.com"),
+            accountKey: "trusted@example.com")
+        store.lastCodexUsagePublicationGuard = trustedGuard
+        store.lastCodexAccountScopedRefreshGuard = trustedGuard
         store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             self.dashboard(email: "trusted@example.com", creditsRemaining: 33, usedPercent: 12)
         }

--- a/Tests/CodexBarTests/CodexAccountVisibleHistoryBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountVisibleHistoryBackfillTests.swift
@@ -6,7 +6,7 @@ import Testing
 @MainActor
 extension CodexAccountScopedRefreshTests {
     @Test
-    func `repairs collapsed codex windows from matching provider account history`() async throws {
+    func `provider only history never backfills account quota publication`() async throws {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountVisibleHistoryBackfillTests")
         settings.refreshFrequency = .manual
@@ -91,11 +91,9 @@ extension CodexAccountScopedRefreshTests {
             $0.account.workspaceAccountID == "acct-target"
         }?.snapshot)
         #expect(targetSnapshot.primary?.usedPercent == 1)
-        #expect(targetSnapshot.primary?.windowMinutes == 300)
-        #expect(targetSnapshot.primary?.resetsAt == sessionReset)
-        #expect(targetSnapshot.secondary?.usedPercent == 13)
-        #expect(targetSnapshot.secondary?.windowMinutes == 10080)
-        #expect(targetSnapshot.secondary?.resetsAt == weeklyReset)
+        #expect(targetSnapshot.primary?.windowMinutes == 0)
+        #expect(targetSnapshot.primary?.resetsAt == nil)
+        #expect(targetSnapshot.secondary == nil)
 
         let siblingSnapshot = try #require(store.codexAccountSnapshots.first {
             $0.account.workspaceAccountID == "acct-sibling"
@@ -107,10 +105,10 @@ extension CodexAccountScopedRefreshTests {
         let persistedTarget = try #require(snapshotStore.storedSnapshots.first {
             $0.account.workspaceAccountID == "acct-target"
         }?.snapshot)
-        #expect(persistedTarget.primary?.resetsAt == sessionReset)
-        #expect(persistedTarget.secondary?.resetsAt == weeklyReset)
-        #expect(store.snapshots[.codex]?.primary?.resetsAt == sessionReset)
-        #expect(store.snapshots[.codex]?.secondary?.resetsAt == weeklyReset)
+        #expect(persistedTarget.primary?.resetsAt == nil)
+        #expect(persistedTarget.secondary == nil)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == nil)
+        #expect(store.snapshots[.codex]?.secondary == nil)
         #expect(store.planUtilizationHistory[.codex]?.accounts[targetHistoryKey]?.count == 2)
     }
 
@@ -400,7 +398,7 @@ extension CodexAccountScopedRefreshTests {
                     resetsAt: nil,
                     resetDescription: nil),
                 secondary: nil,
-                updatedAt: now)
+                updatedAt: now.addingTimeInterval(1))
         }
 
         await store.refreshCodexVisibleAccountsForMenu()
@@ -497,10 +495,12 @@ extension CodexAccountScopedRefreshTests {
             startupBehavior: .testing)
         let sessionReset = now.addingTimeInterval(2 * 60 * 60)
         let weeklyReset = now.addingTimeInterval(2 * 24 * 60 * 60)
-        store.lastCodexAccountScopedRefreshGuard = CodexAccountScopedRefreshGuard(
+        let publicationGuard = CodexAccountScopedRefreshGuard(
             source: .managedAccount(id: targetID),
             identity: .providerAccount(id: "acct-current-target"),
             accountKey: "current@example.com")
+        store.lastCodexUsagePublicationGuard = publicationGuard
+        store.lastCodexAccountScopedRefreshGuard = publicationGuard
         store.lastKnownResetSnapshots[.codex] = UsageSnapshot(
             primary: RateWindow(
                 usedPercent: 44,
@@ -748,7 +748,7 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
-    func `backfills live codex row from same id prior snapshot`() async throws {
+    func `email only live codex row does not inherit prior quota windows`() async throws {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountVisibleHistoryBackfillTests-live-prior")
         settings.refreshFrequency = .manual
@@ -829,8 +829,8 @@ extension CodexAccountScopedRefreshTests {
             $0.account.selectionSource == .liveSystem
         }?.snapshot)
         #expect(liveSnapshot.primary?.usedPercent == 9)
-        #expect(liveSnapshot.primary?.windowMinutes == 300)
-        #expect(liveSnapshot.primary?.resetsAt == priorReset)
+        #expect(liveSnapshot.primary?.windowMinutes == 0)
+        #expect(liveSnapshot.primary?.resetsAt == nil)
     }
 
     @Test
@@ -1102,8 +1102,10 @@ extension CodexAccountScopedRefreshTests {
                 loginMethod: nil))
         store._setSnapshotForTesting(priorDisplayedSnapshot, provider: .codex)
         store.lastKnownResetSnapshots[.codex] = priorDisplayedSnapshot
-        store.lastCodexAccountScopedRefreshGuard = store.currentCodexAccountScopedRefreshGuard(
+        let priorGuard = store.currentCodexAccountScopedRefreshGuard(
             preferCurrentSnapshot: false)
+        store.lastCodexUsagePublicationGuard = priorGuard
+        store.lastCodexAccountScopedRefreshGuard = priorGuard
         let blocker = BlockingCodexFetchStrategy()
         let liveHomePath = liveHome.path
         self.installContextualCodexProvider(on: store) { context in
@@ -1403,14 +1405,22 @@ extension CodexAccountScopedRefreshTests {
 
         #expect(store.snapshots[.codex] == nil)
         #expect(store.lastKnownResetSnapshots[.codex] == nil)
-        #expect(store.codexAccountSnapshots.isEmpty)
+        #expect(!store.codexAccountSnapshots.contains {
+            $0.account.selectionSource == .liveSystem
+        })
+        #expect(store.codexAccountSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-selected-email"
+        })
         #expect(!snapshotStore.storedSnapshots.contains {
             $0.account.selectionSource == .liveSystem
+        })
+        #expect(snapshotStore.storedSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-selected-email"
         })
     }
 
     @Test
-    func `stacked visible refresh keeps selected apply after provider account email changes`() async throws {
+    func `stacked visible refresh discards selected apply after provider account email changes`() async throws {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountVisibleHistoryBackfillTests-selected-provider-email-change")
         settings.refreshFrequency = .manual
@@ -1475,6 +1485,27 @@ extension CodexAccountScopedRefreshTests {
         let targetHomePath = targetHome.path
         let now = Date()
         let reset = now.addingTimeInterval(90 * 60)
+        let prior = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 63,
+                windowMinutes: 300,
+                resetsAt: reset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now.addingTimeInterval(-60),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "old-provider@example.com",
+                accountOrganization: nil,
+                loginMethod: "Provider Team"))
+        let priorGuard = CodexAccountScopedRefreshGuard(
+            source: .managedAccount(id: targetID),
+            identity: .providerAccount(id: "acct-provider-email"),
+            accountKey: "old-provider@example.com")
+        store.snapshots[.codex] = prior
+        store.lastKnownResetSnapshots[.codex] = prior
+        store.lastCodexUsagePublicationGuard = priorGuard
+        store.lastCodexAccountScopedRefreshGuard = priorGuard
         self.installContextualCodexProvider(on: store) { context in
             if context.env["CODEX_HOME"] == targetHomePath {
                 return try await blocker.awaitResult()
@@ -1514,27 +1545,16 @@ extension CodexAccountScopedRefreshTests {
                 loginMethod: "Pro"))))
         await refreshTask.value
 
-        let selectedSnapshot = try #require(store.snapshots[.codex])
-        #expect(selectedSnapshot.primary?.usedPercent == 64)
-        #expect(selectedSnapshot.accountEmail(for: .codex) == "new-provider@example.com")
-        #expect(selectedSnapshot.loginMethod(for: .codex) == "Pro")
-        #expect(store.lastKnownResetSnapshots[.codex]?.primary?.resetsAt == reset)
-        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "new-provider@example.com")
-
-        let targetRow = try #require(store.codexAccountSnapshots.first {
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(!store.codexAccountSnapshots.contains {
             $0.account.workspaceAccountID == "acct-provider-email"
         })
-        #expect(targetRow.account.email == "new-provider@example.com")
-        #expect(targetRow.snapshot?.primary?.usedPercent == 64)
-        #expect(targetRow.snapshot?.accountEmail(for: .codex) == "new-provider@example.com")
-        #expect(targetRow.snapshot?.loginMethod(for: .codex) == "Pro")
-
-        let persistedTarget = try #require(snapshotStore.storedSnapshots.first {
+        #expect(store.codexAccountSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-provider-sibling"
+        })
+        #expect(!snapshotStore.storedSnapshots.contains {
             $0.account.workspaceAccountID == "acct-provider-email"
         })
-        #expect(persistedTarget.account.email == "new-provider@example.com")
-        #expect(persistedTarget.snapshot?.primary?.usedPercent == 64)
-        #expect(persistedTarget.snapshot?.accountEmail(for: .codex) == "new-provider@example.com")
-        #expect(persistedTarget.snapshot?.loginMethod(for: .codex) == "Pro")
     }
 }

--- a/Tests/CodexBarTests/CodexDashboardWeeklyPublicationTests.swift
+++ b/Tests/CodexBarTests/CodexDashboardWeeklyPublicationTests.swift
@@ -1,0 +1,84 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `dashboard cannot publish an unconfirmed first weekly low`() async {
+        let settings = self.makeSettingsStore(
+            suite: "CodexDashboardWeeklyPublicationTests-first-low")
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .auto
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "dashboard-low@example.com",
+            identity: .providerAccount(id: "dashboard-low-owner"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let store = self.makeUsageStore(settings: settings)
+        await store.applyOpenAIDashboard(
+            OpenAIDashboardSnapshot(
+                signedInEmail: "dashboard-low@example.com",
+                codeReviewRemainingPercent: nil,
+                creditEvents: [],
+                dailyBreakdown: [],
+                usageBreakdown: [],
+                creditsPurchaseURL: nil,
+                primaryLimit: nil,
+                secondaryLimit: RateWindow(
+                    usedPercent: 0.2,
+                    windowMinutes: 10080,
+                    resetsAt: now.addingTimeInterval(7 * 24 * 60 * 60),
+                    resetDescription: nil),
+                creditsRemaining: nil,
+                accountPlan: "Pro",
+                updatedAt: now),
+            targetEmail: "dashboard-low@example.com",
+            allowCodexUsageBackfill: true)
+
+        #expect(store.openAIDashboard?.signedInEmail == "dashboard-low@example.com")
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.lastSourceLabels[.codex] == nil)
+    }
+
+    @Test
+    func `dashboard publishes an ordinary first weekly observation`() async {
+        let settings = self.makeSettingsStore(
+            suite: "CodexDashboardWeeklyPublicationTests-ordinary")
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .auto
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "dashboard-ordinary@example.com",
+            identity: .providerAccount(id: "dashboard-ordinary-owner"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let store = self.makeUsageStore(settings: settings)
+        await store.applyOpenAIDashboard(
+            OpenAIDashboardSnapshot(
+                signedInEmail: "dashboard-ordinary@example.com",
+                codeReviewRemainingPercent: nil,
+                creditEvents: [],
+                dailyBreakdown: [],
+                usageBreakdown: [],
+                creditsPurchaseURL: nil,
+                primaryLimit: nil,
+                secondaryLimit: RateWindow(
+                    usedPercent: 28,
+                    windowMinutes: 10080,
+                    resetsAt: now.addingTimeInterval(7 * 24 * 60 * 60),
+                    resetDescription: nil),
+                creditsRemaining: nil,
+                accountPlan: "Pro",
+                updatedAt: now),
+            targetEmail: "dashboard-ordinary@example.com",
+            allowCodexUsageBackfill: true)
+
+        #expect(store.openAIDashboard?.signedInEmail == "dashboard-ordinary@example.com")
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 28)
+        #expect(store.lastSourceLabels[.codex] == "openai-web")
+    }
+}

--- a/Tests/CodexBarTests/CodexLimitResetOwnerKeyTests.swift
+++ b/Tests/CodexBarTests/CodexLimitResetOwnerKeyTests.swift
@@ -1,0 +1,215 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite(.serialized)
+@MainActor
+struct CodexLimitResetOwnerKeyTests {
+    @Test
+    func `limit reset owner stays stable for the same provider workspace and email`() throws {
+        let store = self.makeLimitResetOwnerStore(suffix: "provider-stability")
+        let original = self.limitResetVisibleAccount(
+            id: "original-row",
+            email: " Person-One@Example.Test ",
+            workspaceLabel: "Fixture Team",
+            workspaceAccountID: "workspace-fixture-stable",
+            authFingerprint: "auth-fixture-old")
+        let relabeled = self.limitResetVisibleAccount(
+            id: "relabeled-row",
+            email: "person-one@example.test",
+            workspaceLabel: "Renamed Fixture Team",
+            workspaceAccountID: " workspace-fixture-stable ",
+            authFingerprint: "auth-fixture-new")
+
+        let originalKey = try #require(store.codexLimitResetOwnerKey(
+            forVisibleAccount: original,
+            visibleAccounts: [original]))
+        let relabeledKey = try #require(store.codexLimitResetOwnerKey(
+            forVisibleAccount: relabeled,
+            visibleAccounts: [relabeled]))
+
+        #expect(originalKey == relabeledKey)
+        self.expectOpaqueLimitResetOwnerKey(
+            originalKey,
+            excludes: ["workspace-fixture-stable", "person-one@example.test"])
+    }
+
+    @Test
+    func `different emails in the same provider workspace use different owner keys`() throws {
+        let store = self.makeLimitResetOwnerStore(suffix: "provider-member-distinct")
+        let first = self.limitResetVisibleAccount(
+            id: "first-member",
+            email: "first-member@example.test",
+            workspaceAccountID: "workspace-fixture-shared")
+        let second = self.limitResetVisibleAccount(
+            id: "second-member",
+            email: "second-member@example.test",
+            workspaceAccountID: "workspace-fixture-shared")
+
+        let firstKey = try #require(store.codexLimitResetOwnerKey(
+            forVisibleAccount: first,
+            visibleAccounts: [first, second]))
+        let secondKey = try #require(store.codexLimitResetOwnerKey(
+            forVisibleAccount: second,
+            visibleAccounts: [first, second]))
+
+        #expect(firstKey != secondKey)
+    }
+
+    @Test
+    func `different provider workspaces with the same email use different owner keys`() throws {
+        let store = self.makeLimitResetOwnerStore(suffix: "provider-distinct")
+        let first = self.limitResetVisibleAccount(
+            id: "first-row",
+            email: "shared-person@example.test",
+            workspaceAccountID: "workspace-fixture-one")
+        let second = self.limitResetVisibleAccount(
+            id: "second-row",
+            email: "shared-person@example.test",
+            workspaceAccountID: "workspace-fixture-two")
+        let visibleAccounts = [first, second]
+
+        let firstKey = try #require(store.codexLimitResetOwnerKey(
+            forVisibleAccount: first,
+            visibleAccounts: visibleAccounts))
+        let secondKey = try #require(store.codexLimitResetOwnerKey(
+            forVisibleAccount: second,
+            visibleAccounts: visibleAccounts))
+
+        #expect(firstKey != secondKey)
+        self.expectOpaqueLimitResetOwnerKey(firstKey, excludes: ["workspace-fixture-one", "shared-person@example.test"])
+        self.expectOpaqueLimitResetOwnerKey(
+            secondKey,
+            excludes: ["workspace-fixture-two", "shared-person@example.test"])
+    }
+
+    @Test
+    func `email only owner fails closed even for one visible row`() {
+        let store = self.makeLimitResetOwnerStore(suffix: "email-unique")
+        let account = self.limitResetVisibleAccount(
+            id: "email-row-original",
+            email: " Unique-Person@Example.Test ",
+            workspaceLabel: "Fixture Personal",
+            authFingerprint: "auth-fixture-old")
+
+        #expect(store.codexLimitResetOwnerKey(forVisibleAccount: account, visibleAccounts: [account]) == nil)
+        #expect(CodexLimitResetOwnerKey(
+            identity: .emailOnly(normalizedEmail: "unique-person@example.test"),
+            accountEmail: "unique-person@example.test") == nil)
+    }
+
+    @Test
+    func `duplicate email only rows fail closed`() {
+        let store = self.makeLimitResetOwnerStore(suffix: "email-ambiguous")
+        let first = self.limitResetVisibleAccount(
+            id: "email-row-one",
+            email: "ambiguous-person@example.test")
+        let second = self.limitResetVisibleAccount(
+            id: "email-row-two",
+            email: " Ambiguous-Person@Example.Test ")
+        let visibleAccounts = [first, second]
+
+        #expect(store.codexLimitResetOwnerKey(forVisibleAccount: first, visibleAccounts: visibleAccounts) == nil)
+        #expect(store.codexLimitResetOwnerKey(forVisibleAccount: second, visibleAccounts: visibleAccounts) == nil)
+    }
+
+    @Test
+    func `provider row wins its own identity while same email fallback fails closed`() throws {
+        let store = self.makeLimitResetOwnerStore(suffix: "mixed-identity")
+        let providerBacked = self.limitResetVisibleAccount(
+            id: "provider-row",
+            email: "mixed-person@example.test",
+            workspaceAccountID: "workspace-fixture-provider")
+        let emailOnly = self.limitResetVisibleAccount(
+            id: "email-row",
+            email: "mixed-person@example.test")
+        let visibleAccounts = [providerBacked, emailOnly]
+
+        let providerKey = try #require(store.codexLimitResetOwnerKey(
+            forVisibleAccount: providerBacked,
+            visibleAccounts: visibleAccounts))
+
+        #expect(providerKey == CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "workspace-fixture-provider"),
+            accountEmail: "mixed-person@example.test"))
+        #expect(store.codexLimitResetOwnerKey(forVisibleAccount: emailOnly, visibleAccounts: visibleAccounts) == nil)
+    }
+
+    @Test
+    func `guard and visible row normalize the same provider owner`() throws {
+        let store = self.makeLimitResetOwnerStore(suffix: "provider-normalization")
+        let account = self.limitResetVisibleAccount(
+            id: "provider-row",
+            email: "provider-person@example.test",
+            workspaceAccountID: " workspace-fixture-mixed-case ")
+        let guardValue = CodexAccountScopedRefreshGuard(
+            source: account.selectionSource,
+            identity: .providerAccount(id: " WORKSPACE-FIXTURE-MIXED-CASE "),
+            accountKey: account.email)
+
+        let visibleKey = try #require(store.codexLimitResetOwnerKey(
+            forVisibleAccount: account,
+            visibleAccounts: [account]))
+        let guardKey = try #require(store.codexLimitResetOwnerKey(
+            expectedGuard: guardValue,
+            visibleAccounts: [account]))
+
+        #expect(visibleKey == guardKey)
+    }
+
+    @Test
+    func `unresolved owner identity fails closed`() {
+        let store = self.makeLimitResetOwnerStore(suffix: "unresolved")
+        let guardValue = CodexAccountScopedRefreshGuard(
+            source: .liveSystem,
+            identity: .unresolved,
+            accountKey: nil)
+        let unresolvedRow = self.limitResetVisibleAccount(id: "unresolved-row", email: "   ")
+
+        #expect(store.codexLimitResetOwnerKey(expectedGuard: guardValue, visibleAccounts: []) == nil)
+        #expect(store.codexLimitResetOwnerKey(
+            forVisibleAccount: unresolvedRow,
+            visibleAccounts: [unresolvedRow]) == nil)
+    }
+
+    private func makeLimitResetOwnerStore(suffix: String) -> UsageStore {
+        let support = CodexAccountScopedRefreshTests()
+        let settings = support.makeSettingsStore(suite: "CodexLimitResetOwnerKeyTests-\(suffix)")
+        return support.makeUsageStore(settings: settings)
+    }
+
+    private func limitResetVisibleAccount(
+        id: String,
+        email: String,
+        workspaceLabel: String? = nil,
+        workspaceAccountID: String? = nil,
+        authFingerprint: String? = nil) -> CodexVisibleAccount
+    {
+        CodexVisibleAccount(
+            id: id,
+            email: email,
+            workspaceLabel: workspaceLabel,
+            workspaceAccountID: workspaceAccountID,
+            authFingerprint: authFingerprint,
+            storedAccountID: nil,
+            selectionSource: .profileHome(path: "/tmp/\(id)"),
+            isActive: false,
+            isLive: false,
+            canReauthenticate: true,
+            canRemove: true)
+    }
+
+    private func expectOpaqueLimitResetOwnerKey(
+        _ key: CodexLimitResetOwnerKey,
+        excludes cleartextValues: [String],
+        sourceLocation: SourceLocation = #_sourceLocation)
+    {
+        #expect(
+            key.rawValue.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil,
+            sourceLocation: sourceLocation)
+        for cleartextValue in cleartextValues {
+            #expect(!key.rawValue.contains(cleartextValue), sourceLocation: sourceLocation)
+        }
+    }
+}

--- a/Tests/CodexBarTests/CodexManagedOpenAIWebRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexManagedOpenAIWebRefreshTests.swift
@@ -190,6 +190,9 @@ struct CodexManagedOpenAIWebRefreshTests {
             settings: settings,
             startupBehavior: .testing)
         store.snapshots[.codex] = Self.codexSnapshot(email: managedAccount.email, usedPercent: 18)
+        let publicationGuard = store.currentCodexAccountScopedRefreshGuard()
+        store.lastCodexUsagePublicationGuard = publicationGuard
+        store.lastCodexAccountScopedRefreshGuard = publicationGuard
 
         let creditsBlocker = BlockingCreditsLoader()
         let saver = BlockingWidgetSnapshotSaver()
@@ -277,6 +280,9 @@ struct CodexManagedOpenAIWebRefreshTests {
         await store.widgetSnapshotPersistTask?.value
         settings.openAIWebAccessEnabled = true
         store.snapshots[.codex] = Self.codexSnapshot(email: managedAccount.email, usedPercent: 18)
+        let publicationGuard = store.currentCodexAccountScopedRefreshGuard()
+        store.lastCodexUsagePublicationGuard = publicationGuard
+        store.lastCodexAccountScopedRefreshGuard = publicationGuard
         store.creditsRefreshTask = Task {}
         store.creditsRefreshTaskKey = store.codexCreditsRefreshKey(
             expectedGuard: store.currentCodexAccountScopedRefreshGuard())
@@ -766,7 +772,9 @@ actor BlockingManagedOpenAIDashboardLoader {
     }
 
     func waitUntilStarted(count: Int = 1) async {
-        if self.started >= count { return }
+        if self.started >= count {
+            return
+        }
         await withCheckedContinuation { continuation in
             self.startWaiters.append((count: count, continuation: continuation))
         }
@@ -849,7 +857,9 @@ actor BlockingCreditsLoader {
     }
 
     func waitUntilStarted(count: Int = 1) async {
-        if self.started >= count { return }
+        if self.started >= count {
+            return
+        }
         await withCheckedContinuation { continuation in
             self.startWaiters.append((count: count, continuation: continuation))
         }
@@ -936,7 +946,9 @@ private actor OpenAIDashboardImportCallTracker {
     }
 
     func waitUntilCalls(count: Int) async {
-        if self.calls >= count { return }
+        if self.calls >= count {
+            return
+        }
         await withCheckedContinuation { continuation in
             self.waiters.append((count: count, continuation: continuation))
         }

--- a/Tests/CodexBarTests/CodexResetBackfillSemanticsTests.swift
+++ b/Tests/CodexBarTests/CodexResetBackfillSemanticsTests.swift
@@ -1,0 +1,213 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CodexResetBackfillSemanticsTests {
+    @Test
+    func `merged reset cache preserves semantic lanes across swapped snapshots`() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let sessionReset = now.addingTimeInterval(4 * 60 * 60)
+        let weeklyReset = now.addingTimeInterval(4 * 24 * 60 * 60)
+        let canonicalSessionCache = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 17,
+                windowMinutes: 300,
+                resetsAt: sessionReset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now.addingTimeInterval(-20))
+        let swappedWeeklyCache = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 63,
+                windowMinutes: 10080,
+                resetsAt: weeklyReset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now.addingTimeInterval(-10))
+
+        let merged = try #require(UsageStore.codexMergedResetBackfillSnapshot(
+            [canonicalSessionCache, swappedWeeklyCache],
+            now: now))
+
+        #expect(merged.primary?.usedPercent == 17)
+        #expect(merged.primary?.windowMinutes == 300)
+        #expect(merged.primary?.resetsAt == sessionReset)
+        #expect(merged.secondary?.usedPercent == 63)
+        #expect(merged.secondary?.windowMinutes == 10080)
+        #expect(merged.secondary?.resetsAt == weeklyReset)
+    }
+}
+
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `stacked email only rows use neither prior baselines nor reset backfills`() async throws {
+        let fixture = try self.makeEmailOnlyStackedFixture(
+            suite: "CodexResetBackfillSemanticsTests-email-only-stacked")
+        defer { fixture.cleanup() }
+
+        let now = Date()
+        let weeklyReset = now.addingTimeInterval(3 * 24 * 60 * 60)
+        let targetPrior = self.codexWeeklySnapshot(
+            email: fixture.target.email,
+            weeklyUsedPercent: 74,
+            weeklyReset: weeklyReset,
+            updatedAt: now.addingTimeInterval(-60))
+        let siblingPrior = self.codexWeeklySnapshot(
+            email: fixture.sibling.email,
+            weeklyUsedPercent: 28,
+            weeklyReset: weeklyReset,
+            updatedAt: now.addingTimeInterval(-60))
+        let priorRows = [
+            CodexAccountUsageSnapshot(
+                account: fixture.target,
+                snapshot: targetPrior,
+                error: nil,
+                sourceLabel: "cached-target"),
+            CodexAccountUsageSnapshot(
+                account: fixture.sibling,
+                snapshot: siblingPrior,
+                error: nil,
+                sourceLabel: "cached-sibling"),
+        ]
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: priorRows)
+        let store = self.makeCodexWeeklyPublicationStore(
+            settings: fixture.settings,
+            suite: "CodexResetBackfillSemanticsTests-email-only-stacked",
+            snapshotStore: snapshotStore)
+        #expect(store.codexLimitResetOwnerKey(
+            forVisibleAccount: fixture.target,
+            visibleAccounts: [fixture.target, fixture.sibling]) == nil)
+
+        let initialLow = self.codexWeeklySnapshot(
+            email: fixture.target.email,
+            weeklyUsedPercent: 0.2,
+            weeklyReset: weeklyReset,
+            updatedAt: now.addingTimeInterval(-40))
+        let confirmedLow = self.codexWeeklySnapshot(
+            email: fixture.target.email,
+            weeklyUsedPercent: 0.4,
+            weeklyReset: weeklyReset,
+            updatedAt: now.addingTimeInterval(-30))
+        let partial = self.codexWeeklySnapshot(
+            email: fixture.target.email,
+            weeklyUsedPercent: nil,
+            weeklyReset: nil,
+            updatedAt: now.addingTimeInterval(-20),
+            sessionUsedPercent: 31)
+        let targetLoader = SequencedCodexSnapshotLoader(steps: [
+            .success(initialLow),
+            .success(confirmedLow),
+            .success(partial),
+        ])
+        let siblingCurrent = self.codexWeeklySnapshot(
+            email: fixture.sibling.email,
+            weeklyUsedPercent: 29,
+            weeklyReset: weeklyReset,
+            updatedAt: now.addingTimeInterval(-10))
+        let targetHomePath = fixture.targetHome.path
+        let siblingHomePath = fixture.siblingHome.path
+        self.installContextualCodexProvider(on: store) { context in
+            switch context.env["CODEX_HOME"] {
+            case targetHomePath:
+                try await targetLoader.load()
+            case siblingHomePath:
+                siblingCurrent
+            default:
+                throw TestRefreshError(message: "Unexpected CODEX_HOME routing")
+            }
+        }
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let confirmedTarget = try #require(store.codexAccountSnapshots.first {
+            $0.account.storedAccountID == fixture.target.storedAccountID
+        }?.snapshot)
+        #expect(confirmedTarget.updatedAt == confirmedLow.updatedAt)
+        #expect(confirmedTarget.secondary?.usedPercent == 0.4)
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let partialTarget = try #require(store.codexAccountSnapshots.first {
+            $0.account.storedAccountID == fixture.target.storedAccountID
+        }?.snapshot)
+        #expect(await targetLoader.callCount == 3)
+        #expect(partialTarget.updatedAt == partial.updatedAt)
+        #expect(partialTarget.primary?.usedPercent == 31)
+        #expect(partialTarget.secondary == nil)
+    }
+
+    private func makeEmailOnlyStackedFixture(suite: String) throws -> EmailOnlyStackedFixture {
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings.multiAccountMenuLayout = .stacked
+
+        let targetID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-424242424242"))
+        let siblingID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-434343434343"))
+        let targetHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-email-only-target-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-email-only-sibling-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "email-only-target@example.com",
+            plan: "Pro")
+        try Self.writeCodexAuthFile(
+            homeURL: siblingHome,
+            email: "email-only-sibling@example.com",
+            plan: "Pro")
+        let targetFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        let siblingFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: siblingHome.path))
+        let targetAccount = ManagedCodexAccount(
+            id: targetID,
+            email: "email-only-target@example.com",
+            authFingerprint: targetFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let siblingAccount = ManagedCodexAccount(
+            id: siblingID,
+            email: "email-only-sibling@example.com",
+            authFingerprint: siblingFingerprint,
+            managedHomePath: siblingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let accountStoreURL = try self.makeManagedAccountStoreURL(accounts: [targetAccount, siblingAccount])
+        settings._test_managedCodexAccountStoreURL = accountStoreURL
+        settings.codexActiveSource = .managedAccount(id: targetID)
+
+        let projection = settings.codexVisibleAccountProjection
+        let target = try #require(projection.visibleAccounts.first { $0.storedAccountID == targetID })
+        let sibling = try #require(projection.visibleAccounts.first { $0.storedAccountID == siblingID })
+        #expect(target.workspaceAccountID == nil)
+        #expect(sibling.workspaceAccountID == nil)
+
+        return EmailOnlyStackedFixture(
+            settings: settings,
+            target: target,
+            sibling: sibling,
+            targetHome: targetHome,
+            siblingHome: siblingHome,
+            accountStoreURL: accountStoreURL)
+    }
+}
+
+private struct EmailOnlyStackedFixture {
+    let settings: SettingsStore
+    let target: CodexVisibleAccount
+    let sibling: CodexVisibleAccount
+    let targetHome: URL
+    let siblingHome: URL
+    let accountStoreURL: URL
+
+    @MainActor
+    func cleanup() {
+        self.settings._test_managedCodexAccountStoreURL = nil
+        try? FileManager.default.removeItem(at: self.accountStoreURL)
+        try? FileManager.default.removeItem(at: self.targetHome)
+        try? FileManager.default.removeItem(at: self.siblingHome)
+    }
+}

--- a/Tests/CodexBarTests/CodexUsageOwnerRaceTests.swift
+++ b/Tests/CodexBarTests/CodexUsageOwnerRaceTests.swift
@@ -1,0 +1,465 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `credits completion retires usage from another workspace member`() async {
+        let suite = "CodexUsageOwnerRaceTests-credits-first"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "member-a@example.com",
+            identity: .providerAccount(id: "shared-workspace"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let prior = self.codexWeeklySnapshot(
+            email: "member-a@example.com",
+            weeklyUsedPercent: 72,
+            weeklyReset: now.addingTimeInterval(2 * 24 * 60 * 60),
+            updatedAt: now.addingTimeInterval(-60))
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "member-b@example.com",
+            identity: .providerAccount(id: "shared-workspace"))
+        store._test_codexCreditsLoaderOverride = { self.credits(remaining: 23) }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+
+        await store.refreshCreditsIfNeeded()
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.lastCodexUsagePublicationGuard == nil)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "member-b@example.com")
+        #expect(store.credits?.remaining == 23)
+
+        let nextReset = now.addingTimeInterval(9 * 24 * 60 * 60)
+        let loader = SequencedCodexSnapshotLoader(steps: [
+            .success(self.codexWeeklySnapshot(
+                email: "member-b@example.com",
+                weeklyUsedPercent: 0.2,
+                weeklyReset: nextReset,
+                updatedAt: now.addingTimeInterval(-30))),
+            .failure("confirmation unavailable"),
+        ])
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(await loader.callCount == 2)
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.credits?.remaining == 23)
+    }
+
+    @Test
+    func `dashboard cleanup retires cli usage from another workspace member`() async {
+        let suite = "CodexUsageOwnerRaceTests-dashboard-cleanup"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .auto
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "member-a@example.com",
+            identity: .providerAccount(id: "shared-workspace"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let prior = self.codexWeeklySnapshot(
+            email: "member-a@example.com",
+            weeklyUsedPercent: 72,
+            weeklyReset: Date().addingTimeInterval(2 * 24 * 60 * 60),
+            updatedAt: Date().addingTimeInterval(-60))
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "member-b@example.com",
+            identity: .providerAccount(id: "shared-workspace"))
+        await store.applyOpenAIDashboard(
+            self.dashboard(email: "member-a@example.com", creditsRemaining: 8, usedPercent: 40),
+            targetEmail: "member-b@example.com")
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.lastCodexUsagePublicationGuard == nil)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "member-b@example.com")
+    }
+
+    @Test
+    func `stale usage rejection preserves newer owner credits`() async {
+        let suite = "CodexUsageOwnerRaceTests-stale-usage-new-credits"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-a@example.com",
+            identity: .providerAccount(id: "owner-a"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        let prior = self.codexWeeklySnapshot(
+            email: "owner-a@example.com",
+            weeklyUsedPercent: 61,
+            weeklyReset: Date().addingTimeInterval(2 * 24 * 60 * 60),
+            updatedAt: Date().addingTimeInterval(-60))
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-b@example.com",
+            identity: .providerAccount(id: "owner-b"))
+        store._test_codexCreditsLoaderOverride = { self.credits(remaining: 31) }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+        await store.refreshCreditsIfNeeded()
+        #expect(store.credits?.remaining == 31)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "owner-b@example.com")
+
+        await blocker.resume(with: .success(self.codexSnapshot(email: "owner-a@example.com", usedPercent: 62)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.credits?.remaining == 31)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "owner-b@example.com")
+    }
+
+    @Test
+    func `stacked stale selection preserves newer selected account credits`() async throws {
+        let suite = "CodexUsageOwnerRaceTests-stacked-stale-selection"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings.multiAccountMenuLayout = .stacked
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "stacked-a@example.com",
+            identity: .providerAccount(id: "stacked-owner-a"))
+        let managedID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-515151515151"))
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-stacked-owner-race-\(UUID().uuidString)", isDirectory: true)
+        let managedAccount = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: managedID,
+            email: "stacked-b@example.com",
+            workspaceID: "stacked-owner-b",
+            workspaceLabel: "Team B",
+            homeURL: managedHome)
+        let accountStoreURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_liveSystemCodexAccount = nil
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: accountStoreURL)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = accountStoreURL
+        settings.codexActiveSource = .liveSystem
+
+        let now = Date()
+        let prior = self.codexWeeklySnapshot(
+            email: "stacked-a@example.com",
+            weeklyUsedPercent: 61,
+            weeklyReset: now.addingTimeInterval(2 * 24 * 60 * 60),
+            updatedAt: now.addingTimeInterval(-60))
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        let blocker = BlockingCodexFetchStrategy()
+        let managedHomePath = managedHome.path
+        let managedSnapshot = self.codexSnapshot(email: "stacked-b@example.com", usedPercent: 33)
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == managedHomePath {
+                return managedSnapshot
+            }
+            return try await blocker.awaitResult()
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        settings.codexActiveSource = .managedAccount(id: managedID)
+        store._test_codexCreditsLoaderOverride = { self.credits(remaining: 37) }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+        await store.refreshCreditsIfNeeded()
+        #expect(store.credits?.remaining == 37)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "stacked-b@example.com")
+
+        await blocker.resume(with: .success(self.codexSnapshot(email: "stacked-a@example.com", usedPercent: 62)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.credits?.remaining == 37)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "stacked-b@example.com")
+    }
+
+    @Test
+    func `in flight success retires prior usage after owner switch`() async {
+        let suite = "CodexUsageOwnerRaceTests-in-flight-success"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-a@example.com",
+            identity: .providerAccount(id: "owner-a"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        let prior = self.codexWeeklySnapshot(
+            email: "owner-a@example.com",
+            weeklyUsedPercent: 61,
+            weeklyReset: Date().addingTimeInterval(2 * 24 * 60 * 60),
+            updatedAt: Date().addingTimeInterval(-60))
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-b@example.com",
+            identity: .providerAccount(id: "owner-b"))
+        await blocker.resume(with: .success(self.codexSnapshot(email: "owner-a@example.com", usedPercent: 62)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.lastCodexUsagePublicationGuard == nil)
+    }
+
+    @Test
+    func `in flight failure retires prior usage after owner switch`() async {
+        let suite = "CodexUsageOwnerRaceTests-in-flight-failure"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-a@example.com",
+            identity: .providerAccount(id: "owner-a"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        let prior = self.codexWeeklySnapshot(
+            email: "owner-a@example.com",
+            weeklyUsedPercent: 61,
+            weeklyReset: Date().addingTimeInterval(2 * 24 * 60 * 60),
+            updatedAt: Date().addingTimeInterval(-60))
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-b@example.com",
+            identity: .providerAccount(id: "owner-b"))
+        await blocker.resume(with: .failure(TestRefreshError(message: "old owner failure")))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.lastCodexUsagePublicationGuard == nil)
+    }
+
+    @Test
+    func `in flight confirmation retires prior usage after owner switch`() async {
+        let suite = "CodexUsageOwnerRaceTests-in-flight-confirmation"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-a@example.com",
+            identity: .providerAccount(id: "owner-a"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let priorReset = now.addingTimeInterval(2 * 24 * 60 * 60)
+        let nextReset = priorReset.addingTimeInterval(7 * 24 * 60 * 60)
+        let prior = self.codexWeeklySnapshot(
+            email: "owner-a@example.com",
+            weeklyUsedPercent: 61,
+            weeklyReset: priorReset,
+            updatedAt: now.addingTimeInterval(-60))
+        let loader = SequencedCodexSnapshotLoader(steps: [
+            .success(self.codexWeeklySnapshot(
+                email: "owner-a@example.com",
+                weeklyUsedPercent: 0.2,
+                weeklyReset: nextReset,
+                updatedAt: now.addingTimeInterval(-40))),
+            .success(self.codexWeeklySnapshot(
+                email: "owner-a@example.com",
+                weeklyUsedPercent: 60,
+                weeklyReset: priorReset,
+                updatedAt: now.addingTimeInterval(-20)), gated: true),
+        ])
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        #expect(await loader.waitUntilCallCount(2))
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-b@example.com",
+            identity: .providerAccount(id: "owner-b"))
+        await loader.release(call: 2)
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.lastCodexUsagePublicationGuard == nil)
+    }
+
+    @Test
+    func `unresolved live publication remains stable across the next failed refresh`() async throws {
+        let suite = "CodexUsageOwnerRaceTests-unresolved-continuity"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings.codexActiveSource = .liveSystem
+        settings._test_liveSystemCodexAccount = nil
+
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: self.codexSnapshot(email: "discovered@example.com", usedPercent: 27))
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        let publishedAt = try #require(store.snapshots[.codex]?.updatedAt)
+        #expect(store.lastCodexUsagePublicationGuard?.identity == .emailOnly(
+            normalizedEmail: "discovered@example.com"))
+        self.installFailingCodexProvider(
+            on: store,
+            error: TestRefreshError(message: "temporary failure"))
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(store.snapshots[.codex]?.updatedAt == publishedAt)
+        #expect(store.lastCodexUsagePublicationGuard?.accountKey == "discovered@example.com")
+    }
+
+    @Test
+    func `fresh failure is retired before attaching credits to another owner`() async {
+        let suite = "CodexUsageOwnerRaceTests-fresh-failure-then-credits"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-a@example.com",
+            identity: .providerAccount(id: "owner-a"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        self.installFailingCodexProvider(
+            on: store,
+            error: TestRefreshError(message: "owner A unavailable"))
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == "owner A unavailable")
+        #expect(store.lastFetchAttempts[.codex]?.isEmpty == false)
+        #expect(store.lastCodexUsagePublicationGuard?.accountKey == "owner-a@example.com")
+
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-b@example.com",
+            identity: .providerAccount(id: "owner-b"))
+        store._test_codexCreditsLoaderOverride = { self.credits(remaining: 29) }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+
+        await store.refreshCreditsIfNeeded()
+
+        #expect(store.errors[.codex] == nil)
+        #expect(store.lastFetchAttempts[.codex] == nil)
+        #expect(store.lastSourceLabels[.codex] == nil)
+        #expect(store.credits?.remaining == 29)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "owner-b@example.com")
+    }
+
+    @Test
+    func `stacked fresh failure follows its owner across credits attachment`() async {
+        let suite = "CodexUsageOwnerRaceTests-stacked-failure-then-credits"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-a@example.com",
+            identity: .providerAccount(id: "owner-a"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        let ownerA = CodexVisibleAccount(
+            id: "live:owner-a",
+            email: "owner-a@example.com",
+            workspaceAccountID: "owner-a",
+            storedAccountID: nil,
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: false,
+            canRemove: false)
+        let failure = ProviderFetchOutcome(
+            result: .failure(TestRefreshError(message: "owner A unavailable")),
+            attempts: [ProviderFetchAttempt(
+                strategyID: "stacked-test",
+                kind: .cli,
+                wasAvailable: true,
+                errorDescription: "owner A unavailable")])
+
+        await store.applySelectedCodexVisibleAccountOutcome(
+            failure,
+            account: ownerA,
+            snapshot: nil,
+            sourceLabel: nil,
+            limitResetOwnerKey: nil)
+
+        store._test_codexCreditsLoaderOverride = { self.credits(remaining: 19) }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+        await store.refreshCreditsIfNeeded()
+
+        #expect(store.errors[.codex] == "owner A unavailable")
+        #expect(store.lastFetchAttempts[.codex]?.first?.strategyID == "stacked-test")
+        #expect(store.credits?.remaining == 19)
+
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "owner-b@example.com",
+            identity: .providerAccount(id: "owner-b"))
+        await store.refreshCreditsIfNeeded()
+
+        #expect(store.errors[.codex] == nil)
+        #expect(store.lastFetchAttempts[.codex] == nil)
+        #expect(store.credits?.remaining == 19)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "owner-b@example.com")
+    }
+}

--- a/Tests/CodexBarTests/CodexVisibleAccountProjectionRuntimeIdentityTests.swift
+++ b/Tests/CodexBarTests/CodexVisibleAccountProjectionRuntimeIdentityTests.swift
@@ -1,0 +1,31 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CodexVisibleAccountProjectionRuntimeIdentityTests {
+    @Test
+    func `runtime provider identity supplies missing managed workspace id`() throws {
+        let accountID = UUID()
+        let storedAccount = ManagedCodexAccount(
+            id: accountID,
+            email: "user@example.com",
+            workspaceAccountID: nil,
+            managedHomePath: "/tmp/managed-a",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let snapshot = CodexAccountReconciliationSnapshot(
+            storedAccounts: [storedAccount],
+            activeStoredAccount: storedAccount,
+            liveSystemAccount: nil,
+            matchingStoredAccountForLiveSystemAccount: nil,
+            activeSource: .managedAccount(id: accountID),
+            hasUnreadableAddedAccountStore: false,
+            storedAccountRuntimeIdentities: [accountID: .providerAccount(id: " Account-Live ")])
+
+        let account = try #require(CodexVisibleAccountProjection.make(from: snapshot).visibleAccounts.first)
+
+        #expect(account.workspaceAccountID == "account-live")
+        #expect(account.selectionSource == .managedAccount(id: accountID))
+    }
+}

--- a/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
@@ -1,0 +1,405 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CodexWeeklyResetConfirmationTests {
+    private let capturedAt = Date(timeIntervalSince1970: 1_800_000_000)
+    private let resetAt = Date(timeIntervalSince1970: 1_800_500_000)
+
+    @Test
+    func `ordinary observations publish while stale initial observations preserve`() {
+        let previous = self.snapshot(offset: 0, weeklyUsed: 70, weeklyReset: self.resetAt)
+        let previousWithoutWeekly = self.snapshot(offset: 0, weeklyUsed: nil, weeklyReset: nil)
+        let newer = self.snapshot(offset: 1, weeklyUsed: 71, weeklyReset: self.resetAt)
+        let stale = self.snapshot(offset: 0, weeklyUsed: 72, weeklyReset: self.resetAt)
+
+        #expect(CodexWeeklyResetConfirmation.initialDecision(previous: nil, initial: newer) == .publishInitial)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: previousWithoutWeekly, initial: newer)
+                == .publishInitial)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: newer) == .publishInitial)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: stale) == .preservePrevious)
+    }
+
+    @Test
+    func `first low observation requires matching confirmation without prior state`() {
+        let reset = self.resetAt.addingTimeInterval(7 * 24 * 60 * 60)
+        let previousWithoutWeekly = self.snapshot(offset: 0, weeklyUsed: nil, weeklyReset: nil)
+        let initial = self.snapshot(offset: 1, weeklyUsed: 0.2, weeklyReset: reset)
+        let matching = self.snapshot(offset: 2, weeklyUsed: 0.7, weeklyReset: reset.addingTimeInterval(30))
+        let rebound = self.snapshot(offset: 2, weeklyUsed: 42, weeklyReset: reset)
+
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: nil, initial: initial)
+                == .requiresConfirmation)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(
+                previous: previousWithoutWeekly,
+                initial: initial)
+                == .requiresConfirmation)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(
+                previous: previousWithoutWeekly,
+                initial: self.snapshot(offset: 1, weeklyUsed: 0.2, weeklyReset: nil))
+                == .preservePrevious)
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: nil,
+                initial: initial,
+                confirmation: matching)
+                == .publishConfirmation)
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: nil,
+                initial: initial,
+                confirmation: rebound)
+                == .publishConfirmation)
+    }
+
+    @Test
+    func `reset backfill follows semantic lanes when cached positions are swapped`() {
+        let sessionReset = self.resetAt.addingTimeInterval(60 * 60)
+        let weeklyReset = self.resetAt.addingTimeInterval(7 * 24 * 60 * 60)
+        let partial = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 9,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: self.capturedAt)
+        let swappedCache = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 55,
+                windowMinutes: 10080,
+                resetsAt: weeklyReset,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 44,
+                windowMinutes: 300,
+                resetsAt: sessionReset,
+                resetDescription: nil),
+            updatedAt: self.capturedAt.addingTimeInterval(-1))
+
+        let backfilled = UsageStore.codexBackfillingResetWindows(partial, from: swappedCache)
+
+        #expect(backfilled.primary?.usedPercent == 9)
+        #expect(backfilled.primary?.windowMinutes == 300)
+        #expect(backfilled.primary?.resetsAt == sessionReset)
+        #expect(backfilled.secondary?.usedPercent == 55)
+        #expect(backfilled.secondary?.windowMinutes == 10080)
+        #expect(backfilled.secondary?.resetsAt == weeklyReset)
+    }
+
+    @Test
+    func `semantic weekly lookup handles swapped snapshot lanes`() {
+        let nextReset = self.resetAt.addingTimeInterval(7 * 24 * 60 * 60)
+        let previous = self.snapshot(
+            offset: 0,
+            weeklyUsed: 50,
+            weeklyReset: self.resetAt,
+            weeklyInPrimary: true)
+        let initial = self.snapshot(
+            offset: 1,
+            weeklyUsed: 0,
+            weeklyReset: nextReset,
+            weeklyInPrimary: true)
+        let confirmation = self.snapshot(
+            offset: 2,
+            weeklyUsed: 0.5,
+            weeklyReset: nextReset.addingTimeInterval(60),
+            weeklyInPrimary: true)
+
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: initial)
+                == .requiresConfirmation)
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: confirmation)
+                == .publishConfirmation)
+    }
+
+    @Test
+    func `missing candidate weekly data and reset boundaries fail closed`() {
+        let previous = self.snapshot(offset: 0, weeklyUsed: 50, weeklyReset: self.resetAt)
+        let missingWeekly = self.snapshot(offset: 1, weeklyUsed: nil, weeklyReset: nil)
+        let initialWithoutBoundary = self.snapshot(offset: 1, weeklyUsed: 0, weeklyReset: nil)
+
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: missingWeekly)
+                == .preservePrevious)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: initialWithoutBoundary)
+                == .preservePrevious)
+
+        let initial = self.snapshot(
+            offset: 1,
+            weeklyUsed: 0,
+            weeklyReset: self.resetAt.addingTimeInterval(7 * 24 * 60 * 60))
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: missingWeekly)
+                == .preservePrevious)
+    }
+
+    @Test
+    func `two valid lows establish a reset when the previous boundary is unavailable`() {
+        let nextReset = self.resetAt.addingTimeInterval(7 * 24 * 60 * 60)
+        let initial = self.snapshot(offset: 1, weeklyUsed: 0.2, weeklyReset: nextReset)
+        let confirmation = self.snapshot(
+            offset: 2,
+            weeklyUsed: 0.7,
+            weeklyReset: nextReset.addingTimeInterval(30))
+        let unavailablePreviousBoundaries: [Date?] = [
+            nil,
+            self.capturedAt.addingTimeInterval(-1),
+            Date(timeIntervalSinceReferenceDate: .infinity),
+        ]
+
+        for previousBoundary in unavailablePreviousBoundaries {
+            let previous = self.snapshot(offset: 0, weeklyUsed: 50, weeklyReset: previousBoundary)
+            #expect(
+                CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: initial)
+                    == .requiresConfirmation)
+            #expect(
+                CodexWeeklyResetConfirmation.confirmationDecision(
+                    previous: previous,
+                    initial: initial,
+                    confirmation: confirmation)
+                    == .publishConfirmation)
+        }
+    }
+
+    @Test
+    func `first ordinary high accepts a missing boundary but rejects explicit invalid boundaries`() {
+        let missingBoundary = self.snapshot(offset: 1, weeklyUsed: 42, weeklyReset: nil)
+        let elapsedBoundary = self.snapshot(
+            offset: 1,
+            weeklyUsed: 42,
+            weeklyReset: self.capturedAt)
+        let nonfiniteBoundary = self.snapshot(
+            offset: 1,
+            weeklyUsed: 42,
+            weeklyReset: Date(timeIntervalSinceReferenceDate: .infinity))
+
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: nil, initial: missingBoundary)
+                == .publishInitial)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: nil, initial: elapsedBoundary)
+                == .preservePrevious)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: nil, initial: nonfiniteBoundary)
+                == .preservePrevious)
+    }
+
+    @Test
+    func `newer rebound publishes instead of accepting the transient low`() {
+        let nextReset = self.resetAt.addingTimeInterval(7 * 24 * 60 * 60)
+        let previous = self.snapshot(offset: 0, weeklyUsed: 50, weeklyReset: self.resetAt)
+        let initial = self.snapshot(offset: 1, weeklyUsed: 0, weeklyReset: nextReset)
+        let confirmation = self.snapshot(offset: 2, weeklyUsed: 49, weeklyReset: self.resetAt)
+
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: confirmation)
+                == .publishConfirmation)
+    }
+
+    @Test
+    func `two low observations publish only for an advanced equivalent boundary`() {
+        let nextReset = self.resetAt.addingTimeInterval(7 * 24 * 60 * 60)
+        let previous = self.snapshot(offset: 0, weeklyUsed: 50, weeklyReset: self.resetAt)
+        let initial = self.snapshot(offset: 1, weeklyUsed: 0, weeklyReset: nextReset)
+        let confirmation = self.snapshot(
+            offset: 2,
+            weeklyUsed: 0.5,
+            weeklyReset: nextReset.addingTimeInterval(119))
+
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: confirmation)
+                == .publishConfirmation)
+    }
+
+    @Test
+    func `unchanged regressed and mismatched reset boundaries preserve the previous snapshot`() {
+        let previous = self.snapshot(offset: 0, weeklyUsed: 50, weeklyReset: self.resetAt)
+        let unchanged = self.snapshot(offset: 1, weeklyUsed: 0, weeklyReset: self.resetAt)
+        let regressed = self.snapshot(
+            offset: 1,
+            weeklyUsed: 0,
+            weeklyReset: self.resetAt.addingTimeInterval(-1))
+        let advanced = self.resetAt.addingTimeInterval(7 * 24 * 60 * 60)
+        let initial = self.snapshot(offset: 1, weeklyUsed: 0, weeklyReset: advanced)
+        let mismatched = self.snapshot(
+            offset: 2,
+            weeklyUsed: 0,
+            weeklyReset: advanced.addingTimeInterval(120))
+        let jitteredInitial = self.snapshot(
+            offset: 1,
+            weeklyUsed: 0,
+            weeklyReset: self.resetAt.addingTimeInterval(60))
+        let jitteredConfirmation = self.snapshot(
+            offset: 2,
+            weeklyUsed: 0.5,
+            weeklyReset: self.resetAt.addingTimeInterval(90))
+
+        for candidate in [unchanged, regressed] {
+            #expect(
+                CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: candidate)
+                    == .requiresConfirmation)
+            #expect(
+                CodexWeeklyResetConfirmation.confirmationDecision(
+                    previous: previous,
+                    initial: candidate,
+                    confirmation: self.snapshot(offset: 2, weeklyUsed: 50, weeklyReset: self.resetAt))
+                    == .publishConfirmation)
+            #expect(
+                CodexWeeklyResetConfirmation.confirmationDecision(
+                    previous: previous,
+                    initial: candidate,
+                    confirmation: self.snapshot(
+                        offset: 2,
+                        weeklyUsed: 0,
+                        weeklyReset: candidate.secondary?.resetsAt))
+                    == .preservePrevious)
+        }
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: mismatched)
+                == .preservePrevious)
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: jitteredInitial,
+                confirmation: jitteredConfirmation)
+                == .preservePrevious)
+    }
+
+    @Test
+    func `stale confirmations preserve the previous snapshot`() {
+        let nextReset = self.resetAt.addingTimeInterval(7 * 24 * 60 * 60)
+        let previous = self.snapshot(offset: 0, weeklyUsed: 50, weeklyReset: self.resetAt)
+        let initial = self.snapshot(offset: 2, weeklyUsed: 0, weeklyReset: nextReset)
+        let stale = self.snapshot(offset: 2, weeklyUsed: 50, weeklyReset: self.resetAt)
+
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: stale)
+                == .preservePrevious)
+    }
+
+    @Test
+    func `elapsed and materially regressed boundaries preserve the previous snapshot`() {
+        let nextReset = self.resetAt.addingTimeInterval(7 * 24 * 60 * 60)
+        let high = self.snapshot(offset: 0, weeklyUsed: 50, weeklyReset: self.resetAt)
+        let elapsedLow = self.snapshot(
+            capturedAt: self.resetAt.addingTimeInterval(1),
+            weeklyUsed: 0,
+            weeklyReset: self.resetAt)
+        let confirmedReset = self.snapshot(offset: 2, weeklyUsed: 0, weeklyReset: nextReset)
+        let stalePreReset = self.snapshot(offset: 3, weeklyUsed: 50, weeklyReset: self.resetAt)
+        let elapsedConfirmation = self.snapshot(
+            capturedAt: nextReset.addingTimeInterval(1),
+            weeklyUsed: 0,
+            weeklyReset: nextReset)
+
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: high, initial: elapsedLow)
+                == .preservePrevious)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: confirmedReset, initial: stalePreReset)
+                == .preservePrevious)
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: high,
+                initial: self.snapshot(offset: 1, weeklyUsed: 0, weeklyReset: nextReset),
+                confirmation: elapsedConfirmation)
+                == .preservePrevious)
+    }
+
+    @Test
+    func `nonfinite percentages timestamps and boundaries fail closed`() {
+        let previous = self.snapshot(offset: 0, weeklyUsed: 50, weeklyReset: self.resetAt)
+        let initial = self.snapshot(offset: 1, weeklyUsed: 0, weeklyReset: self.resetAt.addingTimeInterval(100))
+        let nonfiniteBoundary = Date(timeIntervalSinceReferenceDate: .infinity)
+
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(
+                previous: previous,
+                initial: self.snapshot(offset: 1, weeklyUsed: .nan, weeklyReset: self.resetAt))
+                == .preservePrevious)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(
+                previous: previous,
+                initial: self.snapshot(offset: 1, weeklyUsed: 0, weeklyReset: nonfiniteBoundary))
+                == .preservePrevious)
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(
+                previous: previous,
+                initial: self.snapshot(
+                    capturedAt: Date(timeIntervalSinceReferenceDate: .infinity),
+                    weeklyUsed: 0,
+                    weeklyReset: self.resetAt))
+                == .preservePrevious)
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: self.snapshot(offset: 2, weeklyUsed: .infinity, weeklyReset: self.resetAt))
+                == .preservePrevious)
+    }
+
+    private func snapshot(
+        offset: TimeInterval,
+        weeklyUsed: Double?,
+        weeklyReset: Date?,
+        weeklyInPrimary: Bool = false) -> UsageSnapshot
+    {
+        self.snapshot(
+            capturedAt: self.capturedAt.addingTimeInterval(offset),
+            weeklyUsed: weeklyUsed,
+            weeklyReset: weeklyReset,
+            weeklyInPrimary: weeklyInPrimary)
+    }
+
+    private func snapshot(
+        capturedAt: Date,
+        weeklyUsed: Double?,
+        weeklyReset: Date?,
+        weeklyInPrimary: Bool = false) -> UsageSnapshot
+    {
+        let weekly = weeklyUsed.map {
+            RateWindow(
+                usedPercent: $0,
+                windowMinutes: 10080,
+                resetsAt: weeklyReset,
+                resetDescription: nil)
+        }
+        let session = RateWindow(
+            usedPercent: 25,
+            windowMinutes: 300,
+            resetsAt: self.resetAt,
+            resetDescription: nil)
+        return UsageSnapshot(
+            primary: weeklyInPrimary ? weekly : session,
+            secondary: weeklyInPrimary ? session : weekly,
+            updatedAt: capturedAt)
+    }
+}

--- a/Tests/CodexBarTests/CodexWeeklyResetFailureBaselineTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetFailureBaselineTests.swift
@@ -1,0 +1,90 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `hard failure keeps trusted weekly baseline for later low observations`() async {
+        let suite = "CodexWeeklyResetFailureBaselineTests-hard-failure"
+        let email = "failure-baseline@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "failure-baseline-owner"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let boundary = now.addingTimeInterval(2 * 24 * 60 * 60)
+        let prior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 73,
+            weeklyReset: boundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        self.installFailingCodexProvider(
+            on: store,
+            error: TestRefreshError(message: "non-preservable failure"))
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.lastCodexUsagePublicationGuard?.accountKey == email)
+
+        let primaryOnly = OpenAIDashboardSnapshot(
+            signedInEmail: email,
+            codeReviewRemainingPercent: nil,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            primaryLimit: RateWindow(
+                usedPercent: 18,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                resetDescription: nil),
+            secondaryLimit: nil,
+            creditsRemaining: nil,
+            accountPlan: "Pro",
+            updatedAt: now.addingTimeInterval(-40))
+        await store.applyOpenAIDashboard(
+            primaryOnly,
+            targetEmail: email,
+            allowCodexUsageBackfill: true)
+        let primaryOnlyPublishedAt = store.snapshots[.codex]?.updatedAt
+        #expect(primaryOnlyPublishedAt == primaryOnly.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary == nil)
+
+        let loader = SequencedCodexSnapshotLoader(steps: [
+            .success(self.codexWeeklySnapshot(
+                email: email,
+                weeklyUsedPercent: 0.2,
+                weeklyReset: boundary,
+                updatedAt: now.addingTimeInterval(-30))),
+            .success(self.codexWeeklySnapshot(
+                email: email,
+                weeklyUsedPercent: 0.5,
+                weeklyReset: boundary,
+                updatedAt: now.addingTimeInterval(-20))),
+        ])
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(await loader.callCount == 2)
+        #expect(store.snapshots[.codex]?.updatedAt == primaryOnlyPublishedAt)
+        #expect(store.snapshots[.codex]?.secondary == nil)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.lastKnownResetSnapshots[.codex]?.secondary?.usedPercent == 73)
+    }
+}

--- a/Tests/CodexBarTests/CodexWeeklyResetOwnerTransitionTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetOwnerTransitionTests.swift
@@ -1,0 +1,130 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test(arguments: StableEmailOnlyRefreshFailureCase.allCases)
+    func `stable email only refresh failures preserve public account state`(
+        failure: StableEmailOnlyRefreshFailureCase) async throws
+    {
+        let suite = "CodexWeeklyResetOwnerTransitionTests-stable-email-only-\(failure.rawValue)"
+        let email = "stable-email-only@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .emailOnly(normalizedEmail: email))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let prior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 64,
+            weeklyReset: now.addingTimeInterval(2 * 24 * 60 * 60),
+            updatedAt: now.addingTimeInterval(-60))
+        let credits = self.credits(remaining: 17)
+        let dashboard = self.dashboard(email: email, creditsRemaining: 17, usedPercent: 64)
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        store.credits = credits
+        store.lastCreditsSnapshot = credits
+        store.lastCreditsSnapshotAccountKey = email
+        store.openAIDashboard = dashboard
+        store.lastOpenAIDashboardSnapshot = dashboard
+        let refreshGuard = try #require(store.lastCodexAccountScopedRefreshGuard)
+        #expect(store.codexLimitResetOwnerKey(
+            expectedGuard: refreshGuard,
+            visibleAccounts: settings.codexVisibleAccountProjection.visibleAccounts) == nil)
+        self.installFailingCodexProvider(on: store, error: failure.error)
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(store.snapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 64)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.lastKnownResetSnapshots[.codex]?.secondary?.usedPercent == 64)
+        #expect(store.lastSourceLabels[.codex] == "prior-source")
+        #expect(store.credits == credits)
+        #expect(store.lastCreditsSnapshot == credits)
+        #expect(store.openAIDashboard == dashboard)
+        #expect(store.lastOpenAIDashboardSnapshot == dashboard)
+    }
+
+    @Test
+    func `rejected reset confirmation never leaves the previous owner public`() async {
+        let suite = "CodexWeeklyResetOwnerTransitionTests-rejected-confirmation"
+        let email = "owner-transition@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "owner-before"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let previousReset = now.addingTimeInterval(2 * 24 * 60 * 60)
+        let previous = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 82,
+            weeklyReset: previousReset,
+            updatedAt: now.addingTimeInterval(-60))
+        let suspiciousLow = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.2,
+            weeklyReset: previousReset.addingTimeInterval(7 * 24 * 60 * 60),
+            updatedAt: now.addingTimeInterval(-20))
+        let loader = SequencedCodexSnapshotLoader(steps: [
+            .success(suspiciousLow),
+            .failure("confirmation unavailable", gated: true),
+        ])
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: previous)
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "owner-after"))
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        #expect(await loader.waitUntilCallCount(2))
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+        #expect(store.lastSourceLabels[.codex] == nil)
+        #expect(store.codexAccountSnapshots.isEmpty)
+
+        await loader.release(call: 2)
+        await refreshTask.value
+
+        #expect(await loader.callCount == 2)
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+        #expect(store.lastSourceLabels[.codex] == nil)
+    }
+}
+
+enum StableEmailOnlyRefreshFailureCase: String, CaseIterable, Sendable {
+    case failure
+    case cancellation
+
+    var error: any Error {
+        switch self {
+        case .failure:
+            TestRefreshError(message: "stable account refresh failed")
+        case .cancellation:
+            CancellationError()
+        }
+    }
+}

--- a/Tests/CodexBarTests/CodexWeeklyResetPublicationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetPublicationTests.swift
@@ -1,0 +1,933 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `single refresh persists provider snapshot for startup confirmation`() async throws {
+        let suite = "CodexWeeklyResetPublicationTests-single-startup-hydration"
+        let email = "startup-hydrated@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "acct-startup-hydrated"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let priorBoundary = now.addingTimeInterval(2 * 24 * 60 * 60)
+        let nextBoundary = priorBoundary.addingTimeInterval(7 * 24 * 60 * 60)
+        let prior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 69,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let initialLow = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.2,
+            weeklyReset: nextBoundary,
+            updatedAt: now.addingTimeInterval(-40))
+        let rebound = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 68,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-20))
+        let snapshotURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-weekly-round-trip-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: snapshotURL) }
+        let snapshotStore = FileCodexAccountUsageSnapshotStore(fileURL: snapshotURL)
+        let firstStore = self.makeCodexWeeklyPublicationStore(
+            settings: settings,
+            suite: suite,
+            snapshotStore: snapshotStore)
+        self.installContextualCodexProvider(on: firstStore) { _ in prior }
+
+        await firstStore.refreshProvider(.codex, allowDisabled: true)
+
+        let persistedSnapshots = snapshotStore.load(
+            for: settings.codexVisibleAccountProjection.visibleAccounts)
+        let persisted = try #require(persistedSnapshots.first)
+        #expect(persistedSnapshots.count == 1)
+        #expect(firstStore.codexAccountSnapshots.count == 1)
+        #expect(firstStore.codexAccountSnapshots.first?.id == persisted.id)
+        #expect(persisted.account.workspaceAccountID == "acct-startup-hydrated")
+        #expect(persisted.account.email == email)
+        #expect(persisted.snapshot?.updatedAt == prior.updatedAt)
+        #expect(persisted.snapshot?.accountEmail(for: .codex) == email)
+        #expect(persisted.sourceLabel == "test-codex")
+
+        let loader = SequencedCodexSnapshotLoader(steps: [
+            .success(initialLow),
+            .success(rebound, gated: true),
+        ])
+        let store = self.makeCodexWeeklyPublicationStore(
+            settings: settings,
+            suite: suite,
+            snapshotStore: snapshotStore)
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.codexAccountSnapshots.first?.snapshot?.updatedAt == prior.updatedAt)
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+        let recorder = CodexWeeklyPublicationEventRecorder(email: email)
+        defer { recorder.invalidate() }
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        #expect(await loader.waitUntilCallCount(2))
+
+        #expect(store.snapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 69)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.lastSourceLabels[.codex] == "test-codex")
+        #expect(recorder.usedPercents.isEmpty)
+
+        await loader.release(call: 2)
+        await refreshTask.value
+
+        #expect(await loader.callCount == 2)
+        #expect(store.snapshots[.codex]?.updatedAt == rebound.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 68)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.identity == .providerAccount(id: "acct-startup-hydrated"))
+        #expect(recorder.usedPercents.isEmpty)
+    }
+
+    @Test
+    func `single persistence rejects another member in the same workspace`() async {
+        let suite = "CodexWeeklyResetPublicationTests-single-persistence-member-isolation"
+        let email = "current-member@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "acct-shared-workspace"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let otherMember = self.codexWeeklySnapshot(
+            email: "other-member@example.com",
+            weeklyUsedPercent: 42,
+            weeklyReset: Date().addingTimeInterval(2 * 24 * 60 * 60),
+            updatedAt: Date())
+        let store = self.makeCodexWeeklyPublicationStore(
+            settings: settings,
+            suite: suite,
+            snapshotStore: snapshotStore)
+        self.installContextualCodexProvider(on: store) { _ in otherMember }
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.codexAccountSnapshots.isEmpty)
+        #expect(snapshotStore.storedSnapshots.isEmpty)
+    }
+
+    @Test
+    func `single startup rejects hydrated snapshot from another workspace`() async throws {
+        let suite = "CodexWeeklyResetPublicationTests-single-startup-workspace-isolation"
+        let email = "workspace-isolation@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "acct-current-workspace"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let currentAccount = try #require(settings.codexVisibleAccountProjection.visibleAccounts.first)
+        let otherWorkspaceAccount = CodexVisibleAccount(
+            id: currentAccount.id,
+            email: currentAccount.email,
+            workspaceLabel: currentAccount.workspaceLabel,
+            workspaceAccountID: "acct-other-workspace",
+            authFingerprint: currentAccount.authFingerprint,
+            storedAccountID: currentAccount.storedAccountID,
+            selectionSource: currentAccount.selectionSource,
+            isActive: currentAccount.isActive,
+            isLive: currentAccount.isLive,
+            canReauthenticate: currentAccount.canReauthenticate,
+            canRemove: currentAccount.canRemove)
+        let now = Date()
+        let priorBoundary = now.addingTimeInterval(2 * 24 * 60 * 60)
+        let otherWorkspacePrior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 71,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let currentSnapshot = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 42,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-20))
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [
+            CodexAccountUsageSnapshot(
+                account: otherWorkspaceAccount,
+                snapshot: otherWorkspacePrior,
+                error: nil,
+                sourceLabel: "wrong-workspace"),
+        ])
+        let loader = SequencedCodexSnapshotLoader(steps: [.success(currentSnapshot, gated: true)])
+        let store = self.makeCodexWeeklyPublicationStore(
+            settings: settings,
+            suite: suite,
+            snapshotStore: snapshotStore)
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        #expect(await loader.waitUntilCallCount(1))
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+
+        await loader.release(call: 1)
+        await refreshTask.value
+
+        #expect(await loader.callCount == 1)
+        #expect(store.snapshots[.codex]?.updatedAt == currentSnapshot.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 42)
+        let persisted = try #require(snapshotStore.storedSnapshots.first)
+        #expect(snapshotStore.storedSnapshots.count == 1)
+        #expect(store.codexAccountSnapshots.count == 1)
+        #expect(store.codexAccountSnapshots.first?.id == persisted.id)
+        #expect(persisted.account.workspaceAccountID == "acct-current-workspace")
+        #expect(persisted.account.email == email)
+        #expect(persisted.snapshot?.updatedAt == currentSnapshot.updatedAt)
+    }
+
+    @Test
+    func `single refresh retains the weekly lane when a source omits it`() async {
+        let suite = "CodexWeeklyResetPublicationTests-single-missing-weekly"
+        let email = "missing-weekly@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "acct-missing-weekly"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let priorBoundary = now.addingTimeInterval(2 * 24 * 60 * 60)
+        let prior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 57,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let partial = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: nil,
+            weeklyReset: nil,
+            updatedAt: now.addingTimeInterval(-20),
+            sessionUsedPercent: 31)
+        let loader = SequencedCodexSnapshotLoader(steps: [.success(partial)])
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(await loader.callCount == 1)
+        #expect(store.snapshots[.codex]?.updatedAt == partial.updatedAt)
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 31)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 57)
+        #expect(store.snapshots[.codex]?.secondary?.resetsAt == priorBoundary)
+        #expect(store.lastKnownResetSnapshots[.codex]?.secondary?.usedPercent == 57)
+    }
+
+    @Test
+    func `single refresh keeps prior state private until rebound confirmation publishes`() async {
+        let suite = "CodexWeeklyResetPublicationTests-single-gated-rebound"
+        let email = "gated-rebound@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "acct-gated-rebound"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let priorBoundary = now.addingTimeInterval(3 * 24 * 60 * 60)
+        let nextBoundary = priorBoundary.addingTimeInterval(7 * 24 * 60 * 60)
+        let prior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 64,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let initialLow = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.2,
+            weeklyReset: nextBoundary,
+            updatedAt: now.addingTimeInterval(-40))
+        let rebound = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 63,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-20))
+        let loader = SequencedCodexSnapshotLoader(steps: [
+            .success(initialLow),
+            .success(rebound, gated: true),
+        ])
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        let priorRevision = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior)
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+        let recorder = CodexWeeklyPublicationEventRecorder(email: email)
+        defer { recorder.invalidate() }
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        #expect(await loader.waitUntilCallCount(2))
+
+        #expect(store.snapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 64)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.lastKnownResetSnapshots[.codex]?.secondary?.usedPercent == 64)
+        #expect(store.errors[.codex] == "prior error")
+        #expect(store.lastSourceLabels[.codex] == "prior-source")
+        #expect(store.lastFetchAttempts[.codex]?.count == 1)
+        #expect(store.lastFetchAttempts[.codex]?.first?.strategyID == "prior-strategy")
+        #expect(store.lastFetchAttempts[.codex]?.first?.errorDescription == "prior diagnostic")
+        #expect(store.planUtilizationHistoryRevision == priorRevision)
+        #expect(recorder.usedPercents.isEmpty)
+
+        await loader.release(call: 2)
+        await refreshTask.value
+
+        #expect(await loader.callCount == 2)
+        #expect(store.snapshots[.codex]?.updatedAt == rebound.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 63)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == rebound.updatedAt)
+        #expect(store.lastKnownResetSnapshots[.codex]?.secondary?.usedPercent == 63)
+        #expect(store.errors[.codex] == nil)
+        #expect(store.lastSourceLabels[.codex] == "test-codex")
+        #expect(store.lastFetchAttempts[.codex]?.count == 1)
+        #expect(store.lastFetchAttempts[.codex]?.first?.strategyID == "contextual-test-codex")
+        #expect(recorder.usedPercents.isEmpty)
+    }
+
+    @Test
+    func `single refresh publishes the second matching low observation only`() async {
+        let suite = "CodexWeeklyResetPublicationTests-single-confirmed-low"
+        let email = "confirmed-low@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "acct-confirmed-low"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let priorBoundary = now.addingTimeInterval(2 * 24 * 60 * 60)
+        let nextBoundary = priorBoundary.addingTimeInterval(7 * 24 * 60 * 60)
+        let prior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 72,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let initialLow = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.2,
+            weeklyReset: nextBoundary,
+            updatedAt: now.addingTimeInterval(-40))
+        let confirmedLow = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.7,
+            weeklyReset: nextBoundary.addingTimeInterval(30),
+            updatedAt: now.addingTimeInterval(-20))
+        let loader = SequencedCodexSnapshotLoader(steps: [
+            .success(initialLow),
+            .success(confirmedLow),
+        ])
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+        let recorder = CodexWeeklyPublicationEventRecorder(email: email)
+        defer { recorder.invalidate() }
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(await loader.callCount == 2)
+        #expect(store.snapshots[.codex]?.updatedAt == confirmedLow.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 0.7)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent != initialLow.secondary?.usedPercent)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == confirmedLow.updatedAt)
+        #expect(recorder.count == 1)
+        #expect(recorder.usedPercents == [0.7])
+    }
+
+    @Test(arguments: CodexRejectedConfirmationCase.allCases)
+    func `rejected single confirmation preserves every prior public surface`(
+        rejection: CodexRejectedConfirmationCase) async
+    {
+        let suite = "CodexWeeklyResetPublicationTests-rejected-\(rejection.rawValue)"
+        let email = "rejected-\(rejection.rawValue)@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "acct-rejected-\(rejection.rawValue)"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let priorBoundary = now.addingTimeInterval(2 * 24 * 60 * 60)
+        let nextBoundary = priorBoundary.addingTimeInterval(7 * 24 * 60 * 60)
+        let prior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 81,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let initialLow = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.1,
+            weeklyReset: nextBoundary,
+            updatedAt: now.addingTimeInterval(-40))
+        let confirmationStep: SequencedCodexSnapshotLoadStep = switch rejection {
+        case .error:
+            .failure("soft confirmation failure")
+        case .missingBoundary:
+            .success(self.codexWeeklySnapshot(
+                email: email,
+                weeklyUsedPercent: 0.4,
+                weeklyReset: nil,
+                updatedAt: now.addingTimeInterval(-20)))
+        case .mismatchedBoundary:
+            .success(self.codexWeeklySnapshot(
+                email: email,
+                weeklyUsedPercent: 0.4,
+                weeklyReset: nextBoundary.addingTimeInterval(3 * 60),
+                updatedAt: now.addingTimeInterval(-20)))
+        case .differentMember:
+            .success(self.codexWeeklySnapshot(
+                email: "another-member@example.com",
+                weeklyUsedPercent: 0.4,
+                weeklyReset: nextBoundary.addingTimeInterval(30),
+                updatedAt: now.addingTimeInterval(-20)))
+        }
+        let loader = SequencedCodexSnapshotLoader(steps: [.success(initialLow), confirmationStep])
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        let priorRevision = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+        let recorder = CodexWeeklyPublicationEventRecorder(email: email)
+        defer { recorder.invalidate() }
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(await loader.callCount == 2)
+        #expect(store.snapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 81)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.lastKnownResetSnapshots[.codex]?.secondary?.usedPercent == 81)
+        #expect(store.errors[.codex] == nil)
+        #expect(store.lastSourceLabels[.codex] == "prior-source")
+        #expect(store.lastFetchAttempts[.codex]?.count == 1)
+        #expect(store.lastFetchAttempts[.codex]?.first?.strategyID == "prior-strategy")
+        #expect(store.lastFetchAttempts[.codex]?.first?.errorDescription == "prior diagnostic")
+        #expect(store.planUtilizationHistoryRevision == priorRevision)
+        #expect(recorder.usedPercents.isEmpty)
+    }
+
+    @Test
+    func `confirmed reset resists a later stale pre reset observation`() async {
+        let suite = "CodexWeeklyResetPublicationTests-post-reset-stale"
+        let email = "post-reset-stale@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "acct-post-reset-stale"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let priorBoundary = now.addingTimeInterval(2 * 24 * 60 * 60)
+        let nextBoundary = priorBoundary.addingTimeInterval(7 * 24 * 60 * 60)
+        let prior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 78,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let initialLow = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.2,
+            weeklyReset: nextBoundary,
+            updatedAt: now.addingTimeInterval(-40))
+        let confirmedLow = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.6,
+            weeklyReset: nextBoundary.addingTimeInterval(30),
+            updatedAt: now.addingTimeInterval(-20))
+        let stalePreReset = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 77,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-10))
+        let loader = SequencedCodexSnapshotLoader(steps: [
+            .success(initialLow),
+            .success(confirmedLow),
+            .success(stalePreReset),
+        ])
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+        let recorder = CodexWeeklyPublicationEventRecorder(email: email)
+        defer { recorder.invalidate() }
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+        let acceptedRevision = store.planUtilizationHistoryRevision
+        #expect(store.snapshots[.codex]?.updatedAt == confirmedLow.updatedAt)
+        #expect(recorder.usedPercents == [0.6])
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(await loader.callCount == 3)
+        #expect(store.snapshots[.codex]?.updatedAt == confirmedLow.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 0.6)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == confirmedLow.updatedAt)
+        #expect(store.planUtilizationHistoryRevision == acceptedRevision)
+        #expect(recorder.usedPercents == [0.6])
+    }
+
+    @Test
+    func `single refresh never compares a prior snapshot across provider owners`() async {
+        let suite = "CodexWeeklyResetPublicationTests-owner-transition"
+        let email = "owner-transition@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "acct-owner-transition-a"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+
+        let now = Date()
+        let priorBoundary = now.addingTimeInterval(2 * 24 * 60 * 60)
+        let nextBoundary = priorBoundary.addingTimeInterval(7 * 24 * 60 * 60)
+        let prior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 82,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let newOwnerLow = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.3,
+            weeklyReset: nextBoundary,
+            updatedAt: now.addingTimeInterval(-20))
+        let confirmedNewOwnerLow = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.6,
+            weeklyReset: nextBoundary.addingTimeInterval(30),
+            updatedAt: now.addingTimeInterval(-10))
+        let loader = SequencedCodexSnapshotLoader(steps: [
+            .success(newOwnerLow),
+            .success(confirmedNewOwnerLow),
+        ])
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        _ = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: prior,
+            error: nil)
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: email,
+            identity: .providerAccount(id: "acct-owner-transition-b"))
+        self.installContextualCodexProvider(on: store) { _ in try await loader.load() }
+        let recorder = CodexWeeklyPublicationEventRecorder(email: email)
+        defer { recorder.invalidate() }
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(await loader.callCount == 2)
+        #expect(store.snapshots[.codex]?.updatedAt == confirmedNewOwnerLow.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 0.6)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == confirmedNewOwnerLow.updatedAt)
+        #expect(recorder.usedPercents.isEmpty)
+    }
+
+    @Test
+    func `stacked refresh rejects a response explicitly owned by another member`() async throws {
+        let suite = "CodexWeeklyResetPublicationTests-stacked-response-email-mismatch"
+        let targetID = try #require(UUID(uuidString: "11111111-2222-3333-4444-555555555555"))
+        let siblingID = try #require(UUID(uuidString: "66666666-7777-8888-9999-AAAAAAAAAAAA"))
+        let targetHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-stacked-mismatch-target-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-stacked-mismatch-sibling-\(UUID().uuidString)", isDirectory: true)
+        let target = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: targetID,
+            email: "target-member@example.com",
+            workspaceID: "shared-provider-workspace",
+            workspaceLabel: "Target Member",
+            homeURL: targetHome)
+        let sibling = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: siblingID,
+            email: "sibling-member@example.com",
+            workspaceID: "sibling-provider-workspace",
+            workspaceLabel: "Sibling Member",
+            homeURL: siblingHome)
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [target, sibling])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: targetHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: targetID)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = self.makeCodexWeeklyPublicationStore(
+            settings: settings,
+            suite: suite,
+            snapshotStore: snapshotStore)
+        let now = Date()
+        let targetMismatch = self.codexWeeklySnapshot(
+            email: "another-member@example.com",
+            weeklyUsedPercent: 64,
+            weeklyReset: now.addingTimeInterval(2 * 24 * 60 * 60),
+            updatedAt: now)
+        let siblingSnapshot = self.codexWeeklySnapshot(
+            email: sibling.email,
+            weeklyUsedPercent: 22,
+            weeklyReset: now.addingTimeInterval(2 * 24 * 60 * 60),
+            updatedAt: now)
+        self.installContextualCodexProvider(on: store) { context in
+            let isTarget = context.env["CODEX_HOME"] == targetHome.path
+            return isTarget ? targetMismatch : siblingSnapshot
+        }
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(!store.codexAccountSnapshots.contains { $0.account.storedAccountID == targetID })
+        #expect(store.codexAccountSnapshots.contains { $0.account.storedAccountID == siblingID })
+        #expect(!snapshotStore.storedSnapshots.contains { $0.account.storedAccountID == targetID })
+        #expect(snapshotStore.storedSnapshots.contains { $0.account.storedAccountID == siblingID })
+    }
+
+    @Test
+    func `stacked refresh never publishes or persists an unconfirmed account reset`() async throws {
+        let suite = "CodexWeeklyResetPublicationTests-stacked"
+        let email = "shared-stacked@example.com"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings.multiAccountMenuLayout = .stacked
+
+        let suspiciousID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-303030303030"))
+        let siblingID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-313131313131"))
+        let suspiciousHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-weekly-suspicious-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-weekly-sibling-\(UUID().uuidString)", isDirectory: true)
+        let suspiciousAccount = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: suspiciousID,
+            email: email,
+            workspaceID: "acct-stacked-suspicious",
+            workspaceLabel: "Suspicious Workspace",
+            homeURL: suspiciousHome)
+        let siblingAccount = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: siblingID,
+            email: email,
+            workspaceID: "acct-stacked-sibling",
+            workspaceLabel: "Sibling Workspace",
+            homeURL: siblingHome)
+        let managedStoreURL = try self.makeManagedAccountStoreURL(accounts: [suspiciousAccount, siblingAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: managedStoreURL)
+            try? FileManager.default.removeItem(at: suspiciousHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = managedStoreURL
+        settings.codexActiveSource = .managedAccount(id: suspiciousID)
+
+        let visibleAccounts = settings.codexVisibleAccountProjection.visibleAccounts
+        #expect(visibleAccounts.count == 2)
+        let suspiciousVisible = try #require(visibleAccounts.first {
+            $0.workspaceAccountID == "acct-stacked-suspicious"
+        })
+        let siblingVisible = try #require(visibleAccounts.first {
+            $0.workspaceAccountID == "acct-stacked-sibling"
+        })
+        let now = Date()
+        let priorBoundary = now.addingTimeInterval(3 * 24 * 60 * 60)
+        let nextBoundary = priorBoundary.addingTimeInterval(7 * 24 * 60 * 60)
+        let suspiciousPriorAccount = CodexVisibleAccount(
+            id: "prior-email-derived-row",
+            email: email,
+            workspaceLabel: suspiciousVisible.workspaceLabel,
+            workspaceAccountID: suspiciousVisible.workspaceAccountID,
+            authFingerprint: "prior-auth-fingerprint",
+            storedAccountID: suspiciousVisible.storedAccountID,
+            selectionSource: suspiciousVisible.selectionSource,
+            isActive: suspiciousVisible.isActive,
+            isLive: suspiciousVisible.isLive,
+            canReauthenticate: suspiciousVisible.canReauthenticate,
+            canRemove: suspiciousVisible.canRemove)
+        let suspiciousPrior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 84,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let siblingPrior = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 62,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-60))
+        let priorRows = [
+            CodexAccountUsageSnapshot(
+                account: suspiciousPriorAccount,
+                snapshot: suspiciousPrior,
+                error: nil,
+                sourceLabel: "cached-suspicious"),
+            CodexAccountUsageSnapshot(
+                account: siblingVisible,
+                snapshot: siblingPrior,
+                error: nil,
+                sourceLabel: "cached-sibling"),
+        ]
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: priorRows)
+        let store = self.makeCodexWeeklyPublicationStore(
+            settings: settings,
+            suite: suite,
+            snapshotStore: snapshotStore)
+        store.codexAccountSnapshots = priorRows
+        let priorRevision = await self.seedCodexWeeklyPublicationState(
+            store: store,
+            settings: settings,
+            snapshot: suspiciousPrior,
+            error: nil)
+
+        let suspiciousInitial = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.1,
+            weeklyReset: nextBoundary,
+            updatedAt: now.addingTimeInterval(-40))
+        let suspiciousRejected = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 0.4,
+            weeklyReset: nil,
+            updatedAt: now.addingTimeInterval(-20))
+        let siblingUpdated = self.codexWeeklySnapshot(
+            email: email,
+            weeklyUsedPercent: 63,
+            weeklyReset: priorBoundary,
+            updatedAt: now.addingTimeInterval(-20))
+        let suspiciousLoader = SequencedCodexSnapshotLoader(steps: [
+            .success(suspiciousInitial),
+            .success(suspiciousRejected, gated: true),
+        ])
+        let siblingLoader = SequencedCodexSnapshotLoader(steps: [.success(siblingUpdated)])
+        let suspiciousHomePath = suspiciousHome.path
+        let siblingHomePath = siblingHome.path
+        self.installContextualCodexProvider(on: store) { context in
+            switch context.env["CODEX_HOME"] {
+            case suspiciousHomePath:
+                try await suspiciousLoader.load()
+            case siblingHomePath:
+                try await siblingLoader.load()
+            default:
+                throw TestRefreshError(message: "Unexpected CODEX_HOME routing")
+            }
+        }
+        let currentRecorder = CodexWeeklyPublicationEventRecorder(email: email)
+        defer { currentRecorder.invalidate() }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        #expect(await suspiciousLoader.waitUntilCallCount(2))
+        #expect(await siblingLoader.waitUntilCompletedCallCount(1))
+
+        try self.expectBlockedStackedResetState(
+            store: store,
+            snapshotStore: snapshotStore,
+            prior: suspiciousPrior,
+            historyRevision: priorRevision,
+            recorder: currentRecorder)
+
+        await suspiciousLoader.release(call: 2)
+        await refreshTask.value
+
+        #expect(await suspiciousLoader.callCount == 2)
+        #expect(await siblingLoader.callCount == 1)
+        try self.expectFinalStackedResetState(
+            store: store,
+            snapshotStore: snapshotStore,
+            expectation: FinalStackedResetExpectation(
+                targetAccount: suspiciousVisible,
+                siblingAccount: siblingVisible,
+                targetPrior: suspiciousPrior,
+                siblingUpdated: siblingUpdated,
+                historyRevision: priorRevision),
+            recorder: currentRecorder)
+    }
+
+    private func expectBlockedStackedResetState(
+        store: UsageStore,
+        snapshotStore: RecordingCodexAccountUsageSnapshotStore,
+        prior: UsageSnapshot,
+        historyRevision: Int,
+        recorder: CodexWeeklyPublicationEventRecorder) throws
+    {
+        let target = try #require(store.codexAccountSnapshots.first {
+            $0.account.workspaceAccountID == "acct-stacked-suspicious"
+        })
+        #expect(target.snapshot?.updatedAt == prior.updatedAt)
+        #expect(target.snapshot?.secondary?.usedPercent == 84)
+        #expect(target.sourceLabel == "cached-suspicious")
+        #expect(snapshotStore.storedSnapshots.isEmpty)
+        #expect(store.snapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 84)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == prior.updatedAt)
+        #expect(store.errors[.codex] == nil)
+        #expect(store.lastSourceLabels[.codex] == "prior-source")
+        #expect(store.lastFetchAttempts[.codex]?.first?.strategyID == "prior-strategy")
+        #expect(store.planUtilizationHistoryRevision == historyRevision)
+        #expect(recorder.usedPercents.isEmpty)
+    }
+
+    private func expectFinalStackedResetState(
+        store: UsageStore,
+        snapshotStore: RecordingCodexAccountUsageSnapshotStore,
+        expectation: FinalStackedResetExpectation,
+        recorder: CodexWeeklyPublicationEventRecorder) throws
+    {
+        let target = try #require(store.codexAccountSnapshots.first {
+            $0.account.workspaceAccountID == "acct-stacked-suspicious"
+        })
+        #expect(target.account.id == expectation.targetAccount.id)
+        #expect(target.account.email == expectation.targetAccount.email)
+        #expect(target.snapshot?.accountEmail(for: .codex) == expectation.targetAccount.email)
+        #expect(target.snapshot?.updatedAt == expectation.targetPrior.updatedAt)
+        #expect(target.snapshot?.secondary?.usedPercent == 84)
+        #expect(target.error == nil)
+        #expect(target.sourceLabel == "cached-suspicious")
+        #expect(!store.codexAccountSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-stacked-suspicious"
+                && $0.snapshot?.secondary?.usedPercent == 0.1
+        })
+        let persistedTarget = try #require(snapshotStore.storedSnapshots.first {
+            $0.account.workspaceAccountID == "acct-stacked-suspicious"
+        })
+        #expect(persistedTarget.snapshot?.updatedAt == expectation.targetPrior.updatedAt)
+        #expect(persistedTarget.snapshot?.secondary?.usedPercent == 84)
+        #expect(persistedTarget.error == nil)
+        #expect(persistedTarget.sourceLabel == "cached-suspicious")
+        let sibling = try #require(store.codexAccountSnapshots.first {
+            $0.account.workspaceAccountID == "acct-stacked-sibling"
+        })
+        #expect(sibling.snapshot?.updatedAt == expectation.siblingUpdated.updatedAt)
+        #expect(sibling.snapshot?.secondary?.usedPercent == 63)
+        #expect(snapshotStore.storedSnapshots.count == 2)
+        #expect(Set(snapshotStore.storedSnapshots.map(\.id)) == Set([
+            expectation.targetAccount.id,
+            expectation.siblingAccount.id,
+        ]))
+        #expect(!snapshotStore.storedSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-stacked-suspicious"
+                && $0.snapshot?.secondary?.usedPercent == 0.1
+        })
+        #expect(store.snapshots[.codex]?.updatedAt == expectation.targetPrior.updatedAt)
+        #expect(store.snapshots[.codex]?.secondary?.usedPercent == 84)
+        #expect(store.snapshots[.codex]?.accountEmail(for: .codex) == expectation.targetAccount.email)
+        #expect(store.lastKnownResetSnapshots[.codex]?.updatedAt == expectation.targetPrior.updatedAt)
+        #expect(
+            store.lastKnownResetSnapshots[.codex]?.accountEmail(for: .codex) == expectation.targetAccount.email)
+        #expect(store.errors[.codex] == nil)
+        #expect(store.lastSourceLabels[.codex] == "prior-source")
+        #expect(store.lastFetchAttempts[.codex]?.first?.strategyID == "prior-strategy")
+        #expect(store.planUtilizationHistoryRevision == expectation.historyRevision)
+        #expect(recorder.usedPercents.isEmpty)
+    }
+}
+
+private struct FinalStackedResetExpectation {
+    let targetAccount: CodexVisibleAccount
+    let siblingAccount: CodexVisibleAccount
+    let targetPrior: UsageSnapshot
+    let siblingUpdated: UsageSnapshot
+    let historyRevision: Int
+}
+
+enum CodexRejectedConfirmationCase: String, CaseIterable, Sendable {
+    case differentMember
+    case error
+    case missingBoundary
+    case mismatchedBoundary
+}
+
+private final class CodexWeeklyPublicationEventRecorder: @unchecked Sendable {
+    private let email: String
+    private let lock = NSLock()
+    private var observations: [Double] = []
+    private var token: NSObjectProtocol?
+
+    init(email: String) {
+        self.email = email
+        self.token = NotificationCenter.default.addObserver(
+            forName: .codexbarWeeklyLimitReset,
+            object: nil,
+            queue: nil)
+        { [weak self] notification in
+            guard let self,
+                  let event = notification.object as? WeeklyLimitResetEvent
+            else {
+                return
+            }
+            let usedPercent = MainActor.assumeIsolated { () -> Double? in
+                guard event.provider == .codex, event.accountLabel == self.email else { return nil }
+                return event.usedPercent
+            }
+            guard let usedPercent else { return }
+            self.lock.lock()
+            self.observations.append(usedPercent)
+            self.lock.unlock()
+        }
+    }
+
+    var count: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.observations.count
+    }
+
+    var usedPercents: [Double] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.observations
+    }
+
+    func invalidate() {
+        guard let token else { return }
+        NotificationCenter.default.removeObserver(token)
+        self.token = nil
+    }
+
+    deinit {
+        self.invalidate()
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuCodexSwitcherPresentationTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCodexSwitcherPresentationTests.swift
@@ -64,6 +64,14 @@ struct StatusMenuCodexSwitcherPresentationTests {
                 loginMethod: "Plus"))
     }
 
+    private func removeAccountIdentity(fromSnapshotStoreAt fileURL: URL) throws {
+        var payload = try #require(JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any])
+        var records = try #require(payload["records"] as? [[String: Any]])
+        records[0].removeValue(forKey: "accountIdentity")
+        payload["records"] = records
+        try JSONSerialization.data(withJSONObject: payload).write(to: fileURL)
+    }
+
     @Test
     func `codex account ordering keeps workspace groups contiguous`() {
         let teamActive = CodexVisibleAccount(
@@ -255,6 +263,7 @@ struct StatusMenuCodexSwitcherPresentationTests {
         let account = CodexVisibleAccount(
             id: "active@example.com",
             email: "active@example.com",
+            workspaceAccountID: "acct-active",
             storedAccountID: nil,
             selectionSource: .liveSystem,
             isActive: true,
@@ -321,7 +330,7 @@ struct StatusMenuCodexSwitcherPresentationTests {
     }
 
     @Test
-    func `codex account snapshot store rejects same stored account after auth fingerprint changes`() {
+    func `codex account snapshot store keeps same composite owner after auth fingerprint changes`() {
         let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: fileURL) }
 
@@ -329,6 +338,7 @@ struct StatusMenuCodexSwitcherPresentationTests {
         let oldAccount = CodexVisibleAccount(
             id: "reauth@example.com",
             email: "reauth@example.com",
+            workspaceAccountID: "acct-reauth",
             authFingerprint: "old-auth-fingerprint",
             storedAccountID: accountID,
             selectionSource: .managedAccount(id: accountID),
@@ -339,6 +349,7 @@ struct StatusMenuCodexSwitcherPresentationTests {
         let newAccount = CodexVisibleAccount(
             id: "reauth@example.com",
             email: "reauth@example.com",
+            workspaceAccountID: "acct-reauth",
             authFingerprint: "new-auth-fingerprint",
             storedAccountID: accountID,
             selectionSource: .managedAccount(id: accountID),
@@ -357,7 +368,8 @@ struct StatusMenuCodexSwitcherPresentationTests {
 
         let hydrated = store.load(for: [newAccount])
 
-        #expect(hydrated.isEmpty)
+        #expect(hydrated.map(\.id) == [newAccount.id])
+        #expect(hydrated.first?.snapshot?.primary?.usedPercent == 71)
     }
 
     @Test
@@ -396,5 +408,79 @@ struct StatusMenuCodexSwitcherPresentationTests {
         let hydrated = store.load(for: [workspaceAccount])
 
         #expect(hydrated.isEmpty)
+    }
+
+    @Test
+    func `codex account snapshot store rejects normalized legacy email ids without composite owner`() throws {
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let payload = """
+        {
+          "records" : [
+            {
+              "error" : "cached",
+              "id" : "Legacy@Example.com",
+              "snapshot" : null,
+              "sourceLabel" : "legacy"
+            }
+          ],
+          "version" : 1
+        }
+        """
+        try Data(payload.utf8).write(to: fileURL)
+
+        let account = CodexVisibleAccount(
+            id: "Legacy@Example.com",
+            email: "legacy@example.com",
+            storedAccountID: nil,
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: true,
+            canRemove: false)
+        let store = FileCodexAccountUsageSnapshotStore(fileURL: fileURL)
+
+        #expect(store.load(for: [account]).isEmpty)
+    }
+
+    @Test
+    func `codex account snapshot store rejects legacy stable ids crossing workspace members`() throws {
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let managedAccountID = UUID()
+        let visibleID = "managed:\(managedAccountID.uuidString.lowercased())"
+        let priorAccount = CodexVisibleAccount(
+            id: visibleID,
+            email: "first-member@example.com",
+            workspaceAccountID: "shared-workspace",
+            storedAccountID: managedAccountID,
+            selectionSource: .managedAccount(id: managedAccountID),
+            isActive: false,
+            isLive: false,
+            canReauthenticate: true,
+            canRemove: true)
+        let otherMember = CodexVisibleAccount(
+            id: priorAccount.id,
+            email: "second-member@example.com",
+            workspaceAccountID: priorAccount.workspaceAccountID,
+            storedAccountID: managedAccountID,
+            selectionSource: .managedAccount(id: managedAccountID),
+            isActive: true,
+            isLive: false,
+            canReauthenticate: true,
+            canRemove: true)
+        let store = FileCodexAccountUsageSnapshotStore(fileURL: fileURL)
+        store.store([
+            CodexAccountUsageSnapshot(
+                account: priorAccount,
+                snapshot: self.snapshot(email: priorAccount.email, percent: 71),
+                error: nil,
+                sourceLabel: "legacy"),
+        ])
+
+        try self.removeAccountIdentity(fromSnapshotStoreAt: fileURL)
+
+        #expect(store.load(for: [otherMember]).isEmpty)
     }
 }

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
@@ -82,9 +82,12 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
-    func `codex session celebration follows semantic secondary session lane`() async {
+    func `codex session celebration follows semantic secondary session lane`() async throws {
         let store = Self.makeStore()
         let accountLabel = "codex-session-secondary@example.com"
+        let ownerKey = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-session-secondary"),
+            accountEmail: accountLabel))
         let recorder = SessionLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
         defer { recorder.invalidate() }
 
@@ -107,8 +110,16 @@ extension UsageStorePlanUtilizationTests {
                 accountOrganization: nil,
                 loginMethod: "plus"))
 
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: after, now: after.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: before,
+            codexLimitResetOwnerKey: ownerKey,
+            now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: after,
+            codexLimitResetOwnerKey: ownerKey,
+            now: after.updatedAt)
 
         #expect(recorder.events.count == 1)
         #expect(recorder.events.first?.usedPercent == 0)
@@ -116,9 +127,12 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
-    func `codex session celebration ignores transient zero when reset boundary is unchanged`() async {
+    func `codex session celebration ignores transient zero when reset boundary is unchanged`() async throws {
         let store = Self.makeStore()
         let accountLabel = "codex-session-transient-zero@example.com"
+        let ownerKey = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-session-transient-zero"),
+            accountEmail: accountLabel))
         let recorder = SessionLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
         defer { recorder.invalidate() }
 
@@ -163,18 +177,28 @@ extension UsageStorePlanUtilizationTests {
             sessionReset: sessionReset.addingTimeInterval(5 * 3600),
             updatedAt: firstDate.addingTimeInterval(180))
 
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: before,
+            codexLimitResetOwnerKey: ownerKey,
+            now: before.updatedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: regressedBoundaryHigh,
+            codexLimitResetOwnerKey: ownerKey,
             now: regressedBoundaryHigh.updatedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: transientZero,
+            codexLimitResetOwnerKey: ownerKey,
             now: transientZero.updatedAt)
         #expect(recorder.events.isEmpty)
 
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: realReset, now: realReset.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: realReset,
+            codexLimitResetOwnerKey: ownerKey,
+            now: realReset.updatedAt)
 
         #expect(recorder.events.count == 1)
         #expect(recorder.events.first?.usedPercent == 0)
@@ -182,9 +206,12 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
-    func `codex weekly celebration ignores transient zero when reset boundary is unchanged`() async {
+    func `codex weekly celebration ignores transient zero when reset boundary is unchanged`() async throws {
         let store = Self.makeStore()
         let accountLabel = "codex-weekly-transient-zero@example.com"
+        let ownerKey = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-weekly-transient-zero"),
+            accountEmail: accountLabel))
         let recorder = WeeklyLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
         defer { recorder.invalidate() }
 
@@ -225,14 +252,23 @@ extension UsageStorePlanUtilizationTests {
             weeklyReset: weeklyReset.addingTimeInterval(7 * 24 * 3600),
             updatedAt: firstDate.addingTimeInterval(180))
 
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: before,
+            codexLimitResetOwnerKey: ownerKey,
+            now: before.updatedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: transientZero,
+            codexLimitResetOwnerKey: ownerKey,
             now: transientZero.updatedAt)
         #expect(recorder.events.isEmpty)
 
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: realReset, now: realReset.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: realReset,
+            codexLimitResetOwnerKey: ownerKey,
+            now: realReset.updatedAt)
 
         #expect(recorder.events.count == 1)
         #expect(recorder.events.first?.usedPercent == 0)
@@ -240,9 +276,12 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
-    func `codex weekly celebration ignores missing reset boundaries`() async {
+    func `codex weekly celebration ignores missing reset boundaries`() async throws {
         let store = Self.makeStore()
         let accountLabel = "codex-weekly-missing-boundary@example.com"
+        let ownerKey = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-weekly-missing-boundary"),
+            accountEmail: accountLabel))
         let recorder = WeeklyLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
         defer { recorder.invalidate() }
 
@@ -276,10 +315,15 @@ extension UsageStorePlanUtilizationTests {
             weeklyReset: nil,
             updatedAt: firstDate.addingTimeInterval(120))
 
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: before,
+            codexLimitResetOwnerKey: ownerKey,
+            now: before.updatedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: transientZero,
+            codexLimitResetOwnerKey: ownerKey,
             now: transientZero.updatedAt)
         #expect(recorder.events.isEmpty)
 
@@ -295,8 +339,13 @@ extension UsageStorePlanUtilizationTests {
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: establishedBoundary,
+            codexLimitResetOwnerKey: ownerKey,
             now: establishedBoundary.updatedAt)
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: realReset, now: realReset.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: realReset,
+            codexLimitResetOwnerKey: ownerKey,
+            now: realReset.updatedAt)
 
         #expect(recorder.events.count == 1)
         #expect(recorder.events.first?.usedPercent == 0)
@@ -304,9 +353,12 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
-    func `codex weekly celebration preserves a known boundary across missing metadata`() async {
+    func `codex weekly celebration preserves a known boundary across missing metadata`() async throws {
         let store = Self.makeStore()
         let accountLabel = "codex-weekly-intermittent-boundary@example.com"
+        let ownerKey = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-weekly-intermittent-boundary"),
+            accountEmail: accountLabel))
         let recorder = WeeklyLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
         defer { recorder.invalidate() }
 
@@ -343,12 +395,21 @@ extension UsageStorePlanUtilizationTests {
             weeklyReset: weeklyReset.addingTimeInterval(7 * 24 * 3600),
             updatedAt: firstDate.addingTimeInterval(120))
 
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: before,
+            codexLimitResetOwnerKey: ownerKey,
+            now: before.updatedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: missingMetadata,
+            codexLimitResetOwnerKey: ownerKey,
             now: missingMetadata.updatedAt)
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: realReset, now: realReset.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: realReset,
+            codexLimitResetOwnerKey: ownerKey,
+            now: realReset.updatedAt)
 
         #expect(recorder.events.count == 1)
         #expect(recorder.events.first?.usedPercent == 0)
@@ -356,9 +417,12 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
-    func `codex session celebration ignores missing reset boundary after a known boundary`() async {
+    func `codex session celebration ignores missing reset boundary after a known boundary`() async throws {
         let store = Self.makeStore()
         let accountLabel = "codex-session-missing-boundary@example.com"
+        let ownerKey = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-session-missing-boundary"),
+            accountEmail: accountLabel))
         let recorder = SessionLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
         defer { recorder.invalidate() }
 
@@ -403,18 +467,324 @@ extension UsageStorePlanUtilizationTests {
             sessionReset: sessionReset.addingTimeInterval(5 * 3600),
             updatedAt: firstDate.addingTimeInterval(180))
 
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: before,
+            codexLimitResetOwnerKey: ownerKey,
+            now: before.updatedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: missingBoundaryHigh,
+            codexLimitResetOwnerKey: ownerKey,
             now: missingBoundaryHigh.updatedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: missingBoundary,
+            codexLimitResetOwnerKey: ownerKey,
             now: missingBoundary.updatedAt)
         #expect(recorder.events.isEmpty)
 
-        await store.recordPlanUtilizationHistorySample(provider: .codex, snapshot: realReset, now: realReset.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: realReset,
+            codexLimitResetOwnerKey: ownerKey,
+            now: realReset.updatedAt)
+
+        #expect(recorder.events.count == 1)
+        #expect(recorder.events.first?.usedPercent == 0)
+    }
+
+    @MainActor
+    @Test
+    func `codex weekly celebration ignores low usage with an unchanged boundary`() async throws {
+        let store = Self.makeStore()
+        let accountLabel = "codex-weekly-unchanged-boundary@example.com"
+        let ownerKey = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-weekly-unchanged-boundary"),
+            accountEmail: accountLabel))
+        let recorder = WeeklyLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_701_000_000)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+        let before = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 86,
+            resetsAt: weeklyReset,
+            updatedAt: firstDate)
+        let transientLow = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: weeklyReset,
+            updatedAt: firstDate.addingTimeInterval(60))
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: before,
+            codexLimitResetOwnerKey: ownerKey,
+            now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: transientLow,
+            codexLimitResetOwnerKey: ownerKey,
+            now: transientLow.updatedAt)
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func `codex weekly celebration requires both reset boundaries`() async throws {
+        let store = Self.makeStore()
+        let accountLabel = "codex-weekly-requires-boundaries@example.com"
+        let recorder = WeeklyLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_702_000_000)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+        let missingPreviousOwner = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-weekly-missing-previous"),
+            accountEmail: accountLabel))
+        let missingCurrentOwner = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-weekly-missing-current"),
+            accountEmail: accountLabel))
+        let missingPreviousHigh = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 86,
+            resetsAt: nil,
+            updatedAt: firstDate)
+        let boundaryAppearedLow = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: weeklyReset,
+            updatedAt: firstDate.addingTimeInterval(60))
+        let knownBoundaryHigh = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 86,
+            resetsAt: weeklyReset,
+            updatedAt: firstDate.addingTimeInterval(120))
+        let missingCurrentLow = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: nil,
+            updatedAt: firstDate.addingTimeInterval(180))
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: missingPreviousHigh,
+            codexLimitResetOwnerKey: missingPreviousOwner,
+            now: missingPreviousHigh.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: boundaryAppearedLow,
+            codexLimitResetOwnerKey: missingPreviousOwner,
+            now: boundaryAppearedLow.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: knownBoundaryHigh,
+            codexLimitResetOwnerKey: missingCurrentOwner,
+            now: knownBoundaryHigh.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: missingCurrentLow,
+            codexLimitResetOwnerKey: missingCurrentOwner,
+            now: missingCurrentLow.updatedAt)
+
+        #expect(recorder.events.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func `codex weekly celebration posts once for an advanced boundary`() async throws {
+        let store = Self.makeStore()
+        let accountLabel = "codex-weekly-advanced-boundary@example.com"
+        let ownerKey = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-weekly-advanced-boundary"),
+            accountEmail: accountLabel))
+        let recorder = WeeklyLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_703_000_000)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+        let nextWeeklyReset = weeklyReset.addingTimeInterval(7 * 24 * 3600)
+        let before = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 86,
+            resetsAt: weeklyReset,
+            updatedAt: firstDate)
+        let reset = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: nextWeeklyReset,
+            updatedAt: firstDate.addingTimeInterval(60))
+        let repeatedLow = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: nextWeeklyReset,
+            updatedAt: firstDate.addingTimeInterval(120))
+
+        for snapshot in [before, reset, repeatedLow] {
+            await store.recordPlanUtilizationHistorySample(
+                provider: .codex,
+                snapshot: snapshot,
+                codexLimitResetOwnerKey: ownerKey,
+                now: snapshot.updatedAt)
+        }
+
+        #expect(recorder.events.count == 1)
+        #expect(recorder.events.first?.usedPercent == 0)
+    }
+
+    @MainActor
+    @Test
+    func `codex weekly detector isolates same email workspaces`() async throws {
+        let store = Self.makeStore()
+        let accountLabel = "codex-shared-email@example.com"
+        let ownerA = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-workspace-a"),
+            accountEmail: accountLabel))
+        let ownerB = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-workspace-b"),
+            accountEmail: accountLabel))
+        let recorder = WeeklyLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_703_500_000)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+        let nextWeeklyReset = weeklyReset.addingTimeInterval(7 * 24 * 3600)
+        let workspaceAHigh = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 86,
+            resetsAt: weeklyReset,
+            updatedAt: firstDate)
+        let workspaceBLow = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: nextWeeklyReset,
+            updatedAt: firstDate.addingTimeInterval(60))
+        let workspaceAReset = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: nextWeeklyReset,
+            updatedAt: firstDate.addingTimeInterval(120))
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: workspaceAHigh,
+            codexLimitResetOwnerKey: ownerA,
+            now: workspaceAHigh.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: workspaceBLow,
+            codexLimitResetOwnerKey: ownerB,
+            now: workspaceBLow.updatedAt)
+
+        #expect(recorder.events.isEmpty)
+        #expect(store.weeklyLimitResetDetectorStates.count == 2)
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: workspaceAReset,
+            codexLimitResetOwnerKey: ownerA,
+            now: workspaceAReset.updatedAt)
+
+        #expect(recorder.events.count == 1)
+        #expect(recorder.events.first?.usedPercent == 0)
+    }
+
+    @MainActor
+    @Test
+    func `codex weekly detector isolates members of the same workspace`() async throws {
+        let store = Self.makeStore()
+        let firstEmail = "first-workspace-member@example.com"
+        let secondEmail = "second-workspace-member@example.com"
+        let ownerA = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-shared-workspace"),
+            accountEmail: firstEmail))
+        let ownerB = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-shared-workspace"),
+            accountEmail: secondEmail))
+        let recorder = WeeklyLimitResetEventRecorder(provider: .codex, accountLabel: secondEmail)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_703_700_000)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+        let nextWeeklyReset = weeklyReset.addingTimeInterval(7 * 24 * 3600)
+        let firstMemberHigh = codexWeeklySnapshot(
+            accountLabel: firstEmail,
+            usedPercent: 86,
+            resetsAt: weeklyReset,
+            updatedAt: firstDate)
+        let secondMemberLow = codexWeeklySnapshot(
+            accountLabel: secondEmail,
+            usedPercent: 0,
+            resetsAt: nextWeeklyReset,
+            updatedAt: firstDate.addingTimeInterval(60))
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: firstMemberHigh,
+            codexLimitResetOwnerKey: ownerA,
+            now: firstMemberHigh.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: secondMemberLow,
+            codexLimitResetOwnerKey: ownerB,
+            now: secondMemberLow.updatedAt)
+
+        #expect(ownerA != ownerB)
+        #expect(store.weeklyLimitResetDetectorStates.count == 2)
+        #expect(recorder.events.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func `codex weekly celebration preserves baseline across a regressed boundary`() async throws {
+        let store = Self.makeStore()
+        let accountLabel = "codex-weekly-regressed-boundary@example.com"
+        let ownerKey = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "fixture-codex-weekly-regressed-boundary"),
+            accountEmail: accountLabel))
+        let recorder = WeeklyLimitResetEventRecorder(provider: .codex, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_704_000_000)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+        let before = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 86,
+            resetsAt: weeklyReset,
+            updatedAt: firstDate)
+        let regressedHigh = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 87,
+            resetsAt: weeklyReset.addingTimeInterval(-24 * 3600),
+            updatedAt: firstDate.addingTimeInterval(60))
+        let transientLow = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: weeklyReset,
+            updatedAt: firstDate.addingTimeInterval(120))
+        let realReset = codexWeeklySnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: weeklyReset.addingTimeInterval(7 * 24 * 3600),
+            updatedAt: firstDate.addingTimeInterval(180))
+
+        for snapshot in [before, regressedHigh, transientLow] {
+            await store.recordPlanUtilizationHistorySample(
+                provider: .codex,
+                snapshot: snapshot,
+                codexLimitResetOwnerKey: ownerKey,
+                now: snapshot.updatedAt)
+        }
+        #expect(recorder.events.isEmpty)
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .codex,
+            snapshot: realReset,
+            codexLimitResetOwnerKey: ownerKey,
+            now: realReset.updatedAt)
 
         #expect(recorder.events.count == 1)
         #expect(recorder.events.first?.usedPercent == 0)
@@ -1062,6 +1432,31 @@ extension UsageStorePlanUtilizationTests {
 
         #expect(recorder.events.isEmpty)
     }
+}
+
+private func codexWeeklySnapshot(
+    accountLabel: String,
+    usedPercent: Double,
+    resetsAt: Date?,
+    updatedAt: Date) -> UsageSnapshot
+{
+    UsageSnapshot(
+        primary: RateWindow(
+            usedPercent: usedPercent,
+            windowMinutes: 10080,
+            resetsAt: resetsAt,
+            resetDescription: nil),
+        secondary: RateWindow(
+            usedPercent: 14,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: nil),
+        updatedAt: updatedAt,
+        identity: ProviderIdentitySnapshot(
+            providerID: .codex,
+            accountEmail: accountLabel,
+            accountOrganization: nil,
+            loginMethod: "test"))
 }
 
 private final class SessionLimitResetEventRecorder: @unchecked Sendable {

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCodexResetOwnershipTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCodexResetOwnershipTests.swift
@@ -6,7 +6,7 @@ import Testing
 extension UsageStorePlanUtilizationTests {
     @MainActor
     @Test
-    func `codex weekly reset detector derives the active account for default refreshes`() async {
+    func `codex weekly reset detector does not derive an owner for default refreshes`() async {
         let store = Self.makeStore()
         let email = "shared-default@example.com"
         let observedAt = Date(timeIntervalSince1970: 1_700_050_000)
@@ -35,28 +35,26 @@ extension UsageStorePlanUtilizationTests {
                 observedAt: observedAt.addingTimeInterval(60)),
             now: observedAt.addingTimeInterval(60))
 
-        #expect(store.weeklyLimitResetDetectorStates.count == 2)
+        #expect(store.weeklyLimitResetDetectorStates.isEmpty)
     }
 
     @MainActor
     @Test
-    func `codex weekly reset detector separates workspace accounts and ignores plan changes`() async {
+    func `codex weekly reset detector separates workspace accounts and ignores plan changes`() async throws {
         let store = Self.makeStore()
         let email = "shared-workspace@example.com"
-        let workspaceA = Self.codexVisibleAccount(
-            id: "workspace-a",
-            email: email,
-            workspaceAccountID: "account-a")
-        let workspaceB = Self.codexVisibleAccount(
-            id: "workspace-b",
-            email: email,
-            workspaceAccountID: "account-b")
+        let ownerA = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "account-a"),
+            accountEmail: email))
+        let ownerB = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "account-b"),
+            accountEmail: email))
         let observedAt = Date(timeIntervalSince1970: 1_700_000_000)
 
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: Self.codexWeeklySnapshot(email: email, plan: "plus", observedAt: observedAt),
-            codexVisibleAccount: workspaceA,
+            codexLimitResetOwnerKey: ownerA,
             now: observedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
@@ -64,7 +62,7 @@ extension UsageStorePlanUtilizationTests {
                 email: email,
                 plan: "pro",
                 observedAt: observedAt.addingTimeInterval(60)),
-            codexVisibleAccount: workspaceA,
+            codexLimitResetOwnerKey: ownerA,
             now: observedAt.addingTimeInterval(60))
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
@@ -72,7 +70,7 @@ extension UsageStorePlanUtilizationTests {
                 email: email,
                 plan: "plus",
                 observedAt: observedAt.addingTimeInterval(120)),
-            codexVisibleAccount: workspaceB,
+            codexLimitResetOwnerKey: ownerB,
             now: observedAt.addingTimeInterval(120))
 
         #expect(store.weeklyLimitResetDetectorStates.count == 2)
@@ -80,17 +78,16 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
-    func `codex weekly reset detector separates auth fingerprints without workspace ids`() async {
+    func `codex weekly reset detector fails closed without workspace ids`() async {
         let store = Self.makeStore()
         let email = "shared-auth@example.com"
-        let accountA = Self.codexVisibleAccount(id: "auth-a", email: email, authFingerprint: "fingerprint-a")
-        let accountB = Self.codexVisibleAccount(id: "auth-b", email: email, authFingerprint: "fingerprint-b")
         let observedAt = Date(timeIntervalSince1970: 1_700_100_000)
+
+        #expect(CodexLimitResetOwnerKey(identity: .emailOnly(normalizedEmail: email), accountEmail: email) == nil)
 
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: Self.codexWeeklySnapshot(email: email, plan: "plus", observedAt: observedAt),
-            codexVisibleAccount: accountA,
             now: observedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
@@ -98,34 +95,25 @@ extension UsageStorePlanUtilizationTests {
                 email: email,
                 plan: "plus",
                 observedAt: observedAt.addingTimeInterval(60)),
-            codexVisibleAccount: accountB,
             now: observedAt.addingTimeInterval(60))
 
-        #expect(store.weeklyLimitResetDetectorStates.count == 2)
+        #expect(store.weeklyLimitResetDetectorStates.isEmpty)
     }
 
     @MainActor
     @Test
-    func `codex weekly reset detector keeps managed ownership across token refreshes`() async {
+    func `codex weekly reset detector keeps workspace ownership across token refreshes`() async throws {
         let store = Self.makeStore()
         let email = "managed-refresh@example.com"
-        let storedAccountID = UUID()
         let observedAt = Date(timeIntervalSince1970: 1_700_200_000)
-        let beforeRefresh = Self.codexVisibleAccount(
-            id: "managed-before",
-            email: email,
-            authFingerprint: "fingerprint-before",
-            storedAccountID: storedAccountID)
-        let afterRefresh = Self.codexVisibleAccount(
-            id: "managed-after",
-            email: email,
-            authFingerprint: "fingerprint-after",
-            storedAccountID: storedAccountID)
+        let ownerKey = try #require(CodexLimitResetOwnerKey(
+            identity: .providerAccount(id: "managed-workspace"),
+            accountEmail: email))
 
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
             snapshot: Self.codexWeeklySnapshot(email: email, plan: "plus", observedAt: observedAt),
-            codexVisibleAccount: beforeRefresh,
+            codexLimitResetOwnerKey: ownerKey,
             now: observedAt)
         await store.recordPlanUtilizationHistorySample(
             provider: .codex,
@@ -133,7 +121,7 @@ extension UsageStorePlanUtilizationTests {
                 email: email,
                 plan: "plus",
                 observedAt: observedAt.addingTimeInterval(60)),
-            codexVisibleAccount: afterRefresh,
+            codexLimitResetOwnerKey: ownerKey,
             now: observedAt.addingTimeInterval(60))
 
         #expect(store.weeklyLimitResetDetectorStates.count == 1)
@@ -161,26 +149,5 @@ extension UsageStorePlanUtilizationTests {
                 accountEmail: email,
                 accountOrganization: nil,
                 loginMethod: plan))
-    }
-
-    private static func codexVisibleAccount(
-        id: String,
-        email: String,
-        workspaceAccountID: String? = nil,
-        authFingerprint: String? = nil,
-        storedAccountID: UUID? = nil) -> CodexVisibleAccount
-    {
-        CodexVisibleAccount(
-            id: id,
-            email: email,
-            workspaceLabel: nil,
-            workspaceAccountID: workspaceAccountID,
-            authFingerprint: authFingerprint,
-            storedAccountID: storedAccountID,
-            selectionSource: storedAccountID.map { .managedAccount(id: $0) } ?? .liveSystem,
-            isActive: false,
-            isLive: true,
-            canReauthenticate: false,
-            canRemove: false)
     }
 }


### PR DESCRIPTION
## Summary

- hold an apparent Codex weekly reset until a second matching valid observation confirms it
- scope confirmation, persistence, history, and reset detection to a stable composite workspace/account owner
- preserve independently validated sibling rows while rejecting ambiguous or cross-workspace snapshots
- follow up on #2056 / #2054 while retaining @Yuxin-Qiao's contributor credit

## Behavior

The first suspicious weekly drop no longer reaches menu, widget, history, or reset celebration surfaces. A rebound keeps the last trusted snapshot; a repeated low observation with an advanced weekly boundary publishes normally. Email-only or unresolved ownership fails closed for persisted quota state, preventing same-email workspaces from sharing reset baselines.

## Proof

- focused reset/ownership matrix: 243 tests across 9 suites, green
- `make check`: 0 violations across 1,372 files
- full `make test`: 609 selections, all 51 shards green, no retries or failures
- `swift build`: green
- structured autoreview: production, publication, ownership, and fixture slices clean
- exact signed packaged debug bundle: embedded commit `770dcc59`, strict Developer ID signature valid, Gatekeeper accepted
- isolated loopback live QA: outbound network denied except the fixture; synthetic bearer/account shape verified
- transient live path: first zero and blocked confirmation retained 64% used / 36% left, emitted no reset event, then rebound remained at the trusted boundary
- confirmed live path: blocked confirmation retained 64% used / 36% left with zero events; release published 0% used / 100% left at the advanced boundary and emitted exactly one reset, one confetti trigger, and one overlay presentation
- production `/Applications/CodexBar.app` remained the same PID, executable, and start time throughout
- public model identifier gate: PASS; the diff introduces no model-bearing public identifier

Screenshots and fixture traces were retained locally only.

## Risk

Codex snapshot publication and owner reconciliation only. The behavior is conservative: ambiguous or first-pass reset observations retain the last trusted state; ordinary usage increases and confirmed resets still publish. No dependency changes.
