### PR TITLE
Guard logged-out Claude CLI usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Claude OAuth: remember an acknowledged CodexBar Keychain explanation for six hours without suppressing macOS authorization or either Keychain opt-out (#1990). Thanks @harjothkhara!
 - Codex accounts: find the Codex CLI bundled with ChatGPT when it is absent from shell PATH, restoring Add Account after the desktop apps merged (#2044). Thanks @sep1107!
 - Claude: prevent CodexBar's passive CLI probes from starting background Claude Code updates, avoiding repeated partial downloads when a probe exits before an update completes. Thanks @PG2047!
+- Claude CLI: fail fast when usage commands find Claude Code logged out instead of starting its interactive REPL and waiting through probe retries. Thanks @BearHuddleston!
 - Codex cost history: bound malformed session-metadata lines and release read chunks promptly, preventing metadata pre-scans from retaining memory in proportion to oversized JSONL records. Thanks @Yuxin-Qiao!
 - Widgets: add Cursor to configurable and switcher widgets with accurate legacy Requests and current Total, Auto, and API quota labels (#2040). Thanks @Zihao-Qi!
 - Menus: return oversized tracked menus to the provider header after a manual refresh without moving background updates, highlighted rows, open submenus, or newer menu/provider sessions (#2046). Thanks @ss251!

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -201,8 +201,8 @@ private struct ClaudePlannedFetchStrategy: ProviderFetchStrategy {
             return await self.base.isAvailable(context)
         }
         guard self.plannedStep.isPlausiblyAvailable else { return false }
-        if context.runtime == .app,
-           self.plannedStep.dataSource == .cli || self.plannedStep.dataSource == .web
+        if self.plannedStep.dataSource == .cli ||
+            (context.runtime == .app && self.plannedStep.dataSource == .web)
         {
             return await self.base.isAvailable(context)
         }
@@ -641,14 +641,13 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
     let hasWebFallback: Bool
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        // The interactive Claude REPL can open browser OAuth when it starts logged out. Background Auto refreshes
-        // must establish CLI authentication through the non-interactive status command before starting that REPL.
-        guard context.runtime == .app,
-              context.sourceMode == .auto,
-              ProviderInteractionContext.current == .background
-        else {
-            return true
-        }
+        // The interactive Claude REPL can open browser OAuth when it starts logged out. CLI runtime and background
+        // app Auto refreshes must establish authentication through the non-interactive status command first.
+        let requiresAuthPreflight = context.runtime == .cli || (
+            context.runtime == .app &&
+                context.sourceMode == .auto &&
+                ProviderInteractionContext.current == .background)
+        guard requiresAuthPreflight else { return true }
         guard let binary = ClaudeCLIResolver.resolvedBinaryPath(environment: context.env) else { return false }
         return await ClaudeCLIAuthStatusProbe.isLoggedIn(binary: binary, environment: context.env)
     }

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -7,11 +7,13 @@ struct ClaudeWebFetchDeadlineTests {
     func `CLI auto descriptor defers browser probe and falls back after web deadline`() async throws {
         let planningProbe = ClaudeWebPlanningAvailabilityProbe()
         let webProbe = ClaudeWebDeadlineProbe()
+        let cliPath = try Self.makeLoggedInClaudeCLI()
+        defer { try? FileManager.default.removeItem(atPath: cliPath) }
         let context = Self.makeContext(
             sourceMode: .auto,
             webTimeout: 0.01,
             cookieSource: .auto,
-            env: ["CLAUDE_CLI_PATH": "/usr/bin/true"])
+            env: ["CLAUDE_CLI_PATH": cliPath])
         let availabilityOverride: @Sendable (ProviderFetchContext, BrowserDetection) -> Bool = { _, _ in
             planningProbe.stallAndReportUnavailable()
         }
@@ -47,6 +49,7 @@ struct ClaudeWebFetchDeadlineTests {
     func `stalled app auto browser probe does not delay CLI success`() async throws {
         let planningProbe = ClaudeWebPlanningAvailabilityProbe()
         let cliPath = try Self.makeLoggedInClaudeCLI()
+        defer { try? FileManager.default.removeItem(atPath: cliPath) }
         let context = Self.makeContext(
             runtime: .app,
             sourceMode: .auto,

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -19,18 +19,16 @@ struct PlatformGatingTests {
     @Test
     func claudeAutoPipeline_skipsUnsupportedWebAndUsesCLI() async throws {
         #if os(Linux)
-        let context = self.makeClaudeAutoContext()
         let binaryURL = try Self.makeClaudeCLI(loggedIn: true)
         defer { try? FileManager.default.removeItem(at: binaryURL) }
+        let context = self.makeClaudeAutoContext(env: ["CLAUDE_CLI_PATH": binaryURL.path])
         let cliFetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in
             Self.makeClaudeStatus()
         }
-        let outcome = await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(binaryURL.path) {
-            await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
-                await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
-                    context: context,
-                    provider: .claude)
-            }
+        let outcome = await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
+            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                context: context,
+                provider: .claude)
         }
         let result = try outcome.result.get()
 

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -20,10 +20,12 @@ struct PlatformGatingTests {
     func claudeAutoPipeline_skipsUnsupportedWebAndUsesCLI() async throws {
         #if os(Linux)
         let context = self.makeClaudeAutoContext()
+        let binaryURL = try Self.makeClaudeCLI(loggedIn: true)
+        defer { try? FileManager.default.removeItem(at: binaryURL) }
         let cliFetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in
             Self.makeClaudeStatus()
         }
-        let outcome = await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+        let outcome = await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(binaryURL.path) {
             await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
                 await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
                     context: context,
@@ -67,6 +69,52 @@ struct PlatformGatingTests {
         }
         #expect(outcome.attempts.map(\.strategyID) == ["claude.web", "claude.cli"])
         #expect(outcome.attempts.map(\.wasAvailable) == [false, false])
+        #else
+        #expect(Bool(true))
+        #endif
+    }
+
+    @Test(arguments: [ProviderSourceMode.auto, .cli])
+    func `Claude CLI runtime skips logged out interactive fallback`(sourceMode: ProviderSourceMode) async throws {
+        #if os(Linux)
+        let invocationLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-cli-runtime-invocations-\(UUID().uuidString).log")
+        let binaryURL = try Self.makeClaudeCLI(loggedIn: false, invocationLog: invocationLog)
+        defer {
+            try? FileManager.default.removeItem(at: binaryURL)
+            try? FileManager.default.removeItem(at: invocationLog)
+        }
+        let context = self.makeClaudeContext(
+            sourceMode: sourceMode,
+            env: ["CLAUDE_CLI_PATH": binaryURL.path])
+        let cliFetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in
+            Issue.record("Logged-out Claude CLI reached the interactive usage probe")
+            return Self.makeClaudeStatus()
+        }
+
+        let outcome = await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
+            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                context: context,
+                provider: .claude)
+        }
+
+        switch outcome.result {
+        case .success:
+            Issue.record("Expected logged-out Claude CLI to report no available strategy")
+        case let .failure(error):
+            guard let fetchError = error as? ProviderFetchError else {
+                Issue.record("Expected ProviderFetchError, got \(error)")
+                return
+            }
+            switch fetchError {
+            case let .noAvailableStrategy(provider):
+                #expect(provider == .claude)
+            }
+        }
+        let expectedStrategyIDs = sourceMode == .auto ? ["claude.web", "claude.cli"] : ["claude.cli"]
+        #expect(outcome.attempts.map(\.strategyID) == expectedStrategyIDs)
+        #expect(outcome.attempts.allSatisfy { !$0.wasAvailable })
+        #expect(try String(contentsOf: invocationLog, encoding: .utf8) == "auth status --json\n")
         #else
         #expect(Bool(true))
         #endif
@@ -125,24 +173,52 @@ struct PlatformGatingTests {
         #expect(Bool(true))
         #endif
     }
-    private func makeClaudeAutoContext() -> ProviderFetchContext {
+    private func makeClaudeAutoContext(env: [String: String] = [:]) -> ProviderFetchContext {
+        self.makeClaudeContext(sourceMode: .auto, env: env)
+    }
+
+    private func makeClaudeContext(
+        sourceMode: ProviderSourceMode,
+        env: [String: String] = [:]) -> ProviderFetchContext
+    {
         let browserDetection = BrowserDetection(cacheTTL: 0)
+        let usageDataSource: ClaudeUsageDataSource = sourceMode == .cli ? .cli : .auto
         return ProviderFetchContext(
             runtime: .cli,
-            sourceMode: .auto,
+            sourceMode: sourceMode,
             includeCredits: false,
             webTimeout: 1,
             webDebugDumpHTML: false,
             verbose: false,
-            env: [:],
+            env: env,
             settings: ProviderSettingsSnapshot.make(claude: .init(
-                usageDataSource: .auto,
+                usageDataSource: usageDataSource,
                 webExtrasEnabled: false,
                 cookieSource: .auto,
                 manualCookieHeader: nil)),
-            fetcher: UsageFetcher(),
+            fetcher: UsageFetcher(environment: env),
             claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
             browserDetection: browserDetection)
+    }
+
+    private static func makeClaudeCLI(loggedIn: Bool, invocationLog: URL? = nil) throws -> URL {
+        if let invocationLog {
+            try Data().write(to: invocationLog)
+        }
+        let binaryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-cli-runtime-\(UUID().uuidString)")
+        let recordInvocation = invocationLog.map { "printf '%s\\n' \"$*\" >> '\($0.path)'" } ?? ""
+        let loggedInJSON = loggedIn ? "true" : "false"
+        let script = """
+        #!/bin/sh
+        \(recordInvocation)
+        if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+          printf '%s\\n' '{"loggedIn":\(loggedInJSON)}'
+        fi
+        """
+        try Data(script.utf8).write(to: binaryURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
+        return binaryURL
     }
 
     private static func makeClaudeStatus() -> ClaudeStatusSnapshot {


### PR DESCRIPTION
## Summary

- reuse Claude's existing `auth status --json` preflight for CodexBar CLI runtime in both Auto and explicit CLI source modes
- route planned Claude CLI steps through the base strategy's availability check instead of treating them as unconditionally available
- add Linux regression coverage proving a logged-out CLI receives only the auth-status probe and never reaches the interactive usage fetch

## Root cause

#1742 added a fail-closed auth preflight for native-app background Auto refreshes, but intentionally left CLI runtime unchanged. Two conditions kept the command-line path unguarded:

1. `ClaudeCLIFetchStrategy.isAvailable` only preflighted app/background/Auto.
2. `ClaudePlannedFetchStrategy` returned `true` for CLI-runtime planned CLI steps without calling the base strategy's availability check.

On Linux with Claude Code 2.1.207 logged out (`loggedIn: false`, `authMethod: none`), CodexBar 0.42.0 therefore started the interactive `claude --allowed-tools` session and waited through usage-probe retries instead of returning promptly.

This change fails closed when CLI runtime cannot prove Claude is logged in. Native-app explicit CLI selection and user-initiated app behavior remain unchanged. Older or wrapped Claude CLIs that do not support a usable `auth status --json` response will now be unavailable to CodexBar CLI runtime rather than launching an interactive process.

## Validation

- RED: `swift test --filter PlatformGatingTests` reached the interactive fetch override, recorded the CLI strategy available, and issued no auth-status command
- GREEN: `swift test --filter PlatformGatingTests` — 9 tests passed, including Auto and explicit CLI logged-out cases
- `./Scripts/lint.sh lint-linux` — portable checks passed; SwiftLint found 0 violations in 1,374 files
- `swift test --parallel` — 121 tests passed across 19 suites
- `swift build -c release --product CodexBarCLI --static-swift-stdlib`
- exact release-artifact smoke with a fake logged-out Claude whose interactive branch sleeps 60 seconds:
  - Auto exited in 15 ms
  - explicit CLI exited in 13 ms
  - invocation log contained only two `auth status --json` calls and no interactive probe marker
- `git diff --check`

No UI changes; screenshots are not applicable.
