### PR TITLE
Isolate Codex CLI account test from local data

### DIFF
--- a/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
+++ b/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
@@ -698,6 +698,13 @@ struct TokenAccountEnvironmentPrecedenceTests {
 
     @Test
     func `codex CLI ignores relative profile homes`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-cli-relative-profile-\(UUID().uuidString)", isDirectory: true)
+        let ambientHome = root.appendingPathComponent("ambient", isDirectory: true)
+        let managedStoreURL = root.appendingPathComponent("managed-codex-accounts.json")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: ambientHome, withIntermediateDirectories: true)
+
         let config = CodexBarConfig(providers: [
             ProviderConfig(
                 id: .codex,
@@ -708,16 +715,17 @@ struct TokenAccountEnvironmentPrecedenceTests {
             selection: TokenAccountCLISelection(label: nil, index: nil, allAccounts: false),
             config: config,
             verbose: false,
-            baseEnvironment: ["CODEX_HOME": "/tmp/ambient-codex"])
+            baseEnvironment: ["CODEX_HOME": ambientHome.path],
+            managedCodexAccountStoreURL: managedStoreURL)
 
         let environment = context.environment(
-            base: ["CODEX_HOME": "/tmp/ambient-codex"],
+            base: ["CODEX_HOME": ambientHome.path],
             provider: .codex,
             account: nil,
             codexActiveSourceOverride: .profileHome(path: "relative-codex-home"))
 
         #expect(context.visibleCodexAccounts().visibleAccounts.isEmpty)
-        #expect(environment["CODEX_HOME"] == "/tmp/ambient-codex")
+        #expect(environment["CODEX_HOME"] == ambientHome.path)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- isolate the relative-profile Codex CLI test from the contributor's ambient Codex home
- inject an empty managed-account store so local accounts cannot affect the assertion
- preserve the original invalid-profile fallback contract

## Root cause

The fixture supplied a hard-coded ambient `CODEX_HOME` but left `managedCodexAccountStoreURL` at its production default. On machines with managed Codex accounts, `visibleCodexAccounts()` read the real store, failed the empty projection assertion, and could render local account metadata in the test failure.

## Behavior proof

This proof uses only a synthetic one-entry `FileManagedCodexAccountStore` in a disposable worktree. It does not read a real account store, and the failure output below redacts the fixture identity and UUID.

Base `c852c135` (original test logic pointed at the synthetic non-empty store; production code unchanged):

```text
$ CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 OS_ACTIVITY_MODE=disable swift test --skip-build --filter 'codex CLI ignores relative profile homes'
◇ Test "codex CLI ignores relative profile homes" started.
✘ Expectation failed: (context.visibleCodexAccounts().visibleAccounts → [<synthetic account redacted>]).isEmpty → false
✘ Test "codex CLI ignores relative profile homes" failed with 1 issue.
✘ Test run with 1 test in 1 suite failed with 1 issue.
exit 1
```

Head `3276ba40` (the test injects its own empty managed store):

```text
$ CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 OS_ACTIVITY_MODE=disable swift test --skip-build --filter 'codex CLI ignores relative profile homes'
◇ Test "codex CLI ignores relative profile homes" started.
✔ Test "codex CLI ignores relative profile homes" passed after 0.009 seconds.
✔ Suite TokenAccountEnvironmentPrecedenceTests passed after 0.009 seconds.
✔ Test run with 1 test in 1 suite passed after 0.009 seconds.
exit 0
```

## Validation

- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --skip-build --filter 'codex CLI ignores relative profile homes'` - 1 test passed
- `make check` - passed; SwiftFormat reported 0 files requiring formatting and SwiftLint reported 0 violations
- `make test` - all 638 selections passed across 54/54 groups, with zero retries and zero timeouts
- `git diff --check` - passed

Screenshots are not applicable because this is a test-only change.
