### PR TITLE
Scope quota warning state to accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 
 ### Fixed
+- Quota warnings: isolate threshold episodes by stable account ownership so one account cannot duplicate or suppress another account's alert. Thanks @vincent-peng!
 - Claude: cache successful CLI version probes for 30 minutes while invalidating on executable changes, avoiding repeated PTY launches without retaining failed or stale wrapper results. Thanks @Yuxin-Qiao!
 - Linux CLI: bootstrap the configured IANA timezone before Foundation startup on non-FHS systems, preventing SIGILL on NixOS (#2127). Thanks @xikhar!
 - Ollama: release temporary dashboard network sessions after each fetch, preventing repeated refreshes from retaining delegates and URL-cache resources. Thanks @astuteprogrammer!

--- a/Sources/CodexBar/PredictivePaceWarnings.swift
+++ b/Sources/CodexBar/PredictivePaceWarnings.swift
@@ -223,16 +223,16 @@ extension UsageStore {
         return "email:\(account)"
     }
 
-    static func predictivePaceWarningClaudeAccountDiscriminator(
+    static func warningClaudeAccountDiscriminator(
         strategyKind: ProviderFetchKind,
         observation: ClaudeOAuthActiveAccountObservation,
         oauthHistoryOwnerIdentifier: String? = nil) -> String?
     {
         switch strategyKind {
         case .cli:
-            return self.predictivePaceWarningClaudeActiveAccountDiscriminator(observation: observation)
+            return self.warningClaudeActiveAccountDiscriminator(observation: observation)
         case .oauth:
-            if let activeAccount = self.predictivePaceWarningClaudeActiveAccountDiscriminator(
+            if let activeAccount = self.warningClaudeActiveAccountDiscriminator(
                 observation: observation)
             {
                 return activeAccount
@@ -242,15 +242,15 @@ extension UsageStore {
                 .lowercased(),
                 !owner.isEmpty
             else { return nil }
-            // OAuth usage has no email. Keep a credential-scoped fallback so predictive warnings still work
-            // when Claude's active-account metadata is unavailable, without merging unrelated accounts.
+            // OAuth usage has no email. Keep a credential-scoped fallback so warning episodes remain
+            // account-scoped when Claude's active-account metadata is unavailable.
             return "claude-oauth-owner:\(owner)"
         case .apiToken, .localProbe, .web, .webDashboard:
             return nil
         }
     }
 
-    private static func predictivePaceWarningClaudeActiveAccountDiscriminator(
+    private static func warningClaudeActiveAccountDiscriminator(
         observation: ClaudeOAuthActiveAccountObservation) -> String?
     {
         guard case let .stable(identity) = observation,
@@ -260,7 +260,7 @@ extension UsageStore {
         return "claude-account:\(identity)"
     }
 
-    static func predictivePaceWarningTokenAccountDiscriminator(_ account: ProviderTokenAccount?) -> String? {
+    static func warningTokenAccountDiscriminator(_ account: ProviderTokenAccount?) -> String? {
         guard let account else { return nil }
         return "token-account:\(account.id.uuidString.lowercased())"
     }

--- a/Sources/CodexBar/UsageStore+QuotaWarnings.swift
+++ b/Sources/CodexBar/UsageStore+QuotaWarnings.swift
@@ -1,13 +1,57 @@
 import CodexBarCore
 import Foundation
 
+extension UsageStore {
+    struct QuotaWarningStateKey: Hashable {
+        let provider: UsageProvider
+        let window: QuotaWarningWindow
+        /// Keeps independent accounts from sharing threshold-crossing state. `nil` preserves the
+        /// legacy single-account lane when no stable account owner is available.
+        let accountDiscriminator: String?
+        /// Distinguishes independent extra rate windows that share a provider/window lane
+        /// (e.g. multiple `claude-weekly-scoped-*` windows) so their fired-threshold state
+        /// does not clobber each other or the primary session/weekly lanes. `nil` for the
+        /// primary session and weekly lanes.
+        let windowID: String?
+
+        init(
+            provider: UsageProvider,
+            window: QuotaWarningWindow,
+            accountDiscriminator: String?,
+            windowID: String? = nil)
+        {
+            self.provider = provider
+            self.window = window
+            self.accountDiscriminator = accountDiscriminator
+            self.windowID = windowID
+        }
+    }
+
+    struct QuotaWarningState {
+        var lastRemaining: Double?
+        var firedThresholds: Set<Int> = []
+        var source: SessionQuotaWindowSource?
+    }
+}
+
 @MainActor
 extension UsageStore {
-    func handleQuotaWarningTransitions(provider: UsageProvider, snapshot: UsageSnapshot) {
+    private struct QuotaWarningAccountContext {
+        let discriminator: String?
+        let displayName: String?
+    }
+
+    func handleQuotaWarningTransitions(
+        provider: UsageProvider,
+        snapshot: UsageSnapshot,
+        accountDiscriminator: String? = nil)
+    {
         guard self.settings.quotaWarningNotificationsEnabled else { return }
         if provider == .commandcode, snapshot.commandCodeSubscriptionEnrichmentUnavailable { return }
 
-        let accountDisplayName = self.quotaWarningAccountDisplayName(provider: provider, snapshot: snapshot)
+        let accountContext = QuotaWarningAccountContext(
+            discriminator: accountDiscriminator,
+            displayName: self.quotaWarningAccountDisplayName(provider: provider, snapshot: snapshot))
         let source: SessionQuotaWindowSource? = if provider == .antigravity {
             Self.hasAntigravityQuotaSummaryWindows(snapshot: snapshot)
                 ? .antigravityQuotaSummary
@@ -29,17 +73,17 @@ extension UsageStore {
             window: .session,
             rateWindow: primaryWindow,
             source: source,
-            accountDisplayName: accountDisplayName)
+            accountContext: accountContext)
         self.handleQuotaWarningTransition(
             provider: provider,
             window: .weekly,
             rateWindow: secondaryWindow,
             source: source,
-            accountDisplayName: accountDisplayName)
+            accountContext: accountContext)
         self.handleClaudeExtraWindowQuotaWarnings(
             provider: provider,
             snapshot: snapshot,
-            accountDisplayName: accountDisplayName)
+            accountContext: accountContext)
     }
 
     /// Emit weekly-lane quota warnings for Claude's extra rate windows — model-scoped weekly
@@ -49,16 +93,11 @@ extension UsageStore {
     private func handleClaudeExtraWindowQuotaWarnings(
         provider: UsageProvider,
         snapshot: UsageSnapshot,
-        accountDisplayName: String?)
+        accountContext: QuotaWarningAccountContext)
     {
         guard provider == .claude else { return }
         guard self.settings.quotaWarningEnabled(provider: provider, window: .weekly) else {
-            let extraWindowKeys = self.quotaWarningState.keys.filter {
-                $0.provider == provider && $0.windowID != nil
-            }
-            for key in extraWindowKeys {
-                self.quotaWarningState.removeValue(forKey: key)
-            }
+            self.clearQuotaWarningState(provider: provider, window: .weekly)
             return
         }
 
@@ -69,7 +108,7 @@ extension UsageStore {
                 window: .weekly,
                 rateWindow: named.window,
                 source: nil,
-                accountDisplayName: accountDisplayName,
+                accountContext: accountContext,
                 windowID: named.id,
                 windowDisplayLabel: named.title)
         }
@@ -78,7 +117,11 @@ extension UsageStore {
         guard !windows.isEmpty else { return }
         let activeIDs = Set(windows.map(\.id))
         let staleKeys = self.quotaWarningState.keys.filter { key in
-            guard key.provider == provider, let windowID = key.windowID else { return false }
+            guard key.provider == provider,
+                  key.window == .weekly,
+                  key.accountDiscriminator == accountContext.discriminator,
+                  let windowID = key.windowID
+            else { return false }
             return !activeIDs.contains(windowID)
         }
         for key in staleKeys {
@@ -96,13 +139,17 @@ extension UsageStore {
         window: QuotaWarningWindow,
         rateWindow: RateWindow?,
         source: SessionQuotaWindowSource?,
-        accountDisplayName: String?,
+        accountContext: QuotaWarningAccountContext,
         windowID: String? = nil,
         windowDisplayLabel: String? = nil)
     {
-        let key = QuotaWarningStateKey(provider: provider, window: window, windowID: windowID)
+        let key = QuotaWarningStateKey(
+            provider: provider,
+            window: window,
+            accountDiscriminator: accountContext.discriminator,
+            windowID: windowID)
         guard self.settings.quotaWarningEnabled(provider: provider, window: window) else {
-            self.quotaWarningState.removeValue(forKey: key)
+            self.clearQuotaWarningState(provider: provider, window: window)
             return
         }
         guard let rateWindow else {
@@ -140,7 +187,7 @@ extension UsageStore {
                     window: window,
                     threshold: threshold,
                     currentRemaining: currentRemaining,
-                    accountDisplayName: accountDisplayName,
+                    accountDisplayName: accountContext.displayName,
                     windowID: windowID,
                     windowDisplayLabel: windowDisplayLabel),
                 provider: provider)
@@ -148,6 +195,15 @@ extension UsageStore {
 
         state.lastRemaining = currentRemaining
         self.quotaWarningState[key] = state
+    }
+
+    private func clearQuotaWarningState(provider: UsageProvider, window: QuotaWarningWindow) {
+        let keys = self.quotaWarningState.keys.filter {
+            $0.provider == provider && $0.window == window
+        }
+        for key in keys {
+            self.quotaWarningState.removeValue(forKey: key)
+        }
     }
 
     private func quotaWarningAccountDisplayName(provider: UsageProvider, snapshot: UsageSnapshot) -> String? {

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -41,6 +41,25 @@ extension UsageStore {
         let missingWindowBackfillSnapshot: UsageSnapshot?
     }
 
+    private static func warningAccountDiscriminator(
+        provider: UsageProvider,
+        tokenAccount: ProviderTokenAccount?,
+        result: ProviderFetchResult,
+        context: ProviderRefreshOutcomeContext) -> String?
+    {
+        if let tokenAccount {
+            return self.warningTokenAccountDiscriminator(tokenAccount)
+        }
+        if provider == .codex {
+            return context.codexSessionQuotaOwnerKey?.rawValue
+        }
+        guard provider == .claude else { return nil }
+        return self.warningClaudeAccountDiscriminator(
+            strategyKind: result.strategyKind,
+            observation: context.claudeOAuthActiveAccountObservation,
+            oauthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier)
+    }
+
     static func commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
         current: UsageSnapshot,
         previous: UsageSnapshot?) -> UsageSnapshot
@@ -500,15 +519,15 @@ extension UsageStore {
                 current: accountScoped,
                 previous: self.snapshots[provider])
             let backfilled = stabilized.backfillingResetTimes(from: resetBackfillSource)
-            let predictivePaceWarningAccountDiscriminatorOverride: String? = if provider == .claude {
-                Self.predictivePaceWarningClaudeAccountDiscriminator(
-                    strategyKind: result.strategyKind,
-                    observation: context.claudeOAuthActiveAccountObservation,
-                    oauthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier)
-            } else {
-                nil
-            }
-            self.handleQuotaWarningTransitions(provider: provider, snapshot: backfilled)
+            let warningAccountDiscriminator = Self.warningAccountDiscriminator(
+                provider: provider,
+                tokenAccount: currentTokenAccount,
+                result: result,
+                context: context)
+            self.handleQuotaWarningTransitions(
+                provider: provider,
+                snapshot: backfilled,
+                accountDiscriminator: warningAccountDiscriminator)
             self.handleSessionQuotaTransition(
                 provider: provider,
                 snapshot: backfilled,
@@ -516,7 +535,7 @@ extension UsageStore {
             self.handlePredictivePaceWarningTransitions(
                 provider: provider,
                 snapshot: backfilled,
-                accountDiscriminatorOverride: predictivePaceWarningAccountDiscriminatorOverride)
+                accountDiscriminatorOverride: provider == .claude ? warningAccountDiscriminator : nil)
             if provider == .codex {
                 self.handleCodexResetCreditNotifications(snapshot: backfilled)
             }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -1388,12 +1388,17 @@ extension UsageStore {
         case .success:
             guard let snapshot else { return }
             let publicationGuard = Self.codexScopedRefreshGuard(for: account)
+            let codexOwnerKey = Self.codexSessionQuotaOwnerKey(for: publicationGuard)
             self.lastFetchAttempts[.codex] = outcome.attempts
             self.handleCodexResetCreditNotifications(snapshot: snapshot)
+            self.handleQuotaWarningTransitions(
+                provider: .codex,
+                snapshot: snapshot,
+                accountDiscriminator: codexOwnerKey?.rawValue)
             self.handleSessionQuotaTransition(
                 provider: .codex,
                 snapshot: snapshot,
-                codexOwnerKey: Self.codexSessionQuotaOwnerKey(for: publicationGuard))
+                codexOwnerKey: codexOwnerKey)
             self.handlePredictivePaceWarningTransitions(provider: .codex, snapshot: snapshot)
             self.lastKnownResetSnapshots[.codex] = snapshot
             self.lastCodexUsagePublicationGuard = publicationGuard
@@ -1459,17 +1464,16 @@ extension UsageStore {
                     return nil as UsageSnapshot?
                 }
                 let backfilled = labeled.backfillingResetTimes(from: self.lastKnownResetSnapshots[provider])
-                let predictivePaceWarningAccountDiscriminatorOverride: String? = if provider == .claude {
-                    Self.predictivePaceWarningTokenAccountDiscriminator(account)
-                } else {
-                    nil
-                }
-                self.handleQuotaWarningTransitions(provider: provider, snapshot: backfilled)
+                let warningAccountDiscriminator = Self.warningTokenAccountDiscriminator(account)
+                self.handleQuotaWarningTransitions(
+                    provider: provider,
+                    snapshot: backfilled,
+                    accountDiscriminator: warningAccountDiscriminator)
                 self.handleSessionQuotaTransition(provider: provider, snapshot: backfilled)
                 self.handlePredictivePaceWarningTransitions(
                     provider: provider,
                     snapshot: backfilled,
-                    accountDiscriminatorOverride: predictivePaceWarningAccountDiscriminatorOverride)
+                    accountDiscriminatorOverride: provider == .claude ? warningAccountDiscriminator : nil)
                 self.lastKnownResetSnapshots[provider] = backfilled
                 self.snapshots[provider] = backfilled
                 self.lastSourceLabels[provider] = result.sourceLabel

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -830,28 +830,6 @@ final class UsageStore {
         case antigravityLegacy
     }
 
-    struct QuotaWarningStateKey: Hashable {
-        let provider: UsageProvider
-        let window: QuotaWarningWindow
-        /// Distinguishes independent extra rate windows that share a provider/window lane
-        /// (e.g. multiple `claude-weekly-scoped-*` windows) so their fired-threshold state
-        /// does not clobber each other or the primary session/weekly lanes. `nil` for the
-        /// primary session and weekly lanes.
-        let windowID: String?
-
-        init(provider: UsageProvider, window: QuotaWarningWindow, windowID: String? = nil) {
-            self.provider = provider
-            self.window = window
-            self.windowID = windowID
-        }
-    }
-
-    struct QuotaWarningState {
-        var lastRemaining: Double?
-        var firedThresholds: Set<Int> = []
-        var source: SessionQuotaWindowSource?
-    }
-
     func postQuotaWarning(_ event: QuotaWarningEvent, provider: UsageProvider) {
         self.sessionQuotaNotifier.postQuotaWarning(
             event: event,

--- a/Tests/CodexBarTests/ClaudeExtraWindowQuotaWarningTests.swift
+++ b/Tests/CodexBarTests/ClaudeExtraWindowQuotaWarningTests.swift
@@ -74,9 +74,15 @@ struct ClaudeExtraWindowQuotaWarningTests {
 
         // Each window keeps independent fired-threshold state instead of clobbering the shared weekly key.
         let fableKey = UsageStore.QuotaWarningStateKey(
-            provider: .claude, window: .weekly, windowID: "claude-weekly-scoped-fable")
+            provider: .claude,
+            window: .weekly,
+            accountDiscriminator: nil,
+            windowID: "claude-weekly-scoped-fable")
         let routinesKey = UsageStore.QuotaWarningStateKey(
-            provider: .claude, window: .weekly, windowID: "claude-routines")
+            provider: .claude,
+            window: .weekly,
+            accountDiscriminator: nil,
+            windowID: "claude-routines")
         #expect(store.quotaWarningState[fableKey]?.firedThresholds.contains(50) == true)
         #expect(store.quotaWarningState[routinesKey]?.firedThresholds.contains(50) == true)
     }
@@ -170,9 +176,15 @@ struct ClaudeExtraWindowQuotaWarningTests {
         store.handleQuotaWarningTransitions(
             provider: .claude, snapshot: self.claudeExtraWindowSnapshot(fableUsed: 55, routinesUsed: 55))
         let fableKey = UsageStore.QuotaWarningStateKey(
-            provider: .claude, window: .weekly, windowID: "claude-weekly-scoped-fable")
+            provider: .claude,
+            window: .weekly,
+            accountDiscriminator: nil,
+            windowID: "claude-weekly-scoped-fable")
         let routinesKey = UsageStore.QuotaWarningStateKey(
-            provider: .claude, window: .weekly, windowID: "claude-routines")
+            provider: .claude,
+            window: .weekly,
+            accountDiscriminator: nil,
+            windowID: "claude-routines")
         #expect(store.quotaWarningState[fableKey] != nil)
         #expect(store.quotaWarningState[routinesKey] != nil)
 
@@ -185,8 +197,8 @@ struct ClaudeExtraWindowQuotaWarningTests {
     }
 
     @Test
-    func `disabling weekly warnings clears all claude extra-window state`() {
-        let settings = self.makeSettings(suiteName: "ClaudeExtraWindowQuotaWarningTests-disable")
+    func `claude extra-window reconciliation preserves sibling account state`() {
+        let settings = self.makeSettings(suiteName: "ClaudeExtraWindowQuotaWarningTests-account-prune")
         settings.refreshFrequency = .manual
         settings.statusChecksEnabled = false
         settings.quotaWarningNotificationsEnabled = true
@@ -201,22 +213,81 @@ struct ClaudeExtraWindowQuotaWarningTests {
             sessionQuotaNotifier: notifier)
 
         store.handleQuotaWarningTransitions(
-            provider: .claude, snapshot: self.claudeExtraWindowSnapshot(fableUsed: 40, routinesUsed: 40))
+            provider: .claude,
+            snapshot: self.claudeExtraWindowSnapshot(fableUsed: 40, routinesUsed: nil),
+            accountDiscriminator: "account-a")
         store.handleQuotaWarningTransitions(
-            provider: .claude, snapshot: self.claudeExtraWindowSnapshot(fableUsed: 55, routinesUsed: 55))
-        let fableKey = UsageStore.QuotaWarningStateKey(
-            provider: .claude, window: .weekly, windowID: "claude-weekly-scoped-fable")
-        let routinesKey = UsageStore.QuotaWarningStateKey(
-            provider: .claude, window: .weekly, windowID: "claude-routines")
-        #expect(store.quotaWarningState[fableKey] != nil)
-        #expect(store.quotaWarningState[routinesKey] != nil)
+            provider: .claude,
+            snapshot: self.claudeExtraWindowSnapshot(fableUsed: 55, routinesUsed: nil),
+            accountDiscriminator: "account-a")
+        let accountAFableKey = UsageStore.QuotaWarningStateKey(
+            provider: .claude,
+            window: .weekly,
+            accountDiscriminator: "account-a",
+            windowID: "claude-weekly-scoped-fable")
+        #expect(store.quotaWarningState[accountAFableKey] != nil)
+
+        store.handleQuotaWarningTransitions(
+            provider: .claude,
+            snapshot: self.claudeExtraWindowSnapshot(fableUsed: nil, routinesUsed: 40),
+            accountDiscriminator: "account-b")
+        #expect(store.quotaWarningState[accountAFableKey] != nil)
+
+        store.handleQuotaWarningTransitions(
+            provider: .claude,
+            snapshot: self.claudeExtraWindowSnapshot(fableUsed: 55, routinesUsed: nil),
+            accountDiscriminator: "account-a")
+
+        #expect(notifier.quotaWarningPosts.count == 1)
+        #expect(notifier.quotaWarningPosts.first?.event.windowID == "claude-weekly-scoped-fable")
+        #expect(notifier.quotaWarningPosts.first?.event.threshold == 50)
+    }
+
+    @Test
+    func `disabling weekly warnings clears all account-scoped claude extra-window state`() {
+        let settings = self.makeSettings(suiteName: "ClaudeExtraWindowQuotaWarningTests-disable")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50]
+        settings.setQuotaWarningWindowEnabled(.weekly, enabled: true)
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        let accountIDs = ["account-a", "account-b"]
+        for accountID in accountIDs {
+            store.handleQuotaWarningTransitions(
+                provider: .claude,
+                snapshot: self.claudeExtraWindowSnapshot(fableUsed: 40, routinesUsed: 40),
+                accountDiscriminator: accountID)
+        }
+        let seededKeys = accountIDs.flatMap { accountID in
+            [
+                UsageStore.QuotaWarningStateKey(
+                    provider: .claude,
+                    window: .weekly,
+                    accountDiscriminator: accountID,
+                    windowID: "claude-weekly-scoped-fable"),
+                UsageStore.QuotaWarningStateKey(
+                    provider: .claude,
+                    window: .weekly,
+                    accountDiscriminator: accountID,
+                    windowID: "claude-routines"),
+            ]
+        }
+        #expect(seededKeys.allSatisfy { store.quotaWarningState[$0] != nil })
 
         settings.setQuotaWarningWindowEnabled(.weekly, enabled: false)
         store.handleQuotaWarningTransitions(
             provider: .claude,
-            snapshot: UsageSnapshot(primary: nil, secondary: nil, extraRateWindows: nil, updatedAt: Date()))
-        #expect(store.quotaWarningState[fableKey] == nil)
-        #expect(store.quotaWarningState[routinesKey] == nil)
+            snapshot: UsageSnapshot(primary: nil, secondary: nil, extraRateWindows: nil, updatedAt: Date()),
+            accountDiscriminator: accountIDs[0])
+        #expect(seededKeys.allSatisfy { store.quotaWarningState[$0] == nil })
     }
 
     @Test
@@ -242,7 +313,10 @@ struct ClaudeExtraWindowQuotaWarningTests {
             provider: .claude, snapshot: self.claudeExtraWindowSnapshot(fableUsed: 55, routinesUsed: nil))
         #expect(notifier.quotaWarningPosts.count == 1)
         let fableKey = UsageStore.QuotaWarningStateKey(
-            provider: .claude, window: .weekly, windowID: "claude-weekly-scoped-fable")
+            provider: .claude,
+            window: .weekly,
+            accountDiscriminator: nil,
+            windowID: "claude-weekly-scoped-fable")
 
         // A failed web-extras fetch delivers nil extras while the main snapshot is intact. The fired
         // state must persist so the warning is not re-posted when extras recover.

--- a/Tests/CodexBarTests/CodexSessionQuotaFalseRestoreTests.swift
+++ b/Tests/CodexBarTests/CodexSessionQuotaFalseRestoreTests.swift
@@ -683,6 +683,78 @@ extension CodexSessionQuotaFalseRestoreTests {
     }
 
     @Test
+    func `selected Codex accounts keep independent quota warning episodes`() async throws {
+        let managedAccountID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000002"))
+        let firstAccount = CodexVisibleAccount(
+            id: "live:first-quota-account",
+            email: "first-quota@example.test",
+            workspaceAccountID: "workspace-first-quota-account",
+            storedAccountID: nil,
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: false,
+            canRemove: false)
+        let secondAccount = CodexVisibleAccount(
+            id: "managed:\(managedAccountID.uuidString.lowercased())",
+            email: "second-quota@example.test",
+            workspaceAccountID: "workspace-second-quota-account",
+            storedAccountID: managedAccountID,
+            selectionSource: .managedAccount(id: managedAccountID),
+            isActive: false,
+            isLive: false,
+            canReauthenticate: true,
+            canRemove: true)
+        let notifier = SessionQuotaNotifierSpy()
+        let store = Self.makeStore(notifier: notifier)
+        let isolatedCodexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexSessionQuotaFalseRestoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: isolatedCodexHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: isolatedCodexHome) }
+        store.settings._test_codexReconciliationEnvironment = ["CODEX_HOME": isolatedCodexHome.path]
+        defer { store.settings._test_codexReconciliationEnvironment = nil }
+        store.settings.sessionQuotaNotificationsEnabled = false
+        store.settings.quotaWarningNotificationsEnabled = true
+        store.settings.quotaWarningThresholds = [50]
+        store.settings.setQuotaWarningWindowEnabled(.session, enabled: true)
+        store.settings.setQuotaWarningWindowEnabled(.weekly, enabled: false)
+
+        for (account, usedPercent) in [
+            (firstAccount, 40.0),
+            (secondAccount, 40.0),
+            (firstAccount, 55.0),
+            (secondAccount, 30.0),
+            (firstAccount, 55.0),
+            (secondAccount, 55.0),
+        ] {
+            let snapshot = self.snapshot(
+                used: usedPercent,
+                resetBoundary: nil,
+                updatedAt: self.start,
+                email: account.email)
+            let result = ProviderFetchResult(
+                usage: snapshot,
+                credits: nil,
+                dashboard: nil,
+                sourceLabel: "fixture",
+                strategyID: "fixture.oauth",
+                strategyKind: .oauth)
+            await store.applySelectedCodexVisibleAccountOutcome(
+                ProviderFetchOutcome(result: .success(result), attempts: []),
+                account: account,
+                snapshot: snapshot,
+                sourceLabel: "fixture",
+                limitResetOwnerKey: nil)
+        }
+
+        #expect(notifier.quotaWarningPosts.map(\.accountDisplayName) == [
+            "first-quota@example.test",
+            "second-quota@example.test",
+        ])
+        #expect(notifier.quotaWarningPosts.allSatisfy { $0.threshold == 50 })
+    }
+
+    @Test
     func `selected email only Codex account keeps session notifications`() async {
         let email = "email-only-session@example.test"
         let account = CodexVisibleAccount(
@@ -990,15 +1062,18 @@ extension CodexSessionQuotaFalseRestoreTests {
 @MainActor
 private final class SessionQuotaNotifierSpy: SessionQuotaNotifying {
     private(set) var transitions: [SessionQuotaTransition] = []
+    private(set) var quotaWarningPosts: [QuotaWarningEvent] = []
 
     func post(transition: SessionQuotaTransition, provider _: UsageProvider, badge _: NSNumber?) {
         self.transitions.append(transition)
     }
 
     func postQuotaWarning(
-        event _: QuotaWarningEvent,
+        event: QuotaWarningEvent,
         provider _: UsageProvider,
         soundEnabled _: Bool,
         onScreenAlertEnabled _: Bool)
-    {}
+    {
+        self.quotaWarningPosts.append(event)
+    }
 }

--- a/Tests/CodexBarTests/PredictivePaceWarningTests.swift
+++ b/Tests/CodexBarTests/PredictivePaceWarningTests.swift
@@ -444,22 +444,22 @@ struct PredictivePaceWarningTests {
         settings.predictivePaceWarningNotificationsEnabled = true
         let notifier = NotifierSpy()
         let store = self.makeStore(settings: settings, notifier: notifier)
-        let firstAccount = UsageStore.predictivePaceWarningClaudeAccountDiscriminator(
+        let firstAccount = UsageStore.warningClaudeAccountDiscriminator(
             strategyKind: .oauth,
             observation: .stable(identity: "account-a"))
-        let secondAccount = UsageStore.predictivePaceWarningClaudeAccountDiscriminator(
+        let secondAccount = UsageStore.warningClaudeAccountDiscriminator(
             strategyKind: .cli,
             observation: .stable(identity: "account-b"))
-        #expect(UsageStore.predictivePaceWarningClaudeAccountDiscriminator(
+        #expect(UsageStore.warningClaudeAccountDiscriminator(
             strategyKind: .oauth,
             observation: .stable(identity: nil)) == nil)
-        #expect(UsageStore.predictivePaceWarningClaudeAccountDiscriminator(
+        #expect(UsageStore.warningClaudeAccountDiscriminator(
             strategyKind: .cli,
             observation: .changed) == nil)
-        #expect(UsageStore.predictivePaceWarningClaudeAccountDiscriminator(
+        #expect(UsageStore.warningClaudeAccountDiscriminator(
             strategyKind: .web,
             observation: .stable(identity: "account-a")) == nil)
-        #expect(UsageStore.predictivePaceWarningClaudeAccountDiscriminator(
+        #expect(UsageStore.warningClaudeAccountDiscriminator(
             strategyKind: .apiToken,
             observation: .stable(identity: "account-a")) == nil)
         let noEmailRisk = self.snapshot(
@@ -507,19 +507,19 @@ struct PredictivePaceWarningTests {
     func `Claude OAuth owner keeps no email warnings account scoped when active metadata is missing`() {
         let owner = String(repeating: "a", count: 64)
 
-        #expect(UsageStore.predictivePaceWarningClaudeAccountDiscriminator(
+        #expect(UsageStore.warningClaudeAccountDiscriminator(
             strategyKind: .oauth,
             observation: .stable(identity: nil),
             oauthHistoryOwnerIdentifier: owner) == "claude-oauth-owner:\(owner)")
-        #expect(UsageStore.predictivePaceWarningClaudeAccountDiscriminator(
+        #expect(UsageStore.warningClaudeAccountDiscriminator(
             strategyKind: .oauth,
             observation: .changed,
             oauthHistoryOwnerIdentifier: "  \(owner.uppercased())  ") == "claude-oauth-owner:\(owner)")
-        #expect(UsageStore.predictivePaceWarningClaudeAccountDiscriminator(
+        #expect(UsageStore.warningClaudeAccountDiscriminator(
             strategyKind: .cli,
             observation: .stable(identity: nil),
             oauthHistoryOwnerIdentifier: owner) == nil)
-        #expect(UsageStore.predictivePaceWarningClaudeAccountDiscriminator(
+        #expect(UsageStore.warningClaudeAccountDiscriminator(
             strategyKind: .web,
             observation: .stable(identity: nil),
             oauthHistoryOwnerIdentifier: owner) == nil)

--- a/Tests/CodexBarTests/UsageStoreAccountQuotaWarningTests.swift
+++ b/Tests/CodexBarTests/UsageStoreAccountQuotaWarningTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+struct UsageStoreAccountQuotaWarningTests {
+    @MainActor
+    private final class NotifierSpy: SessionQuotaNotifying {
+        private(set) var quotaWarnings: [QuotaWarningEvent] = []
+
+        func post(transition _: SessionQuotaTransition, provider _: UsageProvider, badge _: NSNumber?) {}
+
+        func postQuotaWarning(
+            event: QuotaWarningEvent,
+            provider _: UsageProvider,
+            soundEnabled _: Bool,
+            onScreenAlertEnabled _: Bool)
+        {
+            self.quotaWarnings.append(event)
+        }
+    }
+
+    @Test
+    func `ordinary refresh keeps selected token account warning episodes independent`() async {
+        let settings = testSettingsStore(
+            suiteName: "UsageStoreAccountQuotaWarningTests-selected-account",
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50]
+        settings.setQuotaWarningWindowEnabled(.session, enabled: true)
+        settings.setQuotaWarningWindowEnabled(.weekly, enabled: false)
+        settings.sessionQuotaNotificationsEnabled = false
+        settings.predictivePaceWarningNotificationsEnabled = false
+        settings.addTokenAccount(provider: .deepseek, label: "First", token: "first-token")
+        settings.addTokenAccount(provider: .deepseek, label: "Second", token: "second-token")
+        #expect(settings.tokenAccounts(for: .deepseek).map(\.label) == ["First", "Second"])
+
+        let notifier = NotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier,
+            startupBehavior: .testing)
+        let sequence = [
+            (accountIndex: 0, usedPercent: 40.0),
+            (accountIndex: 1, usedPercent: 40.0),
+            (accountIndex: 0, usedPercent: 55.0),
+            (accountIndex: 1, usedPercent: 30.0),
+            (accountIndex: 0, usedPercent: 55.0),
+            (accountIndex: 1, usedPercent: 55.0),
+        ]
+
+        for (step, observation) in sequence.enumerated() {
+            settings.setActiveTokenAccountIndex(observation.accountIndex, for: .deepseek)
+            let outcome = Self.outcome(
+                usedPercent: observation.usedPercent,
+                updatedAt: Date(timeIntervalSince1970: 1_780_000_000 + Double(step)))
+            store._test_providerFetchOutcomeOverride = { _ in outcome }
+            await store.refreshProvider(.deepseek, allowDisabled: true)
+        }
+
+        #expect(notifier.quotaWarnings.map(\.accountDisplayName) == ["First", "Second"])
+        #expect(notifier.quotaWarnings.allSatisfy { $0.threshold == 50 })
+    }
+
+    @Test
+    func `selected outcome keeps token account warning episodes independent`() async throws {
+        let settings = testSettingsStore(
+            suiteName: "UsageStoreAccountQuotaWarningTests-selected-outcome",
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50]
+        settings.setQuotaWarningWindowEnabled(.session, enabled: true)
+        settings.setQuotaWarningWindowEnabled(.weekly, enabled: false)
+        settings.sessionQuotaNotificationsEnabled = false
+        settings.predictivePaceWarningNotificationsEnabled = false
+
+        let accounts = try [
+            ProviderTokenAccount(
+                id: #require(UUID(uuidString: "00000000-0000-0000-0000-000000000001")),
+                label: "First",
+                token: "first-token",
+                addedAt: 0,
+                lastUsed: nil),
+            ProviderTokenAccount(
+                id: #require(UUID(uuidString: "00000000-0000-0000-0000-000000000002")),
+                label: "Second",
+                token: "second-token",
+                addedAt: 0,
+                lastUsed: nil),
+        ]
+        let notifier = NotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier,
+            startupBehavior: .testing)
+        let sequence = [
+            (accountIndex: 0, usedPercent: 40.0),
+            (accountIndex: 1, usedPercent: 40.0),
+            (accountIndex: 0, usedPercent: 55.0),
+            (accountIndex: 1, usedPercent: 30.0),
+            (accountIndex: 0, usedPercent: 55.0),
+            (accountIndex: 1, usedPercent: 55.0),
+        ]
+
+        for (step, observation) in sequence.enumerated() {
+            await store.applySelectedOutcome(
+                Self.outcome(
+                    usedPercent: observation.usedPercent,
+                    updatedAt: Date(timeIntervalSince1970: 1_780_000_000 + Double(step))),
+                provider: .deepseek,
+                account: accounts[observation.accountIndex],
+                fallbackSnapshot: nil)
+        }
+
+        #expect(notifier.quotaWarnings.map(\.accountDisplayName) == ["First", "Second"])
+        #expect(notifier.quotaWarnings.allSatisfy { $0.threshold == 50 })
+    }
+
+    private static func outcome(usedPercent: Double, updatedAt: Date) -> ProviderFetchOutcome {
+        ProviderFetchOutcome(
+            result: .success(ProviderFetchResult(
+                usage: UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: usedPercent,
+                        windowMinutes: 300,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    secondary: nil,
+                    updatedAt: updatedAt),
+                credits: nil,
+                dashboard: nil,
+                sourceLabel: "fixture",
+                strategyID: "fixture.api-token",
+                strategyKind: .apiToken)),
+            attempts: [])
+    }
+}

--- a/Tests/CodexBarTests/UsageStoreAccountQuotaWarningTests.swift
+++ b/Tests/CodexBarTests/UsageStoreAccountQuotaWarningTests.swift
@@ -34,8 +34,8 @@ struct UsageStoreAccountQuotaWarningTests {
         settings.setQuotaWarningWindowEnabled(.weekly, enabled: false)
         settings.sessionQuotaNotificationsEnabled = false
         settings.predictivePaceWarningNotificationsEnabled = false
-        settings.addTokenAccount(provider: .deepseek, label: "First", token: "first-token")
-        settings.addTokenAccount(provider: .deepseek, label: "Second", token: "second-token")
+        settings.addTokenAccount(provider: .deepseek, label: "First", token: "fixture")
+        settings.addTokenAccount(provider: .deepseek, label: "Second", token: "fixture")
         #expect(settings.tokenAccounts(for: .deepseek).map(\.label) == ["First", "Second"])
 
         let notifier = NotifierSpy()
@@ -83,13 +83,13 @@ struct UsageStoreAccountQuotaWarningTests {
             ProviderTokenAccount(
                 id: #require(UUID(uuidString: "00000000-0000-0000-0000-000000000001")),
                 label: "First",
-                token: "first-token",
+                token: "fixture",
                 addedAt: 0,
                 lastUsed: nil),
             ProviderTokenAccount(
                 id: #require(UUID(uuidString: "00000000-0000-0000-0000-000000000002")),
                 label: "Second",
-                token: "second-token",
+                token: "fixture",
                 addedAt: 0,
                 lastUsed: nil),
         ]

--- a/Tests/CodexBarTests/UsageStoreDisabledProviderCleanupTests.swift
+++ b/Tests/CodexBarTests/UsageStoreDisabledProviderCleanupTests.swift
@@ -447,9 +447,13 @@ struct UsageStoreDisabledProviderCleanupTests {
             unreadablePaths: [],
             components: [],
             updatedAt: Date())
-        store.quotaWarningState[UsageStore.QuotaWarningStateKey(provider: .kilo, window: .session)] =
+        store.quotaWarningState[
+            UsageStore.QuotaWarningStateKey(provider: .kilo, window: .session, accountDiscriminator: nil),
+        ] =
             UsageStore.QuotaWarningState(lastRemaining: 20, firedThresholds: [50], source: .primary)
-        store.quotaWarningState[UsageStore.QuotaWarningStateKey(provider: .codex, window: .session)] =
+        store.quotaWarningState[
+            UsageStore.QuotaWarningStateKey(provider: .codex, window: .session, accountDiscriminator: nil),
+        ] =
             UsageStore.QuotaWarningState(lastRemaining: 80, firedThresholds: [20], source: .primary)
         store.predictivePaceWarningNotifiedKeys = [
             PredictivePaceWarningStateKey(
@@ -472,13 +476,17 @@ struct UsageStoreDisabledProviderCleanupTests {
         #expect(store.lastKnownResetSnapshots[.kilo] == nil)
         #expect(store.kiloScopeSnapshots.isEmpty)
         #expect(store.providerStorageFootprints[.kilo] == nil)
-        #expect(store.quotaWarningState[UsageStore.QuotaWarningStateKey(provider: .kilo, window: .session)] == nil)
+        #expect(store.quotaWarningState[
+            UsageStore.QuotaWarningStateKey(provider: .kilo, window: .session, accountDiscriminator: nil),
+        ] == nil)
         #expect(store.predictivePaceWarningNotifiedKeys.allSatisfy { $0.provider != .kilo })
         #expect(store.lastTokenFetchAt[.kilo] == nil)
         #expect(store.lastTokenFetchScope[.kilo] == nil)
 
         #expect(store.lastKnownResetSnapshots[.codex]?.primary?.usedPercent == 12)
-        #expect(store.quotaWarningState[UsageStore.QuotaWarningStateKey(provider: .codex, window: .session)] != nil)
+        #expect(store.quotaWarningState[
+            UsageStore.QuotaWarningStateKey(provider: .codex, window: .session, accountDiscriminator: nil),
+        ] != nil)
         #expect(store.predictivePaceWarningNotifiedKeys.contains { $0.provider == .codex })
     }
 

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -745,7 +745,10 @@ struct UsageStoreSessionQuotaTransitionTests {
             snapshot: self.antigravityLegacySnapshot(geminiUsed: 80, claudeUsed: 40))
 
         #expect(notifier.quotaWarningPosts.isEmpty)
-        let key = UsageStore.QuotaWarningStateKey(provider: .antigravity, window: .session)
+        let key = UsageStore.QuotaWarningStateKey(
+            provider: .antigravity,
+            window: .session,
+            accountDiscriminator: nil)
         #expect(store.quotaWarningState[key]?.lastRemaining == 20)
         #expect(store.quotaWarningState[key]?.source == .antigravityLegacy)
     }
@@ -788,7 +791,9 @@ struct UsageStoreSessionQuotaTransitionTests {
                 updatedAt: Date()))
 
         #expect(notifier.quotaWarningPosts.count == 1)
-        #expect(store.quotaWarningState[UsageStore.QuotaWarningStateKey(provider: .codex, window: .session)] == nil)
+        #expect(store.quotaWarningState[
+            UsageStore.QuotaWarningStateKey(provider: .codex, window: .session, accountDiscriminator: nil),
+        ] == nil)
     }
 
     private func minimaxSnapshot(sessionUsed: Double, weeklyUsed: Double) -> UsageSnapshot {


### PR DESCRIPTION
## Summary

- key static quota-warning episodes by a stable account discriminator instead of provider/window alone
- forward account ownership through ordinary refresh, selected token-account, stacked Codex, and Claude OAuth/CLI publication paths
- reconcile Claude extra-window warning state per account while preserving provider-wide cleanup when a warning window is disabled
- add focused regressions for ordinary refresh, selected outcomes, stacked Codex accounts, Claude sibling accounts, and provider-wide cleanup

## Root cause

`QuotaWarningStateKey` previously contained only the provider, warning window, and optional extra-window ID. When users switched accounts, one account's observation could clear, suppress, or re-arm another account's threshold episode. The stacked selected-Codex publication path also did not run the static threshold reducer.

This change separates the opaque state discriminator from the optional display identity. Stable token-account UUIDs and hashed provider ownership keys scope reducer state; notification copy still follows the existing Hide Personal Info setting.

## Runtime proof

I ran an identical disposable harness at base `c852c135` and current head `be7f11c4`. It drives the production `UsageStore.refreshProvider` path through six ordinary selected-account refreshes, with two synthetic token accounts and fixture-only provider outcomes. A notifier spy records the same `QuotaWarningEvent` passed to the notification layer.

Sequence: A 40%, B 40%, A 55%, B 30%, A 55%, B 55%, with a 50%-remaining threshold.

Base shared-state trace:

```text
step=3 account=Account-A used=55
emitted account=Account-A threshold=50 remaining=45
step=5 account=Account-A used=55
emitted account=Account-A threshold=50 remaining=45
step=6 account=Account-B used=55
summary emitted=Account-A,Account-A
```

Account B's recovery re-armed A, so A emitted twice; B's own crossing was then suppressed.

Current-head account-scoped trace:

```text
step=3 account=Account-A used=55
emitted account=Account-A threshold=50 remaining=45
step=5 account=Account-A used=55
step=6 account=Account-B used=55
emitted account=Account-B threshold=50 remaining=45
summary emitted=Account-A,Account-B
```

Each account retained an independent episode: no duplicate A warning and no suppressed B warning. Both runs passed one test in one suite using:

```sh
CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter QuotaWarningAccountRuntimeProofTests
```

The proof used isolated settings, synthetic labels/tokens, and stubbed provider outcomes. It did not read a real account store, browser data, provider session, or Keychain item; the disposable harness was not added to either branch.

## Validation

- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 OS_ACTIVITY_MODE=disable swift test --filter 'UsageStoreAccountQuotaWarningTests|UsageStoreSessionQuotaTransitionTests|CodexSessionQuotaFalseRestoreTests|ClaudeExtraWindowQuotaWarningTests|PredictivePaceWarningTests'` - 86 tests in 5 suites passed
- `make check` - passed; SwiftFormat reported 0 files requiring formatting and SwiftLint reported 0 violations across 1,426 files
- `make test` on this commit combined with the test-only isolation from #2128 - all 639 selections passed across 54/54 groups, with zero first-pass failures, retries, or timeouts
- disposable merge simulation against current #2001 head `b14629bd` - 51 focused tests in 5 suites passed; `make check` reported 0/1,437 files requiring formatting and 0 SwiftLint violations across 1,436 files; `git diff --check` passed
- `git diff --check` - passed

## Coordination with #2001

#2001 now has a dedicated `QuotaLowHookUsageKey` at head `b14629bd`, but derives its account key from `snapshot.accountEmail`. That compiles independently, yet is not a sufficient stable discriminator: Claude OAuth accounts can be email-less, generic token accounts can fall back to mutable or duplicate labels, and Codex owners can share an email across workspace/source/auth contexts.

The refreshed disposable merge simulation produced exactly one conflicted file, `UsageStore+QuotaWarnings.swift`, with two adjacent regions. The minimal correct union is to keep #2001's dedicated hook key, notification-independent hook dispatch, and payload behavior while feeding this PR's `accountContext.discriminator` into `dispatchQuotaLowHooks(accountKey:)`; `accountContext.displayName` remains presentation-only.

The combined tree passed 51 focused warning/hook tests across five suites, including a simulation-only regression proving two email-less Claude owners keep separate hook baselines while native notifications are disabled. It also passed `make check` and `git diff --check`. No published branch was changed.

Whichever PR lands second must carry that union and the email-less hook regression. If #2001 lands first, this PR will be rebased and the integration included before merge.

A recording was not available because the host was locked; the exact-head packaged-app runtime log is included above.

## Fresh-bundle runtime proof

I also ran the freshly packaged current-head app, not the disposable harness:

```text
head=be7f11c4ffdc5249a7409af5cd7c50b17eb66869
bundle_embedded_commit=be7f11c4
bundle_binary_sha256=6b4392eef2d9574a1b8929eceea8f12b97ae3f8a7bbaaa4bc582d8db9007b8a6
build=CODEXBAR_ALLOW_LLDB=1 ./Scripts/package_app.sh debug
```

The exact unmodified bundle ran with an isolated HOME/CODEX_HOME/config, both Keychain-access guards set, and only sub2api enabled against a loopback HTTP fixture. The two token accounts had synthetic labels and fixed UUIDs. This does not claim authenticated-provider behavior and did not read a real provider account, browser store, or Keychain item.

Because the host was locked, I drove the same production operations used by the segmented account switcher under LLDB: `setActiveTokenAccountIndex`, cached-account activation, and `refreshProvider(.sub2api)`. Provider outcomes were not stubbed: the packaged app used its production Sub2API URLSession fetcher against the loopback server, then its production reducer, `SessionQuotaNotifier`, and `QuotaWarningAlertOverlayController`.

The redacted server trace was:

```text
[FETCH 01] account=A used=40    # A baseline
[FETCH 02] account=B used=40    # B baseline
[CONTROL] account=A used=55
[FETCH 03] account=A used=55    # A crosses
[FETCH 04] account=B used=40    # B unchanged; no false alert
[FETCH 05] account=A used=55    # repeated low A; no duplicate
[CONTROL] account=B used=55
[FETCH 06] account=B used=55    # B crosses
[FETCH 07] account=B used=55    # repeated low B; no duplicate
```

The real notifier breakpoint was hit exactly twice:

```text
[NOTIFIER 1] account=Proof Account A provider=sub2api window=session threshold=50 remaining=45
2026-07-14 04:53:54.265 [sessionQuotaNotifications] enqueuing (prefix=quota-warning-sub2api-session-50)
2026-07-14 04:53:54.277 [sessionQuotaNotifications] Presenting quota warning overlay

[NOTIFIER 2] account=Proof Account B provider=sub2api window=session threshold=50 remaining=45
2026-07-14 04:56:29.991 [sessionQuotaNotifications] enqueuing (prefix=quota-warning-sub2api-session-50)
2026-07-14 04:56:29.997 [sessionQuotaNotifications] Presenting quota warning overlay

breakpoint hit count = 2
```

The debug bundle was not authorized for Notification Center, so its native UNUserNotificationCenter posts were skipped; the enabled on-screen alert path did present twice. The final in-process state contained exactly two independent owner keys:

```text
owner=token-account:11111111-1111-4111-8111-111111111111 window=session fired=50 remaining=45
owner=token-account:22222222-2222-4222-8222-222222222222 window=session fired=50 remaining=45
cached snapshots: Proof Account A=55%, Proof Account B=55%
```

The source worktree remained clean. The temporary server/app were stopped, the pre-run debug preference snapshot was restored exactly, and the installed release app was left running.
