### PR TITLE
Harden selected Cursor session isolation

### DIFF
--- a/Sources/CodexBar/CursorLoginRunner.swift
+++ b/Sources/CodexBar/CursorLoginRunner.swift
@@ -221,6 +221,9 @@ final class CursorLoginRunner {
             return result
         }
 
+        guard !Task.isCancelled else {
+            return self.cancelAfterTaskCancellation()
+        }
         let launched = await self.launchRoute(route)
         guard !Task.isCancelled else {
             return self.cancelAfterTaskCancellation()

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -10,10 +10,29 @@ import Glibc
 import Musl
 #endif
 
-public enum CookieHeaderCache {
-    public enum AuthenticationFailurePolicy: String, Codable, Equatable, Sendable {
-        case stopFallback
+public enum CookieAuthenticationFailurePolicy: String, Codable, Equatable, Sendable {
+    case stopFallback
+}
+
+public struct CookieHeaderCacheEntry: Codable, Equatable, Sendable {
+    public let cookieHeader: String
+    public let storedAt: Date
+    public let sourceLabel: String
+    public let authenticationFailurePolicy: CookieAuthenticationFailurePolicy?
+
+    public init(
+        cookieHeader: String,
+        storedAt: Date,
+        sourceLabel: String,
+        authenticationFailurePolicy: CookieAuthenticationFailurePolicy? = nil)
+    {
+        (self.cookieHeader, self.storedAt) = (cookieHeader, storedAt)
+        (self.sourceLabel, self.authenticationFailurePolicy) = (sourceLabel, authenticationFailurePolicy)
     }
+}
+
+public enum CookieHeaderCache {
+    public typealias AuthenticationFailurePolicy = CookieAuthenticationFailurePolicy
 
     public enum Scope: Sendable, Equatable {
         case managedAccount(UUID)
@@ -66,24 +85,7 @@ public enum CookieHeaderCache {
         }
     }
 
-    public struct Entry: Codable, Equatable, Sendable {
-        public let cookieHeader: String
-        public let storedAt: Date
-        public let sourceLabel: String
-        public let authenticationFailurePolicy: AuthenticationFailurePolicy?
-
-        public init(
-            cookieHeader: String,
-            storedAt: Date,
-            sourceLabel: String,
-            authenticationFailurePolicy: AuthenticationFailurePolicy? = nil)
-        {
-            self.cookieHeader = cookieHeader
-            self.storedAt = storedAt
-            self.sourceLabel = sourceLabel
-            self.authenticationFailurePolicy = authenticationFailurePolicy
-        }
-    }
+    public typealias Entry = CookieHeaderCacheEntry
 
     public struct ClearSummary: Equatable, Sendable {
         public let clearedCount: Int
@@ -958,7 +960,7 @@ extension CookieHeaderCache {
         scope: Scope? = nil,
         cookieHeader: String,
         sourceLabel: String,
-        authenticationFailurePolicy: AuthenticationFailurePolicy? = nil,
+        authenticationFailurePolicy: CookieAuthenticationFailurePolicy? = nil,
         now: Date = Date()) -> Bool
     {
         let trimmed = cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -11,6 +11,10 @@ import Musl
 #endif
 
 public enum CookieHeaderCache {
+    public enum AuthenticationFailurePolicy: String, Codable, Equatable, Sendable {
+        case stopFallback
+    }
+
     public enum Scope: Sendable, Equatable {
         case managedAccount(UUID)
         case managedStoreUnreadable
@@ -62,15 +66,22 @@ public enum CookieHeaderCache {
         }
     }
 
-    public struct Entry: Codable, Sendable {
+    public struct Entry: Codable, Equatable, Sendable {
         public let cookieHeader: String
         public let storedAt: Date
         public let sourceLabel: String
+        public let authenticationFailurePolicy: AuthenticationFailurePolicy?
 
-        public init(cookieHeader: String, storedAt: Date, sourceLabel: String) {
+        public init(
+            cookieHeader: String,
+            storedAt: Date,
+            sourceLabel: String,
+            authenticationFailurePolicy: AuthenticationFailurePolicy? = nil)
+        {
             self.cookieHeader = cookieHeader
             self.storedAt = storedAt
             self.sourceLabel = sourceLabel
+            self.authenticationFailurePolicy = authenticationFailurePolicy
         }
     }
 
@@ -550,6 +561,7 @@ public enum CookieHeaderCache {
         return current.cookieHeader == expected.cookieHeader
             && current.storedAt == expected.storedAt
             && current.sourceLabel == expected.sourceLabel
+            && current.authenticationFailurePolicy == expected.authenticationFailurePolicy
     }
 
     @discardableResult
@@ -946,11 +958,16 @@ extension CookieHeaderCache {
         scope: Scope? = nil,
         cookieHeader: String,
         sourceLabel: String,
+        authenticationFailurePolicy: AuthenticationFailurePolicy? = nil,
         now: Date = Date()) -> Bool
     {
         let trimmed = cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let normalized = CookieHeaderNormalizer.normalize(trimmed), !normalized.isEmpty else { return false }
-        let entry = Entry(cookieHeader: normalized, storedAt: now, sourceLabel: sourceLabel)
+        let entry = Entry(
+            cookieHeader: normalized,
+            storedAt: now,
+            sourceLabel: sourceLabel,
+            authenticationFailurePolicy: authenticationFailurePolicy)
         do {
             return try self.withLegacyMutationLock {
                 self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -998,6 +998,12 @@ extension CookieHeaderCache {
                 gateGeneration
             }
         }
+
+        /// Updates the expected cache contents after this flow clears its observed entry without
+        /// accepting interactive mutations that happened after the original observation.
+        func afterOwnedClear() -> Self {
+            .authoritative(nil, gateGeneration: self.gateGeneration)
+        }
     }
 
     /// Captures enough state to conditionally persist an asynchronous refresh after a transient

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -481,7 +481,7 @@ public enum CookieHeaderCache {
         let entry = Entry(cookieHeader: normalized, storedAt: now, sourceLabel: sourceLabel)
         do {
             try self.withLegacyMutationLock {
-                _ = self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+                _ = self.storeLocked(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
             }
         } catch {
             self.log.error("Cookie cache store lock failed: \(error)")
@@ -505,7 +505,7 @@ public enum CookieHeaderCache {
         do {
             return try self.withLegacyMutationLock {
                 guard self.currentEntryMatches(expected, provider: provider, scope: scope) else { return false }
-                return self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+                return self.storeLocked(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
             }
         } catch {
             self.log.error("Cookie cache conditional store lock failed: \(error)")
@@ -567,12 +567,15 @@ public enum CookieHeaderCache {
     }
 
     @discardableResult
-    private static func store(
+    private static func storeLocked(
         entry: Entry,
         provider: UsageProvider,
         scope: Scope?,
         sourceLabel: String) -> Bool
     {
+        guard entry.authenticationFailurePolicy == .stopFallback
+            || !self.hasPinnedEntry(provider: provider, scope: scope)
+        else { return false }
         let key = self.key(for: provider, scope: scope)
         guard KeychainCacheStore.storeResult(key: key, entry: entry) else { return false }
         self.updateDisplaySnapshot(key: key, entry: entry)
@@ -972,7 +975,7 @@ extension CookieHeaderCache {
             authenticationFailurePolicy: authenticationFailurePolicy)
         do {
             return try self.withLegacyMutationLock {
-                self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+                self.storeLocked(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
             }
         } catch {
             self.log.error("Cookie cache observable store lock failed: \(error)")
@@ -1067,7 +1070,7 @@ extension CookieHeaderCache {
             do {
                 return try self.withLegacyMutationLock {
                     guard self.currentStateMatches(expected, provider: provider, scope: scope) else { return false }
-                    return self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+                    return self.storeLocked(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
                 }
             } catch {
                 self.log.error("Cookie cache observed store lock failed: \(error)")
@@ -1097,6 +1100,21 @@ extension CookieHeaderCache {
         case (nil, nil): true
         case let (current?, expected?): self.entriesMatch(current, expected)
         default: false
+        }
+    }
+
+    private static func hasPinnedEntry(provider: UsageProvider, scope: Scope?) -> Bool {
+        let key = self.key(for: provider, scope: scope)
+        switch KeychainCacheStore.load(key: key, as: Entry.self) {
+        case let .found(current):
+            return current.authenticationFailurePolicy == .stopFallback
+        case .temporarilyUnavailable:
+            return true
+        case .missing:
+            return scope == nil
+                && self.loadLegacyEntry(for: provider)?.authenticationFailurePolicy == .stopFallback
+        case .invalid:
+            return false
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Cursor/CursorBrowserLoginModels.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorBrowserLoginModels.swift
@@ -25,7 +25,8 @@ extension CursorStatusProbe {
         CookieHeaderCache.storeResult(
             provider: .cursor,
             cookieHeader: session.cookieHeader,
-            sourceLabel: session.sourceLabel)
+            sourceLabel: session.sourceLabel,
+            authenticationFailurePolicy: .stopFallback)
     }
 }
 #else

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -1008,39 +1008,16 @@ public struct CursorStatusProbe: Sendable {
            let cached = CookieHeaderCache.load(provider: .cursor),
            !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
-            log("Using cached cookie header from \(cached.sourceLabel)")
-            do {
-                return try await self.fetchWithCookieHeader(cached.cookieHeader)
-            } catch let error as CursorStatusProbeError {
-                if case .notLoggedIn = error {
-                    if cached.authenticationFailurePolicy == .stopFallback {
-                        if let replacement = CookieHeaderCache.load(provider: .cursor), replacement != cached {
-                            log("Selected cached session changed while its request was in flight; retrying replacement")
-                            return try await self.fetch(
-                                cookieHeaderOverride: cookieHeaderOverride,
-                                allowCachedSessions: allowCachedSessions,
-                                allowAppAuthFallback: allowAppAuthFallback,
-                                logger: logger)
-                        }
-                        log("Selected cached session was rejected; refusing automatic account fallback")
-                        throw error
-                    }
-                    guard CookieHeaderCache.clearIfCurrent(provider: .cursor, expected: cached) else {
-                        if let replacement = CookieHeaderCache.load(provider: .cursor), replacement != cached {
-                            log("Cached session changed while its request was in flight; retrying replacement")
-                            return try await self.fetch(
-                                cookieHeaderOverride: cookieHeaderOverride,
-                                allowCachedSessions: allowCachedSessions,
-                                allowAppAuthFallback: allowAppAuthFallback,
-                                logger: logger)
-                        }
-                        throw error
-                    }
-                } else {
-                    throw error
-                }
-            } catch {
-                throw error
+            switch try await self.fetchCachedSession(
+                cached,
+                cookieHeaderOverride: cookieHeaderOverride,
+                allowCachedSessions: allowCachedSessions,
+                allowAppAuthFallback: allowAppAuthFallback,
+                logger: logger,
+                log: log)
+            {
+            case let .succeeded(snapshot): return snapshot
+            case .resumeFallback: break
             }
         }
 
@@ -1146,6 +1123,51 @@ public struct CursorStatusProbe: Sendable {
         }
 
         throw CursorStatusProbeError.noSessionCookie
+    }
+
+    private enum CachedSessionFetchResult {
+        case succeeded(CursorStatusSnapshot)
+        case resumeFallback
+    }
+
+    private func fetchCachedSession(
+        _ cached: CookieHeaderCache.Entry,
+        cookieHeaderOverride: String?,
+        allowCachedSessions: Bool,
+        allowAppAuthFallback: Bool,
+        logger: ((String) -> Void)?,
+        log: @escaping (String) -> Void) async throws -> CachedSessionFetchResult
+    {
+        log("Using cached cookie header from \(cached.sourceLabel)")
+        do {
+            return try await .succeeded(self.fetchWithCookieHeader(cached.cookieHeader))
+        } catch let error as CursorStatusProbeError {
+            guard case .notLoggedIn = error else { throw error }
+            if let replacement = CookieHeaderCache.load(provider: .cursor), replacement != cached {
+                log("Cached session changed while its request was in flight; retrying replacement")
+                return try await .succeeded(self.fetch(
+                    cookieHeaderOverride: cookieHeaderOverride,
+                    allowCachedSessions: allowCachedSessions,
+                    allowAppAuthFallback: allowAppAuthFallback,
+                    logger: logger))
+            }
+            if cached.authenticationFailurePolicy == .stopFallback {
+                log("Selected cached session was rejected; refusing automatic account fallback")
+                throw error
+            }
+            guard CookieHeaderCache.clearIfCurrent(provider: .cursor, expected: cached) else {
+                if let replacement = CookieHeaderCache.load(provider: .cursor), replacement != cached {
+                    log("Cached session changed before stale-session cleanup; retrying replacement")
+                    return try await .succeeded(self.fetch(
+                        cookieHeaderOverride: cookieHeaderOverride,
+                        allowCachedSessions: allowCachedSessions,
+                        allowAppAuthFallback: allowAppAuthFallback,
+                        logger: logger))
+                }
+                throw error
+            }
+            return .resumeFallback
+        }
     }
 
     /// Fetch every API-valid session from the exact browser that opened an interactive login URL.

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -1001,7 +1001,7 @@ public struct CursorStatusProbe: Sendable {
         #if os(macOS)
         // Capture before any authentication request can suspend. A later browser fallback must not replace an
         // interactive login that commits while this refresh is awaiting an earlier cached-session request.
-        let cacheObservation = CookieHeaderCache.observeForConditionalMutation(provider: .cursor)
+        var cacheObservation = CookieHeaderCache.observeForConditionalMutation(provider: .cursor)
         #endif
 
         if allowCachedSessions,
@@ -1016,7 +1016,12 @@ public struct CursorStatusProbe: Sendable {
                 log: log)
             {
             case let .succeeded(snapshot): return snapshot
-            case .resumeFallback: break
+            case .resumeFallback:
+                #if os(macOS)
+                // The cached-session path cleared its own stale entry. Browser fallback now owns that empty slot,
+                // while the original gate generation still protects any concurrent interactive login.
+                cacheObservation = cacheObservation.afterOwnedClear()
+                #endif
             }
         }
 

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -1013,7 +1013,29 @@ public struct CursorStatusProbe: Sendable {
                 return try await self.fetchWithCookieHeader(cached.cookieHeader)
             } catch let error as CursorStatusProbeError {
                 if case .notLoggedIn = error {
-                    CookieHeaderCache.clear(provider: .cursor)
+                    if cached.authenticationFailurePolicy == .stopFallback {
+                        if let replacement = CookieHeaderCache.load(provider: .cursor), replacement != cached {
+                            log("Selected cached session changed while its request was in flight; retrying replacement")
+                            return try await self.fetch(
+                                cookieHeaderOverride: cookieHeaderOverride,
+                                allowCachedSessions: allowCachedSessions,
+                                allowAppAuthFallback: allowAppAuthFallback,
+                                logger: logger)
+                        }
+                        log("Selected cached session was rejected; refusing automatic account fallback")
+                        throw error
+                    }
+                    guard CookieHeaderCache.clearIfCurrent(provider: .cursor, expected: cached) else {
+                        if let replacement = CookieHeaderCache.load(provider: .cursor), replacement != cached {
+                            log("Cached session changed while its request was in flight; retrying replacement")
+                            return try await self.fetch(
+                                cookieHeaderOverride: cookieHeaderOverride,
+                                allowCachedSessions: allowCachedSessions,
+                                allowAppAuthFallback: allowAppAuthFallback,
+                                logger: logger)
+                        }
+                        throw error
+                    }
                 } else {
                     throw error
                 }

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -1011,7 +1011,6 @@ public struct CursorStatusProbe: Sendable {
             switch try await self.fetchCachedSession(
                 cached,
                 cookieHeaderOverride: cookieHeaderOverride,
-                allowCachedSessions: allowCachedSessions,
                 allowAppAuthFallback: allowAppAuthFallback,
                 logger: logger,
                 log: log)
@@ -1133,7 +1132,6 @@ public struct CursorStatusProbe: Sendable {
     private func fetchCachedSession(
         _ cached: CookieHeaderCache.Entry,
         cookieHeaderOverride: String?,
-        allowCachedSessions: Bool,
         allowAppAuthFallback: Bool,
         logger: ((String) -> Void)?,
         log: @escaping (String) -> Void) async throws -> CachedSessionFetchResult
@@ -1147,7 +1145,7 @@ public struct CursorStatusProbe: Sendable {
                 log("Cached session changed while its request was in flight; retrying replacement")
                 return try await .succeeded(self.fetch(
                     cookieHeaderOverride: cookieHeaderOverride,
-                    allowCachedSessions: allowCachedSessions,
+                    allowCachedSessions: true,
                     allowAppAuthFallback: allowAppAuthFallback,
                     logger: logger))
             }
@@ -1160,7 +1158,7 @@ public struct CursorStatusProbe: Sendable {
                     log("Cached session changed before stale-session cleanup; retrying replacement")
                     return try await .succeeded(self.fetch(
                         cookieHeaderOverride: cookieHeaderOverride,
-                        allowCachedSessions: allowCachedSessions,
+                        allowCachedSessions: true,
                         allowAppAuthFallback: allowAppAuthFallback,
                         logger: logger))
                 }

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -1147,6 +1147,12 @@ public struct CursorStatusProbe: Sendable {
         } catch let error as CursorStatusProbeError {
             guard case .notLoggedIn = error else { throw error }
             if let replacement = CookieHeaderCache.load(provider: .cursor), replacement != cached {
+                if cached.authenticationFailurePolicy == .stopFallback,
+                   replacement.authenticationFailurePolicy != .stopFallback
+                {
+                    log("Selected cached session was rejected; ignoring an unselected cache replacement")
+                    throw error
+                }
                 log("Cached session changed while its request was in flight; retrying replacement")
                 return try await .succeeded(self.fetch(
                     cookieHeaderOverride: cookieHeaderOverride,

--- a/Tests/CodexBarTests/CookieHeaderCacheConditionalMutationTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheConditionalMutationTests.swift
@@ -145,6 +145,42 @@ struct CookieHeaderCacheConditionalMutationTests {
     }
 
     @Test
+    func `owned clear observation accepts fallback but preserves gate generation`() {
+        self.withIsolatedCookieCache {
+            let scope = CookieHeaderCache.Scope.providerVariant(UUID().uuidString)
+            CookieHeaderCache.store(
+                provider: .cursor,
+                scope: scope,
+                cookieHeader: "fixtureSession=stale",
+                sourceLabel: "Stale")
+            let stale = CookieHeaderCache.load(provider: .cursor, scope: scope)
+            let observation = CookieHeaderCache.observeForConditionalMutation(provider: .cursor, scope: scope)
+
+            #expect(CookieHeaderCache.clearIfCurrent(provider: .cursor, scope: scope, expected: stale))
+            let afterClear = observation.afterOwnedClear()
+            #expect(CookieHeaderCache.storeIfObservationCurrent(
+                provider: .cursor,
+                scope: scope,
+                expected: afterClear,
+                cookieHeader: "fixtureSession=browser-fallback",
+                sourceLabel: "Browser fallback"))
+
+            let nextObservation = CookieHeaderCache.observeForConditionalMutation(provider: .cursor, scope: scope)
+            let fallback = CookieHeaderCache.load(provider: .cursor, scope: scope)
+            #expect(CookieHeaderCache.clearIfCurrent(provider: .cursor, scope: scope, expected: fallback))
+            let gate = CookieHeaderCache.beginConditionalMutationGate(provider: .cursor, scope: scope)
+            CookieHeaderCache.endConditionalMutationGate(gate)
+
+            #expect(!CookieHeaderCache.storeIfObservationCurrent(
+                provider: .cursor,
+                scope: scope,
+                expected: nextObservation.afterOwnedClear(),
+                cookieHeader: "fixtureSession=late-background",
+                sourceLabel: "Background"))
+        }
+    }
+
+    @Test
     func `observation captured during cancelled interactive mutation remains stale`() {
         self.withIsolatedCookieCache {
             let scope = CookieHeaderCache.Scope.providerVariant(UUID().uuidString)

--- a/Tests/CodexBarTests/CursorLoginRunnerTests.swift
+++ b/Tests/CodexBarTests/CursorLoginRunnerTests.swift
@@ -96,6 +96,40 @@ struct CursorLoginRunnerTests {
     }
 
     @Test
+    func `cancellation during browser selection does not launch the browser`() async {
+        let launchedRoutes = LockedArray<CursorLoginBrowserRouter.Route>()
+        let runner = CursorLoginRunner(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            timeout: 1,
+            pollInterval: 0.01,
+            launchRoute: { route in
+                launchedRoutes.append(route)
+                return true
+            },
+            loadSnapshot: {
+                Issue.record("Cancelled login should not poll for an account")
+                return Self.snapshot(email: "cursor@example.com")
+            },
+            sleeper: { _ in },
+            browserApplicationResolver: { _ in Self.cometApplicationURL },
+            routeResolver: { loginURL, browserApplicationURL in
+                withUnsafeCurrentTask { $0?.cancel() }
+                return .route(CursorLoginBrowserRouter.Route(
+                    launchURL: loginURL,
+                    browserApplicationURL: browserApplicationURL ?? Self.cometApplicationURL))
+            },
+            replaceSessionCache: { _ in true })
+
+        let result = await Task { await runner.run { _ in } }.value
+
+        guard case .cancelled = result.outcome else {
+            Issue.record("Expected cancellation before browser launch")
+            return
+        }
+        #expect(launchedRoutes.snapshot().isEmpty)
+    }
+
+    @Test
     func `interactive login allows an explicit cookie retry in user initiated context`() async {
         var observedInteraction: ProviderInteraction?
         var retryAllowed = false

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1202,6 +1202,100 @@ extension CursorStatusProbeTests {
         #expect(testSession.requestCookies.contains("cached=bad"))
         #expect(!testSession.requestCookies.contains(appCookie))
     }
+
+    @Test
+    func `rejected selected session does not fall back to another account`() async throws {
+        let selectedSession = CursorStatusProbe.BrowserLoginSession(
+            cookieHeader: "selected=expired",
+            sourceLabel: "Selected browser")
+        #expect(CursorStatusProbe.commitBrowserLoginSession(selectedSession))
+        defer { CookieHeaderCache.clear(provider: .cursor) }
+
+        let accessToken = try makeCursorAppAuthToken()
+        let appSession = CursorAppAuthSession(accessToken: accessToken)
+        let appCookie = try appSession.cookieHeader()
+        let testSession = CursorStatusProbeTestSession { request in
+            let requestURL = try #require(request.url)
+            let cookie = request.value(forHTTPHeaderField: "Cookie")
+            if cookie == appCookie {
+                Issue.record("Rejected selected session unexpectedly switched to Cursor.app auth")
+                throw URLError(.userAuthenticationRequired)
+            }
+            return makeCursorStatusProbeResponse(
+                url: requestURL,
+                body: #"{"error":"unauthorized"}"#,
+                statusCode: 401)
+        }
+
+        let baseURL = try #require(URL(string: "https://cursor-web.test"))
+        let probe = CursorStatusProbe(
+            baseURL: baseURL,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            browserCookieImportOrder: [],
+            urlSession: testSession.urlSession,
+            appAuthStore: CursorAppAuthSessionProviderStub(session: appSession))
+
+        await #expect(throws: CursorStatusProbeError.self) {
+            _ = try await probe.fetch()
+        }
+        await #expect(throws: CursorStatusProbeError.self) {
+            _ = try await probe.fetch()
+        }
+        #expect(testSession.requestCookies.contains("selected=expired"))
+        #expect(!testSession.requestCookies.contains(appCookie))
+        #expect(CookieHeaderCache.load(provider: .cursor)?.authenticationFailurePolicy == .stopFallback)
+    }
+
+    @Test
+    func `rejected stale request retries a concurrently selected session`() async throws {
+        let staleSession = CursorStatusProbe.BrowserLoginSession(
+            cookieHeader: "selected=stale",
+            sourceLabel: "Stale browser")
+        let replacementSession = CursorStatusProbe.BrowserLoginSession(
+            cookieHeader: "selected=replacement",
+            sourceLabel: "Replacement browser")
+        #expect(CursorStatusProbe.commitBrowserLoginSession(staleSession))
+        defer { CookieHeaderCache.clear(provider: .cursor) }
+
+        let testSession = CursorStatusProbeTestSession { request in
+            let requestURL = try #require(request.url)
+            let cookie = request.value(forHTTPHeaderField: "Cookie")
+            if cookie == staleSession.cookieHeader {
+                #expect(CursorStatusProbe.commitBrowserLoginSession(replacementSession))
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: #"{"error":"unauthorized"}"#,
+                    statusCode: 401)
+            }
+            #expect(cookie == replacementSession.cookieHeader)
+            switch requestURL.path {
+            case "/api/usage-summary":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: #"{"membershipType":"pro","individualUsage":{}}"#,
+                    statusCode: 200)
+            case "/api/auth/me":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: #"{"email":"replacement@example.com","sub":"auth0|replacement"}"#,
+                    statusCode: 200)
+            default:
+                throw URLError(.badURL)
+            }
+        }
+
+        let baseURL = try #require(URL(string: "https://cursor-web.test"))
+        let snapshot = try await CursorStatusProbe(
+            baseURL: baseURL,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            browserCookieImportOrder: [],
+            urlSession: testSession.urlSession,
+            appAuthStore: CursorAppAuthSessionProviderStub(session: nil)).fetch()
+
+        #expect(snapshot.accountEmail == "replacement@example.com")
+        #expect(CookieHeaderCache.load(provider: .cursor)?.cookieHeader == replacementSession.cookieHeader)
+        #expect(CookieHeaderCache.load(provider: .cursor)?.authenticationFailurePolicy == .stopFallback)
+    }
 }
 
 private func makeCursorAppAuthToken(

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1296,6 +1296,47 @@ extension CursorStatusProbeTests {
         #expect(CookieHeaderCache.load(provider: .cursor)?.cookieHeader == replacementSession.cookieHeader)
         #expect(CookieHeaderCache.load(provider: .cursor)?.authenticationFailurePolicy == .stopFallback)
     }
+
+    @Test
+    func `rejected selected session ignores an unselected cache replacement`() async throws {
+        let selectedSession = CursorStatusProbe.BrowserLoginSession(
+            cookieHeader: "selected=stale",
+            sourceLabel: "Selected browser")
+        #expect(CursorStatusProbe.commitBrowserLoginSession(selectedSession))
+        defer { CookieHeaderCache.clear(provider: .cursor) }
+
+        let testSession = CursorStatusProbeTestSession { request in
+            let requestURL = try #require(request.url)
+            let cookie = request.value(forHTTPHeaderField: "Cookie")
+            if cookie == selectedSession.cookieHeader {
+                #expect(!CookieHeaderCache.storeResult(
+                    provider: .cursor,
+                    cookieHeader: "background=replacement",
+                    sourceLabel: "Background refresh"))
+            } else {
+                Issue.record("Rejected selected session unexpectedly switched to \(cookie ?? "<none>")")
+            }
+            return makeCursorStatusProbeResponse(
+                url: requestURL,
+                body: #"{"error":"unauthorized"}"#,
+                statusCode: 401)
+        }
+
+        let baseURL = try #require(URL(string: "https://cursor-web.test"))
+        let probe = CursorStatusProbe(
+            baseURL: baseURL,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            browserCookieImportOrder: [],
+            urlSession: testSession.urlSession,
+            appAuthStore: CursorAppAuthSessionProviderStub(session: nil))
+
+        await #expect(throws: CursorStatusProbeError.self) {
+            _ = try await probe.fetch()
+        }
+        #expect(!testSession.requestCookies.contains("background=replacement"))
+        #expect(CookieHeaderCache.load(provider: .cursor)?.cookieHeader == selectedSession.cookieHeader)
+        #expect(CookieHeaderCache.load(provider: .cursor)?.authenticationFailurePolicy == .stopFallback)
+    }
 }
 
 private func makeCursorAppAuthToken(


### PR DESCRIPTION
### Summary

- keep an interactively selected Cursor session pinned across rejected refreshes
- prevent automatic/background cache writes from replacing a pinned account
- retry only a newer explicitly selected session, never an unrelated cache replacement
- preserve cache ownership across stale-session clearing and concurrent interactive login
- stop cancelled browser-selection flows before launching a browser

Follow-up hardening for #2206. Refs #2197. Thanks @chapati23 for the original browser-bound account-switch flow.

### Verification

- `make check` — passed with 0 SwiftLint violations
- focused `CursorStatusProbeTests` and `CookieHeaderCacheConditionalMutationTests` — passed
- `make test` — 651/651 selections, 55/55 groups, 0 failures, 0 retries, 0 timeouts
- whole-branch autoreview — clean after resolving selected-session replacement and cache-ownership races

### Notes

No screenshot: this is session ownership, cancellation, and cache-race behavior with no persistent UI change. Regression coverage exercises rejected selected sessions, concurrent explicit replacement, attempted background replacement, stale-cache recovery, and mutation-gate invalidation.
