### PR TITLE
Add codexbar-plasmoid (KDE Plasma 6 widget) to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ CLI install:
 - [codexbar-cinnamon-applet](https://github.com/jacobcalvert/codexbar-cinnamon-applet) — Linux Mint Cinnamon panel applet powered by CodexBar's JSON output.
 - [noctalia-codex-usage](https://github.com/rayoplateado/noctalia-codex-usage) — Noctalia/Quickshell plugin that shows Codex 5-hour and weekly usage limits, built on top of the bundled Linux CLI.
 - [KodexBar](https://github.com/tylxr59/KodexBar) — KDE Plasma widget that shows CodexBar usage in the Plasma panel, built on top of the bundled Linux CLI.
-- [codexbar-plasmoid](https://github.com/psimaker/codexbar-plasmoid) — KDE Plasma 6 widget that re-creates the CodexBar menu bar experience (meter icon, provider switcher, rate windows, pace, credits, cost and status), built on top of the bundled Linux CLI.
+- [codexbar-plasmoid](https://github.com/psimaker/codexbar-plasmoid) — KDE Plasma 6 widget for CodexBar's meter icon, provider switcher, quota windows, pace, credits, local cost, and status, powered by the bundled Linux CLI.
 
 ## Status bar & terminal integration
 - [showy-quota](https://github.com/enieuwy/showy-quota) — always-on AI plan quota strips for SketchyBar, tmux, and Zellij (standalone WASM plugin), built on `codexbar serve` / the bundled CLI.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ CLI install:
 - [codexbar-cinnamon-applet](https://github.com/jacobcalvert/codexbar-cinnamon-applet) — Linux Mint Cinnamon panel applet powered by CodexBar's JSON output.
 - [noctalia-codex-usage](https://github.com/rayoplateado/noctalia-codex-usage) — Noctalia/Quickshell plugin that shows Codex 5-hour and weekly usage limits, built on top of the bundled Linux CLI.
 - [KodexBar](https://github.com/tylxr59/KodexBar) — KDE Plasma widget that shows CodexBar usage in the Plasma panel, built on top of the bundled Linux CLI.
+- [codexbar-plasmoid](https://github.com/psimaker/codexbar-plasmoid) — KDE Plasma 6 widget that re-creates the CodexBar menu bar experience (meter icon, provider switcher, rate windows, pace, credits, cost and status), built on top of the bundled Linux CLI.
 
 ## Status bar & terminal integration
 - [showy-quota](https://github.com/enieuwy/showy-quota) — always-on AI plan quota strips for SketchyBar, tmux, and Zellij (standalone WASM plugin), built on `codexbar serve` / the bundled CLI.


### PR DESCRIPTION
Adds [codexbar-plasmoid](https://github.com/psimaker/codexbar-plasmoid) to the community integrations list — a KDE Plasma 6 panel widget that re-creates the CodexBar menu bar experience on Linux, driven by the bundled CLI (`codexbar usage --json --status` and `codexbar cost --json`).

It follows the original design closely: the two-capsule meter icon in the panel (merged or one per provider, including the Codex/Claude critters), a provider switcher popup with brand-colored quota bars, session/weekly/extra rate windows with reset countdowns and pace lines, Codex reset credits, local cost (today / last 30 days), provider status, and settings for all 58 CLI providers.

Screenshot in the repo README. Thanks for CodexBar and for shipping the Linux CLI — it made this port straightforward.