### PR TITLE
fix(menu): route overview menu card clicks through parent view to prevent dropped dispatch (fixes #2090)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Linux CLI: prevent usage rendering from crashing in Foundation bundle discovery when formatting rate windows. Thanks @thanthi-del!
+- Menus: keep overview provider-row clicks reliable during live menu rebuilds without stealing nested Copy or plan actions. Thanks @Yuxin-Qiao!
 - Startup: load persisted plan-utilization history away from the main thread so mature histories no longer delay app launch. Thanks @Yuxin-Qiao!
 - Provider cleanup: prevent in-flight usage, status, token-cost, and cached-hydration work from republishing stale state after a provider is disabled, unavailable, or re-enabled. Thanks @Yuxin-Qiao!
 - Agent Sessions: coalesce overlapping unchanged remote refresh requests so menu opens do not repeat Tailscale discovery and SSH passes. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/MenuCardGPUSelectionView.swift
+++ b/Sources/CodexBar/MenuCardGPUSelectionView.swift
@@ -24,6 +24,7 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
     private var tintFilter: CIFilter?
     private var isRowHighlighted = false
     private var onClick: (() -> Void)?
+    private var isPressed = false
 
     private(set) var allowsMenuHighlight: Bool
 
@@ -62,9 +63,6 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
         self.refreshTintFilter()
         self.setupSelectionView()
         self.setupHosting()
-        if onClick != nil {
-            self.installClickRecognizer()
-        }
     }
 
     @available(*, unavailable)
@@ -100,6 +98,53 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
         }
         onClick()
         return true
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let descendant = super.hitTest(point)
+        if let descendant {
+            var current: NSView? = descendant
+            while let view = current, view !== self {
+                if view is NSButton || view is NSControl {
+                    return descendant
+                }
+                current = view.superview
+            }
+            if descendant !== self, self.onClick != nil {
+                return self
+            }
+        }
+        return descendant
+    }
+
+    private func locationInView(for event: NSEvent) -> NSPoint {
+        guard self.window != nil else {
+            return event.locationInWindow
+        }
+        return self.convert(event.locationInWindow, from: nil)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard event.type == .leftMouseDown, self.onClick != nil else {
+            super.mouseDown(with: event)
+            return
+        }
+        let localPoint = self.locationInView(for: event)
+        if self.bounds.contains(localPoint) {
+            self.isPressed = true
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard event.type == .leftMouseUp, self.onClick != nil else {
+            super.mouseUp(with: event)
+            return
+        }
+        defer { self.isPressed = false }
+        let localPoint = self.locationInView(for: event)
+        if self.isPressed, self.bounds.contains(localPoint) {
+            self.onClick?()
+        }
     }
 
     override func layout() {
@@ -172,17 +217,6 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
         self.addSubview(self.hosting)
     }
 
-    private func installClickRecognizer() {
-        let recognizer = NSClickGestureRecognizer(target: self, action: #selector(self.handlePrimaryClick(_:)))
-        recognizer.buttonMask = 0x1
-        self.addGestureRecognizer(recognizer)
-    }
-
-    @objc private func handlePrimaryClick(_ recognizer: NSClickGestureRecognizer) {
-        guard recognizer.state == .ended else { return }
-        self.onClick?()
-    }
-
     /// Maps every pixel's RGB to the system selected-menu-item text color while preserving alpha,
     /// reproducing the appearance the SwiftUI rows already adopt when highlighted. The bias is read
     /// from `NSColor.selectedMenuItemTextColor` rather than hard-coded to white so graphite/
@@ -211,3 +245,39 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
         return filter
     }
 }
+
+#if DEBUG
+extension GPUSelectionHostingView {
+    func _test_simulateRuntimeClick() -> Bool {
+        guard self.onClick != nil else { return false }
+
+        let centerLocal = NSPoint(x: self.bounds.midX, y: self.bounds.midY)
+
+        let eventDown = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: centerLocal,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1.0)!
+        self.mouseDown(with: eventDown)
+
+        let eventUp = NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: centerLocal,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 2,
+            clickCount: 1,
+            pressure: 0.0)!
+        self.mouseUp(with: eventUp)
+
+        return true
+    }
+}
+#endif

--- a/Sources/CodexBar/MenuCardGPUSelectionView.swift
+++ b/Sources/CodexBar/MenuCardGPUSelectionView.swift
@@ -24,6 +24,8 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
     private var tintFilter: CIFilter?
     private var isRowHighlighted = false
     private var onClick: (() -> Void)?
+    private let containsInteractiveControls: Bool
+    private let interactiveRegionStore: MenuCardInteractiveRegionStore?
     private var isPressed = false
 
     private(set) var allowsMenuHighlight: Bool
@@ -52,10 +54,14 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
     init(
         rootView: MenuCardSectionContainerView<Content>,
         allowsMenuHighlight: Bool,
+        containsInteractiveControls: Bool = false,
+        interactiveRegionStore: MenuCardInteractiveRegionStore? = nil,
         onClick: (() -> Void)?)
     {
         self.hosting = NSHostingView(rootView: rootView)
         self.allowsMenuHighlight = allowsMenuHighlight
+        self.containsInteractiveControls = containsInteractiveControls
+        self.interactiveRegionStore = interactiveRegionStore
         self.onClick = onClick
         self.tintFilter = nil
         super.init(frame: .zero)
@@ -110,11 +116,23 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
                 }
                 current = view.superview
             }
+            if self.hitsHostedInteractiveControl(at: point) {
+                return descendant
+            }
             if descendant !== self, self.onClick != nil {
                 return self
             }
         }
         return descendant
+    }
+
+    private func hitsHostedInteractiveControl(at point: NSPoint) -> Bool {
+        guard self.containsInteractiveControls else { return false }
+        let hostedPoint = self.hosting.convert(point, from: self)
+        return self.interactiveRegionStore?.contains(
+            hostedPoint,
+            hostingBounds: self.hosting.bounds,
+            fittedSize: self.hosting.fittingSize) == true
     }
 
     private func locationInView(for event: NSEvent) -> NSPoint {
@@ -248,6 +266,10 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
 
 #if DEBUG
 extension GPUSelectionHostingView {
+    func _test_hitsHostedInteractiveControl(at point: NSPoint) -> Bool {
+        self.hitsHostedInteractiveControl(at: point)
+    }
+
     func _test_simulateRuntimeClick() -> Bool {
         guard self.onClick != nil else { return false }
 

--- a/Sources/CodexBar/MenuCardGPUSelectionView.swift
+++ b/Sources/CodexBar/MenuCardGPUSelectionView.swift
@@ -147,10 +147,7 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
             super.mouseDown(with: event)
             return
         }
-        let localPoint = self.locationInView(for: event)
-        if self.bounds.contains(localPoint) {
-            self.isPressed = true
-        }
+        self.beginPrimaryPress(at: self.locationInView(for: event))
     }
 
     override func mouseUp(with event: NSEvent) {
@@ -158,11 +155,18 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
             super.mouseUp(with: event)
             return
         }
-        defer { self.isPressed = false }
-        let localPoint = self.locationInView(for: event)
-        if self.isPressed, self.bounds.contains(localPoint) {
+        if self.endPrimaryPress(at: self.locationInView(for: event)) {
             self.onClick?()
         }
+    }
+
+    private func beginPrimaryPress(at point: NSPoint) {
+        self.isPressed = self.bounds.contains(point)
+    }
+
+    private func endPrimaryPress(at point: NSPoint) -> Bool {
+        defer { self.isPressed = false }
+        return self.isPressed && self.bounds.contains(point)
     }
 
     override func layout() {
@@ -270,35 +274,12 @@ extension GPUSelectionHostingView {
         self.hitsHostedInteractiveControl(at: point)
     }
 
-    func _test_simulateRuntimeClick() -> Bool {
-        guard self.onClick != nil else { return false }
-
-        let centerLocal = NSPoint(x: self.bounds.midX, y: self.bounds.midY)
-
-        let eventDown = NSEvent.mouseEvent(
-            with: .leftMouseDown,
-            location: centerLocal,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            eventNumber: 1,
-            clickCount: 1,
-            pressure: 1.0)!
-        self.mouseDown(with: eventDown)
-
-        let eventUp = NSEvent.mouseEvent(
-            with: .leftMouseUp,
-            location: centerLocal,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            eventNumber: 2,
-            clickCount: 1,
-            pressure: 0.0)!
-        self.mouseUp(with: eventUp)
-
+    func _test_simulateRuntimeClick(at point: NSPoint? = nil) -> Bool {
+        let clickPoint = point ?? NSPoint(x: self.bounds.midX, y: self.bounds.midY)
+        guard let onClick = self.onClick, self.hitTest(clickPoint) === self else { return false }
+        self.beginPrimaryPress(at: clickPoint)
+        guard self.endPrimaryPress(at: clickPoint) else { return false }
+        onClick()
         return true
     }
 }

--- a/Sources/CodexBar/MenuCardGPUSelectionView.swift
+++ b/Sources/CodexBar/MenuCardGPUSelectionView.swift
@@ -26,7 +26,6 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
     private var onClick: (() -> Void)?
     private let containsInteractiveControls: Bool
     private let interactiveRegionStore: MenuCardInteractiveRegionStore?
-    private var isPressed = false
 
     private(set) var allowsMenuHighlight: Bool
 
@@ -147,26 +146,44 @@ final class GPUSelectionHostingView<Content: View>: NSView, MenuCardHighlighting
             super.mouseDown(with: event)
             return
         }
-        self.beginPrimaryPress(at: self.locationInView(for: event))
-    }
+        guard self.bounds.contains(self.locationInView(for: event)), let window = self.window else { return }
 
-    override func mouseUp(with event: NSEvent) {
-        guard event.type == .leftMouseUp, self.onClick != nil else {
-            super.mouseUp(with: event)
-            return
+        // A submenu-backed NSMenuItem consumes mouseUp in its nested tracking loop before a custom
+        // view receives it. Track the drag/up sequence directly so release-inside cancellation stays
+        // native while the menu never gets a chance to close before the row action runs.
+        var shouldInvoke = false
+        window.trackEvents(
+            matching: [.leftMouseDragged, .leftMouseUp],
+            timeout: NSEvent.foreverDuration,
+            mode: .eventTracking)
+        { [weak self] trackedEvent, stop in
+            guard let self, let trackedEvent else {
+                stop.pointee = true
+                return
+            }
+            if self.primaryPressShouldYieldToMenu(for: trackedEvent) {
+                // We dequeued this drag from the window; put it back so NSMenu's tracking loop can
+                // continue native drag-to-submenu selection from the same event.
+                window.postEvent(trackedEvent, atStart: true)
+                stop.pointee = true
+                return
+            }
+            guard let decision = self.primaryPressDecision(for: trackedEvent) else { return }
+            shouldInvoke = decision
+            stop.pointee = true
         }
-        if self.endPrimaryPress(at: self.locationInView(for: event)) {
+        if shouldInvoke {
             self.onClick?()
         }
     }
 
-    private func beginPrimaryPress(at point: NSPoint) {
-        self.isPressed = self.bounds.contains(point)
+    private func primaryPressDecision(for event: NSEvent) -> Bool? {
+        guard event.type == .leftMouseUp else { return nil }
+        return self.bounds.contains(self.locationInView(for: event))
     }
 
-    private func endPrimaryPress(at point: NSPoint) -> Bool {
-        defer { self.isPressed = false }
-        return self.isPressed && self.bounds.contains(point)
+    private func primaryPressShouldYieldToMenu(for event: NSEvent) -> Bool {
+        event.type == .leftMouseDragged && !self.bounds.contains(self.locationInView(for: event))
     }
 
     override func layout() {
@@ -277,10 +294,17 @@ extension GPUSelectionHostingView {
     func _test_simulateRuntimeClick(at point: NSPoint? = nil) -> Bool {
         let clickPoint = point ?? NSPoint(x: self.bounds.midX, y: self.bounds.midY)
         guard let onClick = self.onClick, self.hitTest(clickPoint) === self else { return false }
-        self.beginPrimaryPress(at: clickPoint)
-        guard self.endPrimaryPress(at: clickPoint) else { return false }
+        guard self.bounds.contains(clickPoint) else { return false }
         onClick()
         return true
+    }
+
+    func _test_primaryPressDecision(for event: NSEvent) -> Bool? {
+        self.primaryPressDecision(for: event)
+    }
+
+    func _test_primaryPressShouldYieldToMenu(for event: NSEvent) -> Bool {
+        self.primaryPressShouldYieldToMenu(for: event)
     }
 }
 #endif

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -334,7 +334,10 @@ private struct UsageMenuCardHeaderView: View {
                 Spacer()
                 if usesErrorLayout {
                     let showsCopyButton = liveSubtitle.style == .error && !liveSubtitle.text.isEmpty
-                    CopyIconButton(copyText: liveSubtitle.text, isHighlighted: self.isHighlighted)
+                    CopyIconButton(
+                        copyText: liveSubtitle.text,
+                        isHighlighted: self.isHighlighted,
+                        isInteractive: showsCopyButton)
                         .opacity(showsCopyButton ? 1 : 0)
                         .allowsHitTesting(showsCopyButton)
                         .accessibilityHidden(!showsCopyButton)
@@ -346,6 +349,7 @@ private struct UsageMenuCardHeaderView: View {
                                 Text(plan)
                             }
                             .buttonStyle(.plain)
+                            .menuCardInteractiveControl()
                             .accessibilityLabel(plan)
                         } else {
                             Text(plan)
@@ -392,6 +396,7 @@ private struct CopyIconButtonStyle: ButtonStyle {
 private struct CopyIconButton: View {
     let copyText: String
     let isHighlighted: Bool
+    let isInteractive: Bool
 
     @State private var didCopy = false
     @State private var resetTask: Task<Void, Never>?
@@ -406,6 +411,7 @@ private struct CopyIconButton: View {
                 .frame(width: 18, height: 18)
         }
         .buttonStyle(CopyIconButtonStyle(isHighlighted: self.isHighlighted))
+        .menuCardInteractiveControl(isEnabled: self.isInteractive)
         .accessibilityLabel(self.didCopy ? L("Copied") : L("Copy error"))
     }
 

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -576,6 +576,7 @@ extension StatusItemController {
                     section: "overview",
                     additional: [UsageMenuCardView.Model.heightFingerprintField("storage", storageText)]),
                 submenu: submenu,
+                containsInteractiveControls: row.model.subtitleStyle == .error || row.model.usesLiveSubtitle,
                 usesGPUSelection: true,
                 onClick: { [weak self, weak interactionMenu] in
                     guard let self, let interactionMenu else { return }

--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -53,18 +53,22 @@ extension StatusItemController {
             // Selection is painted by AppKit/GPU, so the SwiftUI content is pinned to its normal
             // appearance via a `highlightState` that is never flipped; these rows skip hosting-view
             // recycling because the recycler is typed to `MenuCardItemHostingView`.
+            let interactiveRegionStore = MenuCardInteractiveRegionStore()
             let wrapped = MenuCardSectionContainerView(
                 highlightState: MenuCardHighlightState(),
                 showsSubmenuIndicator: submenu != nil,
                 submenuIndicatorAlignment: submenuIndicatorAlignment,
                 submenuIndicatorTopPadding: submenuIndicatorTopPadding,
-                refreshMonitor: self.menuCardRefreshMonitor)
+                refreshMonitor: self.menuCardRefreshMonitor,
+                interactiveRegionStore: interactiveRegionStore)
             {
                 view
             }
             let gpuHosting = GPUSelectionHostingView(
                 rootView: wrapped,
                 allowsMenuHighlight: allowsMenuHighlight,
+                containsInteractiveControls: containsInteractiveControls,
+                interactiveRegionStore: interactiveRegionStore,
                 onClick: onClick)
             let gpuHeight = self.cachedMenuCardHeight(
                 for: id,
@@ -92,23 +96,27 @@ extension StatusItemController {
                 showsSubmenuIndicator: submenu != nil,
                 submenuIndicatorAlignment: submenuIndicatorAlignment,
                 submenuIndicatorTopPadding: submenuIndicatorTopPadding,
-                refreshMonitor: self.menuCardRefreshMonitor)
+                refreshMonitor: self.menuCardRefreshMonitor,
+                interactiveRegionStore: recycled.interactiveRegionStore)
             {
                 view
             }
             recycled.prepareForReuse(
                 rootView: wrapped,
                 allowsMenuHighlight: allowsMenuHighlight,
+                containsInteractiveControls: containsInteractiveControls,
                 onClick: onClick)
             hosting = recycled
         } else {
             let highlightState = MenuCardHighlightState()
+            let interactiveRegionStore = MenuCardInteractiveRegionStore()
             let wrapped = MenuCardSectionContainerView(
                 highlightState: highlightState,
                 showsSubmenuIndicator: submenu != nil,
                 submenuIndicatorAlignment: submenuIndicatorAlignment,
                 submenuIndicatorTopPadding: submenuIndicatorTopPadding,
-                refreshMonitor: self.menuCardRefreshMonitor)
+                refreshMonitor: self.menuCardRefreshMonitor,
+                interactiveRegionStore: interactiveRegionStore)
             {
                 view
             }
@@ -116,6 +124,8 @@ extension StatusItemController {
                 rootView: wrapped,
                 highlightState: highlightState,
                 allowsMenuHighlight: allowsMenuHighlight,
+                containsInteractiveControls: containsInteractiveControls,
+                interactiveRegionStore: interactiveRegionStore,
                 onClick: onClick)
         }
         let height = self.cachedMenuCardHeight(

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -134,7 +134,7 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
     let highlightState: MenuCardHighlightState
     private(set) var allowsMenuHighlight: Bool
     private var onClick: (() -> Void)?
-    private var hasClickRecognizer = false
+    private var isPressed = false
 
     override var allowsVibrancy: Bool {
         true
@@ -156,9 +156,6 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         self.allowsMenuHighlight = allowsMenuHighlight
         self.onClick = onClick
         super.init(rootView: rootView)
-        if onClick != nil {
-            self.installClickRecognizer()
-        }
     }
 
     /// Reuses this hosting view for a rebuilt card with the same identity: the replaced
@@ -169,9 +166,7 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         self.rootView = rootView
         self.allowsMenuHighlight = allowsMenuHighlight
         self.onClick = onClick
-        if onClick != nil, !self.hasClickRecognizer {
-            self.installClickRecognizer()
-        }
+        self.isPressed = false
     }
 
     /// `NSMenu` tracking consumes keyboard events before they reach a menu item's custom view, so
@@ -190,13 +185,6 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         return true
     }
 
-    private func installClickRecognizer() {
-        let recognizer = NSClickGestureRecognizer(target: self, action: #selector(self.handlePrimaryClick(_:)))
-        recognizer.buttonMask = 0x1
-        self.addGestureRecognizer(recognizer)
-        self.hasClickRecognizer = true
-    }
-
     required init(rootView: Content) {
         self.highlightState = MenuCardHighlightState()
         self.allowsMenuHighlight = false
@@ -213,9 +201,51 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         true
     }
 
-    @objc private func handlePrimaryClick(_ recognizer: NSClickGestureRecognizer) {
-        guard recognizer.state == .ended else { return }
-        self.onClick?()
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let descendant = super.hitTest(point)
+        if let descendant {
+            var current: NSView? = descendant
+            while let view = current, view !== self {
+                if view is NSButton || view is NSControl {
+                    return descendant
+                }
+                current = view.superview
+            }
+            if descendant !== self, self.onClick != nil {
+                return self
+            }
+        }
+        return descendant
+    }
+
+    private func locationInView(for event: NSEvent) -> NSPoint {
+        guard self.window != nil else {
+            return event.locationInWindow
+        }
+        return self.convert(event.locationInWindow, from: nil)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard event.type == .leftMouseDown, self.onClick != nil else {
+            super.mouseDown(with: event)
+            return
+        }
+        let localPoint = self.locationInView(for: event)
+        if self.bounds.contains(localPoint) {
+            self.isPressed = true
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard event.type == .leftMouseUp, self.onClick != nil else {
+            super.mouseUp(with: event)
+            return
+        }
+        defer { self.isPressed = false }
+        let localPoint = self.locationInView(for: event)
+        if self.isPressed, self.bounds.contains(localPoint) {
+            self.onClick?()
+        }
     }
 
     func measuredHeight(width: CGFloat) -> CGFloat {
@@ -474,6 +504,42 @@ final class PersistentRefreshMenuView: NSView, MenuCardHighlighting {
         self.onClick?()
     }
 }
+
+#if DEBUG
+extension MenuCardItemHostingView {
+    func _test_simulateRuntimeClick() -> Bool {
+        guard self.onClick != nil else { return false }
+
+        let centerLocal = NSPoint(x: self.bounds.midX, y: self.bounds.midY)
+
+        let eventDown = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: centerLocal,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1.0)!
+        self.mouseDown(with: eventDown)
+
+        let eventUp = NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: centerLocal,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 2,
+            clickCount: 1,
+            pressure: 0.0)!
+        self.mouseUp(with: eventUp)
+
+        return true
+    }
+}
+#endif
 
 struct MenuCardSectionContainerView<Content: View>: View {
     @Bindable var highlightState: MenuCardHighlightState

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -138,6 +138,10 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
     let interactiveRegionStore: MenuCardInteractiveRegionStore?
     private var isPressed = false
     private var isForwardingHostedControlPress = false
+    #if DEBUG
+    private var testForwardedHostedControlMouseDown = false
+    private var testForwardedHostedControlMouseUp = false
+    #endif
 
     override var allowsVibrancy: Bool {
         true
@@ -250,13 +254,11 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
             return
         }
         let localPoint = self.locationInView(for: event)
-        if self.hitsHostedInteractiveControl(at: localPoint) {
-            self.isForwardingHostedControlPress = true
+        if self.beginPrimaryPress(at: localPoint) {
+            #if DEBUG
+            self.testForwardedHostedControlMouseDown = true
+            #endif
             super.mouseDown(with: event)
-            return
-        }
-        if self.bounds.contains(localPoint) {
-            self.isPressed = true
         }
     }
 
@@ -265,16 +267,36 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
             super.mouseUp(with: event)
             return
         }
-        if self.isForwardingHostedControlPress {
-            self.isForwardingHostedControlPress = false
+        let result = self.endPrimaryPress(at: self.locationInView(for: event))
+        if result.forwardToHostedControl {
+            #if DEBUG
+            self.testForwardedHostedControlMouseUp = true
+            #endif
             super.mouseUp(with: event)
             return
         }
-        defer { self.isPressed = false }
-        let localPoint = self.locationInView(for: event)
-        if self.isPressed, self.bounds.contains(localPoint) {
+        if result.invokeRowAction {
             self.onClick?()
         }
+    }
+
+    /// Returns whether AppKit should forward the press into a nested SwiftUI control.
+    private func beginPrimaryPress(at point: NSPoint) -> Bool {
+        if self.hitsHostedInteractiveControl(at: point) {
+            self.isForwardingHostedControlPress = true
+            return true
+        }
+        self.isPressed = self.bounds.contains(point)
+        return false
+    }
+
+    private func endPrimaryPress(at point: NSPoint) -> (forwardToHostedControl: Bool, invokeRowAction: Bool) {
+        if self.isForwardingHostedControlPress {
+            self.isForwardingHostedControlPress = false
+            return (true, false)
+        }
+        defer { self.isPressed = false }
+        return (false, self.isPressed && self.bounds.contains(point))
     }
 
     private func hitsHostedInteractiveControl(at point: NSPoint) -> Bool {
@@ -544,39 +566,24 @@ final class PersistentRefreshMenuView: NSView, MenuCardHighlighting {
 
 #if DEBUG
 extension MenuCardItemHostingView {
+    var _test_forwardedHostedControlEvents: (mouseDown: Bool, mouseUp: Bool) {
+        (self.testForwardedHostedControlMouseDown, self.testForwardedHostedControlMouseUp)
+    }
+
     func _test_hitsHostedInteractiveControl(at point: NSPoint) -> Bool {
         self.hitsHostedInteractiveControl(at: point)
     }
 
-    func _test_simulateRuntimeClick() -> Bool {
-        guard self.onClick != nil else { return false }
-
-        let centerLocal = NSPoint(x: self.bounds.midX, y: self.bounds.midY)
-
-        let eventDown = NSEvent.mouseEvent(
-            with: .leftMouseDown,
-            location: centerLocal,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            eventNumber: 1,
-            clickCount: 1,
-            pressure: 1.0)!
-        self.mouseDown(with: eventDown)
-
-        let eventUp = NSEvent.mouseEvent(
-            with: .leftMouseUp,
-            location: centerLocal,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            eventNumber: 2,
-            clickCount: 1,
-            pressure: 0.0)!
-        self.mouseUp(with: eventUp)
-
+    func _test_simulateRuntimeClick(at point: NSPoint? = nil) -> Bool {
+        let clickPoint = point ?? NSPoint(x: self.bounds.midX, y: self.bounds.midY)
+        guard let onClick = self.onClick else { return false }
+        guard !self.beginPrimaryPress(at: clickPoint) else {
+            _ = self.endPrimaryPress(at: clickPoint)
+            return false
+        }
+        let result = self.endPrimaryPress(at: clickPoint)
+        guard result.invokeRowAction else { return false }
+        onClick()
         return true
     }
 }

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -134,7 +134,10 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
     let highlightState: MenuCardHighlightState
     private(set) var allowsMenuHighlight: Bool
     private var onClick: (() -> Void)?
+    private var containsInteractiveControls: Bool
+    let interactiveRegionStore: MenuCardInteractiveRegionStore?
     private var isPressed = false
+    private var isForwardingHostedControlPress = false
 
     override var allowsVibrancy: Bool {
         true
@@ -150,10 +153,14 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         rootView: Content,
         highlightState: MenuCardHighlightState,
         allowsMenuHighlight: Bool,
+        containsInteractiveControls: Bool = false,
+        interactiveRegionStore: MenuCardInteractiveRegionStore? = nil,
         onClick: (() -> Void)? = nil)
     {
         self.highlightState = highlightState
         self.allowsMenuHighlight = allowsMenuHighlight
+        self.containsInteractiveControls = containsInteractiveControls
+        self.interactiveRegionStore = interactiveRegionStore
         self.onClick = onClick
         super.init(rootView: rootView)
     }
@@ -162,11 +169,18 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
     /// `rootView` is diffed in place by SwiftUI instead of tearing down and recreating the
     /// hosting view and its graph. Callers must construct `rootView` around this view's own
     /// `highlightState` so menu hover highlighting keeps driving the rendered content.
-    func prepareForReuse(rootView: Content, allowsMenuHighlight: Bool, onClick: (() -> Void)?) {
+    func prepareForReuse(
+        rootView: Content,
+        allowsMenuHighlight: Bool,
+        containsInteractiveControls: Bool = false,
+        onClick: (() -> Void)?)
+    {
         self.rootView = rootView
         self.allowsMenuHighlight = allowsMenuHighlight
+        self.containsInteractiveControls = containsInteractiveControls
         self.onClick = onClick
         self.isPressed = false
+        self.isForwardingHostedControlPress = false
     }
 
     /// `NSMenu` tracking consumes keyboard events before they reach a menu item's custom view, so
@@ -188,6 +202,8 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
     required init(rootView: Content) {
         self.highlightState = MenuCardHighlightState()
         self.allowsMenuHighlight = false
+        self.containsInteractiveControls = false
+        self.interactiveRegionStore = nil
         self.onClick = nil
         super.init(rootView: rootView)
     }
@@ -211,6 +227,9 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
                 }
                 current = view.superview
             }
+            if self.hitsHostedInteractiveControl(at: point) {
+                return descendant
+            }
             if descendant !== self, self.onClick != nil {
                 return self
             }
@@ -231,6 +250,11 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
             return
         }
         let localPoint = self.locationInView(for: event)
+        if self.hitsHostedInteractiveControl(at: localPoint) {
+            self.isForwardingHostedControlPress = true
+            super.mouseDown(with: event)
+            return
+        }
         if self.bounds.contains(localPoint) {
             self.isPressed = true
         }
@@ -241,11 +265,24 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
             super.mouseUp(with: event)
             return
         }
+        if self.isForwardingHostedControlPress {
+            self.isForwardingHostedControlPress = false
+            super.mouseUp(with: event)
+            return
+        }
         defer { self.isPressed = false }
         let localPoint = self.locationInView(for: event)
         if self.isPressed, self.bounds.contains(localPoint) {
             self.onClick?()
         }
+    }
+
+    private func hitsHostedInteractiveControl(at point: NSPoint) -> Bool {
+        self.containsInteractiveControls &&
+            (self.interactiveRegionStore?.contains(
+                point,
+                hostingBounds: self.bounds,
+                fittedSize: self.fittingSize) == true)
     }
 
     func measuredHeight(width: CGFloat) -> CGFloat {
@@ -507,6 +544,10 @@ final class PersistentRefreshMenuView: NSView, MenuCardHighlighting {
 
 #if DEBUG
 extension MenuCardItemHostingView {
+    func _test_hitsHostedInteractiveControl(at point: NSPoint) -> Bool {
+        self.hitsHostedInteractiveControl(at: point)
+    }
+
     func _test_simulateRuntimeClick() -> Bool {
         guard self.onClick != nil else { return false }
 
@@ -547,12 +588,35 @@ struct MenuCardSectionContainerView<Content: View>: View {
     let submenuIndicatorAlignment: Alignment
     let submenuIndicatorTopPadding: CGFloat
     var refreshMonitor: MenuCardRefreshMonitor?
+    var interactiveRegionStore: MenuCardInteractiveRegionStore?
     @ViewBuilder let content: () -> Content
+
+    init(
+        highlightState: MenuCardHighlightState,
+        showsSubmenuIndicator: Bool,
+        submenuIndicatorAlignment: Alignment,
+        submenuIndicatorTopPadding: CGFloat,
+        refreshMonitor: MenuCardRefreshMonitor?,
+        interactiveRegionStore: MenuCardInteractiveRegionStore? = nil,
+        @ViewBuilder content: @escaping () -> Content)
+    {
+        self.highlightState = highlightState
+        self.showsSubmenuIndicator = showsSubmenuIndicator
+        self.submenuIndicatorAlignment = submenuIndicatorAlignment
+        self.submenuIndicatorTopPadding = submenuIndicatorTopPadding
+        self.refreshMonitor = refreshMonitor
+        self.interactiveRegionStore = interactiveRegionStore
+        self.content = content
+    }
 
     var body: some View {
         self.content()
             .environment(\.menuItemHighlighted, self.highlightState.isHighlighted)
             .environment(\.menuCardRefreshMonitor, self.refreshMonitor)
+            .coordinateSpace(name: MenuCardInteractiveRegionPreferenceKey.coordinateSpaceName)
+            .onPreferenceChange(MenuCardInteractiveRegionPreferenceKey.self) { regions in
+                self.interactiveRegionStore?.regions = regions
+            }
             .foregroundStyle(MenuHighlightStyle.primary(self.highlightState.isHighlighted))
             .background(alignment: .topLeading) {
                 if self.highlightState.isHighlighted {
@@ -571,5 +635,44 @@ struct MenuCardSectionContainerView<Content: View>: View {
                         .padding(.trailing, 10)
                 }
             }
+    }
+}
+
+@MainActor
+@Observable
+final class MenuCardInteractiveRegionStore {
+    var regions: [CGRect] = []
+
+    func contains(_ point: CGPoint, hostingBounds: CGRect, fittedSize: CGSize) -> Bool {
+        // NSHostingView centers intrinsic-height SwiftUI content in the menu item's padded frame.
+        // Preference rectangles use the SwiftUI root's coordinates, so remove that AppKit offset.
+        let contentOrigin = CGPoint(
+            x: max(0, (hostingBounds.width - fittedSize.width) / 2),
+            y: max(0, (hostingBounds.height - fittedSize.height) / 2))
+        let contentPoint = CGPoint(x: point.x - contentOrigin.x, y: point.y - contentOrigin.y)
+        return self.regions.contains { $0.contains(contentPoint) }
+    }
+}
+
+struct MenuCardInteractiveRegionPreferenceKey: PreferenceKey {
+    static let coordinateSpaceName = "MenuCardInteractiveRegion"
+    static let defaultValue: [CGRect] = []
+
+    static func reduce(value: inout [CGRect], nextValue: () -> [CGRect]) {
+        value.append(contentsOf: nextValue())
+    }
+}
+
+extension View {
+    func menuCardInteractiveControl(isEnabled: Bool = true) -> some View {
+        self.background {
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: MenuCardInteractiveRegionPreferenceKey.self,
+                    value: isEnabled
+                        ? [proxy.frame(in: .named(MenuCardInteractiveRegionPreferenceKey.coordinateSpaceName))]
+                        : [])
+            }
+        }
     }
 }

--- a/Tests/CodexBarTests/StatusMenuOverviewClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOverviewClickTests.swift
@@ -82,7 +82,40 @@ struct StatusMenuOverviewClickTests {
     }
 
     @Test
-    func `standard hosting preserves nested SwiftUI button presses`() {
+    func `gpu hosting preserves nested SwiftUI button target`() {
+        let interactiveRegionStore = MenuCardInteractiveRegionStore()
+        let content = Button("Copy") {}
+            .frame(width: 80, height: 30)
+            .menuCardInteractiveControl()
+            .frame(width: 320, height: 44, alignment: .trailing)
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: MenuCardHighlightState(),
+            showsSubmenuIndicator: false,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0,
+            refreshMonitor: nil,
+            interactiveRegionStore: interactiveRegionStore)
+        {
+            content
+        }
+        let view = GPUSelectionHostingView(
+            rootView: wrapped,
+            allowsMenuHighlight: true,
+            containsInteractiveControls: true,
+            interactiveRegionStore: interactiveRegionStore,
+            onClick: {})
+        view.frame = NSRect(x: 0, y: 0, width: 320, height: 51)
+        Self.settleWindowlessLayout(view)
+        let buttonPoint = NSPoint(x: 280, y: 39)
+
+        #expect(view._test_hitsHostedInteractiveControl(at: buttonPoint))
+        #expect(!view._test_hitsHostedInteractiveControl(at: NSPoint(x: 280, y: 8)))
+        #expect(view.hitTest(buttonPoint) !== view)
+        #expect(!view._test_simulateRuntimeClick(at: buttonPoint))
+    }
+
+    @Test
+    func `standard hosting forwards nested SwiftUI control events without invoking row`() {
         var rowClicked = false
         let interactiveRegionStore = MenuCardInteractiveRegionStore()
         let content = Button("Copy") {}
@@ -106,48 +139,19 @@ struct StatusMenuOverviewClickTests {
             containsInteractiveControls: true,
             interactiveRegionStore: interactiveRegionStore,
             onClick: { rowClicked = true })
-        let window = Self.hostInWindow(view, height: 51)
-        defer { window.close() }
+        view.frame = NSRect(x: 0, y: 0, width: 320, height: 51)
+        Self.settleWindowlessLayout(view)
         let buttonPoint = NSPoint(x: 280, y: 39)
 
         #expect(view._test_hitsHostedInteractiveControl(at: buttonPoint))
         #expect(!view._test_hitsHostedInteractiveControl(at: NSPoint(x: 280, y: 8)))
-        let events = Self.mouseClick(at: buttonPoint, in: window)
+        let events = Self.mouseClick(at: buttonPoint)
         view.mouseDown(with: events.down)
         view.mouseUp(with: events.up)
+        let forwarded = view._test_forwardedHostedControlEvents
+        #expect(forwarded.mouseDown)
+        #expect(forwarded.mouseUp)
         #expect(!rowClicked)
-    }
-
-    @Test
-    func `gpu hosting preserves nested SwiftUI button target`() {
-        let interactiveRegionStore = MenuCardInteractiveRegionStore()
-        let content = Button("Copy") {}
-            .frame(width: 80, height: 30)
-            .menuCardInteractiveControl()
-            .frame(width: 320, height: 44, alignment: .trailing)
-        let wrapped = MenuCardSectionContainerView(
-            highlightState: MenuCardHighlightState(),
-            showsSubmenuIndicator: false,
-            submenuIndicatorAlignment: .trailing,
-            submenuIndicatorTopPadding: 0,
-            refreshMonitor: nil,
-            interactiveRegionStore: interactiveRegionStore)
-        {
-            content
-        }
-        let view = GPUSelectionHostingView(
-            rootView: wrapped,
-            allowsMenuHighlight: true,
-            containsInteractiveControls: true,
-            interactiveRegionStore: interactiveRegionStore,
-            onClick: {})
-        let window = Self.hostInWindow(view, height: 51)
-        defer { window.close() }
-        let buttonPoint = NSPoint(x: 280, y: 39)
-
-        #expect(view._test_hitsHostedInteractiveControl(at: buttonPoint))
-        #expect(!view._test_hitsHostedInteractiveControl(at: NSPoint(x: 280, y: 8)))
-        #expect(view.hitTest(buttonPoint) !== view)
     }
 
     @Test
@@ -175,37 +179,29 @@ struct StatusMenuOverviewClickTests {
             containsInteractiveControls: true,
             interactiveRegionStore: interactiveRegionStore,
             onClick: { rowClicked = true })
-        let window = Self.hostInWindow(view)
-        defer { window.close() }
+        view.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+        Self.settleWindowlessLayout(view)
         let buttonPoint = NSPoint(x: 280, y: 22)
 
         #expect(!view._test_hitsHostedInteractiveControl(at: buttonPoint))
-        let events = Self.mouseClick(at: buttonPoint, in: window)
-        view.mouseDown(with: events.down)
-        view.mouseUp(with: events.up)
+        #expect(view._test_simulateRuntimeClick(at: buttonPoint))
         #expect(rowClicked)
     }
 
-    private static func hostInWindow(_ view: NSView, height: CGFloat = 44) -> NSWindow {
-        let frame = NSRect(x: 0, y: 0, width: 320, height: height)
-        view.frame = frame
-        let window = NSWindow(contentRect: frame, styleMask: .borderless, backing: .buffered, defer: false)
-        let container = NSView(frame: frame)
-        container.addSubview(view)
-        window.contentView = container
-        window.makeKeyAndOrderFront(nil)
+    private static func settleWindowlessLayout(_ view: NSView) {
+        view.needsLayout = true
         view.layoutSubtreeIfNeeded()
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        return window
+        RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        view.layoutSubtreeIfNeeded()
     }
 
-    private static func mouseClick(at point: NSPoint, in window: NSWindow) -> (down: NSEvent, up: NSEvent) {
+    private static func mouseClick(at point: NSPoint) -> (down: NSEvent, up: NSEvent) {
         let down = NSEvent.mouseEvent(
             with: .leftMouseDown,
             location: point,
             modifierFlags: [],
             timestamp: 0,
-            windowNumber: window.windowNumber,
+            windowNumber: 0,
             context: nil,
             eventNumber: 1,
             clickCount: 1,
@@ -215,7 +211,7 @@ struct StatusMenuOverviewClickTests {
             location: point,
             modifierFlags: [],
             timestamp: 0,
-            windowNumber: window.windowNumber,
+            windowNumber: 0,
             context: nil,
             eventNumber: 2,
             clickCount: 1,

--- a/Tests/CodexBarTests/StatusMenuOverviewClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOverviewClickTests.swift
@@ -42,6 +42,72 @@ struct StatusMenuOverviewClickTests {
     }
 
     @Test
+    func `gpu tracking activates only for mouseUp inside row`() {
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: MenuCardHighlightState(),
+            showsSubmenuIndicator: false,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0,
+            refreshMonitor: nil)
+        {
+            Text("Overview GPU row")
+        }
+        let view = GPUSelectionHostingView(
+            rootView: wrapped,
+            allowsMenuHighlight: true,
+            onClick: {})
+        view.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+        let events = Self.mouseClick(at: NSPoint(x: 160, y: 22))
+
+        #expect(view._test_primaryPressDecision(for: events.down) == nil)
+        #expect(view._test_primaryPressDecision(for: events.up) == true)
+    }
+
+    @Test
+    func `gpu tracking cancels when release leaves row`() {
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: MenuCardHighlightState(),
+            showsSubmenuIndicator: true,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0,
+            refreshMonitor: nil)
+        {
+            Text("Overview GPU row")
+        }
+        let view = GPUSelectionHostingView(
+            rootView: wrapped,
+            allowsMenuHighlight: true,
+            onClick: {})
+        view.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+        let outsideUp = Self.mouseClick(at: NSPoint(x: 340, y: 22)).up
+
+        #expect(view._test_primaryPressDecision(for: outsideUp) == false)
+    }
+
+    @Test
+    func `gpu tracking yields an outside drag to native submenu tracking`() {
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: MenuCardHighlightState(),
+            showsSubmenuIndicator: true,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0,
+            refreshMonitor: nil)
+        {
+            Text("Overview GPU row")
+        }
+        let view = GPUSelectionHostingView(
+            rootView: wrapped,
+            allowsMenuHighlight: true,
+            onClick: {})
+        view.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+
+        let insideDrag = Self.mouseDrag(at: NSPoint(x: 160, y: 22))
+        let outsideDrag = Self.mouseDrag(at: NSPoint(x: 340, y: 22))
+        #expect(!view._test_primaryPressShouldYieldToMenu(for: insideDrag))
+        #expect(view._test_primaryPressShouldYieldToMenu(for: outsideDrag))
+    }
+
+    @Test
     func `hitTest preserves button targets in standard hosting view`() {
         let view = MenuCardItemHostingView(
             rootView: Text("Overview row"),
@@ -217,5 +283,18 @@ struct StatusMenuOverviewClickTests {
             clickCount: 1,
             pressure: 0)!
         return (down, up)
+    }
+
+    private static func mouseDrag(at point: NSPoint) -> NSEvent {
+        NSEvent.mouseEvent(
+            with: .leftMouseDragged,
+            location: point,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 3,
+            clickCount: 1,
+            pressure: 1)!
     }
 }

--- a/Tests/CodexBarTests/StatusMenuOverviewClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOverviewClickTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuOverviewClickTests {
+    @Test
+    func `routes runtime click without gesture recognizer`() {
+        var clicked = false
+        let view = MenuCardItemHostingView(
+            rootView: Text("Overview row"),
+            highlightState: MenuCardHighlightState(),
+            allowsMenuHighlight: true,
+            onClick: { clicked = true })
+        view.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+        #expect(view._test_simulateRuntimeClick())
+        #expect(clicked)
+    }
+
+    @Test
+    func `routes gpu selection runtime click without gesture recognizer`() {
+        var clicked = false
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: MenuCardHighlightState(),
+            showsSubmenuIndicator: false,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0,
+            refreshMonitor: nil)
+        {
+            Text("Overview GPU row")
+        }
+        let view = GPUSelectionHostingView(
+            rootView: wrapped,
+            allowsMenuHighlight: true,
+            onClick: { clicked = true })
+        view.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+        #expect(view._test_simulateRuntimeClick())
+        #expect(clicked)
+    }
+
+    @Test
+    func `hitTest preserves button targets in standard hosting view`() {
+        let view = MenuCardItemHostingView(
+            rootView: Text("Overview row"),
+            highlightState: MenuCardHighlightState(),
+            allowsMenuHighlight: true,
+            onClick: {})
+        view.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+        let button = NSButton(frame: NSRect(x: 10, y: 10, width: 50, height: 20))
+        view.addSubview(button)
+
+        let hit = view.hitTest(NSPoint(x: 15, y: 15))
+        #expect(hit !== view)
+        #expect(hit === button || hit?.isDescendant(of: button) == true)
+    }
+
+    @Test
+    func `hitTest preserves button targets in gpu selection hosting view`() {
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: MenuCardHighlightState(),
+            showsSubmenuIndicator: false,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0,
+            refreshMonitor: nil)
+        {
+            Text("Overview GPU row")
+        }
+        let view = GPUSelectionHostingView(
+            rootView: wrapped,
+            allowsMenuHighlight: true,
+            onClick: {})
+        view.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+        let button = NSButton(frame: NSRect(x: 10, y: 10, width: 50, height: 20))
+        view.addSubview(button)
+
+        let hit = view.hitTest(NSPoint(x: 15, y: 15))
+        #expect(hit !== view)
+        #expect(hit === button || hit?.isDescendant(of: button) == true)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuOverviewClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOverviewClickTests.swift
@@ -80,4 +80,146 @@ struct StatusMenuOverviewClickTests {
         #expect(hit !== view)
         #expect(hit === button || hit?.isDescendant(of: button) == true)
     }
+
+    @Test
+    func `standard hosting preserves nested SwiftUI button presses`() {
+        var rowClicked = false
+        let interactiveRegionStore = MenuCardInteractiveRegionStore()
+        let content = Button("Copy") {}
+            .frame(width: 80, height: 30)
+            .menuCardInteractiveControl()
+            .frame(width: 320, height: 44, alignment: .trailing)
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: MenuCardHighlightState(),
+            showsSubmenuIndicator: false,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0,
+            refreshMonitor: nil,
+            interactiveRegionStore: interactiveRegionStore)
+        {
+            content
+        }
+        let view = MenuCardItemHostingView(
+            rootView: wrapped,
+            highlightState: MenuCardHighlightState(),
+            allowsMenuHighlight: true,
+            containsInteractiveControls: true,
+            interactiveRegionStore: interactiveRegionStore,
+            onClick: { rowClicked = true })
+        let window = Self.hostInWindow(view, height: 51)
+        defer { window.close() }
+        let buttonPoint = NSPoint(x: 280, y: 39)
+
+        #expect(view._test_hitsHostedInteractiveControl(at: buttonPoint))
+        #expect(!view._test_hitsHostedInteractiveControl(at: NSPoint(x: 280, y: 8)))
+        let events = Self.mouseClick(at: buttonPoint, in: window)
+        view.mouseDown(with: events.down)
+        view.mouseUp(with: events.up)
+        #expect(!rowClicked)
+    }
+
+    @Test
+    func `gpu hosting preserves nested SwiftUI button target`() {
+        let interactiveRegionStore = MenuCardInteractiveRegionStore()
+        let content = Button("Copy") {}
+            .frame(width: 80, height: 30)
+            .menuCardInteractiveControl()
+            .frame(width: 320, height: 44, alignment: .trailing)
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: MenuCardHighlightState(),
+            showsSubmenuIndicator: false,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0,
+            refreshMonitor: nil,
+            interactiveRegionStore: interactiveRegionStore)
+        {
+            content
+        }
+        let view = GPUSelectionHostingView(
+            rootView: wrapped,
+            allowsMenuHighlight: true,
+            containsInteractiveControls: true,
+            interactiveRegionStore: interactiveRegionStore,
+            onClick: {})
+        let window = Self.hostInWindow(view, height: 51)
+        defer { window.close() }
+        let buttonPoint = NSPoint(x: 280, y: 39)
+
+        #expect(view._test_hitsHostedInteractiveControl(at: buttonPoint))
+        #expect(!view._test_hitsHostedInteractiveControl(at: NSPoint(x: 280, y: 8)))
+        #expect(view.hitTest(buttonPoint) !== view)
+    }
+
+    @Test
+    func `hidden SwiftUI button region keeps row clickable`() {
+        var rowClicked = false
+        let interactiveRegionStore = MenuCardInteractiveRegionStore()
+        let content = Button("Hidden copy") {}
+            .frame(width: 80, height: 30)
+            .menuCardInteractiveControl(isEnabled: false)
+            .frame(width: 320, height: 44, alignment: .trailing)
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: MenuCardHighlightState(),
+            showsSubmenuIndicator: false,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0,
+            refreshMonitor: nil,
+            interactiveRegionStore: interactiveRegionStore)
+        {
+            content
+        }
+        let view = MenuCardItemHostingView(
+            rootView: wrapped,
+            highlightState: MenuCardHighlightState(),
+            allowsMenuHighlight: true,
+            containsInteractiveControls: true,
+            interactiveRegionStore: interactiveRegionStore,
+            onClick: { rowClicked = true })
+        let window = Self.hostInWindow(view)
+        defer { window.close() }
+        let buttonPoint = NSPoint(x: 280, y: 22)
+
+        #expect(!view._test_hitsHostedInteractiveControl(at: buttonPoint))
+        let events = Self.mouseClick(at: buttonPoint, in: window)
+        view.mouseDown(with: events.down)
+        view.mouseUp(with: events.up)
+        #expect(rowClicked)
+    }
+
+    private static func hostInWindow(_ view: NSView, height: CGFloat = 44) -> NSWindow {
+        let frame = NSRect(x: 0, y: 0, width: 320, height: height)
+        view.frame = frame
+        let window = NSWindow(contentRect: frame, styleMask: .borderless, backing: .buffered, defer: false)
+        let container = NSView(frame: frame)
+        container.addSubview(view)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        view.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        return window
+    }
+
+    private static func mouseClick(at point: NSPoint, in window: NSWindow) -> (down: NSEvent, up: NSEvent) {
+        let down = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: point,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1)!
+        let up = NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: point,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 2,
+            clickCount: 1,
+            pressure: 0)!
+        return (down, up)
+    }
 }


### PR DESCRIPTION
### Problem

Clickable provider cards in the Overview menu used an `NSClickGestureRecognizer` inside `NSMenu` tracking. Rebuilds under the pointer could drop that gesture, so selecting a provider sometimes did nothing (#2090).

### Solution

- Route row presses through the AppKit hosting views with explicit down/up tracking.
- Use `NSWindow.trackEvents` for submenu-backed GPU rows so `NSMenu` cannot consume mouse-up before selection, while release-outside still cancels and outside drags return to native submenu tracking.
- Preserve native AppKit controls and explicitly marked SwiftUI Copy/plan controls instead of stealing their clicks for the provider row.
- Translate SwiftUI control regions through the centered, padded `NSHostingView` geometry for both standard and GPU-selected cards.
- Keep routing correct when standard card hosts are recycled.
- Add the user-facing changelog entry with contributor credit.

### Verification

- `swift test --filter StatusMenuOverviewClickTests` — 10 passed, including padded geometry, native controls, real SwiftUI interactive-region publication, tracked release/cancellation, native submenu drag handoff, production event forwarding, and hidden Copy controls.
- Exact prior CI crash group repeated 10 times — 10/10 passed without constructing a live `NSWindow`.
- `swift test --filter MenuCardViewRecyclingTests` — passed.
- `swift test --filter StatusMenuSwitcherClickTests` — 19 passed.
- `make check` — SwiftFormat clean; SwiftLint 0 violations.
- `make test` — 635/635 selections; 53/53 groups passed first attempt; 0 retries, failures, or timeouts.
- Signed-bundle live replay — reproduced the old behavior (menu closed, Overview retained), then verified the repaired card keeps the menu open and selects Codex; dragging out keeps Overview and preserves its native submenu.
- Pre-commit autoreview — clean after correcting the SwiftUI/AppKit coordinate offset, replacing the crash-prone window test with production-path instrumentation, and preserving native drag-to-submenu routing.

Fixes #2090
