### PR TITLE
fix: keep Tailscale session discovery headless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 
 ### Fixed
+- Agent Sessions: keep Tailscale discovery headless and fall through across installed CLI variants, preventing repeated Tailscale menu-bar launches. Thanks @willsarg!
 - Quota warnings: isolate threshold episodes by stable account ownership so one account cannot duplicate or suppress another account's alert. Thanks @vincent-peng!
 - Claude: cache successful CLI version probes for 30 minutes while invalidating on executable changes, avoiding repeated PTY launches without retaining failed or stale wrapper results. Thanks @Yuxin-Qiao!
 - Linux CLI: bootstrap the configured IANA timezone before Foundation startup on non-FHS systems, preventing SIGILL on NixOS (#2127). Thanks @xikhar!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 
 ### Fixed
-- Agent Sessions: keep Tailscale discovery headless and fall through across installed CLI variants, preventing repeated Tailscale menu-bar launches. Thanks @willsarg!
 - Quota warnings: isolate threshold episodes by stable account ownership so one account cannot duplicate or suppress another account's alert. Thanks @vincent-peng!
 - Claude: cache successful CLI version probes for 30 minutes while invalidating on executable changes, avoiding repeated PTY launches without retaining failed or stale wrapper results. Thanks @Yuxin-Qiao!
 - Linux CLI: bootstrap the configured IANA timezone before Foundation startup on non-FHS systems, preventing SIGILL on NixOS (#2127). Thanks @xikhar!
@@ -19,6 +18,7 @@
 - Startup: load persisted plan-utilization history away from the main thread so mature histories no longer delay app launch. Thanks @Yuxin-Qiao!
 - Provider cleanup: prevent in-flight usage, status, token-cost, and cached-hydration work from republishing stale state after a provider is disabled, unavailable, or re-enabled. Thanks @Yuxin-Qiao!
 - Agent Sessions: coalesce overlapping unchanged remote refresh requests so menu opens do not repeat Tailscale discovery and SSH passes. Thanks @Yuxin-Qiao!
+- Agent Sessions: keep Tailscale discovery headless and fall through across installed CLI variants, preventing repeated Tailscale menu-bar launches. Thanks @willsarg!
 - Cost usage: zero the scanner's 60-second refresh debounce on app-driven fetches so non-forced refreshes (hourly timer, post-launch, scope/settings changes) reflect rows appended between fetches instead of serving a stale snapshot that `UsageStore.tokenFetchTTL` then pins for up to an hour (#2089). Thanks @Yuxin-Qiao!
 - Codex cost usage: contain interleaved cumulative counters from Ultra-mode fork lineages so repeated lineage switches cannot inflate token and cost history (#2037). Thanks @Zihao-Qi!
 

--- a/Sources/CodexBarCore/RemoteSessionFetcher.swift
+++ b/Sources/CodexBarCore/RemoteSessionFetcher.swift
@@ -71,7 +71,7 @@ public struct RemoteSessionFetcher: Sendable {
               let result = try? await SubprocessRunner.run(
                   binary: tailscale,
                   arguments: ["status", "--json"],
-                  environment: environment,
+                  environment: Self.tailscaleCLIEnvironment(from: environment),
                   timeout: 5,
                   label: "Tailscale session host discovery"),
               let data = result.stdout.data(using: .utf8)
@@ -155,10 +155,46 @@ public struct RemoteSessionFetcher: Sendable {
     }
 
     private func tailscaleBinary(environment: [String: String]) -> String? {
-        self.findExecutable("tailscale", environment: environment) ?? {
-            let bundled = "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
-            return FileManager.default.isExecutableFile(atPath: bundled) ? bundled : nil
-        }()
+        Self.tailscaleBinaryCandidates(path: environment["PATH"])
+            .first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    /// Ordered candidate paths for the `tailscale` CLI, most-preferred first.
+    ///
+    /// The macOS app ships its CLI as a thin `/bin/sh` wrapper (usually
+    /// `/usr/local/bin/tailscale`) around the app's dual-mode binary. We prefer the
+    /// wrapper, but a GUI-launched CodexBar inherits a minimal `PATH` (`/usr/bin:/bin`)
+    /// that omits the standard CLI locations, so we also probe them explicitly before
+    /// falling back to the app binary itself.
+    public static func tailscaleBinaryCandidates(path: String?) -> [String] {
+        let pathDirs = path?.split(separator: ":").map(String.init) ?? []
+        var seen = Set<String>()
+        var candidates = (pathDirs + ["/usr/local/bin", "/opt/homebrew/bin"])
+            .filter { seen.insert($0).inserted }
+            .map { $0 + "/tailscale" }
+        // Last resort: the dual-mode app binary. Must be run via
+        // `tailscaleCLIEnvironment(from:)` so it stays in CLI mode.
+        candidates.append("/Applications/Tailscale.app/Contents/MacOS/Tailscale")
+        return candidates
+    }
+
+    /// Environment that keeps the dual-mode Tailscale app binary in CLI mode.
+    ///
+    /// With no shell/terminal marker present the binary boots the full menu-bar GUI
+    /// (SkyLight/WindowServer, status icon) instead of running the CLI: it never emits
+    /// JSON, the probe times out, and the Tailscale icon flickers on every refresh. A
+    /// set `TERM` or `SHLVL` forces CLI mode (argv[0] casing and `XPC_SERVICE_NAME` do
+    /// not). `SHLVL` is what the app's own `/bin/sh` CLI wrapper injects, so we mirror it here.
+    ///
+    /// Applied to every probe, not just the app-binary fallback: it is redundant but harmless for the
+    /// CLI wrapper (itself a `/bin/sh` script that already exports `SHLVL`), and injecting it
+    /// unconditionally keeps CLI mode guaranteed regardless of which binary `tailscaleBinary` resolves.
+    /// An existing `TERM`/`SHLVL` (real terminal context) is left untouched.
+    public static func tailscaleCLIEnvironment(from environment: [String: String]) -> [String: String] {
+        guard environment["TERM"] == nil, environment["SHLVL"] == nil else { return environment }
+        var environment = environment
+        environment["SHLVL"] = "1"
+        return environment
     }
 
     private func findExecutable(_ name: String, environment: [String: String]) -> String? {

--- a/Sources/CodexBarCore/RemoteSessionFetcher.swift
+++ b/Sources/CodexBarCore/RemoteSessionFetcher.swift
@@ -30,6 +30,11 @@ public enum TailscaleStatusParser {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               root["Self"] != nil || root["Version"] != nil || root["BackendState"] != nil || root["Peer"] != nil
         else { return nil }
+        if let backendState = root["BackendState"] as? String,
+           backendState.caseInsensitiveCompare("Running") != .orderedSame
+        {
+            return nil
+        }
         let peers: [[String: Any]] = if let dictionary = root["Peer"] as? [String: [String: Any]] {
             Array(dictionary.values)
         } else if let array = root["Peer"] as? [[String: Any]] {
@@ -96,7 +101,7 @@ public struct RemoteSessionFetcher: Sendable {
     }
 
     /// Runs `tailscale status --json` on each candidate in order, falling through to the next when a
-    /// candidate fails (`run` returns nil) or returns output that isn't valid Tailscale status JSON.
+    /// candidate fails (`run` returns nil), returns invalid status JSON, or reports an inactive backend.
     /// Returns the first candidate's parsed hosts (possibly empty), or `[]` if none succeed. This keeps
     /// the app-binary fallback working even when an earlier — but non-functional — `tailscale` variant
     /// is installed (e.g. an open-source/Homebrew CLI that isn't the active client).

--- a/Sources/CodexBarCore/RemoteSessionFetcher.swift
+++ b/Sources/CodexBarCore/RemoteSessionFetcher.swift
@@ -27,22 +27,40 @@ public enum TailscaleStatusParser {
     /// non-Tailscale `tailscale` binary — so callers can fall through to the next candidate. Returns a
     /// possibly-empty list for a valid status that simply has no eligible peers (a real answer, stop).
     package static func parseHosts(from data: Data, excludingLocalHost localHost: String? = nil) -> [String]? {
-        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              root["Self"] != nil || root["Version"] != nil || root["BackendState"] != nil || root["Peer"] != nil
-        else { return nil }
-        if let backendState = root["BackendState"] as? String,
-           backendState.caseInsensitiveCompare("Running") != .orderedSame
-        {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        if let rawBackendState = root["BackendState"] {
+            guard let backendState = rawBackendState as? String,
+                  backendState.caseInsensitiveCompare("Running") == .orderedSame
+            else { return nil }
+        }
+
+        let selfStatus: [String: Any]?
+        if let rawSelf = root["Self"] {
+            guard let parsedSelf = rawSelf as? [String: Any] else { return nil }
+            selfStatus = parsedSelf
+        } else {
+            selfStatus = nil
+        }
+
+        let peers: [[String: Any]]
+        let hasPeerShape: Bool
+        switch root["Peer"] {
+        case let dictionary as [String: [String: Any]]:
+            peers = Array(dictionary.values)
+            hasPeerShape = true
+        case let array as [[String: Any]]:
+            peers = array
+            hasPeerShape = true
+        case is NSNull:
+            peers = []
+            hasPeerShape = true
+        case nil:
+            peers = []
+            hasPeerShape = false
+        default:
             return nil
         }
-        let peers: [[String: Any]] = if let dictionary = root["Peer"] as? [String: [String: Any]] {
-            Array(dictionary.values)
-        } else if let array = root["Peer"] as? [[String: Any]] {
-            array
-        } else {
-            []
-        }
-        let selfStatus = root["Self"] as? [String: Any]
+        guard selfStatus != nil || hasPeerShape else { return nil }
         let localLabels = Set([
             localHost,
             selfStatus?["DNSName"] as? String,

--- a/Sources/CodexBarCore/RemoteSessionFetcher.swift
+++ b/Sources/CodexBarCore/RemoteSessionFetcher.swift
@@ -21,8 +21,15 @@ public struct RemoteSessionHostResult: Equatable, Sendable, Identifiable {
 }
 
 public enum TailscaleStatusParser {
-    public static func hosts(from data: Data, excludingLocalHost localHost: String? = nil) -> [String] {
-        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [] }
+    /// Parses hosts from `tailscale status --json` output.
+    ///
+    /// Returns `nil` when `data` is not recognizable Tailscale status JSON — a failed, wrong, or
+    /// non-Tailscale `tailscale` binary — so callers can fall through to the next candidate. Returns a
+    /// possibly-empty list for a valid status that simply has no eligible peers (a real answer, stop).
+    public static func parseHosts(from data: Data, excludingLocalHost localHost: String? = nil) -> [String]? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              root["Self"] != nil || root["Version"] != nil || root["BackendState"] != nil || root["Peer"] != nil
+        else { return nil }
         let peers: [[String: Any]] = if let dictionary = root["Peer"] as? [String: [String: Any]] {
             Array(dictionary.values)
         } else if let array = root["Peer"] as? [[String: Any]] {
@@ -50,6 +57,12 @@ public enum TailscaleStatusParser {
         }.sorted()
     }
 
+    /// Convenience returning `[]` for unparseable output. Prefer `parseHosts` when the caller needs to
+    /// distinguish a failed probe from an empty tailnet.
+    public static func hosts(from data: Data, excludingLocalHost localHost: String? = nil) -> [String] {
+        self.parseHosts(from: data, excludingLocalHost: localHost) ?? []
+    }
+
     private static func firstDNSLabel(_ value: String?) -> String? {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: CharacterSet(charactersIn: "."))
@@ -67,16 +80,38 @@ public struct RemoteSessionFetcher: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         localHost: String = ProcessInfo.processInfo.hostName) async -> [String]
     {
-        guard let tailscale = self.tailscaleBinary(environment: environment),
-              let result = try? await SubprocessRunner.run(
-                  binary: tailscale,
-                  arguments: ["status", "--json"],
-                  environment: Self.tailscaleCLIEnvironment(from: environment),
-                  timeout: 5,
-                  label: "Tailscale session host discovery"),
-              let data = result.stdout.data(using: .utf8)
-        else { return [] }
-        return TailscaleStatusParser.hosts(from: data, excludingLocalHost: localHost)
+        let probeEnvironment = Self.tailscaleCLIEnvironment(from: environment)
+        let candidates = Self.tailscaleBinaryCandidates(path: environment["PATH"])
+            .filter { FileManager.default.isExecutableFile(atPath: $0) }
+        return await Self.firstDiscoveredHosts(candidates: candidates, localHost: localHost) { binary in
+            guard let result = try? await SubprocessRunner.run(
+                binary: binary,
+                arguments: ["status", "--json"],
+                environment: probeEnvironment,
+                timeout: 5,
+                label: "Tailscale session host discovery")
+            else { return nil }
+            return Data(result.stdout.utf8)
+        }
+    }
+
+    /// Runs `tailscale status --json` on each candidate in order, falling through to the next when a
+    /// candidate fails (`run` returns nil) or returns output that isn't valid Tailscale status JSON.
+    /// Returns the first candidate's parsed hosts (possibly empty), or `[]` if none succeed. This keeps
+    /// the app-binary fallback working even when an earlier — but non-functional — `tailscale` variant
+    /// is installed (e.g. an open-source/Homebrew CLI that isn't the active client).
+    public static func firstDiscoveredHosts(
+        candidates: [String],
+        localHost: String?,
+        run: (String) async -> Data?) async -> [String]
+    {
+        for binary in candidates {
+            guard let data = await run(binary),
+                  let hosts = TailscaleStatusParser.parseHosts(from: data, excludingLocalHost: localHost)
+            else { continue }
+            return hosts
+        }
+        return []
     }
 
     public func fetch(
@@ -152,11 +187,6 @@ public struct RemoteSessionFetcher: Sendable {
         } catch {
             return RemoteSessionHostResult(host: host, sessions: [], error: error.localizedDescription)
         }
-    }
-
-    private func tailscaleBinary(environment: [String: String]) -> String? {
-        Self.tailscaleBinaryCandidates(path: environment["PATH"])
-            .first { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
     /// Ordered candidate paths for the `tailscale` CLI, most-preferred first.

--- a/Sources/CodexBarCore/RemoteSessionFetcher.swift
+++ b/Sources/CodexBarCore/RemoteSessionFetcher.swift
@@ -26,7 +26,7 @@ public enum TailscaleStatusParser {
     /// Returns `nil` when `data` is not recognizable Tailscale status JSON — a failed, wrong, or
     /// non-Tailscale `tailscale` binary — so callers can fall through to the next candidate. Returns a
     /// possibly-empty list for a valid status that simply has no eligible peers (a real answer, stop).
-    public static func parseHosts(from data: Data, excludingLocalHost localHost: String? = nil) -> [String]? {
+    package static func parseHosts(from data: Data, excludingLocalHost localHost: String? = nil) -> [String]? {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               root["Self"] != nil || root["Version"] != nil || root["BackendState"] != nil || root["Peer"] != nil
         else { return nil }
@@ -100,7 +100,7 @@ public struct RemoteSessionFetcher: Sendable {
     /// Returns the first candidate's parsed hosts (possibly empty), or `[]` if none succeed. This keeps
     /// the app-binary fallback working even when an earlier — but non-functional — `tailscale` variant
     /// is installed (e.g. an open-source/Homebrew CLI that isn't the active client).
-    public static func firstDiscoveredHosts(
+    package static func firstDiscoveredHosts(
         candidates: [String],
         localHost: String?,
         run: (String) async -> Data?) async -> [String]
@@ -196,7 +196,7 @@ public struct RemoteSessionFetcher: Sendable {
     /// wrapper, but a GUI-launched CodexBar inherits a minimal `PATH` (`/usr/bin:/bin`)
     /// that omits the standard CLI locations, so we also probe them explicitly before
     /// falling back to the app binary itself.
-    public static func tailscaleBinaryCandidates(path: String?) -> [String] {
+    package static func tailscaleBinaryCandidates(path: String?) -> [String] {
         let pathDirs = path?.split(separator: ":").map(String.init) ?? []
         var seen = Set<String>()
         var candidates = (pathDirs + ["/usr/local/bin", "/opt/homebrew/bin"])
@@ -220,7 +220,7 @@ public struct RemoteSessionFetcher: Sendable {
     /// CLI wrapper (itself a `/bin/sh` script that already exports `SHLVL`), and injecting it
     /// unconditionally keeps CLI mode guaranteed regardless of which binary `tailscaleBinary` resolves.
     /// An existing `TERM`/`SHLVL` (real terminal context) is left untouched.
-    public static func tailscaleCLIEnvironment(from environment: [String: String]) -> [String: String] {
+    package static func tailscaleCLIEnvironment(from environment: [String: String]) -> [String: String] {
         guard environment["TERM"] == nil, environment["SHLVL"] == nil else { return environment }
         var environment = environment
         environment["SHLVL"] = "1"

--- a/Tests/CodexBarTests/TailscaleSessionTests.swift
+++ b/Tests/CodexBarTests/TailscaleSessionTests.swift
@@ -14,6 +14,46 @@ struct TailscaleSessionTests {
     }
 
     @Test
+    func `binary candidates prefer the CLI wrapper over the app binary`() throws {
+        // A GUI-launched app inherits a minimal PATH that omits the CLI locations.
+        let candidates = RemoteSessionFetcher.tailscaleBinaryCandidates(path: "/usr/bin:/bin")
+
+        // The standard wrapper locations are still probed, ahead of the app binary…
+        #expect(candidates.contains("/usr/local/bin/tailscale"))
+        #expect(candidates.contains("/opt/homebrew/bin/tailscale"))
+        // …and the dual-mode app binary is the last resort.
+        #expect(candidates.last == "/Applications/Tailscale.app/Contents/MacOS/Tailscale")
+        #expect(try #require(candidates.firstIndex(of: "/usr/local/bin/tailscale")) < candidates.count - 1)
+    }
+
+    @Test
+    func `binary candidates keep PATH entries first and dedupe well-known dirs`() {
+        let candidates = RemoteSessionFetcher.tailscaleBinaryCandidates(path: "/opt/homebrew/bin:/usr/bin")
+
+        #expect(candidates.first == "/opt/homebrew/bin/tailscale")
+        #expect(candidates.count(where: { $0 == "/opt/homebrew/bin/tailscale" }) == 1)
+    }
+
+    @Test
+    func `cli environment injects a shell marker for the app-binary fallback`() {
+        // Without a marker the dual-mode binary launches the GUI instead of the CLI.
+        let env = RemoteSessionFetcher.tailscaleCLIEnvironment(from: ["PATH": "/usr/bin"])
+
+        #expect(env["SHLVL"] == "1")
+    }
+
+    @Test
+    func `cli environment preserves an existing terminal context`() {
+        // Already CLI-safe: leave TERM alone and don't fabricate a SHLVL…
+        let withTerm = RemoteSessionFetcher.tailscaleCLIEnvironment(from: ["TERM": "xterm-256color"])
+        #expect(withTerm["SHLVL"] == nil)
+
+        // …and never clobber a caller-provided SHLVL.
+        let withShlvl = RemoteSessionFetcher.tailscaleCLIEnvironment(from: ["SHLVL": "3"])
+        #expect(withShlvl["SHLVL"] == "3")
+    }
+
+    @Test
     func `ssh destinations reject options whitespace and controls`() {
         let hosts = RemoteSessionFetcher.sanitizedHosts([
             "user@clawmac",

--- a/Tests/CodexBarTests/TailscaleSessionTests.swift
+++ b/Tests/CodexBarTests/TailscaleSessionTests.swift
@@ -75,6 +75,26 @@ struct TailscaleSessionTests {
     }
 
     @Test
+    func `discovery falls through when an earlier candidate needs login`() async {
+        let inactiveStatus = Data(#"{"Version":"1.0","BackendState":"NeedsLogin","Peer":null}"#.utf8)
+        let runningStatus = Data(#"""
+        {"Version":"1.0","BackendState":"Running","Self":{"HostName":"local-mac"},
+         "Peer":{"n":{"Online":true,"OS":"linux","DNSName":"linuxbox.tail.ts.net."}}}
+        """#.utf8)
+        var probed: [String] = []
+        let hosts = await RemoteSessionFetcher.firstDiscoveredHosts(
+            candidates: ["/inactive/tailscale", "/running/tailscale"],
+            localHost: "local-mac")
+        { binary in
+            probed.append(binary)
+            return binary == "/inactive/tailscale" ? inactiveStatus : runningStatus
+        }
+
+        #expect(hosts == ["linuxbox"])
+        #expect(probed == ["/inactive/tailscale", "/running/tailscale"])
+    }
+
+    @Test
     func `discovery returns empty when no candidate yields a valid status`() async {
         let hosts = await RemoteSessionFetcher.firstDiscoveredHosts(
             candidates: ["/a/tailscale", "/b/tailscale"],
@@ -89,8 +109,11 @@ struct TailscaleSessionTests {
         #expect(TailscaleStatusParser.parseHosts(from: Data("not json".utf8)) == nil)
         #expect(TailscaleStatusParser.parseHosts(from: Data("Tailscale help text".utf8)) == nil)
         // …a valid status with no eligible peers -> [] (a real answer, stop probing).
-        let empty = TailscaleStatusParser.parseHosts(from: Data(#"{"Version":"1.0","Self":{},"Peer":null}"#.utf8))
+        let empty = TailscaleStatusParser.parseHosts(
+            from: Data(#"{"Version":"1.0","BackendState":"Running","Self":{},"Peer":null}"#.utf8))
         #expect(empty == [])
+        #expect(TailscaleStatusParser.parseHosts(
+            from: Data(#"{"Version":"1.0","BackendState":"NeedsLogin","Peer":null}"#.utf8)) == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/TailscaleSessionTests.swift
+++ b/Tests/CodexBarTests/TailscaleSessionTests.swift
@@ -67,7 +67,7 @@ struct TailscaleSessionTests {
             localHost: "local-mac")
         { binary in
             probed.append(binary)
-            return binary == "/first/tailscale" ? Data("command not found".utf8) : validStatus
+            return binary == "/first/tailscale" ? Data(#"{"Version":"1.0"}"#.utf8) : validStatus
         }
 
         #expect(hosts == ["linuxbox"])
@@ -108,6 +108,9 @@ struct TailscaleSessionTests {
         // Non-status output -> nil so the caller falls through to the next candidate…
         #expect(TailscaleStatusParser.parseHosts(from: Data("not json".utf8)) == nil)
         #expect(TailscaleStatusParser.parseHosts(from: Data("Tailscale help text".utf8)) == nil)
+        #expect(TailscaleStatusParser.parseHosts(from: Data(#"{"Version":"1.0"}"#.utf8)) == nil)
+        #expect(TailscaleStatusParser.parseHosts(from: Data(#"{"Self":null}"#.utf8)) == nil)
+        #expect(TailscaleStatusParser.parseHosts(from: Data(#"{"Peer":"error"}"#.utf8)) == nil)
         // …a valid status with no eligible peers -> [] (a real answer, stop probing).
         let empty = TailscaleStatusParser.parseHosts(
             from: Data(#"{"Version":"1.0","BackendState":"Running","Self":{},"Peer":null}"#.utf8))

--- a/Tests/CodexBarTests/TailscaleSessionTests.swift
+++ b/Tests/CodexBarTests/TailscaleSessionTests.swift
@@ -54,6 +54,46 @@ struct TailscaleSessionTests {
     }
 
     @Test
+    func `discovery falls through to the next candidate when the first fails`() async {
+        // First candidate exists but is a wrong/broken tailscale variant: its status output isn't valid
+        // Tailscale JSON. Discovery must try the next candidate rather than returning no hosts.
+        let validStatus = Data(#"""
+        {"Version":"1.0","Self":{"HostName":"local-mac"},
+         "Peer":{"n":{"Online":true,"OS":"linux","DNSName":"linuxbox.tail.ts.net."}}}
+        """#.utf8)
+        var probed: [String] = []
+        let hosts = await RemoteSessionFetcher.firstDiscoveredHosts(
+            candidates: ["/first/tailscale", "/second/tailscale"],
+            localHost: "local-mac")
+        { binary in
+            probed.append(binary)
+            return binary == "/first/tailscale" ? Data("command not found".utf8) : validStatus
+        }
+
+        #expect(hosts == ["linuxbox"])
+        #expect(probed == ["/first/tailscale", "/second/tailscale"]) // fell through, in order
+    }
+
+    @Test
+    func `discovery returns empty when no candidate yields a valid status`() async {
+        let hosts = await RemoteSessionFetcher.firstDiscoveredHosts(
+            candidates: ["/a/tailscale", "/b/tailscale"],
+            localHost: nil) { _ in Data("nope".utf8) }
+
+        #expect(hosts.isEmpty)
+    }
+
+    @Test
+    func `parseHosts distinguishes invalid output from an empty tailnet`() {
+        // Non-status output -> nil so the caller falls through to the next candidate…
+        #expect(TailscaleStatusParser.parseHosts(from: Data("not json".utf8)) == nil)
+        #expect(TailscaleStatusParser.parseHosts(from: Data("Tailscale help text".utf8)) == nil)
+        // …a valid status with no eligible peers -> [] (a real answer, stop probing).
+        let empty = TailscaleStatusParser.parseHosts(from: Data(#"{"Version":"1.0","Self":{},"Peer":null}"#.utf8))
+        #expect(empty == [])
+    }
+
+    @Test
     func `ssh destinations reject options whitespace and controls`() {
         let hosts = RemoteSessionFetcher.sanitizedHosts([
             "user@clawmac",


### PR DESCRIPTION
## Summary
- Resolve the `tailscale` CLI wrapper during Agent Sessions host discovery even under a minimal `PATH` (probe `/usr/local/bin` and `/opt/homebrew/bin`, not just the inherited `PATH`), before falling back to the app bundle binary.
- Run the probe with a shell marker (`SHLVL`) in its environment so the app-binary fallback stays in CLI mode instead of launching the Tailscale menu bar GUI.

Fixes the Tailscale menu bar icon flickering on and off every refresh. Related to the Agent Sessions discovery work in #2079.

Closes #2098.

## Root cause
`RemoteSessionFetcher.discoveredHosts` resolves the Tailscale binary via `findExecutable("tailscale", environment:)`, which searches only `environment["PATH"]`, then falls back to `/Applications/Tailscale.app/Contents/MacOS/Tailscale`. A GUI-launched CodexBar inherits a minimal `PATH` (`/usr/bin:/bin`) that omits `/usr/local/bin`, so the CLI wrapper is missed and the probe hits the app bundle binary.

That binary is dual-mode: with no shell/terminal marker in its environment it launches the full menu bar GUI (SkyLight/WindowServer, status icon) instead of running the CLI. It never emits JSON, the 5s timeout kills it, and the icon flickers. Logs show repeated `Subprocess timed out (binary=Tailscale label=Tailscale session host discovery)`.

Verified levers (Tailscale 1.98.5, each `env -i … status --json`):

| Invocation | Result |
|---|---|
| `/usr/local/bin/tailscale` (CLI wrapper) | CLI ✓ |
| bundle binary + `TERM` | CLI ✓ |
| bundle binary + `SHLVL` | CLI ✓ |
| bundle binary, no marker | GUI / hangs ✗ |
| bundle binary, lowercase `argv[0]`, empty env | GUI / hangs ✗ |
| bundle binary + `XPC_SERVICE_NAME=0` | GUI / hangs ✗ |

The `/usr/local/bin/tailscale` wrapper is a `#!/bin/sh` script that re-execs the bundle binary; it stays in CLI mode only because `/bin/sh` sets `SHLVL`. So the reliable lever is a shell/terminal marker in the environment — this PR mirrors `SHLVL`. (Foundation's `Process` derives `argv[0]` from the executable URL and can't set it independently, so the lowercase-`argv[0]` route isn't available without `posix_spawn`.)

## Behavior proof (CodexBar path)
Exercised the actual `RemoteSessionFetcher.discoveredHosts()` under a GUI-minimal `PATH`, with a `ps` watcher checking for any Tailscale GUI process for the duration:

```
[[PROOF]] resolved binary under PATH=/usr/bin:/bin -> /usr/local/bin/tailscale
[[PROOF]] discoveredHosts -> 3 host(s) in 135ms: [<hostnames redacted>]
GUI Tailscale processes observed during run: NONE
```

- Resolution selects the CLI **wrapper** even under the minimal PATH.
- Discovery returns real hosts in **135 ms** — the CLI path, not the ~5 s subprocess timeout the GUI launch produced.
- **Zero** Tailscale GUI processes spawned (bare `…/MacOS/Tailscale`, no CLI args) while the probe ran.

## Tests / checks
- `swift test --filter TailscaleSessionTests` — 6/6 (candidate-ordering + CLI-environment coverage; pure, no bundle/GUI launches per AGENTS.md).
- `make check` — SwiftFormat + SwiftLint `--strict` clean.

## Review follow-ups
- **CHANGELOG** — removed; the release process owns `CHANGELOG.md`. (This also resolved a merge conflict with `main`.)
- **Env-marker scope (P2)** — kept unconditional by design: `SHLVL` is redundant but harmless for the wrapper (itself a `/bin/sh` script that already exports `SHLVL`), and injecting it for every probe guarantees CLI mode regardless of which binary resolves. Documented in the helper's doc comment.
- The `AdaptiveRefreshTimerTests` flake noticed during validation is tracked and fixed separately in #2099 / #2101; unrelated to this change.


## Update — round 2 (addresses review P1)
Discovery previously selected the first existing `tailscale` candidate and committed to it. On a machine with multiple Tailscale variants (e.g. a Homebrew/open-source CLI *plus* the GUI app), a non-active earlier candidate could return no hosts without falling back to the app binary — a compatibility regression vs. the prior behavior. Fixed: `discoveredHosts` now **tries candidates in order and falls through** when one fails or returns output that isn't valid Tailscale status JSON, restoring the app-binary fallback. `TailscaleStatusParser.parseHosts` distinguishes a failed probe (`nil`) from a valid empty tailnet (`[]`), and a failing-first-candidate regression test covers it (`swift test --filter TailscaleSessionTests` — 9/9). End-to-end re-verified: `discoveredHosts` under a minimal PATH still returns hosts headlessly (202 ms, zero GUI launches).
