### PR TITLE
Preserve Claude quota state across placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Settings: split provider pane "Settings" sections into "Menu bar" and "Connection" so metric pickers and auth/cookie/source controls are grouped by topic.
 
 ### Fixed
+- Claude quotas: ignore synthetic no-session placeholders when tracking notifications, history, and reset events, preventing false restores and duplicate threshold or pace warnings while weekly usage continues updating. Thanks @vincent-peng!
 - German localization: label manual cookie-source and refresh options as “Manuell” instead of the handbook noun “Handbuch.” Thanks @fbrettnich!
 - Codex notifications: suppress false session-restored alerts while the reset boundary is unchanged, without hiding a real reset after the known boundary passes. Thanks @Yuxin-Qiao!
 - Codex cost history: keep opening and refreshing the submenu fast as project history grows by comparing only the content it renders. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/PredictivePaceWarnings.swift
+++ b/Sources/CodexBar/PredictivePaceWarnings.swift
@@ -159,6 +159,7 @@ extension UsageStore {
         let now = snapshot.updatedAt
 
         if let sessionWindow = self.predictivePaceWarningSessionWindow(provider: provider, snapshot: snapshot),
+           !sessionWindow.isSyntheticPlaceholder,
            let sessionPace = UsagePaceText.sessionPace(provider: provider, window: sessionWindow, now: now)
         {
             candidates.append((window: .session, rateWindow: sessionWindow, pace: sessionPace))

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -452,6 +452,7 @@ extension UsageStore {
     private static func isSemanticSessionResetWindow(
         _ resolved: (window: RateWindow, source: SessionQuotaWindowSource)) -> Bool
     {
+        guard !resolved.window.isSyntheticPlaceholder else { return false }
         switch resolved.source {
         case .primary:
             guard let minutes = resolved.window.windowMinutes else { return false }
@@ -571,6 +572,7 @@ extension UsageStore {
         func appendWindow(_ window: RateWindow?, name: PlanUtilizationSeriesName?) {
             guard let name,
                   let window,
+                  !window.isSyntheticPlaceholder,
                   let windowMinutes = window.windowMinutes,
                   windowMinutes > 0,
                   let usedPercent = Self.clampedPercent(window.usedPercent)

--- a/Sources/CodexBar/UsageStore+QuotaWarnings.swift
+++ b/Sources/CodexBar/UsageStore+QuotaWarnings.swift
@@ -109,6 +109,7 @@ extension UsageStore {
             self.quotaWarningState.removeValue(forKey: key)
             return
         }
+        guard !rateWindow.isSyntheticPlaceholder else { return }
 
         let thresholds = self.settings.resolvedQuotaWarningThresholds(provider: provider, window: window)
         let currentRemaining = rateWindow.remainingPercent

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -862,6 +862,7 @@ final class UsageStore {
             self.clearSessionQuotaTransitionState(provider: provider)
             return
         }
+        guard !sessionWindow.window.isSyntheticPlaceholder else { return }
         let currentRemaining = sessionWindow.window.remainingPercent
         let currentSource = sessionWindow.source
         let currentResetBoundary = sessionWindow.window.resetsAt

--- a/Tests/CodexBarTests/ClaudeSyntheticPlaceholderNotificationTests.swift
+++ b/Tests/CodexBarTests/ClaudeSyntheticPlaceholderNotificationTests.swift
@@ -1,0 +1,257 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite("Claude synthetic session placeholder notifications")
+struct ClaudeSyntheticPlaceholderNotificationTests {
+    private let start = Date(timeIntervalSince1970: 1_780_000_000)
+
+    @Test
+    func `placeholder preserves depleted state without a reset boundary`() {
+        let notifier = NotifierSpy()
+        let store = self.makeStore(
+            suiteName: "ClaudeSyntheticPlaceholderNotificationTests-depleted-no-boundary",
+            notifier: notifier)
+
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: self.snapshot(sessionUsed: 20))
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: self.snapshot(sessionUsed: 100))
+        store.handleSessionQuotaTransition(
+            provider: .claude,
+            snapshot: self.snapshot(sessionUsed: 0, sessionIsSyntheticPlaceholder: true))
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: self.snapshot(sessionUsed: 100))
+
+        #expect(notifier.transitions == [.depleted])
+        #expect(store.lastKnownSessionRemaining[.claude] == 0)
+    }
+
+    @Test
+    func `placeholder stays non authoritative after the prior boundary elapses`() {
+        let notifier = NotifierSpy()
+        let store = self.makeStore(
+            suiteName: "ClaudeSyntheticPlaceholderNotificationTests-depleted-elapsed-boundary",
+            notifier: notifier)
+        let boundary = self.start.addingTimeInterval(5 * 60)
+
+        store.handleSessionQuotaTransition(
+            provider: .claude,
+            snapshot: self.snapshot(sessionUsed: 20, sessionReset: boundary))
+        store.handleSessionQuotaTransition(
+            provider: .claude,
+            snapshot: self.snapshot(sessionUsed: 100, sessionReset: boundary, secondsAfterStart: 60))
+        store.handleSessionQuotaTransition(
+            provider: .claude,
+            snapshot: self.snapshot(
+                sessionUsed: 0,
+                sessionReset: boundary,
+                sessionIsSyntheticPlaceholder: true,
+                secondsAfterStart: 6 * 60))
+        store.handleSessionQuotaTransition(
+            provider: .claude,
+            snapshot: self.snapshot(sessionUsed: 100, sessionReset: boundary, secondsAfterStart: 7 * 60))
+
+        #expect(notifier.transitions == [.depleted])
+        #expect(store.lastKnownSessionRemaining[.claude] == 0)
+    }
+
+    @Test
+    func `placeholder cannot rearm depletion while notifications are disabled`() {
+        let notifier = NotifierSpy()
+        let store = self.makeStore(
+            suiteName: "ClaudeSyntheticPlaceholderNotificationTests-disabled",
+            notifier: notifier)
+
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: self.snapshot(sessionUsed: 20))
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: self.snapshot(sessionUsed: 100))
+
+        store.settings.sessionQuotaNotificationsEnabled = false
+        store.handleSessionQuotaTransition(
+            provider: .claude,
+            snapshot: self.snapshot(sessionUsed: 0, sessionIsSyntheticPlaceholder: true))
+        store.settings.sessionQuotaNotificationsEnabled = true
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: self.snapshot(sessionUsed: 100))
+
+        #expect(notifier.transitions == [.depleted])
+        #expect(store.lastKnownSessionRemaining[.claude] == 0)
+    }
+
+    @Test
+    func `real zero usage remains an authoritative restore`() {
+        let notifier = NotifierSpy()
+        let store = self.makeStore(
+            suiteName: "ClaudeSyntheticPlaceholderNotificationTests-real-zero",
+            notifier: notifier)
+
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: self.snapshot(sessionUsed: 20))
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: self.snapshot(sessionUsed: 100))
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: self.snapshot(sessionUsed: 0))
+
+        #expect(notifier.transitions == [.depleted, .restored])
+        #expect(store.lastKnownSessionRemaining[.claude] == 100)
+    }
+
+    @Test
+    func `placeholder preserves threshold state while weekly warnings continue`() {
+        let notifier = NotifierSpy()
+        let store = self.makeStore(
+            suiteName: "ClaudeSyntheticPlaceholderNotificationTests-threshold",
+            notifier: notifier)
+        store.settings.quotaWarningNotificationsEnabled = true
+        store.settings.quotaWarningThresholds = [50]
+        store.settings.setQuotaWarningWindowEnabled(.session, enabled: true)
+        store.settings.setQuotaWarningWindowEnabled(.weekly, enabled: true)
+        let sessionReset = self.start.addingTimeInterval(2 * 60 * 60)
+        let weeklyReset = self.start.addingTimeInterval(2 * 24 * 60 * 60)
+
+        store.handleQuotaWarningTransitions(
+            provider: .claude,
+            snapshot: self.snapshot(
+                sessionUsed: 40,
+                weeklyUsed: 40,
+                sessionReset: sessionReset,
+                weeklyReset: weeklyReset))
+        store.handleQuotaWarningTransitions(
+            provider: .claude,
+            snapshot: self.snapshot(
+                sessionUsed: 60,
+                weeklyUsed: 40,
+                sessionReset: sessionReset,
+                weeklyReset: weeklyReset,
+                secondsAfterStart: 60))
+        store.handleQuotaWarningTransitions(
+            provider: .claude,
+            snapshot: self.snapshot(
+                sessionUsed: 0,
+                weeklyUsed: 60,
+                sessionReset: sessionReset,
+                weeklyReset: weeklyReset,
+                sessionIsSyntheticPlaceholder: true,
+                secondsAfterStart: 120))
+        store.handleQuotaWarningTransitions(
+            provider: .claude,
+            snapshot: self.snapshot(
+                sessionUsed: 60,
+                weeklyUsed: 60,
+                sessionReset: sessionReset,
+                weeklyReset: weeklyReset,
+                secondsAfterStart: 180))
+
+        #expect(notifier.quotaWarnings.map(\.window) == [.session, .weekly])
+        #expect(notifier.quotaWarnings.map(\.threshold) == [50, 50])
+    }
+
+    @Test
+    func `placeholder preserves predictive episode while weekly risk continues`() {
+        let notifier = NotifierSpy()
+        let store = self.makeStore(
+            suiteName: "ClaudeSyntheticPlaceholderNotificationTests-predictive",
+            notifier: notifier)
+        store.settings.predictivePaceWarningNotificationsEnabled = true
+        let sessionReset = self.start.addingTimeInterval(2 * 60 * 60)
+        let weeklyReset = self.start.addingTimeInterval(2 * 24 * 60 * 60)
+
+        store.handlePredictivePaceWarningTransitions(
+            provider: .claude,
+            snapshot: self.snapshot(
+                sessionUsed: 80,
+                weeklyUsed: 20,
+                sessionReset: sessionReset,
+                weeklyReset: weeklyReset))
+        store.handlePredictivePaceWarningTransitions(
+            provider: .claude,
+            snapshot: self.snapshot(
+                sessionUsed: 0,
+                weeklyUsed: 90,
+                sessionReset: sessionReset,
+                weeklyReset: weeklyReset,
+                sessionIsSyntheticPlaceholder: true,
+                secondsAfterStart: 60))
+        store.handlePredictivePaceWarningTransitions(
+            provider: .claude,
+            snapshot: self.snapshot(
+                sessionUsed: 80,
+                weeklyUsed: 90,
+                sessionReset: sessionReset,
+                weeklyReset: weeklyReset,
+                secondsAfterStart: 120))
+
+        #expect(notifier.predictiveWarnings == [.session, .weekly])
+    }
+
+    private func makeStore(suiteName: String, notifier: NotifierSpy) -> UsageStore {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suiteName),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.sessionQuotaNotificationsEnabled = true
+        return UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+    }
+
+    private func snapshot(
+        sessionUsed: Double,
+        weeklyUsed: Double = 20,
+        sessionReset: Date? = nil,
+        weeklyReset: Date? = nil,
+        sessionIsSyntheticPlaceholder: Bool = false,
+        secondsAfterStart: TimeInterval = 0) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: sessionUsed,
+                windowMinutes: 5 * 60,
+                resetsAt: sessionReset,
+                resetDescription: nil,
+                isSyntheticPlaceholder: sessionIsSyntheticPlaceholder),
+            secondary: RateWindow(
+                usedPercent: weeklyUsed,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: weeklyReset,
+                resetDescription: nil),
+            updatedAt: self.start.addingTimeInterval(secondsAfterStart),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "placeholder@example.com",
+                accountOrganization: nil,
+                loginMethod: "web"))
+    }
+}
+
+@MainActor
+private final class NotifierSpy: SessionQuotaNotifying {
+    private(set) var transitions: [SessionQuotaTransition] = []
+    private(set) var quotaWarnings: [QuotaWarningEvent] = []
+    private(set) var predictiveWarnings: [QuotaWarningWindow] = []
+
+    func post(transition: SessionQuotaTransition, provider _: UsageProvider, badge _: NSNumber?) {
+        self.transitions.append(transition)
+    }
+
+    func postQuotaWarning(
+        event: QuotaWarningEvent,
+        provider _: UsageProvider,
+        soundEnabled _: Bool,
+        onScreenAlertEnabled _: Bool)
+    {
+        self.quotaWarnings.append(event)
+    }
+
+    func postPredictivePaceWarning(
+        event: PredictivePaceWarningEvent,
+        provider _: UsageProvider,
+        soundEnabled _: Bool,
+        onScreenAlertEnabled _: Bool,
+        now _: Date)
+    {
+        self.predictiveWarnings.append(event.window)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeSyntheticPlaceholderPlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/ClaudeSyntheticPlaceholderPlanUtilizationTests.swift
@@ -1,0 +1,38 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+extension UsageStorePlanUtilizationTests {
+    @MainActor
+    @Test
+    func `Claude placeholder is omitted from session history while weekly history continues`() async {
+        let store = Self.makeStore()
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 5 * 60,
+                resetsAt: now.addingTimeInterval(2 * 60 * 60),
+                resetDescription: nil,
+                isSyntheticPlaceholder: true),
+            secondary: RateWindow(
+                usedPercent: 42,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(2 * 24 * 60 * 60),
+                resetDescription: nil),
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "placeholder-history@example.com",
+                accountOrganization: nil,
+                loginMethod: "web"))
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: snapshot, now: now)
+
+        let histories = store.planUtilizationHistory(for: .claude)
+        #expect(findSeries(histories, name: .session, windowMinutes: 5 * 60) == nil)
+        #expect(findSeries(histories, name: .weekly, windowMinutes: 7 * 24 * 60)?
+            .entries.map(\.usedPercent) == [42])
+    }
+}

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
@@ -43,6 +43,61 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
+    func `Claude placeholder does not post or consume a genuine session reset`() async {
+        let store = Self.makeStore()
+        let accountLabel = "synthetic-session-reset@example.com"
+        let recorder = SessionLimitResetEventRecorder(provider: .claude, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        func snapshot(usedPercent: Double, isPlaceholder: Bool, updatedAt: Date) -> UsageSnapshot {
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: usedPercent,
+                    windowMinutes: 5 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil,
+                    isSyntheticPlaceholder: isPlaceholder),
+                secondary: RateWindow(
+                    usedPercent: 20,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: updatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .claude,
+                    accountEmail: accountLabel,
+                    accountOrganization: nil,
+                    loginMethod: "web"))
+        }
+
+        let start = Date(timeIntervalSince1970: 1_780_000_000)
+        let before = snapshot(usedPercent: 65, isPlaceholder: false, updatedAt: start)
+        let placeholder = snapshot(
+            usedPercent: 0,
+            isPlaceholder: true,
+            updatedAt: start.addingTimeInterval(60 * 60))
+        let genuineReset = snapshot(
+            usedPercent: 0,
+            isPlaceholder: false,
+            updatedAt: start.addingTimeInterval(2 * 60 * 60))
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: placeholder,
+            now: placeholder.updatedAt)
+        #expect(recorder.events.isEmpty)
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: genuineReset,
+            now: genuineReset.updatedAt)
+        #expect(recorder.events.count == 1)
+        #expect(recorder.events.first?.usedPercent == 0)
+    }
+
+    @MainActor
+    @Test
     func `legacy session detector state preserves first reset after upgrade`() async throws {
         let store = Self.makeStore()
         let accountLabel = "session-reset-upgrade@example.com"

--- a/docs/superpowers/specs/2026-07-01-predictive-pace-warning-notifications-design.md
+++ b/docs/superpowers/specs/2026-07-01-predictive-pace-warning-notifications-design.md
@@ -7,7 +7,7 @@ read_when:
 
 # Predictive pace warning notifications
 
-**Status:** accepted design; not implemented
+**Status:** implemented by #1960 and released in v0.42.0
 **Date:** 2026-07-01
 **Issue:** #1299
 
@@ -56,6 +56,7 @@ For each key:
    notify once.
 4. Low-confidence risk, missing pace, missing window, failed refresh, or incomplete provider enrichment neither notifies
    nor counts as recovery. Preserve current state until a successful, authoritative observation arrives.
+   A synthetic placeholder for an unreported quota window is also non-authoritative and must preserve state.
 5. A new reset-window identity starts with fresh state. Prune expired window keys rather than carrying episode state
    across resets.
 6. Keep this state in memory only. App restart resets episodes; do not add persisted notification history.
@@ -84,7 +85,7 @@ When personal information is hidden, do not include email, organization, workspa
 
 - A pure evaluator/state reducer accepting provider, account discriminator, reset-window identity, pace, and prior state.
 - A small `UsageStore` integration after successful snapshot/pace calculation, separate from static threshold transition state.
-- One default-off `SettingsStore` value and one General notifications control.
+- One default-off `SettingsStore` value and one Notifications-pane control.
 - Localized notification title/body through the existing presenter.
 - No new dependency and no provider fetch changes.
 


### PR DESCRIPTION
## Summary

- treat Claude's synthetic no-session window as a non-authoritative observation for depleted/restored, threshold, and predictive warning state
- keep synthetic session samples out of plan-utilization history and reset events while continuing to evaluate weekly usage
- update the accepted predictive-warning spec to reflect the released default-off Notifications setting and placeholder semantics

Follow-up to #1960. This complements #2060's reset-boundary hardening by handling the explicit Claude placeholder marker before any notification or history state mutates.

## Behavior proof

Before the fix, real -> placeholder -> same-real sequences could emit restored/depleted loops, clear fired thresholds, or re-arm predictive session warnings. The new regressions fail against the unguarded implementation and now prove that:

- depleted, threshold, and predictive state survives a synthetic placeholder
- weekly threshold and predictive evaluation still proceeds during that placeholder
- a genuine reported 0%-used session remains authoritative
- synthetic sessions do not create history points or consume reset detection state

## Validation

- `swift test --filter 'ClaudeSyntheticPlaceholderNotificationTests|RateWindowSyntheticPlaceholderTests|PredictivePaceWarningTests|UsageStoreSessionQuotaTransitionTests|UsageStorePlanUtilizationTests|CodexSessionQuotaFalseRestoreTests'` - 135 tests in 6 suites passed
- `make check` - passed (format, lint, repository, documentation, and locale checks)
- `make test` - the local sharded run reached an unrelated existing `CodexAccountScopedRefreshTests/default dashboard refresh path discards stale completion after account switch` timeout (exit 124); no changed-area assertion failed, and CI remains the clean-environment full-matrix gate
- exact-head CI - all 8 checks passed, including both macOS Swift-test shards, both Linux build/test lanes, lint, the aggregate gate, and GitGuardian

Dependencies are unchanged. Unit validation used isolated stores, notifier spies, and fictitious identities; no live provider or Keychain probes were run.

## Exact-head fixture runtime proof

Exact commit `246d2da5adadfaa6ef49b48b13f0c86239196a48`, debug app executable SHA-256 `368a3c12e8518da6d1eea61dc7df1e4db54a1e44a25eb3cc010ae62072c9b043`:

- launched the actual app process under LLDB with an isolated `CFFIXED_USER_HOME`, config, and `CODEX_HOME`; every provider was disabled, test-mode notification delivery was suppressed, and logs confirmed Keychain access stayed disabled
- drove the real `AppDelegate` `UsageStore` and `SessionQuotaNotifier` through real -> synthetic placeholder -> same-real session observations, with weekly usage changing during the placeholder
- notifier logs contained exactly one each of `quota-warning-claude-session-50`, `predictive-pace-warning-claude-session`, `quota-warning-claude-weekly-50`, `predictive-pace-warning-claude-weekly`, and `session-claude-depleted`; `session-claude-restored` appeared zero times
- post-sequence state retained `session_remaining=0`, session/weekly fired thresholds `[50]`, and one predictive episode key per lane
- the isolated persisted history contained session `[40, 80, 80]` and weekly `[20, 20, 90, 90]`: the synthetic session `0` was absent while the same observation's weekly `90` point was retained

No real credentials, browser cookies, network provider calls, sounds, or on-screen alerts were used.
