### PR TITLE
Fix dropped overview menu-card row clicks (NSMenu tracking loop)

### DIFF
--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -134,7 +134,7 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
     let highlightState: MenuCardHighlightState
     private(set) var allowsMenuHighlight: Bool
     private var onClick: (() -> Void)?
-    private var hasClickRecognizer = false
+    private var isPressed = false
 
     override var allowsVibrancy: Bool {
         true
@@ -156,9 +156,6 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         self.allowsMenuHighlight = allowsMenuHighlight
         self.onClick = onClick
         super.init(rootView: rootView)
-        if onClick != nil {
-            self.installClickRecognizer()
-        }
     }
 
     /// Reuses this hosting view for a rebuilt card with the same identity: the replaced
@@ -169,9 +166,6 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         self.rootView = rootView
         self.allowsMenuHighlight = allowsMenuHighlight
         self.onClick = onClick
-        if onClick != nil, !self.hasClickRecognizer {
-            self.installClickRecognizer()
-        }
     }
 
     /// `NSMenu` tracking consumes keyboard events before they reach a menu item's custom view, so
@@ -190,13 +184,6 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         return true
     }
 
-    private func installClickRecognizer() {
-        let recognizer = NSClickGestureRecognizer(target: self, action: #selector(self.handlePrimaryClick(_:)))
-        recognizer.buttonMask = 0x1
-        self.addGestureRecognizer(recognizer)
-        self.hasClickRecognizer = true
-    }
-
     required init(rootView: Content) {
         self.highlightState = MenuCardHighlightState()
         self.allowsMenuHighlight = false
@@ -210,13 +197,77 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
     }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        // NSMenu's tracking run loop occasionally drops NSClickGestureRecognizer / NSButton
+        // target-action dispatch when the menu is rebuilt under the cursor (e.g. a background
+        // refresh reusing this row via prepareForReuse while the pointer sits over it). The
+        // overrides below hit-test this view itself, then drive the click from mouseDown/mouseUp
+        // here so it never has to round-trip through a gesture recognizer's begin→end state
+        // machine inside the tracking loop. Same fix as #867 (ProviderSwitcherView); see #2090.
         true
     }
 
-    @objc private func handlePrimaryClick(_ recognizer: NSClickGestureRecognizer) {
-        guard recognizer.state == .ended else { return }
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let descendant = super.hitTest(point)
+        if self.onClick != nil, descendant != nil, descendant !== self {
+            // Swallow hits on the hosted SwiftUI content so its view hierarchy never owns the
+            // click; this view drives it instead via mouseDown/mouseUp below.
+            return self
+        }
+        return descendant
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard self.onClick != nil else {
+            super.mouseDown(with: event)
+            return
+        }
+        let location = self.convert(event.locationInWindow, from: nil)
+        self.isPressed = self.bounds.contains(location)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard self.onClick != nil else {
+            super.mouseUp(with: event)
+            return
+        }
+        defer { self.isPressed = false }
+        guard self.isPressed else { return }
+        let location = self.convert(event.locationInWindow, from: nil)
+        guard self.bounds.contains(location) else { return }
         self.onClick?()
     }
+
+    #if DEBUG
+    /// Drives the production mouseDown/mouseUp click path with synthetic events, bypassing
+    /// NSMenu's tracking loop entirely — the loop and any gesture recognizer are exactly what a
+    /// unit test can't reproduce, and were the actual failure mode in #2090. Returns whether a
+    /// click was recognized (both events landed inside bounds and `onClick` fired). Mirrors
+    /// CodexAccountSwitcherView._test_simulateRuntimeClick's event construction (#867).
+    @discardableResult
+    func _test_simulateRuntimeClick() -> Bool {
+        if self.frame.width <= 0 || self.frame.height <= 0 {
+            self.setFrameSize(NSSize(width: max(self.frame.width, 1), height: max(self.frame.height, 1)))
+        }
+        let point = NSPoint(x: self.bounds.midX, y: self.bounds.midY)
+        var fired = false
+        let originalOnClick = self.onClick
+        self.onClick = {
+            fired = true
+            originalOnClick?()
+        }
+        defer { self.onClick = originalOnClick }
+        guard let mouseDownEvent = NSEvent.mouseEvent(
+            with: .leftMouseDown, location: point, modifierFlags: [], timestamp: 0,
+            windowNumber: 0, context: nil, eventNumber: 1, clickCount: 1, pressure: 1),
+            let mouseUpEvent = NSEvent.mouseEvent(
+                with: .leftMouseUp, location: point, modifierFlags: [], timestamp: 0,
+                windowNumber: 0, context: nil, eventNumber: 2, clickCount: 1, pressure: 0)
+        else { return false }
+        self.mouseDown(with: mouseDownEvent)
+        self.mouseUp(with: mouseUpEvent)
+        return fired
+    }
+    #endif
 
     func measuredHeight(width: CGFloat) -> CGFloat {
         self.frame = NSRect(origin: self.frame.origin, size: NSSize(width: width, height: 1))

--- a/Tests/CodexBarTests/MenuCardItemHostingViewClickTests.swift
+++ b/Tests/CodexBarTests/MenuCardItemHostingViewClickTests.swift
@@ -1,0 +1,76 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import CodexBar
+
+// Regression coverage for GitHub issue #2090: MenuCardItemHostingView used to deliver `onClick`
+// through an NSClickGestureRecognizer, which — like the NSButton dispatch fixed for the provider
+// switcher in #867 — can be dropped by NSMenu's tracking run loop when the row is rebuilt under
+// the cursor. The fix routes clicks through the view's own hitTest/mouseDown/mouseUp instead, the
+// same technique #867 used, so a click never has to round-trip through a gesture recognizer's
+// begin→end state machine inside the tracking loop.
+@MainActor
+struct MenuCardItemHostingViewClickTests {
+    @Test
+    func `routes runtime click without gesture recognizer`() {
+        var clicked = false
+        let view = MenuCardItemHostingView(
+            rootView: Text("Overview row"),
+            highlightState: MenuCardHighlightState(),
+            allowsMenuHighlight: true,
+            onClick: { clicked = true })
+
+        #expect(view._test_simulateRuntimeClick())
+        #expect(clicked)
+    }
+
+    @Test
+    func `runtime click still routes correctly after prepareForReuse`() {
+        // Mirrors how the overview menu actually drives this view: a background refresh calls
+        // prepareForReuse in place on an existing row instead of tearing it down. The original
+        // gesture-recognizer path could have a begun-but-not-completed gesture disturbed by the
+        // in-place SwiftUI diff; the hitTest/mouseDown/mouseUp path has no such state to disturb.
+        var firstClicked = false
+        let view = MenuCardItemHostingView(
+            rootView: Text("Row A"),
+            highlightState: MenuCardHighlightState(),
+            allowsMenuHighlight: true,
+            onClick: { firstClicked = true })
+
+        var secondClicked = false
+        view.prepareForReuse(
+            rootView: Text("Row B"),
+            allowsMenuHighlight: true,
+            onClick: { secondClicked = true })
+
+        #expect(view._test_simulateRuntimeClick())
+        #expect(!firstClicked)
+        #expect(secondClicked)
+    }
+
+    @Test
+    func `mouse up outside bounds cancels the click`() {
+        var clicked = false
+        let view = MenuCardItemHostingView(
+            rootView: Text("Overview row"),
+            highlightState: MenuCardHighlightState(),
+            allowsMenuHighlight: true,
+            onClick: { clicked = true })
+        view.setFrameSize(NSSize(width: 200, height: 24))
+
+        guard let mouseDownEvent = NSEvent.mouseEvent(
+            with: .leftMouseDown, location: NSPoint(x: 100, y: 12), modifierFlags: [], timestamp: 0,
+            windowNumber: 0, context: nil, eventNumber: 1, clickCount: 1, pressure: 1),
+            let mouseUpEvent = NSEvent.mouseEvent(
+                with: .leftMouseUp, location: NSPoint(x: 100, y: 999), modifierFlags: [], timestamp: 0,
+                windowNumber: 0, context: nil, eventNumber: 2, clickCount: 1, pressure: 0)
+        else {
+            Issue.record("failed to construct synthetic mouse events")
+            return
+        }
+        view.mouseDown(with: mouseDownEvent)
+        view.mouseUp(with: mouseUpEvent)
+
+        #expect(!clicked)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #2090.

- `MenuCardItemHostingView` delivered `onClick` through an `NSClickGestureRecognizer`, which needs its full begin→end state machine to run inside `NSMenu`'s tracking loop to fire.
- That loop can drop the dispatch when the row is rebuilt under the cursor — the same failure class already diagnosed and fixed for the provider switcher's `NSButton`s in #867 (commit `9907f749`), and made worse here by `prepareForReuse` swapping `rootView`/`onClick` in place on a view whose recognizer state a gesture-in-progress could be tied to.
- Applies the #867 technique: route the click through the view itself instead of a gesture recognizer.
  - `hitTest` swallows hits on the hosted SwiftUI content so it never owns the click.
  - `mouseDown`/`mouseUp` track a simple `isPressed` flag and fire `onClick` only when both the press and release land inside bounds (preserving click-cancel-by-drag-out semantics).
- `accessibilityPerformPress()` already calls `onClick` directly and is unaffected.

## Test plan
- [x] Added `Tests/CodexBarTests/MenuCardItemHostingViewClickTests.swift` with a `#if DEBUG _test_simulateRuntimeClick()` helper (mirrors `CodexAccountSwitcherView`'s existing one) and three tests:
  - basic click fires `onClick`
  - click still routes correctly after `prepareForReuse` (the actual reuse-under-refresh scenario from the report)
  - mouse-up outside bounds cancels the click
- [x] `swiftc -parse` on both changed files (syntax-only, no diagnostics)
- [ ] Could not run a full `swift build`/`swift test` in my environment — `KeyboardShortcuts`' `#Preview` macro plugin isn't found there (pre-existing, unrelated to this change; same failure on a pristine checkout of `main`), which blocks the `CodexBar` target specifically. Would appreciate CI or a maintainer confirming the new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)