### PR TITLE
test: assert quota alert presentation state

### DIFF
--- a/Tests/CodexBarTests/QuotaWarningAlertPresentationStateTests.swift
+++ b/Tests/CodexBarTests/QuotaWarningAlertPresentationStateTests.swift
@@ -17,7 +17,8 @@ struct QuotaWarningAlertPresentationStateTests {
     @Test
     func `manual dismissal clears current alert`() {
         var state = QuotaWarningAlertPresentationState()
-        state.present(title: "Session quota low", message: "20% left")
+        let presentation = state.present(title: "Session quota low", message: "20% left")
+        #expect(state.current == presentation)
 
         state.dismiss()
 


### PR DESCRIPTION
## Summary
- capture the presentation returned by the quota alert state test before dismissal
- assert it is the current alert so the test covers setup and avoids Swift no-usage warnings

## Tests
- swift test --filter QuotaWarningAlertPresentationStateTests
- node Scripts/check-site-locales.mjs
- node Scripts/generate-llms.mjs check
- swift test --filter ConfigurationDocsProviderIDTests
- make check

## Focused proof
```text
$ swift test --filter QuotaWarningAlertPresentationStateTests
[0/1] Planning build
Building for debugging...
Build complete! (7.22s)
◇ Suite QuotaWarningAlertPresentationStateTests started.
◇ Test "replacement alert ignores stale dismissal" started.
◇ Test "manual dismissal clears current alert" started.
✔ Test "replacement alert ignores stale dismissal" passed after 0.001 seconds.
✔ Test "manual dismissal clears current alert" passed after 0.001 seconds.
✔ Suite QuotaWarningAlertPresentationStateTests passed after 0.001 seconds.
✔ Test run with 2 tests in 1 suite passed after 0.001 seconds.
```

## Compatibility
- Test-only change; no runtime behavior.