### PR TITLE
fix: amp free fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - German localization: label manual cookie-source and refresh options as “Manuell” instead of the handbook noun “Handbuch.” Thanks @fbrettnich!
+- Amp: parse the current percentage-based daily Amp Free usage output while preserving individual and workspace balances. Thanks @3kh0!
 - Codex notifications: suppress false session-restored alerts while the reset boundary is unchanged, without hiding a real reset after the known boundary passes. Thanks @Yuxin-Qiao!
 - Codex cost history: keep opening and refreshing the submenu fast as project history grows by comparing only the content it renders. Thanks @Yuxin-Qiao!
 - Codex cost history: keep model-less token events explicitly unpriced and unattributed instead of pricing them as GPT-5 while preserving current turn model attribution. Thanks @hhh2210!

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
@@ -70,7 +70,7 @@ enum AmpUsageParser {
                 used: 100 - clampedRemaining,
                 hourlyReplenishment: 0,
                 windowHours: 24,
-                resetDescription: "daily")
+                resetDescription: "resets daily")
         }()
         let resolvedFreeUsage = freeUsage ?? freePercentUsage
         guard resolvedFreeUsage != nil || individualCredits != nil || !workspaceBalances.isEmpty else {

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
@@ -29,6 +29,8 @@ enum AmpUsageParser {
         let freePattern = #"(?im)^\s*Amp Free:\s*\$?"# + amountPattern +
             #"\s*/\s*\$?"# + amountPattern +
             #"\s+remaining(?:\s*\(replenishes\s*\+\$?"# + amountPattern + #"\s*/\s*hour\))?"#
+        let freePercentPattern = #"(?im)^\s*Amp Free:\s*"# + amountPattern +
+            #"\s*%\s+remaining(?:\s+today)?(?:\s*\(resets\s+daily\))?"#
         let creditsPattern = #"(?im)^\s*Individual credits:\s*\$?"# + amountPattern + #"\s+remaining"#
         let individualCredits = self.captures(in: text, pattern: creditsPattern)?.first
             .flatMap(self.number(from:))
@@ -57,20 +59,33 @@ enum AmpUsageParser {
                 hourlyReplenishment: hourlyReplenishment,
                 windowHours: windowHours)
         }()
-        guard freeUsage != nil || individualCredits != nil || !workspaceBalances.isEmpty else {
+        let freePercentUsage: FreeTierUsage? = {
+            guard let remainingText = self.captures(in: text, pattern: freePercentPattern)?.first,
+                  let remaining = self.number(from: remainingText)
+            else { return nil }
+            let clampedRemaining = min(100, max(0, remaining))
+            return FreeTierUsage(
+                quota: 100,
+                used: 100 - clampedRemaining,
+                hourlyReplenishment: 0,
+                windowHours: 24)
+        }()
+        let resolvedFreeUsage = freeUsage ?? freePercentUsage
+        guard resolvedFreeUsage != nil || individualCredits != nil || !workspaceBalances.isEmpty else {
             throw AmpUsageError.parseFailed("Missing Amp usage data.")
         }
 
         return AmpUsageSnapshot(
-            freeQuota: freeUsage?.quota,
-            freeUsed: freeUsage?.used,
-            hourlyReplenishment: freeUsage?.hourlyReplenishment,
-            windowHours: freeUsage?.windowHours,
+            freeQuota: resolvedFreeUsage?.quota,
+            freeUsed: resolvedFreeUsage?.used,
+            hourlyReplenishment: resolvedFreeUsage?.hourlyReplenishment,
+            windowHours: resolvedFreeUsage?.windowHours,
             individualCredits: individualCredits,
             workspaceBalances: workspaceBalances,
             accountEmail: self.nonEmpty(identity?[0]),
             accountOrganization: self.nonEmpty(identity?[1]),
-            updatedAt: now)
+            updatedAt: now,
+            freeResetDescription: freePercentUsage == nil ? nil : "daily")
     }
 
     private struct FreeTierUsage {

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
@@ -57,7 +57,8 @@ enum AmpUsageParser {
                 quota: quota,
                 used: max(0, quota - remaining),
                 hourlyReplenishment: hourlyReplenishment,
-                windowHours: windowHours)
+                windowHours: windowHours,
+                resetDescription: nil)
         }()
         let freePercentUsage: FreeTierUsage? = {
             guard let remainingText = self.captures(in: text, pattern: freePercentPattern)?.first,
@@ -68,7 +69,8 @@ enum AmpUsageParser {
                 quota: 100,
                 used: 100 - clampedRemaining,
                 hourlyReplenishment: 0,
-                windowHours: 24)
+                windowHours: 24,
+                resetDescription: "daily")
         }()
         let resolvedFreeUsage = freeUsage ?? freePercentUsage
         guard resolvedFreeUsage != nil || individualCredits != nil || !workspaceBalances.isEmpty else {
@@ -85,7 +87,7 @@ enum AmpUsageParser {
             accountEmail: self.nonEmpty(identity?[0]),
             accountOrganization: self.nonEmpty(identity?[1]),
             updatedAt: now,
-            freeResetDescription: freePercentUsage == nil ? nil : "daily")
+            freeResetDescription: resolvedFreeUsage?.resetDescription)
     }
 
     private struct FreeTierUsage {
@@ -93,6 +95,7 @@ enum AmpUsageParser {
         let used: Double
         let hourlyReplenishment: Double
         let windowHours: Double?
+        let resetDescription: String?
     }
 
     private static func parseFreeTierUsage(_ html: String) -> FreeTierUsage? {
@@ -118,7 +121,8 @@ enum AmpUsageParser {
             quota: quota,
             used: used,
             hourlyReplenishment: hourly,
-            windowHours: windowHours)
+            windowHours: windowHours,
+            resetDescription: nil)
     }
 
     private static func extractObject(named token: String, in text: String) -> String? {

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageSnapshot.swift
@@ -30,6 +30,7 @@ public struct AmpUsageSnapshot: Sendable {
     public let accountEmail: String?
     public let accountOrganization: String?
     public let updatedAt: Date
+    public let freeResetDescription: String?
 
     public init(
         freeQuota: Double?,
@@ -40,7 +41,8 @@ public struct AmpUsageSnapshot: Sendable {
         workspaceBalances: [AmpWorkspaceBalance] = [],
         accountEmail: String? = nil,
         accountOrganization: String? = nil,
-        updatedAt: Date)
+        updatedAt: Date,
+        freeResetDescription: String? = nil)
     {
         self.freeQuota = freeQuota
         self.freeUsed = freeUsed
@@ -51,6 +53,7 @@ public struct AmpUsageSnapshot: Sendable {
         self.accountEmail = accountEmail
         self.accountOrganization = accountOrganization
         self.updatedAt = updatedAt
+        self.freeResetDescription = freeResetDescription
     }
 }
 
@@ -74,7 +77,7 @@ extension AmpUsageSnapshot {
                     usedPercent: percent,
                     windowMinutes: windowMinutes,
                     resetsAt: resetsAt,
-                    resetDescription: nil)
+                    resetDescription: self.freeResetDescription)
             }()
         } else {
             nil

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -73,9 +73,6 @@ public struct RateWindow: Codable, Equatable, Sendable {
 
     public func backfillingResetTime(from cached: RateWindow?, now: Date = .init()) -> RateWindow {
         if self.resetsAt != nil { return self }
-        // A changed textual reset schedule is fresh provider authority. Reusing the prior exact timestamp would
-        // attach a stale reset boundary to a different quota cadence (for example, rolling Amp usage becoming daily).
-        if self.resetDescription != nil, self.resetDescription != cached?.resetDescription { return self }
         guard let cachedReset = cached?.resetsAt, cachedReset > now else { return self }
         let windowMinutes = if let windowMinutes = self.windowMinutes, windowMinutes > 0 {
             windowMinutes
@@ -510,7 +507,16 @@ public struct UsageSnapshot: Codable, Sendable {
     public func backfillingResetTimes(from cached: UsageSnapshot?, now: Date = .init()) -> UsageSnapshot {
         guard let cached else { return self }
         guard Self.identitiesMatch(self.identity, cached.identity) else { return self }
-        let primary = self.primary?.backfillingResetTime(from: cached.primary, now: now)
+        // Amp's percentage-based daily quota supersedes the legacy rolling-replenishment cadence. Do not attach
+        // that older exact reset to the new daily window; other providers retain the shared backfill behavior.
+        let cachedPrimary: RateWindow? = if self.identity?.providerID == .amp,
+                                            self.primary?.resetDescription == "daily"
+        {
+            nil
+        } else {
+            cached.primary
+        }
+        let primary = self.primary?.backfillingResetTime(from: cachedPrimary, now: now)
         let secondary = self.secondary?.backfillingResetTime(from: cached.secondary, now: now)
         let tertiary = self.tertiary?.backfillingResetTime(from: cached.tertiary, now: now)
         if primary == self.primary, secondary == self.secondary, tertiary == self.tertiary {

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -510,7 +510,7 @@ public struct UsageSnapshot: Codable, Sendable {
         // Amp's percentage-based daily quota supersedes the legacy rolling-replenishment cadence. Do not attach
         // that older exact reset to the new daily window; other providers retain the shared backfill behavior.
         let cachedPrimary: RateWindow? = if self.identity?.providerID == .amp,
-                                            self.primary?.resetDescription == "daily"
+                                            self.primary?.resetDescription == "resets daily"
         {
             nil
         } else {

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -73,6 +73,9 @@ public struct RateWindow: Codable, Equatable, Sendable {
 
     public func backfillingResetTime(from cached: RateWindow?, now: Date = .init()) -> RateWindow {
         if self.resetsAt != nil { return self }
+        // A changed textual reset schedule is fresh provider authority. Reusing the prior exact timestamp would
+        // attach a stale reset boundary to a different quota cadence (for example, rolling Amp usage becoming daily).
+        if self.resetDescription != nil, self.resetDescription != cached?.resetDescription { return self }
         guard let cachedReset = cached?.resetsAt, cachedReset > now else { return self }
         let windowMinutes = if let windowMinutes = self.windowMinutes, windowMinutes > 0 {
             windowMinutes

--- a/Tests/CodexBarTests/AmpUsageParserTests.swift
+++ b/Tests/CodexBarTests/AmpUsageParserTests.swift
@@ -82,7 +82,7 @@ struct AmpUsageParserTests {
         #expect(usage.primary?.usedPercent == 39)
         #expect(usage.primary?.windowMinutes == 1440)
         #expect(usage.primary?.resetsAt == nil)
-        #expect(usage.primary?.resetDescription == "daily")
+        #expect(usage.primary?.resetDescription == "resets daily")
     }
 
     @Test
@@ -117,7 +117,7 @@ struct AmpUsageParserTests {
 
         #expect(legacy.primary?.resetsAt == now.addingTimeInterval(8 * 3600))
         #expect(published.primary?.resetsAt == nil)
-        #expect(published.primary?.resetDescription == "daily")
+        #expect(published.primary?.resetDescription == "resets daily")
     }
 
     @Test

--- a/Tests/CodexBarTests/AmpUsageParserTests.swift
+++ b/Tests/CodexBarTests/AmpUsageParserTests.swift
@@ -59,6 +59,51 @@ struct AmpUsageParserTests {
     }
 
     @Test
+    func `parses percentage based amp free usage`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let output = """
+        Signed in as user@example.com (example)
+        Amp Free: 61% remaining today (resets daily) - https://ampcode.com/settings#amp-free
+        Individual credits: $9.86 remaining (set up automatic top-up to avoid running out)
+        Workspace example: $5.33 remaining (set up automatic top-up to avoid running out)
+        """
+
+        let snapshot = try AmpUsageParser.parse(displayText: output, now: now)
+        let usage = snapshot.toUsageSnapshot(now: now)
+
+        #expect(snapshot.freeQuota == 100)
+        #expect(snapshot.freeUsed == 39)
+        #expect(snapshot.hourlyReplenishment == 0)
+        #expect(snapshot.windowHours == 24)
+        #expect(snapshot.individualCredits == 9.86)
+        #expect(snapshot.workspaceBalances == [AmpWorkspaceBalance(name: "example", remaining: 5.33)])
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(snapshot.accountOrganization == "example")
+        #expect(usage.primary?.usedPercent == 39)
+        #expect(usage.primary?.windowMinutes == 1440)
+        #expect(usage.primary?.resetsAt == nil)
+        #expect(usage.primary?.resetDescription == "daily")
+    }
+
+    @Test
+    func `legacy amp free usage keeps replenishment reset when percentage text also exists`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let output = """
+        Signed in as user@example.com
+        Amp Free: $6/$10 remaining (replenishes +$0.5/hour)
+        Amp Free: 61% remaining today (resets daily)
+        """
+
+        let snapshot = try AmpUsageParser.parse(displayText: output, now: now)
+        let usage = snapshot.toUsageSnapshot(now: now)
+
+        #expect(snapshot.freeUsed == 4)
+        #expect(snapshot.freeResetDescription == nil)
+        #expect(usage.primary?.resetsAt == now.addingTimeInterval(8 * 3600))
+        #expect(usage.primary?.resetDescription == nil)
+    }
+
+    @Test
     func `parses individual credits without free tier usage`() throws {
         let output = """
         Signed in as paid@example.com

--- a/Tests/CodexBarTests/AmpUsageParserTests.swift
+++ b/Tests/CodexBarTests/AmpUsageParserTests.swift
@@ -104,6 +104,23 @@ struct AmpUsageParserTests {
     }
 
     @Test
+    func `daily amp usage rejects cached rolling reset`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let legacy = try AmpUsageParser.parse(
+            displayText: "Signed in as user@example.com\nAmp Free: $6/$10 remaining (replenishes +$0.5/hour)",
+            now: now).toUsageSnapshot(now: now)
+        let daily = try AmpUsageParser.parse(
+            displayText: "Signed in as user@example.com\nAmp Free: 61% remaining today (resets daily)",
+            now: now).toUsageSnapshot(now: now)
+
+        let published = daily.backfillingResetTimes(from: legacy, now: now)
+
+        #expect(legacy.primary?.resetsAt == now.addingTimeInterval(8 * 3600))
+        #expect(published.primary?.resetsAt == nil)
+        #expect(published.primary?.resetDescription == "daily")
+    }
+
+    @Test
     func `parses individual credits without free tier usage`() throws {
         let output = """
         Signed in as paid@example.com

--- a/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
+++ b/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
@@ -76,6 +76,22 @@ struct MenuBarResetTimeDisplayTests {
         #expect(text == "↻ in 2h 15m")
     }
 
+    @Test
+    func `reset time mode surfaces daily reset metadata`() {
+        let window = RateWindow(
+            usedPercent: 39,
+            windowMinutes: 1440,
+            resetsAt: nil,
+            resetDescription: "resets daily")
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .resetTime,
+            percentWindow: window,
+            showUsed: true)
+
+        #expect(text == "↻ resets daily")
+    }
+
     @Test(arguments: [
         "Resets in 2h",
         "tomorrow, 3:00 PM",

--- a/Tests/CodexBarTests/ResetTimeBackfillTests.swift
+++ b/Tests/CodexBarTests/ResetTimeBackfillTests.swift
@@ -60,26 +60,6 @@ final class ResetTimeBackfillTests: XCTestCase {
         XCTAssertNil(result.resetDescription)
     }
 
-    func test_changedResetDescriptionSkipsCachedExactReset() {
-        let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let cached = RateWindow(
-            usedPercent: 50,
-            windowMinutes: 300,
-            resetsAt: now.addingTimeInterval(3600),
-            resetDescription: nil)
-        let fresh = RateWindow(
-            usedPercent: 62,
-            windowMinutes: 1440,
-            resetsAt: nil,
-            resetDescription: "daily")
-
-        let result = fresh.backfillingResetTime(from: cached, now: now)
-
-        XCTAssertNil(result.resetsAt)
-        XCTAssertEqual(result.windowMinutes, 1440)
-        XCTAssertEqual(result.resetDescription, "daily")
-    }
-
     func test_snapshotBackfillPreservesCurrentSnapshotFields() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let reset = now.addingTimeInterval(3600)
@@ -158,5 +138,38 @@ final class ResetTimeBackfillTests: XCTestCase {
         let result = fresh.backfillingResetTimes(from: cached, now: now)
 
         XCTAssertNil(result.primary?.resetsAt)
+    }
+
+    func test_snapshotBackfillKeepsOtherProviderResetWhenDescriptionChanges() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = now.addingTimeInterval(3600)
+        let identity = ProviderIdentitySnapshot(
+            providerID: .claude,
+            accountEmail: "user@example.com",
+            accountOrganization: nil,
+            loginMethod: nil)
+        let cached = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 40,
+                windowMinutes: 300,
+                resetsAt: reset,
+                resetDescription: "40 / 100 used"),
+            secondary: nil,
+            updatedAt: now.addingTimeInterval(-300),
+            identity: identity)
+        let fresh = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 50,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: "50 / 100 used"),
+            secondary: nil,
+            updatedAt: now,
+            identity: identity)
+
+        let result = fresh.backfillingResetTimes(from: cached, now: now)
+
+        XCTAssertEqual(result.primary?.resetsAt, reset)
+        XCTAssertEqual(result.primary?.resetDescription, "50 / 100 used")
     }
 }

--- a/Tests/CodexBarTests/ResetTimeBackfillTests.swift
+++ b/Tests/CodexBarTests/ResetTimeBackfillTests.swift
@@ -60,6 +60,26 @@ final class ResetTimeBackfillTests: XCTestCase {
         XCTAssertNil(result.resetDescription)
     }
 
+    func test_changedResetDescriptionSkipsCachedExactReset() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let cached = RateWindow(
+            usedPercent: 50,
+            windowMinutes: 300,
+            resetsAt: now.addingTimeInterval(3600),
+            resetDescription: nil)
+        let fresh = RateWindow(
+            usedPercent: 62,
+            windowMinutes: 1440,
+            resetsAt: nil,
+            resetDescription: "daily")
+
+        let result = fresh.backfillingResetTime(from: cached, now: now)
+
+        XCTAssertNil(result.resetsAt)
+        XCTAssertEqual(result.windowMinutes, 1440)
+        XCTAssertEqual(result.resetDescription, "daily")
+    }
+
     func test_snapshotBackfillPreservesCurrentSnapshotFields() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let reset = now.addingTimeInterval(3600)


### PR DESCRIPTION
Amp updated their text display once again! This pull request patches CodexBar to adapt to the new logic. This has been fully tested by running the app locally and I have proved it to work (see screenshow below)

```
~ → amp usage
Signed in as example@example.net (example)
Amp Free: 61% remaining today (resets daily) - https://ampcode.com/settings#amp-free
Individual credits: $9.86 remaining (set up automatic top-up to avoid running out) - https://ampcode.com/settings
Workspace example: $5.33 remaining (set up automatic top-up to avoid running out) - https://ampcode.com/workspaces/example
```

<img width="397" height="500" alt="image@2x" src="https://github.com/user-attachments/assets/5507335a-a6c4-4d92-9589-1ca427ea0be7" />
