### PR TITLE
Fix Ollama URLSession retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 
 ### Fixed
+- Ollama: release temporary dashboard network sessions after each fetch, preventing repeated refreshes from retaining delegates and URL-cache resources. Thanks @astuteprogrammer!
 - Linux CLI: prevent usage rendering from crashing in Foundation bundle discovery when formatting rate windows. Thanks @thanthi-del!
 - Menus: keep overview provider-row clicks reliable during live menu rebuilds without stealing nested Copy or plan actions. Thanks @Yuxin-Qiao!
 - Startup: load persisted plan-utilization history away from the main thread so mature histories no longer delay app launch. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -250,20 +250,24 @@ public struct OllamaUsageFetcher: Sendable {
 
     public let browserDetection: BrowserDetection
     private let makeURLSession: @Sendable (URLSessionTaskDelegate?) -> URLSession
+    private let finishURLSession: @Sendable (URLSession) -> Void
 
     public init(browserDetection: BrowserDetection) {
         self.browserDetection = browserDetection
         self.makeURLSession = { delegate in
             URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
         }
+        self.finishURLSession = { $0.finishTasksAndInvalidate() }
     }
 
     init(
         browserDetection: BrowserDetection,
-        makeURLSession: @escaping @Sendable (URLSessionTaskDelegate?) -> URLSession)
+        makeURLSession: @escaping @Sendable (URLSessionTaskDelegate?) -> URLSession,
+        finishURLSession: @escaping @Sendable (URLSession) -> Void = { $0.finishTasksAndInvalidate() })
     {
         self.browserDetection = browserDetection
         self.makeURLSession = makeURLSession
+        self.finishURLSession = finishURLSession
     }
 
     public func fetch(
@@ -527,6 +531,7 @@ public struct OllamaUsageFetcher: Sendable {
         request.setValue(Self.settingsURL.absoluteString, forHTTPHeaderField: "referer")
 
         let session = self.makeURLSession(diagnostics)
+        defer { self.finishURLSession(session) }
         let httpResponse = try await session.response(for: request)
         let responseInfo = ResponseInfo(
             statusCode: httpResponse.statusCode,

--- a/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
@@ -440,6 +440,56 @@ struct OllamaUsageFetcherRetryMappingTests {
         }
     }
 
+    @Test
+    func `temporary session is finished after a successful request`() async throws {
+        defer { OllamaRetryMappingStubURLProtocol.handler = nil }
+
+        OllamaRetryMappingStubURLProtocol.handler = { request in
+            let url = try #require(request.url)
+            let body = """
+            <div>
+              <span>Session usage</span>
+              <span>1.2% used</span>
+              <span>Weekly usage</span>
+              <span>3.4% used</span>
+            </div>
+            """
+            return Self.makeResponse(url: url, body: body, statusCode: 200)
+        }
+        let recorder = OllamaSessionFinishRecorder()
+        let fetcher = self.makeCookieFetcher(finishURLSession: { session in
+            recorder.record(session)
+            session.finishTasksAndInvalidate()
+        })
+
+        _ = try await fetcher.fetch(
+            cookieHeaderOverride: "session=test-cookie",
+            manualCookieMode: true)
+
+        #expect(recorder.count == 1)
+    }
+
+    @Test
+    func `temporary session is finished after a transport failure`() async {
+        defer { OllamaRetryMappingStubURLProtocol.handler = nil }
+
+        OllamaRetryMappingStubURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+        let recorder = OllamaSessionFinishRecorder()
+        let fetcher = self.makeCookieFetcher(finishURLSession: { session in
+            recorder.record(session)
+            session.finishTasksAndInvalidate()
+        })
+
+        await #expect(throws: URLError.self) {
+            _ = try await fetcher.fetch(
+                cookieHeaderOverride: "session=test-cookie",
+                manualCookieMode: true)
+        }
+        #expect(recorder.count == 1)
+    }
+
     private func makeCookieFetcher(
         finishURLSession: @escaping @Sendable (URLSession) -> Void = { $0.finishTasksAndInvalidate() })
         -> OllamaUsageFetcher

--- a/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
@@ -416,14 +416,42 @@ struct OllamaUsageFetcherRetryMappingTests {
         }
     }
 
-    private func makeCookieFetcher() -> OllamaUsageFetcher {
+    @Test
+    func `temporary session is finished after a failed request`() async throws {
+        defer { OllamaRetryMappingStubURLProtocol.handler = nil }
+
+        let landingURL = try #require(URL(string: "https://ollama.com/settings"))
+        OllamaRetryMappingStubURLProtocol.handler = { _ in
+            Self.makeResponse(url: landingURL, body: "Service unavailable", statusCode: 503)
+        }
+        let recorder = OllamaSessionFinishRecorder()
+        let fetcher = self.makeCookieFetcher(finishURLSession: { session in
+            recorder.record(session)
+            session.finishTasksAndInvalidate()
+        })
+
+        do {
+            _ = try await fetcher.fetch(
+                cookieHeaderOverride: "session=expired-cookie",
+                manualCookieMode: true)
+            Issue.record("Expected OllamaUsageError.networkError")
+        } catch is OllamaUsageError {
+            #expect(recorder.count == 1)
+        }
+    }
+
+    private func makeCookieFetcher(
+        finishURLSession: @escaping @Sendable (URLSession) -> Void = { $0.finishTasksAndInvalidate() })
+        -> OllamaUsageFetcher
+    {
         OllamaUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),
             makeURLSession: { delegate in
                 let config = URLSessionConfiguration.ephemeral
                 config.protocolClasses = [OllamaRetryMappingStubURLProtocol.self]
                 return URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
-            })
+            },
+            finishURLSession: finishURLSession)
     }
 
     private static func makeResponse(
@@ -437,6 +465,21 @@ struct OllamaUsageFetcherRetryMappingTests {
             httpVersion: "HTTP/1.1",
             headerFields: ["Content-Type": "text/html"])!
         return (response, Data(body.utf8))
+    }
+}
+
+private final class OllamaSessionFinishRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var sessions: [URLSession] = []
+
+    var count: Int {
+        self.lock.withLock { self.sessions.count }
+    }
+
+    func record(_ session: URLSession) {
+        self.lock.withLock {
+            self.sessions.append(session)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- finish and invalidate each temporary Ollama dashboard `URLSession` after its request completes
- cover cleanup on the error path with an injected session-finishing hook
- prevent repeated Ollama refreshes from retaining delegates, URL caches, SQLite connections, queues, and dispatch sources

## Runtime evidence

Three heap snapshots from the same CodexBar 0.41.0 process showed these objects growing in lockstep:

| Object | Baseline | Later | Final |
|---|---:|---:|---:|
| `OllamaUsageFetcher.RedirectDiagnostics` | 160 | 217 | 557 |
| `__NSURLSessionLocal` | 163 | 220 | 560 |
| URL-cache SQLite connections | 161 | 218 | 558 |
| `NSURLSessionConfiguration` | 165 | 222 | 562 |

Over the same run, heap usage grew from 83.6 MB to 166.4 MB and physical footprint from 118 MB to 228 MB (311.9 MB peak). `URLSession` retains its delegate until invalidated; the temporary session in `fetchHTMLWithDiagnostics` was never invalidated.

## Validation

- `swift test --filter OllamaUsageFetcherRetryMappingTests` (18 tests passed)
- `make check` (0 violations)
- `make test` reached an unrelated pre-existing timing failure in `AdaptiveRefreshTimerTests`: `manual mode performs the initial refresh but no recurring ticks` observed 2 refreshes instead of 1, including on the automatic full-group retry

## Post-fix runtime retention proof

I built the final PR branch (`09e26606`) and ran 100 consecutive Ollama dashboard fetches in one long-lived process. Each fetch created the production ephemeral delegated `URLSession`, exercised the HTTP 503/error exit through `URLProtocol`, and used the branch's production `finishTasksAndInvalidate()` cleanup. I paused the same process before and after the 100 requests and captured `heap` plus `footprint` snapshots.

| Live object / metric | Before 100 fetches | After 100 fetches |
|---|---:|---:|
| `OllamaUsageFetcher.RedirectDiagnostics` | 0 | 0 |
| `__NSURLSessionLocal` | 0 | 0 |
| `NSURLSessionConfiguration` | 0 | 0 |
| URL-cache SQLite connections | 0 | 0 |
| `CFURLCache` instances | 0 | 0 |
| `CFHTTPCookieStorage` | 0 | 0 |
| serial dispatch queues | 12 | 12 |
| dispatch sources | 8 | 8 |
| physical footprint | 26 MB | 26 MB |
| total heap | 1,698,832 bytes | 1,748,816 bytes |

The relevant retained-resource families remained flat after 100 requests. Total heap changed by only 49,984 bytes (~0.05 MB), while physical footprint remained 26 MB. This contrasts with the pre-fix app process, where each refresh left one matching Ollama delegate/session/cache/SQLite group and counts rose from approximately 160 to 557.

The proof used no real credentials, cookies, Keychain access, or provider response contents. The temporary stress harness was removed afterward; the working tree is clean and the PR commit is unchanged.
