### PR TITLE
Make URLProtocol test stubs' handler thread-safe

### DIFF
--- a/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
@@ -1076,7 +1076,11 @@ struct AlibabaCodingPlanUsageFetcherRequestTests {
 }
 
 final class AlibabaUsageFetcherStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "bailian.console.aliyun.com"
@@ -1106,7 +1110,11 @@ final class AlibabaUsageFetcherStubURLProtocol: URLProtocol {
 }
 
 final class AlibabaConsoleSECTokenStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         guard let host = request.url?.host else { return false }

--- a/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
@@ -893,7 +893,11 @@ struct AlibabaTokenPlanWebStrategyTests {
 }
 
 final class AlibabaTokenPlanStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         guard let host = request.url?.host else { return false }

--- a/Tests/CodexBarTests/AmpUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AmpUsageFetcherTests.swift
@@ -271,7 +271,11 @@ private final class AmpSessionFinishRecorder: @unchecked Sendable {
 }
 
 private final class AmpStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host?.hasSuffix("ampcode.com") == true

--- a/Tests/CodexBarTests/BedrockUsageStatsTests.swift
+++ b/Tests/CodexBarTests/BedrockUsageStatsTests.swift
@@ -683,7 +683,11 @@ private final class BedrockRequestCapture: @unchecked Sendable {
 }
 
 final class BedrockStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "bedrock.test"

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
@@ -648,7 +648,11 @@ struct ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests {
 }
 
 private final class ClaudeOAuthTokenRefreshStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     static func reset() {
         self.handler = nil

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -1299,7 +1299,11 @@ struct ClaudeAutoFetcherCharacterizationTests {
 }
 
 final class ClaudeAutoFetcherStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "claude.ai"

--- a/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
@@ -437,7 +437,12 @@ private actor CodebuffRequestGate {
 }
 
 final class CodebuffStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
+
     nonisolated(unsafe) static var requests: [URLRequest] = []
     nonisolated(unsafe) static var requestBodies: [Data?] = []
 

--- a/Tests/CodexBarTests/CodexOpenAIWorkspaceResolverTests.swift
+++ b/Tests/CodexBarTests/CodexOpenAIWorkspaceResolverTests.swift
@@ -140,7 +140,11 @@ struct CodexOpenAIWorkspaceResolverTests {
 
 final class CodexOpenAIWorkspaceStubURLProtocol: URLProtocol {
     nonisolated(unsafe) static var requests: [URLRequest] = []
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<(@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         true

--- a/Tests/CodexBarTests/CopilotBudgetWebFetcherTests.swift
+++ b/Tests/CodexBarTests/CopilotBudgetWebFetcherTests.swift
@@ -655,7 +655,12 @@ struct CopilotBudgetWebFetcherTests {
 
 final class CopilotBudgetBindingStubURLProtocol: URLProtocol {
     private static let lock = NSLock()
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, URLResponse))?
+    private static let _handlerBox = LockIsolated<(@Sendable (URLRequest) throws -> (Data, URLResponse))?>(nil)
+    static var handler: (@Sendable (URLRequest) throws -> (Data, URLResponse))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
+
     private nonisolated(unsafe) static var recordedRequests: [URLRequest] = []
 
     static func reset() {

--- a/Tests/CodexBarTests/CrofUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CrofUsageFetcherTests.swift
@@ -205,7 +205,12 @@ struct CrofUsageFetcherTests {
 }
 
 final class CrofStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
+
     nonisolated(unsafe) static var requests: [URLRequest] = []
 
     override static func canInit(with request: URLRequest) -> Bool {

--- a/Tests/CodexBarTests/CrossModelUsageStatsTests.swift
+++ b/Tests/CodexBarTests/CrossModelUsageStatsTests.swift
@@ -612,7 +612,11 @@ private final class CrossModelRequestPathRecorder: @unchecked Sendable {
 }
 
 final class CrossModelStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "crossmodel.test"

--- a/Tests/CodexBarTests/ElevenLabsUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/ElevenLabsUsageFetcherTests.swift
@@ -149,7 +149,11 @@ struct ElevenLabsUsageFetcherTests {
 }
 
 final class ElevenLabsStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "elevenlabs.test"

--- a/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
+++ b/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
@@ -760,7 +760,12 @@ struct FactoryStatusProbeFetchTests {
 }
 
 final class FactoryStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
+
     nonisolated(unsafe) static var requests: [URLRequest] = []
 
     override static func canInit(with request: URLRequest) -> Bool {

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -833,7 +833,11 @@ struct GrokWebBillingFetcherTests {
 final class GrokWebBillingStubURLProtocol: URLProtocol {
     nonisolated(unsafe) static var requests: [URLRequest] = []
     nonisolated(unsafe) static var requestBodies: [Data?] = []
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<(@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with _: URLRequest) -> Bool {
         true

--- a/Tests/CodexBarTests/LockIsolated.swift
+++ b/Tests/CodexBarTests/LockIsolated.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// A minimal `NSLock`-backed thread-safe box used by the `URLProtocol` test stubs to hold
+/// their per-test `handler` closure.
+///
+/// The stubs' `handler` is read on URLSession's background thread (`canInit` / `startLoading`)
+/// while tests assign it from another thread. Storing it here and exposing `handler` as a
+/// computed property over the box serializes both the read and the write without changing any
+/// call site. Before this, the stubs used an unsynchronized `nonisolated(unsafe) static var`,
+/// which ThreadSanitizer reports as a data race under parallel Swift Testing.
+final class LockIsolated<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Value
+
+    init(_ value: Value) {
+        self.storage = value
+    }
+
+    var value: Value {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.storage
+    }
+
+    func setValue(_ value: Value) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.storage = value
+    }
+}

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -1200,7 +1200,11 @@ extension MiMoProviderTests {
 }
 
 final class MiMoStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "mimo.test"

--- a/Tests/CodexBarTests/MiniMaxAPITokenFetchTests.swift
+++ b/Tests/CodexBarTests/MiniMaxAPITokenFetchTests.swift
@@ -201,7 +201,12 @@ struct MiniMaxAPITokenFetchTests {
 }
 
 final class MiniMaxAPITokenStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
+
     nonisolated(unsafe) static var requests: [URLRequest] = []
 
     override static func canInit(with request: URLRequest) -> Bool {

--- a/Tests/CodexBarTests/MoonshotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/MoonshotUsageFetcherTests.swift
@@ -189,7 +189,11 @@ struct MoonshotUsageFetcherTests {
 
 final class MoonshotStubURLProtocol: URLProtocol {
     nonisolated(unsafe) static var requests: [URLRequest] = []
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<(@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with _: URLRequest) -> Bool {
         true

--- a/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
@@ -534,7 +534,11 @@ private final class OllamaSessionFinishRecorder: @unchecked Sendable {
 }
 
 final class OllamaRetryMappingStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         guard let host = request.url?.host?.lowercased() else { return false }

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -844,7 +844,11 @@ struct OpenCodeGoUsageFetcherErrorTests {
 }
 
 final class OpenCodeGoStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "opencode.ai"

--- a/Tests/CodexBarTests/OpenCodeUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeUsageFetcherErrorTests.swift
@@ -279,7 +279,11 @@ struct OpenCodeUsageFetcherErrorTests {
 }
 
 final class OpenCodeStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "opencode.ai"

--- a/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
+++ b/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
@@ -265,7 +265,11 @@ struct OpenRouterUsageStatsTests {
 }
 
 final class OpenRouterStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "openrouter.test"

--- a/Tests/CodexBarTests/ProviderHTTPClientTests.swift
+++ b/Tests/CodexBarTests/ProviderHTTPClientTests.swift
@@ -242,7 +242,12 @@ private actor ScriptedHTTPTransport: ProviderHTTPTransport {
 }
 
 final class StubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (Data, URLResponse))?
+    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (Data, URLResponse))?>(nil)
+    static var handler: ((URLRequest) throws -> (Data, URLResponse))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
+
     nonisolated(unsafe) static var requests: [URLRequest] = []
 
     override static func canInit(with request: URLRequest) -> Bool {

--- a/Tests/CodexBarTests/StepFunUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/StepFunUsageFetcherTests.swift
@@ -769,7 +769,11 @@ private final class StepFunRequestRecorder: @unchecked Sendable {
 }
 
 private final class StepFunStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<(@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "platform.stepfun.com"

--- a/Tests/CodexBarTests/StubURLProtocolHandlerConcurrencyTests.swift
+++ b/Tests/CodexBarTests/StubURLProtocolHandlerConcurrencyTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+/// Regression probe for the `URLProtocol` test-stub `handler` data race fixed by backing each
+/// stub's handler with a `LockIsolated` box. The stubs store their per-test handler in a static
+/// that URLSession reads on a background thread while the test assigns it from another — a data
+/// race under ThreadSanitizer. This mirrors that exact shape on a representative stub-style static
+/// and asserts TSan sees no race once the storage is boxed.
+///
+/// Opt-in: it hammers a static thousands of times, so it is gated behind `CODEXBAR_TSAN_STRESS` and
+/// run in isolation via `CODEXBAR_TSAN_STRESS=1 swift test --sanitize=thread --filter
+/// StubURLProtocolHandlerConcurrencyTests`, never in the normal parallel suite.
+private enum StubHandlerRaceProbe {
+    // Mirrors the fixed stub shape: handler stored behind a LockIsolated box, exposed as a
+    // computed property so read and write are both serialized.
+    private static let box = LockIsolated<(@Sendable (Int) -> Int)?>(nil)
+    static var handler: (@Sendable (Int) -> Int)? {
+        get { self.box.value }
+        set { self.box.setValue(newValue) }
+    }
+}
+
+@Suite(.serialized)
+struct StubURLProtocolHandlerConcurrencyTests {
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["CODEXBAR_TSAN_STRESS"] == "1"))
+    func `concurrent stub handler writes and reads are race-free`() {
+        let iterations = 5000
+        let lanes = 4
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "stub-handler.concurrency", attributes: .concurrent)
+        for lane in 0..<lanes {
+            group.enter()
+            queue.async {
+                for i in 0..<iterations {
+                    if (lane + i) % 2 == 0 {
+                        StubHandlerRaceProbe.handler = { $0 + lane }
+                    } else {
+                        _ = StubHandlerRaceProbe.handler
+                    }
+                }
+                group.leave()
+            }
+        }
+        group.wait()
+        StubHandlerRaceProbe.handler = nil
+    }
+}

--- a/Tests/CodexBarTests/StubURLProtocolHandlerConcurrencyTests.swift
+++ b/Tests/CodexBarTests/StubURLProtocolHandlerConcurrencyTests.swift
@@ -1,25 +1,15 @@
 import Foundation
 import Testing
 
-/// Regression probe for the `URLProtocol` test-stub `handler` data race fixed by backing each
+/// Regression test for the `URLProtocol` test-stub `handler` data race fixed by backing each
 /// stub's handler with a `LockIsolated` box. The stubs store their per-test handler in a static
 /// that URLSession reads on a background thread while the test assigns it from another — a data
-/// race under ThreadSanitizer. This mirrors that exact shape on a representative stub-style static
-/// and asserts TSan sees no race once the storage is boxed.
+/// race under ThreadSanitizer. This hammers the real representative stub from
+/// `ProviderHTTPClientTests` so the test covers the production declaration rather than a copy.
 ///
 /// Opt-in: it hammers a static thousands of times, so it is gated behind `CODEXBAR_TSAN_STRESS` and
 /// run in isolation via `CODEXBAR_TSAN_STRESS=1 swift test --sanitize=thread --filter
 /// StubURLProtocolHandlerConcurrencyTests`, never in the normal parallel suite.
-private enum StubHandlerRaceProbe {
-    // Mirrors the fixed stub shape: handler stored behind a LockIsolated box, exposed as a
-    // computed property so read and write are both serialized.
-    private static let box = LockIsolated<(@Sendable (Int) -> Int)?>(nil)
-    static var handler: (@Sendable (Int) -> Int)? {
-        get { self.box.value }
-        set { self.box.setValue(newValue) }
-    }
-}
-
 @Suite(.serialized)
 struct StubURLProtocolHandlerConcurrencyTests {
     @Test(.enabled(if: ProcessInfo.processInfo.environment["CODEXBAR_TSAN_STRESS"] == "1"))
@@ -33,15 +23,15 @@ struct StubURLProtocolHandlerConcurrencyTests {
             queue.async {
                 for i in 0..<iterations {
                     if (lane + i) % 2 == 0 {
-                        StubHandlerRaceProbe.handler = { $0 + lane }
+                        StubURLProtocol.handler = { _ in throw URLError(.badServerResponse) }
                     } else {
-                        _ = StubHandlerRaceProbe.handler
+                        _ = StubURLProtocol.handler
                     }
                 }
                 group.leave()
             }
         }
         group.wait()
-        StubHandlerRaceProbe.handler = nil
+        StubURLProtocol.handler = nil
     }
 }

--- a/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
+++ b/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
@@ -534,7 +534,11 @@ struct WindsurfWebFetcherTests {
 
 final class WindsurfWebFetcherStubURLProtocol: URLProtocol {
     nonisolated(unsafe) static var requests: [URLRequest] = []
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static let _handlerBox = LockIsolated<(@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
+    static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { Self._handlerBox.value }
+        set { Self._handlerBox.setValue(newValue) }
+    }
 
     override static func canInit(with _: URLRequest) -> Bool {
         true


### PR DESCRIPTION
## Summary

Twenty-five `URLProtocol` test stubs stored their response handler in an unsynchronized mutable static. Tests assign that closure while `URLSession` reads it from a background thread, producing ThreadSanitizer races under parallel testing.

This adds a small test-only `NSLock`-backed `LockIsolated<Value>` and preserves every existing stub call site through a computed `handler` property. Reads and writes are serialized; handlers are still invoked after the lock is released.

Maintainer review strengthened the regression proof. The opt-in ThreadSanitizer stress test now hammers the real `StubURLProtocol.handler` declaration from `ProviderHTTPClientTests`, not a duplicate probe that could drift from production test code.

## Proof

- `CODEXBAR_TSAN_STRESS=1 swift test --sanitize=thread --filter StubURLProtocolHandlerConcurrencyTests`: 1/1 passed; no ThreadSanitizer race.
- `make check`: passed; zero violations.
- `make test`: 645 selections across 54/54 groups; zero failures, retries, or timeouts.
- Autoreview: clean, 0.96 confidence.

No changelog entry: test-only synchronization.

The existing unsynchronized request-recorder arrays remain separate follow-up scope.

Part of #2200.
