### PR TITLE
perf: cache Claude CLI version probes by executable fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 
 ### Fixed
+- Claude: cache successful CLI version probes for 30 minutes while invalidating on executable changes, avoiding repeated PTY launches without retaining failed or stale wrapper results. Thanks @Yuxin-Qiao!
 - Linux CLI: prevent usage rendering from crashing in Foundation bundle discovery when formatting rate windows. Thanks @thanthi-del!
 - Menus: keep overview provider-row clicks reliable during live menu rebuilds without stealing nested Copy or plan actions. Thanks @Yuxin-Qiao!
 - Startup: load persisted plan-utilization history away from the main thread so mature histories no longer delay app launch. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
+++ b/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
@@ -8,28 +8,161 @@ import Musl
 import Foundation
 
 public enum ProviderVersionDetector {
-    public static func claudeVersion() -> String? {
-        guard let path = TTYCommandRunner.which("claude") else { return nil }
+    private struct ClaudeExecutableFingerprint: Equatable, Hashable {
+        let realPath: String
+        let modificationDate: Date
+        let fileSize: UInt64
+        let inode: UInt64
+    }
+
+    private final class PendingDetection {
+        let group = DispatchGroup()
+        var result: String?
+    }
+
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var claudeVersionCache: [ClaudeExecutableFingerprint: String] = [:]
+    private nonisolated(unsafe) static var claudePendingDetections: [ClaudeExecutableFingerprint: PendingDetection] =
+        [:]
+
+    #if DEBUG
+    public nonisolated(unsafe) static var whichHook: ((String) -> String?)?
+    public nonisolated(unsafe) static var attributesHook: ((String) -> [FileAttributeKey: Any]?)?
+    public nonisolated(unsafe) static var runClaudeVersionHook: ((String) throws -> String?)?
+
+    public static func resetHooksAndCache() {
+        self.lock.lock()
+        self.claudeVersionCache.removeAll()
+        self.claudePendingDetections.removeAll()
+        self.whichHook = nil
+        self.attributesHook = nil
+        self.runClaudeVersionHook = nil
+        self.lock.unlock()
+    }
+    #endif
+
+    private static func resolveRealPath(_ path: String) -> String {
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        if realpath(path, &buffer) != nil {
+            return buffer.withUnsafeBufferPointer { rawBuffer in
+                guard let baseAddress = rawBuffer.baseAddress else { return path }
+                return String(cString: baseAddress)
+            }
+        }
+        return URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+    }
+
+    private static func getClaudeFingerprint(forPath path: String) -> ClaudeExecutableFingerprint? {
+        let resolvedPath = self.resolveRealPath(path)
+        #if DEBUG
+        let attributesOpt = self.attributesHook != nil ? self.attributesHook?(resolvedPath) : try? FileManager.default
+            .attributesOfItem(atPath: resolvedPath)
+        #else
+        let attributesOpt = try? FileManager.default.attributesOfItem(atPath: resolvedPath)
+        #endif
+        guard let attributes = attributesOpt else {
+            return nil
+        }
+        guard let modificationDate = attributes[.modificationDate] as? Date,
+              let fileSize = (attributes[.size] as? NSNumber)?.uint64Value,
+              let inode = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value
+        else {
+            return nil
+        }
+        return ClaudeExecutableFingerprint(
+            realPath: resolvedPath,
+            modificationDate: modificationDate,
+            fileSize: fileSize,
+            inode: inode)
+    }
+
+    private static func runClaudeVersionCommand(path: String) -> String? {
+        let rawOut: String?
+        #if DEBUG
+        if let hook = runClaudeVersionHook {
+            do {
+                rawOut = try hook(path)
+            } catch {
+                rawOut = nil
+            }
+        } else {
+            do {
+                rawOut = try TTYCommandRunner().run(
+                    binary: path,
+                    send: "",
+                    options: TTYCommandRunner.Options(
+                        timeout: 5.0,
+                        extraArgs: ["--version"],
+                        initialDelay: 0.0,
+                        useClaudeProbeWorkingDirectory: true)).text
+            } catch {
+                rawOut = nil
+            }
+        }
+        #else
         do {
-            let out = try TTYCommandRunner().run(
+            rawOut = try TTYCommandRunner().run(
                 binary: path,
                 send: "",
                 options: TTYCommandRunner.Options(
                     timeout: 5.0,
-                    // `--version` alone makes Claude Code print and exit before it
-                    // initializes its credential subsystem. Passing `--allowed-tools`
-                    // (even empty) makes it treat the invocation as a real session and
-                    // read the OAuth token from the macOS keychain ("Claude Code-credentials"),
-                    // which spawns `/usr/bin/security` and triggers a keychain prompt on
-                    // every probe when no ~/.claude/.credentials.json / env token exists.
                     extraArgs: ["--version"],
                     initialDelay: 0.0,
                     useClaudeProbeWorkingDirectory: true)).text
-            let trimmed = TextParsing.stripANSICodes(out).trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
         } catch {
-            return nil
+            rawOut = nil
         }
+        #endif
+
+        guard let out = rawOut else { return nil }
+        let trimmed = TextParsing.stripANSICodes(out).trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    public static func claudeVersion() -> String? {
+        #if DEBUG
+        let pathOpt = self.whichHook != nil ? self.whichHook!("claude") : TTYCommandRunner.which("claude")
+        #else
+        let pathOpt = TTYCommandRunner.which("claude")
+        #endif
+        guard let path = pathOpt else { return nil }
+
+        guard let fingerprint = getClaudeFingerprint(forPath: path) else {
+            return self.runClaudeVersionCommand(path: path)
+        }
+
+        self.lock.lock()
+        if let cached = claudeVersionCache[fingerprint] {
+            self.lock.unlock()
+            return cached
+        }
+
+        if let pending = claudePendingDetections[fingerprint] {
+            self.lock.unlock()
+            pending.group.wait()
+            self.lock.lock()
+            let result = pending.result
+            self.lock.unlock()
+            return result
+        }
+
+        let pending = PendingDetection()
+        pending.group.enter()
+        self.claudePendingDetections[fingerprint] = pending
+        self.lock.unlock()
+
+        let result = self.runClaudeVersionCommand(path: path)
+
+        self.lock.lock()
+        pending.result = result
+        if let version = result {
+            self.claudeVersionCache[fingerprint] = version
+        }
+        self.claudePendingDetections.removeValue(forKey: fingerprint)
+        pending.group.leave()
+        self.lock.unlock()
+
+        return result
     }
 
     public static func codexVersion() -> String? {

--- a/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
+++ b/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
@@ -15,31 +15,48 @@ public enum ProviderVersionDetector {
         let inode: UInt64
     }
 
+    private struct ClaudeVersionCacheEntry {
+        let fingerprint: ClaudeExecutableFingerprint
+        let version: String
+        let cachedAt: Date
+    }
+
     private final class PendingDetection {
         let group = DispatchGroup()
         var result: String?
     }
 
+    static let claudeVersionCacheTTL: TimeInterval = 30 * 60
     private static let lock = NSLock()
-    private nonisolated(unsafe) static var claudeVersionCache: [ClaudeExecutableFingerprint: String] = [:]
+    private nonisolated(unsafe) static var claudeVersionCache: ClaudeVersionCacheEntry?
     private nonisolated(unsafe) static var claudePendingDetections: [ClaudeExecutableFingerprint: PendingDetection] =
         [:]
 
     #if DEBUG
     public nonisolated(unsafe) static var whichHook: ((String) -> String?)?
     public nonisolated(unsafe) static var attributesHook: ((String) -> [FileAttributeKey: Any]?)?
-    public nonisolated(unsafe) static var runClaudeVersionHook: ((String) throws -> String?)?
+    public nonisolated(unsafe) static var runClaudeVersionHook: ((String) throws -> TTYCommandRunner.Result?)?
+    public nonisolated(unsafe) static var nowHook: (() -> Date)?
 
     public static func resetHooksAndCache() {
         self.lock.lock()
-        self.claudeVersionCache.removeAll()
+        self.claudeVersionCache = nil
         self.claudePendingDetections.removeAll()
         self.whichHook = nil
         self.attributesHook = nil
         self.runClaudeVersionHook = nil
+        self.nowHook = nil
         self.lock.unlock()
     }
     #endif
+
+    private static func currentDate() -> Date {
+        #if DEBUG
+        return self.nowHook?() ?? Date()
+        #else
+        return Date()
+        #endif
+    }
 
     private static func resolveRealPath(_ path: String) -> String {
         var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
@@ -77,45 +94,48 @@ public enum ProviderVersionDetector {
     }
 
     private static func runClaudeVersionCommand(path: String) -> String? {
-        let rawOut: String?
+        let commandResult: TTYCommandRunner.Result?
         #if DEBUG
         if let hook = runClaudeVersionHook {
             do {
-                rawOut = try hook(path)
+                commandResult = try hook(path)
             } catch {
-                rawOut = nil
+                commandResult = nil
             }
         } else {
             do {
-                rawOut = try TTYCommandRunner().run(
+                commandResult = try TTYCommandRunner().run(
                     binary: path,
                     send: "",
                     options: TTYCommandRunner.Options(
                         timeout: 5.0,
                         extraArgs: ["--version"],
                         initialDelay: 0.0,
-                        useClaudeProbeWorkingDirectory: true)).text
+                        useClaudeProbeWorkingDirectory: true))
             } catch {
-                rawOut = nil
+                commandResult = nil
             }
         }
         #else
         do {
-            rawOut = try TTYCommandRunner().run(
+            commandResult = try TTYCommandRunner().run(
                 binary: path,
                 send: "",
                 options: TTYCommandRunner.Options(
                     timeout: 5.0,
                     extraArgs: ["--version"],
                     initialDelay: 0.0,
-                    useClaudeProbeWorkingDirectory: true)).text
+                    useClaudeProbeWorkingDirectory: true))
         } catch {
-            rawOut = nil
+            commandResult = nil
         }
         #endif
 
-        guard let out = rawOut else { return nil }
-        let trimmed = TextParsing.stripANSICodes(out).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let commandResult,
+              commandResult.completion == .processExited(status: 0)
+        else { return nil }
+        let trimmed = TextParsing.stripANSICodes(commandResult.text)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
 
@@ -130,12 +150,19 @@ public enum ProviderVersionDetector {
         guard let fingerprint = getClaudeFingerprint(forPath: path) else {
             return self.runClaudeVersionCommand(path: path)
         }
-
         self.lock.lock()
-        if let cached = claudeVersionCache[fingerprint] {
+        let now = self.currentDate()
+        let cacheAge = self.claudeVersionCache.map { now.timeIntervalSince($0.cachedAt) }
+        if let cached = claudeVersionCache,
+           cached.fingerprint == fingerprint,
+           let cacheAge,
+           cacheAge >= 0,
+           cacheAge < self.claudeVersionCacheTTL
+        {
             self.lock.unlock()
-            return cached
+            return cached.version
         }
+        self.claudeVersionCache = nil
 
         if let pending = claudePendingDetections[fingerprint] {
             self.lock.unlock()
@@ -152,11 +179,15 @@ public enum ProviderVersionDetector {
         self.lock.unlock()
 
         let result = self.runClaudeVersionCommand(path: path)
+        let completedAt = self.currentDate()
 
         self.lock.lock()
         pending.result = result
         if let version = result {
-            self.claudeVersionCache[fingerprint] = version
+            self.claudeVersionCache = ClaudeVersionCacheEntry(
+                fingerprint: fingerprint,
+                version: version,
+                cachedAt: completedAt)
         }
         self.claudePendingDetections.removeValue(forKey: fingerprint)
         pending.group.leave()
@@ -173,7 +204,9 @@ public enum ProviderVersionDetector {
             ["-v"],
         ]
         for args in candidates {
-            if let version = Self.run(path: path, args: args) { return version }
+            if let version = Self.run(path: path, args: args) {
+                return version
+            }
         }
         return nil
     }
@@ -187,7 +220,9 @@ public enum ProviderVersionDetector {
             ["-v"],
         ]
         for args in candidates {
-            if let version = Self.run(path: path, args: args) { return version }
+            if let version = Self.run(path: path, args: args) {
+                return version
+            }
         }
         return nil
     }

--- a/Tests/CodexBarTests/ProviderVersionDetectorTests.swift
+++ b/Tests/CodexBarTests/ProviderVersionDetectorTests.swift
@@ -67,4 +67,271 @@ final class ProviderVersionDetectorTests: XCTestCase {
                 .trimmingCharacters(in: .whitespacesAndNewlines)))
         XCTAssertEqual(kill(childPID, 0), 0, "Descendant should still hold the inherited pipe open")
     }
+
+    override func setUp() {
+        super.setUp()
+        ProviderVersionDetector.resetHooksAndCache()
+    }
+
+    override func tearDown() {
+        ProviderVersionDetector.resetHooksAndCache()
+        super.tearDown()
+    }
+
+    private final class MockDetectorState {
+        var callCount = 0
+        var runDelay: TimeInterval?
+        var runnerResult: String? = "claude-code 2.1.70"
+        let lock = NSLock()
+
+        func increment() -> String? {
+            self.lock.lock()
+            self.callCount += 1
+            let delay = self.runDelay
+            let res = self.runnerResult
+            self.lock.unlock()
+            if let delay {
+                Thread.sleep(forTimeInterval: delay)
+            }
+            return res
+        }
+    }
+
+    func test_claudeVersion_cachesSuccessfulResult() {
+        let state = MockDetectorState()
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in
+            state.increment()
+        }
+
+        let first = ProviderVersionDetector.claudeVersion()
+        XCTAssertEqual(first, "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 1)
+
+        let second = ProviderVersionDetector.claudeVersion()
+        XCTAssertEqual(second, "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 1)
+    }
+
+    func test_claudeVersion_productionPathProof() {
+        let state = MockDetectorState()
+        var size = 5000
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: size),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in
+            state.increment()
+        }
+
+        let cold = ProviderVersionDetector.claudeVersion()
+        let warm = ProviderVersionDetector.claudeVersion()
+        size = 6000
+        let afterFingerprintChange = ProviderVersionDetector.claudeVersion()
+
+        print(
+            "ProviderVersionDetector proof: cold=\(cold ?? "nil") "
+                + "warm=\(warm ?? "nil") "
+                + "afterFingerprintChange=\(afterFingerprintChange ?? "nil") "
+                + "productionProbeCount=\(state.callCount)")
+        XCTAssertEqual(cold, "claude-code 2.1.70")
+        XCTAssertEqual(warm, "claude-code 2.1.70")
+        XCTAssertEqual(afterFingerprintChange, "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 2)
+    }
+
+    func test_claudeVersion_realExecutableProof() throws {
+        guard let path = TTYCommandRunner.which("claude") else {
+            throw XCTSkip("claude executable is not installed in PATH")
+        }
+
+        let direct = try XCTUnwrap(ProviderVersionDetector.run(path: path, args: ["--version"]))
+        let cold = try XCTUnwrap(ProviderVersionDetector.claudeVersion())
+        let warm = try XCTUnwrap(ProviderVersionDetector.claudeVersion())
+
+        print(
+            "Claude real executable proof: path=\(URL(fileURLWithPath: path).lastPathComponent) "
+                + "direct=\(direct) cold=\(cold) warm=\(warm)")
+        XCTAssertEqual(cold, direct)
+        XCTAssertEqual(warm, direct)
+    }
+
+    func test_claudeVersion_coalescesConcurrentProbes() {
+        let state = MockDetectorState()
+        state.runDelay = 0.1
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in
+            state.increment()
+        }
+
+        let totalThreads = 20
+        let semaphore = DispatchSemaphore(value: 0)
+
+        for _ in 0..<totalThreads {
+            DispatchQueue.global().async {
+                let res = ProviderVersionDetector.claudeVersion()
+                XCTAssertEqual(res, "claude-code 2.1.70")
+                semaphore.signal()
+            }
+        }
+
+        for _ in 0..<totalThreads {
+            let result = semaphore.wait(timeout: .now() + 2.0)
+            XCTAssertEqual(result, .success, "Concurrent call timed out")
+        }
+
+        XCTAssertEqual(state.callCount, 1)
+    }
+
+    func test_claudeVersion_invalidatesOnModificationDateChange() {
+        let state = MockDetectorState()
+        var modDate = Date(timeIntervalSince1970: 1000)
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: modDate,
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in
+            state.increment()
+        }
+
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 1)
+
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 1)
+
+        modDate = Date(timeIntervalSince1970: 2000)
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 2)
+    }
+
+    func test_claudeVersion_invalidatesOnSizeOrInodeOrPathChange() {
+        let state = MockDetectorState()
+        var path = "/mock/bin/claude"
+        var size = 5000
+        var inode = 99
+        ProviderVersionDetector.whichHook = { _ in path }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: size),
+                .systemFileNumber: NSNumber(value: inode),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in
+            state.increment()
+        }
+
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 1)
+
+        size = 6000
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 2)
+
+        inode = 100
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 3)
+
+        path = "/mock/bin/claude2"
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 4)
+    }
+
+    func test_claudeVersion_doesNotCacheFailurePermanently() {
+        let state = MockDetectorState()
+        state.runnerResult = nil
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in
+            state.increment()
+        }
+
+        XCTAssertNil(ProviderVersionDetector.claudeVersion())
+        XCTAssertEqual(state.callCount, 1)
+
+        XCTAssertNil(ProviderVersionDetector.claudeVersion())
+        XCTAssertEqual(state.callCount, 2)
+
+        state.lock.lock()
+        state.runnerResult = "claude-code 2.1.70"
+        state.lock.unlock()
+
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 3)
+
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 3)
+    }
+
+    func test_claudeVersion_doesNotCacheEmptyOutput() {
+        let state = MockDetectorState()
+        state.runnerResult = "  "
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in
+            state.increment()
+        }
+
+        XCTAssertNil(ProviderVersionDetector.claudeVersion())
+        XCTAssertEqual(state.callCount, 1)
+
+        XCTAssertNil(ProviderVersionDetector.claudeVersion())
+        XCTAssertEqual(state.callCount, 2)
+    }
+
+    func test_claudeVersion_benchmark1000SequentialCalls() {
+        let state = MockDetectorState()
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in
+            state.increment()
+        }
+
+        for _ in 0..<1000 {
+            _ = ProviderVersionDetector.claudeVersion()
+        }
+
+        XCTAssertEqual(state.callCount, 1)
+    }
 }

--- a/Tests/CodexBarTests/ProviderVersionDetectorTests.swift
+++ b/Tests/CodexBarTests/ProviderVersionDetectorTests.swift
@@ -81,10 +81,12 @@ final class ProviderVersionDetectorTests: XCTestCase {
     private final class MockDetectorState {
         var callCount = 0
         var runDelay: TimeInterval?
-        var runnerResult: String? = "claude-code 2.1.70"
+        var runnerResult: TTYCommandRunner.Result? = .init(
+            text: "claude-code 2.1.70",
+            completion: .processExited(status: 0))
         let lock = NSLock()
 
-        func increment() -> String? {
+        func increment() -> TTYCommandRunner.Result? {
             self.lock.lock()
             self.callCount += 1
             let delay = self.runDelay
@@ -94,6 +96,12 @@ final class ProviderVersionDetectorTests: XCTestCase {
                 Thread.sleep(forTimeInterval: delay)
             }
             return res
+        }
+
+        func setResult(text: String, completion: TTYCommandRunner.Result.Completion = .processExited(status: 0)) {
+            self.lock.lock()
+            self.runnerResult = .init(text: text, completion: completion)
+            self.lock.unlock()
         }
     }
 
@@ -152,6 +160,9 @@ final class ProviderVersionDetectorTests: XCTestCase {
     }
 
     func test_claudeVersion_realExecutableProof() throws {
+        guard ProcessInfo.processInfo.environment["LIVE_CLAUDE_TTY"] == "1" else {
+            throw XCTSkip("Set LIVE_CLAUDE_TTY=1 to probe the installed Claude executable")
+        }
         guard let path = TTYCommandRunner.which("claude") else {
             throw XCTSkip("claude executable is not installed in PATH")
         }
@@ -281,9 +292,7 @@ final class ProviderVersionDetectorTests: XCTestCase {
         XCTAssertNil(ProviderVersionDetector.claudeVersion())
         XCTAssertEqual(state.callCount, 2)
 
-        state.lock.lock()
-        state.runnerResult = "claude-code 2.1.70"
-        state.lock.unlock()
+        state.setResult(text: "claude-code 2.1.70")
 
         XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
         XCTAssertEqual(state.callCount, 3)
@@ -294,7 +303,7 @@ final class ProviderVersionDetectorTests: XCTestCase {
 
     func test_claudeVersion_doesNotCacheEmptyOutput() {
         let state = MockDetectorState()
-        state.runnerResult = "  "
+        state.setResult(text: "  ")
         ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
         ProviderVersionDetector.attributesHook = { _ in
             [
@@ -311,6 +320,102 @@ final class ProviderVersionDetectorTests: XCTestCase {
         XCTAssertEqual(state.callCount, 1)
 
         XCTAssertNil(ProviderVersionDetector.claudeVersion())
+        XCTAssertEqual(state.callCount, 2)
+    }
+
+    func test_claudeVersion_doesNotCacheNonzeroExitDiagnostics() {
+        let state = MockDetectorState()
+        state.setResult(
+            text: "claude-code 2.1.70 failed to load",
+            completion: .processExited(status: 1))
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in state.increment() }
+
+        XCTAssertNil(ProviderVersionDetector.claudeVersion())
+        XCTAssertEqual(state.callCount, 1)
+
+        state.setResult(text: "claude-code 2.1.70")
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 2)
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 2)
+    }
+
+    func test_claudeVersion_doesNotCacheDeadlineOutput() {
+        let state = MockDetectorState()
+        state.setResult(text: "claude-code 2.1.70", completion: .deadlineExceeded)
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in state.increment() }
+
+        XCTAssertNil(ProviderVersionDetector.claudeVersion())
+        XCTAssertEqual(state.callCount, 1)
+
+        state.setResult(text: "claude-code 2.1.70")
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 2)
+    }
+
+    func test_claudeVersion_refreshesStableWrapperAfterTTL() {
+        let state = MockDetectorState()
+        var now = Date(timeIntervalSince1970: 10000)
+        ProviderVersionDetector.nowHook = { now }
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in state.increment() }
+
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 1)
+
+        state.setResult(text: "claude-code 2.1.71")
+        now.addTimeInterval(ProviderVersionDetector.claudeVersionCacheTTL - 1)
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 1)
+
+        now.addTimeInterval(2)
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.71")
+        XCTAssertEqual(state.callCount, 2)
+    }
+
+    func test_claudeVersion_refreshesAfterClockRollback() {
+        let state = MockDetectorState()
+        var now = Date(timeIntervalSince1970: 10000)
+        ProviderVersionDetector.nowHook = { now }
+        ProviderVersionDetector.whichHook = { _ in "/mock/bin/claude" }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in state.increment() }
+
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.70")
+        XCTAssertEqual(state.callCount, 1)
+
+        state.setResult(text: "claude-code 2.1.71")
+        now.addTimeInterval(-1)
+        XCTAssertEqual(ProviderVersionDetector.claudeVersion(), "claude-code 2.1.71")
         XCTAssertEqual(state.callCount, 2)
     }
 


### PR DESCRIPTION
### Summary

- Cache successful Claude CLI version probes for 30 minutes.
- Invalidate immediately when the resolved executable fingerprint changes.
- Coalesce concurrent probes without retaining nonzero, timed-out, empty, or thrown results.
- Keep real installed-CLI probing explicit through `LIVE_CLAUDE_TTY=1`.

### Maintainer hardening

- Replaced the unbounded fingerprint dictionary with one bounded cache entry.
- Added TTL refresh for stable wrapper paths whose target may change without wrapper metadata changing.
- Require a successful exit status before accepting output as a version.
- Reject negative cache ages after wall-clock rollback and sample cache time inside the lock.
- Added deterministic coverage for failure retry, deadline retry, TTL expiry, clock rollback, fingerprint invalidation, and concurrent single-flight behavior.

### Verification

- `swift test --filter ProviderVersionDetectorTests`: 16 tests, 1 explicit live-test skip, 0 failures.
- `make test`: 638 selections across 54 groups, 0 failures or retries.
- `make check`: clean.
- Autoreview: clean after two concurrency/time-edge fixes.

The live installed-Claude proof remains available with `LIVE_CLAUDE_TTY=1 swift test --filter ProviderVersionDetectorTests/test_claudeVersion_realExecutableProof`; it is opt-in to avoid unexpected PTY/account interaction in ordinary test runs.
