### PR TITLE
fix: skip cost-usage first-launch auto-enable under tests

### DIFF
--- a/Sources/CodexBar/SettingsStore+TokenCost.swift
+++ b/Sources/CodexBar/SettingsStore+TokenCost.swift
@@ -13,12 +13,7 @@ extension SettingsStore {
     }
 
     func applyTokenCostDefaultIfNeeded() {
-        // Skip the first-launch auto-enable under tests: it scans the real home directory for usage
-        // sources and, when it finds them, writes `costUsageEnabled` mid-startup. That write trips the
-        // background-work settings observer and adds a second, machine-dependent startup refresh, which
-        // flakes exact-count/version assertions (e.g. AdaptiveRefreshTimerTests, CodexAccountMenu…) on
-        // developer machines that have real usage logs. Tests cover the detection logic directly via
-        // `hasAnyTokenCostUsageSources`. Mirrors the other `isRunningTests` defaults in `SettingsStore`.
+        // Tests cover detection directly; skip filesystem-driven auto-enablement to keep startup deterministic.
         guard !Self.isRunningTests else { return }
         // Settings are persisted in UserDefaults.standard.
         guard UserDefaults.standard.object(forKey: "tokenCostUsageEnabled") == nil else { return }

--- a/Sources/CodexBar/SettingsStore+TokenCost.swift
+++ b/Sources/CodexBar/SettingsStore+TokenCost.swift
@@ -13,6 +13,13 @@ extension SettingsStore {
     }
 
     func applyTokenCostDefaultIfNeeded() {
+        // Skip the first-launch auto-enable under tests: it scans the real home directory for usage
+        // sources and, when it finds them, writes `costUsageEnabled` mid-startup. That write trips the
+        // background-work settings observer and adds a second, machine-dependent startup refresh, which
+        // flakes exact-count/version assertions (e.g. AdaptiveRefreshTimerTests, CodexAccountMenu…) on
+        // developer machines that have real usage logs. Tests cover the detection logic directly via
+        // `hasAnyTokenCostUsageSources`. Mirrors the other `isRunningTests` defaults in `SettingsStore`.
+        guard !Self.isRunningTests else { return }
         // Settings are persisted in UserDefaults.standard.
         guard UserDefaults.standard.object(forKey: "tokenCostUsageEnabled") == nil else { return }
 


### PR DESCRIPTION
## Summary
Skip the token-cost first-launch auto-enable when running tests, so it can't add a machine-dependent startup refresh that flakes timer/menu assertions.

Closes #2099.

## Root cause
`SettingsStore.applyTokenCostDefaultIfNeeded()` runs on every `SettingsStore` init. On first launch (key unset) it asynchronously scans the **real home directory** (`hasAnyTokenCostUsageSources()`), and if it finds usage logs it sets `costUsageEnabled = true` mid-startup. That write calls `noteBackgroundWorkSettingsChanged()`, which trips the background-work settings observer and fires an extra `refreshForSettingsChange()` — a second, one-shot startup refresh.

In tests this is non-deterministic and machine-dependent:
- Every test builds a fresh `UserDefaults` suite, so the "IfNeeded" gate is always open.
- Whether the auto-enable fires depends on whether the developer's home dir has usage logs, and whether the async write lands inside a test's timing window.

So on a developer machine with real Codex/Claude usage logs, exact-count/version assertions see an extra startup refresh and fail; on a clean CI runner they pass. Confirmed by tracing the settings-observer `onChange` back to `applyTokenCostDefaultIfNeeded → costUsageEnabled.setter`.

Two suites are affected by the same mechanism:
- `AdaptiveRefreshTimerTests."manual mode performs the initial refresh but no recurring ticks"` (`completedRefreshCount == 1`)
- `CodexAccountMenuDisplaySnapshotTests."fresh menu open coalesces account projection revalidation…"` (`menuContentVersion == versionBeforeOpen + 1`)

## Fix
Guard the auto-enable behind `!Self.isRunningTests`, mirroring the other `isRunningTests` defaults already in `SettingsStore` (e.g. the `claudeWebExtrasEnabled` reset). Production behavior is unchanged (`isRunningTests` is false there); the detection logic remains covered directly by `hasAnyTokenCostUsageSources` tests. One product line, no test-file changes.

## Proof
- `make test` ×3: both affected suites green every run (they previously flaked). Format + SwiftLint `--strict` clean.
- Isolated: `AdaptiveRefreshTimerTests` and `CodexAccountMenuDisplaySnapshotTests` pass repeatedly.

Note: one run surfaced an unrelated flake in `AntigravityCLIHTTPSFetchStrategyTests` (a network-fetch suite, not cost-usage); it recovered on the group retry and is out of scope here.

No changelog entry: test-only behavior change; production output is unaffected.

## Behavior proof (this machine has real usage logs)
The flake only fires when `hasAnyTokenCostUsageSources()` finds usage logs. This machine has them, and the affected suites pass repeatedly with the fix:

```
codex usage .jsonl: 262 ; claude usage .jsonl: 1509  => hasAnyTokenCostUsageSources = true

run 1 | ✔ Suite CodexAccountMenuDisplaySnapshotTests passed after 3.476s
run 1 | ✔ Suite AdaptiveRefreshTimerTests passed after 4.927s
run 2 | ✔ Suite CodexAccountMenuDisplaySnapshotTests passed after 1.908s
run 2 | ✔ Suite AdaptiveRefreshTimerTests passed after 4.088s
run 3 | ✔ Suite CodexAccountMenuDisplaySnapshotTests passed after 2.073s
run 3 | ✔ Suite AdaptiveRefreshTimerTests passed after 4.050s
```

Before the fix, both suites failed intermittently on this machine (the second startup refresh landing inside their timing windows). Full `make test` ×3 also passed (one unrelated `AntigravityCLIHTTPSFetchStrategyTests` network flake recovered on retry).

## On direct coverage of `applyTokenCostDefaultIfNeeded()`
The guard means the orchestration no longer runs in the test process. That removes no *intentional* coverage: previously the method ran incidentally in every test but no test asserted its outcome. The only non-trivial part — source detection — is tested directly via `hasAnyTokenCostUsageSources` with injected paths; the remainder is trivial gate→scan→set-flag wiring. A direct test of the orchestration would have to re-enable the machine-dependent home-directory scan that this change deliberately keeps out of tests. The two previously-flaky suites now serve as regression coverage that the guard holds on a machine with real logs.
