### PR TITLE
ci: defer macOS tests for draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +21,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       macos-tests: ${{ steps.macos-tests.outputs.macos-tests }}
+      macos-tests-deferred: ${{ steps.macos-tests.outputs.macos-tests-deferred }}
       macos-tests-reason: ${{ steps.macos-tests.outputs.macos-tests-reason }}
       changed-path-count: ${{ steps.macos-tests.outputs.changed-path-count }}
     steps:
@@ -30,6 +32,8 @@ jobs:
       - name: Detect macOS test impact
         id: macos-tests
         shell: bash
+        env:
+          CI_PULL_REQUEST_DRAFT: ${{ github.event.pull_request.draft || false }}
         run: |
           set -euo pipefail
 
@@ -173,7 +177,8 @@ jobs:
             "${{ needs.lint.result }}" \
             "${{ needs.changes.result }}" \
             "${{ needs.changes.outputs.macos-tests }}" \
-            "${{ needs.swift-test-macos.result }}"
+            "${{ needs.swift-test-macos.result }}" \
+            "${{ needs.changes.outputs.macos-tests-deferred }}"
 
       - name: Summarize aggregate CI gate
         if: ${{ always() }}
@@ -182,6 +187,7 @@ jobs:
           LINT_RESULT: ${{ needs.lint.result }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           MACOS_TESTS: ${{ needs.changes.outputs.macos-tests }}
+          MACOS_TESTS_DEFERRED: ${{ needs.changes.outputs.macos-tests-deferred }}
           MACOS_TESTS_REASON: ${{ needs.changes.outputs.macos-tests-reason }}
           MACOS_RESULT: ${{ needs.swift-test-macos.result }}
         run: |
@@ -195,6 +201,7 @@ jobs:
             printf '| lint result | `%s` |\n' "$LINT_RESULT"
             printf '| changes result | `%s` |\n' "$CHANGES_RESULT"
             printf '| macOS Swift tests required | `%s` |\n' "${MACOS_TESTS:-<unset>}"
+            printf '| macOS Swift tests deferred | `%s` |\n' "${MACOS_TESTS_DEFERRED:-<unset>}"
             printf '| macOS gate reason | %s |\n' "$reason"
             printf '| swift-test-macos result | `%s` |\n' "$MACOS_RESULT"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Scripts/ci_macos_test_gate.sh
+++ b/Scripts/ci_macos_test_gate.sh
@@ -10,8 +10,19 @@ if [[ -z "$changed_paths_file" || ! -f "$changed_paths_file" ]]; then
 fi
 
 macos_tests=false
+macos_tests_deferred=false
 macos_tests_reason=""
 path_count=0
+draft_pull_request="${CI_PULL_REQUEST_DRAFT:-false}"
+
+case "$draft_pull_request" in
+  true|false)
+    ;;
+  *)
+    printf 'CI_PULL_REQUEST_DRAFT must be true or false.\n' >&2
+    exit 2
+    ;;
+esac
 
 require_macos_tests() {
   local path="$1"
@@ -86,7 +97,11 @@ if [[ "$path_count" -eq 0 ]]; then
   require_macos_tests '<empty diff>' 'no changed paths were reported'
 fi
 
-if [[ "$macos_tests" == true ]]; then
+if [[ "$macos_tests" == true && "$draft_pull_request" == true ]]; then
+  macos_tests=false
+  macos_tests_deferred=true
+  summary_reason="draft pull request: macOS Swift tests deferred until ready for review"
+elif [[ "$macos_tests" == true ]]; then
   summary_reason="$macos_tests_reason"
 else
   summary_reason="docs/site-only changes covered by portable checks"
@@ -94,6 +109,7 @@ fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   printf 'macos-tests=%s\n' "$macos_tests" >> "$GITHUB_OUTPUT"
+  printf 'macos-tests-deferred=%s\n' "$macos_tests_deferred" >> "$GITHUB_OUTPUT"
   printf 'macos-tests-reason=%s\n' "$summary_reason" >> "$GITHUB_OUTPUT"
   printf 'changed-path-count=%s\n' "$path_count" >> "$GITHUB_OUTPUT"
 fi
@@ -101,5 +117,5 @@ fi
 if [[ "$macos_tests" == true ]]; then
   printf 'macOS Swift tests required for this change set: %s.\n' "$macos_tests_reason"
 else
-  printf 'Skipping macOS Swift tests for docs/site-only changes covered by portable checks.\n'
+  printf 'Skipping macOS Swift tests: %s.\n' "$summary_reason"
 fi

--- a/Scripts/ci_verify_test_jobs.sh
+++ b/Scripts/ci_verify_test_jobs.sh
@@ -6,6 +6,7 @@ lint_result="${1:-}"
 changes_result="${2:-}"
 macos_tests_required="${3:-}"
 macos_test_result="${4:-}"
+macos_tests_deferred="${5:-}"
 
 if [[ "$lint_result" != "success" ]]; then
   printf 'lint job finished with %s\n' "${lint_result:-<empty>}" >&2
@@ -19,10 +20,23 @@ fi
 
 case "${macos_tests_required}:${macos_test_result}" in
   true:success)
+    if [[ "$macos_tests_deferred" != false ]]; then
+      printf 'macOS test gate marked a required test as deferred\n' >&2
+      exit 1
+    fi
     printf 'Lint and macOS Swift test shards passed.\n'
     ;;
   false:skipped)
-    printf 'Lint passed; macOS Swift tests skipped for docs/site-only changes.\n'
+    if [[ "$macos_tests_deferred" == true ]]; then
+      printf 'Lint passed; macOS Swift tests are deferred until the pull request is ready for review.\n'
+      exit 0
+    fi
+    if [[ "$macos_tests_deferred" != false ]]; then
+      printf 'macOS test gate returned invalid deferred state: %s\n' \
+        "${macos_tests_deferred:-<empty>}" >&2
+      exit 1
+    fi
+    printf 'Lint passed; macOS Swift tests skipped by the macOS test gate.\n'
     ;;
   *)
     printf 'macOS test gate/result mismatch: required=%s result=%s\n' \

--- a/Scripts/test_ci_path_gate.sh
+++ b/Scripts/test_ci_path_gate.sh
@@ -29,6 +29,13 @@ assert_gate() {
     exit 1
   fi
 
+  local deferred
+  deferred="$(sed -n 's/^macos-tests-deferred=//p' "$output_file")"
+  if [[ "$deferred" != false ]]; then
+    printf '%s: expected macos-tests-deferred=false, got %s\n' "$name" "${deferred:-<empty>}" >&2
+    exit 1
+  fi
+
   local path_count
   path_count="$(sed -n 's/^changed-path-count=//p' "$output_file")"
   if ! [[ "$path_count" =~ ^[0-9]+$ ]]; then
@@ -62,6 +69,26 @@ assert_gate true source-to-docs $'R100\tSources/CodexBar/App.swift\tdocs/App.md'
 assert_gate true docs-to-source $'R100\tdocs/App.md\tSources/CodexBar/App.swift'
 assert_gate false docs-to-site $'R100\tdocs/old.md\tdocs/site.css'
 
+draft_paths="${tmp_dir}/draft-source.paths"
+draft_output="${tmp_dir}/draft-source.output"
+printf '%s\n' $'M\tSources/CodexBar/App.swift' > "$draft_paths"
+CI_PULL_REQUEST_DRAFT=true GITHUB_OUTPUT="$draft_output" \
+  "${ROOT_DIR}/Scripts/ci_macos_test_gate.sh" "$draft_paths" >/dev/null
+if [[ "$(sed -n 's/^macos-tests=//p' "$draft_output")" != false ]]; then
+  printf 'draft source: expected macOS tests to be deferred\n' >&2
+  exit 1
+fi
+if [[ "$(sed -n 's/^macos-tests-reason=//p' "$draft_output")" != \
+  "draft pull request: macOS Swift tests deferred until ready for review" ]]
+then
+  printf 'draft source: expected draft deferral reason\n' >&2
+  exit 1
+fi
+if [[ "$(sed -n 's/^macos-tests-deferred=//p' "$draft_output")" != true ]]; then
+  printf 'draft source: expected macOS tests to be marked deferred\n' >&2
+  exit 1
+fi
+
 assert_gate_fails() {
   local name="$1"
   local paths_file="${tmp_dir}/${name}.paths"
@@ -85,6 +112,13 @@ assert_gate_fails missing-rename-score $'R\tREADME.md\tdocs/README.md'
 assert_gate_fails invalid-rename-score $'Rfoo\tREADME.md\tdocs/README.md'
 assert_gate_fails out-of-range-rename-score $'R101\tREADME.md\tdocs/README.md'
 
+if CI_PULL_REQUEST_DRAFT=maybe GITHUB_OUTPUT="${tmp_dir}/invalid-draft.output" \
+  "${ROOT_DIR}/Scripts/ci_macos_test_gate.sh" "${tmp_dir}/docs-only.paths" >/dev/null 2>&1
+then
+  printf 'invalid draft flag unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
 unterminated_paths="${tmp_dir}/unterminated.paths"
 unterminated_output="${tmp_dir}/unterminated.output"
 printf '%s' $'M\tREADME.md\tdocs/configuration.md' > "$unterminated_paths"
@@ -100,8 +134,9 @@ if [[ -s "$unterminated_output" ]]; then
 fi
 
 verify="${ROOT_DIR}/Scripts/ci_verify_test_jobs.sh"
-"$verify" success success true success >/dev/null
-"$verify" success success false skipped >/dev/null
+"$verify" success success true success false >/dev/null
+"$verify" success success false skipped false >/dev/null
+"$verify" success success false skipped true >/dev/null
 
 assert_verify_fails() {
   if "$verify" "$@" >/dev/null 2>&1; then
@@ -110,10 +145,10 @@ assert_verify_fails() {
   fi
 }
 
-assert_verify_fails success success true skipped
-assert_verify_fails success success false success
-assert_verify_fails success success "" skipped
-assert_verify_fails failure success true success
-assert_verify_fails success failure true success
+assert_verify_fails success success true skipped false
+assert_verify_fails success success false success false
+assert_verify_fails success success "" skipped false
+assert_verify_fails failure success true success false
+assert_verify_fails success failure true success false
 
 printf 'CI macOS path gate tests passed.\n'

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -103,6 +103,12 @@ import re
 import sys
 
 workflow = pathlib.Path(sys.argv[1]).read_text()
+if "types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]" not in workflow:
+    raise SystemExit("CI must rerun when a pull request becomes ready or draft")
+if "CI_PULL_REQUEST_DRAFT: ${{ github.event.pull_request.draft || false }}" not in workflow:
+    raise SystemExit("CI must pass draft state to the macOS test gate")
+if "macos-tests-deferred: ${{ steps.macos-tests.outputs.macos-tests-deferred }}" not in workflow:
+    raise SystemExit("CI must expose whether macOS tests were deferred")
 job_match = re.search(r"(?ms)^  swift-test-macos:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:|\Z)", workflow)
 if not job_match:
     raise SystemExit("swift-test-macos job not found in CI workflow")

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -935,7 +935,7 @@ extension KiroStatusProbeTests {
         fi
 
         if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
-          exit 0
+          printf 'Context window: 40%% used\\n'; exit 0
         fi
 
         exit 1
@@ -964,9 +964,9 @@ extension KiroStatusProbeTests {
             try await Task.sleep(for: .milliseconds(20))
         }
 
-        // The PTY runner must return promptly and reap a detached helper that keeps the terminal open.
+        // Keep the optional context probe parseable so this timing check covers detached-child cleanup.
         #expect(snapshot.planName == "KIRO FREE")
-        #expect(snapshot.creditsUsed == 12.50)
+        #expect(snapshot.creditsUsed == 12.50 && snapshot.contextUsage?.totalPercentUsed == 40)
         #expect(elapsed < 8, "Kiro usage capture should return promptly even with a detached child, took \(elapsed)s")
         #expect(kill(childPID, 0) == -1)
     }


### PR DESCRIPTION
## Summary
- defer macOS Swift shards for code-changing Draft PRs while retaining Linux lint/build checks
- report Draft deferral as a successful aggregate check with an explicit workflow summary, rather than presenting the policy as a CI failure
- re-run CI when a PR becomes ready for review or returns to Draft
- make the Kiro detached-child timing fixture return and assert parseable context output, so its 8-second bound measures PTY cleanup rather than an empty optional-context probe timing out

## Why
Independent code PR batches can exhaust the scarce hosted macOS runner queue. A Draft PR is already unmergeable, so it should receive fast portable feedback and a clear deferred-validation state, then consume macOS capacity only when promoted for review.

The Kiro timing failure was concrete: the fixture exited with empty `/context` output, while `fetch()` subsequently performs an optional context probe with an 8-second bound. That made the test's own `< 8s` assertion contradictory. This change preserves the strict bound and validates parsed context usage instead of relaxing the timeout.

## Safety
- `ready_for_review` starts a fresh workflow where code changes again require both macOS Swift shards to pass
- `converted_to_draft` starts a new run in the same concurrency group, canceling queued or running macOS work for that branch
- a code-changing Draft PR can be green only for completed portable checks; the workflow summary records that macOS validation is deferred
- non-draft PRs and pushes to `main` retain the existing macOS path gate
- no test retries, timeout relaxations, or required-gate weakening

## Validation
- `bash Scripts/test_ci_path_gate.sh`
- `bash Scripts/test_swift_test_sharding.sh`
- GitHub Actions YAML parse and shell syntax checks
- exact repaired test: `swift test --filter 'CodexBarTests.KiroStatusProbeTests/`fetch returns promptly when usage helper spawns a detached child`'`
- `git diff --check`

## Follow-up identified during validation
The broader `KiroStatusProbeTests` suite still has a separate, pre-existing failure in `accepted pipe output cannot overrun the usage deadline`: a PTY marker file remains after the deadline assertion. This PR does not hide it or add retries; it should be reproduced and fixed as its own process-cleanup regression.