### PR TITLE
fix: clear inherited signal masks for spawned CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 
 ### Fixed
+- Kiro: clear inherited signal masks in spawned pipe and PTY probes, preventing the CLI from ignoring termination under a blocked parent mask. Thanks @txarly89!
 - Quota warnings: isolate threshold episodes by stable account ownership so one account cannot duplicate or suppress another account's alert. Thanks @vincent-peng!
 - Claude: cache successful CLI version probes for 30 minutes while invalidating on executable changes, avoiding repeated PTY launches without retaining failed or stale wrapper results. Thanks @Yuxin-Qiao!
 - Linux CLI: bootstrap the configured IANA timezone before Foundation startup on non-FHS systems, preventing SIGILL on NixOS (#2127). Thanks @xikhar!

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -390,10 +390,16 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         }
         defer { posix_spawnattr_destroy(&attributes) }
 
+        var emptySignalMask = sigset_t()
+        guard sigemptyset(&emptySignalMask) == 0,
+              posix_spawnattr_setsigmask(&attributes, &emptySignalMask) == 0
+        else {
+            throw LaunchError.setupFailed("posix_spawn signal mask")
+        }
         #if canImport(Darwin)
-        let flags = POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_CLOEXEC_DEFAULT
+        let flags = POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_CLOEXEC_DEFAULT
         #else
-        let flags = POSIX_SPAWN_SETPGROUP
+        let flags = POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGMASK
         #endif
         guard posix_spawnattr_setflags(&attributes, Int16(flags)) == 0,
               posix_spawnattr_setpgroup(&attributes, 0) == 0
@@ -489,10 +495,16 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         }
         defer { posix_spawnattr_destroy(&attributes) }
 
+        var emptySignalMask = sigset_t()
+        guard sigemptyset(&emptySignalMask) == 0,
+              posix_spawnattr_setsigmask(&attributes, &emptySignalMask) == 0
+        else {
+            throw LaunchError.setupFailed("posix_spawn PTY signal mask")
+        }
         #if canImport(Darwin)
-        let flags = POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_CLOEXEC_DEFAULT
+        let flags = POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_CLOEXEC_DEFAULT
         #else
-        let flags = POSIX_SPAWN_SETPGROUP
+        let flags = POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGMASK
         #endif
         guard posix_spawnattr_setflags(&attributes, Int16(flags)) == 0,
               posix_spawnattr_setpgroup(&attributes, 0) == 0

--- a/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
+++ b/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
@@ -72,6 +72,39 @@ struct SpawnedProcessGroupTests {
     }
 
     @Test
+    func `launch clears the parent thread signal mask`() throws {
+        var blockedMask = sigset_t()
+        var previousMask = sigset_t()
+        sigemptyset(&blockedMask)
+        sigaddset(&blockedMask, SIGTERM)
+        try #require(pthread_sigmask(SIG_BLOCK, &blockedMask, &previousMask) == 0)
+        defer { pthread_sigmask(SIG_SETMASK, &previousMask, nil) }
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        let script = """
+        import signal
+        import sys
+
+        blocked = signal.pthread_sigmask(signal.SIG_BLOCK, set())
+        sys.exit(1 if signal.SIGTERM in blocked else 0)
+        """
+        let process = try SpawnedProcessGroup.launch(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", script],
+            environment: ProcessInfo.processInfo.environment,
+            stdoutPipe: stdoutPipe,
+            stderrPipe: stderrPipe)
+
+        while process.isRunning {
+            usleep(20000)
+        }
+        process.finishSynchronously()
+
+        #expect(process.terminationStatus == 0)
+    }
+
+    @Test
     func `launch closes unrelated parent descriptors`() async throws {
         let sourceFD = open("/dev/null", O_RDONLY)
         let inheritedFD = fcntl(sourceFD, F_DUPFD, 200)

--- a/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
+++ b/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
@@ -105,6 +105,48 @@ struct SpawnedProcessGroupTests {
     }
 
     @Test
+    func `PTY launch clears the parent thread signal mask`() throws {
+        var blockedMask = sigset_t()
+        var previousMask = sigset_t()
+        sigemptyset(&blockedMask)
+        sigaddset(&blockedMask, SIGTERM)
+        try #require(pthread_sigmask(SIG_BLOCK, &blockedMask, &previousMask) == 0)
+        defer { pthread_sigmask(SIG_SETMASK, &previousMask, nil) }
+
+        var primaryFD: Int32 = -1
+        var secondaryFD: Int32 = -1
+        try #require(openpty(&primaryFD, &secondaryFD, nil, nil, nil) == 0)
+        let primaryHandle = FileHandle(fileDescriptor: primaryFD, closeOnDealloc: true)
+        let secondaryHandle = FileHandle(fileDescriptor: secondaryFD, closeOnDealloc: true)
+        defer {
+            try? primaryHandle.close()
+            try? secondaryHandle.close()
+        }
+
+        let script = """
+        import signal
+        import sys
+
+        blocked = signal.pthread_sigmask(signal.SIG_BLOCK, set())
+        sys.exit(1 if signal.SIGTERM in blocked else 0)
+        """
+        let process = try SpawnedProcessGroup.launchPTY(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", script],
+            environment: ProcessInfo.processInfo.environment,
+            workingDirectory: nil,
+            fileDescriptors: (primary: primaryFD, secondary: secondaryFD))
+        try? secondaryHandle.close()
+
+        while process.isRunning {
+            usleep(20000)
+        }
+        process.finishSynchronously()
+
+        #expect(process.terminationStatus == 0)
+    }
+
+    @Test
     func `launch closes unrelated parent descriptors`() async throws {
         let sourceFD = open("/dev/null", O_RDONLY)
         let inheritedFD = fcntl(sourceFD, F_DUPFD, 200)
@@ -151,12 +193,12 @@ struct SpawnedProcessGroupTests {
             [
                 sys.executable,
                 "-c",
-                "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)",
+                "import os,signal,sys,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                "open(sys.argv[1], 'w').write(str(os.getpid())); time.sleep(30)",
+                sys.argv[1],
             ],
             start_new_session=True,
         )
-        with open(sys.argv[1], "w") as handle:
-            handle.write(str(child.pid))
         time.sleep(30)
         """
         let stdoutPipe = Pipe()


### PR DESCRIPTION
## Summary

- Clear the inherited per-thread signal mask for both pipe and PTY children launched by `SpawnedProcessGroup`.
- Add a regression test that blocks `SIGTERM` in the parent thread and verifies that a spawned child starts with it unblocked.

This is a follow-up to #1883 and #2012. The transport fallback added there is present in 0.42.1, but authenticated Kiro CLI refreshes can still time out because `posix_spawn` inherits the calling Swift worker thread's blocked signal mask unless `POSIX_SPAWN_SETSIGMASK` is set explicitly.

## Root cause

On affected launches, the Kiro child inherited a non-empty signal mask from the Swift worker thread. Both the pipe attempt and its PTY fallback therefore reached the shared CodexBar deadline even though the same authenticated Kiro CLI command completed normally when run directly.

A shell wrapper appeared to fix the problem because the shell normalizes its signal state before `exec`. A controlled native launcher isolated that behavior:

| Native launcher behavior | Result |
| --- | --- |
| Inherit mask and dispositions | Timeout (~22 s) |
| Reset dispositions only | Timeout (~22 s) |
| Clear signal mask only | Success (~4 s) |

The fix supplies an empty `sigset_t` with `posix_spawnattr_setsigmask` and enables `POSIX_SPAWN_SETSIGMASK` for both launch paths.

## Authenticated reproduction and validation

All live output below was reduced to provider/version and boolean presence checks; no identity, account, or usage values are included.

Tested against upstream `main` at `9c3e09870b5e5ecea23d6fb998f31aaf23f84b54`, Kiro CLI 2.12.1, and the released CodexBar 0.42.1 (build 103). The release bundle identifies commit `7db921fe4`, which contains #2012.

| Machine | Released 0.42.1, no workaround | Patched `main`, no workaround |
| --- | --- | --- |
| MacBook (arm64) | Timeout (~21-22 s) | 3/3 successful: 4 s, 4 s, 3 s |
| Mac mini (arm64) | Timeout (~22 s) | 3/3 successful: 4 s, 3 s, 4 s |

Every patched run returned provider `kiro`, CLI version `2.12.1`, a populated usage payload, and Kiro-specific usage data. Both three-run series ended with zero residual Kiro processes.

Manual PTY invocation of the same authenticated Kiro CLI completed in about 3 seconds on both machines, which rules out credentials or provider availability as the cause.

## Checks

- `swift build --product CodexBarCLI` passes on both Macs.
- `swiftc -parse Tests/CodexBarTests/SpawnedProcessGroupTests.swift` passes.
- SwiftFormat lint: 0 of 1,426 files require formatting.
- Live authenticated Kiro matrix: 6/6 patched runs pass across two Macs; zero residual Kiro processes.
- Focused unit test is included, but cannot be executed locally because both hosts only have Command Line Tools; SwiftPM stops before test compilation because `actool` requires full Xcode.
- SwiftLint likewise cannot load `sourcekitdInProc.framework` from the Command Line Tools-only environment. CI should provide the full Xcode validation for both checks.

## Scope

The change is intentionally limited to process spawn attributes and one regression test. No Kiro-specific parsing, deadlines, credentials, or usage data are changed.
