### PR TITLE
Bound CLI and RPC output buffering

### DIFF
--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -287,6 +287,7 @@ public struct TTYCommandRunner {
         case binaryNotFound(String)
         case launchFailed(String)
         case timedOut
+        case outputTooLarge
 
         public var errorDescription: String? {
             switch self {
@@ -294,6 +295,7 @@ public struct TTYCommandRunner {
                 "Missing CLI '\(bin)'. Install it (e.g. npm i -g @openai/codex) or add it to PATH."
             case let .launchFailed(msg): "Failed to launch process: \(msg)"
             case .timedOut: "PTY command timed out."
+            case .outputTooLarge: "PTY command produced more output than CodexBar can safely process."
             }
         }
     }
@@ -676,7 +678,16 @@ public struct TTYCommandRunner {
         let isCodex = (binaryName == "codex") || options.forceCodexStatusMode
         let isCodexStatus = isCodex && trimmed == "/status"
 
-        var buffer = Data()
+        var buffer = BoundedOutputBuffer()
+        var didExceedOutputLimit = false
+
+        func checkOutputLimit() throws {
+            if didExceedOutputLimit {
+                Self.log.warning("PTY output exceeded memory limit", metadata: ["binary": binaryName])
+                throw Error.outputTooLarge
+            }
+        }
+
         func readChunkResult() -> (data: Data, terminalRead: Int, errno: Int32) {
             var appended = Data()
             var terminalRead = 0
@@ -687,7 +698,10 @@ public struct TTYCommandRunner {
                 let n = read(primaryFD, &tmp, tmp.count)
                 if n > 0 {
                     let slice = tmp.prefix(n)
-                    buffer.append(contentsOf: slice)
+                    guard buffer.append(Data(slice)) else {
+                        didExceedOutputLimit = true
+                        break
+                    }
                     appended.append(contentsOf: slice)
                     continue
                 }
@@ -703,6 +717,9 @@ public struct TTYCommandRunner {
         }
 
         func readDrainChunk() -> DrainReadResult {
+            if didExceedOutputLimit {
+                return .closed
+            }
             let result = readChunkResult()
             return Self.drainReadResult(for: result.data, terminalRead: result.terminalRead, errno: result.errno)
         }
@@ -825,6 +842,7 @@ public struct TTYCommandRunner {
                     ptyClosed = true
                     newData = Data()
                 }
+                try checkOutputLimit()
                 if processNonCodexChunk(newData, allowSends: true, allowStop: true) {
                     stoppedEarly = true
                     break
@@ -877,6 +895,7 @@ public struct TTYCommandRunner {
                     while Date() < settleDeadline {
                         try checkCancellation()
                         let newData = readChunk()
+                        try checkOutputLimit()
                         let scanData = scanBuffer.append(newData)
                         if Date() >= nextCursorCheckAt,
                            !scanData.isEmpty,
@@ -894,7 +913,8 @@ public struct TTYCommandRunner {
                 drainNonCodexOutput(for: min(0.5, max(0.2, options.settleAfterStop)))
             }
 
-            let text = String(data: buffer, encoding: .utf8) ?? ""
+            try checkOutputLimit()
+            let text = String(data: buffer.data, encoding: .utf8) ?? ""
             let exitStatus: Int32? = if stoppedEarly {
                 !process.isRunning ? process.finishSynchronously() : nil
             } else {
@@ -957,6 +977,7 @@ public struct TTYCommandRunner {
         while Date() < deadline {
             try checkCancellation()
             let newData = readChunk()
+            try checkOutputLimit()
             let scanData = statusScanBuffer.append(newData)
             if Date() >= nextCursorCheckAt,
                !scanData.isEmpty,
@@ -1049,6 +1070,7 @@ public struct TTYCommandRunner {
             while Date() < settleDeadline {
                 try checkCancellation()
                 let newData = readChunk()
+                try checkOutputLimit()
                 let scanData = statusScanBuffer.append(newData)
                 if Date() >= nextCursorCheckAt,
                    !scanData.isEmpty,
@@ -1061,7 +1083,8 @@ public struct TTYCommandRunner {
             }
         }
 
-        guard let text = String(data: buffer, encoding: .utf8), !text.isEmpty else {
+        try checkOutputLimit()
+        guard let text = String(data: buffer.data, encoding: .utf8), !text.isEmpty else {
             throw Error.timedOut
         }
 

--- a/Sources/CodexBarCore/Host/Process/BoundedOutputBuffer.swift
+++ b/Sources/CodexBarCore/Host/Process/BoundedOutputBuffer.swift
@@ -48,19 +48,26 @@ final class BoundedLineBuffer: @unchecked Sendable {
         self.lock.lock()
         defer { self.lock.unlock() }
 
-        guard chunk.count <= self.maxBytes - self.buffer.count else {
-            return AppendResult(lines: [], didExceedLimit: true)
+        var lines: [Data] = []
+        var segmentStart = chunk.startIndex
+        while let newline = chunk[segmentStart...].firstIndex(of: 0x0A) {
+            let segment = chunk[segmentStart..<newline]
+            guard segment.count <= self.maxBytes - self.buffer.count else {
+                return AppendResult(lines: [], didExceedLimit: true)
+            }
+            self.buffer.append(segment)
+            if !self.buffer.isEmpty {
+                lines.append(self.buffer)
+            }
+            self.buffer.removeAll(keepingCapacity: true)
+            segmentStart = chunk.index(after: newline)
         }
 
-        self.buffer.append(chunk)
-        var lines: [Data] = []
-        while let newline = self.buffer.firstIndex(of: 0x0A) {
-            let line = Data(self.buffer[..<newline])
-            self.buffer.removeSubrange(...newline)
-            if !line.isEmpty {
-                lines.append(line)
-            }
+        let tail = chunk[segmentStart...]
+        guard tail.count <= self.maxBytes - self.buffer.count else {
+            return AppendResult(lines: [], didExceedLimit: true)
         }
+        self.buffer.append(contentsOf: tail)
         return AppendResult(lines: lines, didExceedLimit: false)
     }
 }

--- a/Sources/CodexBarCore/Host/Process/BoundedOutputBuffer.swift
+++ b/Sources/CodexBarCore/Host/Process/BoundedOutputBuffer.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Keeps output collected from an untrusted child process within a fixed memory budget.
+///
+/// Callers must treat a failed append as a terminal condition rather than silently parsing
+/// truncated output.
+struct BoundedOutputBuffer: Sendable {
+    static let defaultMaxBytes = 1 * 1024 * 1024
+
+    private(set) var data = Data()
+    private let maxBytes: Int
+
+    var isEmpty: Bool {
+        self.data.isEmpty
+    }
+
+    init(maxBytes: Int = Self.defaultMaxBytes) {
+        self.maxBytes = max(0, maxBytes)
+    }
+
+    mutating func append(_ chunk: Data) -> Bool {
+        guard chunk.count <= self.maxBytes - self.data.count else { return false }
+        self.data.append(chunk)
+        return true
+    }
+
+    mutating func removeAll(keepingCapacity: Bool = false) {
+        self.data.removeAll(keepingCapacity: keepingCapacity)
+    }
+}
+
+/// Splits newline-delimited child-process output without retaining an unbounded partial line.
+final class BoundedLineBuffer: @unchecked Sendable {
+    struct AppendResult: Sendable {
+        let lines: [Data]
+        let didExceedLimit: Bool
+    }
+
+    private let lock = NSLock()
+    private let maxBytes: Int
+    private var buffer = Data()
+
+    init(maxBytes: Int = BoundedOutputBuffer.defaultMaxBytes) {
+        self.maxBytes = max(0, maxBytes)
+    }
+
+    func appendAndDrainLines(_ chunk: Data) -> AppendResult {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+
+        guard chunk.count <= self.maxBytes - self.buffer.count else {
+            return AppendResult(lines: [], didExceedLimit: true)
+        }
+
+        self.buffer.append(chunk)
+        var lines: [Data] = []
+        while let newline = self.buffer.firstIndex(of: 0x0A) {
+            let line = Data(self.buffer[..<newline])
+            self.buffer.removeSubrange(...newline)
+            if !line.isEmpty {
+                lines.append(line)
+            }
+        }
+        return AppendResult(lines: lines, didExceedLimit: false)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
@@ -35,6 +35,7 @@ actor ClaudeCLISession {
         case ioFailed(String)
         case timedOut
         case processExited
+        case outputTooLarge
 
         var errorDescription: String? {
             switch self {
@@ -42,6 +43,7 @@ actor ClaudeCLISession {
             case let .ioFailed(msg): "Claude CLI PTY I/O failed: \(msg)"
             case .timedOut: "Claude CLI session timed out."
             case .processExited: "Claude CLI session exited."
+            case .outputTooLarge: "Claude CLI session produced more output than CodexBar can safely process."
             }
         }
     }
@@ -156,7 +158,13 @@ actor ClaudeCLISession {
         var scanBuffer = RollingBuffer(maxNeedle: maxNeedle)
         var triggeredSends = Set<String>()
 
-        var buffer = Data()
+        var buffer = BoundedOutputBuffer()
+        func appendOutput(_ data: Data) throws {
+            guard buffer.append(data) else {
+                self.cleanup()
+                throw SessionError.outputTooLarge
+            }
+        }
         var scanTailText = ""
         var normalizedScan = ""
         var utf8Carry = Data()
@@ -171,7 +179,7 @@ actor ClaudeCLISession {
         while Date() < deadline {
             let newData = self.readChunk()
             if !newData.isEmpty {
-                buffer.append(newData)
+                try appendOutput(newData)
                 lastOutputAt = Date()
                 Self.appendScanText(newData: newData, scanTailText: &scanTailText, utf8Carry: &utf8Carry)
                 if scanTailText.count > 8192 {
@@ -224,14 +232,14 @@ actor ClaudeCLISession {
                 while Date() < settleDeadline {
                     let newData = self.readChunk()
                     if !newData.isEmpty {
-                        buffer.append(newData)
+                        try appendOutput(newData)
                     }
                     try await Task.sleep(nanoseconds: 50_000_000)
                 }
             }
         }
 
-        guard !buffer.isEmpty, let text = String(data: buffer, encoding: .utf8) else {
+        guard !buffer.data.isEmpty, let text = String(data: buffer.data, encoding: .utf8) else {
             throw SessionError.timedOut
         }
         return text

--- a/Sources/CodexBarCore/Providers/Codex/CodexCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexCLISession.swift
@@ -14,12 +14,14 @@ actor CodexCLISession {
         case launchFailed(String)
         case timedOut
         case processExited
+        case outputTooLarge
 
         var errorDescription: String? {
             switch self {
             case let .launchFailed(msg): "Failed to launch Codex CLI session: \(msg)"
             case .timedOut: "Codex CLI session timed out."
             case .processExited: "Codex CLI session exited."
+            case .outputTooLarge: "Codex CLI session produced more output than CodexBar can safely process."
             }
         }
     }
@@ -126,7 +128,13 @@ actor CodexCLISession {
         var statusScanBuffer = RollingBuffer(maxNeedle: statusMaxNeedle)
         var updateScanBuffer = RollingBuffer(maxNeedle: updateMaxNeedle)
 
-        var buffer = Data()
+        var buffer = BoundedOutputBuffer()
+        func appendOutput(_ data: Data) throws {
+            guard buffer.append(data) else {
+                self.cleanup()
+                throw SessionError.outputTooLarge
+            }
+        }
         let deadline = Date().addingTimeInterval(options.timeout)
         var nextCursorCheckAt = Date(timeIntervalSince1970: 0)
 
@@ -143,7 +151,7 @@ actor CodexCLISession {
         while Date() < deadline {
             let newData = self.readChunk()
             if !newData.isEmpty {
-                buffer.append(newData)
+                try appendOutput(newData)
             }
             let scanData = statusScanBuffer.append(newData)
             if Date() >= nextCursorCheckAt,
@@ -234,7 +242,7 @@ actor CodexCLISession {
             while Date() < settleDeadline {
                 let newData = self.readChunk()
                 if !newData.isEmpty {
-                    buffer.append(newData)
+                    try appendOutput(newData)
                 }
                 let scanData = statusScanBuffer.append(newData)
                 if Date() >= nextCursorCheckAt,
@@ -248,7 +256,7 @@ actor CodexCLISession {
             }
         }
 
-        guard !buffer.isEmpty, let text = String(data: buffer, encoding: .utf8) else {
+        guard !buffer.data.isEmpty, let text = String(data: buffer.data, encoding: .utf8) else {
             throw SessionError.timedOut
         }
         return text

--- a/Sources/CodexBarCore/Providers/Grok/GrokRPCClient.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokRPCClient.swift
@@ -61,7 +61,8 @@ final class GrokRPCClient: @unchecked Sendable {
 
         let stdoutHandle = self.stdoutPipe.fileHandleForReading
         let stdoutLineContinuation = self.stdoutLineContinuation
-        let stdoutBuffer = LineBuffer()
+        let stdoutBuffer = BoundedLineBuffer()
+        let process = self.process
         stdoutHandle.readabilityHandler = { handle in
             let data = handle.availableData
             if data.isEmpty {
@@ -69,8 +70,15 @@ final class GrokRPCClient: @unchecked Sendable {
                 stdoutLineContinuation.finish()
                 return
             }
-            let lines = stdoutBuffer.appendAndDrainLines(data)
-            for lineData in lines {
+            let result = stdoutBuffer.appendAndDrainLines(data)
+            if result.didExceedLimit {
+                Self.log.warning("Grok RPC line exceeded memory limit; terminating process")
+                handle.readabilityHandler = nil
+                process.terminate()
+                stdoutLineContinuation.finish()
+                return
+            }
+            for lineData in result.lines {
                 stdoutLineContinuation.yield(lineData)
             }
         }
@@ -241,26 +249,6 @@ final class GrokRPCClient: @unchecked Sendable {
         case let int as Int: int
         case let number as NSNumber: number.intValue
         default: nil
-        }
-    }
-
-    private final class LineBuffer: @unchecked Sendable {
-        private var buffer = Data()
-        private let lock = NSLock()
-
-        func appendAndDrainLines(_ data: Data) -> [Data] {
-            self.lock.lock()
-            defer { lock.unlock() }
-            self.buffer.append(data)
-            var out: [Data] = []
-            while let newline = self.buffer.firstIndex(of: 0x0A) {
-                let lineData = Data(self.buffer[..<newline])
-                self.buffer.removeSubrange(...newline)
-                if !lineData.isEmpty {
-                    out.append(lineData)
-                }
-            }
-            return out
         }
     }
 }

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -971,27 +971,6 @@ private final class CodexRPCClient: @unchecked Sendable {
     private let initializeTimeoutSeconds: TimeInterval
     private let requestTimeoutSeconds: TimeInterval
 
-    private final class LineBuffer: @unchecked Sendable {
-        private let lock = NSLock()
-        private var buffer = Data()
-
-        func appendAndDrainLines(_ data: Data) -> [Data] {
-            self.lock.lock()
-            defer { self.lock.unlock() }
-
-            self.buffer.append(data)
-            var out: [Data] = []
-            while let newline = self.buffer.firstIndex(of: 0x0A) {
-                let lineData = Data(self.buffer[..<newline])
-                self.buffer.removeSubrange(...newline)
-                if !lineData.isEmpty {
-                    out.append(lineData)
-                }
-            }
-            return out
-        }
-    }
-
     private static func debugWriteStderr(_ message: String) {
         #if !os(Linux)
         fputs(message, stderr)
@@ -1052,7 +1031,8 @@ private final class CodexRPCClient: @unchecked Sendable {
 
         let stdoutHandle = self.stdoutPipe.fileHandleForReading
         let stdoutLineContinuation = self.stdoutLineContinuation
-        let stdoutBuffer = LineBuffer()
+        let stdoutBuffer = BoundedLineBuffer()
+        let process = self.process
         stdoutHandle.readabilityHandler = { handle in
             let data = handle.availableData
             if data.isEmpty {
@@ -1061,9 +1041,16 @@ private final class CodexRPCClient: @unchecked Sendable {
                 return
             }
 
-            let lines = stdoutBuffer.appendAndDrainLines(data)
+            let result = stdoutBuffer.appendAndDrainLines(data)
+            if result.didExceedLimit {
+                Self.log.warning("Codex RPC line exceeded memory limit; terminating process")
+                handle.readabilityHandler = nil
+                process.terminate()
+                stdoutLineContinuation.finish()
+                return
+            }
 
-            for lineData in lines {
+            for lineData in result.lines {
                 stdoutLineContinuation.yield(lineData)
             }
         }

--- a/Tests/CodexBarTests/BoundedChildProcessProofTests.swift
+++ b/Tests/CodexBarTests/BoundedChildProcessProofTests.swift
@@ -71,7 +71,10 @@ struct BoundedChildProcessProofTests {
         let client = try GrokRPCClient(
             executable: scriptURL.path,
             arguments: [],
-            environment: ["PATH": "/usr/bin:/bin"],
+            environment: [
+                "PATH": "/usr/bin:/bin",
+                "GROK_CLI_PATH": scriptURL.path,
+            ],
             initializeTimeoutSeconds: 2,
             requestTimeoutSeconds: 2)
         defer { client.shutdown() }
@@ -82,5 +85,60 @@ struct BoundedChildProcessProofTests {
         #expect(billing.monthlyLimit?.val == 100)
         #expect(billing.usage?.totalUsed?.val == 25)
         #expect(billing.monthlyUsedPercent == 25)
+    }
+
+    @Test
+    func `synthetic Grok RPC child overflow terminates the process`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarBoundedRPCOverflowProof-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let pidURL = directory.appendingPathComponent("child.pid")
+        let scriptURL = directory.appendingPathComponent("grok-overflow-proof.sh")
+        let script = """
+        #!/bin/sh
+        printf '%s\\n' "$$" > "$CODEXBAR_PROOF_PID_FILE"
+        IFS= read -r initialize_request
+        block='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+        while :; do
+            printf '%s' "$block"
+        done
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        let client = try GrokRPCClient(
+            executable: scriptURL.path,
+            arguments: [],
+            environment: [
+                "PATH": "/usr/bin:/bin",
+                "GROK_CLI_PATH": scriptURL.path,
+                "CODEXBAR_PROOF_PID_FILE": pidURL.path,
+            ],
+            initializeTimeoutSeconds: 10,
+            requestTimeoutSeconds: 2)
+        defer { client.shutdown() }
+
+        let start = ContinuousClock.now
+        do {
+            try await client.initialize()
+            Issue.record("Expected the oversized Grok response to close the stream")
+        } catch let GrokRPCError.malformed(message) {
+            #expect(message == "grok agent stdio closed stdout")
+        } catch {
+            Issue.record("Unexpected Grok overflow error: \(error)")
+        }
+        #expect(start.duration(to: .now) < .seconds(5))
+
+        let pidText = try String(contentsOf: pidURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let pid = try #require(pid_t(pidText))
+        let deadline = Date().addingTimeInterval(2)
+        while kill(pid, 0) == 0, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(kill(pid, 0) == -1)
+        #expect(errno == ESRCH)
     }
 }

--- a/Tests/CodexBarTests/BoundedChildProcessProofTests.swift
+++ b/Tests/CodexBarTests/BoundedChildProcessProofTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+@Suite(.serialized)
+struct BoundedChildProcessProofTests {
+    @Test
+    func `synthetic PTY child overflow propagates and cleans up the process`() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarBoundedProcessProof-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let pidURL = directory.appendingPathComponent("child.pid")
+        let scriptURL = directory.appendingPathComponent("overflow-child.sh")
+        let script = """
+        #!/bin/sh
+        printf '%s\\n' "$$" > "$CODEXBAR_PROOF_PID_FILE"
+        /usr/bin/yes x | /usr/bin/head -c 1100000
+        /bin/sleep 30
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CODEXBAR_PROOF_PID_FILE"] = pidURL.path
+        let runner = TTYCommandRunner()
+        do {
+            _ = try runner.run(
+                binary: scriptURL.path,
+                send: "",
+                options: .init(timeout: 10, baseEnvironment: environment, initialDelay: 0))
+            Issue.record("Expected the synthetic child to exceed the PTY output limit")
+        } catch TTYCommandRunner.Error.outputTooLarge {
+            // Expected: the production runner propagated the bounded-output error.
+        } catch {
+            Issue.record("Unexpected overflow error: \(error)")
+        }
+
+        let pidText = try String(contentsOf: pidURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let pid = try #require(pid_t(pidText))
+        #expect(kill(pid, 0) == -1)
+        #expect(errno == ESRCH)
+    }
+
+    @Test
+    func `synthetic Grok RPC child returns a normal framed response`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarBoundedRPCProof-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let scriptURL = directory.appendingPathComponent("grok-proof.sh")
+        let script = """
+        #!/bin/sh
+        IFS= read -r initialize_request
+        printf '%s\\n' '{"jsonrpc":"2.0","id":1,"result":{}}'
+        IFS= read -r billing_request
+        printf '%s\\n' '{"jsonrpc":"2.0","id":2,"result":{"monthlyLimit":{"val":100},"usage":{"totalUsed":{"val":25}}}}'
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        let client = try GrokRPCClient(
+            executable: scriptURL.path,
+            arguments: [],
+            environment: ["PATH": "/usr/bin:/bin"],
+            initializeTimeoutSeconds: 2,
+            requestTimeoutSeconds: 2)
+        defer { client.shutdown() }
+
+        try await client.initialize()
+        let billing = try await client.fetchBilling()
+
+        #expect(billing.monthlyLimit?.val == 100)
+        #expect(billing.usage?.totalUsed?.val == 25)
+        #expect(billing.monthlyUsedPercent == 25)
+    }
+}

--- a/Tests/CodexBarTests/BoundedOutputBufferTests.swift
+++ b/Tests/CodexBarTests/BoundedOutputBufferTests.swift
@@ -39,4 +39,27 @@ struct BoundedOutputBufferTests {
         #expect(!first.didExceedLimit)
         #expect(!second.didExceedLimit)
     }
+
+    @Test
+    func `line buffer drains a completed line before limiting the same chunk tail`() {
+        let buffer = BoundedLineBuffer(maxBytes: 4)
+
+        let partial = buffer.appendAndDrainLines(Data("abc".utf8))
+        let completed = buffer.appendAndDrainLines(Data("d\nxy".utf8))
+
+        #expect(!partial.didExceedLimit)
+        #expect(completed.lines == [Data("abcd".utf8)])
+        #expect(!completed.didExceedLimit)
+    }
+
+    @Test
+    func `line buffer rejects an oversized line even when newline arrives`() {
+        let buffer = BoundedLineBuffer(maxBytes: 4)
+
+        _ = buffer.appendAndDrainLines(Data("abc".utf8))
+        let overflow = buffer.appendAndDrainLines(Data("de\n".utf8))
+
+        #expect(overflow.lines.isEmpty)
+        #expect(overflow.didExceedLimit)
+    }
 }

--- a/Tests/CodexBarTests/BoundedOutputBufferTests.swift
+++ b/Tests/CodexBarTests/BoundedOutputBufferTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct BoundedOutputBufferTests {
+    @Test
+    func `output buffer rejects data beyond its byte limit`() {
+        var buffer = BoundedOutputBuffer(maxBytes: 4)
+
+        let accepted = buffer.append(Data("abcd".utf8))
+        let rejected = buffer.append(Data("e".utf8))
+
+        #expect(accepted)
+        #expect(!rejected)
+        #expect(buffer.data == Data("abcd".utf8))
+    }
+
+    @Test
+    func `line buffer rejects an unterminated line beyond its byte limit`() {
+        let buffer = BoundedLineBuffer(maxBytes: 4)
+
+        let first = buffer.appendAndDrainLines(Data("abcd".utf8))
+        let overflow = buffer.appendAndDrainLines(Data("e".utf8))
+
+        #expect(first.lines.isEmpty)
+        #expect(!first.didExceedLimit)
+        #expect(overflow.lines.isEmpty)
+        #expect(overflow.didExceedLimit)
+    }
+
+    @Test
+    func `line buffer frees completed lines before accepting more output`() {
+        let buffer = BoundedLineBuffer(maxBytes: 4)
+
+        let first = buffer.appendAndDrainLines(Data("a\n".utf8))
+        let second = buffer.appendAndDrainLines(Data("bcde".utf8))
+
+        #expect(first.lines == [Data("a".utf8)])
+        #expect(!first.didExceedLimit)
+        #expect(!second.didExceedLimit)
+    }
+}


### PR DESCRIPTION
## Summary
- bound PTY and cached Codex/Claude CLI output to 1 MiB, returning an explicit error and cleaning up the child process on overflow
- bound newline-delimited Codex and Grok RPC buffers so an unterminated response terminates the child instead of growing in memory
- drain complete RPC records before enforcing the retained partial-line limit
- add focused buffer-boundary and real synthetic-child process coverage

## Root cause
Several CLI and RPC paths appended child-process output to `Data` without a total byte limit. A misbehaving process or an unterminated RPC line could therefore grow memory until its timeout. The first bounded line-buffer implementation also checked the combined partial buffer and incoming chunk before draining complete records, which could reject a healthy same-chunk newline response.

## Real process proof
Ran the PR branch on macOS against two real synthetic child processes. The overflow child wrote its PID, produced 1,100,000 bytes through a real PTY, and then attempted to sleep for 30 seconds. The production runner propagated `outputTooLarge`; the test then verified `kill(pid, 0) == -1` with `ESRCH`, proving cleanup reaped the child instead of leaving it running. A second real stdio child completed Grok `initialize` and `x.ai/billing` JSON-RPC exchanges and returned a decoded 25% result.

```console
$ swift test --disable-sandbox --scratch-path /private/tmp/codexbar-pr-fixes --filter BoundedChildProcessProofTests
◇ Suite BoundedChildProcessProofTests started.
◇ Test "synthetic PTY child overflow propagates and cleans up the process" started.
warning com.steipete.codexbar.tty-runner: binary=overflow-child.sh PTY output exceeded memory limit
✔ Test "synthetic PTY child overflow propagates and cleans up the process" passed after 4.340 seconds.
◇ Test "synthetic Grok RPC child returns a normal framed response" started.
✔ Test "synthetic Grok RPC child returns a normal framed response" passed after 1.222 seconds.
✔ Suite BoundedChildProcessProofTests passed after 5.562 seconds.
✔ Test run with 2 tests in 1 suite passed after 5.562 seconds.
```

The proof uses generated scripts and synthetic JSON only; it contains no credentials, account identifiers, or provider data.

## Validation
- `swift test --filter BoundedOutputBufferTests` — 5 tests passed
- `swift test --disable-sandbox --scratch-path /private/tmp/codexbar-pr-fixes --filter BoundedChildProcessProofTests` — 2 real child-process tests passed
- `swift test --filter TTYCommandRunnerEnvTests` (one timing-sensitive test was rerun in isolation and passed)
- changed-file SwiftFormat, SwiftLint, and `git diff --check` — clean
- `make check`
