### PR TITLE
Fix stale cost/token cache pinned by non-forced refreshes

### DIFF
--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -172,16 +172,18 @@ public struct CostUsageFetcher: Sendable {
         } else if provider == .claude {
             options.claudeLogProviderFilter = .excludeVertexAI
         }
-        if forceRefresh {
-            options.refreshMinIntervalSeconds = 0
-        }
+        // Always disarm the scanner's own debounce here, not just for forceRefresh: UsageStore
+        // already TTL-gates its own callers (tokenFetchTTL, 60 min), so this debounce never saves
+        // real work at the app layer. Left conditional, it silently pins a stale scan — from this
+        // process or any other sharing the on-disk cache (the CLI, a second scan) — for the full
+        // TTL window whenever a non-forced fetch lands within refreshMinIntervalSeconds of a prior
+        // scan. The scanner's incremental cache still keeps re-scans cheap. See GitHub issue #2089.
+        options.refreshMinIntervalSeconds = 0
         var resolvedPiOptions = overridePiScannerOptions ?? PiSessionCostScanner.Options()
         if resolvedPiOptions.cacheRoot == nil {
             resolvedPiOptions.cacheRoot = options.cacheRoot
         }
-        if forceRefresh {
-            resolvedPiOptions.refreshMinIntervalSeconds = 0
-        }
+        resolvedPiOptions.refreshMinIntervalSeconds = 0
         let piOptions = resolvedPiOptions
 
         try Task.checkCancellation()

--- a/Tests/CodexBarTests/CostUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CostUsageFetcherTests.swift
@@ -820,6 +820,91 @@ struct CostUsageFetcherTests {
         #expect(refreshed.daily.first?.totalTokens == 176)
     }
 
+    // Regression test for GitHub issue #2089: a non-forced refresh must reflect usage appended
+    // to the session log since the prior scan, even when it lands inside the scanner's internal
+    // refreshMinIntervalSeconds debounce window. UsageStore already TTL-gates its own callers, so
+    // that debounce should never cause the app layer to silently pin a stale scan.
+    @Test
+    func `non-forced refresh keeps incremental cost cache current`() async throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 4, day: 11)
+        let iso0 = env.isoString(for: day)
+        let iso1 = env.isoString(for: day.addingTimeInterval(1))
+        let iso2 = env.isoString(for: day.addingTimeInterval(2))
+        let model = "openai/gpt-5.4"
+
+        let turnContext: [String: Any] = [
+            "type": "turn_context",
+            "timestamp": iso0,
+            "payload": ["model": model],
+        ]
+        let firstTokenCount: [String: Any] = [
+            "type": "event_msg",
+            "timestamp": iso1,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "model": model,
+                    "total_token_usage": [
+                        "input_tokens": 100,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 10,
+                    ],
+                ],
+            ],
+        ]
+        let fileURL = try env.writeCodexSessionFile(
+            day: day,
+            filename: "session.jsonl",
+            contents: env.jsonl([turnContext, firstTokenCount]))
+
+        let nativeOptions = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: [env.claudeProjectsRoot],
+            cacheRoot: env.cacheRoot)
+        let piOptions = PiSessionCostScanner.Options(
+            piSessionsRoot: env.piSessionsRoot,
+            cacheRoot: env.cacheRoot)
+
+        let first = try await CostUsageFetcher.loadTokenSnapshot(
+            provider: .codex,
+            now: day,
+            scannerOptions: nativeOptions,
+            piScannerOptions: piOptions)
+        #expect(first.daily.first?.totalTokens == 110)
+
+        let appendedTokenCount: [String: Any] = [
+            "type": "event_msg",
+            "timestamp": iso2,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "model": model,
+                    "total_token_usage": [
+                        "input_tokens": 160,
+                        "cached_input_tokens": 40,
+                        "output_tokens": 16,
+                    ],
+                ],
+            ],
+        ]
+        try env.jsonl([turnContext, firstTokenCount, appendedTokenCount])
+            .write(to: fileURL, atomically: true, encoding: .utf8)
+
+        // Same `now` and no forceRefresh: this lands inside the scanner's default 60s
+        // refreshMinIntervalSeconds window. Stock (unfixed) behavior throttles the scan and
+        // returns the stale cached 110; the fix makes this non-forced call see the appended row.
+        let refreshed = try await CostUsageFetcher.loadTokenSnapshot(
+            provider: .codex,
+            now: day,
+            scannerOptions: nativeOptions,
+            piScannerOptions: piOptions)
+
+        #expect(refreshed.daily.first?.totalTokens == 176)
+    }
+
     private static func writeCodexSessionFile(
         homeRoot: URL,
         env: CostUsageTestEnvironment,


### PR DESCRIPTION
## Summary
Fixes #2089.

- `CostUsageFetcher.loadDailyReport` only zeroed the scanner's `refreshMinIntervalSeconds` debounce (default 60s) when `forceRefresh` was true. Every non-forced fetch — the hourly token-cost timer, the first fetch after launch, cost-scope/settings changes — kept the default debounce.
- A non-forced fetch landing within 60s of *any* prior scan (including one from another process sharing the on-disk cache, e.g. `codexbar cost`) skipped file inspection entirely and returned the previous cached report.
- `UsageStore` then treats that snapshot as fresh for the full `tokenFetchTTL` (60 min), so a single throttled fetch pins stale cost/token totals in the menu bar for up to an hour.
- `UsageStore` already TTL-gates its own callers, so the scanner-level debounce never saved real work at the app layer on this path — it only ever manifested as this staleness window. This applies option 1 from the issue: zero `refreshMinIntervalSeconds` unconditionally instead of only on `forceRefresh`. The scanner's incremental cache (`keepCachedCodexFileIfFresh` / `appendCodexFileIncrementIfPossible`) still keeps re-scans of unchanged files cheap.

## Test plan
- [x] `swift build --target CodexBarCore` builds clean
- [x] Added `non-forced refresh keeps incremental cost cache current` to `CostUsageFetcherTests.swift`, mirroring the existing `force refresh keeps incremental cost cache` test but without `forceRefresh`: appends a second `token_count` row to a session log within the same debounce window and asserts the non-forced refresh picks it up (110 → 176 tokens)
- [ ] Could not execute `swift test` in my environment — `AdaptiveReplayKitTests` fails to build here with "no such module 'Testing'" (pre-existing, unrelated to this change; same failure on a pristine checkout of `main`). Would appreciate CI or a maintainer confirming the new test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)