### PR TITLE
Fix duplicate menu bar items under Icon + Percentage style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.43.1 — Unreleased
 
 ### Fixed
+- Menu bar: prevent duplicate provider items when usage updates re-enter initial status-item setup (#2162). Thanks @ss251!
 - Ollama: explain that API-key verification cannot show Cloud quota limits and direct users to browser-cookie mode (#2159). Thanks @kiranmagic7!
 - Claude: suppress duplicate all-model scoped quota rows that could appear as “All models only” beside Weekly.
 

--- a/Sources/CodexBar/StatusItemController+StatusItemVending.swift
+++ b/Sources/CodexBar/StatusItemController+StatusItemVending.swift
@@ -1,0 +1,41 @@
+import AppKit
+import CodexBarCore
+
+extension StatusItemController {
+    /// Lazily retrieves or creates a status item for the given provider.
+    func lazyStatusItem(for provider: UsageProvider) -> NSStatusItem {
+        self.vendStatusItem(for: provider)
+    }
+
+    private func vendStatusItem(
+        for provider: UsageProvider,
+        onCreated: ((NSStatusItem) -> Void)? = nil)
+        -> NSStatusItem
+    {
+        if let existing = self.statusItems[provider] {
+            return existing
+        }
+        return Self.makeStatusItem(
+            statusBar: self.statusBar,
+            identity: .provider(provider),
+            defaults: self.settings.userDefaults,
+            legacyDefaultItemIndex: self.legacyDefaultItemIndex(forNewProvider: provider),
+            onCreated: { item in
+                // Register before invoking the caller/setup callbacks: button configuration and
+                // icon-observation can synchronously re-enter vending for this provider, and an
+                // unregistered item there vends a duplicate (issue #2162).
+                self.statusItems[provider] = item
+                onCreated?(item)
+            })
+    }
+
+    #if DEBUG
+    func _test_vendStatusItem(
+        for provider: UsageProvider,
+        onCreated: @escaping (NSStatusItem) -> Void)
+        -> NSStatusItem
+    {
+        self.vendStatusItem(for: provider, onCreated: onCreated)
+    }
+    #endif
+}

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -299,11 +299,12 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         set { self.settings.selectedMenuProvider = newValue }
     }
 
-    private static func makeStatusItem(
+    static func makeStatusItem(
         statusBar: NSStatusBar,
         identity: StatusItemIdentity,
         defaults: UserDefaults,
-        legacyDefaultItemIndex: Int?)
+        legacyDefaultItemIndex: Int?,
+        onCreated: ((NSStatusItem) -> Void)? = nil)
         -> NSStatusItem
     {
         MenuBarStatusItemPlacementPreflight.prepare(
@@ -311,6 +312,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             autosaveName: identity.autosaveName,
             legacyDefaultItemIndex: legacyDefaultItemIndex)
         let item = statusBar.statusItem(withLength: NSStatusItem.variableLength)
+        onCreated?(item)
         item.autosaveName = identity.autosaveName
         if let button = item.button {
             let title = self.statusItemAccessibilityTitle(
@@ -739,20 +741,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         return self.openMenus[ObjectIdentifier(mergedMenu)] != nil
     }
 
-    /// Lazily retrieves or creates a status item for the given provider
-    func lazyStatusItem(for provider: UsageProvider) -> NSStatusItem {
-        if let existing = self.statusItems[provider] {
-            return existing
-        }
-        let item = Self.makeStatusItem(
-            statusBar: self.statusBar,
-            identity: .provider(provider),
-            defaults: self.settings.userDefaults,
-            legacyDefaultItemIndex: self.legacyDefaultItemIndex(forNewProvider: provider))
-        self.statusItems[provider] = item
-        return item
-    }
-
     func recreateStatusItemsForVisibilityRecovery() {
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
@@ -1007,7 +995,7 @@ extension StatusItemController {
 #endif
 
 extension StatusItemController {
-    private func legacyDefaultItemIndex(forNewProvider provider: UsageProvider) -> Int? {
+    func legacyDefaultItemIndex(forNewProvider provider: UsageProvider) -> Int? {
         let visibleProviders = self.settings.orderedProviders().filter { self.isVisible($0) }
         guard let providerOffset = visibleProviders.firstIndex(of: provider) else { return nil }
         return Self.mergedLegacyDefaultItemIndex + 1 + providerOffset

--- a/Tests/CodexBarTests/StatusItemReuseRegressionTests.swift
+++ b/Tests/CodexBarTests/StatusItemReuseRegressionTests.swift
@@ -1,0 +1,75 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusItemReuseRegressionTests {
+    @Test
+    func `usage update during vending reuses the provider status item`() throws {
+        let suite = "StatusItemReuseRegressionTests-\(UUID().uuidString)"
+        let settings = testSettingsStore(suiteName: suite)
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.providerDetectionCompleted = true
+        settings.menuBarShowsBrandIconWithPercent = true
+        settings.menuBarDisplayMode = .percent
+
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            settings.setProviderEnabled(
+                provider: provider,
+                metadata: metadata,
+                enabled: provider == .codex)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: testStatusBar())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let initialItem = try #require(controller.statusItems[.codex])
+        controller.statusItems.removeValue(forKey: .codex)
+        controller.statusBar.removeStatusItem(initialItem)
+
+        var itemSeenByUpdate: NSStatusItem?
+        let vendedItem = controller._test_vendStatusItem(for: .codex) { _ in
+            store._setSnapshotForTesting(
+                UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: 23,
+                        windowMinutes: 300,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    secondary: nil,
+                    updatedAt: Date()),
+                provider: .codex)
+            controller.updateIcons()
+            itemSeenByUpdate = controller.statusItems[.codex]
+        }
+        defer {
+            if let itemSeenByUpdate, itemSeenByUpdate !== vendedItem {
+                controller.statusBar.removeStatusItem(itemSeenByUpdate)
+            }
+        }
+
+        let updatedItem = try #require(itemSeenByUpdate)
+        #expect(updatedItem === vendedItem)
+        #expect(controller.statusItems.count == 1)
+        #expect(controller.statusItems[.codex] === vendedItem)
+        #expect(vendedItem.button?.title.contains("77%") == true)
+    }
+}


### PR DESCRIPTION
Fixes #2162.

## Problem

With **Menu bar style = Icon + Percentage** and **Display mode = Percentage**, frequent usage changes could produce duplicate provider menu-bar items instead of updating one item in place.

The creation path checked `statusItems[provider]` before vending, but recorded the new item only after all AppKit setup returned. Any synchronous re-entry during that setup therefore saw no registered item and could vend another one.

## Fix

- Register the raw `NSStatusItem` immediately after creation, before autosave/accessibility setup or callbacks can re-enter vending.
- Keep status-item vending in a small dedicated extension.
- Add a deterministic regression test that injects a usage update during the vulnerable window and verifies the same item is reused.
- Add an Unreleased changelog entry with contributor credit.

## Before / after

| Before | After repeated live refreshes |
| --- | --- |
| ![Duplicate provider menu-bar items](https://github.com/user-attachments/assets/33313e0a-a210-432d-8ac1-17957c5db068) | ![One stable provider item after repeated refreshes](https://raw.githubusercontent.com/ss251/CodexBar/proof-2167-assets/t5.png) |

The contributor captured six consecutive refresh cycles from a fresh debug bundle, with usage changing from 48% to 68% while one debug status item remained. The data came from a local mock endpoint; the app's real refresh timer drove each update.

## Verification

- `swift test --filter StatusItemReuseRegressionTests` — 1 passed
- `swift test --filter 'MenuBarVisibilityWatcherTests|StatusItemControllerSplitLifecycleTests'` — 61 passed
- `make check` — clean
- `make test` — 643 selections, 54/54 groups, zero failures or retries
- Autoreview — clean, confidence 0.93

Caveat: the pre-fix startup race did not reproduce reliably in three live launches. The deterministic test proves the re-entry window and exact duplicate identity failure; the live after-fix series proves stable identity across real timed refreshes.
