### PR TITLE
perf: match cost history fingerprint to visible content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Settings: split provider pane "Settings" sections into "Menu bar" and "Connection" so metric pickers and auth/cookie/source controls are grouped by topic.
 
 ### Fixed
+- Codex cost history: keep opening and refreshing the submenu fast as project history grows by comparing only the content it renders. Thanks @Yuxin-Qiao!
 - Codex cost history: keep model-less token events explicitly unattributed instead of pricing them as GPT-5 while preserving current turn model attribution. Thanks @hhh2210!
 - Gemini: recover expired Workspace and education OAuth sessions when current CLI packages omit `oauth2.js`, with explicit credential and install-path discovery fallbacks. Thanks @Yuxin-Qiao!
 - Codex accounts: confirm apparent weekly resets before publishing them and isolate reset detection by stable account ownership, preventing transient full gauges and confetti across same-email workspaces (#2054). Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -774,6 +774,7 @@ extension CostHistoryChartMenuView {
         let historyDays: Int
         let windowLabel: String?
         let totalCostBitPattern: UInt64?
+        let hasDailyEntries: Bool
         let daily: [VisibleDailyFingerprint]
         let projects: [VisibleProjectFingerprint]
     }
@@ -822,6 +823,7 @@ extension CostHistoryChartMenuView {
             historyDays: snapshot.historyDays,
             windowLabel: snapshot.historyLabel,
             totalCostBitPattern: snapshot.last30DaysCostUSD.map(\.bitPattern),
+            hasDailyEntries: !snapshot.daily.isEmpty,
             daily: snapshot.daily
                 .filter { self.chartPointInput(for: $0) != nil }
                 .sorted { $0.date < $1.date }

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -363,8 +363,7 @@ struct CostHistoryChartMenuView: View {
         var maxDetailRows = 0
         var hasModeDetails = false
         for entry in sorted {
-            guard let costUSD = entry.costUSD, costUSD >= 0 else { continue }
-            guard let date = self.dateFromDayKey(entry.date) else { continue }
+            guard let (costUSD, date) = self.chartPointInput(for: entry) else { continue }
             let point = Point(
                 date: date,
                 costUSD: costUSD,
@@ -453,6 +452,12 @@ struct CostHistoryChartMenuView: View {
         comps.day = day
         comps.hour = 12
         return comps.date
+    }
+
+    private static func chartPointInput(for entry: DailyEntry) -> (costUSD: Double, date: Date)? {
+        guard let costUSD = entry.costUSD, costUSD >= 0 else { return nil }
+        guard let date = self.dateFromDayKey(entry.date) else { return nil }
+        return (costUSD, date)
     }
 
     private static func peakPoint(model: Model) -> Point? {
@@ -769,8 +774,26 @@ extension CostHistoryChartMenuView {
         let historyDays: Int
         let windowLabel: String?
         let totalCostBitPattern: UInt64?
-        let daily: [DailyEntry]
+        let daily: [VisibleDailyFingerprint]
         let projects: [VisibleProjectFingerprint]
+    }
+
+    struct VisibleDailyFingerprint: Equatable {
+        let date: String
+        let totalTokens: Int?
+        let requestCount: Int?
+        let costBitPattern: UInt64?
+        let modelBreakdowns: [VisibleModelBreakdownFingerprint]
+    }
+
+    struct VisibleModelBreakdownFingerprint: Equatable {
+        let modelName: String
+        let costBitPattern: UInt64?
+        let totalTokens: Int?
+        let standardCostBitPattern: UInt64?
+        let priorityCostBitPattern: UInt64?
+        let standardTokens: Int?
+        let priorityTokens: Int?
     }
 
     struct VisibleProjectFingerprint: Equatable {
@@ -789,33 +812,21 @@ extension CostHistoryChartMenuView {
         let totalCostBitPattern: UInt64?
     }
 
-    static func renderFingerprint(from snapshot: CostUsageTokenSnapshot) -> RenderFingerprint {
-        self.makeRenderFingerprint(RenderFingerprintInputs(
+    static func renderFingerprint(
+        from snapshot: CostUsageTokenSnapshot,
+        provider: UsageProvider) -> RenderFingerprint
+    {
+        let projects = provider == .codex ? snapshot.projects : []
+        return RenderFingerprint(
             currencyCode: snapshot.currencyCode,
             historyDays: snapshot.historyDays,
             windowLabel: snapshot.historyLabel,
-            totalCostUSD: snapshot.last30DaysCostUSD,
-            daily: snapshot.daily,
-            projects: snapshot.projects))
-    }
-
-    private struct RenderFingerprintInputs {
-        let currencyCode: String
-        let historyDays: Int
-        let windowLabel: String?
-        let totalCostUSD: Double?
-        let daily: [DailyEntry]
-        let projects: [CostUsageProjectBreakdown]
-    }
-
-    private static func makeRenderFingerprint(_ inputs: RenderFingerprintInputs) -> RenderFingerprint {
-        RenderFingerprint(
-            currencyCode: inputs.currencyCode,
-            historyDays: inputs.historyDays,
-            windowLabel: inputs.windowLabel,
-            totalCostBitPattern: inputs.totalCostUSD.map(\.bitPattern),
-            daily: inputs.daily,
-            projects: Array(inputs.projects.prefix(self.maxVisibleProjectRows)).map { project in
+            totalCostBitPattern: snapshot.last30DaysCostUSD.map(\.bitPattern),
+            daily: snapshot.daily
+                .filter { self.chartPointInput(for: $0) != nil }
+                .sorted { $0.date < $1.date }
+                .map(self.visibleDailyFingerprint),
+            projects: Array(projects.prefix(self.maxVisibleProjectRows)).map { project in
                 let visibleSources = self.visibleProjectSources(project)
                 return VisibleProjectFingerprint(
                     name: project.name,
@@ -830,6 +841,24 @@ extension CostHistoryChartMenuView {
                             totalTokens: source.totalTokens,
                             totalCostBitPattern: source.totalCostUSD.map(\.bitPattern))
                     })
+            })
+    }
+
+    private static func visibleDailyFingerprint(_ entry: DailyEntry) -> VisibleDailyFingerprint {
+        VisibleDailyFingerprint(
+            date: entry.date,
+            totalTokens: entry.totalTokens,
+            requestCount: entry.requestCount,
+            costBitPattern: entry.costUSD.map(\.bitPattern),
+            modelBreakdowns: self.orderedBreakdownItems(entry.modelBreakdowns ?? []).map { item in
+                VisibleModelBreakdownFingerprint(
+                    modelName: item.modelName,
+                    costBitPattern: item.costUSD.map(\.bitPattern),
+                    totalTokens: item.totalTokens,
+                    standardCostBitPattern: item.standardCostUSD.map(\.bitPattern),
+                    priorityCostBitPattern: item.priorityCostUSD.map(\.bitPattern),
+                    standardTokens: item.standardCostUSD == nil ? nil : item.standardTokens,
+                    priorityTokens: item.priorityCostUSD == nil ? nil : item.priorityTokens)
             })
     }
 

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -306,7 +306,7 @@ extension StatusItemController {
         guard let snapshot = self.tokenSnapshotForCostHistorySubmenu(provider: provider) else {
             return .text("none")
         }
-        return .costHistory(CostHistoryChartMenuView.renderFingerprint(from: snapshot))
+        return .costHistory(CostHistoryChartMenuView.renderFingerprint(from: snapshot, provider: provider))
     }
 
     private func usageHistoryRenderSignature(for provider: UsageProvider) -> String {

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -466,8 +466,8 @@ struct CostHistoryChartMenuViewTests {
         ]
         let empty = Self.fingerprint(daily: [])
 
-        #expect(Self.fingerprint(daily: invalidRows) == empty)
-        #expect(Self.fingerprint(daily: differentInvalidRows) == empty)
+        #expect(Self.fingerprint(daily: invalidRows) == Self.fingerprint(daily: differentInvalidRows))
+        #expect(Self.fingerprint(daily: invalidRows) != empty)
         #expect(Self.fingerprint(daily: [Self.dailyEntry(date: "2026-06-07", costUSD: 1)]) != empty)
     }
 

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -291,8 +291,8 @@ struct CostHistoryChartMenuViewTests {
     @MainActor
     func `render fingerprint is stable for identical snapshots`() {
         let snapshot = Self.makeSnapshot(dailyCost: 1.23, projectCount: 5)
-        let first = CostHistoryChartMenuView.renderFingerprint(from: snapshot)
-        let second = CostHistoryChartMenuView.renderFingerprint(from: snapshot)
+        let first = CostHistoryChartMenuView.renderFingerprint(from: snapshot, provider: .codex)
+        let second = CostHistoryChartMenuView.renderFingerprint(from: snapshot, provider: .codex)
 
         #expect(first == second)
         #expect(first.projects.count == 5)
@@ -302,8 +302,12 @@ struct CostHistoryChartMenuViewTests {
     @Test
     @MainActor
     func `render fingerprint changes when daily cost changes`() {
-        let before = CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(dailyCost: 1.0))
-        let after = CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(dailyCost: 2.0))
+        let before = CostHistoryChartMenuView.renderFingerprint(
+            from: Self.makeSnapshot(dailyCost: 1.0),
+            provider: .codex)
+        let after = CostHistoryChartMenuView.renderFingerprint(
+            from: Self.makeSnapshot(dailyCost: 2.0),
+            provider: .codex)
 
         #expect(before != after)
     }
@@ -313,25 +317,25 @@ struct CostHistoryChartMenuViewTests {
     func `render fingerprint changes for total currency history window and label`() {
         let base = Self.makeSnapshot(dailyCost: 1.0)
         #expect(
-            CostHistoryChartMenuView.renderFingerprint(from: base)
+            CostHistoryChartMenuView.renderFingerprint(from: base, provider: .codex)
                 != CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(
                     dailyCost: 1.0,
-                    totalCostUSD: 9.99)))
+                    totalCostUSD: 9.99), provider: .codex))
         #expect(
-            CostHistoryChartMenuView.renderFingerprint(from: base)
+            CostHistoryChartMenuView.renderFingerprint(from: base, provider: .codex)
                 != CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(
                     dailyCost: 1.0,
-                    currencyCode: "EUR")))
+                    currencyCode: "EUR"), provider: .codex))
         #expect(
-            CostHistoryChartMenuView.renderFingerprint(from: base)
+            CostHistoryChartMenuView.renderFingerprint(from: base, provider: .codex)
                 != CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(
                     dailyCost: 1.0,
-                    historyDays: 7)))
+                    historyDays: 7), provider: .codex))
         #expect(
-            CostHistoryChartMenuView.renderFingerprint(from: base)
+            CostHistoryChartMenuView.renderFingerprint(from: base, provider: .codex)
                 != CostHistoryChartMenuView.renderFingerprint(from: Self.makeSnapshot(
                     dailyCost: 1.0,
-                    historyLabel: "Last week")))
+                    historyLabel: "Last week"), provider: .codex))
     }
 
     @Test
@@ -382,6 +386,183 @@ struct CostHistoryChartMenuViewTests {
 
     @Test
     @MainActor
+    func `render fingerprint ignores hidden daily accounting fields and source order`() {
+        let visibleModel = CostUsageDailyReport.ModelBreakdown(
+            modelName: "model-visible",
+            costUSD: 0.75,
+            totalTokens: 120,
+            requestCount: 1,
+            standardCostUSD: 0.5,
+            priorityCostUSD: 0.25,
+            standardTokens: 80,
+            priorityTokens: 40)
+        let base = CostUsageDailyReport.Entry(
+            date: "2026-06-07",
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheReadTokens: 20,
+            cacheCreationTokens: 10,
+            totalTokens: 150,
+            requestCount: 2,
+            costUSD: 1,
+            modelsUsed: ["model-visible"],
+            modelBreakdowns: [visibleModel])
+        let hiddenFieldsChanged = CostUsageDailyReport.Entry(
+            date: base.date,
+            inputTokens: 999,
+            outputTokens: 888,
+            cacheReadTokens: 777,
+            cacheCreationTokens: 666,
+            totalTokens: base.totalTokens,
+            requestCount: base.requestCount,
+            costUSD: base.costUSD,
+            modelsUsed: ["unused-model-name"],
+            modelBreakdowns: [CostUsageDailyReport.ModelBreakdown(
+                modelName: visibleModel.modelName,
+                costUSD: visibleModel.costUSD,
+                totalTokens: visibleModel.totalTokens,
+                requestCount: 999,
+                standardCostUSD: visibleModel.standardCostUSD,
+                priorityCostUSD: visibleModel.priorityCostUSD,
+                standardTokens: visibleModel.standardTokens,
+                priorityTokens: visibleModel.priorityTokens)])
+
+        #expect(Self.fingerprint(daily: [base]) == Self.fingerprint(daily: [hiddenFieldsChanged]))
+
+        let secondDay = Self.entry(date: "2026-06-08", modelCount: 1)
+        #expect(
+            Self.fingerprint(daily: [base, secondDay])
+                == Self.fingerprint(daily: [secondDay, base]))
+
+        let hiddenModeTokens = CostUsageDailyReport.ModelBreakdown(
+            modelName: visibleModel.modelName,
+            costUSD: visibleModel.costUSD,
+            totalTokens: visibleModel.totalTokens,
+            standardTokens: 1,
+            priorityTokens: 2)
+        let changedHiddenModeTokens = CostUsageDailyReport.ModelBreakdown(
+            modelName: visibleModel.modelName,
+            costUSD: visibleModel.costUSD,
+            totalTokens: visibleModel.totalTokens,
+            standardTokens: 999,
+            priorityTokens: 888)
+        #expect(
+            Self.fingerprint(daily: [Self.entry(modelBreakdowns: [hiddenModeTokens])])
+                == Self.fingerprint(daily: [Self.entry(modelBreakdowns: [changedHiddenModeTokens])]))
+    }
+
+    @Test
+    @MainActor
+    func `render fingerprint excludes invalid daily rows that the chart drops`() {
+        let invalidRows = [
+            Self.dailyEntry(date: "2026-06-07", costUSD: nil),
+            Self.dailyEntry(date: "2026-06-08", costUSD: -1),
+            Self.dailyEntry(date: "not-a-date", costUSD: 1),
+        ]
+        let differentInvalidRows = [
+            Self.dailyEntry(date: "2026-06-09", costUSD: nil),
+            Self.dailyEntry(date: "2026-06-10", costUSD: -99),
+            Self.dailyEntry(date: "still-not-a-date", costUSD: 99),
+        ]
+        let empty = Self.fingerprint(daily: [])
+
+        #expect(Self.fingerprint(daily: invalidRows) == empty)
+        #expect(Self.fingerprint(daily: differentInvalidRows) == empty)
+        #expect(Self.fingerprint(daily: [Self.dailyEntry(date: "2026-06-07", costUSD: 1)]) != empty)
+    }
+
+    @Test
+    @MainActor
+    func `render fingerprint tracks every visible model breakdown field`() {
+        let base = CostUsageDailyReport.ModelBreakdown(
+            modelName: "model-visible",
+            costUSD: 1,
+            totalTokens: 100,
+            standardCostUSD: 0.75,
+            priorityCostUSD: 0.25,
+            standardTokens: 75,
+            priorityTokens: 25)
+        let variants = [
+            CostUsageDailyReport.ModelBreakdown(
+                modelName: "model-renamed",
+                costUSD: base.costUSD,
+                totalTokens: base.totalTokens,
+                standardCostUSD: base.standardCostUSD,
+                priorityCostUSD: base.priorityCostUSD,
+                standardTokens: base.standardTokens,
+                priorityTokens: base.priorityTokens),
+            CostUsageDailyReport.ModelBreakdown(
+                modelName: base.modelName,
+                costUSD: 2,
+                totalTokens: base.totalTokens,
+                standardCostUSD: base.standardCostUSD,
+                priorityCostUSD: base.priorityCostUSD,
+                standardTokens: base.standardTokens,
+                priorityTokens: base.priorityTokens),
+            CostUsageDailyReport.ModelBreakdown(
+                modelName: base.modelName,
+                costUSD: base.costUSD,
+                totalTokens: 200,
+                standardCostUSD: base.standardCostUSD,
+                priorityCostUSD: base.priorityCostUSD,
+                standardTokens: base.standardTokens,
+                priorityTokens: base.priorityTokens),
+            CostUsageDailyReport.ModelBreakdown(
+                modelName: base.modelName,
+                costUSD: base.costUSD,
+                totalTokens: base.totalTokens,
+                standardCostUSD: 0.5,
+                priorityCostUSD: base.priorityCostUSD,
+                standardTokens: base.standardTokens,
+                priorityTokens: base.priorityTokens),
+            CostUsageDailyReport.ModelBreakdown(
+                modelName: base.modelName,
+                costUSD: base.costUSD,
+                totalTokens: base.totalTokens,
+                standardCostUSD: base.standardCostUSD,
+                priorityCostUSD: 0.5,
+                standardTokens: base.standardTokens,
+                priorityTokens: base.priorityTokens),
+            CostUsageDailyReport.ModelBreakdown(
+                modelName: base.modelName,
+                costUSD: base.costUSD,
+                totalTokens: base.totalTokens,
+                standardCostUSD: base.standardCostUSD,
+                priorityCostUSD: base.priorityCostUSD,
+                standardTokens: 50,
+                priorityTokens: base.priorityTokens),
+            CostUsageDailyReport.ModelBreakdown(
+                modelName: base.modelName,
+                costUSD: base.costUSD,
+                totalTokens: base.totalTokens,
+                standardCostUSD: base.standardCostUSD,
+                priorityCostUSD: base.priorityCostUSD,
+                standardTokens: base.standardTokens,
+                priorityTokens: 50),
+        ]
+        let baseFingerprint = Self.fingerprint(daily: [Self.entry(modelBreakdowns: [base])])
+
+        for variant in variants {
+            #expect(baseFingerprint != Self.fingerprint(daily: [Self.entry(modelBreakdowns: [variant])]))
+        }
+    }
+
+    @Test
+    @MainActor
+    func `render fingerprint excludes projects hidden for non-codex providers`() {
+        let first = Self.fingerprint(
+            projects: [Self.makeProject(index: 0, sourceCount: 2)],
+            provider: .claude)
+        let changed = Self.fingerprint(
+            projects: [Self.makeProject(index: 0, sourceCount: 2, totalCostUSD: 99)],
+            provider: .claude)
+
+        #expect(first.projects.isEmpty)
+        #expect(first == changed)
+    }
+
+    @Test
+    @MainActor
     func `render fingerprint tracks visible project and source fields only`() {
         let daily = [Self.entry(date: "2026-06-07", modelCount: 1)]
         let projects = Self.makeProjects(count: 6, sourcesPerProject: 3)
@@ -413,7 +594,7 @@ struct CostHistoryChartMenuViewTests {
         changedTopProjectTotals[0] = Self.makeProject(index: 0, sourceCount: 3, totalCostUSD: 42.0, totalTokens: 9999)
         #expect(base != Self.fingerprint(totalCostUSD: 6.0, daily: daily, projects: changedTopProjectTotals))
 
-        var reorderedProjects = Array(projects.reversed())
+        let reorderedProjects = Array(projects.reversed())
         #expect(base != Self.fingerprint(totalCostUSD: 6.0, daily: daily, projects: reorderedProjects))
 
         var promotedHiddenProject = projects
@@ -523,6 +704,30 @@ struct CostHistoryChartMenuViewTests {
                 : nil)
     }
 
+    private static func entry(
+        modelBreakdowns: [CostUsageDailyReport.ModelBreakdown]) -> CostUsageDailyReport.Entry
+    {
+        CostUsageDailyReport.Entry(
+            date: "2026-06-07",
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+            costUSD: 1,
+            modelsUsed: modelBreakdowns.map(\.modelName),
+            modelBreakdowns: modelBreakdowns)
+    }
+
+    private static func dailyEntry(date: String, costUSD: Double?) -> CostUsageDailyReport.Entry {
+        CostUsageDailyReport.Entry(
+            date: date,
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+            costUSD: costUSD,
+            modelsUsed: nil,
+            modelBreakdowns: nil)
+    }
+
     private static func makeSnapshot(
         dailyCost: Double = 1.0,
         projectCount: Int = 0,
@@ -562,7 +767,8 @@ struct CostHistoryChartMenuViewTests {
         historyDays: Int = 30,
         historyLabel: String? = nil,
         daily: [CostUsageDailyReport.Entry]? = nil,
-        projects: [CostUsageProjectBreakdown]? = nil) -> CostHistoryChartMenuView.RenderFingerprint
+        projects: [CostUsageProjectBreakdown]? = nil,
+        provider: UsageProvider = .codex) -> CostHistoryChartMenuView.RenderFingerprint
     {
         CostHistoryChartMenuView.renderFingerprint(from: self.makeSnapshot(
             dailyCost: dailyCost,
@@ -571,7 +777,7 @@ struct CostHistoryChartMenuViewTests {
             historyDays: historyDays,
             historyLabel: historyLabel,
             daily: daily,
-            projects: projects))
+            projects: projects), provider: provider)
     }
 
     private static func makeProjects(count: Int, sourcesPerProject: Int) -> [CostUsageProjectBreakdown] {
@@ -609,8 +815,12 @@ struct CostHistoryChartMenuViewTests {
         let sources = (0..<sourceCount).map { sourceIndex in
             CostUsageProjectSourceBreakdown(
                 name: {
-                    if renameThirdSource, sourceIndex == 2 { return "Renamed Source" }
-                    if renameFirstSource, sourceIndex == 0 { return "Renamed Source" }
+                    if renameThirdSource, sourceIndex == 2 {
+                        return "Renamed Source"
+                    }
+                    if renameFirstSource, sourceIndex == 0 {
+                        return "Renamed Source"
+                    }
                     return "Source-\(sourceIndex)"
                 }(),
                 path: "/tmp/project-\(index)\(pathSuffix)/source-\(sourceIndex)",


### PR DESCRIPTION
## Summary

- compare only cost-history fields the hosted submenu actually renders
- preserve refreshes for raw daily-history availability transitions
- omit Codex project rows from providers whose cost view does not render them
- add focused fingerprint regressions and the missing changelog credit for @Yuxin-Qiao

Follow-up to #2063. The original performance fix landed while its deeper review and packaged QA were still running.

## Why

The first typed fingerprint still retained complete daily entries, so hidden accounting fields could invalidate the hosted submenu as history grew. This projects the fingerprint onto visible chart/model/project/source data, bounds it to the five rendered projects and two rendered sources, and keeps the raw empty/nonempty state used by submenu availability.

## Proof

- focused: 60 tests across `CostHistoryChartMenuViewTests`, `StatusMenuCodexCostHistoryRefreshTests`, and `StatusMenuOpenRefreshTests`
- `make check`
- full suite: 610 selections, 51/51 groups, zero retries/timeouts
- autoreview: clean after fixing the raw daily availability transition
- release build: passed on the reviewed candidate
- signed packaged debug QA: Developer ID + Gatekeeper accepted; 20 projects × 30 days × 2 sources; menu rendered only projects 00–04 and both visible sources; 30 open/hover/close cycles stayed byte-identical; no external TCP connection or hang/crash log signal; production app PID unchanged
- optimized benchmark: typed visible fingerprint was 396× faster at 5 projects and 1,442× faster at 20 projects than the legacy reflective signature

## Risk

Low and localized to cost-history hosted-submenu invalidation. No dependencies, persistence, credentials, or provider network behavior changed.
