### PR TITLE
fix: Linux SIGILL during timezone resolution on non-FHS systems (fixes #2127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 
 ### Fixed
+- Linux CLI: bootstrap the configured IANA timezone before Foundation startup on non-FHS systems, preventing SIGILL on NixOS (#2127). Thanks @xikhar!
 - Linux CLI: prevent usage rendering from crashing in Foundation bundle discovery when formatting rate windows. Thanks @thanthi-del!
 - Menus: keep overview provider-row clicks reliable during live menu rebuilds without stealing nested Copy or plan actions. Thanks @Yuxin-Qiao!
 - Startup: load persisted plan-utilization history away from the main thread so mature histories no longer delay app launch. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBarCLI/CLIEntry.swift
+++ b/Sources/CodexBarCLI/CLIEntry.swift
@@ -1,5 +1,8 @@
 import CodexBarCore
 import Commander
+#if os(Linux)
+import CoreFoundation
+#endif
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -203,23 +206,82 @@ enum CodexBarCLI {
 
     // MARK: - Helpers
 
-    static func linuxTimeZoneFallback(currentValue: String?, localTimeReadable: Bool) -> String? {
+    static func linuxTimeZoneFallback(
+        currentValue: String?,
+        localTimeReadable: Bool,
+        resolvedLocalTimePath: String?) -> String?
+    {
         guard currentValue == nil, localTimeReadable else { return nil }
+        if let identifier = self.linuxTimeZoneIdentifier(from: resolvedLocalTimePath) {
+            return identifier
+        }
         return ":/etc/localtime"
+    }
+
+    static func linuxTimeZoneIdentifier(from resolvedLocalTimePath: String?) -> String? {
+        guard let resolvedLocalTimePath,
+              let marker = resolvedLocalTimePath.range(of: "/zoneinfo/")
+        else { return nil }
+
+        var identifier = String(resolvedLocalTimePath[marker.upperBound...])
+        for prefix in ["posix/", "right/"] where identifier.hasPrefix(prefix) {
+            identifier.removeFirst(prefix.count)
+        }
+
+        let components = identifier.split(separator: "/", omittingEmptySubsequences: false)
+        guard !components.isEmpty,
+              components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." })
+        else { return nil }
+        return identifier
     }
 
     private static func configureLinuxTimeZoneIfNeeded() {
         #if os(Linux)
         let currentValue = getenv("TZ").map { String(cString: $0) }
         let localTimeReadable = access("/etc/localtime", R_OK) == 0
+        let resolvedLocalTimePath = self.resolvedLinuxLocalTimePath()
         guard let fallback = self.linuxTimeZoneFallback(
             currentValue: currentValue,
-            localTimeReadable: localTimeReadable)
+            localTimeReadable: localTimeReadable,
+            resolvedLocalTimePath: resolvedLocalTimePath)
         else { return }
 
-        // Swift Foundation otherwise assumes /usr/share/zoneinfo exists. The absolute TZ file form
-        // preserves the configured local timezone on non-FHS systems such as NixOS.
+        if let identifier = self.linuxTimeZoneIdentifier(from: resolvedLocalTimePath) {
+            _ = self.primeCoreFoundationTimeZone(identifier: identifier, filePath: "/etc/localtime")
+        }
+
+        // Prefer the IANA identifier so FoundationEssentials retains DST rules. Legacy formatters
+        // use the CoreFoundation cache primed above when /usr/share/zoneinfo is unavailable.
         setenv("TZ", fallback, 0)
+        #endif
+    }
+
+    static func primeCoreFoundationTimeZone(identifier: String, filePath: String) -> Bool {
+        #if os(Linux)
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)), !data.isEmpty else { return false }
+        guard let name = identifier.withCString({
+            CFStringCreateWithCString(nil, $0, CFStringBuiltInEncodings.UTF8.rawValue)
+        }) else { return false }
+        guard let timeZoneData = data.withUnsafeBytes({ rawBuffer -> CFData? in
+            let bytes = rawBuffer.bindMemory(to: UInt8.self)
+            return CFDataCreate(nil, bytes.baseAddress, bytes.count)
+        }) else { return false }
+        return CFTimeZoneCreate(nil, name, timeZoneData) != nil
+        #else
+        return false
+        #endif
+    }
+
+    private static func resolvedLinuxLocalTimePath() -> String? {
+        #if os(Linux)
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        guard realpath("/etc/localtime", &buffer) != nil else { return nil }
+        return buffer.withUnsafeBufferPointer { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return nil }
+            return String(cString: baseAddress)
+        }
+        #else
+        return nil
         #endif
     }
 

--- a/Sources/CodexBarCLI/CLIEntry.swift
+++ b/Sources/CodexBarCLI/CLIEntry.swift
@@ -206,16 +206,13 @@ enum CodexBarCLI {
 
     // MARK: - Helpers
 
-    static func linuxTimeZoneFallback(
+    static func linuxTimeZoneBootstrapIdentifier(
         currentValue: String?,
         localTimeReadable: Bool,
         resolvedLocalTimePath: String?) -> String?
     {
         guard currentValue == nil, localTimeReadable else { return nil }
-        if let identifier = self.linuxTimeZoneIdentifier(from: resolvedLocalTimePath) {
-            return identifier
-        }
-        return ":/etc/localtime"
+        return self.linuxTimeZoneIdentifier(from: resolvedLocalTimePath)
     }
 
     static func linuxTimeZoneIdentifier(from resolvedLocalTimePath: String?) -> String? {
@@ -240,19 +237,17 @@ enum CodexBarCLI {
         let currentValue = getenv("TZ").map { String(cString: $0) }
         let localTimeReadable = access("/etc/localtime", R_OK) == 0
         let resolvedLocalTimePath = self.resolvedLinuxLocalTimePath()
-        guard let fallback = self.linuxTimeZoneFallback(
+        guard let identifier = self.linuxTimeZoneBootstrapIdentifier(
             currentValue: currentValue,
             localTimeReadable: localTimeReadable,
             resolvedLocalTimePath: resolvedLocalTimePath)
         else { return }
 
-        if let identifier = self.linuxTimeZoneIdentifier(from: resolvedLocalTimePath) {
-            _ = self.primeCoreFoundationTimeZone(identifier: identifier, filePath: "/etc/localtime")
-        }
+        guard self.primeCoreFoundationTimeZone(identifier: identifier, filePath: "/etc/localtime") else { return }
 
-        // Prefer the IANA identifier so FoundationEssentials retains DST rules. Legacy formatters
-        // use the CoreFoundation cache primed above when /usr/share/zoneinfo is unavailable.
-        setenv("TZ", fallback, 0)
+        // FoundationEssentials reads the IANA identifier while legacy formatters use the
+        // CoreFoundation cache primed above when /usr/share/zoneinfo is unavailable.
+        setenv("TZ", identifier, 0)
         #endif
     }
 
@@ -304,7 +299,9 @@ enum CodexBarCLI {
 
     static func effectiveArgv(_ argv: [String]) -> [String] {
         guard let first = argv.first else { return ["usage"] }
-        if first.hasPrefix("-") { return ["usage"] + argv }
+        if first.hasPrefix("-") {
+            return ["usage"] + argv
+        }
         return argv
     }
 }

--- a/Sources/CodexBarCLI/CLIEntry.swift
+++ b/Sources/CodexBarCLI/CLIEntry.swift
@@ -15,6 +15,8 @@ import FoundationNetworking
 @main
 enum CodexBarCLI {
     static func main() async {
+        self.configureLinuxTimeZoneIfNeeded()
+
         let rawArgv = Array(CommandLine.arguments.dropFirst())
         let argv = Self.effectiveArgv(rawArgv)
         let outputPreferences = CLIOutputPreferences.from(argv: argv)
@@ -200,6 +202,26 @@ enum CodexBarCLI {
     }
 
     // MARK: - Helpers
+
+    static func linuxTimeZoneFallback(currentValue: String?, localTimeReadable: Bool) -> String? {
+        guard currentValue == nil, localTimeReadable else { return nil }
+        return ":/etc/localtime"
+    }
+
+    private static func configureLinuxTimeZoneIfNeeded() {
+        #if os(Linux)
+        let currentValue = getenv("TZ").map { String(cString: $0) }
+        let localTimeReadable = access("/etc/localtime", R_OK) == 0
+        guard let fallback = self.linuxTimeZoneFallback(
+            currentValue: currentValue,
+            localTimeReadable: localTimeReadable)
+        else { return }
+
+        // Swift Foundation otherwise assumes /usr/share/zoneinfo exists. The absolute TZ file form
+        // preserves the configured local timezone on non-FHS systems such as NixOS.
+        setenv("TZ", fallback, 0)
+        #endif
+    }
 
     private static func bootstrapLogging(path: [String], values: ParsedValues) {
         CodexBarLog.bootstrapIfNeeded(self.loggingConfiguration(path: path, values: values))

--- a/TestsLinux/CLITimeZoneBootstrapTests.swift
+++ b/TestsLinux/CLITimeZoneBootstrapTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct CLITimeZoneBootstrapTests {
     @Test
     func `derives IANA identifier from resolved zoneinfo path`() {
-        #expect(CodexBarCLI.linuxTimeZoneFallback(
+        #expect(CodexBarCLI.linuxTimeZoneBootstrapIdentifier(
             currentValue: nil,
             localTimeReadable: true,
             resolvedLocalTimePath: "/nix/store/hash-tzdata/share/zoneinfo/America/New_York")
@@ -22,16 +22,16 @@ struct CLITimeZoneBootstrapTests {
     }
 
     @Test
-    func `uses localtime file when no identifier can be derived`() {
-        #expect(CodexBarCLI.linuxTimeZoneFallback(
+    func `does not bootstrap an unrecognized localtime path`() {
+        #expect(CodexBarCLI.linuxTimeZoneBootstrapIdentifier(
             currentValue: nil,
             localTimeReadable: true,
-            resolvedLocalTimePath: "/etc/localtime") == ":/etc/localtime")
+            resolvedLocalTimePath: "/etc/localtime") == nil)
     }
 
     @Test(arguments: ["Asia/Kolkata", "", ":/custom/zoneinfo"])
     func `preserves caller timezone`(currentValue: String) {
-        #expect(CodexBarCLI.linuxTimeZoneFallback(
+        #expect(CodexBarCLI.linuxTimeZoneBootstrapIdentifier(
             currentValue: currentValue,
             localTimeReadable: true,
             resolvedLocalTimePath: "/nix/store/hash-tzdata/share/zoneinfo/Asia/Kolkata") == nil)
@@ -39,7 +39,7 @@ struct CLITimeZoneBootstrapTests {
 
     @Test
     func `does not set an unreadable localtime file`() {
-        #expect(CodexBarCLI.linuxTimeZoneFallback(
+        #expect(CodexBarCLI.linuxTimeZoneBootstrapIdentifier(
             currentValue: nil,
             localTimeReadable: false,
             resolvedLocalTimePath: "/nix/store/hash-tzdata/share/zoneinfo/Asia/Kolkata") == nil)
@@ -61,6 +61,7 @@ struct CLITimeZoneBootstrapTests {
             filePath: "/dev/null"))
     }
 
+    #if os(Linux)
     @Test
     func `primes the legacy formatter bridge with system timezone data`() throws {
         let resolvedPath = URL(fileURLWithPath: "/etc/localtime").resolvingSymlinksInPath().path
@@ -77,4 +78,5 @@ struct CLITimeZoneBootstrapTests {
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         #expect(!formatter.string(from: Date(timeIntervalSince1970: 0)).isEmpty)
     }
+    #endif
 }

--- a/TestsLinux/CLITimeZoneBootstrapTests.swift
+++ b/TestsLinux/CLITimeZoneBootstrapTests.swift
@@ -1,25 +1,80 @@
+import Foundation
 import Testing
 @testable import CodexBarCLI
 
 struct CLITimeZoneBootstrapTests {
     @Test
-    func `uses localtime file when timezone is unset`() {
+    func `derives IANA identifier from resolved zoneinfo path`() {
         #expect(CodexBarCLI.linuxTimeZoneFallback(
             currentValue: nil,
-            localTimeReadable: true) == ":/etc/localtime")
+            localTimeReadable: true,
+            resolvedLocalTimePath: "/nix/store/hash-tzdata/share/zoneinfo/America/New_York")
+            == "America/New_York")
+    }
+
+    @Test(arguments: [
+        ("/usr/share/zoneinfo/Europe/Berlin", "Europe/Berlin"),
+        ("/usr/share/zoneinfo/posix/Australia/Sydney", "Australia/Sydney"),
+        ("/usr/share/zoneinfo/right/Etc/UTC", "Etc/UTC"),
+    ])
+    func `normalizes conventional zoneinfo paths`(resolvedPath: String, expectedIdentifier: String) {
+        #expect(CodexBarCLI.linuxTimeZoneIdentifier(from: resolvedPath) == expectedIdentifier)
+    }
+
+    @Test
+    func `uses localtime file when no identifier can be derived`() {
+        #expect(CodexBarCLI.linuxTimeZoneFallback(
+            currentValue: nil,
+            localTimeReadable: true,
+            resolvedLocalTimePath: "/etc/localtime") == ":/etc/localtime")
     }
 
     @Test(arguments: ["Asia/Kolkata", "", ":/custom/zoneinfo"])
     func `preserves caller timezone`(currentValue: String) {
         #expect(CodexBarCLI.linuxTimeZoneFallback(
             currentValue: currentValue,
-            localTimeReadable: true) == nil)
+            localTimeReadable: true,
+            resolvedLocalTimePath: "/nix/store/hash-tzdata/share/zoneinfo/Asia/Kolkata") == nil)
     }
 
     @Test
     func `does not set an unreadable localtime file`() {
         #expect(CodexBarCLI.linuxTimeZoneFallback(
             currentValue: nil,
-            localTimeReadable: false) == nil)
+            localTimeReadable: false,
+            resolvedLocalTimePath: "/nix/store/hash-tzdata/share/zoneinfo/Asia/Kolkata") == nil)
+    }
+
+    @Test(arguments: [
+        "/nix/store/hash-tzdata/share/zoneinfo/",
+        "/nix/store/hash-tzdata/share/zoneinfo/../UTC",
+        "/var/lib/timezone/Asia/Kolkata",
+    ])
+    func `rejects invalid or unrelated resolved paths`(resolvedPath: String) {
+        #expect(CodexBarCLI.linuxTimeZoneIdentifier(from: resolvedPath) == nil)
+    }
+
+    @Test
+    func `rejects invalid CoreFoundation timezone data`() {
+        #expect(!CodexBarCLI.primeCoreFoundationTimeZone(
+            identifier: "Etc/CodexBarInvalid",
+            filePath: "/dev/null"))
+    }
+
+    @Test
+    func `primes the legacy formatter bridge with system timezone data`() throws {
+        let resolvedPath = URL(fileURLWithPath: "/etc/localtime").resolvingSymlinksInPath().path
+        guard let identifier = CodexBarCLI.linuxTimeZoneIdentifier(from: resolvedPath) else { return }
+
+        #expect(CodexBarCLI.primeCoreFoundationTimeZone(
+            identifier: identifier,
+            filePath: "/etc/localtime"))
+
+        let timeZone = try #require(TimeZone(identifier: identifier))
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        #expect(!formatter.string(from: Date(timeIntervalSince1970: 0)).isEmpty)
     }
 }

--- a/TestsLinux/CLITimeZoneBootstrapTests.swift
+++ b/TestsLinux/CLITimeZoneBootstrapTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import CodexBarCLI
+
+struct CLITimeZoneBootstrapTests {
+    @Test
+    func `uses localtime file when timezone is unset`() {
+        #expect(CodexBarCLI.linuxTimeZoneFallback(
+            currentValue: nil,
+            localTimeReadable: true) == ":/etc/localtime")
+    }
+
+    @Test(arguments: ["Asia/Kolkata", "", ":/custom/zoneinfo"])
+    func `preserves caller timezone`(currentValue: String) {
+        #expect(CodexBarCLI.linuxTimeZoneFallback(
+            currentValue: currentValue,
+            localTimeReadable: true) == nil)
+    }
+
+    @Test
+    func `does not set an unreadable localtime file`() {
+        #expect(CodexBarCLI.linuxTimeZoneFallback(
+            currentValue: nil,
+            localTimeReadable: false) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2127.

- Bootstrap timezone discovery before the Linux CLI enters Commander or other Foundation-dependent setup.
- When `TZ` is absent, require readable `/etc/localtime` whose resolved path contains a valid IANA `zoneinfo` identifier.
- Prime CoreFoundation with the actual timezone data, then expose the same IANA identifier to FoundationEssentials only after priming succeeds.
- Preserve every caller-provided `TZ` value and decline unsafe or unrecognized path fallbacks.
- Add focused pure-policy and Linux CoreFoundation bridge tests.

## Problem

On NixOS, `/etc/localtime` points into the Nix store and conventional `/usr/share/zoneinfo` paths may not exist. With `TZ` unset, Swift Foundation timezone conversion could terminate the CLI with `SIGILL` while constructing the default timezone.

The contributor reproduced this with both v0.42.1 x86_64 Linux artifacts and an unmodified `main` build. The repaired branch returned real Claude usage normally on that affected NixOS host.

## Fix

The Linux-only bootstrap runs at the start of `CodexBarCLI.main()`. It derives an IANA identifier only from a resolved `/zoneinfo/` path, rejects empty and traversal components, loads `/etc/localtime` data into CoreFoundation, and sets process-local `TZ` only when the bridge accepts that data.

No provider, authentication, account storage, parser, macOS, or system configuration behavior changes.

## Validation

- [x] Affected NixOS live before/after: v0.42.1 exited with SIGILL; repaired branch returned real Claude usage.
- [x] Linux Swift 6.2.1 container: `CLITimeZoneBootstrapTests`, 8 tests passed.
- [x] macOS focused suite: 7 applicable tests passed; Linux-only CoreFoundation integration is compile-time gated.
- [x] `make check`: SwiftFormat clean; SwiftLint 0 violations.
- [x] `make test`: 639 selections in 54 groups; 54 first-pass successes, zero retries or failures.
- [x] Maintainer autoreview: no accepted or actionable findings.
- [x] Exact-head x86_64 and arm64 musl static builds, smoke tests, and packages passed in https://github.com/steipete/CodexBar/actions/runs/29287924777.

No UI changes; screenshots are not applicable.
