### PR TITLE
Fix duplicate Claude all-model quota row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.43.1 — Unreleased
 
+### Fixed
+- Claude: suppress duplicate all-model scoped quota rows that could appear as “All models only” beside Weekly.
+
 ## 0.43.0 — 2026-07-14
 
 ### Added

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeScopedWeeklyLimitMapper.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeScopedWeeklyLimitMapper.swift
@@ -22,6 +22,7 @@ enum ClaudeScopedWeeklyLimitMapper {
             guard limit.group == "weekly", limit.kind == "weekly_scoped" else { return nil }
             guard let percent = limit.percent, percent.isFinite else { return nil }
             guard let modelName = self.nonEmpty(limit.modelName) else { return nil }
+            guard !self.isAllModelsScope(modelID: limit.modelID, modelName: modelName) else { return nil }
             let identity = self.nonEmpty(limit.modelID) ?? modelName
             let slug = self.slug(identity)
             guard !slug.isEmpty else { return nil }
@@ -58,5 +59,14 @@ enum ClaudeScopedWeeklyLimitMapper {
             }
         }
         return result.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    private static func isAllModelsScope(modelID: String?, modelName: String) -> Bool {
+        if self.slug(modelName) == "all-models" {
+            return true
+        }
+        guard let modelID = self.nonEmpty(modelID) else { return false }
+        let idSlug = self.slug(modelID)
+        return idSlug == "all-models" || idSlug.hasSuffix("-all-models")
     }
 }

--- a/Tests/CodexBarTests/ClaudeScopedWeeklyLimitMapperTests.swift
+++ b/Tests/CodexBarTests/ClaudeScopedWeeklyLimitMapperTests.swift
@@ -46,6 +46,19 @@ struct ClaudeScopedWeeklyLimitMapperTests {
         #expect(ClaudeScopedWeeklyLimitMapper.extraRateWindows(from: limits).isEmpty)
     }
 
+    @Test
+    func `all models scope stays in the primary weekly lane`() {
+        let limits = [
+            Self.limit(modelID: nil, modelName: "All models"),
+            Self.limit(modelID: "claude/all_models", modelName: "Weekly"),
+            Self.limit(modelID: nil, modelName: "Fable"),
+        ]
+
+        let windows = ClaudeScopedWeeklyLimitMapper.extraRateWindows(from: limits)
+
+        #expect(windows.map(\.title) == ["Fable only"])
+    }
+
     private static func limit(
         kind: String = "weekly_scoped",
         group: String = "weekly",

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -76,6 +76,7 @@ Admin API key setup:
   - `five_hour` → session window.
   - `seven_day` → weekly window; also becomes the primary fallback when `five_hour` is absent or has no utilization.
   - `seven_day_sonnet` / `seven_day_opus` → model-specific weekly window.
+  - `limits[].weekly_scoped` → model-specific weekly windows; generic `All models` scopes stay in the main weekly row.
   - `seven_day_routines` / `seven_day_cowork` → Daily Routines extra window.
   - Claude Design/Omelette keys are ignored because Claude Design shares the main Claude usage limit.
   - `extra_usage` → Extra usage cost (monthly spend/limit).


### PR DESCRIPTION
## Summary

- suppress generic Anthropic `All models` scoped entries from the model-only quota rows
- keep real model-scoped windows such as `Fable only`
- document the mapping and add a regression fixture for both all-model representations

Fixes the duplicate `All models only` row reported in https://x.com/cryptodev9/status/2077157896341618799.

## Proof

- `swift test --filter ClaudeScopedWeeklyLimitMapperTests` — 4 passed
- `make check` — SwiftFormat clean; SwiftLint zero violations
- `make test` — 643 selections; 54/54 groups passed; zero retries/failures/timeouts
- Codex autoreview — clean; no accepted/actionable findings

## Caveat

No live Claude account probe. Repository policy requires explicit approval for real provider/account tests; regression proof uses parser fixtures.
