### PR TITLE
Respect work days for Codex pace

### DIFF
--- a/Sources/CodexBar/PreferencesMenuPicker.swift
+++ b/Sources/CodexBar/PreferencesMenuPicker.swift
@@ -78,7 +78,7 @@ enum MenuSettingsMenuOptions {
 
     static func weeklyProgressWorkDaysLabel(_ workDays: Int?) -> String {
         switch workDays {
-        case nil: L("Off")
+        case nil: L("Automatic")
         case 4: L("4 days")
         case 5: L("5 days")
         case 7: L("7 days")

--- a/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
@@ -70,12 +70,16 @@ struct CodexProviderImplementation: ProviderImplementation {
                 }
             })
         let batterySaverBinding = context.boolBinding(\.openAIWebBatterySaverEnabled)
+        let historicalTrackingSubtitle = [
+            L("Stores local Codex usage history (8 weeks) to personalize Pace predictions."),
+            "(\(L("weekly_progress_work_days_title")): \(L("Automatic")))",
+        ].joined(separator: " ")
 
         return [
             ProviderSettingsToggleDescriptor(
                 id: "codex-historical-tracking",
                 title: "Historical tracking",
-                subtitle: "Stores local Codex usage history (8 weeks) to personalize Pace predictions.",
+                subtitle: historicalTrackingSubtitle,
                 binding: context.boolBinding(\.historicalTrackingEnabled),
                 statusText: nil,
                 actions: [],

--- a/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
@@ -72,7 +72,7 @@ struct CodexProviderImplementation: ProviderImplementation {
         let batterySaverBinding = context.boolBinding(\.openAIWebBatterySaverEnabled)
         let historicalTrackingSubtitle = [
             L("Stores local Codex usage history (8 weeks) to personalize Pace predictions."),
-            "(\(L("weekly_progress_work_days_title")): \(L("Automatic")))",
+            "[\(L("weekly_progress_work_days_title")) = \(L("Automatic"))]",
         ].joined(separator: " ")
 
         return [

--- a/Sources/CodexBar/UsageStore+HistoricalPace.swift
+++ b/Sources/CodexBar/UsageStore+HistoricalPace.swift
@@ -13,7 +13,7 @@ extension UsageStore {
         // Codex can refine pace with historical samples because its dashboard exposes enough weekly history to build
         // an account-scoped usage curve. Other providers should not need a hard-coded allowlist: if their RateWindow
         // includes a reset time and window duration, the generic linear pace calculation is already defensible.
-        if provider == .codex, self.settings.historicalTrackingEnabled {
+        if provider == .codex, self.settings.historicalTrackingEnabled, workDays == nil {
             let codexAccountKey = self.codexOwnershipContext().canonicalKey
             if self.codexHistoricalDatasetAccountKey == codexAccountKey,
                let historical = CodexHistoricalPaceEvaluator.evaluate(
@@ -25,6 +25,10 @@ extension UsageStore {
             } else {
                 resolved = UsagePace.weekly(window: window, now: now, defaultWindowMinutes: 10080, workDays: workDays)
             }
+        } else if provider == .codex, self.settings.historicalTrackingEnabled {
+            // An explicit work-day schedule is the user's declared plan and takes precedence over learned history.
+            // Keep collecting history in the background so Automatic can resume historical pacing immediately.
+            resolved = UsagePace.weekly(window: window, now: now, defaultWindowMinutes: 10080, workDays: workDays)
         } else {
             // Generic providers must carry an explicit window duration. Using the 10080-minute fallback for
             // windows without windowMinutes would fabricate a weekly pace for non-weekly windows

--- a/Tests/CodexBarTests/HistoricalUsagePaceBackfillAuthorityTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceBackfillAuthorityTests.swift
@@ -286,7 +286,7 @@ extension HistoricalUsagePaceTests {
 
     @MainActor
     @Test
-    func `usage store falls back to linear when history disabled or insufficient`() throws {
+    func `usage store falls back to linear when Codex history is insufficient`() throws {
         let suite = "HistoricalUsagePaceTests-usage-store"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -309,7 +309,7 @@ extension HistoricalUsagePaceTests {
             copilotTokenStore: InMemoryCopilotTokenStore(),
             tokenAccountStore: InMemoryTokenAccountStore())
         settings.historicalTrackingEnabled = true
-        settings.weeklyProgressWorkDays = 5
+        settings.weeklyProgressWorkDays = nil
 
         let planHistoryStore = testPlanUtilizationHistoryStore(
             suiteName: "HistoricalUsagePaceTests-\(UUID().uuidString)")
@@ -341,19 +341,19 @@ extension HistoricalUsagePaceTests {
         store._setCodexHistoricalDatasetForTesting(twoWeeksDataset)
 
         let computed = store.weeklyPace(provider: .codex, window: window, now: now)
-        let workdayAware = UsagePace.weekly(
+        let linear = UsagePace.weekly(
             window: window,
             now: now,
             defaultWindowMinutes: 10080,
-            workDays: 5)
+            workDays: nil)
         #expect(computed != nil)
-        #expect(abs((computed?.deltaPercent ?? 0) - (workdayAware?.deltaPercent ?? 0)) < 0.001)
+        #expect(abs((computed?.deltaPercent ?? 0) - (linear?.deltaPercent ?? 0)) < 0.001)
     }
 
     @MainActor
     @Test
-    func `usage store preserves historical Codex pace when work days are off`() throws {
-        let suite = "HistoricalUsagePaceTests-workdays-off-preserve-history-\(UUID().uuidString)"
+    func `usage store preserves historical Codex pace in Automatic mode`() throws {
+        let suite = "HistoricalUsagePaceTests-workdays-automatic-preserve-history-\(UUID().uuidString)"
         let store = try Self.makeUsageStoreForBackfillTests(
             suite: suite,
             historyFileURL: Self.makeTempURL())
@@ -367,7 +367,7 @@ extension HistoricalUsagePaceTests {
             windowMinutes: 10080,
             resetsAt: resetsAt,
             resetDescription: nil)
-        let dataset = CodexHistoricalDataset(weeks: (0..<4).map { index in
+        let dataset = CodexHistoricalDataset(weeks: (0..<5).map { index in
             HistoricalWeekProfile(
                 resetsAt: resetsAt.addingTimeInterval(-duration * Double(index + 1)),
                 windowMinutes: 10080,
@@ -385,6 +385,7 @@ extension HistoricalUsagePaceTests {
         let computed = try #require(store.weeklyPace(provider: .codex, window: window, now: now))
 
         #expect(abs(expected.expectedUsedPercent - linear.expectedUsedPercent) > 0.001)
+        #expect(expected.runOutProbability != nil)
         #expect(abs(computed.expectedUsedPercent - expected.expectedUsedPercent) < 0.001)
         #expect(abs(computed.deltaPercent - expected.deltaPercent) < 0.001)
         #expect(computed.etaSeconds == expected.etaSeconds)
@@ -393,44 +394,63 @@ extension HistoricalUsagePaceTests {
     }
 
     @MainActor
-    @Test
-    func `usage store preserves historical Codex pace when work days are configured`() throws {
-        let suite = "HistoricalUsagePaceTests-workdays-preserve-history-\(UUID().uuidString)"
+    @Test(arguments: [4, 5, 7])
+    func `explicit work day schedule overrides historical Codex pace`(workDays: Int) throws {
+        let suite = "HistoricalUsagePaceTests-workdays-override-history-\(workDays)-\(UUID().uuidString)"
         let store = try Self.makeUsageStoreForBackfillTests(
             suite: suite,
             historyFileURL: Self.makeTempURL())
-        store.settings.weeklyProgressWorkDays = 5
+        store.settings.weeklyProgressWorkDays = workDays
 
-        let now = Date(timeIntervalSince1970: 0)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        let resetsAt = try #require(calendar.date(from: DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 6,
+            day: 14)))
+        let now = try #require(calendar.date(from: DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 6,
+            day: 11)))
         let duration = TimeInterval(10080 * 60)
-        let resetsAt = now.addingTimeInterval(duration / 2)
         let window = RateWindow(
             usedPercent: 60,
             windowMinutes: 10080,
             resetsAt: resetsAt,
             resetDescription: nil)
-        let weeks = (0..<4).map { index in
+        let weeks = (0..<5).map { index in
             HistoricalWeekProfile(
                 resetsAt: resetsAt.addingTimeInterval(-duration * Double(index + 1)),
                 windowMinutes: 10080,
-                curve: Self.linearCurve(end: 80))
+                curve: Self.linearCurve(end: 100))
         }
         let dataset = CodexHistoricalDataset(weeks: weeks)
-        let expected = try #require(CodexHistoricalPaceEvaluator.evaluate(
+        let historical = try #require(CodexHistoricalPaceEvaluator.evaluate(
             window: window,
             now: now,
             dataset: dataset))
+        let scheduled = try #require(UsagePace.weekly(
+            window: window,
+            now: now,
+            workDays: workDays,
+            calendar: calendar))
         store._setCodexHistoricalDatasetForTesting(
             dataset,
             accountKey: store.codexOwnershipContext().canonicalKey)
 
         let computed = try #require(store.weeklyPace(provider: .codex, window: window, now: now))
 
-        #expect(abs(computed.expectedUsedPercent - expected.expectedUsedPercent) < 0.001)
-        #expect(abs(computed.deltaPercent - expected.deltaPercent) < 0.001)
-        #expect(computed.etaSeconds == expected.etaSeconds)
-        #expect(computed.willLastToReset == expected.willLastToReset)
-        #expect(computed.runOutProbability == expected.runOutProbability)
+        #expect(historical.runOutProbability != nil)
+        #expect(abs(computed.expectedUsedPercent - scheduled.expectedUsedPercent) < 0.001)
+        #expect(abs(computed.deltaPercent - scheduled.deltaPercent) < 0.001)
+        #expect(computed.etaSeconds == scheduled.etaSeconds)
+        #expect(computed.willLastToReset == scheduled.willLastToReset)
+        #expect(computed.runOutProbability == nil)
+        #expect(computed.speedMultiplierToReset == scheduled.speedMultiplierToReset)
     }
 
     @MainActor

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -93,6 +93,7 @@ struct PreferencesPaneSmokeTests {
         #expect(MenuBarSettingsMenuOptions.iconStyles == MenuBarIconStyle.allCases)
         #expect(MenuBarSettingsMenuOptions.switcherRows == SwitcherRowsOption.allCases)
         #expect(MenuSettingsMenuOptions.weeklyProgressWorkDays == [nil, 4, 5, 7])
+        #expect(MenuSettingsMenuOptions.weeklyProgressWorkDaysLabel(nil) == L("Automatic"))
         #expect(MenuSettingsMenuOptions.multiAccountLayouts == MultiAccountMenuLayout.allCases)
         #expect(MenuSettingsMenuOptions.usageBarsFill == UsageBarsFillOption.allCases)
         #expect(MenuSettingsMenuOptions.resetTimes == ResetTimesOption.allCases)

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -41,6 +41,8 @@ read_when:
 
 Pace compares your actual usage against the expected consumption rate for the current window. Most providers use an even-consumption budget; Codex can use historical pace data when historical tracking is available.
 
+The **Work days** setting selects the weekly pace model. **Automatic** uses Codex historical pace when enough data is available. Selecting 4, 5, or 7 days uses that explicit schedule for pace and ETA instead; CodexBar continues collecting history in the background, but does not use historical predictions until the setting returns to Automatic.
+
 - **On pace** – usage matches the expected rate.
 - **X% in deficit** – you're consuming faster than the even rate; at this pace you'll run out before the window resets.
 - **X% in reserve** – you're consuming slower than the even rate; you have headroom to spare.


### PR DESCRIPTION
## Summary

- treat **Automatic** as the only mode that may use Codex historical pace predictions
- make explicit 4, 5, and 7-day schedules override historical predictions while continuing to collect history
- clarify the Work days and historical-tracking UI copy and document the behavior
- cover Automatic fallback/history and every explicit schedule with focused tests

## Why

CodexBar read the Work days preference, but once enough Codex history existed the historical evaluator took over and ignored an explicit schedule. That made a selected 4/5/7-day plan behave differently over time and contradicted the setting's promise.

The explicit schedule is now authoritative. Historical tracking remains useful in Automatic mode and continues recording in the background so switching back to Automatic works immediately.

Fixes #2176

## Validation

- `make test` — passed all 54 groups / 642 selections
- focused historical pace, preferences, and Codex provider settings tests — passed 78 tests
- `make check` — passed formatting, lint, and repository checks
