### PR TITLE
Clarify Claude OAuth recovery action

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -231,7 +231,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         {
             throw ClaudeUsageError.oauthFailed(
                 "Claude OAuth token expired, but background repair is suppressed when Keychain prompt policy "
-                    + "is set to only prompt on user action. Open the CodexBar menu or click Refresh to retry.")
+                    + "is set to only prompt on user action. Click Refresh in the CodexBar menu to retry.")
         }
     }
 

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -317,6 +317,8 @@ struct ClaudeUsageTests {
                 return
             }
             #expect(message.contains("background repair is suppressed"))
+            #expect(message.contains("Click Refresh in the CodexBar menu"))
+            #expect(!message.contains("Open the CodexBar menu or"))
         } catch {
             Issue.record("Expected ClaudeUsageError, got \(error)")
         }

--- a/TestsLinux/ClaudeOAuthDelegatedRefreshLinuxTests.swift
+++ b/TestsLinux/ClaudeOAuthDelegatedRefreshLinuxTests.swift
@@ -65,6 +65,8 @@ struct ClaudeOAuthDelegatedRefreshLinuxTests {
 
         #expect(result.attempts == 0)
         #expect(result.message.contains("background repair is suppressed"))
+        #expect(result.message.contains("Click Refresh in the CodexBar menu"))
+        #expect(!result.message.contains("Open the CodexBar menu or"))
     }
 
     private func runDelegatedRefresh(


### PR DESCRIPTION
## Summary

- clarify that a suppressed Claude OAuth background repair requires clicking **Refresh** in the CodexBar menu
- remove the incorrect claim that merely opening the menu retries the repair
- cover the user-facing recovery direction in both macOS and Linux delegated-refresh regression tests

## Why

With the Keychain prompt policy set to **Only on user action**, background OAuth repair intentionally fails closed so CodexBar cannot trigger Claude, a Keychain prompt, or a browser launch. Automatic refresh after opening the menu still runs in the background, while the explicit Refresh action is user-initiated. The previous error text incorrectly promised that opening the menu would retry the repair.

## Validation

- `swift test --filter 'oauth delegated retry only on user action background suppresses delegation|appOAuthBackgroundRespectsPlatformKeychainPromptPolicy'`
- `make check`
