### PR TITLE
ci: move portable checks off macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install lint tools
-        run: ./Scripts/install_lint_tools.sh swiftlint
+        run: ./Scripts/install_lint_tools.sh all
 
       - name: Lint
+        # SwiftFormat is portable; keep it off the scarce macOS runners.
         run: ./Scripts/lint.sh lint-linux
 
   swift-test-macos:
@@ -120,9 +121,9 @@ jobs:
           swift --version
           swift package --version
 
-      - name: Check app locales and Swift formatting
+      - name: Check app locales
         if: ${{ matrix.shard-index == 0 }}
-        run: ./Scripts/lint.sh lint-macos
+        run: ./Scripts/lint.sh lint-macos-locales
 
       - name: Swift Test
         # Keep small batches to reduce SwiftPM process overhead without returning to one aggregate run.
@@ -141,7 +142,6 @@ jobs:
         env:
           SHARD_INDEX: ${{ matrix.shard-index }}
           SHARD_COUNT: ${{ matrix.shard-count }}
-          RUNS_LINT_MACOS: ${{ matrix.shard-index == 0 }}
         run: |
           set -euo pipefail
           display_shard_index=$((SHARD_INDEX + 1))
@@ -153,7 +153,6 @@ jobs:
             printf '| Shard | `%s / %s` |\n' "$display_shard_index" "$SHARD_COUNT"
             printf '| Runner | `%s` |\n' "${RUNNER_NAME:-unknown}"
             printf '| Xcode | `%s` |\n' "${xcode_version:-unknown}"
-            printf '| Runs lint-macos | `%s` |\n' "$RUNS_LINT_MACOS"
           } >> "$GITHUB_STEP_SUMMARY"
 
   lint-build-test:

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -116,18 +116,22 @@ case "$cmd" in
     ;;
   lint-linux)
     run_portable_checks
+    run_swiftformat_lint
     run_swiftlint
     ;;
   lint-macos)
     check_app_locales
     run_swiftformat_lint
     ;;
+  lint-macos-locales)
+    check_app_locales
+    ;;
   format)
     ensure_swiftformat
     "${BIN_DIR}/swiftformat" Sources Tests
     ;;
   *)
-    printf 'Usage: %s [lint|lint-linux|lint-macos|format]\n' "$(basename "$0")" >&2
+    printf 'Usage: %s [lint|lint-linux|lint-macos|lint-macos-locales|format]\n' "$(basename "$0")" >&2
     exit 2
     ;;
 esac

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -116,6 +116,17 @@ if "CODEXBAR_TEST_SHARD_INDEX=${{ matrix.shard-index }}" not in job:
     raise SystemExit("swift-test-macos must pass matrix.shard-index to Scripts/test.sh")
 if "CODEXBAR_TEST_SHARD_COUNT=${{ matrix.shard-count }}" not in job:
     raise SystemExit("swift-test-macos must pass matrix.shard-count to Scripts/test.sh")
+if "lint-macos" in job and "lint-macos-locales" not in job:
+    raise SystemExit("only the macOS-specific locale check may run in a macOS shard")
+
+lint_match = re.search(r"(?ms)^  lint:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:|\Z)", workflow)
+if not lint_match:
+    raise SystemExit("lint job not found in CI workflow")
+lint_job = lint_match.group("body")
+if "./Scripts/install_lint_tools.sh all" not in lint_job:
+    raise SystemExit("lint job must install both portable lint tools")
+if "./Scripts/lint.sh lint-linux" not in lint_job:
+    raise SystemExit("lint job must run the portable static-check suite")
 PY
 
 reset_case retry


### PR DESCRIPTION
## Summary
- run portable validation, SwiftFormat, and SwiftLint in the existing Ubuntu `lint` job
- keep the macOS-only app-locale (`plutil`) check on macOS shard 0
- remove the redundant macOS SwiftFormat step and assert this workflow contract in the sharding harness

## Why
SwiftFormat is portable. Running it in a macOS shard consumed scarce macOS runner time before Swift tests without adding platform-specific coverage. The locale checker remains on macOS because it invokes `plutil`.

## Impact
- preserves app locale validation, portable validation, SwiftFormat, SwiftLint, two macOS Swift shards, strict test failures, and the aggregate gate
- removes redundant macOS SwiftFormat work, reducing macOS runner minutes and improving shard balance during queue pressure

## Validation
- `bash Scripts/test_swift_test_sharding.sh`
- `bash Scripts/test_ci_path_gate.sh`
- GitHub Actions YAML parse
- `node Scripts/check-app-locales.mjs --test` and full locale check
- `git diff --check`
- Local `Scripts/lint.sh lint-linux` completed all substantive checks with 0 SwiftFormat changes and 0 SwiftLint violations; its final exit is blocked only by this workstation's cache-plist write permission, so hosted CI remains authoritative for final lint status.