### PR TITLE
Fix Claude background Keychain prompts

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+SecurityCLIReader.swift
@@ -357,7 +357,16 @@ extension ClaudeOAuthCredentialsStore {
         guard !keychainAccessDisabled || self.isolatedSecurityCLIKeychainPath(environment: environment) != nil else {
             return false
         }
-        guard ClaudeOAuthKeychainPromptPreference.effectiveMode(readStrategy: readStrategy) != .never else {
+        let promptMode = ClaudeOAuthKeychainPromptPreference.effectiveMode(readStrategy: readStrategy)
+        guard promptMode != .never else {
+            return false
+        }
+        // A Security.framework query configured as "no UI" can still display a legacy Keychain ACL dialog.
+        // Respect the user-action-only policy before background discovery touches Claude Code credentials.
+        guard readStrategy != .securityFramework
+            || promptMode != .onlyOnUserAction
+            || interaction == .userInitiated
+        else {
             return false
         }
         let payload: Data? = switch readStrategy {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -19,6 +19,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
 
     public enum Outcome: Sendable, Equatable {
         case skippedByCooldown
+        case skippedByPromptPolicy
         case cliUnavailable
         case attemptedSucceeded
         case attemptedFailed(String)
@@ -59,7 +60,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             let outcome = await task.value
             self.clearInFlightTaskIfStillCurrent(id: id, state: state)
             switch outcome {
-            case .attemptedFailed, .skippedByCooldown, .cliUnavailable:
+            case .attemptedFailed, .skippedByCooldown, .skippedByPromptPolicy, .cliUnavailable:
                 return await self.attempt(now: now, timeout: timeout, environment: environment)
             case .attemptedSucceeded:
                 return outcome
@@ -81,6 +82,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         let environment: [String: String]
         let interaction: ProviderInteraction
         let readStrategy: ClaudeOAuthKeychainReadStrategy
+        let promptMode: ClaudeOAuthKeychainPromptMode
         let keychainAccessDisabled: Bool
         #if DEBUG
         let cliAvailableOverride: Bool?
@@ -113,20 +115,24 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         let attemptID = state.nextAttemptID
         // Detached to avoid inheriting the caller's executor context (e.g. MainActor) and cancellation state.
         #if DEBUG
+        let readStrategy = ClaudeOAuthKeychainReadStrategyPreference.current()
         let configuration = AttemptConfiguration(
             environment: environment,
             interaction: interaction,
-            readStrategy: ClaudeOAuthKeychainReadStrategyPreference.current(),
+            readStrategy: readStrategy,
+            promptMode: ClaudeOAuthKeychainPromptPreference.effectiveMode(readStrategy: readStrategy),
             keychainAccessDisabled: KeychainAccessGate.isDisabled,
             cliAvailableOverride: self.cliAvailableOverrideForTesting,
             touchAuthPathOverride: self.touchAuthPathOverrideForTesting,
             keychainFingerprintOverride: self.keychainFingerprintOverrideForTesting)
         let securityCLIReadOverride = ClaudeOAuthCredentialsStore.currentSecurityCLIReadOverrideForTesting()
         #else
+        let readStrategy = ClaudeOAuthKeychainReadStrategyPreference.current()
         let configuration = AttemptConfiguration(
             environment: environment,
             interaction: interaction,
-            readStrategy: ClaudeOAuthKeychainReadStrategyPreference.current(),
+            readStrategy: readStrategy,
+            promptMode: ClaudeOAuthKeychainPromptPreference.effectiveMode(readStrategy: readStrategy),
             keychainAccessDisabled: KeychainAccessGate.isDisabled)
         #endif
         let task = Task.detached(priority: .utility) {
@@ -158,6 +164,16 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         configuration: AttemptConfiguration,
         state: AttemptStateStorage) async -> Outcome
     {
+        // `/status` is an opaque Claude CLI invocation and may launch `/usr/bin/security` outside
+        // CodexBar's own no-UI query controls. Background work may not cross that boundary unless
+        // the user explicitly opted into always allowing Keychain access.
+        if configuration.interaction == .background,
+           configuration.keychainAccessDisabled || configuration.promptMode != .always
+        {
+            self.log.info("Claude OAuth delegated refresh skipped by Keychain prompt policy")
+            return .skippedByPromptPolicy
+        }
+
         guard self.isClaudeCLIAvailable(environment: configuration.environment, configuration: configuration) else {
             self.log.info("Claude OAuth delegated refresh skipped: claude CLI unavailable")
             return .cliUnavailable

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -120,7 +120,9 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             environment: environment,
             interaction: interaction,
             readStrategy: readStrategy,
-            promptMode: ClaudeOAuthKeychainPromptPreference.effectiveMode(readStrategy: readStrategy),
+            // The delegated Claude process is an opaque Keychain boundary. Its policy must come
+            // from the user's stored preference, not the strategy-adjusted mode used by our own reads.
+            promptMode: ClaudeOAuthKeychainPromptPreference.storedMode(),
             keychainAccessDisabled: KeychainAccessGate.isDisabled,
             cliAvailableOverride: self.cliAvailableOverrideForTesting,
             touchAuthPathOverride: self.touchAuthPathOverrideForTesting,
@@ -132,7 +134,9 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             environment: environment,
             interaction: interaction,
             readStrategy: readStrategy,
-            promptMode: ClaudeOAuthKeychainPromptPreference.effectiveMode(readStrategy: readStrategy),
+            // The delegated Claude process is an opaque Keychain boundary. Its policy must come
+            // from the user's stored preference, not the strategy-adjusted mode used by our own reads.
+            promptMode: ClaudeOAuthKeychainPromptPreference.storedMode(),
             keychainAccessDisabled: KeychainAccessGate.isDisabled)
         #endif
         let task = Task.detached(priority: .utility) {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -641,12 +641,23 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
     let hasWebFallback: Bool
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        // The interactive Claude REPL can open browser OAuth when it starts logged out. CLI runtime and background
-        // app Auto refreshes must establish authentication through the non-interactive status command first.
-        let requiresAuthPreflight = context.runtime == .cli || (
-            context.runtime == .app &&
-                context.sourceMode == .auto &&
-                ProviderInteractionContext.current == .background)
+        // Claude's "auth status" command is a child process that may invoke /usr/bin/security itself. A no-prompt
+        // policy in CodexBar cannot constrain that child process, so background Auto refresh must not launch it
+        // unless the user explicitly opted into Keychain access for background work.
+        let isBackgroundAutoRefresh = context.runtime == .app
+            && context.sourceMode == .auto
+            && ProviderInteractionContext.current == .background
+        if isBackgroundAutoRefresh {
+            guard !KeychainAccessGate.isDisabled,
+                  ClaudeOAuthKeychainPromptPreference.current() == .always
+            else {
+                return false
+            }
+        }
+
+        // The interactive Claude REPL can open browser OAuth when it starts logged out. CLI runtime and the
+        // explicitly opted-in background Auto path establish authentication through the status command first.
+        let requiresAuthPreflight = context.runtime == .cli || isBackgroundAutoRefresh
         guard requiresAuthPreflight else { return true }
         guard let binary = ClaudeCLIResolver.resolvedBinaryPath(environment: context.env) else { return false }
         return await ClaudeCLIAuthStatusProbe.isLoggedIn(binary: binary, environment: context.env)

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -328,6 +328,14 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
                 guard sourceMode == .auto else { return true }
                 guard claudeCLIAvailable else { return false }
                 guard ProviderInteractionContext.current == .background else { return true }
+                // An expired Claude CLI credential requires the delegated Claude CLI refresh path.
+                // That child process can access Keychain outside CodexBar's no-UI controls, so do
+                // not plan it during background Auto refresh without an explicit opt-in.
+                guard !KeychainAccessGate.isDisabled,
+                      ClaudeOAuthKeychainPromptPreference.current() == .always
+                else {
+                    return false
+                }
                 return !Self.hasMcpOAuthOnlyClaudeKeychainPayload(environment: environment)
             case .environment:
                 return sourceMode != .auto

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -332,7 +332,7 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
                 // That child process can access Keychain outside CodexBar's no-UI controls, so do
                 // not plan it during background Auto refresh without an explicit opt-in.
                 guard !KeychainAccessGate.isDisabled,
-                      ClaudeOAuthKeychainPromptPreference.current() == .always
+                      ClaudeOAuthKeychainPromptPreference.storedMode() == .always
                 else {
                     return false
                 }
@@ -657,7 +657,7 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
             && ProviderInteractionContext.current == .background
         if isBackgroundAutoRefresh {
             guard !KeychainAccessGate.isDisabled,
-                  ClaudeOAuthKeychainPromptPreference.current() == .always
+                  ClaudeOAuthKeychainPromptPreference.storedMode() == .always
             else {
                 return false
             }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -231,7 +231,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         {
             throw ClaudeUsageError.oauthFailed(
                 "Claude OAuth token expired, but background repair is suppressed when Keychain prompt policy "
-                    + "is set to only prompt on user action. Open the CodexBar menu or click Refresh to retry.")
+                    + "is set to only prompt on user action. Click Refresh in the CodexBar menu to retry.")
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -401,7 +401,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             do {
                 if self.fetcher.oauthKeychainPromptCooldownEnabled {
                     switch delegatedOutcome {
-                    case .skippedByCooldown, .cliUnavailable:
+                    case .skippedByCooldown, .skippedByPromptPolicy, .cliUnavailable:
                         throw ClaudeUsageError.oauthFailed(
                             "Claude OAuth token expired; delegated refresh is unavailable (outcome="
                                 + "\(ClaudeUsageFetcher.delegatedRefreshOutcomeLabel(delegatedOutcome))).")
@@ -925,6 +925,8 @@ extension ClaudeUsageFetcher {
         switch outcome {
         case .skippedByCooldown:
             "skippedByCooldown"
+        case .skippedByPromptPolicy:
+            "skippedByPromptPolicy"
         case .cliUnavailable:
             "cliUnavailable"
         case .attemptedSucceeded:
@@ -948,6 +950,9 @@ extension ClaudeUsageFetcher {
         case .skippedByCooldown:
             return "Claude OAuth token expired and delegated refresh is cooling down. "
                 + "Please retry shortly, or run `claude login`."
+        case .skippedByPromptPolicy:
+            return "Claude OAuth token expired; background refresh is disabled by the Keychain prompt policy. "
+                + "Refresh CodexBar manually or run `claude login`."
         case .cliUnavailable:
             return "Claude OAuth token expired and Claude CLI is not available for delegated refresh. "
                 + "Install/configure `claude`, or run `claude login`."

--- a/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
@@ -108,6 +108,12 @@ struct ClaudeBaselineCharacterizationTests {
         }
     }
 
+    private func withBackgroundKeychainAccess<T>(operation: () async throws -> T) async rethrows -> T {
+        try await KeychainAccessGate.withTaskOverrideForTesting(false) {
+            try await operation()
+        }
+    }
+
     @Test
     func `app auto pipeline order is OAuth then CLI then web`() async {
         let settings = ProviderSettingsSnapshot.make(claude: .init(
@@ -201,15 +207,75 @@ struct ClaudeBaselineCharacterizationTests {
         let stubCLIPath = try self.makeStubClaudeCLI(loggedIn: false, invocationLog: invocationLog)
         let env = ["CLAUDE_CLI_PATH": stubCLIPath]
 
-        await self.withNoOAuthCredentials {
-            let outcome = await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
+        await self.withBackgroundKeychainAccess {
+            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                await self.withNoOAuthCredentials {
+                    let outcome = await self.fetchOutcome(
+                        runtime: .app,
+                        sourceMode: .auto,
+                        env: env,
+                        settings: settings)
 
-            #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli", "claude.web"])
-            #expect(outcome.attempts.map(\.wasAvailable) == [false, false, false])
+                    #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli", "claude.web"])
+                    #expect(outcome.attempts.map(\.wasAvailable) == [false, false, false])
+                }
+            }
         }
 
         let invocations = try String(contentsOf: invocationLog, encoding: .utf8)
         #expect(invocations == "auth status --json\n")
+    }
+
+    @Test
+    func `app background auto does not launch Claude CLI under user action prompt policy`() async throws {
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .auto,
+            webExtrasEnabled: false,
+            cookieSource: .off,
+            manualCookieHeader: nil))
+        let invocationLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-invocations-\(UUID().uuidString).log")
+        let stubCLIPath = try self.makeStubClaudeCLI(invocationLog: invocationLog)
+        let env = ["CLAUDE_CLI_PATH": stubCLIPath]
+
+        await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
+            await self.withNoOAuthCredentials {
+                let outcome = await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
+                #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli", "claude.web"])
+                #expect(outcome.attempts.map(\.wasAvailable) == [false, false, false])
+            }
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: invocationLog.path))
+    }
+
+    @Test
+    func `app background auto does not launch Claude CLI when Keychain access is disabled`() async throws {
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .auto,
+            webExtrasEnabled: false,
+            cookieSource: .off,
+            manualCookieHeader: nil))
+        let invocationLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-invocations-\(UUID().uuidString).log")
+        let stubCLIPath = try self.makeStubClaudeCLI(invocationLog: invocationLog)
+        let env = ["CLAUDE_CLI_PATH": stubCLIPath]
+
+        await KeychainAccessGate.withTaskOverrideForTesting(true) {
+            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                await self.withNoOAuthCredentials {
+                    let outcome = await self.fetchOutcome(
+                        runtime: .app,
+                        sourceMode: .auto,
+                        env: env,
+                        settings: settings)
+                    #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli", "claude.web"])
+                    #expect(outcome.attempts.map(\.wasAvailable) == [false, false, false])
+                }
+            }
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: invocationLog.path))
     }
 
     @Test(arguments: ["nonzero", "timeout", "malformed"])
@@ -251,9 +317,13 @@ struct ClaudeBaselineCharacterizationTests {
                 rawText: nil)
         }
 
-        let outcome = await self.withNoOAuthCredentials {
-            await ClaudeWebFetchStrategy.$usageLoaderOverrideForTesting.withValue(usageLoader) {
-                await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
+        let outcome = await self.withBackgroundKeychainAccess {
+            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                await self.withNoOAuthCredentials {
+                    await ClaudeWebFetchStrategy.$usageLoaderOverrideForTesting.withValue(usageLoader) {
+                        await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
+                    }
+                }
             }
         }
         let result = try outcome.result.get()
@@ -333,39 +403,43 @@ struct ClaudeBaselineCharacterizationTests {
         let stubCLIPath = try self.makeStubClaudeCLI()
         let env = ["CLAUDE_CLI_PATH": stubCLIPath]
 
-        await self.withNoOAuthCredentials {
-            let fetchOverride: @Sendable (String, TimeInterval, Bool) async throws
-                -> ClaudeStatusSnapshot = { binary, _, _ in
-                    #expect(binary == stubCLIPath)
-                    return ClaudeStatusSnapshot(
-                        sessionPercentLeft: 88,
-                        weeklyPercentLeft: 60,
-                        opusPercentLeft: 95,
-                        accountEmail: "user@example.com",
-                        accountOrganization: "Example Org",
-                        loginMethod: nil,
-                        primaryResetDescription: "Resets 11am",
-                        secondaryResetDescription: "Resets Nov 21",
-                        opusResetDescription: "Resets Nov 21",
-                        rawText: "stub")
+        await self.withBackgroundKeychainAccess {
+            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                await self.withNoOAuthCredentials {
+                    let fetchOverride: @Sendable (String, TimeInterval, Bool) async throws
+                        -> ClaudeStatusSnapshot = { binary, _, _ in
+                            #expect(binary == stubCLIPath)
+                            return ClaudeStatusSnapshot(
+                                sessionPercentLeft: 88,
+                                weeklyPercentLeft: 60,
+                                opusPercentLeft: 95,
+                                accountEmail: "user@example.com",
+                                accountOrganization: "Example Org",
+                                loginMethod: nil,
+                                primaryResetDescription: "Resets 11am",
+                                secondaryResetDescription: "Resets Nov 21",
+                                opusResetDescription: "Resets Nov 21",
+                                rawText: "stub")
+                        }
+                    let outcome = await ClaudeStatusProbe.$fetchOverride.withValue(fetchOverride) {
+                        await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
+                    }
+
+                    #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli"])
+                    #expect(outcome.attempts.map(\.wasAvailable) == [false, true])
+
+                    switch outcome.result {
+                    case let .success(result):
+                        #expect(result.strategyID == "claude.cli")
+                        #expect(result.sourceLabel == "claude")
+                        #expect(result.usage.primary?.usedPercent == 12)
+                        #expect(result.usage.secondary?.usedPercent == 40)
+                        #expect(result.usage.tertiary?.usedPercent == 5)
+                        #expect(result.usage.identity?.accountEmail == "user@example.com")
+                    case let .failure(error):
+                        Issue.record("Unexpected failure: \(error)")
+                    }
                 }
-            let outcome = await ClaudeStatusProbe.$fetchOverride.withValue(fetchOverride) {
-                await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
-            }
-
-            #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli"])
-            #expect(outcome.attempts.map(\.wasAvailable) == [false, true])
-
-            switch outcome.result {
-            case let .success(result):
-                #expect(result.strategyID == "claude.cli")
-                #expect(result.sourceLabel == "claude")
-                #expect(result.usage.primary?.usedPercent == 12)
-                #expect(result.usage.secondary?.usedPercent == 40)
-                #expect(result.usage.tertiary?.usedPercent == 5)
-                #expect(result.usage.identity?.accountEmail == "user@example.com")
-            case let .failure(error):
-                Issue.record("Unexpected failure: \(error)")
             }
         }
     }

--- a/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
@@ -227,7 +227,7 @@ struct ClaudeBaselineCharacterizationTests {
     }
 
     @Test
-    func `app background auto does not launch Claude CLI under user action prompt policy`() async throws {
+    func `app background auto honors stored user action policy with experimental reader`() async throws {
         let settings = ProviderSettingsSnapshot.make(claude: .init(
             usageDataSource: .auto,
             webExtrasEnabled: false,
@@ -238,11 +238,17 @@ struct ClaudeBaselineCharacterizationTests {
         let stubCLIPath = try self.makeStubClaudeCLI(invocationLog: invocationLog)
         let env = ["CLAUDE_CLI_PATH": stubCLIPath]
 
-        await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
-            await self.withNoOAuthCredentials {
-                let outcome = await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
-                #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli", "claude.web"])
-                #expect(outcome.attempts.map(\.wasAvailable) == [false, false, false])
+        await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityCLIExperimental) {
+            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
+                await self.withNoOAuthCredentials {
+                    let outcome = await self.fetchOutcome(
+                        runtime: .app,
+                        sourceMode: .auto,
+                        env: env,
+                        settings: settings)
+                    #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli", "claude.web"])
+                    #expect(outcome.attempts.map(\.wasAvailable) == [false, false, false])
+                }
             }
         }
 

--- a/Tests/CodexBarTests/ClaudeKeychainLiveProofTests.swift
+++ b/Tests/CodexBarTests/ClaudeKeychainLiveProofTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct ClaudeKeychainLiveProofTests {
+    private static var isEnabled: Bool {
+        ProcessInfo.processInfo.environment["LIVE_CLAUDE_KEYCHAIN_PROOF"] == "1"
+    }
+
+    @Test
+    func `live background Auto skips the opaque Claude Keychain boundary`() async {
+        guard Self.isEnabled else { return }
+        let mode = ClaudeOAuthKeychainPromptPreference.storedMode()
+        guard mode == .onlyOnUserAction || mode == .never else {
+            Issue.record("Live proof requires a restrictive stored Claude Keychain prompt mode; found \(mode.rawValue)")
+            return
+        }
+
+        let outcome = await ClaudeOAuthDelegatedRefreshCoordinator.withIsolatedStateForTesting {
+            await ProviderInteractionContext.$current.withValue(.background) {
+                await ClaudeOAuthDelegatedRefreshCoordinator.attempt(timeout: 8)
+            }
+        }
+
+        #expect(outcome == .skippedByPromptPolicy)
+    }
+
+    @Test
+    func `live explicit user auth probe reports Claude login`() async throws {
+        guard Self.isEnabled else { return }
+        let binary = try #require(TTYCommandRunner.which("claude"))
+
+        let isLoggedIn = await ProviderInteractionContext.$current.withValue(.userInitiated) {
+            await ClaudeCLIAuthStatusProbe.isLoggedIn(
+                binary: binary,
+                environment: ProcessInfo.processInfo.environment,
+                timeout: 8)
+        }
+
+        #expect(isLoggedIn)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreMCPOnlyGuardTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreMCPOnlyGuardTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite(.serialized)
 struct ClaudeOAuthCredentialsStoreMCPOnlyGuardTests {
     @Test
-    func `standard reader blocks expired CLI owner in background but preserves user refresh`() async throws {
+    func `standard reader skips MCP keychain probe in background but preserves user refresh`() async throws {
         let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
         let mcpOAuthOnly = Data(#"{"mcpOAuth":{"plugin:test":{"accessToken":"synthetic"}}}"#.utf8)
         let tempDir = FileManager.default.temporaryDirectory
@@ -37,7 +37,17 @@ struct ClaudeOAuthCredentialsStoreMCPOnlyGuardTests {
                                         keychainAccessDisabled: false,
                                         environment: [:])
                                 }
-                                #expect(isMcpOnly)
+                                #expect(!isMcpOnly)
+
+                                let userInitiatedIsMcpOnly = ProviderInteractionContext.$current
+                                    .withValue(.userInitiated) {
+                                        ClaudeOAuthCredentialsStore.isMcpOAuthOnlyClaudeKeychainPayloadPresent(
+                                            interaction: .userInitiated,
+                                            readStrategy: .securityFramework,
+                                            keychainAccessDisabled: false,
+                                            environment: [:])
+                                    }
+                                #expect(userInitiatedIsMcpOnly)
 
                                 ClaudeOAuthCredentialsStore.invalidateCache()
                                 let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
@@ -54,10 +64,10 @@ struct ClaudeOAuthCredentialsStoreMCPOnlyGuardTests {
                                         environment: [:],
                                         allowKeychainPrompt: false,
                                         respectKeychainPromptCooldown: true)
-                                    Issue.record("Expected MCP-only keychain failure")
+                                    Issue.record("Expected background refresh delegation")
                                 } catch let error as ClaudeOAuthCredentialsError {
-                                    guard case .mcpOAuthOnlyKeychain = error else {
-                                        Issue.record("Expected .mcpOAuthOnlyKeychain, got \(error)")
+                                    guard case .refreshDelegatedToClaudeCLI = error else {
+                                        Issue.record("Expected .refreshDelegatedToClaudeCLI, got \(error)")
                                         return
                                     }
                                 } catch {

--- a/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
@@ -2,6 +2,23 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+private final class ClaudeDelegatedTouchCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        self.lock.lock()
+        self.value += 1
+        self.lock.unlock()
+    }
+
+    func count() -> Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.value
+    }
+}
+
 @Suite(.serialized)
 struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
     private enum StubError: Error, LocalizedError {
@@ -141,24 +158,7 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
         promptMode: ClaudeOAuthKeychainPromptMode,
         keychainAccessDisabled: Bool) async
     {
-        final class TouchCounter: @unchecked Sendable {
-            private let lock = NSLock()
-            private var value = 0
-
-            func increment() {
-                self.lock.lock()
-                self.value += 1
-                self.lock.unlock()
-            }
-
-            func count() -> Int {
-                self.lock.lock()
-                defer { self.lock.unlock() }
-                return self.value
-            }
-        }
-
-        let touches = TouchCounter()
+        let touches = ClaudeDelegatedTouchCounter()
         let outcome = await self.withCoordinatorOverrides(
             cliAvailable: true,
             promptMode: promptMode,
@@ -178,24 +178,7 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
 
     @Test
     func `opaque delegated CLI honors stored prompt mode when read strategy effective mode differs`() async {
-        final class TouchCounter: @unchecked Sendable {
-            private let lock = NSLock()
-            private var value = 0
-
-            func increment() {
-                self.lock.lock()
-                self.value += 1
-                self.lock.unlock()
-            }
-
-            func count() -> Int {
-                self.lock.lock()
-                defer { self.lock.unlock() }
-                return self.value
-            }
-        }
-
-        let touches = TouchCounter()
+        let touches = ClaudeDelegatedTouchCounter()
         let backgroundOutcome = await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(
             .securityCLIExperimental)
         {

--- a/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
@@ -32,39 +32,47 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
     private func withCoordinatorOverrides<T>(
         isolateState: Bool = true,
         cliAvailable: Bool? = nil,
+        promptMode: ClaudeOAuthKeychainPromptMode = .always,
+        keychainAccessDisabled: Bool = false,
         touchAuthPath: (@Sendable (TimeInterval, [String: String]) async throws -> Void)? = nil,
         keychainFingerprint: (@Sendable () -> ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint?)? = nil,
         operation: () async throws -> T) async rethrows -> T
     {
-        if isolateState {
-            return try await ClaudeOAuthDelegatedRefreshCoordinator.withIsolatedStateForTesting {
+        try await KeychainAccessGate.withTaskOverrideForTesting(keychainAccessDisabled) {
+            try await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(promptMode) {
+                if isolateState {
+                    return try await ClaudeOAuthDelegatedRefreshCoordinator.withIsolatedStateForTesting {
+                        ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting()
+                        defer { ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting() }
+                        return try await ClaudeOAuthDelegatedRefreshCoordinator
+                            .withKeychainFingerprintOverrideForTesting(
+                                keychainFingerprint)
+                            {
+                                try await ClaudeOAuthDelegatedRefreshCoordinator.withCLIAvailableOverrideForTesting(
+                                    cliAvailable)
+                                {
+                                    try await ClaudeOAuthDelegatedRefreshCoordinator
+                                        .withTouchAuthPathOverrideForTesting(
+                                            touchAuthPath)
+                                        {
+                                            try await operation()
+                                        }
+                                }
+                            }
+                    }
+                }
                 ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting()
                 defer { ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting() }
                 return try await ClaudeOAuthDelegatedRefreshCoordinator.withKeychainFingerprintOverrideForTesting(
                     keychainFingerprint)
                 {
-                    try await ClaudeOAuthDelegatedRefreshCoordinator.withCLIAvailableOverrideForTesting(
-                        cliAvailable)
-                    {
+                    try await ClaudeOAuthDelegatedRefreshCoordinator.withCLIAvailableOverrideForTesting(cliAvailable) {
                         try await ClaudeOAuthDelegatedRefreshCoordinator.withTouchAuthPathOverrideForTesting(
                             touchAuthPath)
                         {
                             try await operation()
                         }
                     }
-                }
-            }
-        }
-        ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting()
-        defer { ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting() }
-        return try await ClaudeOAuthDelegatedRefreshCoordinator.withKeychainFingerprintOverrideForTesting(
-            keychainFingerprint)
-        {
-            try await ClaudeOAuthDelegatedRefreshCoordinator.withCLIAvailableOverrideForTesting(cliAvailable) {
-                try await ClaudeOAuthDelegatedRefreshCoordinator.withTouchAuthPathOverrideForTesting(
-                    touchAuthPath)
-                {
-                    try await operation()
                 }
             }
         }
@@ -122,6 +130,50 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
         })
 
         #expect(outcome == .cliUnavailable)
+    }
+
+    @Test(arguments: [
+        (ClaudeOAuthKeychainPromptMode.onlyOnUserAction, false),
+        (ClaudeOAuthKeychainPromptMode.never, false),
+        (ClaudeOAuthKeychainPromptMode.always, true),
+    ])
+    func `background refresh never launches delegated Claude CLI without Keychain opt in`(
+        promptMode: ClaudeOAuthKeychainPromptMode,
+        keychainAccessDisabled: Bool) async
+    {
+        final class TouchCounter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value = 0
+
+            func increment() {
+                self.lock.lock()
+                self.value += 1
+                self.lock.unlock()
+            }
+
+            func count() -> Int {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                return self.value
+            }
+        }
+
+        let touches = TouchCounter()
+        let outcome = await self.withCoordinatorOverrides(
+            cliAvailable: true,
+            promptMode: promptMode,
+            keychainAccessDisabled: keychainAccessDisabled,
+            touchAuthPath: { _, _ in touches.increment() },
+            operation: {
+                await ProviderInteractionContext.$current.withValue(.background) {
+                    await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                        now: Date(timeIntervalSince1970: 20001),
+                        timeout: 0.1)
+                }
+            })
+
+        #expect(outcome == .skippedByPromptPolicy)
+        #expect(touches.count() == 0)
     }
 
     @Test
@@ -693,10 +745,7 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
                     }
                 })
 
-            guard case .attemptedFailed = outcome else {
-                Issue.record("Expected .attemptedFailed outcome")
-                return
-            }
+            #expect(outcome == .skippedByPromptPolicy)
             #expect(securityReadCounter.count < 1)
         }
     }

--- a/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
@@ -177,6 +177,71 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
     }
 
     @Test
+    func `opaque delegated CLI honors stored prompt mode when read strategy effective mode differs`() async {
+        final class TouchCounter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value = 0
+
+            func increment() {
+                self.lock.lock()
+                self.value += 1
+                self.lock.unlock()
+            }
+
+            func count() -> Int {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                return self.value
+            }
+        }
+
+        let touches = TouchCounter()
+        let backgroundOutcome = await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(
+            .securityCLIExperimental)
+        {
+            #expect(ClaudeOAuthKeychainPromptPreference.effectiveMode() == .always)
+            return await self.withCoordinatorOverrides(
+                cliAvailable: true,
+                promptMode: .onlyOnUserAction,
+                touchAuthPath: { _, _ in touches.increment() },
+                operation: {
+                    await ProviderInteractionContext.$current.withValue(.background) {
+                        await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                            now: Date(timeIntervalSince1970: 20002),
+                            timeout: 0.1)
+                    }
+                })
+        }
+
+        #expect(backgroundOutcome == .skippedByPromptPolicy)
+        #expect(touches.count() == 0)
+
+        let userOutcome = await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(
+            .securityCLIExperimental)
+        {
+            await self.withCoordinatorOverrides(
+                cliAvailable: true,
+                promptMode: .onlyOnUserAction,
+                touchAuthPath: { _, _ in touches.increment() },
+                operation: {
+                    await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.data(Data("stub".utf8))) {
+                        await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                            await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                                now: Date(timeIntervalSince1970: 20003),
+                                timeout: 0.1)
+                        }
+                    }
+                })
+        }
+
+        guard case .attemptedFailed = userOutcome else {
+            Issue.record("Expected explicit user refresh to launch the delegated CLI")
+            return
+        }
+        #expect(touches.count() == 1)
+    }
+
+    @Test
     func `successful auth touch reports attempted succeeded`() async {
         ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting()
         defer { ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting() }

--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -50,15 +50,19 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
     }
 
     @Test
-    func `auto mode expired creds cli available returns available`() async {
+    func `auto mode expired CLI creds remain available after Keychain opt in`() async {
         let context = self.makeContext(sourceMode: .auto)
         let strategy = ClaudeOAuthFetchStrategy()
-        let available = await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
-            .withValue(self.expiredRecord()) {
-                await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
-                    await strategy.isAvailable(context)
-                }
+        let available = await KeychainAccessGate.withTaskOverrideForTesting(false) {
+            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
+                    .withValue(self.expiredRecord()) {
+                        await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
+                            await strategy.isAvailable(context)
+                        }
+                    }
             }
+        }
         #expect(available == true)
     }
 
@@ -93,24 +97,24 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
     }
 
     @Test
-    func `auto mode keeps expired CLI credentials available with ordinary O auth keychain`() async {
+    func `auto mode keeps expired CLI credentials unavailable in background`() async {
         let available = await self.expiredCLIAvailability(
             sourceMode: .auto,
             interaction: .background,
             keychainData: self.ordinaryOAuthKeychainPayload)
 
-        #expect(available)
+        #expect(!available)
     }
 
     @Test
-    func `auto mode ignores MCP-only keychain when keychain access is disabled`() async {
+    func `auto mode disables expired Claude CLI credentials when keychain access is disabled`() async {
         let available = await self.expiredCLIAvailability(
             sourceMode: .auto,
             interaction: .background,
             keychainData: self.mcpOAuthOnlyKeychainPayload,
             keychainAccessDisabled: true)
 
-        #expect(available)
+        #expect(!available)
     }
 
     @Test
@@ -264,10 +268,14 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
             sourceMode: .auto,
             env: ["CLAUDE_CLI_PATH": cliURL.path])
         let strategy = ClaudeOAuthFetchStrategy()
-        let available = await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
-            .withValue(self.expiredRecord()) {
-                await strategy.isAvailable(context)
+        let available = await KeychainAccessGate.withTaskOverrideForTesting(false) {
+            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
+                    .withValue(self.expiredRecord()) {
+                        await strategy.isAvailable(context)
+                    }
             }
+        }
 
         #expect(available == true)
     }
@@ -445,7 +453,8 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
         sourceMode: ProviderSourceMode,
         interaction: ProviderInteraction,
         keychainData: Data,
-        keychainAccessDisabled: Bool = false) async -> Bool
+        keychainAccessDisabled: Bool = false,
+        promptMode: ClaudeOAuthKeychainPromptMode = .onlyOnUserAction) async -> Bool
     {
         let context = self.makeContext(sourceMode: sourceMode)
         let strategy = ClaudeOAuthFetchStrategy()
@@ -453,15 +462,18 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
             .withValue(self.expiredRecord()) {
                 await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
                     await KeychainAccessGate.withTaskOverrideForTesting(keychainAccessDisabled) {
-                        await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(.securityFramework) {
-                            await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
-                                data: keychainData,
-                                fingerprint: nil)
-                            {
-                                await ProviderInteractionContext.$current.withValue(interaction) {
-                                    await strategy.isAvailable(context)
+                        await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(promptMode) {
+                            await ClaudeOAuthKeychainReadStrategyPreference
+                                .withTaskOverrideForTesting(.securityFramework) {
+                                    await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+                                        data: keychainData,
+                                        fingerprint: nil)
+                                    {
+                                        await ProviderInteractionContext.$current.withValue(interaction) {
+                                            await strategy.isAvailable(context)
+                                        }
+                                    }
                                 }
-                            }
                         }
                     }
                 }

--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -99,11 +99,12 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
     }
 
     @Test
-    func `auto mode keeps expired CLI credentials unavailable in background`() async {
+    func `stored user action policy blocks expired CLI credentials with experimental reader`() async {
         let available = await self.expiredCLIAvailability(
             sourceMode: .auto,
             interaction: .background,
-            keychainData: self.ordinaryOAuthKeychainPayload)
+            keychainData: self.ordinaryOAuthKeychainPayload,
+            readStrategy: .securityCLIExperimental)
 
         #expect(!available)
     }
@@ -458,7 +459,8 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
         interaction: ProviderInteraction,
         keychainData: Data,
         keychainAccessDisabled: Bool = false,
-        promptMode: ClaudeOAuthKeychainPromptMode = .onlyOnUserAction) async -> Bool
+        promptMode: ClaudeOAuthKeychainPromptMode = .onlyOnUserAction,
+        readStrategy: ClaudeOAuthKeychainReadStrategy = .securityFramework) async -> Bool
     {
         let context = self.makeContext(sourceMode: sourceMode)
         let strategy = ClaudeOAuthFetchStrategy()
@@ -468,7 +470,7 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                     await KeychainAccessGate.withTaskOverrideForTesting(keychainAccessDisabled) {
                         await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(promptMode) {
                             await ClaudeOAuthKeychainReadStrategyPreference
-                                .withTaskOverrideForTesting(.securityFramework) {
+                                .withTaskOverrideForTesting(readStrategy) {
                                     await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
                                         data: keychainData,
                                         fingerprint: nil)

--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -54,13 +54,15 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
         let context = self.makeContext(sourceMode: .auto)
         let strategy = ClaudeOAuthFetchStrategy()
         let available = await KeychainAccessGate.withTaskOverrideForTesting(false) {
-            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
-                await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
-                    .withValue(self.expiredRecord()) {
-                        await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
-                            await strategy.isAvailable(context)
+            await self.withAvailabilityKeychainDoubles {
+                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                    await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
+                        .withValue(self.expiredRecord()) {
+                            await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
+                                await strategy.isAvailable(context)
+                            }
                         }
-                    }
+                }
             }
         }
         #expect(available == true)
@@ -269,11 +271,13 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
             env: ["CLAUDE_CLI_PATH": cliURL.path])
         let strategy = ClaudeOAuthFetchStrategy()
         let available = await KeychainAccessGate.withTaskOverrideForTesting(false) {
-            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
-                await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
-                    .withValue(self.expiredRecord()) {
-                        await strategy.isAvailable(context)
-                    }
+            await self.withAvailabilityKeychainDoubles {
+                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                    await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride
+                        .withValue(self.expiredRecord()) {
+                            await strategy.isAvailable(context)
+                        }
+                }
             }
         }
 

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -317,6 +317,8 @@ struct ClaudeUsageTests {
                 return
             }
             #expect(message.contains("background repair is suppressed"))
+            #expect(message.contains("Click Refresh in the CodexBar menu"))
+            #expect(!message.contains("Open the CodexBar menu or"))
         } catch {
             Issue.record("Expected ClaudeUsageError, got \(error)")
         }

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -71,14 +71,18 @@ struct ClaudeWebFetchDeadlineTests {
         let cliFetchOverride: @Sendable (String, TimeInterval, Bool) async throws -> ClaudeStatusSnapshot =
             { _, _, _ in Self.makeClaudeStatus() }
 
-        let outcome = await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
-            availabilityOverride)
-        {
-            await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(oauthLoadOverride) {
-                await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
-                    await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
-                        context: context,
-                        provider: .claude)
+        let outcome = await KeychainAccessGate.withTaskOverrideForTesting(false) {
+            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                await ClaudeWebFetchStrategy.$availabilityProbeOverrideForTesting.withValue(
+                    availabilityOverride)
+                {
+                    await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(oauthLoadOverride) {
+                        await ClaudeStatusProbe.$fetchOverride.withValue(cliFetchOverride) {
+                            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                                context: context,
+                                provider: .claude)
+                        }
+                    }
                 }
             }
         }

--- a/TestsLinux/ClaudeOAuthDelegatedRefreshLinuxTests.swift
+++ b/TestsLinux/ClaudeOAuthDelegatedRefreshLinuxTests.swift
@@ -65,6 +65,8 @@ struct ClaudeOAuthDelegatedRefreshLinuxTests {
 
         #expect(result.attempts == 0)
         #expect(result.message.contains("background repair is suppressed"))
+        #expect(result.message.contains("Click Refresh in the CodexBar menu"))
+        #expect(!result.message.contains("Open the CodexBar menu or"))
     }
 
     private func runDelegatedRefresh(


### PR DESCRIPTION
## Summary

- prevent background Auto refresh from launching either opaque Claude CLI Keychain path unless the user explicitly selected the `Always allow Keychain prompts` policy:
  - `claude auth status --json` preflight
  - delegated OAuth-expiry `/status` refresh
- prevent planning an expired Claude CLI OAuth credential for background Auto refresh when that delegated refresh is disallowed
- honor the global Disable Keychain Access setting before invoking the Claude CLI, including its child `/usr/bin/security` access
- stop background MCP-only Claude credential discovery from touching Keychain under the default user-action-only policy
- add stubbed regressions plus an opt-in live macOS proof for background and explicit-user behavior

## Root cause

CodexBar had two background Claude CLI paths: the `claude auth status --json` preflight and the delegated OAuth-expiry `/status` refresh. Both can invoke `/usr/bin/security` outside CodexBar's in-process Keychain prompt policy. That allowed recurring `Claude Code-credentials` dialogs during background refreshes even when prompts were disabled. Separately, a Security.framework MCP-only discovery path could read the same item from background work despite the user-action-only policy.

This patch treats child-process Keychain behavior as opaque: background Auto refresh does not start it unless the user explicitly opts into background Keychain access. Explicit refresh and explicit CLI use remain available.

Fixes #2115.

## Live affected-Mac proof (redacted)

Tested on a real macOS account with Claude Code 2.1.207 installed, a live OAuth login, and the default restrictive prompt policy (`onlyOnUserAction`). The opt-in proof exercises production code, not a process stub:

```console
$ LIVE_CLAUDE_KEYCHAIN_PROOF=1 swift test --disable-sandbox \
    --scratch-path /private/tmp/codexbar-pr2191-proof \
    --filter ClaudeKeychainLiveProofTests

Suite ClaudeKeychainLiveProofTests started.
Test "live background Auto skips the opaque Claude Keychain boundary" started.
Claude OAuth delegated refresh skipped by Keychain prompt policy
Test "live background Auto skips the opaque Claude Keychain boundary" passed after 0.004 seconds.
Test "live explicit user auth probe reports Claude login" started.
Test "live explicit user auth probe reports Claude login" passed after 0.195 seconds.
Suite ClaudeKeychainLiveProofTests passed after 0.200 seconds.
Test run with 2 tests in 1 suite passed after 0.200 seconds.
```

The background assertion returns `.skippedByPromptPolicy` before either opaque Claude CLI/`/usr/bin/security` boundary can launch. The explicit-user assertion invokes the real installed `claude auth status --json` path and correctly reports the existing OAuth login. No email, token, Keychain item, or account identifier is collected or printed. CI leaves this live suite disabled unless `LIVE_CLAUDE_KEYCHAIN_PROOF=1` is explicitly set.

## Validation

- `LIVE_CLAUDE_KEYCHAIN_PROOF=1 swift test --disable-sandbox --scratch-path /private/tmp/codexbar-pr2191-proof --filter ClaudeKeychainLiveProofTests` — 2 real macOS tests passed
- `swift test --filter 'ClaudeBaselineCharacterizationTests|ClaudeOAuthCredentialsStoreMCPOnlyGuardTests|ClaudeCLIAuthStatusProbeTests|ClaudeOAuthDelegatedRefreshCoordinatorTests|ClaudeOAuthFetchStrategyAvailabilityTests'` — 48 tests passed
- changed-file SwiftFormat, SwiftLint, and `git diff --check` — clean
- `make check` — repository checks and formatting complete; SwiftLint reported then I fixed one new line-length warning. The check's final result is otherwise blocked by its existing sandbox-generated plist write behavior.
