### PR TITLE
[security] Fix upstream monitor script injection

### DIFF
--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -92,16 +92,23 @@ jobs:
       - name: Create or update issue
         if: steps.check.outputs.upstream_commits > 0 || steps.check.outputs.quotio_commits > 0
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          UPSTREAM_COMMITS: ${{ steps.check.outputs.upstream_commits }}
+          QUOTIO_COMMITS: ${{ steps.check.outputs.quotio_commits }}
+          UPSTREAM_REF: ${{ steps.check.outputs.upstream_ref }}
+          QUOTIO_REF: ${{ steps.check.outputs.quotio_ref }}
+          UPSTREAM_SUMMARY: ${{ steps.check.outputs.upstream_summary }}
+          QUOTIO_SUMMARY: ${{ steps.check.outputs.quotio_summary }}
         with:
           script: |
-            const upstreamCommits = '${{ steps.check.outputs.upstream_commits }}';
-            const quotioCommits = '${{ steps.check.outputs.quotio_commits }}';
-            const upstreamRef = '${{ steps.check.outputs.upstream_ref }}';
-            const quotioRef = '${{ steps.check.outputs.quotio_ref }}';
+            const upstreamCommits = process.env.UPSTREAM_COMMITS;
+            const quotioCommits = process.env.QUOTIO_COMMITS;
+            const upstreamRef = process.env.UPSTREAM_REF;
+            const quotioRef = process.env.QUOTIO_REF;
             const upstreamBranch = upstreamRef.replace('upstream/', '');
             const quotioBranch = quotioRef.replace('quotio/', '');
-            const upstreamSummary = `${{ steps.check.outputs.upstream_summary }}`;
-            const quotioSummary = `${{ steps.check.outputs.quotio_summary }}`;
+            const upstreamSummary = process.env.UPSTREAM_SUMMARY;
+            const quotioSummary = process.env.QUOTIO_SUMMARY;
             
             const body = `## 🔄 Upstream Changes Detected
             


### PR DESCRIPTION
## Summary

This PR prevents external upstream commit summaries from being interpreted as JavaScript by the scheduled upstream-monitor workflow.

- pass all `steps.check.outputs` values to `actions/github-script` through `env`
- read the values from `process.env` inside the script
- preserve the existing issue body, update logic, pinned actions, and least-privilege token permissions

## Why this matters

The workflow fetches the independently controlled Quotio repository and includes recent commit subjects in an automatically managed CodexBar issue. Those subjects were interpolated directly into JavaScript template literals before `actions/github-script` parsed the script.

A commit subject containing a backtick could therefore terminate the intended template literal and inject JavaScript into the scheduled workflow. The action receives the workflow's authenticated GitHub client with `issues: write` access.

Passing the values through environment variables keeps them as data instead of executable source.

## Affected code

- `.github/workflows/upstream-monitor.yml`
- `Create or update issue` step

## Root cause

Untrusted step outputs were embedded directly into the `github-script` source:

```yaml
const quotioSummary = `${{ steps.check.outputs.quotio_summary }}`;
```

GitHub expands the expression before the JavaScript is parsed, so JavaScript-significant characters in an upstream commit subject could change the generated program.

## Repro conditions

- an attacker-controlled commit subject reaches the monitored Quotio default branch, for example through a squash-merged contribution
- the scheduled or manually dispatched upstream-monitor workflow observes that commit
- the commit summary is inserted into the `github-script` source

## Steps to reproduce

A safe synthetic regression used a commit-summary string containing a backtick and a harmless assignment. Under the old source-concatenation shape, the assignment executed. Under this patch, the same string is read from `process.env`, remains inert, and is preserved in the generated issue body.

No real GitHub token, issue, credential, or external repository was modified during validation.

## Impact

Injected code runs with the workflow's existing permissions:

```yaml
permissions:
  issues: write
  contents: read
```

This can affect issue integrity and availability, including issue creation, modification, comments, labels, and state changes. The explicit permission block prevents direct source or release modification.

## CVSS assessment

- Score: **5.4 (Medium)**
- Vector: `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:L`
- CWE: CWE-94 / CWE-95

## Suggested fix

Implemented here: move all step-output expressions to the action's `env` mapping and consume them through `process.env`. This avoids constructing JavaScript source from externally influenced data.

## Validation

- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color -shellcheck= .github/workflows/upstream-monitor.yml`
- Docker Node 24 regression: crafted summary remained inert data and remained present in the generated body
- structural regression: confirmed the `github-script` block contains no direct `steps.check.outputs` interpolation and reads all six values through `process.env`
- `git diff --check`

`make check` reached the repository lint stage but the downloaded SwiftLint binary could not load `sourcekitdInProc.framework` in this Command Line Tools-only environment. `make test` was also blocked before project tests ran because the local toolchain could not import the Swift `Testing` module. These failures are environment/toolchain setup issues and do not touch the workflow-only change.

## Disclosure status

This PR contains the complete fix and bounded impact description. No credentials or live exploitation were used.
