### PR TITLE
Fix German manual action labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Settings: split provider pane "Settings" sections into "Menu bar" and "Connection" so metric pickers and auth/cookie/source controls are grouped by topic.
 
 ### Fixed
+- German localization: label manual cookie-source and refresh options as “Manuell” instead of the handbook noun “Handbuch.” Thanks @fbrettnich!
 - Codex notifications: suppress false session-restored alerts while the reset boundary is unchanged, without hiding a real reset after the known boundary passes. Thanks @Yuxin-Qiao!
 - Codex cost history: keep opening and refreshing the submenu fast as project history grows by comparing only the content it renders. Thanks @Yuxin-Qiao!
 - Codex cost history: keep model-less token events explicitly unpriced and unattributed instead of pricing them as GPT-5 while preserving current turn model attribution. Thanks @hhh2210!

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "MCP details" = "MCP-Details";
 "Managed Codex accounts unavailable" = "Verwaltete Codex-Konten nicht verfügbar";
 "Managed account storage is unreadable. Live account access is still available, " = "Der verwaltete Kontospeicher ist nicht lesbar. Der Live-Kontozugriff ist weiterhin verfügbar.";
-"Manual" = "Handbuch";
+"Manual" = "Manuell";
 "May your tokens never run out—keep agent limits in view." = "Mögen Ihre Token nie ausgehen – behalten Sie die Agentenlimits im Blick.";
 "Menu bar" = "Menüleiste";
 "Menu bar auto-shows the provider closest to its rate limit." = "In der Menüleiste wird automatisch der Anbieter angezeigt, der seinem Tariflimit am nächsten kommt.";
@@ -696,7 +696,7 @@
 "status_unknown" = "Status unbekannt";
 
 /* Refresh frequency */
-"refresh_manual" = "Handbuch";
+"refresh_manual" = "Manuell";
 "refresh_1min" = "1 Minute";
 "refresh_2min" = "2 Min";
 "refresh_5min" = "5 Min";

--- a/Tests/CodexBarTests/LocalizationLanguageCatalogTests.swift
+++ b/Tests/CodexBarTests/LocalizationLanguageCatalogTests.swift
@@ -236,6 +236,19 @@ struct LocalizationLanguageCatalogTests {
     }
 
     @Test
+    func `german manual action labels do not describe a handbook`() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let germanURL = root.appendingPathComponent("Sources/CodexBar/Resources/de.lproj/Localizable.strings")
+        let german = try #require(NSDictionary(contentsOf: germanURL) as? [String: String])
+
+        #expect(german["Manual"] == "Manuell")
+        #expect(german["refresh_manual"] == "Manuell")
+    }
+
+    @Test
     func `galician localization matches the English catalog`() throws {
         let root = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()


### PR DESCRIPTION
## Summary
This PR corrects an inaccurate German translation in the localization file. The English word "Manual" was previously translated as "Handbuch" (which refers to a guidebook or instruction manual). It has been updated to "Manuell" to properly reflect the intended context of a manual action or setting (e.g., manual refresh frequency).