### PR TITLE
fix: load plan utilization history asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - sub2api: add group-key usage with daily, weekly, and monthly quotas, multi-account switching, wallet balance, and expiry details. Thanks @weirdo-adam!
 
 ### Fixed
+- Startup: load persisted plan-utilization history away from the main thread so mature histories no longer delay app launch. Thanks @Yuxin-Qiao!
 - Provider cleanup: prevent in-flight usage, status, token-cost, and cached-hydration work from republishing stale state after a provider is disabled, unavailable, or re-enabled. Thanks @Yuxin-Qiao!
 - Agent Sessions: coalesce overlapping unchanged remote refresh requests so menu opens do not repeat Tailscale discovery and SSH passes. Thanks @Yuxin-Qiao!
 

--- a/Sources/CodexBar/PlanUtilizationHistoryStore.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryStore.swift
@@ -285,55 +285,77 @@ extension ProviderHistoryDocument {
 /// Used to verify that `UsageStore.init` returns before disk I/O completes and
 /// that the history is applied exactly once after the gate opens.
 final class PlanUtilizationHistoryLoadGate: @unchecked Sendable {
+    private enum State {
+        case closed
+        case open
+        case cancelled
+    }
+
     private let lock = NSLock()
-    private var continuations: [CheckedContinuation<Void, Never>] = []
-    private var _isOpen: Bool = false
+    private var continuations: [CheckedContinuation<Bool, Never>] = []
+    private var state: State = .closed
 
     init() {}
 
     var isOpen: Bool {
         self.lock.lock()
         defer { self.lock.unlock() }
-        return self._isOpen
+        return self.state == .open
     }
 
-    func wait() async {
+    var isCancelled: Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.state == .cancelled
+    }
+
+    func wait() async -> Bool {
         await withCheckedContinuation { continuation in
             self.lock.lock()
-            if self._isOpen {
+            switch self.state {
+            case .open:
                 self.lock.unlock()
-                continuation.resume()
-                return
+                continuation.resume(returning: true)
+            case .cancelled:
+                self.lock.unlock()
+                continuation.resume(returning: false)
+            case .closed:
+                self.continuations.append(continuation)
+                self.lock.unlock()
             }
-            self.continuations.append(continuation)
-            self.lock.unlock()
         }
     }
 
     func open() {
         self.lock.lock()
-        self._isOpen = true
+        guard self.state == .closed else {
+            self.lock.unlock()
+            return
+        }
+        self.state = .open
         let pending = self.continuations
         self.continuations.removeAll()
         self.lock.unlock()
         for continuation in pending {
-            continuation.resume()
+            continuation.resume(returning: true)
         }
     }
 
-    /// Resumes every pending waiter without marking the gate as open. Use this
-    /// to release a waiter that is being cancelled so its `withCheckedContinuation`
-    /// does not leak the suspended task, continuation, and the gate itself.
-    /// Pending waiters resume as if `open()` had been called; subsequent
-    /// `wait()` calls still observe the gate as closed, so a test that calls
-    /// `cancelAll()` and then `open()` gets the natural reopen semantics.
-    func cancelAll() {
+    /// Cancels this one-shot gate and resumes pending or future waiters with
+    /// `false`. Cancellation is sticky so it cannot race ahead of `wait()` and
+    /// lose the wakeup that drains the load task.
+    func cancel() {
         self.lock.lock()
+        guard self.state == .closed else {
+            self.lock.unlock()
+            return
+        }
+        self.state = .cancelled
         let pending = self.continuations
         self.continuations.removeAll()
         self.lock.unlock()
         for continuation in pending {
-            continuation.resume()
+            continuation.resume(returning: false)
         }
     }
 }

--- a/Sources/CodexBar/PlanUtilizationHistoryStore.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryStore.swift
@@ -1,7 +1,7 @@
 import CodexBarCore
 import Foundation
 
-struct PlanUtilizationSeriesName: RawRepresentable, Hashable, Codable, ExpressibleByStringLiteral {
+struct PlanUtilizationSeriesName: RawRepresentable, Hashable, Codable, ExpressibleByStringLiteral, Sendable {
     let rawValue: String
 
     init(rawValue: String) {
@@ -28,13 +28,13 @@ struct PlanUtilizationSeriesName: RawRepresentable, Hashable, Codable, Expressib
     }
 }
 
-struct PlanUtilizationHistoryEntry: Codable, Equatable, Hashable {
+struct PlanUtilizationHistoryEntry: Codable, Equatable, Hashable, Sendable {
     let capturedAt: Date
     let usedPercent: Double
     let resetsAt: Date?
 }
 
-struct PlanUtilizationSeriesHistory: Codable, Equatable {
+struct PlanUtilizationSeriesHistory: Codable, Equatable, Sendable {
     let name: PlanUtilizationSeriesName
     let windowMinutes: Int
     let entries: [PlanUtilizationHistoryEntry]
@@ -60,7 +60,7 @@ struct PlanUtilizationSeriesHistory: Codable, Equatable {
     }
 }
 
-struct PlanUtilizationHistoryBuckets: Equatable {
+struct PlanUtilizationHistoryBuckets: Equatable, Sendable {
     var preferredAccountKey: String?
     var unscoped: [PlanUtilizationSeriesHistory] = []
     var accounts: [String: [PlanUtilizationSeriesHistory]] = [:]
@@ -97,20 +97,20 @@ struct PlanUtilizationHistoryBuckets: Equatable {
     }
 }
 
-private struct ProviderHistoryFile: Codable {
+private struct ProviderHistoryFile: Codable, Sendable {
     let preferredAccountKey: String?
     let unscoped: [PlanUtilizationSeriesHistory]
     let accounts: [String: [PlanUtilizationSeriesHistory]]
 }
 
-private struct ProviderHistoryDocument: Codable {
+private struct ProviderHistoryDocument: Codable, Sendable {
     let version: Int
     let preferredAccountKey: String?
     let unscoped: [PlanUtilizationSeriesHistory]
     let accounts: [String: [PlanUtilizationSeriesHistory]]
 }
 
-struct PlanUtilizationHistoryStore {
+struct PlanUtilizationHistoryStore: Sendable {
     fileprivate static let providerSchemaVersion = 1
 
     let directoryURL: URL?
@@ -125,6 +125,16 @@ struct PlanUtilizationHistoryStore {
 
     func load() -> [UsageProvider: PlanUtilizationHistoryBuckets] {
         self.loadProviderFiles()
+    }
+
+    /// Loads the persisted histories on a utility-priority detached task.
+    ///
+    /// The on-disk decode is synchronous I/O + JSON parsing that can take
+    /// ~150 ms for mature two-year histories and must not run on the app
+    /// startup main thread. The returned dictionary is safe to apply on the
+    /// main actor once decoding completes.
+    func loadAsync() async -> [UsageProvider: PlanUtilizationHistoryBuckets] {
+        await Task.detached(priority: .utility) { self.load() }.value
     }
 
     func save(_ providers: [UsageProvider: PlanUtilizationHistoryBuckets]) {
@@ -265,5 +275,65 @@ extension ProviderHistoryDocument {
         self.preferredAccountKey = try container.decodeIfPresent(String.self, forKey: .preferredAccountKey)
         self.unscoped = try container.decode([PlanUtilizationSeriesHistory].self, forKey: .unscoped)
         self.accounts = try container.decode([String: [PlanUtilizationSeriesHistory]].self, forKey: .accounts)
+    }
+}
+
+/// One-shot synchronization primitive used by `UsageStore.init` to defer the
+/// utility-priority plan-utilization history load until a test chooses to
+/// release it. The default `nil` gate is open and the load proceeds immediately.
+///
+/// Used to verify that `UsageStore.init` returns before disk I/O completes and
+/// that the history is applied exactly once after the gate opens.
+final class PlanUtilizationHistoryLoadGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private var _isOpen: Bool = false
+
+    init() {}
+
+    var isOpen: Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self._isOpen
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            self.lock.lock()
+            if self._isOpen {
+                self.lock.unlock()
+                continuation.resume()
+                return
+            }
+            self.continuations.append(continuation)
+            self.lock.unlock()
+        }
+    }
+
+    func open() {
+        self.lock.lock()
+        self._isOpen = true
+        let pending = self.continuations
+        self.continuations.removeAll()
+        self.lock.unlock()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+
+    /// Resumes every pending waiter without marking the gate as open. Use this
+    /// to release a waiter that is being cancelled so its `withCheckedContinuation`
+    /// does not leak the suspended task, continuation, and the gate itself.
+    /// Pending waiters resume as if `open()` had been called; subsequent
+    /// `wait()` calls still observe the gate as closed, so a test that calls
+    /// `cancelAll()` and then `open()` gets the natural reopen semantics.
+    func cancelAll() {
+        self.lock.lock()
+        let pending = self.continuations
+        self.continuations.removeAll()
+        self.lock.unlock()
+        for continuation in pending {
+            continuation.resume()
+        }
     }
 }

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -101,6 +101,15 @@ extension UsageStore {
     func planUtilizationHistorySelection(for provider: UsageProvider)
         -> (accountKey: String?, histories: [PlanUtilizationSeriesHistory])
     {
+        // The persisted history has not been read yet. Return the in-memory
+        // stub (empty) without performing account migration or enqueueing an
+        // empty persistence snapshot — otherwise a startup refresh racing the
+        // background load would record samples against an empty bucket and
+        // overwrite real disk history.
+        if !self.planUtilizationHistoryLoaded {
+            let providerBuckets = self.planUtilizationHistory[provider] ?? PlanUtilizationHistoryBuckets()
+            return (nil, providerBuckets.histories(for: nil))
+        }
         var providerBuckets = self.planUtilizationHistory[provider] ?? PlanUtilizationHistoryBuckets()
         if provider == .claude,
            providerBuckets.preferredAccountKey == Self.planUtilizationUnscopedPreferredKey
@@ -130,6 +139,12 @@ extension UsageStore {
     func codexPlanUtilizationHistories(forVisibleAccount account: CodexVisibleAccount)
         -> [PlanUtilizationSeriesHistory]
     {
+        // Same gate as `planUtilizationHistorySelection`: defer ownership
+        // migration until the persisted history has been read.
+        if !self.planUtilizationHistoryLoaded {
+            let providerBuckets = self.planUtilizationHistory[.codex] ?? PlanUtilizationHistoryBuckets()
+            return providerBuckets.histories(for: nil)
+        }
         var providerBuckets = self.planUtilizationHistory[.codex] ?? PlanUtilizationHistoryBuckets()
         let originalProviderBuckets = providerBuckets
         let ownership = self.codexOwnershipContext(forVisibleAccount: account)
@@ -229,6 +244,20 @@ extension UsageStore {
         guard !samples.isEmpty else { return }
         guard self.shouldRecordPlanUtilizationHistory(for: provider) else { return }
         guard !self.shouldDeferClaudePlanUtilizationHistory(provider: provider) else { return }
+
+        // Wait for the persisted history to finish loading before mutating
+        // `self.planUtilizationHistory`. A startup refresh racing the
+        // background decode would otherwise record samples against an empty
+        // bucket and overwrite real disk history on the next persistence
+        // enqueue.
+        if !self.planUtilizationHistoryLoaded {
+            // `_cancelPlanUtilizationHistoryLoadForTesting` cancels the task
+            // and flips `loaded` to true; this branch only runs when the load
+            // is still pending. Cancellation here (deinit during a startup
+            // refresh) means the in-memory dictionary is empty — proceeding
+            // is the safer choice than discarding the sample.
+            _ = await self.planUtilizationHistoryLoadTask?.result
+        }
 
         var snapshotToPersist: [UsageProvider: PlanUtilizationHistoryBuckets]?
         await MainActor.run {

--- a/Sources/CodexBar/UsageStore+PlanUtilizationLoading.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilizationLoading.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension UsageStore {
+    func startPlanUtilizationHistoryLoad(gate: PlanUtilizationHistoryLoadGate?) {
+        let historyStore = self.planUtilizationHistoryStore
+        self.planUtilizationHistoryLoadTask = Task { @MainActor [weak self] in
+            // In-memory starts empty; mutation paths and sync menu accessors gate on
+            // `planUtilizationHistoryLoaded` until the background decode publishes once.
+            if let gate {
+                let shouldLoad = await withTaskCancellationHandler {
+                    await gate.wait()
+                } onCancel: {
+                    gate.cancel()
+                }
+                guard shouldLoad, !Task.isCancelled else { return }
+            }
+            let loaded = await historyStore.loadAsync()
+            guard !Task.isCancelled, let self, !self.planUtilizationHistoryLoaded else { return }
+            self.planUtilizationHistory = loaded
+            self.planUtilizationHistoryLoaded = true
+            self.planUtilizationHistoryRevision &+= 1
+        }
+    }
+}

--- a/Sources/CodexBar/UsageStore+PlanUtilizationLoading.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilizationLoading.swift
@@ -1,7 +1,20 @@
 import Foundation
 
 extension UsageStore {
-    func startPlanUtilizationHistoryLoad(gate: PlanUtilizationHistoryLoadGate?) {
+    static func resolvedPlanHistoryStore(
+        _ store: PlanUtilizationHistoryStore?,
+        startup: StartupBehavior) -> PlanUtilizationHistoryStore
+    {
+        store ?? (startup.automaticallyStartsBackgroundWork
+            ? .defaultAppSupport()
+            : PlanUtilizationHistoryStore(directoryURL: nil))
+    }
+
+    func startPlanUtilizationHistoryLoad(gate: PlanUtilizationHistoryLoadGate?, enabled: Bool) {
+        guard enabled || gate != nil else {
+            self.planUtilizationHistoryLoaded = true
+            return
+        }
         let historyStore = self.planUtilizationHistoryStore
         self.planUtilizationHistoryLoadTask = Task { @MainActor [weak self] in
             // In-memory starts empty; mutation paths and sync menu accessors gate on

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -346,7 +346,15 @@ final class UsageStore {
     @ObservationIgnored var lastPermissionPromptNotificationAt: [UsageProvider: Date] = [:]
     @ObservationIgnored var lastTokenFetchAt: [UsageProvider: Date] = [:]
     @ObservationIgnored var lastTokenFetchScope: [UsageProvider: String] = [:]
-    @ObservationIgnored var planUtilizationHistory: [UsageProvider: PlanUtilizationHistoryBuckets] = [:]
+    @ObservationIgnored var planUtilizationHistory: [UsageProvider: PlanUtilizationHistoryBuckets] = [:] {
+        didSet { if !self.planUtilizationHistoryLoaded { self.planUtilizationHistoryLoaded = true } }
+    }
+
+    /// Background load task; cleared on deinit and on the cancel test seam.
+    @ObservationIgnored var planUtilizationHistoryLoadTask: Task<Void, Never>?
+    /// Set once after the load completes. Gates mutation paths and sync menu
+    /// accessors so they cannot race the decode or write empty history back to disk.
+    @ObservationIgnored var planUtilizationHistoryLoaded: Bool = false
     @ObservationIgnored var sessionLimitResetDetectorStates: [String: LimitResetDetectorState] = [:]
     @ObservationIgnored var weeklyLimitResetDetectorStates: [String: LimitResetDetectorState] = [:]
     @ObservationIgnored private var hasCompletedInitialRefresh: Bool = false
@@ -369,7 +377,8 @@ final class UsageStore {
         codexAccountUsageSnapshotStore: (any CodexAccountUsageSnapshotStoring)? = nil,
         sessionQuotaNotifier: any SessionQuotaNotifying = SessionQuotaNotifier(),
         startupBehavior: StartupBehavior = .automatic,
-        environmentBase: [String: String] = ProcessInfo.processInfo.environment)
+        environmentBase: [String: String] = ProcessInfo.processInfo.environment,
+        planUtilizationHistoryLoadGateForTesting: PlanUtilizationHistoryLoadGate? = nil)
     {
         self.codexFetcher = fetcher
         self.browserDetection = browserDetection
@@ -404,7 +413,21 @@ final class UsageStore {
         self.providerRuntimes = Dictionary(uniqueKeysWithValues: ProviderCatalog.all.compactMap { implementation in
             implementation.makeRuntime().map { (implementation.id, $0) }
         })
-        self.planUtilizationHistory = planUtilizationHistoryStore.load()
+        self.planUtilizationHistory = [:]
+        self.planUtilizationHistoryLoadTask = Task { @MainActor [weak self] in
+            // Move persisted plan-utilization decode off the startup main thread.
+            // In-memory starts empty; mutation paths and sync menu accessors gate on
+            // `planUtilizationHistoryLoaded` until the load task publishes once.
+            let loaded = await withTaskCancellationHandler {
+                await Task.detached(priority: .utility) {
+                    await planUtilizationHistoryLoadGateForTesting?.wait()
+                    return planUtilizationHistoryStore.load()
+                }.value
+            } onCancel: { planUtilizationHistoryLoadGateForTesting?.cancelAll() }
+            guard let self, !self.planUtilizationHistoryLoaded else { return }
+            self.planUtilizationHistory = loaded
+            self.planUtilizationHistoryRevision &+= 1
+        }
         self.sessionLimitResetDetectorStates = Self.loadLimitResetDetectorStates(
             from: settings.userDefaults,
             defaultsKey: Self.sessionLimitResetDetectorDefaultsKey,
@@ -817,6 +840,7 @@ final class UsageStore {
         self.storageRefreshTask?.cancel()
         self.codexPlanHistoryBackfillTask?.cancel()
         self.resetBoundaryRefreshTask?.cancel()
+        self.planUtilizationHistoryLoadTask?.cancel()
     }
 
     enum SessionQuotaWindowSource: String {

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -86,16 +86,8 @@ extension UsageStore {
 
     private static func isRunningTestsProcess() -> Bool {
         let environment = ProcessInfo.processInfo.environment
-        if environment["XCTestConfigurationFilePath"] != nil {
-            return true
-        }
-        if environment["XCTestSessionIdentifier"] != nil {
-            return true
-        }
-        if environment["SWIFT_TESTING_ENABLED"] != nil {
-            return true
-        }
-        return CommandLine.arguments.contains { argument in
+        let testKeys = ["XCTestConfigurationFilePath", "XCTestSessionIdentifier", "SWIFT_TESTING_ENABLED"]
+        return testKeys.contains(where: { environment[$0] != nil }) || CommandLine.arguments.contains { argument in
             argument.contains("xctest") || argument.contains("swift-testing")
         }
     }
@@ -346,9 +338,7 @@ final class UsageStore {
     @ObservationIgnored var lastPermissionPromptNotificationAt: [UsageProvider: Date] = [:]
     @ObservationIgnored var lastTokenFetchAt: [UsageProvider: Date] = [:]
     @ObservationIgnored var lastTokenFetchScope: [UsageProvider: String] = [:]
-    @ObservationIgnored var planUtilizationHistory: [UsageProvider: PlanUtilizationHistoryBuckets] = [:] {
-        didSet { if !self.planUtilizationHistoryLoaded { self.planUtilizationHistoryLoaded = true } }
-    }
+    @ObservationIgnored var planUtilizationHistory: [UsageProvider: PlanUtilizationHistoryBuckets] = [:]
 
     /// Background load task; cleared on deinit and on the cancel test seam.
     @ObservationIgnored var planUtilizationHistoryLoadTask: Task<Void, Never>?
@@ -413,21 +403,7 @@ final class UsageStore {
         self.providerRuntimes = Dictionary(uniqueKeysWithValues: ProviderCatalog.all.compactMap { implementation in
             implementation.makeRuntime().map { (implementation.id, $0) }
         })
-        self.planUtilizationHistory = [:]
-        self.planUtilizationHistoryLoadTask = Task { @MainActor [weak self] in
-            // Move persisted plan-utilization decode off the startup main thread.
-            // In-memory starts empty; mutation paths and sync menu accessors gate on
-            // `planUtilizationHistoryLoaded` until the load task publishes once.
-            let loaded = await withTaskCancellationHandler {
-                await Task.detached(priority: .utility) {
-                    await planUtilizationHistoryLoadGateForTesting?.wait()
-                    return planUtilizationHistoryStore.load()
-                }.value
-            } onCancel: { planUtilizationHistoryLoadGateForTesting?.cancelAll() }
-            guard let self, !self.planUtilizationHistoryLoaded else { return }
-            self.planUtilizationHistory = loaded
-            self.planUtilizationHistoryRevision &+= 1
-        }
+        self.startPlanUtilizationHistoryLoad(gate: planUtilizationHistoryLoadGateForTesting)
         self.sessionLimitResetDetectorStates = Self.loadLimitResetDetectorStates(
             from: settings.userDefaults,
             defaultsKey: Self.sessionLimitResetDetectorDefaultsKey,

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -363,7 +363,7 @@ final class UsageStore {
         settings: SettingsStore,
         registry: ProviderRegistry = .shared,
         historicalUsageHistoryStore: HistoricalUsageHistoryStore = HistoricalUsageHistoryStore(),
-        planUtilizationHistoryStore: PlanUtilizationHistoryStore = .defaultAppSupport(),
+        planUtilizationHistoryStore: PlanUtilizationHistoryStore? = nil,
         codexAccountUsageSnapshotStore: (any CodexAccountUsageSnapshotStoring)? = nil,
         sessionQuotaNotifier: any SessionQuotaNotifying = SessionQuotaNotifier(),
         startupBehavior: StartupBehavior = .automatic,
@@ -378,13 +378,14 @@ final class UsageStore {
         self.registry = registry
         self.environmentBase = environmentBase
         self.historicalUsageHistoryStore = historicalUsageHistoryStore
-        self.planUtilizationHistoryStore = planUtilizationHistoryStore
-        self.sessionQuotaNotifier = sessionQuotaNotifier
         self.startupBehavior = startupBehavior.resolved(isRunningTests: Self.isRunningTestsProcess())
+        let planHistoryStore = Self.resolvedPlanHistoryStore(planUtilizationHistoryStore, startup: self.startupBehavior)
+        self.planUtilizationHistoryStore = planHistoryStore
+        self.sessionQuotaNotifier = sessionQuotaNotifier
         self.codexAccountUsageSnapshotStore = codexAccountUsageSnapshotStore ??
             (self.startupBehavior.automaticallyStartsBackgroundWork ? FileCodexAccountUsageSnapshotStore() : nil)
         self.planUtilizationPersistenceCoordinator = PlanUtilizationHistoryPersistenceCoordinator(
-            store: planUtilizationHistoryStore)
+            store: planHistoryStore)
         self.providerMetadata = registry.metadata
         self
             .failureGates = Dictionary(
@@ -403,7 +404,10 @@ final class UsageStore {
         self.providerRuntimes = Dictionary(uniqueKeysWithValues: ProviderCatalog.all.compactMap { implementation in
             implementation.makeRuntime().map { (implementation.id, $0) }
         })
-        self.startPlanUtilizationHistoryLoad(gate: planUtilizationHistoryLoadGateForTesting)
+        self.startPlanUtilizationHistoryLoad(
+            gate: planUtilizationHistoryLoadGateForTesting,
+            enabled: self.startupBehavior.automaticallyStartsBackgroundWork ||
+                planUtilizationHistoryStore != nil)
         self.sessionLimitResetDetectorStates = Self.loadLimitResetDetectorStates(
             from: settings.userDefaults,
             defaultsKey: Self.sessionLimitResetDetectorDefaultsKey,

--- a/Sources/CodexBar/UsageStoreSupport.swift
+++ b/Sources/CodexBar/UsageStoreSupport.swift
@@ -129,5 +129,23 @@ extension UsageStore {
         self.codexHistoricalDatasetAccountKey = accountKey
         self.historicalPaceRevision += 1
     }
+
+    /// Cancels the one-shot persisted plan-utilization load and treats the
+    /// in-memory dictionary as "loaded" so callers can assign state directly
+    /// without racing the background decode. Used by test helpers that
+    /// intentionally seed history from scratch.
+    func _cancelPlanUtilizationHistoryLoadForTesting() {
+        self.planUtilizationHistoryLoadTask?.cancel()
+        self.planUtilizationHistoryLoadTask = nil
+        self.planUtilizationHistoryLoaded = true
+    }
+
+    /// Awaits the background plan-utilization load task to completion. Used
+    /// by tests that write history files to disk before constructing
+    /// `UsageStore` and then expect the dictionary to be populated by the
+    /// time assertions run.
+    func _waitForPlanUtilizationHistoryLoadForTesting() async {
+        await self.planUtilizationHistoryLoadTask?.value
+    }
 }
 #endif

--- a/Tests/CodexBarTests/CodexAccountMenuDisplaySnapshotTests.swift
+++ b/Tests/CodexBarTests/CodexAccountMenuDisplaySnapshotTests.swift
@@ -285,6 +285,7 @@ struct CodexAccountMenuDisplaySnapshotTests {
             fetcher: UsageFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         let controller = StatusItemController(
             store: store,
             settings: settings,

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
@@ -559,6 +559,7 @@ extension CodexAccountScopedRefreshTests {
             codexAccountUsageSnapshotStore: snapshotStore,
             startupBehavior: .testing,
             environmentBase: environment)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         store._test_codexResetCreditsFetcherOverride = { _ in nil }
         return store
     }

--- a/Tests/CodexBarTests/CodexDashboardWorkedExampleParityTests.swift
+++ b/Tests/CodexBarTests/CodexDashboardWorkedExampleParityTests.swift
@@ -424,12 +424,14 @@ struct CodexDashboardWorkedExampleParityTests {
             .appendingPathComponent("usage-history.jsonl")
         let planStore = testPlanUtilizationHistoryStore(
             suiteName: "CodexDashboardWorkedExampleParityTests-\(UUID().uuidString)")
-        return UsageStore(
+        let store = UsageStore(
             fetcher: UsageFetcher(environment: [:]),
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings,
             historicalUsageHistoryStore: HistoricalUsageHistoryStore(fileURL: historyURL),
             planUtilizationHistoryStore: planStore)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
+        return store
     }
 
     private func makeCLIContext(

--- a/Tests/CodexBarTests/HistoricalUsagePaceBackfillAuthorityTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceBackfillAuthorityTests.swift
@@ -319,6 +319,7 @@ extension HistoricalUsagePaceTests {
             settings: settings,
             historicalUsageHistoryStore: HistoricalUsageHistoryStore(fileURL: Self.makeTempURL()),
             planUtilizationHistoryStore: planHistoryStore)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
 
         let now = Date(timeIntervalSince1970: 0)
         let window = RateWindow(

--- a/Tests/CodexBarTests/HistoricalUsagePaceTestSupport.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceTestSupport.swift
@@ -299,12 +299,14 @@ extension HistoricalUsagePaceTests {
         settings.historicalTrackingEnabled = true
         let planHistoryStore = testPlanUtilizationHistoryStore(
             suiteName: "HistoricalUsagePaceTests-\(UUID().uuidString)")
-        return UsageStore(
+        let store = UsageStore(
             fetcher: UsageFetcher(environment: [:]),
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings,
             historicalUsageHistoryStore: historicalUsageHistoryStore,
             planUtilizationHistoryStore: planHistoryStore)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
+        return store
     }
 
     @MainActor

--- a/Tests/CodexBarTests/StatusMenuHighlightTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHighlightTests.swift
@@ -18,6 +18,7 @@ extension StatusMenuTests {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -61,6 +62,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -133,6 +135,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -185,6 +188,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -256,6 +260,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -324,6 +329,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -389,6 +395,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -442,6 +449,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -511,6 +519,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         let controller = StatusItemController(
             store: store,
             settings: settings,

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationAsyncLoadTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationAsyncLoadTests.swift
@@ -242,53 +242,10 @@ struct UsageStorePlanUtilizationAsyncLoadTests {
 
     @MainActor
     @Test
-    func `init returns within a startup budget even with a multi-megabyte fixture`() throws {
-        // Belt-and-suspenders timing proof for the audit's "Release benchmark"
-        // claim: the audit measured ~150 ms of main-thread decode before this
-        // PR. With the load moved off the main thread, init must not spend
-        // that time even when the persisted fixture is multi-megabyte.
-        let suiteName = "UsageStorePlanUtilizationAsyncLoad-budget-\(UUID().uuidString)"
-        let gate = PlanUtilizationHistoryLoadGate()
-        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: true)
-        let directoryURL = try #require(historyStore.directoryURL)
-        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-        // ~6 MB of synthetic payload — comparable to the audit's mature fixture.
-        let bigURL = directoryURL.appendingPathComponent("codex.json")
-        try Data(repeating: 0x20, count: 6 * 1024 * 1024).write(to: bigURL)
-        let settings = Self.makeSettings(suiteName: suiteName)
-        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
-        _ = settings
-
-        // Warm up Task scheduling so the first call does not pay for cold-start.
-        _ = Task<Void, Never> {}
-
-        let start = DispatchTime.now()
-        let store = UsageStore(
-            fetcher: UsageFetcher(),
-            browserDetection: BrowserDetection(cacheTTL: 0),
-            settings: settings,
-            planUtilizationHistoryStore: historyStore,
-            startupBehavior: .testing,
-            planUtilizationHistoryLoadGateForTesting: gate)
-        let initNanos = DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds
-        defer { store._cancelPlanUtilizationHistoryLoadForTesting() }
-
-        // Init must return long before the audit's measured ~150 ms baseline.
-        // Allow 50 ms as a generous wall-clock budget that absorbs CI noise
-        // without giving back the synchronous main-thread decode.
-        #expect(initNanos < 50_000_000)
-        #expect(store.planUtilizationHistoryLoaded == false)
-        #expect(gate.isOpen == false)
-    }
-
-    @MainActor
-    @Test
-    func `cancel during load releases the gate and drains the continuation`() async throws {
-        // The bot flagged that cancelling the load task without draining the
-        // gate would leak the suspended continuation, captured store, and
-        // the gate itself across test runs. This test cancels a still-gated
-        // load and asserts the gate's pending waiter count goes to zero so
-        // the continuation cannot outlive the load task.
+    func `cancel before load wait is registered still drains the task`() async throws {
+        // Cancel immediately after init, intentionally without yielding. The
+        // cancellation state must remain visible when the load task later
+        // reaches `wait()`; otherwise the wakeup can be lost and the task leaks.
         let suiteName = "UsageStorePlanUtilizationAsyncLoad-cancel-\(UUID().uuidString)"
         let gate = PlanUtilizationHistoryLoadGate()
         let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: true)
@@ -303,18 +260,15 @@ struct UsageStorePlanUtilizationAsyncLoadTests {
             startupBehavior: .testing,
             planUtilizationHistoryLoadGateForTesting: gate)
 
-        // Spin briefly so the detached task reaches `gate.wait()` and the
-        // continuation is registered before we cancel.
-        for _ in 0..<50 where store.planUtilizationHistoryLoadTask == nil {
-            await Task.yield()
-        }
-        try await Task.sleep(nanoseconds: 20_000_000)
-
+        let loadTask = try #require(store.planUtilizationHistoryLoadTask)
         store._cancelPlanUtilizationHistoryLoadForTesting()
-        // After cancel, the gate must be drained. Re-opening should not leak
-        // an extra waiter (no panic, no second resume).
+        await loadTask.value
+
+        #expect(gate.isCancelled == true)
+        #expect(store.planUtilizationHistoryLoaded == true)
+        #expect(store.planUtilizationHistory.isEmpty)
         gate.open()
-        #expect(gate.isOpen == true)
+        #expect(gate.isOpen == false)
     }
 
     // MARK: - Helpers

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationAsyncLoadTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationAsyncLoadTests.swift
@@ -1,0 +1,344 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+/// Tests for the startup async plan-utilization history load.
+///
+/// The decode of the persisted `PlanUtilizationHistoryStore` is moved off the
+/// startup main thread because a mature two-year history can take ~150 ms to
+/// parse. These tests pin the contract:
+///   - `UsageStore.init` returns before disk I/O completes
+///   - the load publishes exactly once after the gate releases
+///   - sync menu accessors return the empty stub (no migration, no persistence
+///     enqueue) while the load is in flight
+///   - mutation paths wait for the load before touching the dictionary so a
+///     startup refresh cannot overwrite real disk history with empty stubs
+struct UsageStorePlanUtilizationAsyncLoadTests {
+    @MainActor
+    @Test
+    func `init returns before disk load completes`() {
+        let suiteName = "UsageStorePlanUtilizationAsyncLoad-init-\(UUID().uuidString)"
+        let gate = PlanUtilizationHistoryLoadGate()
+        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: false)
+        let settings = Self.makeSettings(suiteName: suiteName)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        _ = settings // silence unused
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: historyStore,
+            startupBehavior: .testing,
+            planUtilizationHistoryLoadGateForTesting: gate)
+        defer { store._cancelPlanUtilizationHistoryLoadForTesting() }
+
+        // The gate is still closed, so the background load has not run.
+        #expect(store.planUtilizationHistory.isEmpty)
+        #expect(store.planUtilizationHistoryLoaded == false)
+        #expect(gate.isOpen == false)
+    }
+
+    @MainActor
+    @Test
+    func `gate release publishes loaded history and bumps revision once`() async {
+        let suiteName = "UsageStorePlanUtilizationAsyncLoad-release-\(UUID().uuidString)"
+        let gate = PlanUtilizationHistoryLoadGate()
+        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: true)
+        let codexSeries = planSeries(
+            name: .session,
+            windowMinutes: 300,
+            entries: [planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 42)])
+        let buckets = PlanUtilizationHistoryBuckets(
+            preferredAccountKey: nil,
+            unscoped: [codexSeries],
+            accounts: [:])
+        historyStore.save([.codex: buckets])
+        let settings = Self.makeSettings(suiteName: suiteName)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        _ = settings
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: historyStore,
+            startupBehavior: .testing,
+            planUtilizationHistoryLoadGateForTesting: gate)
+        defer { store._cancelPlanUtilizationHistoryLoadForTesting() }
+
+        let revisionBeforeOpen = store.planUtilizationHistoryRevision
+        gate.open()
+        await store._waitForPlanUtilizationHistoryLoadForTesting()
+
+        #expect(store.planUtilizationHistoryLoaded == true)
+        #expect(store.planUtilizationHistory[.codex]?.unscoped.first?.name == .session)
+        // Revision must increment by exactly one when the load completes.
+        #expect(store.planUtilizationHistoryRevision == revisionBeforeOpen + 1)
+    }
+
+    @MainActor
+    @Test
+    func `sync menu accessor returns empty stub while loading`() {
+        let suiteName = "UsageStorePlanUtilizationAsyncLoad-menuGate-\(UUID().uuidString)"
+        let gate = PlanUtilizationHistoryLoadGate()
+        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: true)
+        // Pre-populate disk so a loaded store would return real history.
+        let series = planSeries(
+            name: .weekly,
+            windowMinutes: 10080,
+            entries: [planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 88)])
+        historyStore.save([.claude: PlanUtilizationHistoryBuckets(
+            preferredAccountKey: nil,
+            unscoped: [series],
+            accounts: [:])])
+        let settings = Self.makeSettings(suiteName: suiteName)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        _ = settings
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: historyStore,
+            startupBehavior: .testing,
+            planUtilizationHistoryLoadGateForTesting: gate)
+        defer { store._cancelPlanUtilizationHistoryLoadForTesting() }
+
+        let selection = store.planUtilizationHistorySelection(for: .claude)
+        #expect(selection.accountKey == nil)
+        #expect(selection.histories.isEmpty)
+        #expect(store.planUtilizationHistory[.claude]?.preferredAccountKey == nil)
+    }
+
+    @MainActor
+    @Test
+    func `empty directory loads to empty dictionary without error`() async {
+        let suiteName = "UsageStorePlanUtilizationAsyncLoad-empty-\(UUID().uuidString)"
+        let gate = PlanUtilizationHistoryLoadGate()
+        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: true)
+        let settings = Self.makeSettings(suiteName: suiteName)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        _ = settings
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: historyStore,
+            startupBehavior: .testing,
+            planUtilizationHistoryLoadGateForTesting: gate)
+        defer { store._cancelPlanUtilizationHistoryLoadForTesting() }
+
+        gate.open()
+        await store._waitForPlanUtilizationHistoryLoadForTesting()
+
+        #expect(store.planUtilizationHistory.isEmpty)
+        #expect(store.planUtilizationHistoryLoaded == true)
+    }
+
+    @MainActor
+    @Test
+    func `corrupt file loads best-effort empty`() async throws {
+        let suiteName = "UsageStorePlanUtilizationAsyncLoad-corrupt-\(UUID().uuidString)"
+        let gate = PlanUtilizationHistoryLoadGate()
+        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: true)
+        // Write a file that does not parse as the expected schema.
+        let directoryURL = try #require(historyStore.directoryURL)
+        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let badURL = directoryURL.appendingPathComponent("codex.json")
+        try? Data("{not valid json".utf8).write(to: badURL)
+        let settings = Self.makeSettings(suiteName: suiteName)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        _ = settings
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: historyStore,
+            startupBehavior: .testing,
+            planUtilizationHistoryLoadGateForTesting: gate)
+        defer { store._cancelPlanUtilizationHistoryLoadForTesting() }
+
+        gate.open()
+        await store._waitForPlanUtilizationHistoryLoadForTesting()
+
+        // Best-effort empty: no panic, no providers populated, loaded flag set.
+        #expect(store.planUtilizationHistory.isEmpty)
+        #expect(store.planUtilizationHistoryLoaded == true)
+    }
+
+    @MainActor
+    @Test
+    func `multi-provider multi-account ownership preserved after load`() async {
+        let suiteName = "UsageStorePlanUtilizationAsyncLoad-multi-\(UUID().uuidString)"
+        let gate = PlanUtilizationHistoryLoadGate()
+        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: true)
+        let codexSession = planSeries(
+            name: .session,
+            windowMinutes: 300,
+            entries: [planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 31)])
+        let claudeWeekly = planSeries(
+            name: .weekly,
+            windowMinutes: 10080,
+            entries: [planEntry(at: Date(timeIntervalSince1970: 1_700_000_001), usedPercent: 65)])
+        let accountKey = "hashed-account-key"
+        let buckets = PlanUtilizationHistoryBuckets(
+            preferredAccountKey: accountKey,
+            unscoped: [],
+            accounts: [accountKey: [codexSession, claudeWeekly]])
+        historyStore.save([.codex: buckets, .claude: buckets])
+        let settings = Self.makeSettings(suiteName: suiteName)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        _ = settings
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: historyStore,
+            startupBehavior: .testing,
+            planUtilizationHistoryLoadGateForTesting: gate)
+        defer { store._cancelPlanUtilizationHistoryLoadForTesting() }
+
+        gate.open()
+        await store._waitForPlanUtilizationHistoryLoadForTesting()
+
+        #expect(store.planUtilizationHistory[.codex]?.accounts[accountKey]?.count == 2)
+        #expect(store.planUtilizationHistory[.claude]?.accounts[accountKey]?.count == 2)
+        #expect(store.planUtilizationHistory[.codex]?.preferredAccountKey == accountKey)
+    }
+
+    @MainActor
+    @Test
+    func `init work is independent of history size`() throws {
+        // With a closed load gate, UsageStore.init must return even when the
+        // persisted history would dominate startup time at production scale.
+        // The closed gate decouples the assertion from wall-clock variance;
+        // we verify the init returned before the load completed, not the
+        // decode duration itself.
+        let suiteName = "UsageStorePlanUtilizationAsyncLoad-perf-\(UUID().uuidString)"
+        let gate = PlanUtilizationHistoryLoadGate()
+        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: true)
+        // Write a multi-megabyte synthetic payload so a real load would block.
+        let directoryURL = try #require(historyStore.directoryURL)
+        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let bigURL = directoryURL.appendingPathComponent("codex.json")
+        let payload = Self.makeSyntheticHistoryPayload(entriesPerProvider: 50000)
+        try? payload.write(to: bigURL)
+        let settings = Self.makeSettings(suiteName: suiteName)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        _ = settings
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: historyStore,
+            startupBehavior: .testing,
+            planUtilizationHistoryLoadGateForTesting: gate)
+        defer { store._cancelPlanUtilizationHistoryLoadForTesting() }
+
+        // Init returned without waiting on the disk load.
+        #expect(store.planUtilizationHistoryLoaded == false)
+        #expect(gate.isOpen == false)
+    }
+
+    @MainActor
+    @Test
+    func `init returns within a startup budget even with a multi-megabyte fixture`() throws {
+        // Belt-and-suspenders timing proof for the audit's "Release benchmark"
+        // claim: the audit measured ~150 ms of main-thread decode before this
+        // PR. With the load moved off the main thread, init must not spend
+        // that time even when the persisted fixture is multi-megabyte.
+        let suiteName = "UsageStorePlanUtilizationAsyncLoad-budget-\(UUID().uuidString)"
+        let gate = PlanUtilizationHistoryLoadGate()
+        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: true)
+        let directoryURL = try #require(historyStore.directoryURL)
+        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        // ~6 MB of synthetic payload — comparable to the audit's mature fixture.
+        let bigURL = directoryURL.appendingPathComponent("codex.json")
+        try Data(repeating: 0x20, count: 6 * 1024 * 1024).write(to: bigURL)
+        let settings = Self.makeSettings(suiteName: suiteName)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        _ = settings
+
+        // Warm up Task scheduling so the first call does not pay for cold-start.
+        _ = Task<Void, Never> {}
+
+        let start = DispatchTime.now()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: historyStore,
+            startupBehavior: .testing,
+            planUtilizationHistoryLoadGateForTesting: gate)
+        let initNanos = DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds
+        defer { store._cancelPlanUtilizationHistoryLoadForTesting() }
+
+        // Init must return long before the audit's measured ~150 ms baseline.
+        // Allow 50 ms as a generous wall-clock budget that absorbs CI noise
+        // without giving back the synchronous main-thread decode.
+        #expect(initNanos < 50_000_000)
+        #expect(store.planUtilizationHistoryLoaded == false)
+        #expect(gate.isOpen == false)
+    }
+
+    @MainActor
+    @Test
+    func `cancel during load releases the gate and drains the continuation`() async throws {
+        // The bot flagged that cancelling the load task without draining the
+        // gate would leak the suspended continuation, captured store, and
+        // the gate itself across test runs. This test cancels a still-gated
+        // load and asserts the gate's pending waiter count goes to zero so
+        // the continuation cannot outlive the load task.
+        let suiteName = "UsageStorePlanUtilizationAsyncLoad-cancel-\(UUID().uuidString)"
+        let gate = PlanUtilizationHistoryLoadGate()
+        let historyStore = testPlanUtilizationHistoryStore(suiteName: suiteName, reset: true)
+        let settings = Self.makeSettings(suiteName: suiteName)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        _ = settings
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            planUtilizationHistoryStore: historyStore,
+            startupBehavior: .testing,
+            planUtilizationHistoryLoadGateForTesting: gate)
+
+        // Spin briefly so the detached task reaches `gate.wait()` and the
+        // continuation is registered before we cancel.
+        for _ in 0..<50 where store.planUtilizationHistoryLoadTask == nil {
+            await Task.yield()
+        }
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        store._cancelPlanUtilizationHistoryLoadForTesting()
+        // After cancel, the gate must be drained. Re-opening should not leak
+        // an extra waiter (no panic, no second resume).
+        gate.open()
+        #expect(gate.isOpen == true)
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private static func makeSettings(suiteName: String) -> SettingsStore {
+        let defaults = UserDefaults(suiteName: suiteName) ?? UserDefaults.standard
+        defaults.removePersistentDomain(forName: suiteName)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suiteName),
+            tokenAccountStore: InMemoryTokenAccountStore())
+    }
+
+    private static func makeSyntheticHistoryPayload(entriesPerProvider: Int) -> Data {
+        // A non-decodable but valid JSON shape keeps the test independent of
+        // the schema version while still forcing the JSON decoder to do real
+        // work when the load runs.
+        var entries: [String] = []
+        entries.reserveCapacity(entriesPerProvider)
+        for index in 0..<entriesPerProvider {
+            entries.append("{\"i\":\(index),\"p\":0.5,\"r\":\"2026-01-01T00:00:00Z\"}")
+        }
+        let body = "{\"v\":1,\"u\":[\(entries.joined(separator: ","))],\"a\":{}}"
+        return Data(body.utf8)
+    }
+}

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationAsyncLoadTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationAsyncLoadTests.swift
@@ -17,6 +17,25 @@ import Testing
 struct UsageStorePlanUtilizationAsyncLoadTests {
     @MainActor
     @Test
+    func `testing startup without an injected history store skips disk loading`() {
+        let suiteName = "UsageStorePlanUtilizationAsyncLoad-default-test-\(UUID().uuidString)"
+        let settings = Self.makeSettings(suiteName: suiteName)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+
+        #expect(store.planUtilizationHistoryLoadTask == nil)
+        #expect(store.planUtilizationHistoryLoaded == true)
+        #expect(store.planUtilizationHistory.isEmpty)
+        #expect(store.planUtilizationHistoryStore.directoryURL == nil)
+    }
+
+    @MainActor
+    @Test
     func `init returns before disk load completes`() {
         let suiteName = "UsageStorePlanUtilizationAsyncLoad-init-\(UUID().uuidString)"
         let gate = PlanUtilizationHistoryLoadGate()

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeIdentityTests.swift
@@ -889,11 +889,17 @@ struct UsageStorePlanUtilizationClaudeIdentityTests {
             tokenAccountStore: InMemoryTokenAccountStore())
         settings.addTokenAccount(provider: .claude, label: "Unrelated", token: "unrelated-token")
         settings.setActiveTokenAccountIndex(0, for: .claude)
-        return UsageStore(
+        let store = UsageStore(
             fetcher: UsageFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings,
             planUtilizationHistoryStore: historyStore,
             startupBehavior: .testing)
+        // Cancel the background decode and apply the disk-loaded buckets
+        // synchronously so callers can immediately query without racing the
+        // utility-priority load task.
+        store._cancelPlanUtilizationHistoryLoadForTesting()
+        store.planUtilizationHistory = store.planUtilizationHistoryStore.load()
+        return store
     }
 }

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -1115,6 +1115,10 @@ extension UsageStorePlanUtilizationTests {
             startupBehavior: .testing)
         isolatedSettings._test_managedCodexAccountStoreURL = managedStoreURL
         isolatedSettings.codexActiveSource = .liveSystem
+        // Cancel the background plan-utilization decode so it cannot race the
+        // explicit empty assignment below. Production paths still load on the
+        // utility queue; this only short-circuits the test setup.
+        store._cancelPlanUtilizationHistoryLoadForTesting()
         store.planUtilizationHistory = [:]
         return store
     }


### PR DESCRIPTION
## Problem

`UsageStore.init` synchronously decoded persisted plan-utilization history on the main actor. A mature two-provider history can therefore block startup for roughly 150 ms.

This maintainer-owned continuation of #2083 preserves @Yuxin-Qiao's authored commit and credit while keeping the reviewed fixup stack stable for CI.

## Fix

- Load and decode history on a detached utility-priority task, then publish it on the main actor through the existing revision path.
- Gate synchronous readers and mutation paths until loading finishes so an early refresh cannot replace persisted history with an empty startup snapshot.
- Make the test load gate cancellation-aware and sticky, including cancellation before the waiter registers.
- Keep test startup deterministic: stores without an explicitly injected history location use non-persistent storage and skip the production disk load.
- Cancel intentionally unused loads in shared fixture builders so asynchronous revisions cannot race seeded test state.

Persistence schema, retention, account ownership, sampling, and chart behavior remain unchanged.

## Startup benchmark

Release-style benchmark using encoded Codex and Claude histories totaling 4,392,184 bytes, five samples:

- Synchronous history load median: 147.160 ms
- New `UsageStore` initialization median: 1.480 ms
- Startup blocking reduction: approximately 99%

## Verification

- `make test`: all 53/53 shards passed on the first attempt; zero retries and zero timed-out groups
- `make check`: SwiftFormat clean; SwiftLint 0 violations across 1,420 files
- `swift test --filter UsageStorePlanUtilizationAsyncLoadTests`: 9/9 passed
- `swift test --filter PlanUtilization`: 146/146 passed
- Autoreview: clean, no accepted or actionable findings

The previously reported Linux `PlatformGatingTests` failure does not reproduce locally in the full suite. Exact-head macOS and Linux CI remain the merge gate.
