### PR TITLE
Stabilize shell cleanup timeout test

### DIFF
--- a/Tests/CodexBarTests/ShellCommandLocatorProcessTests.swift
+++ b/Tests/CodexBarTests/ShellCommandLocatorProcessTests.swift
@@ -30,6 +30,18 @@ struct ShellCommandLocatorProcessTests {
             .path
         let stdoutPIDFile = "\(pidFile).stdout"
         let stderrPIDFile = "\(pidFile).stderr"
+        let pidFiles = [stdoutPIDFile, stderrPIDFile]
+        defer {
+            for file in pidFiles {
+                if let pidText = try? String(contentsOfFile: file, encoding: .utf8)
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                    let pid = pid_t(pidText)
+                {
+                    kill(pid, SIGKILL)
+                }
+                try? FileManager.default.removeItem(atPath: file)
+            }
+        }
         let script = """
         import os
         import signal
@@ -57,25 +69,17 @@ struct ShellCommandLocatorProcessTests {
         let data = ShellCommandLocator.test_runShellCommand(
             shell: "/usr/bin/python3",
             arguments: ["-c", script, pidFile],
-            timeout: 0.2)
+            timeout: 2.0)
         let elapsed = Date().timeIntervalSince(start)
 
-        let pids = try [stdoutPIDFile, stderrPIDFile].map { file in
+        let pids = try pidFiles.map { file in
             let pidText = try String(contentsOfFile: file, encoding: .utf8)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             return try #require(pid_t(pidText))
         }
-        defer {
-            for pid in pids {
-                kill(pid, SIGKILL)
-            }
-            for file in [stdoutPIDFile, stderrPIDFile] {
-                try? FileManager.default.removeItem(atPath: file)
-            }
-        }
 
         #expect(data == nil)
-        #expect(elapsed < 3.0, "Timed-out PATH probes should remain bounded")
+        #expect(elapsed < 4.0, "Timed-out PATH probes should remain bounded")
         for pid in pids {
             #expect(kill(pid, 0) != 0)
         }


### PR DESCRIPTION
## Summary

- Give the Python fixture 2 seconds to reach the escaped-helper state before timeout cleanup.
- Keep the timeout behavior bounded with a 4-second elapsed assertion.
- Always remove partial PID files and kill any fixture helpers that started, even when fixture setup fails.

## Why

The previous 0.2-second timeout also acted as the fixture startup budget. Under the exact CI grouping, Python sometimes had not written the stdout helper PID before the timeout fired, so the test failed while reading the fixture file instead of testing process cleanup.

This exact missing-.stdout failure occurred six times across #2155 and #2170.

## Validation

- `swift test --filter ShellCommandLocatorProcessTests`
- 20 repeated focused runs: 20/20 passed; cleanup test 2.438–2.469 seconds
- 10 repeated runs with SettingsStoreTests, SettingsWindowAppearanceTests, ShellCommandForegroundTests, and ShellCommandLocatorProcessTests: 10/10 passed; cleanup test 2.444–2.464 seconds; full group maximum 3.924 seconds
- `make check`

`make test` was also run. Its default local group size of 12 stopped in the unrelated ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests suite with existing in-memory credential-store failures; the suite reproduces alone without this patch. Upstream CI on the exact base commit c61e01e7 passes both macOS shards with the configured group size of 4.