### PR TITLE
Show claude-swap accounts in CLI cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - ZenMux: add Management API usage with five-hour and weekly quotas, subscription expiry, and USD PAYG balance. Thanks @kays0x!
+- CLI: show opt-in claude-swap multi-account usage in full and brief terminal cards while preserving explicit account/source overrides and ambient fallback diagnostics.
 
 ### Fixed
 - Claude: preserve each account’s last-good OAuth usage during rate limits and isolate retry cooldowns per credential. Thanks @ruushu!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Added
 - ZenMux: add Management API usage with five-hour and weekly quotas, subscription expiry, and USD PAYG balance. Thanks @kays0x!
-- CLI: show opt-in claude-swap multi-account usage in full and brief terminal cards while preserving explicit account/source overrides and ambient fallback diagnostics.
 
 ### Fixed
 - Claude: preserve each account’s last-good OAuth usage during rate limits and isolate retry cooldowns per credential. Thanks @ruushu!

--- a/Sources/CodexBarCLI/CLICardsBriefRenderer.swift
+++ b/Sources/CodexBarCLI/CLICardsBriefRenderer.swift
@@ -7,6 +7,8 @@ struct CLICardsBriefRow: Sendable, Equatable {
     let sourceLabel: String
     let planBadge: String?
     let accountLabel: String?
+    let isActive: Bool
+    let accountProblem: String?
     let metricLabel: String?
     let usedPercent: Double?
     let resetLabel: String?
@@ -44,6 +46,8 @@ enum CLICardsBriefRenderer {
                 sourceLabel: card.sourceLabel,
                 planBadge: card.planBadge,
                 accountLabel: card.accountLine,
+                isActive: card.isActive,
+                accountProblem: card.accountProblem,
                 metricLabel: metric?.label,
                 usedPercent: usedPercent,
                 resetLabel: resetLabel,
@@ -145,7 +149,8 @@ enum CLICardsBriefRenderer {
 
     private static func providerPlainLabel(_ row: CLICardsBriefRow) -> String {
         if let account = row.accountLabel?.trimmingCharacters(in: .whitespacesAndNewlines), !account.isEmpty {
-            return "\(row.providerName) · \(account) · \(row.sourceLabel)"
+            let active = row.isActive ? " [active]" : ""
+            return "\(row.providerName)\(active) · \(account) · \(row.sourceLabel)"
         }
         if let plan = row.planBadge, !plan.isEmpty {
             return "\(row.providerName) · \(row.sourceLabel) · \(plan)"
@@ -287,6 +292,13 @@ enum CLICardsBriefRenderer {
         useColor: Bool,
         enhanced: Bool) -> String
     {
+        if row.isActive, width < row.providerName.count + " [active]".count {
+            let fitted = Self.fitCell("[active]", width: width)
+            if useColor, enhanced {
+                return CLIRenderer.colorizeEnhancedReadable(fitted)
+            }
+            return useColor ? CLIRenderer.colorizeReadable(fitted) : fitted
+        }
         if row.accountLabel?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
             let fitted = Self.fitCell(Self.providerPlainLabel(row), width: width)
             if useColor, enhanced {
@@ -388,7 +400,16 @@ enum CLICardsBriefRenderer {
             useColor: useColor,
             enhanced: enhanced)
         let usage: String
-        if let used = row.usedPercent {
+        if let problem = row.accountProblem, !problem.isEmpty {
+            let fitted = Self.fitCell(problem, width: columns.usage)
+            if useColor, enhanced {
+                usage = CLIRenderer.colorizeEnhancedReadable(fitted)
+            } else if useColor {
+                usage = CLIRenderer.colorizeReadable(fitted)
+            } else {
+                usage = fitted
+            }
+        } else if let used = row.usedPercent {
             let percent = String(format: "%.0f%%", used.rounded())
             let barWidth = max(4, min(Self.usageBarMaxWidth, columns.usage - Self.visibleLength(percent) - 1))
             let bar: String = if useColor, enhanced {

--- a/Sources/CodexBarCLI/CLICardsCommand.swift
+++ b/Sources/CodexBarCLI/CLICardsCommand.swift
@@ -97,6 +97,7 @@ extension CodexBarCLI {
         let resetStyle = Self.resetTimeDisplayStyleFromDefaults()
         let weeklyWorkDays = Self.weeklyProgressWorkDaysFromDefaults()
         let providerList = provider.asList
+        let claudeConfig = config.providerConfig(for: .claude)
 
         let tokenSelection: TokenAccountCLISelection
         do {
@@ -171,13 +172,29 @@ extension CodexBarCLI {
 
         for provider in providerList {
             let status = includeStatus ? await Self.fetchStatus(for: provider) : nil
-            let result = await ProviderInteractionContext.$current.withValue(.background) {
-                await Self.fetchUsageOutputs(
-                    provider: provider,
+            let claudeSwapEligible = CLIClaudeSwapCards.isEligible(
+                provider: provider,
+                integrationEnabled: claudeConfig?.claudeSwapEnabled == true,
+                hasExplicitAccountSelection: tokenSelection.usesOverride,
+                sourceModeOverride: parsedSourceMode)
+            let result = await CLIClaudeSwapCards.fetch(
+                eligible: claudeSwapEligible,
+                executablePath: claudeConfig?.claudeSwapExecutablePath ?? "",
+                renderOptions: CLIClaudeSwapCardsRenderOptions(
                     status: status,
-                    tokenContext: tokenContext,
-                    command: command)
-            }
+                    useColor: useColor,
+                    resetStyle: resetStyle,
+                    weeklyWorkDays: weeklyWorkDays,
+                    now: Date()),
+                ambientFetch: {
+                    await ProviderInteractionContext.$current.withValue(.background) {
+                        await Self.fetchUsageOutputs(
+                            provider: provider,
+                            status: status,
+                            tokenContext: tokenContext,
+                            command: command)
+                    }
+                })
             if result.exitCode != .success {
                 exitCode = result.exitCode
             }

--- a/Sources/CodexBarCLI/CLICardsCommand.swift
+++ b/Sources/CodexBarCLI/CLICardsCommand.swift
@@ -179,7 +179,7 @@ extension CodexBarCLI {
                 sourceModeOverride: parsedSourceMode)
             let result = await CLIClaudeSwapCards.fetch(
                 eligible: claudeSwapEligible,
-                executablePath: claudeConfig?.claudeSwapExecutablePath ?? "",
+                executablePath: CLIClaudeSwapCards.executablePath(from: claudeConfig),
                 renderOptions: CLIClaudeSwapCardsRenderOptions(
                     status: status,
                     useColor: useColor,

--- a/Sources/CodexBarCLI/CLICardsRenderer.swift
+++ b/Sources/CodexBarCLI/CLICardsRenderer.swift
@@ -36,10 +36,38 @@ struct CLICardModel: Sendable, Equatable {
     let sourceLabel: String
     let planBadge: String?
     let accountLine: String?
+    let isActive: Bool
+    let accountProblem: String?
     let infoLines: [String]
     let metrics: [CLICardMetric]
     let extraLines: [String]
     let statusLine: String?
+
+    init(
+        provider: UsageProvider,
+        title: String,
+        sourceLabel: String,
+        planBadge: String?,
+        accountLine: String?,
+        isActive: Bool = false,
+        accountProblem: String? = nil,
+        infoLines: [String],
+        metrics: [CLICardMetric],
+        extraLines: [String],
+        statusLine: String?)
+    {
+        self.provider = provider
+        self.title = title
+        self.sourceLabel = sourceLabel
+        self.planBadge = planBadge
+        self.accountLine = accountLine
+        self.isActive = isActive
+        self.accountProblem = accountProblem
+        self.infoLines = infoLines
+        self.metrics = metrics
+        self.extraLines = extraLines
+        self.statusLine = statusLine
+    }
 }
 
 struct CLICardFailure: Sendable, Equatable {
@@ -146,6 +174,62 @@ enum CLICardsRenderer {
             statusLine: statusLine)
     }
 
+    static func makeClaudeSwapCard(
+        account: ProviderAccountUsageSnapshot,
+        renderOptions: CLIClaudeSwapCardsRenderOptions) -> CLICardModel
+    {
+        let sanitizedLabel = CLIClaudeSwapText.sanitizeLabel(account.displayLabel)
+        let label = sanitizedLabel.isEmpty
+            ? CLIClaudeSwapText.sanitizeLabel("Account \(account.id.opaqueID)")
+            : sanitizedLabel
+        let problem = account.error.map(CLIClaudeSwapText.sanitizeDiagnostic)
+        if let snapshot = account.snapshot {
+            let base = Self.makeCard(CLICardBuildInput(
+                provider: .claude,
+                snapshot: snapshot,
+                credits: nil,
+                source: ClaudeSwapAccountProjection.sourceLabel,
+                status: renderOptions.status,
+                notes: [],
+                useColor: renderOptions.useColor,
+                resetStyle: renderOptions.resetStyle,
+                weeklyWorkDays: renderOptions.weeklyWorkDays,
+                now: renderOptions.now))
+            return CLICardModel(
+                provider: base.provider,
+                title: base.title,
+                sourceLabel: base.sourceLabel,
+                planBadge: nil,
+                accountLine: label,
+                isActive: account.isActive,
+                accountProblem: problem,
+                infoLines: base.infoLines,
+                metrics: base.metrics,
+                extraLines: base.extraLines,
+                statusLine: base.statusLine)
+        }
+
+        let statusLine: String? = renderOptions.status.map { status in
+            let line = "Status: \(status.indicator.label)\(status.descriptionSuffix)"
+            return CLIRenderer.colorizeStatusLine(
+                line,
+                indicator: status.indicator,
+                useColor: renderOptions.useColor)
+        }
+        return CLICardModel(
+            provider: .claude,
+            title: ProviderDescriptorRegistry.descriptor(for: .claude).metadata.displayName,
+            sourceLabel: ClaudeSwapAccountProjection.sourceLabel,
+            planBadge: nil,
+            accountLine: label,
+            isActive: account.isActive,
+            accountProblem: problem,
+            infoLines: [],
+            metrics: [],
+            extraLines: [],
+            statusLine: statusLine)
+    }
+
     static func render(
         cards: [CLICardModel],
         failures: [CLICardFailure],
@@ -199,7 +283,9 @@ enum CLICardsRenderer {
         lines.append(Self.headerLine(card: card, innerWidth: innerWidth, useColor: useColor, enhanced: enhanced))
 
         if let account = card.accountLine?.trimmingCharacters(in: .whitespacesAndNewlines), !account.isEmpty {
-            let accountText = "@ \(account)"
+            let active = card.isActive ? " [active]" : ""
+            let labelWidth = max(1, innerWidth - 2 - active.count)
+            let accountText = "@ \(Self.truncatePlain(account, width: labelWidth))\(active)"
             lines.append(Self.contentLine(
                 accountText,
                 innerWidth: innerWidth,
@@ -209,6 +295,16 @@ enum CLICardsRenderer {
         }
 
         lines.append(Self.separatorLine(innerWidth: innerWidth, useColor: useColor, enhanced: enhanced))
+
+        if let problem = card.accountProblem, !problem.isEmpty {
+            for problemLine in Self.wrapPlainText(problem, width: innerWidth) {
+                lines.append(Self.contentLine(
+                    problemLine,
+                    innerWidth: innerWidth,
+                    useColor: useColor,
+                    enhanced: enhanced))
+            }
+        }
 
         for infoLine in card.infoLines {
             lines.append(Self.detailLine(
@@ -482,6 +578,38 @@ enum CLICardsRenderer {
         guard text.count > width else { return text }
         if width <= 1 { return String(text.prefix(width)) }
         return String(text.prefix(width - 1)) + "…"
+    }
+
+    private static func wrapPlainText(_ text: String, width: Int) -> [String] {
+        guard width > 0 else { return [] }
+        var lines: [String] = []
+        var line = ""
+        for word in text.split(whereSeparator: \.isWhitespace).map(String.init) {
+            if word.count > width {
+                if !line.isEmpty {
+                    lines.append(line)
+                    line = ""
+                }
+                var remainder = word[...]
+                while remainder.count > width {
+                    let end = remainder.index(remainder.startIndex, offsetBy: width)
+                    lines.append(String(remainder[..<end]))
+                    remainder = remainder[end...]
+                }
+                line = String(remainder)
+            } else if line.isEmpty {
+                line = word
+            } else if line.count + 1 + word.count <= width {
+                line += " " + word
+            } else {
+                lines.append(line)
+                line = word
+            }
+        }
+        if !line.isEmpty {
+            lines.append(line)
+        }
+        return lines
     }
 
     private static func fitContent(_ text: String, width: Int) -> String {

--- a/Sources/CodexBarCLI/CLIClaudeSwapCards.swift
+++ b/Sources/CodexBarCLI/CLIClaudeSwapCards.swift
@@ -1,0 +1,184 @@
+import CodexBarCore
+import Foundation
+
+enum CLIClaudeSwapText {
+    static let labelScalarLimit = 256
+    static let diagnosticScalarLimit = 512
+
+    static func sanitizeLabel(_ text: String) -> String {
+        self.sanitize(text, scalarLimit: self.labelScalarLimit)
+    }
+
+    static func sanitizeDiagnostic(_ text: String) -> String {
+        self.sanitize(text, scalarLimit: self.diagnosticScalarLimit)
+    }
+
+    private enum EscapeState {
+        case plain
+        case escape
+        case controlSequence
+        case operatingSystemCommand
+        case operatingSystemCommandEscape
+    }
+
+    private static func sanitize(_ text: String, scalarLimit: Int) -> String {
+        var state = EscapeState.plain
+        var scalars: [Unicode.Scalar] = []
+        scalars.reserveCapacity(min(text.unicodeScalars.count, scalarLimit))
+
+        for scalar in text.unicodeScalars {
+            switch state {
+            case .escape:
+                if scalar.value == 0x5B {
+                    state = .controlSequence
+                } else if scalar.value == 0x5D {
+                    state = .operatingSystemCommand
+                } else if (0x30...0x7E).contains(scalar.value) {
+                    state = .plain
+                }
+            case .controlSequence:
+                if (0x40...0x7E).contains(scalar.value) {
+                    state = .plain
+                }
+            case .operatingSystemCommand:
+                if scalar.value == 0x07 {
+                    state = .plain
+                } else if scalar.value == 0x1B {
+                    state = .operatingSystemCommandEscape
+                }
+            case .operatingSystemCommandEscape:
+                state = scalar.value == 0x5C ? .plain : .operatingSystemCommand
+            case .plain:
+                switch scalar.value {
+                case 0x0A, 0x0D, 0x2028, 0x2029:
+                    scalars.append(" ")
+                case 0x1B:
+                    state = .escape
+                case 0x9B:
+                    state = .controlSequence
+                case 0x9D:
+                    state = .operatingSystemCommand
+                default:
+                    let category = scalar.properties.generalCategory
+                    if category != .control, category != .format {
+                        scalars.append(scalar)
+                    }
+                }
+            }
+        }
+
+        return String(String.UnicodeScalarView(scalars.prefix(scalarLimit)))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+struct CLIClaudeSwapCardsRenderOptions: Sendable {
+    let status: ProviderStatusPayload?
+    let useColor: Bool
+    let resetStyle: ResetTimeDisplayStyle
+    let weeklyWorkDays: Int?
+    let now: Date
+}
+
+enum CLIClaudeSwapCards {
+    typealias AccountListReader = @Sendable (String) async throws -> ClaudeSwapAccountList
+    typealias AmbientFetch = @Sendable () async -> UsageCommandOutput
+
+    private enum ReadResult: Sendable {
+        case success(ClaudeSwapAccountList)
+        case failure(String)
+    }
+
+    private enum ChildResult: @unchecked Sendable {
+        case ambient(UsageCommandOutput)
+        case claudeSwap(ReadResult)
+    }
+
+    static func isEligible(
+        provider: UsageProvider,
+        integrationEnabled: Bool,
+        hasExplicitAccountSelection: Bool,
+        sourceModeOverride: ProviderSourceMode?) -> Bool
+    {
+        provider == .claude
+            && integrationEnabled
+            && !hasExplicitAccountSelection
+            && (sourceModeOverride == nil || sourceModeOverride == .auto)
+    }
+
+    static func fetch(
+        eligible: Bool,
+        executablePath: String,
+        renderOptions: CLIClaudeSwapCardsRenderOptions,
+        ambientFetch: @escaping AmbientFetch) async -> UsageCommandOutput
+    {
+        await self.fetch(
+            eligible: eligible,
+            executablePath: executablePath,
+            renderOptions: renderOptions,
+            ambientFetch: ambientFetch,
+            accountListReader: { path in
+                try await ClaudeSwapAccountReader.readAccountList(executablePath: path)
+            })
+    }
+
+    static func fetch(
+        eligible: Bool,
+        executablePath: String,
+        renderOptions: CLIClaudeSwapCardsRenderOptions,
+        ambientFetch: @escaping AmbientFetch,
+        accountListReader: @escaping AccountListReader) async -> UsageCommandOutput
+    {
+        guard eligible else { return await ambientFetch() }
+
+        var ambientOutput: UsageCommandOutput?
+        var readResult: ReadResult?
+        await withTaskGroup(of: ChildResult.self) { group in
+            group.addTask {
+                let output = await ambientFetch()
+                return .ambient(output)
+            }
+            group.addTask {
+                do {
+                    let list = try await accountListReader(executablePath)
+                    return .claudeSwap(.success(list))
+                } catch {
+                    let diagnostic = CLIClaudeSwapText.sanitizeDiagnostic(error.localizedDescription)
+                    let message = diagnostic.isEmpty ? "claude-swap list failed." : diagnostic
+                    return .claudeSwap(.failure(message))
+                }
+            }
+            for await result in group {
+                switch result {
+                case let .ambient(output):
+                    ambientOutput = output
+                case let .claudeSwap(output):
+                    readResult = output
+                }
+            }
+        }
+
+        var output = ambientOutput ?? UsageCommandOutput()
+        switch readResult {
+        case let .success(list):
+            let accounts = ClaudeSwapAccountProjection.accountSnapshots(from: list, now: renderOptions.now)
+            guard accounts.count > 1 else { return output }
+            output = UsageCommandOutput()
+            output.cards = accounts.map { account in
+                CLICardsRenderer.makeClaudeSwapCard(
+                    account: account,
+                    renderOptions: renderOptions)
+            }
+            return output
+        case let .failure(message):
+            output.cardFailures.append(CLICardFailure(
+                provider: .claude,
+                accountLabel: ClaudeSwapAccountProjection.sourceLabel,
+                message: message))
+            output.exitCode = .failure
+            return output
+        case nil:
+            return output
+        }
+    }
+}

--- a/Sources/CodexBarCLI/CLIClaudeSwapCards.swift
+++ b/Sources/CodexBarCLI/CLIClaudeSwapCards.swift
@@ -94,6 +94,10 @@ enum CLIClaudeSwapCards {
         case claudeSwap(ReadResult)
     }
 
+    static func executablePath(from config: ProviderConfig?) -> String {
+        config?.sanitizedClaudeSwapExecutablePath ?? ""
+    }
+
     static func isEligible(
         provider: UsageProvider,
         integrationEnabled: Bool,

--- a/Sources/CodexBarCLI/CLIClaudeSwapCards.swift
+++ b/Sources/CodexBarCLI/CLIClaudeSwapCards.swift
@@ -84,16 +84,6 @@ enum CLIClaudeSwapCards {
     typealias AccountListReader = @Sendable (String) async throws -> ClaudeSwapAccountList
     typealias AmbientFetch = @Sendable () async -> UsageCommandOutput
 
-    private enum ReadResult: Sendable {
-        case success(ClaudeSwapAccountList)
-        case failure(String)
-    }
-
-    private enum ChildResult: @unchecked Sendable {
-        case ambient(UsageCommandOutput)
-        case claudeSwap(ReadResult)
-    }
-
     static func executablePath(from config: ProviderConfig?) -> String {
         config?.sanitizedClaudeSwapExecutablePath ?? ""
     }
@@ -135,53 +125,27 @@ enum CLIClaudeSwapCards {
     {
         guard eligible else { return await ambientFetch() }
 
-        var ambientOutput: UsageCommandOutput?
-        var readResult: ReadResult?
-        await withTaskGroup(of: ChildResult.self) { group in
-            group.addTask {
-                let output = await ambientFetch()
-                return .ambient(output)
-            }
-            group.addTask {
-                do {
-                    let list = try await accountListReader(executablePath)
-                    return .claudeSwap(.success(list))
-                } catch {
-                    let diagnostic = CLIClaudeSwapText.sanitizeDiagnostic(error.localizedDescription)
-                    let message = diagnostic.isEmpty ? "claude-swap list failed." : diagnostic
-                    return .claudeSwap(.failure(message))
-                }
-            }
-            for await result in group {
-                switch result {
-                case let .ambient(output):
-                    ambientOutput = output
-                case let .claudeSwap(output):
-                    readResult = output
-                }
-            }
-        }
-
-        var output = ambientOutput ?? UsageCommandOutput()
-        switch readResult {
-        case let .success(list):
+        do {
+            let list = try await accountListReader(executablePath)
             let accounts = ClaudeSwapAccountProjection.accountSnapshots(from: list, now: renderOptions.now)
-            guard accounts.count > 1 else { return output }
-            output = UsageCommandOutput()
+            guard accounts.count > 1 else { return await ambientFetch() }
+
+            var output = UsageCommandOutput()
             output.cards = accounts.map { account in
                 CLICardsRenderer.makeClaudeSwapCard(
                     account: account,
                     renderOptions: renderOptions)
             }
             return output
-        case let .failure(message):
+        } catch {
+            var output = await ambientFetch()
+            let diagnostic = CLIClaudeSwapText.sanitizeDiagnostic(error.localizedDescription)
+            let message = diagnostic.isEmpty ? "claude-swap list failed." : diagnostic
             output.cardFailures.append(CLICardFailure(
                 provider: .claude,
                 accountLabel: ClaudeSwapAccountProjection.sourceLabel,
                 message: message))
             output.exitCode = .failure
-            return output
-        case nil:
             return output
         }
     }

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -18,6 +18,9 @@ extension CodexBarCLI {
           Print a one-shot usage snapshot as a responsive card grid in the terminal.
           Honors enabled providers from config and reuses the same fetch flags as codexbar usage.
           Failed providers are summarized in a footer instead of error cards.
+          Enabled claude-swap lists with 2+ accounts replace Claude cards unless an account or
+          explicit non-auto `--source` CLI flag is selected.
+          Sentinel accounts remain visible without metrics; claude-swap adapter failures use a separate footer entry.
           Use --brief for a compact table layout (Provider / Usage / Reset).
           Stdout is always the rendered card/table text; --json-output only affects stderr logs.
 

--- a/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
+++ b/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
@@ -64,6 +64,15 @@ struct CLICardsClaudeSwapTests {
     }
 
     @Test
+    func `configured executable path strips surrounding quotes`() {
+        for rawPath in ["  \"/tmp/cswap\"  ", "  '/tmp/cswap'  "] {
+            let config = ProviderConfig(id: .claude, claudeSwapExecutablePath: rawPath)
+            #expect(CLIClaudeSwapCards.executablePath(from: config) == "/tmp/cswap")
+        }
+        #expect(CLIClaudeSwapCards.executablePath(from: nil).isEmpty)
+    }
+
+    @Test
     func `eligibility preserves explicit account and source intent`() {
         let eligibleSourceModes: [ProviderSourceMode?] = [nil, .auto]
         for sourceMode in eligibleSourceModes {

--- a/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
+++ b/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
@@ -1,0 +1,347 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBarCLI
+
+struct CLICardsClaudeSwapTests {
+    private actor InvocationCounter {
+        private(set) var value = 0
+
+        func increment() {
+            self.value += 1
+        }
+    }
+
+    private struct AdapterError: LocalizedError, Sendable {
+        let text: String
+        var errorDescription: String? {
+            self.text
+        }
+    }
+
+    private func ambientOutput(failed: Bool = false) -> UsageCommandOutput {
+        var output = UsageCommandOutput()
+        output.cards = [CLICardModel(
+            provider: .claude,
+            title: "Ambient Claude",
+            sourceLabel: "oauth",
+            planBadge: "Max",
+            accountLine: "ambient@example.com",
+            infoLines: [],
+            metrics: [CLICardMetric(label: "Session", remainingPercent: 50, resetText: nil)],
+            extraLines: [],
+            statusLine: nil)]
+        if failed {
+            output.cardFailures = [CLICardFailure(provider: .claude, accountLabel: nil, message: "ambient failed")]
+            output.exitCode = .failure
+        }
+        return output
+    }
+
+    private func renderOptions(status: ProviderStatusPayload? = nil) -> CLIClaudeSwapCardsRenderOptions {
+        CLIClaudeSwapCardsRenderOptions(
+            status: status,
+            useColor: false,
+            resetStyle: .countdown,
+            weeklyWorkDays: nil,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    private func row(
+        number: Int,
+        active: Bool = false,
+        status: ClaudeSwapUsageStatus = .ok,
+        email: String? = nil,
+        hasUsage: Bool = true) -> ClaudeSwapAccountRow
+    {
+        ClaudeSwapAccountRow(
+            number: number,
+            email: email ?? "account-\(number)@example.com",
+            isActive: active,
+            usageStatus: status,
+            fiveHour: hasUsage ? ClaudeSwapUsageWindow(usedPercent: Double(number * 10), resetsAt: nil) : nil,
+            sevenDay: nil)
+    }
+
+    @Test
+    func `eligibility preserves explicit account and source intent`() {
+        let eligibleSourceModes: [ProviderSourceMode?] = [nil, .auto]
+        for sourceMode in eligibleSourceModes {
+            #expect(CLIClaudeSwapCards.isEligible(
+                provider: .claude,
+                integrationEnabled: true,
+                hasExplicitAccountSelection: false,
+                sourceModeOverride: sourceMode))
+        }
+
+        for sourceMode in [ProviderSourceMode.web, .cli, .oauth, .api] {
+            #expect(!CLIClaudeSwapCards.isEligible(
+                provider: .claude,
+                integrationEnabled: true,
+                hasExplicitAccountSelection: false,
+                sourceModeOverride: sourceMode))
+        }
+
+        #expect(!CLIClaudeSwapCards.isEligible(
+            provider: .claude,
+            integrationEnabled: false,
+            hasExplicitAccountSelection: false,
+            sourceModeOverride: nil))
+        #expect(!CLIClaudeSwapCards.isEligible(
+            provider: .claude,
+            integrationEnabled: true,
+            hasExplicitAccountSelection: true,
+            sourceModeOverride: nil))
+        #expect(!CLIClaudeSwapCards.isEligible(
+            provider: .codex,
+            integrationEnabled: true,
+            hasExplicitAccountSelection: false,
+            sourceModeOverride: nil))
+    }
+
+    @Test
+    func `bypass does not invoke the adapter`() async {
+        let counter = InvocationCounter()
+        let ambient = self.ambientOutput()
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: false,
+            executablePath: "/unused/cswap",
+            renderOptions: self.renderOptions(),
+            ambientFetch: { ambient },
+            accountListReader: { _ in
+                await counter.increment()
+                return ClaudeSwapAccountList(activeAccountNumber: nil, accounts: [])
+            })
+
+        #expect(await counter.value == 0)
+        #expect(output.cards == ambient.cards)
+    }
+
+    @Test
+    func `zero and one account lists retain ambient output`() async {
+        let ambient = self.ambientOutput()
+        for accounts in [[], [self.row(number: 1)]] {
+            let output = await CLIClaudeSwapCards.fetch(
+                eligible: true,
+                executablePath: "/fake/cswap",
+                renderOptions: self.renderOptions(),
+                ambientFetch: { ambient },
+                accountListReader: { _ in
+                    ClaudeSwapAccountList(activeAccountNumber: nil, accounts: accounts)
+                })
+            #expect(output.cards == ambient.cards)
+            #expect(output.cardFailures.isEmpty)
+        }
+    }
+
+    @Test
+    func `multi account list atomically replaces ambient output in active slot order`() async {
+        let counter = InvocationCounter()
+        let ambient = self.ambientOutput(failed: true)
+        let list = ClaudeSwapAccountList(activeAccountNumber: 2, accounts: [
+            self.row(number: 3),
+            self.row(number: 2, active: true),
+            self.row(number: 1),
+        ])
+        let status = ProviderStatusPayload(
+            indicator: .minor,
+            description: "Degraded performance",
+            updatedAt: Date(timeIntervalSince1970: 0),
+            url: "https://status.example.com")
+
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "/fake/cswap",
+            renderOptions: self.renderOptions(status: status),
+            ambientFetch: { ambient },
+            accountListReader: { _ in
+                await counter.increment()
+                return list
+            })
+
+        #expect(await counter.value == 1)
+        #expect(output.cards.map(\.accountLine) == [
+            "account-2@example.com",
+            "account-1@example.com",
+            "account-3@example.com",
+        ])
+        #expect(output.cards.map(\.isActive) == [true, false, false])
+        #expect(output.cards.allSatisfy { $0.sourceLabel == "claude-swap" && $0.planBadge == nil })
+        #expect(output.cards.allSatisfy { $0.statusLine == "Status: Partial outage – Degraded performance" })
+        #expect(output.cardFailures.isEmpty)
+        #expect(output.exitCode == .success)
+    }
+
+    @Test
+    func `all sentinel rows remain successful metrics less cards`() async {
+        let statuses: [ClaudeSwapUsageStatus] = [
+            .apiKey,
+            .tokenExpired,
+            .keychainUnavailable,
+            .noCredentials,
+            .unavailable,
+            .unknown("future_status"),
+            .ok,
+        ]
+        let rows = statuses.enumerated().map { index, status in
+            self.row(number: index + 1, status: status, hasUsage: false)
+        }
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "/fake/cswap",
+            renderOptions: self.renderOptions(),
+            ambientFetch: { self.ambientOutput(failed: true) },
+            accountListReader: { _ in
+                ClaudeSwapAccountList(activeAccountNumber: nil, accounts: rows)
+            })
+
+        #expect(output.exitCode == .success)
+        #expect(output.cards.count == statuses.count)
+        #expect(output.cards.allSatisfy { $0.metrics.isEmpty && !$0.isActive })
+        #expect(output.cards.map(\.accountProblem) == [
+            "API-key account; subscription usage is unavailable.",
+            "Token expired. Switch to this account in claude-swap to refresh it.",
+            "claude-swap could not read the active account's Keychain entry.",
+            "No stored credentials for this account slot.",
+            "Usage fetch failed.",
+            "Unrecognized claude-swap status: future_status",
+            "No usage windows reported.",
+        ])
+    }
+
+    @Test
+    func `active sentinel account remains active and metrics less in full and brief cards`() async {
+        let problem = "Usage fetch failed."
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "/fake/cswap",
+            renderOptions: self.renderOptions(),
+            ambientFetch: { self.ambientOutput(failed: true) },
+            accountListReader: { _ in
+                ClaudeSwapAccountList(activeAccountNumber: 1, accounts: [
+                    self.row(
+                        number: 1,
+                        active: true,
+                        status: .unavailable,
+                        email: "active@example.com",
+                        hasUsage: false),
+                    self.row(number: 2),
+                ])
+            })
+
+        #expect(output.exitCode == .success)
+        #expect(output.cardFailures.isEmpty)
+        #expect(output.cards.count == 2)
+        let activeCard = output.cards.first
+        #expect(activeCard?.accountLine == "active@example.com")
+        #expect(activeCard?.isActive == true)
+        #expect(activeCard?.accountProblem == problem)
+        #expect(activeCard?.metrics.isEmpty == true)
+
+        let rows = CLICardsBriefRenderer.makeRows(cards: activeCard.map { [$0] } ?? [])
+        #expect(rows.count == 1)
+        #expect(rows.first?.accountLabel == "active@example.com")
+        #expect(rows.first?.isActive == true)
+        #expect(rows.first?.accountProblem == problem)
+        #expect(rows.first?.metricLabel == nil)
+        #expect(rows.first?.usedPercent == nil)
+    }
+
+    @Test
+    func `blank executable path preserves ambient output and fails distinctly`() async {
+        let ambient = self.ambientOutput()
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "   ",
+            renderOptions: self.renderOptions(),
+            ambientFetch: { ambient })
+
+        #expect(output.cards == ambient.cards)
+        #expect(output.exitCode != .success)
+        #expect(output.cardFailures == [CLICardFailure(
+            provider: .claude,
+            accountLabel: "claude-swap",
+            message: "No claude-swap executable path is configured.")])
+    }
+
+    @Test
+    func `adapter failures follow ambient failures and are bounded and sanitized`() async {
+        let raw = "\u{1B}]0;owned\u{07}reader\r\nfailed\u{1B}[31m" + String(repeating: "x", count: 700)
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "   ",
+            renderOptions: self.renderOptions(),
+            ambientFetch: { self.ambientOutput(failed: true) },
+            accountListReader: { _ in throw AdapterError(text: raw) })
+
+        #expect(output.exitCode != .success)
+        #expect(output.cards.first?.title == "Ambient Claude")
+        #expect(output.cardFailures.map(\.accountLabel) == [nil, "claude-swap"])
+        let diagnostic = output.cardFailures.last?.message ?? ""
+        #expect(diagnostic.contains("reader  failed"))
+        #expect(!diagnostic.contains("\u{1B}"))
+        #expect(diagnostic.unicodeScalars.count == CLIClaudeSwapText.diagnosticScalarLimit)
+    }
+
+    @Test
+    func `fake executable receives only one read only list command`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cards-claude-swap-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let executable = directory.appendingPathComponent("cswap")
+        let arguments = directory.appendingPathComponent("arguments")
+        let script = """
+        #!/bin/sh
+        printf '%s\\n' "$@" >> '\(arguments.path)'
+        cat <<'JSON'
+        {"schemaVersion":1,"activeAccountNumber":2,"accounts":[
+          {"number":1,"email":"one@example.com","active":false,"usageStatus":"api_key"},
+          {"number":2,"email":"two@example.com","active":true,"usageStatus":"unavailable"}
+        ]}
+        JSON
+        """
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: executable.path,
+            renderOptions: self.renderOptions(),
+            ambientFetch: { self.ambientOutput() })
+        let invokedArguments = try String(contentsOf: arguments, encoding: .utf8)
+
+        #expect(invokedArguments == "--list\n--json\n")
+        #expect(!invokedArguments.contains("switch"))
+        #expect(output.cards.count == 2)
+    }
+
+    @Test
+    func `cancellation drains the adapter child and preserves ambient output`() async {
+        let cancellationCount = InvocationCounter()
+        let ambient = self.ambientOutput()
+        let task = Task {
+            await CLIClaudeSwapCards.fetch(
+                eligible: true,
+                executablePath: "/fake/cswap",
+                renderOptions: self.renderOptions(),
+                ambientFetch: { ambient },
+                accountListReader: { _ in
+                    do {
+                        try await Task.sleep(for: .seconds(30))
+                        return ClaudeSwapAccountList(activeAccountNumber: nil, accounts: [])
+                    } catch {
+                        await cancellationCount.increment()
+                        throw error
+                    }
+                })
+        }
+        await Task.yield()
+        task.cancel()
+        let output = await task.value
+
+        #expect(await cancellationCount.value == 1)
+        #expect(output.cards == ambient.cards)
+        #expect(output.cardFailures.last?.accountLabel == "claude-swap")
+        #expect(output.exitCode != .success)
+    }
+}

--- a/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
+++ b/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
@@ -128,24 +128,30 @@ struct CLICardsClaudeSwapTests {
 
     @Test
     func `zero and one account lists retain ambient output`() async {
+        let ambientCounter = InvocationCounter()
         let ambient = self.ambientOutput()
         for accounts in [[], [self.row(number: 1)]] {
             let output = await CLIClaudeSwapCards.fetch(
                 eligible: true,
                 executablePath: "/fake/cswap",
                 renderOptions: self.renderOptions(),
-                ambientFetch: { ambient },
+                ambientFetch: {
+                    await ambientCounter.increment()
+                    return ambient
+                },
                 accountListReader: { _ in
                     ClaudeSwapAccountList(activeAccountNumber: nil, accounts: accounts)
                 })
             #expect(output.cards == ambient.cards)
             #expect(output.cardFailures.isEmpty)
         }
+        #expect(await ambientCounter.value == 2)
     }
 
     @Test
-    func `multi account list atomically replaces ambient output in active slot order`() async {
-        let counter = InvocationCounter()
+    func `multi account list skips ambient output and renders in active slot order`() async {
+        let adapterCounter = InvocationCounter()
+        let ambientCounter = InvocationCounter()
         let ambient = self.ambientOutput(failed: true)
         let list = ClaudeSwapAccountList(activeAccountNumber: 2, accounts: [
             self.row(number: 3),
@@ -162,13 +168,17 @@ struct CLICardsClaudeSwapTests {
             eligible: true,
             executablePath: "/fake/cswap",
             renderOptions: self.renderOptions(status: status),
-            ambientFetch: { ambient },
+            ambientFetch: {
+                await ambientCounter.increment()
+                return ambient
+            },
             accountListReader: { _ in
-                await counter.increment()
+                await adapterCounter.increment()
                 return list
             })
 
-        #expect(await counter.value == 1)
+        #expect(await adapterCounter.value == 1)
+        #expect(await ambientCounter.value == 0)
         #expect(output.cards.map(\.accountLine) == [
             "account-2@example.com",
             "account-1@example.com",

--- a/Tests/CodexBarTests/CLICardsRendererTests.swift
+++ b/Tests/CodexBarTests/CLICardsRendererTests.swift
@@ -612,4 +612,90 @@ struct CLICardsRendererTests {
         #expect(output.contains("48;2;"))
         #expect(output.contains("[ "))
     }
+
+    @Test
+    func `claude swap active account renders without inferred plan`() {
+        let snapshot = UsageSnapshot(
+            primary: .init(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: Date(timeIntervalSince1970: 0),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "active@example.com",
+                accountOrganization: nil,
+                loginMethod: "claude-swap"))
+        let account = ProviderAccountUsageSnapshot(
+            id: ProviderAccountIdentity(source: "claude-swap", opaqueID: "2"),
+            provider: .claude,
+            displayLabel: "active@example.com",
+            isActive: true,
+            snapshot: snapshot,
+            error: nil,
+            sourceLabel: "claude-swap")
+        let card = CLICardsRenderer.makeClaudeSwapCard(
+            account: account,
+            renderOptions: CLIClaudeSwapCardsRenderOptions(
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown,
+                weeklyWorkDays: nil,
+                now: Date(timeIntervalSince1970: 0)))
+        let full = CLICardsRenderer.renderCard(card, width: 38, useColor: false).joined(separator: "\n")
+        let brief = CLICardsBriefRenderer.render(
+            rows: CLICardsBriefRenderer.makeRows(cards: [card]),
+            failures: [],
+            terminalWidth: 40,
+            useColor: false,
+            now: Date(timeIntervalSince1970: 0))
+
+        #expect(card.planBadge == nil)
+        #expect(full.contains("@ active@example.com [active]"))
+        #expect(!full.contains("PLAN Claude-Swap"))
+        #expect(brief.contains("[active]"))
+        #expect(!brief.contains("Claude-Swap"))
+        #expect(full.split(separator: "\n").allSatisfy { $0.count == 38 })
+        #expect(brief.split(separator: "\n", omittingEmptySubsequences: false).allSatisfy { $0.count <= 40 })
+    }
+
+    @Test
+    func `claude swap sentinel text survives full and brief projections`() {
+        let account = ProviderAccountUsageSnapshot(
+            id: ProviderAccountIdentity(source: "claude-swap", opaqueID: "7"),
+            provider: .claude,
+            displayLabel: "bad\u{1B}[31m\r\n" + String(repeating: "x", count: 300),
+            isActive: true,
+            snapshot: nil,
+            error: "API-key account; subscription usage is unavailable.",
+            sourceLabel: "claude-swap")
+        let card = CLICardsRenderer.makeClaudeSwapCard(
+            account: account,
+            renderOptions: CLIClaudeSwapCardsRenderOptions(
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown,
+                weeklyWorkDays: nil,
+                now: Date(timeIntervalSince1970: 0)))
+        let full = CLICardsRenderer.renderCard(card, width: 42, useColor: false).joined(separator: "\n")
+        let brief = CLICardsBriefRenderer.render(
+            rows: CLICardsBriefRenderer.makeRows(cards: [card]),
+            failures: [],
+            terminalWidth: 80,
+            useColor: false,
+            now: Date(timeIntervalSince1970: 0))
+        let briefRow = brief.split(separator: "\n").first { $0.contains("API-key") } ?? ""
+
+        #expect(card.accountLine?.unicodeScalars.count == CLIClaudeSwapText.labelScalarLimit)
+        #expect(card.accountLine?.contains("\u{1B}") == false)
+        #expect(card.accountLine?.contains("\n") == false)
+        #expect(card.isActive)
+        #expect(full.contains("[active]"))
+        #expect(full.contains("API-key account;"))
+        #expect(full.contains("subscription usage"))
+        #expect(full.contains("unavailable."))
+        #expect(brief.contains("Claude [active]"))
+        #expect(brief.contains("API-key account"))
+        #expect(briefRow.hasSuffix(" — │"))
+        #expect(card.metrics.isEmpty)
+    }
 }

--- a/TestsLinux/CLICardsClaudeSwapTests.swift
+++ b/TestsLinux/CLICardsClaudeSwapTests.swift
@@ -64,6 +64,15 @@ struct CLICardsClaudeSwapTests {
     }
 
     @Test
+    func `configured executable path strips surrounding quotes`() {
+        for rawPath in ["  \"/tmp/cswap\"  ", "  '/tmp/cswap'  "] {
+            let config = ProviderConfig(id: .claude, claudeSwapExecutablePath: rawPath)
+            #expect(CLIClaudeSwapCards.executablePath(from: config) == "/tmp/cswap")
+        }
+        #expect(CLIClaudeSwapCards.executablePath(from: nil).isEmpty)
+    }
+
+    @Test
     func `eligibility preserves explicit account and source intent`() {
         let eligibleSourceModes: [ProviderSourceMode?] = [nil, .auto]
         for sourceMode in eligibleSourceModes {

--- a/TestsLinux/CLICardsClaudeSwapTests.swift
+++ b/TestsLinux/CLICardsClaudeSwapTests.swift
@@ -1,0 +1,347 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBarCLI
+
+struct CLICardsClaudeSwapTests {
+    private actor InvocationCounter {
+        private(set) var value = 0
+
+        func increment() {
+            self.value += 1
+        }
+    }
+
+    private struct AdapterError: LocalizedError, Sendable {
+        let text: String
+        var errorDescription: String? {
+            self.text
+        }
+    }
+
+    private func ambientOutput(failed: Bool = false) -> UsageCommandOutput {
+        var output = UsageCommandOutput()
+        output.cards = [CLICardModel(
+            provider: .claude,
+            title: "Ambient Claude",
+            sourceLabel: "oauth",
+            planBadge: "Max",
+            accountLine: "ambient@example.com",
+            infoLines: [],
+            metrics: [CLICardMetric(label: "Session", remainingPercent: 50, resetText: nil)],
+            extraLines: [],
+            statusLine: nil)]
+        if failed {
+            output.cardFailures = [CLICardFailure(provider: .claude, accountLabel: nil, message: "ambient failed")]
+            output.exitCode = .failure
+        }
+        return output
+    }
+
+    private func renderOptions(status: ProviderStatusPayload? = nil) -> CLIClaudeSwapCardsRenderOptions {
+        CLIClaudeSwapCardsRenderOptions(
+            status: status,
+            useColor: false,
+            resetStyle: .countdown,
+            weeklyWorkDays: nil,
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    private func row(
+        number: Int,
+        active: Bool = false,
+        status: ClaudeSwapUsageStatus = .ok,
+        email: String? = nil,
+        hasUsage: Bool = true) -> ClaudeSwapAccountRow
+    {
+        ClaudeSwapAccountRow(
+            number: number,
+            email: email ?? "account-\(number)@example.com",
+            isActive: active,
+            usageStatus: status,
+            fiveHour: hasUsage ? ClaudeSwapUsageWindow(usedPercent: Double(number * 10), resetsAt: nil) : nil,
+            sevenDay: nil)
+    }
+
+    @Test
+    func `eligibility preserves explicit account and source intent`() {
+        let eligibleSourceModes: [ProviderSourceMode?] = [nil, .auto]
+        for sourceMode in eligibleSourceModes {
+            #expect(CLIClaudeSwapCards.isEligible(
+                provider: .claude,
+                integrationEnabled: true,
+                hasExplicitAccountSelection: false,
+                sourceModeOverride: sourceMode))
+        }
+
+        for sourceMode in [ProviderSourceMode.web, .cli, .oauth, .api] {
+            #expect(!CLIClaudeSwapCards.isEligible(
+                provider: .claude,
+                integrationEnabled: true,
+                hasExplicitAccountSelection: false,
+                sourceModeOverride: sourceMode))
+        }
+
+        #expect(!CLIClaudeSwapCards.isEligible(
+            provider: .claude,
+            integrationEnabled: false,
+            hasExplicitAccountSelection: false,
+            sourceModeOverride: nil))
+        #expect(!CLIClaudeSwapCards.isEligible(
+            provider: .claude,
+            integrationEnabled: true,
+            hasExplicitAccountSelection: true,
+            sourceModeOverride: nil))
+        #expect(!CLIClaudeSwapCards.isEligible(
+            provider: .codex,
+            integrationEnabled: true,
+            hasExplicitAccountSelection: false,
+            sourceModeOverride: nil))
+    }
+
+    @Test
+    func `bypass does not invoke the adapter`() async {
+        let counter = InvocationCounter()
+        let ambient = self.ambientOutput()
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: false,
+            executablePath: "/unused/cswap",
+            renderOptions: self.renderOptions(),
+            ambientFetch: { ambient },
+            accountListReader: { _ in
+                await counter.increment()
+                return ClaudeSwapAccountList(activeAccountNumber: nil, accounts: [])
+            })
+
+        #expect(await counter.value == 0)
+        #expect(output.cards == ambient.cards)
+    }
+
+    @Test
+    func `zero and one account lists retain ambient output`() async {
+        let ambient = self.ambientOutput()
+        for accounts in [[], [self.row(number: 1)]] {
+            let output = await CLIClaudeSwapCards.fetch(
+                eligible: true,
+                executablePath: "/fake/cswap",
+                renderOptions: self.renderOptions(),
+                ambientFetch: { ambient },
+                accountListReader: { _ in
+                    ClaudeSwapAccountList(activeAccountNumber: nil, accounts: accounts)
+                })
+            #expect(output.cards == ambient.cards)
+            #expect(output.cardFailures.isEmpty)
+        }
+    }
+
+    @Test
+    func `multi account list atomically replaces ambient output in active slot order`() async {
+        let counter = InvocationCounter()
+        let ambient = self.ambientOutput(failed: true)
+        let list = ClaudeSwapAccountList(activeAccountNumber: 2, accounts: [
+            self.row(number: 3),
+            self.row(number: 2, active: true),
+            self.row(number: 1),
+        ])
+        let status = ProviderStatusPayload(
+            indicator: .minor,
+            description: "Degraded performance",
+            updatedAt: Date(timeIntervalSince1970: 0),
+            url: "https://status.example.com")
+
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "/fake/cswap",
+            renderOptions: self.renderOptions(status: status),
+            ambientFetch: { ambient },
+            accountListReader: { _ in
+                await counter.increment()
+                return list
+            })
+
+        #expect(await counter.value == 1)
+        #expect(output.cards.map(\.accountLine) == [
+            "account-2@example.com",
+            "account-1@example.com",
+            "account-3@example.com",
+        ])
+        #expect(output.cards.map(\.isActive) == [true, false, false])
+        #expect(output.cards.allSatisfy { $0.sourceLabel == "claude-swap" && $0.planBadge == nil })
+        #expect(output.cards.allSatisfy { $0.statusLine == "Status: Partial outage – Degraded performance" })
+        #expect(output.cardFailures.isEmpty)
+        #expect(output.exitCode == .success)
+    }
+
+    @Test
+    func `all sentinel rows remain successful metrics less cards`() async {
+        let statuses: [ClaudeSwapUsageStatus] = [
+            .apiKey,
+            .tokenExpired,
+            .keychainUnavailable,
+            .noCredentials,
+            .unavailable,
+            .unknown("future_status"),
+            .ok,
+        ]
+        let rows = statuses.enumerated().map { index, status in
+            self.row(number: index + 1, status: status, hasUsage: false)
+        }
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "/fake/cswap",
+            renderOptions: self.renderOptions(),
+            ambientFetch: { self.ambientOutput(failed: true) },
+            accountListReader: { _ in
+                ClaudeSwapAccountList(activeAccountNumber: nil, accounts: rows)
+            })
+
+        #expect(output.exitCode == .success)
+        #expect(output.cards.count == statuses.count)
+        #expect(output.cards.allSatisfy { $0.metrics.isEmpty && !$0.isActive })
+        #expect(output.cards.map(\.accountProblem) == [
+            "API-key account; subscription usage is unavailable.",
+            "Token expired. Switch to this account in claude-swap to refresh it.",
+            "claude-swap could not read the active account's Keychain entry.",
+            "No stored credentials for this account slot.",
+            "Usage fetch failed.",
+            "Unrecognized claude-swap status: future_status",
+            "No usage windows reported.",
+        ])
+    }
+
+    @Test
+    func `active sentinel account remains active and metrics less in full and brief cards`() async {
+        let problem = "Usage fetch failed."
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "/fake/cswap",
+            renderOptions: self.renderOptions(),
+            ambientFetch: { self.ambientOutput(failed: true) },
+            accountListReader: { _ in
+                ClaudeSwapAccountList(activeAccountNumber: 1, accounts: [
+                    self.row(
+                        number: 1,
+                        active: true,
+                        status: .unavailable,
+                        email: "active@example.com",
+                        hasUsage: false),
+                    self.row(number: 2),
+                ])
+            })
+
+        #expect(output.exitCode == .success)
+        #expect(output.cardFailures.isEmpty)
+        #expect(output.cards.count == 2)
+        let activeCard = output.cards.first
+        #expect(activeCard?.accountLine == "active@example.com")
+        #expect(activeCard?.isActive == true)
+        #expect(activeCard?.accountProblem == problem)
+        #expect(activeCard?.metrics.isEmpty == true)
+
+        let rows = CLICardsBriefRenderer.makeRows(cards: activeCard.map { [$0] } ?? [])
+        #expect(rows.count == 1)
+        #expect(rows.first?.accountLabel == "active@example.com")
+        #expect(rows.first?.isActive == true)
+        #expect(rows.first?.accountProblem == problem)
+        #expect(rows.first?.metricLabel == nil)
+        #expect(rows.first?.usedPercent == nil)
+    }
+
+    @Test
+    func `blank executable path preserves ambient output and fails distinctly`() async {
+        let ambient = self.ambientOutput()
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "   ",
+            renderOptions: self.renderOptions(),
+            ambientFetch: { ambient })
+
+        #expect(output.cards == ambient.cards)
+        #expect(output.exitCode != .success)
+        #expect(output.cardFailures == [CLICardFailure(
+            provider: .claude,
+            accountLabel: "claude-swap",
+            message: "No claude-swap executable path is configured.")])
+    }
+
+    @Test
+    func `adapter failures follow ambient failures and are bounded and sanitized`() async {
+        let raw = "\u{1B}]0;owned\u{07}reader\r\nfailed\u{1B}[31m" + String(repeating: "x", count: 700)
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "   ",
+            renderOptions: self.renderOptions(),
+            ambientFetch: { self.ambientOutput(failed: true) },
+            accountListReader: { _ in throw AdapterError(text: raw) })
+
+        #expect(output.exitCode != .success)
+        #expect(output.cards.first?.title == "Ambient Claude")
+        #expect(output.cardFailures.map(\.accountLabel) == [nil, "claude-swap"])
+        let diagnostic = output.cardFailures.last?.message ?? ""
+        #expect(diagnostic.contains("reader  failed"))
+        #expect(!diagnostic.contains("\u{1B}"))
+        #expect(diagnostic.unicodeScalars.count == CLIClaudeSwapText.diagnosticScalarLimit)
+    }
+
+    @Test
+    func `fake executable receives only one read only list command`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cards-claude-swap-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let executable = directory.appendingPathComponent("cswap")
+        let arguments = directory.appendingPathComponent("arguments")
+        let script = """
+        #!/bin/sh
+        printf '%s\\n' "$@" >> '\(arguments.path)'
+        cat <<'JSON'
+        {"schemaVersion":1,"activeAccountNumber":2,"accounts":[
+          {"number":1,"email":"one@example.com","active":false,"usageStatus":"api_key"},
+          {"number":2,"email":"two@example.com","active":true,"usageStatus":"unavailable"}
+        ]}
+        JSON
+        """
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: executable.path,
+            renderOptions: self.renderOptions(),
+            ambientFetch: { self.ambientOutput() })
+        let invokedArguments = try String(contentsOf: arguments, encoding: .utf8)
+
+        #expect(invokedArguments == "--list\n--json\n")
+        #expect(!invokedArguments.contains("switch"))
+        #expect(output.cards.count == 2)
+    }
+
+    @Test
+    func `cancellation drains the adapter child and preserves ambient output`() async {
+        let cancellationCount = InvocationCounter()
+        let ambient = self.ambientOutput()
+        let task = Task {
+            await CLIClaudeSwapCards.fetch(
+                eligible: true,
+                executablePath: "/fake/cswap",
+                renderOptions: self.renderOptions(),
+                ambientFetch: { ambient },
+                accountListReader: { _ in
+                    do {
+                        try await Task.sleep(for: .seconds(30))
+                        return ClaudeSwapAccountList(activeAccountNumber: nil, accounts: [])
+                    } catch {
+                        await cancellationCount.increment()
+                        throw error
+                    }
+                })
+        }
+        await Task.yield()
+        task.cancel()
+        let output = await task.value
+
+        #expect(await cancellationCount.value == 1)
+        #expect(output.cards == ambient.cards)
+        #expect(output.cardFailures.last?.accountLabel == "claude-swap")
+        #expect(output.exitCode != .success)
+    }
+}

--- a/TestsLinux/CLICardsClaudeSwapTests.swift
+++ b/TestsLinux/CLICardsClaudeSwapTests.swift
@@ -128,24 +128,30 @@ struct CLICardsClaudeSwapTests {
 
     @Test
     func `zero and one account lists retain ambient output`() async {
+        let ambientCounter = InvocationCounter()
         let ambient = self.ambientOutput()
         for accounts in [[], [self.row(number: 1)]] {
             let output = await CLIClaudeSwapCards.fetch(
                 eligible: true,
                 executablePath: "/fake/cswap",
                 renderOptions: self.renderOptions(),
-                ambientFetch: { ambient },
+                ambientFetch: {
+                    await ambientCounter.increment()
+                    return ambient
+                },
                 accountListReader: { _ in
                     ClaudeSwapAccountList(activeAccountNumber: nil, accounts: accounts)
                 })
             #expect(output.cards == ambient.cards)
             #expect(output.cardFailures.isEmpty)
         }
+        #expect(await ambientCounter.value == 2)
     }
 
     @Test
-    func `multi account list atomically replaces ambient output in active slot order`() async {
-        let counter = InvocationCounter()
+    func `multi account list skips ambient output and renders in active slot order`() async {
+        let adapterCounter = InvocationCounter()
+        let ambientCounter = InvocationCounter()
         let ambient = self.ambientOutput(failed: true)
         let list = ClaudeSwapAccountList(activeAccountNumber: 2, accounts: [
             self.row(number: 3),
@@ -162,13 +168,17 @@ struct CLICardsClaudeSwapTests {
             eligible: true,
             executablePath: "/fake/cswap",
             renderOptions: self.renderOptions(status: status),
-            ambientFetch: { ambient },
+            ambientFetch: {
+                await ambientCounter.increment()
+                return ambient
+            },
             accountListReader: { _ in
-                await counter.increment()
+                await adapterCounter.increment()
                 return list
             })
 
-        #expect(await counter.value == 1)
+        #expect(await adapterCounter.value == 1)
+        #expect(await ambientCounter.value == 0)
         #expect(output.cards.map(\.accountLine) == [
             "account-2@example.com",
             "account-1@example.com",

--- a/TestsLinux/CLICardsRendererTests.swift
+++ b/TestsLinux/CLICardsRendererTests.swift
@@ -612,4 +612,90 @@ struct CLICardsRendererTests {
         #expect(output.contains("48;2;"))
         #expect(output.contains("[ "))
     }
+
+    @Test
+    func `claude swap active account renders without inferred plan`() {
+        let snapshot = UsageSnapshot(
+            primary: .init(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: Date(timeIntervalSince1970: 0),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "active@example.com",
+                accountOrganization: nil,
+                loginMethod: "claude-swap"))
+        let account = ProviderAccountUsageSnapshot(
+            id: ProviderAccountIdentity(source: "claude-swap", opaqueID: "2"),
+            provider: .claude,
+            displayLabel: "active@example.com",
+            isActive: true,
+            snapshot: snapshot,
+            error: nil,
+            sourceLabel: "claude-swap")
+        let card = CLICardsRenderer.makeClaudeSwapCard(
+            account: account,
+            renderOptions: CLIClaudeSwapCardsRenderOptions(
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown,
+                weeklyWorkDays: nil,
+                now: Date(timeIntervalSince1970: 0)))
+        let full = CLICardsRenderer.renderCard(card, width: 38, useColor: false).joined(separator: "\n")
+        let brief = CLICardsBriefRenderer.render(
+            rows: CLICardsBriefRenderer.makeRows(cards: [card]),
+            failures: [],
+            terminalWidth: 40,
+            useColor: false,
+            now: Date(timeIntervalSince1970: 0))
+
+        #expect(card.planBadge == nil)
+        #expect(full.contains("@ active@example.com [active]"))
+        #expect(!full.contains("PLAN Claude-Swap"))
+        #expect(brief.contains("[active]"))
+        #expect(!brief.contains("Claude-Swap"))
+        #expect(full.split(separator: "\n").allSatisfy { $0.count == 38 })
+        #expect(brief.split(separator: "\n", omittingEmptySubsequences: false).allSatisfy { $0.count <= 40 })
+    }
+
+    @Test
+    func `claude swap sentinel text survives full and brief projections`() {
+        let account = ProviderAccountUsageSnapshot(
+            id: ProviderAccountIdentity(source: "claude-swap", opaqueID: "7"),
+            provider: .claude,
+            displayLabel: "bad\u{1B}[31m\r\n" + String(repeating: "x", count: 300),
+            isActive: true,
+            snapshot: nil,
+            error: "API-key account; subscription usage is unavailable.",
+            sourceLabel: "claude-swap")
+        let card = CLICardsRenderer.makeClaudeSwapCard(
+            account: account,
+            renderOptions: CLIClaudeSwapCardsRenderOptions(
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown,
+                weeklyWorkDays: nil,
+                now: Date(timeIntervalSince1970: 0)))
+        let full = CLICardsRenderer.renderCard(card, width: 42, useColor: false).joined(separator: "\n")
+        let brief = CLICardsBriefRenderer.render(
+            rows: CLICardsBriefRenderer.makeRows(cards: [card]),
+            failures: [],
+            terminalWidth: 80,
+            useColor: false,
+            now: Date(timeIntervalSince1970: 0))
+        let briefRow = brief.split(separator: "\n").first { $0.contains("API-key") } ?? ""
+
+        #expect(card.accountLine?.unicodeScalars.count == CLIClaudeSwapText.labelScalarLimit)
+        #expect(card.accountLine?.contains("\u{1B}") == false)
+        #expect(card.accountLine?.contains("\n") == false)
+        #expect(card.isActive)
+        #expect(full.contains("[active]"))
+        #expect(full.contains("API-key account;"))
+        #expect(full.contains("subscription usage"))
+        #expect(full.contains("unavailable."))
+        #expect(brief.contains("Claude [active]"))
+        #expect(brief.contains("API-key account"))
+        #expect(briefRow.hasSuffix(" — │"))
+        #expect(card.metrics.isEmpty)
+    }
 }

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -125,14 +125,20 @@ The accepted multi-account design in
 - Behavior: on each Claude refresh, CodexBar runs `cswap --list --json` independently of the ambient Claude fetch (no
   shell, fixed arguments, bounded runtime and output), requires `schemaVersion == 1`, and parses only slot number,
   active state, usage status, email (display only), and the 5-hour/7-day windows.
-- Display: when claude-swap reports more than one account, the Claude menu shows one stacked card per
-  account (active account first) alongside nothing else changing; with zero or one account the menu is
-  unchanged. Account identity is `claude-swap:<slot>`.
+- Display: when claude-swap reports more than one account, the Claude menu and `codexbar cards` show one card per
+  account (active account first, then numeric slot) instead of ambient/token-account Claude cards; with zero or one
+  account those views are unchanged. Account identity is `claude-swap:<slot>`, never the display email.
+- Terminal scope: this automatic precedence is cards-only and works on every supported CLI platform. An explicit
+  Claude provider or `--source auto` remains eligible, while `--account`, `--account-index`, `--all-accounts`, and
+  explicit non-auto source flags bypass the adapter. `codexbar usage` and `codexbar serve` are unchanged.
 - Isolation: CodexBar never reads claude-swap or Claude Code credential storage for this feature; the
-  subprocess handles its own credential access. Adapter failures keep the last successful accounts as
-  stale data, surface the error in provider settings, and never affect the ambient Claude usage card.
+  subprocess handles its own credential access. In the app, adapter failures keep the last successful accounts as
+  stale data, surface the error in provider settings, and never affect the ambient Claude usage card. In terminal
+  cards, a list failure retains the current ambient output, adds a distinct `Claude (claude-swap)` footer entry, and
+  exits non-zero.
 - Sentinel statuses (`token_expired`, `api_key`, `keychain_unavailable`, `no_credentials`,
-  `unavailable`) render as per-account notes instead of usage bars.
+  `unavailable`, and unknown future values) render as per-account notes instead of usage bars in both full and brief
+  cards. Active rows are marked `[active]`; no claude-swap row infers a plan badge.
 - Switching: an inactive account with usable source credentials shows “Switch Account…”. Clicking it runs exactly
   `cswap --switch-to <slot> --json`, validates the versioned result and requested slot, then refreshes both ambient
   Claude usage and every claude-swap account card. Switches are serialized; no automatic switching occurs.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -53,6 +53,15 @@ See `docs/configuration.md` for the schema.
   - `--brief` renders a compact table (Provider / Usage / Reset) instead of the card grid.
   - Stdout is always rendered text; `--json-output` only affects stderr logs (no JSON card payload).
   - Failed providers are summarized in a footer (not rendered as error cards).
+  - When the opt-in Claude claude-swap integration returns two or more accounts, cards renders every account in
+    active-first/slot order instead of the ambient or token-account Claude cards. This applies on macOS and Linux,
+    including an explicit `--provider claude`; `--source auto` remains eligible.
+  - `--account`, `--account-index`, `--all-accounts`, and explicit non-auto source flags preserve their requested
+    ambient behavior and do not invoke claude-swap. Zero/one-account lists likewise retain ambient Claude output.
+  - claude-swap sentinel accounts remain successful cards with their problem text and no fabricated usage metrics.
+    A list adapter, parser, or timeout failure retains useful ambient Claude output, adds a distinct
+    `Claude (claude-swap)` failure footer entry, and makes the command exit non-zero.
+  - This precedence is cards-only: `codexbar usage` and `codexbar serve` keep their existing output cardinality.
   - Honors `$COLUMNS` for layout; falls back to 80 columns. Use `--no-color` for plain output.
   - Kitty, Ghostty, WezTerm, and other truecolor terminals auto-enable enhanced gradients/outlines.
   - Force enhanced mode elsewhere with `CODEXBAR_CARDS_ENHANCED=1`.


### PR DESCRIPTION
## Summary

- add opt-in claude-swap multi-account usage to `codexbar cards` and `--brief`
- mirror the menu-bar app's precedence: 2+ swap accounts replace ambient/token Claude cards, while zero/one account keeps existing output
- preserve explicit account and non-auto `--source` intent, ambient fallback diagnostics, active-account state, and sentinel/no-usage rows
- reuse the bounded schema-v1 Core reader/projection without reading credentials or exposing switching from the cards command
- keep macOS and Linux CLI coverage synchronized, including every explicit source override and active sentinel rendering

## Testing

- `swift build --target CodexBarCLI`
- `git diff --check`
- byte-identical macOS/Linux cswap and renderer test suites (`diff -q`)
- `make test` attempted; the local Command Line Tools environment cannot import the pre-existing Swift `Testing` module, so discovery fails before selected tests execute
- `make check` ran repository checks and SwiftFormat cleanly, then the local SwiftLint/SourceKit toolchain crashed loading `sourcekitdInProc.framework`

No live provider probes, browser imports, Keychain reads, credentials, or real `cswap` accounts were used; the integration tests use injected results and fake executables.
