### PR TITLE
fix: patch groq API support

### DIFF
--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -252,7 +252,7 @@ extension UsageMenuCardView.Model {
     }
 
     static func usesProviderCostHistoryAsPrimaryDashboard(_ provider: UsageProvider) -> Bool {
-        provider == .openai || provider == .mistral
+        provider == .openai || provider == .mistral || provider == .groq
     }
 
     static func primaryCostHistorySnapshot(input: Input) -> CostUsageTokenSnapshot? {
@@ -264,6 +264,11 @@ extension UsageMenuCardView.Model {
             return input.snapshot == nil ? input.tokenSnapshot : nil
         case .mistral:
             if let projected = input.snapshot?.mistralUsage?.toCostUsageTokenSnapshot() {
+                return projected
+            }
+            return input.snapshot == nil ? input.tokenSnapshot : nil
+        case .groq:
+            if let projected = input.snapshot?.groqConsoleUsage?.toCostUsageTokenSnapshot() {
                 return projected
             }
             return input.snapshot == nil ? input.tokenSnapshot : nil

--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -383,13 +383,16 @@ extension UsageMenuCardView.Model {
         if let topModel = Self.topCostModel(from: snapshot.daily) {
             details.append("\(L("Top model")): \(Self.shortModelName(topModel))")
         }
-        if let requestCount = snapshot.last30DaysRequests {
-            details.append("\(requestHistoryTitle): \(UsageFormatter.tokenCountString(requestCount)) \(L("requests"))")
-        }
-        if let hint = Self.tokenUsageHint(provider: provider) {
-            details.append(hint)
-        } else {
-            details.append(L("cost_estimate_hint"))
+        if provider != .groq {
+            if let requestCount = snapshot.last30DaysRequests {
+                details
+                    .append("\(requestHistoryTitle): \(UsageFormatter.tokenCountString(requestCount)) \(L("requests"))")
+            }
+            if let hint = Self.tokenUsageHint(provider: provider) {
+                details.append(hint)
+            } else {
+                details.append(L("cost_estimate_hint"))
+            }
         }
         let providerName = ProviderDefaults.metadata[provider]?.displayName ?? provider.rawValue
         var model = InlineUsageDashboardModel(

--- a/Sources/CodexBar/Providers/Groq/GroqProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Groq/GroqProviderImplementation.swift
@@ -14,6 +14,9 @@ struct GroqProviderImplementation: ProviderImplementation {
         _ = settings.groqAPIKey
     }
 
+    // No `isAvailable` override: when Groq is enabled, the fetch pipeline resolves
+    // the console browser session (primary) or the optional API key (Enterprise
+    // Prometheus fallback). Matches the MiMo cookie provider.
 
     @MainActor
     func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {

--- a/Sources/CodexBar/Providers/Groq/GroqProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Groq/GroqProviderImplementation.swift
@@ -14,11 +14,6 @@ struct GroqProviderImplementation: ProviderImplementation {
         _ = settings.groqAPIKey
     }
 
-    @MainActor
-    func isAvailable(context: ProviderAvailabilityContext) -> Bool {
-        ProviderTokenResolver.groqToken(environment: context.environment) != nil ||
-            !context.settings.groqAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
 
     @MainActor
     func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {

--- a/Sources/CodexBar/Providers/Groq/GroqProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Groq/GroqProviderImplementation.swift
@@ -26,7 +26,8 @@ struct GroqProviderImplementation: ProviderImplementation {
             ProviderSettingsFieldDescriptor(
                 id: "groq-api-key",
                 title: "API key",
-                subtitle: "Stored in ~/.codexbar/config.json. Metrics require Groq Enterprise Prometheus access.",
+                subtitle: "Usage & spend come from your console.groq.com browser session automatically. " +
+                    "An API key is optional and only adds Enterprise Prometheus metrics.",
                 kind: .secure,
                 placeholder: "gsk_...",
                 binding: context.stringBinding(\.groqAPIKey),

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLIAuthStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLIAuthStatusProbe.swift
@@ -5,11 +5,25 @@ enum ClaudeCLIAuthStatusProbe {
         let loggedIn: Bool
     }
 
+    @TaskLocal private static var resultOverrideForTesting: Bool?
+
+    static func withResultOverrideForTesting<T>(
+        _ result: Bool?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$resultOverrideForTesting.withValue(result) {
+            try await operation()
+        }
+    }
+
     static func isLoggedIn(
         binary: String,
         environment: [String: String],
         timeout: TimeInterval = 5) async -> Bool
     {
+        if let resultOverrideForTesting = self.resultOverrideForTesting {
+            return resultOverrideForTesting
+        }
         do {
             let result = try await SubprocessRunner.run(
                 binary: binary,

--- a/Sources/CodexBarCore/Providers/Groq/GroqConsoleFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqConsoleFetcher.swift
@@ -1,0 +1,288 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum GroqConsoleError: LocalizedError, Sendable, Equatable {
+    case missingSession
+    case invalidSession(String)
+    case accessDenied(String)
+    case apiError(String)
+    case parseFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingSession:
+            "No Groq console session found. Sign in at console.groq.com in your browser."
+        case let .invalidSession(message):
+            "Groq console session is invalid: \(message)"
+        case let .accessDenied(message):
+            "Groq console access denied: \(message)"
+        case let .apiError(message):
+            "Groq console API error: \(message)"
+        case let .parseFailed(message):
+            "Groq console parse error: \(message)"
+        }
+    }
+}
+
+/// One row from `/platform/v1/organizations/{org}/activity`. Each row is a
+/// per-model, per-day (daily `timestamp` bucket) usage/spend record.
+private struct GroqActivityResponse: Decodable {
+    struct Row: Decodable {
+        let organizationName: String?
+        let model: String?
+        let timestamp: Double
+        let numRequests: Int?
+        let nContextTokensTotal: Int?
+        let nNonCachedContextTokensTotal: Int?
+        let nGeneratedTokensTotal: Int?
+        let cost: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case organizationName = "organization_name"
+            case model
+            case timestamp
+            case numRequests = "num_requests"
+            case nContextTokensTotal = "n_context_tokens_total"
+            case nNonCachedContextTokensTotal = "n_non_cached_context_tokens_total"
+            case nGeneratedTokensTotal = "n_generated_tokens_total"
+            case cost
+        }
+    }
+
+    let data: [Row]
+}
+
+public struct GroqConsoleFetcher: Sendable {
+    public init() {}
+
+    static func fetchUsage(
+        session: GroqConsoleSession.SessionInfo,
+        historyDays: Int = 30,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        now: Date = Date()) async throws -> GroqConsoleUsageSnapshot
+    {
+        let jwt = try await GroqConsoleSession.resolveJWT(
+            for: session,
+            environment: environment,
+            transport: transport)
+        return try await self.fetchUsage(
+            sessionJWT: jwt,
+            historyDays: historyDays,
+            environment: environment,
+            transport: transport,
+            now: now)
+    }
+
+    public static func fetchUsage(
+        sessionJWT: String,
+        historyDays: Int = 30,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        now: Date = Date()) async throws -> GroqConsoleUsageSnapshot
+    {
+        let token = sessionJWT.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { throw GroqConsoleError.missingSession }
+
+        guard let orgID = Self.organizationID(fromJWT: token) else {
+            throw GroqConsoleError.invalidSession("session token is missing the organization claim")
+        }
+
+        try GroqSettingsReader.validateEndpointOverrides(environment: environment)
+        let days = max(1, min(365, historyDays))
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: now)
+        // Include the full current day; the platform API bounds by unix seconds.
+        let end = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? now
+        let start = calendar.date(byAdding: .day, value: -(days - 1), to: startOfToday) ?? startOfToday
+
+        let rows = try await Self.fetchActivity(
+            orgID: orgID,
+            sessionJWT: token,
+            window: DateInterval(start: start, end: end),
+            environment: environment,
+            transport: transport)
+
+        return Self.makeSnapshot(rows: rows, historyDays: days, updatedAt: now, calendar: calendar)
+    }
+
+    public static func _makeSnapshotForTesting(
+        activityJSON: Data,
+        historyDays: Int = 30,
+        updatedAt: Date,
+        calendar: Calendar = .current) throws -> GroqConsoleUsageSnapshot
+    {
+        let rows = try JSONDecoder().decode(GroqActivityResponse.self, from: activityJSON).data
+        return Self.makeSnapshot(rows: rows, historyDays: historyDays, updatedAt: updatedAt, calendar: calendar)
+    }
+
+    /// Extracts the Groq organization id from the session JWT's
+    /// `https://groq.com/organization` claim (no signature verification — the
+    /// API authenticates the token, this only reads the routing claim).
+    public static func organizationID(fromJWT jwt: String) -> String? {
+        let segments = jwt.split(separator: ".")
+        guard segments.count >= 2 else { return nil }
+        guard let payload = Self.base64URLDecode(String(segments[1])),
+              let object = try? JSONSerialization.jsonObject(with: payload) as? [String: Any]
+        else { return nil }
+        if let org = object["https://groq.com/organization"] as? [String: Any],
+           let id = org["id"] as? String, !id.isEmpty
+        {
+            return id
+        }
+        if let org = object["https://stytch.com/organization"] as? [String: Any],
+           let slug = org["slug"] as? String, !slug.isEmpty
+        {
+            return slug
+        }
+        return nil
+    }
+
+    static func base64URLDecode(_ input: String) -> Data? {
+        var value = input.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = value.count % 4
+        if remainder > 0 {
+            value.append(String(repeating: "=", count: 4 - remainder))
+        }
+        return Data(base64Encoded: value)
+    }
+
+    private static func fetchActivity(
+        orgID: String,
+        sessionJWT: String,
+        window: DateInterval,
+        environment: [String: String],
+        transport: any ProviderHTTPTransport) async throws -> [GroqActivityResponse.Row]
+    {
+        // The console platform API is rooted at the host, not under the
+        // public `/v1` base that GroqSettingsReader.apiURL returns.
+        let apiURL = GroqSettingsReader.apiURL(environment: environment)
+        guard var components = URLComponents(url: apiURL, resolvingAgainstBaseURL: false) else {
+            throw GroqConsoleError.invalidSession("could not build activity URL")
+        }
+        components.path = "/platform/v1/organizations/\(orgID)/activity"
+        components.queryItems = [
+            URLQueryItem(name: "start_date", value: String(Int(window.start.timeIntervalSince1970))),
+            URLQueryItem(name: "end_date", value: String(Int(window.end.timeIntervalSince1970))),
+        ]
+        guard let url = components.url else {
+            throw GroqConsoleError.invalidSession("could not build activity URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 20
+        request.setValue("Bearer \(sessionJWT)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let response = try await transport.response(for: request)
+        guard (200..<300).contains(response.statusCode) else {
+            let summary = Self.responseSummary(response.data)
+            if response.statusCode == 401 || response.statusCode == 403 {
+                throw GroqConsoleError.accessDenied(summary)
+            }
+            throw GroqConsoleError.apiError("HTTP \(response.statusCode): \(summary)")
+        }
+
+        do {
+            return try JSONDecoder().decode(GroqActivityResponse.self, from: response.data).data
+        } catch {
+            throw GroqConsoleError.parseFailed(error.localizedDescription)
+        }
+    }
+
+    fileprivate static func makeSnapshot(
+        rows: [GroqActivityResponse.Row],
+        historyDays: Int,
+        updatedAt: Date,
+        calendar: Calendar) -> GroqConsoleUsageSnapshot
+    {
+        let dayFormatter = DateFormatter()
+        dayFormatter.calendar = calendar
+        dayFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dayFormatter.timeZone = calendar.timeZone
+        dayFormatter.dateFormat = "yyyy-MM-dd"
+
+        struct ModelAccumulator {
+            var requests = 0
+            var inputTokens = 0
+            var cachedInputTokens = 0
+            var outputTokens = 0
+            var totalTokens = 0
+            var costUSD = 0.0
+        }
+        struct DayAccumulator {
+            var startTime: Date
+            var models: [String: ModelAccumulator] = [:]
+        }
+
+        var byDay: [String: DayAccumulator] = [:]
+        var organizationName: String?
+
+        for row in rows {
+            if organizationName == nil, let name = row.organizationName, !name.isEmpty {
+                organizationName = name
+            }
+            let date = Date(timeIntervalSince1970: row.timestamp)
+            let dayStart = calendar.startOfDay(for: date)
+            let key = dayFormatter.string(from: dayStart)
+            let modelName = (row.model?.isEmpty == false ? row.model : nil) ?? "unknown"
+
+            let contextTokens = row.nContextTokensTotal ?? 0
+            let nonCached = row.nNonCachedContextTokensTotal ?? contextTokens
+            let cached = max(0, contextTokens - nonCached)
+            let generated = row.nGeneratedTokensTotal ?? 0
+
+            var day = byDay[key] ?? DayAccumulator(startTime: dayStart)
+            var model = day.models[modelName] ?? ModelAccumulator()
+            model.requests += row.numRequests ?? 0
+            model.inputTokens += nonCached
+            model.cachedInputTokens += cached
+            model.outputTokens += generated
+            model.totalTokens += contextTokens + generated
+            model.costUSD += row.cost ?? 0
+            day.models[modelName] = model
+            byDay[key] = day
+        }
+
+        let buckets = byDay.map { key, day -> GroqConsoleUsageSnapshot.DailyBucket in
+            let models = day.models.map { name, acc in
+                GroqConsoleUsageSnapshot.ModelBreakdown(
+                    name: name,
+                    requests: acc.requests,
+                    inputTokens: acc.inputTokens,
+                    cachedInputTokens: acc.cachedInputTokens,
+                    outputTokens: acc.outputTokens,
+                    totalTokens: acc.totalTokens,
+                    costUSD: acc.costUSD)
+            }.sorted { $0.totalTokens > $1.totalTokens }
+            let endTime = calendar.date(byAdding: .day, value: 1, to: day.startTime) ?? day.startTime
+            return GroqConsoleUsageSnapshot.DailyBucket(
+                day: key,
+                startTime: day.startTime,
+                endTime: endTime,
+                costUSD: models.reduce(0) { $0 + $1.costUSD },
+                requests: models.reduce(0) { $0 + $1.requests },
+                inputTokens: models.reduce(0) { $0 + $1.inputTokens },
+                cachedInputTokens: models.reduce(0) { $0 + $1.cachedInputTokens },
+                outputTokens: models.reduce(0) { $0 + $1.outputTokens },
+                totalTokens: models.reduce(0) { $0 + $1.totalTokens },
+                models: models)
+        }
+
+        return GroqConsoleUsageSnapshot(
+            daily: buckets,
+            updatedAt: updatedAt,
+            historyDays: historyDays,
+            organizationName: organizationName)
+    }
+
+    private static func responseSummary(_ data: Data) -> String {
+        String(bytes: data.prefix(500), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? ""
+    }
+}

--- a/Sources/CodexBarCore/Providers/Groq/GroqConsoleSession.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqConsoleSession.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+public enum GroqConsoleSession {
+    /// Long-lived (~30 day) opaque session cookie. Exchanged for a fresh JWT.
+    public static let sessionCookieName = "stytch_session"
+    /// Short-lived session JWT cookie. Used directly if a refresh isn't possible.
+    public static let jwtCookieName = "stytch_session_jwt"
+    /// Environment override (a session JWT), primarily for CLI/testing.
+    public static let sessionEnvironmentKey = "GROQ_SESSION_JWT"
+    /// Environment override (an opaque session token) for CLI/testing the refresh path.
+    public static let sessionTokenEnvironmentKey = "GROQ_SESSION_TOKEN"
+
+    public struct SessionInfo: Sendable {
+        /// Long-lived opaque token; when present, exchanged for a fresh JWT.
+        public let sessionToken: String?
+        /// Short-lived JWT read straight from the browser (fallback / override).
+        public let directJWT: String?
+        public let sourceLabel: String
+
+        public init(sessionToken: String?, directJWT: String?, sourceLabel: String) {
+            self.sessionToken = sessionToken
+            self.directJWT = directJWT
+            self.sourceLabel = sourceLabel
+        }
+    }
+
+    /// Resolves a usable session JWT for `SessionInfo`: refreshes the opaque
+    /// token when available (robust for background polling), else falls back to
+    /// the short-lived JWT cookie.
+    static func resolveJWT(
+        for session: SessionInfo,
+        environment: [String: String],
+        transport: any ProviderHTTPTransport) async throws -> String
+    {
+        if let token = session.sessionToken?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !token.isEmpty
+        {
+            do {
+                return try await GroqConsoleStytch.refreshSessionJWT(
+                    sessionToken: token,
+                    environment: environment,
+                    transport: transport)
+            } catch {
+                // Fall through to a direct JWT if the refresh failed but we have one.
+                if let jwt = session.directJWT?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !jwt.isEmpty
+                {
+                    return jwt
+                }
+                throw error
+            }
+        }
+        if let jwt = session.directJWT?.trimmingCharacters(in: .whitespacesAndNewlines), !jwt.isEmpty {
+            return jwt
+        }
+        throw GroqConsoleError.missingSession
+    }
+
+    static func environmentSession(_ environment: [String: String]) -> SessionInfo? {
+        let jwt = environment[self.sessionEnvironmentKey]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let token = environment[self.sessionTokenEnvironmentKey]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let token, !token.isEmpty {
+            return SessionInfo(sessionToken: token, directJWT: jwt?.nonEmpty, sourceLabel: "env")
+        }
+        if let jwt, !jwt.isEmpty {
+            return SessionInfo(sessionToken: nil, directJWT: jwt, sourceLabel: "env")
+        }
+        return nil
+    }
+
+    /// Pulls the session JWT out of a raw `Cookie:` header string (manual entry).
+    public static func session(fromCookieHeader header: String?) -> SessionInfo? {
+        guard let normalized = CookieHeaderNormalizer.normalize(header) else { return nil }
+        var token: String?
+        var jwt: String?
+        for pair in CookieHeaderNormalizer.pairs(from: normalized) {
+            let name = pair.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = pair.value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else { continue }
+            if name == self.sessionCookieName { token = value }
+            if name == self.jwtCookieName { jwt = value }
+        }
+        guard token != nil || jwt != nil else { return nil }
+        return SessionInfo(sessionToken: token, directJWT: jwt, sourceLabel: "manual")
+    }
+}
+
+extension String {
+    fileprivate var nonEmpty: String? {
+        self.isEmpty ? nil : self
+    }
+}
+
+#if os(macOS)
+import SweetCookieKit
+
+extension GroqConsoleSession {
+    private static let log = CodexBarLog.logger(LogCategories.providers)
+    private static let cookieClient = BrowserCookieClient()
+    private static let cookieDomains = ["groq.com", "console.groq.com"]
+    private static let cookieImportOrder: BrowserCookieImportOrder =
+        ProviderDefaults.metadata[.groq]?.browserCookieOrder ?? Browser.defaultImportOrder
+
+    /// Resolves candidate sessions from (1) the environment override, then
+    /// (2) browser cookie stores in the configured import order.
+    public static func resolveSessions(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        browserDetection: BrowserDetection = BrowserDetection(),
+        logger: ((String) -> Void)? = nil) -> [SessionInfo]
+    {
+        if let override = self.environmentSession(environment) {
+            return [override]
+        }
+        return self.importSessions(browserDetection: browserDetection, logger: logger)
+    }
+
+    public static func hasSession(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        browserDetection: BrowserDetection = BrowserDetection(),
+        logger: ((String) -> Void)? = nil) -> Bool
+    {
+        !self.resolveSessions(
+            environment: environment,
+            browserDetection: browserDetection,
+            logger: logger).isEmpty
+    }
+
+    static func importSessions(
+        browserDetection: BrowserDetection,
+        logger: ((String) -> Void)?) -> [SessionInfo]
+    {
+        var sessions: [SessionInfo] = []
+        let candidates = self.cookieImportOrder.cookieImportCandidates(using: browserDetection)
+        for browserSource in candidates {
+            do {
+                let query = BrowserCookieQuery(domains: self.cookieDomains)
+                let sources = try self.cookieClient.codexBarRecords(
+                    matching: query,
+                    in: browserSource,
+                    logger: { self.emit($0, logger: logger) })
+                sessions.append(contentsOf: self.sessionInfos(from: sources, origin: query.origin))
+            } catch {
+                BrowserCookieAccessGate.recordIfNeeded(error)
+                self.emit(
+                    "\(browserSource.displayName) cookie import failed: \(error.localizedDescription)",
+                    logger: logger)
+            }
+        }
+        return sessions
+    }
+
+    static func sessionInfos(
+        from sources: [BrowserCookieStoreRecords],
+        origin: BrowserCookieOriginStrategy) -> [SessionInfo]
+    {
+        let grouped = Dictionary(grouping: sources, by: { $0.store.profile.id })
+        let sortedGroups = grouped.values.sorted { lhs, rhs in
+            self.mergedLabel(for: lhs) < self.mergedLabel(for: rhs)
+        }
+
+        var sessions: [SessionInfo] = []
+        for group in sortedGroups where !group.isEmpty {
+            let label = self.mergedLabel(for: group)
+            let merged = self.mergeRecords(group)
+            let cookies = BrowserCookieClient.makeHTTPCookies(merged, origin: origin)
+            let token = cookies.first { $0.name == self.sessionCookieName }?.value.nonEmpty
+            let jwt = cookies.first { $0.name == self.jwtCookieName }?.value.nonEmpty
+            guard token != nil || jwt != nil else { continue }
+            sessions.append(SessionInfo(sessionToken: token, directJWT: jwt, sourceLabel: label))
+        }
+        return sessions
+    }
+
+    private static func emit(_ message: String, logger: ((String) -> Void)?) {
+        logger?("[groq-cookie] \(message)")
+        self.log.debug("\(message)")
+    }
+
+    private static func mergedLabel(for sources: [BrowserCookieStoreRecords]) -> String {
+        guard let base = sources.map(\.label).min() else { return "Unknown" }
+        if base.hasSuffix(" (Network)") {
+            return String(base.dropLast(" (Network)".count))
+        }
+        return base
+    }
+
+    private static func mergeRecords(_ sources: [BrowserCookieStoreRecords]) -> [BrowserCookieRecord] {
+        let sortedSources = sources.sorted { lhs, rhs in
+            self.storePriority(lhs.store.kind) < self.storePriority(rhs.store.kind)
+        }
+        var mergedByKey: [String: BrowserCookieRecord] = [:]
+        for source in sortedSources {
+            for record in source.records {
+                let key = "\(record.name)|\(record.domain)|\(record.path)"
+                if let existing = mergedByKey[key] {
+                    if self.shouldReplace(existing: existing, candidate: record) {
+                        mergedByKey[key] = record
+                    }
+                } else {
+                    mergedByKey[key] = record
+                }
+            }
+        }
+        return Array(mergedByKey.values)
+    }
+
+    private static func storePriority(_ kind: BrowserCookieStoreKind) -> Int {
+        switch kind {
+        case .network: 0
+        case .primary: 1
+        case .safari: 2
+        }
+    }
+
+    private static func shouldReplace(existing: BrowserCookieRecord, candidate: BrowserCookieRecord) -> Bool {
+        switch (existing.expires, candidate.expires) {
+        case let (lhs?, rhs?): rhs > lhs
+        case (nil, .some): true
+        case (.some, nil): false
+        case (nil, nil): false
+        }
+    }
+}
+#else
+extension GroqConsoleSession {
+    public static func resolveSessions(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        browserDetection _: BrowserDetection = BrowserDetection(),
+        logger _: ((String) -> Void)? = nil) -> [SessionInfo]
+    {
+        guard let override = self.environmentSession(environment) else { return [] }
+        return [override]
+    }
+
+    public static func hasSession(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        browserDetection _: BrowserDetection = BrowserDetection(),
+        logger _: ((String) -> Void)? = nil) -> Bool
+    {
+        self.environmentSession(environment) != nil
+    }
+}
+#endif

--- a/Sources/CodexBarCore/Providers/Groq/GroqConsoleStytch.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqConsoleStytch.swift
@@ -1,0 +1,93 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Exchanges the long-lived Groq console session cookie (`stytch_session`,
+/// ~30 days) for a fresh, short-lived session JWT via Stytch's B2B frontend
+/// SDK endpoint — the same call the console web app makes. This keeps
+/// background polling working even when no console tab is open to refresh the
+/// short-lived `stytch_session_jwt` cookie on its own.
+enum GroqConsoleStytch {
+    /// Public (publishable) token for Groq's Stytch B2B project. Publishable by
+    /// design — it only authorizes SDK calls from the allowed `console.groq.com`
+    /// origin. Overridable in case Groq rotates it.
+    static let defaultPublicToken = "public-token-live-58df57a9-a1f5-4066-bc0c-2ff942db684f"
+    static let publicTokenEnvironmentKey = "GROQ_STYTCH_PUBLIC_TOKEN"
+    static let baseURLEnvironmentKey = "GROQ_STYTCH_URL"
+    private static let defaultBaseURL = "https://api.stytchb2b.groq.com"
+    private static let origin = "https://console.groq.com"
+    private static let sdkVersion = "5.43.0"
+
+    private struct AuthenticateResponse: Decodable {
+        struct Payload: Decodable {
+            let sessionJWT: String?
+            enum CodingKeys: String, CodingKey { case sessionJWT = "session_jwt" }
+        }
+
+        let data: Payload?
+    }
+
+    static func refreshSessionJWT(
+        sessionToken: String,
+        environment: [String: String],
+        transport: any ProviderHTTPTransport) async throws -> String
+    {
+        let token = sessionToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { throw GroqConsoleError.missingSession }
+
+        let publicToken = environment[self.publicTokenEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty ?? self.defaultPublicToken
+        let base = environment[self.baseURLEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty ?? self.defaultBaseURL
+
+        guard let url = URL(string: base + "/sdk/v1/b2b/sessions/authenticate") else {
+            throw GroqConsoleError.invalidSession("invalid Stytch URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 20
+        // Stytch SDK auth: Basic base64(publicToken:sessionToken).
+        let credential = Data("\(publicToken):\(token)".utf8).base64EncodedString()
+        request.setValue("Basic \(credential)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(self.origin, forHTTPHeaderField: "Origin")
+        request.setValue(self.origin, forHTTPHeaderField: "X-SDK-Parent-Host")
+        request.setValue(self.sdkClientHeader(), forHTTPHeaderField: "X-SDK-Client")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "session_token": token,
+            "session_duration_minutes": 30,
+        ])
+
+        let response = try await transport.response(for: request)
+        guard (200..<300).contains(response.statusCode) else {
+            let summary = String(bytes: response.data.prefix(300), encoding: .utf8) ?? ""
+            if response.statusCode == 401 || response.statusCode == 403 {
+                throw GroqConsoleError.accessDenied(summary)
+            }
+            throw GroqConsoleError.apiError("Stytch HTTP \(response.statusCode): \(summary)")
+        }
+
+        guard let jwt = (try? JSONDecoder().decode(AuthenticateResponse.self, from: response.data))?
+            .data?.sessionJWT?.trimmingCharacters(in: .whitespacesAndNewlines), !jwt.isEmpty
+        else {
+            throw GroqConsoleError.parseFailed("Stytch response missing session_jwt")
+        }
+        return jwt
+    }
+
+    /// Base64 telemetry blob the Stytch SDK expects; identifies the calling app
+    /// by hostname (matched against the project's allowed domains).
+    private static func sdkClientHeader() -> String {
+        let blob = "{\"app\":{\"identifier\":\"console.groq.com\"}," +
+            "\"sdk\":{\"identifier\":\"Stytch.js Javascript SDK\",\"version\":\"\(self.sdkVersion)\"}}"
+        return Data(blob.utf8).base64EncodedString()
+    }
+}
+
+extension String {
+    fileprivate var nonEmpty: String? {
+        self.isEmpty ? nil : self
+    }
+}

--- a/Sources/CodexBarCore/Providers/Groq/GroqConsoleUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqConsoleUsageSnapshot.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+/// Usage/spend history sourced from the Groq console platform API
+/// (`/platform/v1/organizations/{org}/activity`). Mirrors the OpenAI API
+/// provider's daily cost-history shape so it renders through the shared
+/// cost-history inline dashboard.
+public struct GroqConsoleUsageSnapshot: Codable, Equatable, Sendable {
+    public struct ModelBreakdown: Codable, Equatable, Sendable, Identifiable {
+        public let name: String
+        public let requests: Int
+        public let inputTokens: Int
+        public let cachedInputTokens: Int
+        public let outputTokens: Int
+        public let totalTokens: Int
+        public let costUSD: Double
+
+        public var id: String {
+            self.name
+        }
+
+        public init(
+            name: String,
+            requests: Int,
+            inputTokens: Int,
+            cachedInputTokens: Int,
+            outputTokens: Int,
+            totalTokens: Int,
+            costUSD: Double)
+        {
+            self.name = name
+            self.requests = requests
+            self.inputTokens = inputTokens
+            self.cachedInputTokens = cachedInputTokens
+            self.outputTokens = outputTokens
+            self.totalTokens = totalTokens
+            self.costUSD = costUSD
+        }
+    }
+
+    public struct DailyBucket: Codable, Equatable, Sendable, Identifiable {
+        public let day: String
+        public let startTime: Date
+        public let endTime: Date
+        public let costUSD: Double
+        public let requests: Int
+        public let inputTokens: Int
+        public let cachedInputTokens: Int
+        public let outputTokens: Int
+        public let totalTokens: Int
+        public let models: [ModelBreakdown]
+
+        public var id: String {
+            self.day
+        }
+
+        public init(
+            day: String,
+            startTime: Date,
+            endTime: Date,
+            costUSD: Double,
+            requests: Int,
+            inputTokens: Int,
+            cachedInputTokens: Int,
+            outputTokens: Int,
+            totalTokens: Int,
+            models: [ModelBreakdown])
+        {
+            self.day = day
+            self.startTime = startTime
+            self.endTime = endTime
+            self.costUSD = costUSD
+            self.requests = requests
+            self.inputTokens = inputTokens
+            self.cachedInputTokens = cachedInputTokens
+            self.outputTokens = outputTokens
+            self.totalTokens = totalTokens
+            self.models = models
+        }
+    }
+
+    public let daily: [DailyBucket]
+    public let updatedAt: Date
+    public let historyDays: Int
+    public let organizationName: String?
+    public let accountEmail: String?
+
+    public init(
+        daily: [DailyBucket],
+        updatedAt: Date,
+        historyDays: Int = 30,
+        organizationName: String? = nil,
+        accountEmail: String? = nil)
+    {
+        self.daily = daily.sorted { $0.startTime < $1.startTime }
+        self.updatedAt = updatedAt
+        self.historyDays = max(1, min(365, historyDays))
+        self.organizationName = organizationName
+        self.accountEmail = accountEmail
+    }
+
+    public var historyWindowPeriodLabel: String {
+        self.historyDays == 1 ? "Today" : "Last \(self.historyDays) days"
+    }
+
+    public var windowCostUSD: Double {
+        self.daily.reduce(0) { $0 + $1.costUSD }
+    }
+
+    private var loginMethod: String {
+        "Console"
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: self.windowCostUSD,
+                limit: 0,
+                currencyCode: "USD",
+                period: self.historyWindowPeriodLabel,
+                updatedAt: self.updatedAt),
+            groqConsoleUsage: self,
+            updatedAt: self.updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: .groq,
+                accountEmail: self.accountEmail,
+                accountOrganization: self.organizationName,
+                loginMethod: self.loginMethod))
+    }
+
+    public func toCostUsageTokenSnapshot() -> CostUsageTokenSnapshot {
+        let daily = self.daily.map { bucket in
+            let modelBreakdowns = bucket.models.map {
+                CostUsageDailyReport.ModelBreakdown(
+                    modelName: $0.name,
+                    costUSD: $0.costUSD,
+                    totalTokens: $0.totalTokens,
+                    requestCount: $0.requests)
+            }
+            let modelsUsed = bucket.models.map(\.name)
+            return CostUsageDailyReport.Entry(
+                date: bucket.day,
+                inputTokens: bucket.inputTokens,
+                outputTokens: bucket.outputTokens,
+                cacheReadTokens: bucket.cachedInputTokens,
+                cacheCreationTokens: nil,
+                totalTokens: bucket.totalTokens,
+                requestCount: bucket.requests,
+                costUSD: bucket.costUSD,
+                modelsUsed: modelsUsed.isEmpty ? nil : modelsUsed,
+                modelBreakdowns: modelBreakdowns.isEmpty ? nil : modelBreakdowns)
+        }
+        let today = self.summary(forLocalDayContaining: self.updatedAt)
+        let total = self.summary(days: self.historyDays)
+        return CostUsageTokenSnapshot(
+            sessionTokens: today.totalTokens,
+            sessionCostUSD: today.costUSD,
+            sessionRequests: today.requests,
+            last30DaysTokens: total.totalTokens,
+            last30DaysCostUSD: total.costUSD,
+            last30DaysRequests: total.requests,
+            historyDays: self.historyDays,
+            daily: daily,
+            updatedAt: self.updatedAt)
+    }
+
+    public var topModels: [ModelBreakdown] {
+        var totals: [String: ModelBreakdown] = [:]
+        for day in self.daily {
+            for model in day.models {
+                let existing = totals[model.name]
+                totals[model.name] = ModelBreakdown(
+                    name: model.name,
+                    requests: (existing?.requests ?? 0) + model.requests,
+                    inputTokens: (existing?.inputTokens ?? 0) + model.inputTokens,
+                    cachedInputTokens: (existing?.cachedInputTokens ?? 0) + model.cachedInputTokens,
+                    outputTokens: (existing?.outputTokens ?? 0) + model.outputTokens,
+                    totalTokens: (existing?.totalTokens ?? 0) + model.totalTokens,
+                    costUSD: (existing?.costUSD ?? 0) + model.costUSD)
+            }
+        }
+        return totals.values.sorted {
+            if $0.totalTokens == $1.totalTokens { return $0.name < $1.name }
+            return $0.totalTokens > $1.totalTokens
+        }
+    }
+
+    private struct Summary {
+        var costUSD = 0.0
+        var requests = 0
+        var inputTokens = 0
+        var cachedInputTokens = 0
+        var outputTokens = 0
+        var totalTokens = 0
+    }
+
+    private func summary(days: Int) -> Summary {
+        self.reduce(self.daily.suffix(max(1, days)))
+    }
+
+    private func summary(forLocalDayContaining date: Date) -> Summary {
+        let selected = self.daily.filter { bucket in
+            CostUsageBucketInterval.contains(date, startTime: bucket.startTime, endTime: bucket.endTime)
+        }
+        return self.reduce(selected)
+    }
+
+    private func reduce(_ buckets: some Sequence<DailyBucket>) -> Summary {
+        var summary = Summary()
+        for bucket in buckets {
+            summary.costUSD += bucket.costUSD
+            summary.requests += bucket.requests
+            summary.inputTokens += bucket.inputTokens
+            summary.cachedInputTokens += bucket.cachedInputTokens
+            summary.outputTokens += bucket.outputTokens
+            summary.totalTokens += bucket.totalTokens
+        }
+        return summary
+    }
+}

--- a/Sources/CodexBarCore/Providers/Groq/GroqProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqProviderDescriptor.swift
@@ -21,7 +21,7 @@ public enum GroqProviderDescriptor {
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
                 browserCookieOrder: nil,
-                dashboardURL: "https://console.groq.com/dashboard/metrics",
+                dashboardURL: "https://console.groq.com/dashboard/usage",
                 statusPageURL: nil,
                 statusLinkURL: "https://status.groq.com"),
             branding: ProviderBranding(
@@ -30,20 +30,96 @@ public enum GroqProviderDescriptor {
                 color: ProviderColor(red: 245 / 255, green: 104 / 255, blue: 68 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
-                noDataMessage: { "Groq cost history is not available via the metrics API." }),
-            fetchPlan: .apiToken(
-                strategyID: "groq.api",
-                sourceLabel: "metrics",
-                resolveToken: { ProviderTokenResolver.groqToken(environment: $0) },
-                missingCredentialsError: { GroqUsageError.missingCredentials },
-                loadUsage: { apiKey, context in
-                    try await GroqUsageFetcher.fetchUsage(
-                        apiKey: apiKey,
-                        environment: context.env).toUsageSnapshot()
-                }),
+                noDataMessage: { "Sign in at console.groq.com to show Groq spend and token usage." }),
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.auto, .web, .api],
+                pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                    switch context.sourceMode {
+                    case .web:
+                        [GroqConsoleWebFetchStrategy()]
+                    case .api:
+                        [Self.prometheusStrategy()]
+                    default:
+                        [GroqConsoleWebFetchStrategy(), Self.prometheusStrategy()]
+                    }
+                })),
             cli: ProviderCLIConfig(
                 name: "groqcloud",
                 aliases: ["groq", "groq-api"],
                 versionDetector: nil))
+    }
+
+    /// Enterprise-tier Prometheus metrics fallback for org API keys that have
+    /// the feature enabled. Standard keys 404 here and simply yield no data.
+    private static func prometheusStrategy() -> APITokenFetchStrategy {
+        APITokenFetchStrategy(
+            id: "groq.api",
+            sourceLabel: "metrics",
+            resolveToken: { ProviderTokenResolver.groqToken(environment: $0) },
+            missingCredentialsError: { GroqUsageError.missingCredentials },
+            loadUsage: { apiKey, context in
+                try await GroqUsageFetcher.fetchUsage(
+                    apiKey: apiKey,
+                    environment: context.env).toUsageSnapshot()
+            })
+    }
+}
+
+/// Primary Groq source: the console platform API (`/platform/v1/.../activity`),
+/// authenticated with the browser `stytch_session_jwt` session cookie. Returns
+/// real spend/token/request history like the OpenAI API provider.
+struct GroqConsoleWebFetchStrategy: ProviderFetchStrategy {
+    let id: String = "groq.console"
+    let kind: ProviderFetchKind = .web
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        GroqConsoleSession.hasSession(
+            environment: context.env,
+            browserDetection: context.browserDetection)
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let sessions = GroqConsoleSession.resolveSessions(
+            environment: context.env,
+            browserDetection: context.browserDetection)
+        guard !sessions.isEmpty else {
+            throw GroqConsoleError.missingSession
+        }
+
+        var lastError: Error?
+        for session in sessions {
+            do {
+                let snapshot = try await GroqConsoleFetcher.fetchUsage(
+                    session: session,
+                    historyDays: context.costUsageHistoryDays,
+                    environment: context.env)
+                return self.makeResult(usage: snapshot.toUsageSnapshot(), sourceLabel: "console")
+            } catch {
+                guard Self.shouldRetryNextSession(for: error) else { throw error }
+                lastError = error
+            }
+        }
+        throw lastError ?? GroqConsoleError.missingSession
+    }
+
+    func shouldFallback(on error: Error, context _: ProviderFetchContext) -> Bool {
+        // Fall back to the Prometheus API key path when there's no usable session.
+        guard let consoleError = error as? GroqConsoleError else { return false }
+        switch consoleError {
+        case .missingSession, .invalidSession, .accessDenied:
+            return true
+        case .apiError, .parseFailed:
+            return false
+        }
+    }
+
+    private static func shouldRetryNextSession(for error: Error) -> Bool {
+        guard let consoleError = error as? GroqConsoleError else { return false }
+        switch consoleError {
+        case .accessDenied, .invalidSession:
+            return true
+        case .missingSession, .apiError, .parseFailed:
+            return false
+        }
     }
 }

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -198,6 +198,7 @@ public struct UsageSnapshot: Codable, Sendable {
     public let sub2APIUsage: Sub2APIUsageDetails?
     public let wayfinderUsage: WayfinderUsageSnapshot?
     public let openAIAPIUsage: OpenAIAPIUsageSnapshot?
+    public let groqConsoleUsage: GroqConsoleUsageSnapshot?
     public let codexResetCredits: CodexRateLimitResetCreditsSnapshot?
     public let claudeAdminAPIUsage: ClaudeAdminAPIUsageSnapshot?
     public let mistralUsage: MistralUsageSnapshot?
@@ -232,6 +233,7 @@ public struct UsageSnapshot: Codable, Sendable {
         case sub2APIUsage
         case wayfinderUsage
         case openAIAPIUsage
+        case groqConsoleUsage
         case codexResetCredits
         case claudeAdminAPIUsage
         case mistralUsage
@@ -266,6 +268,7 @@ public struct UsageSnapshot: Codable, Sendable {
         sub2APIUsage: Sub2APIUsageDetails? = nil,
         wayfinderUsage: WayfinderUsageSnapshot? = nil,
         openAIAPIUsage: OpenAIAPIUsageSnapshot? = nil,
+        groqConsoleUsage: GroqConsoleUsageSnapshot? = nil,
         codexResetCredits: CodexRateLimitResetCreditsSnapshot? = nil,
         claudeAdminAPIUsage: ClaudeAdminAPIUsageSnapshot? = nil,
         mistralUsage: MistralUsageSnapshot? = nil,
@@ -299,6 +302,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.sub2APIUsage = sub2APIUsage
         self.wayfinderUsage = wayfinderUsage
         self.openAIAPIUsage = openAIAPIUsage
+        self.groqConsoleUsage = groqConsoleUsage
         self.codexResetCredits = codexResetCredits
         self.claudeAdminAPIUsage = claudeAdminAPIUsage
         self.mistralUsage = mistralUsage
@@ -351,6 +355,9 @@ public struct UsageSnapshot: Codable, Sendable {
         self.sub2APIUsage = try container.decodeIfPresent(Sub2APIUsageDetails.self, forKey: .sub2APIUsage)
         self.wayfinderUsage = try container.decodeIfPresent(WayfinderUsageSnapshot.self, forKey: .wayfinderUsage)
         self.openAIAPIUsage = try container.decodeIfPresent(OpenAIAPIUsageSnapshot.self, forKey: .openAIAPIUsage)
+        self.groqConsoleUsage = try container.decodeIfPresent(
+            GroqConsoleUsageSnapshot.self,
+            forKey: .groqConsoleUsage)
         self.codexResetCredits = try container.decodeIfPresent(
             CodexRateLimitResetCreditsSnapshot.self,
             forKey: .codexResetCredits)
@@ -408,6 +415,7 @@ public struct UsageSnapshot: Codable, Sendable {
         try container.encodeIfPresent(self.sub2APIUsage, forKey: .sub2APIUsage)
         try container.encodeIfPresent(self.wayfinderUsage, forKey: .wayfinderUsage)
         try container.encodeIfPresent(self.openAIAPIUsage, forKey: .openAIAPIUsage)
+        try container.encodeIfPresent(self.groqConsoleUsage, forKey: .groqConsoleUsage)
         try container.encodeIfPresent(self.codexResetCredits, forKey: .codexResetCredits)
         try container.encodeIfPresent(self.claudeAdminAPIUsage, forKey: .claudeAdminAPIUsage)
         try container.encodeIfPresent(self.mistralUsage, forKey: .mistralUsage)
@@ -609,6 +617,7 @@ public struct UsageSnapshot: Codable, Sendable {
             sub2APIUsage: self.sub2APIUsage,
             wayfinderUsage: self.wayfinderUsage,
             openAIAPIUsage: self.openAIAPIUsage,
+            groqConsoleUsage: self.groqConsoleUsage,
             codexResetCredits: codexResetCredits.resolving(self.codexResetCredits),
             claudeAdminAPIUsage: self.claudeAdminAPIUsage,
             mistralUsage: self.mistralUsage,

--- a/Tests/CodexBarTests/GroqConsoleFetcherTests.swift
+++ b/Tests/CodexBarTests/GroqConsoleFetcherTests.swift
@@ -1,0 +1,117 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct GroqConsoleFetcherTests {
+    /// A JWT whose payload carries the Groq organization claim. Signature is a
+    /// placeholder — only the (unverified) payload segment is read.
+    private static func makeJWT(orgID: String) -> String {
+        let payload = "{\"https://groq.com/organization\":{\"id\":\"\(orgID)\"}}"
+        let encoded = Data(payload.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "header.\(encoded).signature"
+    }
+
+    @Test
+    func `decodes organization id from jwt claim`() {
+        let jwt = Self.makeJWT(orgID: "org_abc123")
+        #expect(GroqConsoleFetcher.organizationID(fromJWT: jwt) == "org_abc123")
+    }
+
+    @Test
+    func `falls back to stytch slug when groq claim absent`() {
+        let payload = "{\"https://stytch.com/organization\":{\"slug\":\"org_slug9\"}}"
+        let encoded = Data(payload.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        let jwt = "h.\(encoded).s"
+        #expect(GroqConsoleFetcher.organizationID(fromJWT: jwt) == "org_slug9")
+    }
+
+    @Test
+    func `returns nil for malformed jwt`() {
+        #expect(GroqConsoleFetcher.organizationID(fromJWT: "not-a-jwt") == nil)
+        #expect(GroqConsoleFetcher.organizationID(fromJWT: "only.two") == nil)
+    }
+
+    @Test
+    func `aggregates activity rows into daily buckets`() throws {
+        // Two models on the same UTC day plus one on the next day.
+        let json = """
+        {"object":"list","data":[
+          {"organization_name":"Personal","model":"llama-3.1-8b-instant","timestamp":1783900800,
+           "num_requests":3,"n_context_tokens_total":100,"n_non_cached_context_tokens_total":80,
+           "n_generated_tokens_total":40,"cost":0.01},
+          {"organization_name":"Personal","model":"openai/gpt-oss-120b","timestamp":1783901000,
+           "num_requests":2,"n_context_tokens_total":50,"n_non_cached_context_tokens_total":50,
+           "n_generated_tokens_total":10,"cost":0.02},
+          {"organization_name":"Personal","model":"llama-3.1-8b-instant","timestamp":1783987200,
+           "num_requests":1,"n_context_tokens_total":10,"n_non_cached_context_tokens_total":10,
+           "n_generated_tokens_total":5,"cost":0.005}
+        ]}
+        """
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        let snapshot = try GroqConsoleFetcher._makeSnapshotForTesting(
+            activityJSON: Data(json.utf8),
+            historyDays: 30,
+            updatedAt: Date(timeIntervalSince1970: 1_783_987_200),
+            calendar: calendar)
+
+        #expect(snapshot.daily.count == 2)
+        #expect(snapshot.organizationName == "Personal")
+
+        // Day one merges the two models.
+        let dayOne = snapshot.daily.first
+        #expect(dayOne?.requests == 5)
+        #expect(dayOne?.inputTokens == 130) // 80 + 50 non-cached
+        #expect(dayOne?.cachedInputTokens == 20) // (100-80) + (50-50)
+        #expect(dayOne?.outputTokens == 50) // 40 + 10
+        #expect(dayOne?.totalTokens == 200) // (100+40) + (50+10)
+        #expect((dayOne?.costUSD ?? 0) == 0.03)
+        #expect(dayOne?.models.count == 2)
+
+        // Window totals surface via the cost-history projection.
+        let projected = snapshot.toCostUsageTokenSnapshot()
+        #expect(projected.last30DaysRequests == 6)
+        #expect(abs((projected.last30DaysCostUSD ?? 0) - 0.035) < 1e-9)
+    }
+
+    @Test
+    func `parses session and jwt from cookie header`() {
+        let header = "stytch_session=opaque123; stytch_session_jwt=jwt.abc.def; other=x"
+        let session = GroqConsoleSession.session(fromCookieHeader: header)
+        #expect(session?.sessionToken == "opaque123")
+        #expect(session?.directJWT == "jwt.abc.def")
+    }
+
+    @Test
+    func `usage snapshot exposes provider cost and console usage`() {
+        let bucket = GroqConsoleUsageSnapshot.DailyBucket(
+            day: "2026-07-13",
+            startTime: Date(timeIntervalSince1970: 1_783_900_800),
+            endTime: Date(timeIntervalSince1970: 1_783_987_200),
+            costUSD: 0.5,
+            requests: 10,
+            inputTokens: 100,
+            cachedInputTokens: 0,
+            outputTokens: 50,
+            totalTokens: 150,
+            models: [])
+        let snapshot = GroqConsoleUsageSnapshot(
+            daily: [bucket],
+            updatedAt: Date(timeIntervalSince1970: 1_783_987_200),
+            historyDays: 30,
+            organizationName: "Personal")
+            .toUsageSnapshot()
+
+        #expect(snapshot.identity?.providerID == .groq)
+        #expect(snapshot.identity?.loginMethod == "Console")
+        #expect(snapshot.providerCost?.used == 0.5)
+        #expect(snapshot.groqConsoleUsage?.daily.count == 1)
+    }
+}

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -35,10 +35,12 @@ struct PlatformGatingTests {
             Self.makeClaudeStatus()
         }
         let outcome = await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(binaryURL.path) {
-            await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
-                await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
-                    context: context,
-                    provider: .claude)
+            await ClaudeCLIAuthStatusProbe.withResultOverrideForTesting(true) {
+                await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
+                    await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                        context: context,
+                        provider: .claude)
+                }
             }
         }
         let result = try outcome.result.get()

--- a/docs/groq.md
+++ b/docs/groq.md
@@ -1,0 +1,70 @@
+---
+summary: "Groq provider: console spend/usage via the browser session (Stytch), with an optional Enterprise Prometheus fallback."
+read_when:
+  - Updating Groq usage/spend display
+  - Debugging Groq console session, Stytch refresh, or GROQ_API_KEY behavior
+---
+
+# Groq provider
+
+CodexBar shows Groq organization usage and spend from the **console.groq.com** dashboard API, read through your
+browser session. This replaces the old public-API rate-limit metric, which only described request/token throttles
+rather than actual usage.
+
+## Data sources + selection order
+
+Default (`auto`) pipeline:
+
+1. **Console (web, preferred).** Reads the console session cookie from the browser and calls the platform activity
+   API for daily spend/token/request history.
+2. **Prometheus metrics (Enterprise API key, fallback).** Only used when a session isn't available and an API key is
+   configured; Enterprise-only, so standard keys return no data here.
+
+Source modes: `web` (console only), `api` (Prometheus only), `auto` (console then Prometheus).
+
+## Console (web)
+
+- Session comes from the `groq.com` cookies, in browser import order:
+  - `stytch_session` — long-lived (~30 day) opaque token. Preferred.
+  - `stytch_session_jwt` — short-lived (~5 min) JWT. Used directly only as a fallback.
+- Because the JWT cookie expires quickly and is refreshed by the SPA only while a console tab is open, CodexBar
+  exchanges the long-lived opaque token for a fresh JWT on each fetch via Stytch's B2B frontend SDK endpoint (the same
+  call the console web app makes):
+  - `POST https://api.stytchb2b.groq.com/sdk/v1/b2b/sessions/authenticate`
+  - Auth: `Authorization: Basic base64(<publicToken>:<sessionToken>)`, plus `X-SDK-Client`, `X-SDK-Parent-Host`, and
+    `Origin: https://console.groq.com` headers.
+  - The publishable Stytch token is built in; override with `GROQ_STYTCH_PUBLIC_TOKEN` / `GROQ_STYTCH_URL` if Groq
+    rotates it.
+- Usage/spend:
+  - `GET https://api.groq.com/platform/v1/organizations/{orgId}/activity?start_date={unix}&end_date={unix}`
+  - `Authorization: Bearer <fresh session JWT>`.
+  - The organization id is read from the JWT's `https://groq.com/organization` claim (no signature verification —
+    the API authenticates the token, this only reads the routing claim).
+- Each activity row is per-model, per-day: `cost`, `n_context_tokens_total`, `n_non_cached_context_tokens_total`
+  (cached = context − non-cached), `n_generated_tokens_total`, `num_requests`. CodexBar aggregates these into daily
+  buckets and renders the shared cost-history inline dashboard (as used by the OpenAI API provider).
+- Identity login method: `Console`.
+
+### Testing / CLI overrides
+
+- `GROQ_SESSION_TOKEN` — an opaque `stytch_session` value; exercises the full refresh path.
+- `GROQ_SESSION_JWT` — a session JWT used directly (skips refresh); handy for a quick check but expires in minutes.
+
+```bash
+GROQ_SESSION_TOKEN=<stytch_session> codexbar usage --provider groq --json
+```
+
+## Prometheus metrics (Enterprise, optional)
+
+- Requires an Enterprise API key stored in `~/.codexbar/config.json` (Settings → Providers → Groq) or `GROQ_API_KEY`.
+- `GET https://api.groq.com/v1/metrics/prometheus/api/v1/query` for `rate5m` request/token/cache series.
+- Standard keys receive HTTP 404 here (Enterprise-only feature), so this path simply yields no data for them.
+
+## Key files
+
+- Console fetch: `Sources/CodexBarCore/Providers/Groq/GroqConsoleFetcher.swift`
+- Session import + JWT resolution: `Sources/CodexBarCore/Providers/Groq/GroqConsoleSession.swift`
+- Stytch refresh: `Sources/CodexBarCore/Providers/Groq/GroqConsoleStytch.swift`
+- Snapshot / cost-history projection: `Sources/CodexBarCore/Providers/Groq/GroqConsoleUsageSnapshot.swift`
+- Prometheus fallback: `Sources/CodexBarCore/Providers/Groq/GroqUsageFetcher.swift`
+- Provider wiring: `Sources/CodexBarCore/Providers/Groq/GroqProviderDescriptor.swift`


### PR DESCRIPTION
The old provider hit the public `api.groq.com/v1/metrics/prometheus` endpoint, which is Enterprise-only. Standard keys get a 404 error. Instead, we now pull real spend/usage from the console.groq.com browser session when the Prometheus endpoint fails.

<img width="386" height="552" alt="image@2x" src="https://github.com/user-attachments/assets/aadb21c9-08fd-47db-84f9-442dec2e05cf" />

Unit tests green; live end-to-end via both the env override and the real browser-cookie importµ; full build + lint clean.