### PR TITLE
Clarify Ollama API quota guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.43.1 — Unreleased
 
 ### Fixed
+- Ollama: explain that API-key verification cannot show Cloud quota limits and direct users to browser-cookie mode (#2159). Thanks @kiranmagic7!
 - Claude: suppress duplicate all-model scoped quota rows that could appear as “All models only” beside Weekly.
 
 ## 0.43.0 — 2026-07-14

--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -110,7 +110,7 @@ extension UsageMenuCardView.Model {
         if input.provider == .ollama,
            input.snapshot?.identity?.loginMethod == "API key"
         {
-            return [L("API key verified. Sign in to Ollama in the selected browser to show Cloud quota limits.")]
+            return [L("API key verified. Cloud quotas need browser cookies. Sign in to Ollama.")]
         }
 
         return nil

--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -110,7 +110,7 @@ extension UsageMenuCardView.Model {
         if input.provider == .ollama,
            input.snapshot?.identity?.loginMethod == "API key"
         {
-            return [L("API key verified. Ollama does not expose Cloud quota limits through the API.")]
+            return [L("API key verified. Sign in to Ollama in the selected browser to show Cloud quota limits.")]
         }
 
         return nil

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -887,7 +887,7 @@
 "Hourly Usage" = "الاستخدام بالساعة";
 "Usage remaining" = "الاستخدام المتبقي";
 "Usage used" = "الاستخدام المستخدم";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "تم التحقق من API المفتاح. Ollama لا يكشف حدود حصص السحابة عبر API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "تم التحقق من مفتاح API. تتطلب حصص Cloud ملفات تعريف ارتباط المتصفح. سجّل الدخول إلى Ollama.";
 "Last 30 days: %@ tokens" = "آخر 30 يوما: %@ الرموز";
 "7d spend" = "7d تنفق";
 "30d spend" = "30d تنفق";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -750,7 +750,7 @@
 "Hourly Usage" = "Ús per hora";
 "Usage remaining" = "Ús restant";
 "Usage used" = "Ús consumit";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "Clau d'API verificada. Ollama no exposa els límits de quota de Cloud a través de l'API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "Clau d'API verificada. Les quotes de Cloud necessiten galetes del navegador. Inicieu sessió a Ollama.";
 "Last 30 days: %@ tokens" = "Últims 30 dies: %@ tokens";
 "7d spend" = "Despesa 7 d";
 "30d spend" = "Despesa 30 d";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -883,7 +883,7 @@
 "Hourly Usage" = "Stündliche Nutzung";
 "Usage remaining" = "Verbleibende Nutzung";
 "Usage used" = "Verbraucht";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API-Schlüssel überprüft. Ollama legt über die API keine Cloud-Kontingentgrenzen offen.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "API-Schlüssel bestätigt. Cloud-Kontingente erfordern Browser-Cookies. Melde dich bei Ollama an.";
 "Last 30 days: %@ tokens" = "Letzte 30 Tage: %@ Token";
 "7d spend" = "7d ausgeben";
 "30d spend" = "30 Tage ausgeben";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -887,7 +887,7 @@
 "Hourly Usage" = "Hourly Usage";
 "Usage remaining" = "Usage remaining";
 "Usage used" = "Usage used";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API key verified. Ollama does not expose Cloud quota limits through the API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "API key verified. Cloud quotas need browser cookies. Sign in to Ollama.";
 "Last 30 days: %@ tokens" = "Last 30 days: %@ tokens";
 "7d spend" = "7d spend";
 "30d spend" = "30d spend";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -764,7 +764,7 @@
 "Hourly Usage" = "Uso por hora";
 "Usage remaining" = "Uso restante";
 "Usage used" = "Uso utilizado";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "Clave de API verificada. Ollama no expone los límites de cuota de Cloud mediante la API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "Clave de API verificada. Las cuotas de Cloud requieren cookies del navegador. Inicia sesión en Ollama.";
 "Last 30 days: %@ tokens" = "Últimos 30 días: %@ tokens";
 "7d spend" = "Gasto 7 d";
 "30d spend" = "Gasto 30 d";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -887,7 +887,7 @@
 "Hourly Usage" = "استفاده ساعتی";
 "Usage remaining" = "کاربرد باقی مانده";
 "Usage used" = "کاربرد مورد استفاده";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API کلید تأیید شد. Ollama محدودیت های سهمیه ابری را از طریق API آشکار نمی کند.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "کلید API تأیید شد. سهمیه‌های Cloud به کوکی‌های مرورگر نیاز دارند. وارد Ollama شوید.";
 "Last 30 days: %@ tokens" = "۳۰ روز آخر: توکن های %@";
 "7d spend" = "7d خرج می کنم";
 "30d spend" = "30d خرج می کنم";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -885,7 +885,7 @@
 "Hourly Usage" = "Utilisation horaire";
 "Usage remaining" = "Utilisation restante";
 "Usage used" = "Utilisation utilisée";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "Clé API vérifiée. Ollama n'expose pas les limites de quota Cloud via l'API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "Clé API vérifiée. Les quotas Cloud nécessitent les cookies du navigateur. Connectez-vous à Ollama.";
 "Last 30 days: %@ tokens" = "30 derniers jours : jetons %@";
 "7d spend" = "7j dépensés";
 "30d spend" = "30 jours de dépenses";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -744,7 +744,7 @@
 "Hourly Usage" = "Uso horario";
 "Usage remaining" = "Uso restante";
 "Usage used" = "Uso consumido";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "Chave de API verificada. Ollama non expón os límites da cota de Cloud mediante a API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "Chave de API verificada. As cotas de Cloud requiren cookies do navegador. Inicie sesión en Ollama.";
 "Last 30 days: %@ tokens" = "Últimos 30 días: %@ tokens";
 "7d spend" = "Gasto en 7 d";
 "30d spend" = "Gasto en 30 d";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -889,7 +889,7 @@
 "Hourly Usage" = "Penggunaan Per Jam";
 "Usage remaining" = "Penggunaan tersisa";
 "Usage used" = "Penggunaan terpakai";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "Kunci API terverifikasi. Ollama tidak menampilkan batas kuota Cloud melalui API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "Kunci API terverifikasi. Kuota Cloud memerlukan cookie browser. Masuk ke Ollama.";
 "Last 30 days: %@ tokens" = "30 hari terakhir: %@ token";
 "7d spend" = "Pengeluaran 7 hari";
 "30d spend" = "Pengeluaran 30 hari";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -889,7 +889,7 @@
 "Hourly Usage" = "Utilizzo orario";
 "Usage remaining" = "Utilizzo rimanente";
 "Usage used" = "Utilizzo consumato";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "Chiave API verificata. Ollama non espone i limiti di quota Cloud tramite API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "Chiave API verificata. Le quote Cloud richiedono i cookie del browser. Accedi a Ollama.";
 "Last 30 days: %@ tokens" = "Ultimi 30 giorni: %@ token";
 "7d spend" = "Spesa 7 g";
 "30d spend" = "Spesa 30 g";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -882,7 +882,7 @@
 "Hourly Usage" = "時間別使用量";
 "Usage remaining" = "残りの使用量";
 "Usage used" = "使用済みの使用量";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API キーを確認しました。OllamaはAPI経由でCloudクォータ上限を公開していません。";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "APIキーを確認しました。CloudクォータにはブラウザCookieが必要です。Ollamaにサインインしてください。";
 "Last 30 days: %@ tokens" = "過去30日間: %@ トークン";
 "7d spend" = "7日間の支出";
 "30d spend" = "過去30日間の支出";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -853,7 +853,7 @@
 "Hourly Usage" = "시간별 사용량";
 "Usage remaining" = "남은 사용량";
 "Usage used" = "사용한 사용량";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API 키가 확인되었습니다. Ollama는 API를 통해 클라우드 할당량 한도를 제공하지 않습니다.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "API 키가 확인되었습니다. Cloud 할당량에는 브라우저 쿠키가 필요합니다. Ollama에 로그인하세요.";
 "Last 30 days: %@ tokens" = "지난 30일: %@ 토큰";
 "7d spend" = "7일 지출";
 "30d spend" = "30일 지출";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -885,7 +885,7 @@
 "Hourly Usage" = "Uurgebruik";
 "Usage remaining" = "Resterend gebruik";
 "Usage used" = "Gebruik gebruikt";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API-sleutel geverifieerd. Ollama stelt geen Cloud-quotumlimieten bloot via de API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "API-sleutel geverifieerd. Cloud-quota vereisen browsercookies. Meld je aan bij Ollama.";
 "Last 30 days: %@ tokens" = "Afgelopen 30 dagen: %@ tokens";
 "7d spend" = "7d uitgaven";
 "30d spend" = "30d uitgaven";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -889,7 +889,7 @@
 "Hourly Usage" = "Użycie godzinowe";
 "Usage remaining" = "Pozostałe użycie";
 "Usage used" = "Wykorzystane użycie";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "Klucz API został zweryfikowany. Ollama nie udostępnia limitów Cloud przez API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "Klucz API został zweryfikowany. Limity Cloud wymagają plików cookie przeglądarki. Zaloguj się do Ollama.";
 "Last 30 days: %@ tokens" = "Ostatnie 30 dni: %@ tokenów";
 "7d spend" = "Wydatki 7 dni";
 "30d spend" = "Wydatki 30 dni";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -882,7 +882,7 @@
 "Hourly Usage" = "Uso por hora";
 "Usage remaining" = "Uso restante";
 "Usage used" = "Uso usado";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "Chave de API verificada. O Ollama não expõe limites de cota do Cloud pela API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "Chave de API verificada. As cotas do Cloud exigem cookies do navegador. Entre no Ollama.";
 "Last 30 days: %@ tokens" = "Últimos 30 dias: %@ tokens";
 "7d spend" = "Gasto 7 d";
 "30d spend" = "Gasto 30 d";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -887,7 +887,7 @@
 "Hourly Usage" = "Использование по часам";
 "Usage remaining" = "Осталось";
 "Usage used" = "Использовано";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API-ключ проверен. Ollama не раскрывает лимиты квот Cloud через API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "API-ключ проверен. Для квот Cloud нужны файлы cookie браузера. Войдите в Ollama.";
 "Last 30 days: %@ tokens" = "За последние 30 дней: %@ токенов";
 "7d spend" = "Расходы за 7 дн.";
 "30d spend" = "Расходы за 30 дн.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1101,7 +1101,7 @@
 "Username" = "Användarnamn";
 "CodexBar will ask macOS Keychain for your MiniMax cookie header so it can fetch usage. Click OK to continue." = "CodexBar kommer att be macOS Nyckelring om din MiniMax-cookie-header så att användning kan hämtas. Klicka på OK för att fortsätta.";
 "30d spend" = "30 d kostnad";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API-nyckeln har verifierats. Ollama exponerar inte Cloud-kvotgränser via API:t.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "API-nyckeln har verifierats. Cloud-kvoter kräver webbläsarcookies. Logga in på Ollama.";
 "Series" = "Serie";
 "Total (30d): %@ credits" = "Totalt (30 d): %@ krediter";
 "Paste a Cookie header or full cURL capture from T3 Chat settings." = "Klistra in en Cookie-header eller fullständig cURL-fångst från T3 Chat-inställningarna.";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -887,7 +887,7 @@
 "Hourly Usage" = "การใช้งานรายชั่วโมง";
 "Usage remaining" = "การใช้งานที่เหลืออยู่";
 "Usage used" = "การใช้งานที่ใช้";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API คีย์ที่ตรวจสอบแล้ว Ollama ไม่เปิดเผยขีดจํากัดโควต้าระบบคลาวด์ผ่าน API";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "ยืนยันคีย์ API แล้ว โควตา Cloud ต้องใช้คุกกี้ของเบราว์เซอร์ ลงชื่อเข้าใช้ Ollama";
 "Last 30 days: %@ tokens" = "30 วันที่ผ่านมา: %@ โทเค็น";
 "7d spend" = "7d ใช้จ่าย";
 "30d spend" = "30d ใช้จ่าย";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -883,7 +883,7 @@
 "Hourly Usage" = "Saatlik Kullanım";
 "Usage remaining" = "Kalan kullanım";
 "Usage used" = "Harcanan kullanım";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API anahtarı doğrulandı. Ollama, Cloud kota limitlerini API üzerinden göstermez.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "API anahtarı doğrulandı. Cloud kotaları için tarayıcı çerezleri gerekir. Ollama'da oturum açın.";
 "Last 30 days: %@ tokens" = "Son 30 gün: %@ jeton";
 "7d spend" = "7 günlük harcama";
 "30d spend" = "30 günlük harcama";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -885,7 +885,7 @@
 "Hourly Usage" = "Погодинне використання";
 "Usage remaining" = "Залишилося використання";
 "Usage used" = "Використання використано";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "Ключ API перевірено. Ollama не розкриває обмеження квот Cloud через API.";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "Ключ API перевірено. Для квот Cloud потрібні файли cookie браузера. Увійдіть в Ollama.";
 "Last 30 days: %@ tokens" = "Останні 30 днів: %@ токенів";
 "7d spend" = "7д витратити";
 "30d spend" = "витратити 30 днів";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -881,7 +881,7 @@
 "Hourly Usage" = "Hàng giờ Mức sử dụng";
 "Usage remaining" = "Mức sử dụng";
 "Usage used" = "Mức sử dụng đã sử dụng khóa";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API đã được xác minh. Ollama không đưa ra các giới hạn Hạn mức của Đám mây thông qua API .";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "Đã xác minh khóa API. Hạn mức Cloud yêu cầu cookie trình duyệt. Hãy đăng nhập vào Ollama.";
 "Last 30 days: %@ tokens" = "30 ngày qua: %@ mã thông báo";
 "7d spend" = "chi tiêu 7 ngày";
 "30d spend" = "chi tiêu 30 ngày";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -851,7 +851,7 @@
 "Hourly Usage" = "每小时用量";
 "Usage remaining" = "剩余用量";
 "Usage used" = "已使用用量";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API 密钥已验证。Ollama 不会通过 API 暴露 Cloud 配额限制。";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "API 密钥已验证。Cloud 配额需要浏览器 Cookie。请登录 Ollama。";
 "Last 30 days: %@ tokens" = "近 30 天：%@ token";
 "7d spend" = "7 天支出";
 "30d spend" = "30 天支出";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -758,7 +758,7 @@
 "Hourly Usage" = "每小時使用量";
 "Usage remaining" = "剩餘使用量";
 "Usage used" = "已使用使用量";
-"API key verified. Ollama does not expose Cloud quota limits through the API." = "API 金鑰已驗證。Ollama 不會透過 API 提供 Cloud 配額限制。";
+"API key verified. Cloud quotas need browser cookies. Sign in to Ollama." = "API 金鑰已驗證。Cloud 配額需要瀏覽器 Cookie。請登入 Ollama。";
 "Last 30 days: %@ tokens" = "近 30 天：%@ token";
 "7d spend" = "7 天支出";
 "30d spend" = "30 天支出";

--- a/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
+++ b/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
@@ -97,7 +97,7 @@ struct MenuCardProviderRegressionTests {
         #expect(model.placeholder == nil)
         #expect(model.planText == "API key")
         #expect(model.usageNotes == [
-            "API key verified. Sign in to Ollama in the selected browser to show Cloud quota limits.",
+            "API key verified. Cloud quotas need browser cookies. Sign in to Ollama.",
         ])
     }
 

--- a/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
+++ b/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
@@ -67,6 +67,41 @@ struct MenuCardProviderRegressionTests {
     }
 
     @Test
+    func `ollama api key model explains browser session quota requirement`() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.ollama])
+        let snapshot = OllamaAPIUsageSnapshot(modelCount: 3, updatedAt: now).toUsageSnapshot()
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .ollama,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            sourceLabel: "api",
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.isEmpty)
+        #expect(model.placeholder == nil)
+        #expect(model.planText == "API key")
+        #expect(model.usageNotes == [
+            "API key verified. Sign in to Ollama in the selected browser to show Cloud quota limits.",
+        ])
+    }
+
+    @Test
     func `wayfinder model shows gateway routing savings and latency`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.wayfinder])


### PR DESCRIPTION
Refs #2159

## Summary

- Clarifies the Ollama API-key-only menu card: Cloud quota windows require browser cookies, so users get an actionable sign-in path instead of a silent card.
- Keeps the API-key snapshot free of fabricated quota bars and placeholders.
- Localizes the guidance across all 23 bundled catalogs and adds regression coverage.

## Before / after

| Before | After |
| --- | --- |
| ![Before: API key card with non-actionable quota limitation](https://github.com/user-attachments/assets/e03f05fb-65e2-4548-b4d2-fa52baebfdca) | ![After: API key card with browser-cookie sign-in guidance](https://github.com/user-attachments/assets/f09b07ab-3af7-4556-9dad-268b7150d1b9) |

Fresh synthetic SwiftUI menu-card renders. No account or provider data.

## Tests

- `swift test --filter MenuCardProviderRegressionTests` — 6 passed
- `swift test --filter LocalizationLanguageCatalogTests` — 28 passed
- `make check` — clean
- `make test` — 642 selections, 54/54 groups, zero failures or retries
- Autoreview — clean, confidence 0.98

Live Ollama account/browser-cookie verification was not run; repository policy requires explicit authorization for real provider and cookie probes.

Compatibility risk: low. Presentation text and localization only; no auth, cookie import, or fetch behavior changes.
