### PR TITLE
Remove Claude keychain global test overrides

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+TestingOverrides.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+TestingOverrides.swift
@@ -2,8 +2,6 @@ import Foundation
 
 #if DEBUG
 extension ClaudeOAuthCredentialsStore {
-    nonisolated(unsafe) static var claudeKeychainDataOverride: Data?
-    nonisolated(unsafe) static var claudeKeychainFingerprintOverride: ClaudeKeychainFingerprint?
     @TaskLocal static var taskClaudeKeychainDataOverride: Data?
     @TaskLocal static var taskClaudeKeychainFingerprintOverride: ClaudeKeychainFingerprint?
     @TaskLocal static var taskMemoryCacheStoreOverride: MemoryCacheStore?
@@ -51,14 +49,6 @@ extension ClaudeOAuthCredentialsStore {
     final class MemoryCacheStore: @unchecked Sendable {
         var record: ClaudeOAuthCredentialRecord?
         var timestamp: Date?
-    }
-
-    static func setClaudeKeychainDataOverrideForTesting(_ data: Data?) {
-        self.claudeKeychainDataOverride = data
-    }
-
-    static func setClaudeKeychainFingerprintOverrideForTesting(_ fingerprint: ClaudeKeychainFingerprint?) {
-        self.claudeKeychainFingerprintOverride = fingerprint
     }
 
     static func withClaudeKeychainOverridesForTesting<T>(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -635,9 +635,7 @@ public enum ClaudeOAuthCredentialsStore {
                 {
                     return (try? ClaudeOAuthCredentials.parse(data: data)) != nil
                 }
-                if let data = ClaudeOAuthCredentialsStore.taskClaudeKeychainDataOverride
-                    ?? ClaudeOAuthCredentialsStore.claudeKeychainDataOverride
-                {
+                if let data = ClaudeOAuthCredentialsStore.taskClaudeKeychainDataOverride {
                     return (try? ClaudeOAuthCredentials.parse(data: data)) != nil
                 }
                 #endif
@@ -931,7 +929,6 @@ public enum ClaudeOAuthCredentialsStore {
                 #if DEBUG
                 let override = ClaudeOAuthCredentialsStore.taskClaudeKeychainOverrideStore?.data
                     ?? ClaudeOAuthCredentialsStore.taskClaudeKeychainDataOverride
-                    ?? ClaudeOAuthCredentialsStore.claudeKeychainDataOverride
                 if let override,
                    !override.isEmpty,
                    let creds = try? ClaudeOAuthCredentials.parse(data: override),
@@ -1426,8 +1423,8 @@ public enum ClaudeOAuthCredentialsStore {
                 data: store.data,
                 persistentRefHash: store.fingerprint?.persistentRefHash).map { .value($0) } ?? .unavailable
         }
-        let overrideData = self.taskClaudeKeychainDataOverride ?? self.claudeKeychainDataOverride
-        let overrideFingerprint = self.taskClaudeKeychainFingerprintOverride ?? self.claudeKeychainFingerprintOverride
+        let overrideData = self.taskClaudeKeychainDataOverride
+        let overrideFingerprint = self.taskClaudeKeychainFingerprintOverride
         if overrideData != nil || overrideFingerprint != nil {
             return self.makeClaudeKeychainCredentialEvidence(
                 data: overrideData,
@@ -1541,12 +1538,12 @@ public enum ClaudeOAuthCredentialsStore {
                 return true
             }
         }
-        if let data = self.taskClaudeKeychainDataOverride ?? self.claudeKeychainDataOverride,
+        if let data = self.taskClaudeKeychainDataOverride,
            !data.isEmpty
         {
             return true
         }
-        if self.taskClaudeKeychainFingerprintOverride ?? self.claudeKeychainFingerprintOverride != nil {
+        if self.taskClaudeKeychainFingerprintOverride != nil {
             return true
         }
         #endif
@@ -1574,9 +1571,7 @@ public enum ClaudeOAuthCredentialsStore {
         // Unit tests can supply TaskLocal overrides for the Claude keychain data/fingerprint. Those tests often run
         // concurrently with other suites, so the global throttle becomes nondeterministic. When an override is
         // present, bypass the throttle so test expectations don't depend on unrelated activity.
-        if self.taskClaudeKeychainOverrideStore != nil || self.taskClaudeKeychainFingerprintOverride != nil
-            || self.claudeKeychainFingerprintOverride != nil
-        {
+        if self.taskClaudeKeychainOverrideStore != nil || self.taskClaudeKeychainFingerprintOverride != nil {
             return true
         }
         #endif
@@ -1642,9 +1637,7 @@ public enum ClaudeOAuthCredentialsStore {
         if let store = taskClaudeKeychainOverrideStore {
             return .value(store.fingerprint)
         }
-        if let override = taskClaudeKeychainFingerprintOverride ?? self
-            .claudeKeychainFingerprintOverride
-        {
+        if let override = taskClaudeKeychainFingerprintOverride {
             return .value(override)
         }
         #endif
@@ -1718,7 +1711,7 @@ public enum ClaudeOAuthCredentialsStore {
         if let store = taskClaudeKeychainOverrideStore {
             return store.data
         }
-        if let override = taskClaudeKeychainDataOverride ?? self.claudeKeychainDataOverride {
+        if let override = taskClaudeKeychainDataOverride {
             return override
         }
         #endif
@@ -1754,7 +1747,7 @@ public enum ClaudeOAuthCredentialsStore {
         if let store = self.taskClaudeKeychainOverrideStore {
             return store.data
         }
-        if let override = self.taskClaudeKeychainDataOverride ?? self.claudeKeychainDataOverride {
+        if let override = self.taskClaudeKeychainDataOverride {
             return override
         }
         #endif
@@ -1791,7 +1784,7 @@ public enum ClaudeOAuthCredentialsStore {
         if let store = taskClaudeKeychainOverrideStore, let override = store.data {
             return override
         }
-        if let override = taskClaudeKeychainDataOverride ?? self.claudeKeychainDataOverride {
+        if let override = taskClaudeKeychainDataOverride {
             return override
         }
         #endif
@@ -1837,7 +1830,7 @@ public enum ClaudeOAuthCredentialsStore {
         if let store = taskClaudeKeychainOverrideStore, let override = store.data {
             return override
         }
-        if let override = taskClaudeKeychainDataOverride ?? self.claudeKeychainDataOverride {
+        if let override = taskClaudeKeychainDataOverride {
             return override
         }
         #endif
@@ -2452,8 +2445,6 @@ public enum ClaudeOAuthCredentialsStore {
     static func _resetClaudeKeychainChangeTrackingForTesting() {
         UserDefaults.standard.removeObject(forKey: self.claudeKeychainFingerprintKey)
         UserDefaults.standard.removeObject(forKey: self.claudeKeychainFingerprintLegacyKey)
-        self.setClaudeKeychainDataOverrideForTesting(nil)
-        self.setClaudeKeychainFingerprintOverrideForTesting(nil)
         self.claudeKeychainChangeCheckLock.lock()
         self.lastClaudeKeychainChangeCheckAt = nil
         self.claudeKeychainChangeCheckLock.unlock()

--- a/Tests/CodexBarTests/ClaudeKeychainOverrideIsolationTests.swift
+++ b/Tests/CodexBarTests/ClaudeKeychainOverrideIsolationTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+private actor TwoTaskBarrier {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            self.continuations.append(continuation)
+            guard self.continuations.count == 2 else {
+                return
+            }
+            let continuations = self.continuations
+            self.continuations.removeAll()
+            continuations.forEach { $0.resume() }
+        }
+    }
+}
+
+struct ClaudeKeychainOverrideIsolationTests {
+    @Test
+    func `keychain overrides stay isolated across concurrent tasks`() async {
+        let expected = [Data([0x01]), Data([0x02])]
+        let barrier = TwoTaskBarrier()
+        let observed = await withTaskGroup(of: Data?.self, returning: [Data].self) { group in
+            for data in expected {
+                group.addTask {
+                    await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+                        data: data,
+                        fingerprint: nil)
+                    {
+                        await barrier.wait()
+                        return ClaudeOAuthCredentialsStore.taskClaudeKeychainDataOverride
+                    }
+                }
+            }
+
+            var values: [Data] = []
+            for await value in group {
+                if let value {
+                    values.append(value)
+                }
+            }
+            return values
+        }
+
+        #expect(Set(observed) == Set(expected))
+        #expect(ClaudeOAuthCredentialsStore.taskClaudeKeychainDataOverride == nil)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreSecurityCLITests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreSecurityCLITests.swift
@@ -35,8 +35,6 @@ struct ClaudeOAuthCredentialsStoreSecurityCLITests {
                 defer {
                     ClaudeOAuthCredentialsStore.invalidateCache()
                     ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
-                    ClaudeOAuthCredentialsStore.setClaudeKeychainDataOverrideForTesting(nil)
-                    ClaudeOAuthCredentialsStore.setClaudeKeychainFingerprintOverrideForTesting(nil)
                 }
 
                 let tempDir = FileManager.default.temporaryDirectory
@@ -89,8 +87,6 @@ struct ClaudeOAuthCredentialsStoreSecurityCLITests {
                 defer {
                     ClaudeOAuthCredentialsStore.invalidateCache()
                     ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
-                    ClaudeOAuthCredentialsStore.setClaudeKeychainDataOverrideForTesting(nil)
-                    ClaudeOAuthCredentialsStore.setClaudeKeychainFingerprintOverrideForTesting(nil)
                 }
 
                 let tempDir = FileManager.default.temporaryDirectory
@@ -148,8 +144,6 @@ struct ClaudeOAuthCredentialsStoreSecurityCLITests {
                 defer {
                     ClaudeOAuthCredentialsStore.invalidateCache()
                     ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
-                    ClaudeOAuthCredentialsStore.setClaudeKeychainDataOverrideForTesting(nil)
-                    ClaudeOAuthCredentialsStore.setClaudeKeychainFingerprintOverrideForTesting(nil)
                 }
 
                 let tempDir = FileManager.default.temporaryDirectory
@@ -205,8 +199,6 @@ struct ClaudeOAuthCredentialsStoreSecurityCLITests {
                 defer {
                     ClaudeOAuthCredentialsStore.invalidateCache()
                     ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
-                    ClaudeOAuthCredentialsStore.setClaudeKeychainDataOverrideForTesting(nil)
-                    ClaudeOAuthCredentialsStore.setClaudeKeychainFingerprintOverrideForTesting(nil)
                 }
 
                 let tempDir = FileManager.default.temporaryDirectory

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreTests.swift
@@ -505,8 +505,6 @@ struct ClaudeOAuthCredentialsStoreTests {
                     defer {
                         ClaudeOAuthCredentialsStore.invalidateCache()
                         ClaudeOAuthCredentialsStore._resetClaudeKeychainChangeTrackingForTesting()
-                        ClaudeOAuthCredentialsStore.setClaudeKeychainDataOverrideForTesting(nil)
-                        ClaudeOAuthCredentialsStore.setClaudeKeychainFingerprintOverrideForTesting(nil)
                     }
 
                     // Avoid cross-suite interference from UserDefaults fingerprint persistence.
@@ -599,8 +597,6 @@ struct ClaudeOAuthCredentialsStoreTests {
                     ClaudeOAuthCredentialsStore.invalidateCache()
                     ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
                     ClaudeOAuthCredentialsStore._resetClaudeKeychainChangeTrackingForTesting()
-                    ClaudeOAuthCredentialsStore.setClaudeKeychainDataOverrideForTesting(nil)
-                    ClaudeOAuthCredentialsStore.setClaudeKeychainFingerprintOverrideForTesting(nil)
                 }
 
                 let tempDir = FileManager.default.temporaryDirectory

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -34,10 +34,12 @@ struct PlatformGatingTests {
         let cliFetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in
             Self.makeClaudeStatus()
         }
-        let outcome = await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
-            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
-                context: context,
-                provider: .claude)
+        let outcome = await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(binaryURL.path) {
+            await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
+                await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                    context: context,
+                    provider: .claude)
+            }
         }
         let result = try outcome.result.get()
 


### PR DESCRIPTION
## Summary
- remove the legacy process-global Claude keychain data/fingerprint test overrides
- keep the Claude keychain test path on the existing task-local override scope
- drop now-redundant nil cleanup calls from the affected tests
- add a barrier-backed concurrency regression proving independent task-local values and parent restoration
- stabilize the Linux planner fallback test by scoping its synthetic CLI resolver override

Addresses part of #2204.

## Testing
- `swift test --filter 'keychain overrides stay isolated across concurrent tasks'` (1 test passed)
- `make check`
- `make test` (646 selections, 54 groups, zero failures, zero retries)
- `autoreview --mode branch --base origin/main --parallel-tests 'make test'` (clean, 0.93)
- final `autoreview --mode branch --base origin/main` after Linux CI repair (clean, 0.95)

No changelog entry: internal test synchronization only; no user-visible behavior change.
