### PR TITLE
Stop background Claude keychain discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Kimi: reuse fresh signed-in Kimi Code CLI credentials in Auto mode without refreshing or rewriting CLI-owned authentication state. Thanks @Leechael!
 
 ### Fixed
+- Claude: keep MCP-only credential discovery out of background Security.framework reads when Keychain prompts are limited to user actions, preventing recurring macOS password dialogs (#2115).
 - Claude: cache successful CLI version probes for 30 minutes while invalidating on executable changes, avoiding repeated PTY launches without retaining failed or stale wrapper results. Thanks @Yuxin-Qiao!
 - Linux CLI: bootstrap the configured IANA timezone before Foundation startup on non-FHS systems, preventing SIGILL on NixOS (#2127). Thanks @xikhar!
 - Ollama: release temporary dashboard network sessions after each fetch, preventing repeated refreshes from retaining delegates and URL-cache resources. Thanks @astuteprogrammer!

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
@@ -357,7 +357,17 @@ extension ClaudeOAuthCredentialsStore {
         guard !keychainAccessDisabled || self.isolatedSecurityCLIKeychainPath(environment: environment) != nil else {
             return false
         }
-        guard ClaudeOAuthKeychainPromptPreference.effectiveMode(readStrategy: readStrategy) != .never else {
+        let promptMode = ClaudeOAuthKeychainPromptPreference.effectiveMode(readStrategy: readStrategy)
+        guard promptMode != .never else {
+            return false
+        }
+        // Security.framework "no UI" queries can still display the legacy Keychain ACL password dialog on some
+        // systems. Do not touch the Claude Code keychain from background discovery when the stored policy only
+        // permits user-initiated access. Explicit refreshes retain MCP-only detection, and `.always` remains opt-in.
+        if readStrategy == .securityFramework,
+           promptMode == .onlyOnUserAction,
+           interaction != .userInitiated
+        {
             return false
         }
         let payload: Data? = switch readStrategy {

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreMCPOnlyGuardTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreMCPOnlyGuardTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite(.serialized)
 struct ClaudeOAuthCredentialsStoreMCPOnlyGuardTests {
     @Test
-    func `standard reader blocks expired CLI owner in background but preserves user refresh`() async throws {
+    func `standard reader skips MCP keychain probe in background but preserves user refresh`() async throws {
         let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
         let mcpOAuthOnly = Data(#"{"mcpOAuth":{"plugin:test":{"accessToken":"synthetic"}}}"#.utf8)
         let tempDir = FileManager.default.temporaryDirectory
@@ -37,7 +37,17 @@ struct ClaudeOAuthCredentialsStoreMCPOnlyGuardTests {
                                         keychainAccessDisabled: false,
                                         environment: [:])
                                 }
-                                #expect(isMcpOnly)
+                                #expect(!isMcpOnly)
+
+                                let userInitiatedIsMcpOnly = ProviderInteractionContext.$current
+                                    .withValue(.userInitiated) {
+                                        ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
+                                            interaction: .userInitiated,
+                                            readStrategy: .securityFramework,
+                                            keychainAccessDisabled: false,
+                                            environment: [:])
+                                    }
+                                #expect(userInitiatedIsMcpOnly)
 
                                 ClaudeOAuthCredentialsStore.invalidateCache()
                                 let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
@@ -54,10 +64,10 @@ struct ClaudeOAuthCredentialsStoreMCPOnlyGuardTests {
                                         environment: [:],
                                         allowKeychainPrompt: false,
                                         respectKeychainPromptCooldown: true)
-                                    Issue.record("Expected MCP-only keychain failure")
+                                    Issue.record("Expected background refresh delegation")
                                 } catch let error as ClaudeOAuthCredentialsError {
-                                    guard case .mcpOAuthOnlyKeychain = error else {
-                                        Issue.record("Expected .mcpOAuthOnlyKeychain, got \(error)")
+                                    guard case .refreshDelegatedToClaudeCLI = error else {
+                                        Issue.record("Expected .refreshDelegatedToClaudeCLI, got \(error)")
                                         return
                                     }
                                 } catch {


### PR DESCRIPTION
## Summary

- prevent background MCP-only credential discovery from reading `Claude Code-credentials` through Security.framework when the prompt policy is `onlyOnUserAction`
- preserve MCP-only detection for explicit user refreshes and the opt-in `always` policy
- add regression coverage for both interaction modes

## Root cause

The MCP-only payload detector bypassed the normal Claude prompt-policy gate and issued a Security.framework “no UI” read during background availability checks. Legacy Keychain ACLs can still display the macOS password dialog for these reads, causing recurring prompts even though the call was marked non-interactive.

Fixes #2115.

## User impact

Background refreshes no longer touch the Claude Code Keychain item under the default `onlyOnUserAction` policy. Explicit refreshes can still inspect it when needed.

## Validation

- `swift test --filter ClaudeOAuthCredentialsStoreMCPOnlyGuardTests`
- `make check`
- `make test` *(blocked by an unrelated current-main `AdaptiveRefreshTimerTests` baseline failure: “manual mode performs the initial refresh but no recurring ticks” observes 2 refreshes instead of 1; reproduced when running that suite alone)*

No live Keychain read was used for validation.
