### PR TITLE
Fix Linux segfault in UsageFormatter localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - sub2api: add group-key usage with daily, weekly, and monthly quotas, multi-account switching, wallet balance, and expiry details. Thanks @weirdo-adam!
 
 ### Fixed
+- Linux CLI: prevent usage rendering from crashing in Foundation bundle discovery when formatting rate windows. Thanks @thanthi-del!
 - Startup: load persisted plan-utilization history away from the main thread so mature histories no longer delay app launch. Thanks @Yuxin-Qiao!
 - Provider cleanup: prevent in-flight usage, status, token-cost, and cached-hydration work from republishing stale state after a provider is disabled, unavailable, or re-enabled. Thanks @Yuxin-Qiao!
 - Agent Sessions: coalesce overlapping unchanged remote refresh requests so menu opens do not repeat Tailscale discovery and SSH passes. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -50,12 +50,20 @@ public enum UsageFormatter {
         if let provider {
             return provider(key)
         }
+        #if canImport(ObjectiveC)
+        // Bundle(for:) walks CFBundleGetAllBundles to find the bundle that defines
+        // BundleToken, which requires Objective-C runtime introspection swift-corelibs-
+        // foundation cannot provide on Linux — it segfaults in _CFIsSwift there (GitHub
+        // issue #2092). CodexBarCore ships no .lproj resources of its own anyway (real
+        // localized strings come from the macOS app via setLocalizationProvider above),
+        // so on non-Darwin platforms skip straight to the hardcoded English fallback table.
         let coreBundle = Bundle(for: BundleToken.self)
         let coreValue = NSLocalizedString(key, tableName: "Localizable", bundle: coreBundle, value: key, comment: "")
         if coreValue != key { return coreValue }
 
         let mainValue = NSLocalizedString(key, tableName: "Localizable", bundle: .main, value: key, comment: "")
         if mainValue != key { return mainValue }
+        #endif
 
         switch key {
         case "Updated relative %@": return "Updated %@"

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -51,12 +51,8 @@ public enum UsageFormatter {
             return provider(key)
         }
         #if canImport(ObjectiveC)
-        // Bundle(for:) walks CFBundleGetAllBundles to find the bundle that defines
-        // BundleToken, which requires Objective-C runtime introspection swift-corelibs-
-        // foundation cannot provide on Linux — it segfaults in _CFIsSwift there (GitHub
-        // issue #2092). CodexBarCore ships no .lproj resources of its own anyway (real
-        // localized strings come from the macOS app via setLocalizationProvider above),
-        // so on non-Darwin platforms skip straight to the hardcoded English fallback table.
+        // Bundle(for:) requires Objective-C bundle introspection. Linux uses the English
+        // fallback below; app localization is injected through localizationProvider.
         let coreBundle = Bundle(for: BundleToken.self)
         let coreValue = NSLocalizedString(key, tableName: "Localizable", bundle: coreBundle, value: key, comment: "")
         if coreValue != key { return coreValue }

--- a/TestsLinux/UsageFormatterLinuxTests.swift
+++ b/TestsLinux/UsageFormatterLinuxTests.swift
@@ -1,0 +1,15 @@
+import CodexBarCore
+import Testing
+
+@Suite(.serialized)
+struct UsageFormatterLinuxTests {
+    @Test
+    func `rate-window formatting uses the standalone English fallback`() {
+        UsageFormatter.clearLocalizationProvider()
+        UsageFormatter.clearLocaleProvider()
+
+        #expect(UsageFormatter.usageLine(remaining: 25, used: 75, showUsed: false) == "25% left")
+        #expect(UsageFormatter.usageLine(remaining: 25, used: 75, showUsed: true) == "75% used")
+        #expect(UsageFormatter.usageLine(remaining: 0.75, used: 99.25, showUsed: false) == "<1% left")
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #2092: `codexbar usage --provider claude` (and any provider rendering rate-window lines) segfaults on Linux.
- Root cause: `UsageFormatter.localized(key:)` calls `Bundle(for: BundleToken.self)`, which walks `CFBundleGetAllBundles` to locate the defining bundle — Objective-C runtime introspection that `swift-corelibs-foundation` cannot provide on Linux, crashing in `_CFIsSwift`.
- `CodexBarCore` ships no `.lproj` resources of its own (real localized strings are injected by the macOS app via `setLocalizationProvider`), so the `Bundle(for:)`/`NSLocalizedString` lookup was never useful on Linux to begin with.
- Fix: skip that block behind `#if canImport(ObjectiveC)` and fall straight through to the existing hardcoded English fallback table on non-Darwin platforms. Zero behavior change on macOS (same code path as before).

## Test plan
- [x] `swift build --target CodexBarCore` builds clean
- [x] Added `UsageFormatterLinuxTests` covering left/used and sub-percent output
- [x] `swift test --filter UsageFormatterTests`
- [x] `swift test --filter UsageFormatterLinuxTests`
- [x] Linux arm64 Swift 6.3.3 Docker: `swift test --filter UsageFormatterLinuxTests`
- [x] `make check`
- [x] Traced every `localized(...)` call site in `UsageFormatter.swift` — keys not covered by the fallback `switch` are themselves valid English text (standard `NSLocalizedString` key-as-default-value convention), so Linux output stays correct even without a table entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
