### PR TITLE
Remove cookie importer global test overrides

### DIFF
--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -43,6 +43,7 @@ public enum KeychainCacheStore {
     private static let cacheLabel = "CodexBar Cache"
     private nonisolated(unsafe) static var globalServiceOverride: String?
     @TaskLocal private static var serviceOverride: String?
+    @TaskLocal private static var forceImplicitTestStore = false
     #if DEBUG
     @TaskLocal private static var operationRecorder: OperationRecorder?
 
@@ -287,6 +288,22 @@ public enum KeychainCacheStore {
     {
         let service = self.serviceOverride
         return try await self.$serviceOverride.withValue(service) {
+            try await operation()
+        }
+    }
+
+    static func withImplicitTestStoreForTesting<T>(
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$forceImplicitTestStore.withValue(true) {
+            try operation()
+        }
+    }
+
+    static func withImplicitTestStoreForTesting<T>(
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$forceImplicitTestStore.withValue(true) {
             try await operation()
         }
     }
@@ -585,7 +602,9 @@ public enum KeychainCacheStore {
     {
         self.testStoreLock.lock()
         defer { self.testStoreLock.unlock() }
-        guard let store = self.testStore ?? (self.shouldUseImplicitTestStore ? self.implicitTestStore : nil)
+        guard let store = self.forceImplicitTestStore
+            ? self.implicitTestStore
+            : self.testStore ?? (self.shouldUseImplicitTestStore ? self.implicitTestStore : nil)
         else { return nil }
         let testKey = TestStoreKey(service: self.serviceName, account: key.account)
         guard let data = store[testKey] else { return .missing }
@@ -602,6 +621,10 @@ public enum KeychainCacheStore {
         let encoder = Self.makeEncoder()
         guard let data = try? encoder.encode(entry) else { return false }
         let testKey = TestStoreKey(service: self.serviceName, account: key.account)
+        if self.forceImplicitTestStore {
+            self.implicitTestStore[testKey] = data
+            return true
+        }
         if var store = self.testStore {
             store[testKey] = data
             self.testStore = store
@@ -618,6 +641,9 @@ public enum KeychainCacheStore {
         self.testStoreLock.lock()
         defer { self.testStoreLock.unlock() }
         let testKey = TestStoreKey(service: self.serviceName, account: key.account)
+        if self.forceImplicitTestStore {
+            return self.implicitTestStore.removeValue(forKey: testKey) != nil
+        }
         if var store = self.testStore {
             let removed = store.removeValue(forKey: testKey) != nil
             self.testStore = store
@@ -632,7 +658,9 @@ public enum KeychainCacheStore {
     private static func keysFromTestStore(category: String) -> [Key]? {
         self.testStoreLock.lock()
         defer { self.testStoreLock.unlock() }
-        guard let store = self.testStore ?? (self.shouldUseImplicitTestStore ? self.implicitTestStore : nil)
+        guard let store = self.forceImplicitTestStore
+            ? self.implicitTestStore
+            : self.testStore ?? (self.shouldUseImplicitTestStore ? self.implicitTestStore : nil)
         else { return nil }
         return store.keys
             .filter { $0.service == self.serviceName }

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanCookieImporter.swift
@@ -63,16 +63,45 @@ public enum AlibabaCodingPlanCookieImporter {
         }
     }
 
-    nonisolated(unsafe) static var importSessionOverrideForTesting:
-        ((BrowserDetection, ((String) -> Void)?) throws -> SessionInfo)?
+    #if DEBUG
+    final class ImportSessionOverrideStore: @unchecked Sendable {
+        let importSession: (BrowserDetection, ((String) -> Void)?) throws -> SessionInfo
+
+        init(importSession: @escaping (BrowserDetection, ((String) -> Void)?) throws -> SessionInfo) {
+            self.importSession = importSession
+        }
+    }
+
+    @TaskLocal private static var taskImportSessionOverrideStore: ImportSessionOverrideStore?
+
+    static func withImportSessionOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) throws -> SessionInfo)?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$taskImportSessionOverrideStore.withValue(override.map(ImportSessionOverrideStore.init)) {
+            try operation()
+        }
+    }
+
+    static func withImportSessionOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) throws -> SessionInfo)?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskImportSessionOverrideStore.withValue(override.map(ImportSessionOverrideStore.init)) {
+            try await operation()
+        }
+    }
+    #endif
 
     public static func importSession(
         browserDetection: BrowserDetection,
         logger: ((String) -> Void)? = nil) throws -> SessionInfo
     {
-        if let override = self.importSessionOverrideForTesting {
+        #if DEBUG
+        if let override = self.taskImportSessionOverrideStore?.importSession {
             return try override(browserDetection, logger)
         }
+        #endif
         let log: (String) -> Void = { msg in logger?("[alibaba-cookie] \(msg)") }
         var accessDeniedHints: [String] = []
         var failureDetails: [String] = []

--- a/Sources/CodexBarCore/Providers/Devin/DevinSessionImporter.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinSessionImporter.swift
@@ -5,8 +5,26 @@ import SweetCookieKit
 
 #if os(macOS)
 enum DevinSessionImporter {
-    nonisolated(unsafe) static var importSessionOverrideForTesting:
-        ((BrowserDetection, String?, ((String) -> Void)?) -> SessionInfo?)?
+    #if DEBUG
+    final class ImportSessionOverrideStore: @unchecked Sendable {
+        let importSession: (BrowserDetection, String?, ((String) -> Void)?) -> SessionInfo?
+
+        init(importSession: @escaping (BrowserDetection, String?, ((String) -> Void)?) -> SessionInfo?) {
+            self.importSession = importSession
+        }
+    }
+
+    @TaskLocal private static var taskImportSessionOverrideStore: ImportSessionOverrideStore?
+
+    static func withImportSessionOverrideForTesting<T>(
+        _ override: ((BrowserDetection, String?, ((String) -> Void)?) -> SessionInfo?)?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskImportSessionOverrideStore.withValue(override.map(ImportSessionOverrideStore.init)) {
+            try await operation()
+        }
+    }
+    #endif
 
     private static let storageOrigin = "https://app.devin.ai"
     private static let externalOrgPrefix = "last-internal-org-for-external-org-v1-"
@@ -28,9 +46,11 @@ enum DevinSessionImporter {
         organizationOverride: String? = nil,
         logger: ((String) -> Void)? = nil) -> SessionInfo?
     {
-        if let override = self.importSessionOverrideForTesting {
+        #if DEBUG
+        if let override = self.taskImportSessionOverrideStore?.importSession {
             return override(browserDetection, organizationOverride, logger)
         }
+        #endif
 
         let sessions = self.importSessions(
             browserDetection: browserDetection,
@@ -44,9 +64,11 @@ enum DevinSessionImporter {
         organizationOverride: String? = nil,
         logger: ((String) -> Void)? = nil) -> [SessionInfo]
     {
-        if let override = self.importSessionOverrideForTesting {
+        #if DEBUG
+        if let override = self.taskImportSessionOverrideStore?.importSession {
             return override(browserDetection, organizationOverride, logger).map { [$0] } ?? []
         }
+        #endif
 
         let log: (String) -> Void = { msg in logger?("[devin-storage] \(msg)") }
         let candidates = self.chromeLocalStorageCandidates(browserDetection: browserDetection)

--- a/Sources/CodexBarCore/Providers/Manus/ManusCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Manus/ManusCookieImporter.swift
@@ -9,10 +9,44 @@ public enum ManusCookieImporter {
     private static let cookieDomains = ["manus.im", "www.manus.im"]
     private static let cookieImportOrder: BrowserCookieImportOrder =
         ProviderDefaults.metadata[.manus]?.browserCookieOrder ?? Browser.defaultImportOrder
-    nonisolated(unsafe) static var importSessionOverrideForTesting:
-        ((BrowserDetection, ((String) -> Void)?) throws -> SessionInfo)?
-    nonisolated(unsafe) static var importSessionsOverrideForTesting:
-        ((BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo])?
+    #if DEBUG
+    final class ImportSessionOverrideStore: @unchecked Sendable {
+        let importSession: (BrowserDetection, ((String) -> Void)?) throws -> SessionInfo
+
+        init(importSession: @escaping (BrowserDetection, ((String) -> Void)?) throws -> SessionInfo) {
+            self.importSession = importSession
+        }
+    }
+
+    final class ImportSessionsOverrideStore: @unchecked Sendable {
+        let importSessions: (BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo]
+
+        init(importSessions: @escaping (BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo]) {
+            self.importSessions = importSessions
+        }
+    }
+
+    @TaskLocal private static var taskImportSessionOverrideStore: ImportSessionOverrideStore?
+    @TaskLocal private static var taskImportSessionsOverrideStore: ImportSessionsOverrideStore?
+
+    static func withImportSessionOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) throws -> SessionInfo)?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskImportSessionOverrideStore.withValue(override.map(ImportSessionOverrideStore.init)) {
+            try await operation()
+        }
+    }
+
+    static func withImportSessionsOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo])?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskImportSessionsOverrideStore.withValue(override.map(ImportSessionsOverrideStore.init)) {
+            try await operation()
+        }
+    }
+    #endif
 
     public struct SessionInfo: Sendable {
         public let cookies: [HTTPCookie]
@@ -32,12 +66,14 @@ public enum ManusCookieImporter {
         browserDetection: BrowserDetection = BrowserDetection(),
         logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
     {
-        if let override = self.importSessionsOverrideForTesting {
+        #if DEBUG
+        if let override = self.taskImportSessionsOverrideStore?.importSessions {
             return try override(browserDetection, logger)
         }
-        if let override = self.importSessionOverrideForTesting {
+        if let override = self.taskImportSessionOverrideStore?.importSession {
             return try [override(browserDetection, logger)]
         }
+        #endif
 
         var sessions: [SessionInfo] = []
         let candidates = self.cookieImportOrder.cookieImportCandidates(using: browserDetection)

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
@@ -118,16 +118,45 @@ public enum MiMoCookieImporter {
         }
     }
 
-    nonisolated(unsafe) static var importSessionsOverrideForTesting:
-        ((BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo])?
+    #if DEBUG
+    final class ImportSessionsOverrideStore: @unchecked Sendable {
+        let importSessions: (BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo]
+
+        init(importSessions: @escaping (BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo]) {
+            self.importSessions = importSessions
+        }
+    }
+
+    @TaskLocal private static var taskImportSessionsOverrideStore: ImportSessionsOverrideStore?
+
+    static func withImportSessionsOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo])?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$taskImportSessionsOverrideStore.withValue(override.map(ImportSessionsOverrideStore.init)) {
+            try operation()
+        }
+    }
+
+    static func withImportSessionsOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo])?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskImportSessionsOverrideStore.withValue(override.map(ImportSessionsOverrideStore.init)) {
+            try await operation()
+        }
+    }
+    #endif
 
     public static func importSessions(
         browserDetection: BrowserDetection,
         logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
     {
-        if let override = self.importSessionsOverrideForTesting {
+        #if DEBUG
+        if let override = self.taskImportSessionsOverrideStore?.importSessions {
             return try override(browserDetection, logger)
         }
+        #endif
 
         return try self.importSessions(
             browserDetection: browserDetection,

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityCookieImporter.swift
@@ -11,10 +11,44 @@ public enum PerplexityCookieImporter {
     private static let cookieDomains = ["www.perplexity.ai", "perplexity.ai"]
     private static let cookieImportOrder: BrowserCookieImportOrder =
         ProviderDefaults.metadata[.perplexity]?.browserCookieOrder ?? Browser.defaultImportOrder
-    nonisolated(unsafe) static var importSessionOverrideForTesting:
-        ((BrowserDetection, ((String) -> Void)?) throws -> SessionInfo)?
-    nonisolated(unsafe) static var importSessionsOverrideForTesting:
-        ((BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo])?
+    #if DEBUG
+    final class ImportSessionOverrideStore: @unchecked Sendable {
+        let importSession: (BrowserDetection, ((String) -> Void)?) throws -> SessionInfo
+
+        init(importSession: @escaping (BrowserDetection, ((String) -> Void)?) throws -> SessionInfo) {
+            self.importSession = importSession
+        }
+    }
+
+    final class ImportSessionsOverrideStore: @unchecked Sendable {
+        let importSessions: (BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo]
+
+        init(importSessions: @escaping (BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo]) {
+            self.importSessions = importSessions
+        }
+    }
+
+    @TaskLocal private static var taskImportSessionOverrideStore: ImportSessionOverrideStore?
+    @TaskLocal private static var taskImportSessionsOverrideStore: ImportSessionsOverrideStore?
+
+    static func withImportSessionOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) throws -> SessionInfo)?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskImportSessionOverrideStore.withValue(override.map(ImportSessionOverrideStore.init)) {
+            try await operation()
+        }
+    }
+
+    static func withImportSessionsOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo])?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskImportSessionsOverrideStore.withValue(override.map(ImportSessionsOverrideStore.init)) {
+            try await operation()
+        }
+    }
+    #endif
 
     public struct SessionInfo: Sendable {
         public let cookies: [HTTPCookie]
@@ -41,17 +75,19 @@ public enum PerplexityCookieImporter {
         if let cached = self.cachedImportSessions() {
             return cached
         }
-        if let override = self.importSessionsOverrideForTesting {
+        #if DEBUG
+        if let override = self.taskImportSessionsOverrideStore?.importSessions {
             let sessions = try override(browserDetection, logger)
             self.storeImportSessions(sessions)
             return sessions
         }
-        if let override = self.importSessionOverrideForTesting {
+        if let override = self.taskImportSessionOverrideStore?.importSession {
             let session = try override(browserDetection, logger)
             let sessions = [session]
             self.storeImportSessions(sessions)
             return sessions
         }
+        #endif
 
         var sessions: [SessionInfo] = []
         let candidates = self.cookieImportOrder.cookieImportCandidates(using: browserDetection)

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityCookieImporter.swift
@@ -14,17 +14,49 @@ public enum PerplexityCookieImporter {
     #if DEBUG
     final class ImportSessionOverrideStore: @unchecked Sendable {
         let importSession: (BrowserDetection, ((String) -> Void)?) throws -> SessionInfo
+        private let lock = NSLock()
+        private var cachedSessions: [SessionInfo]?
 
         init(importSession: @escaping (BrowserDetection, ((String) -> Void)?) throws -> SessionInfo) {
             self.importSession = importSession
+        }
+
+        func sessions(
+            browserDetection: BrowserDetection,
+            logger: ((String) -> Void)?) throws -> [SessionInfo]
+        {
+            try self.lock.withLock {
+                if let cachedSessions = self.cachedSessions {
+                    return cachedSessions
+                }
+                let sessions = try [self.importSession(browserDetection, logger)]
+                self.cachedSessions = sessions
+                return sessions
+            }
         }
     }
 
     final class ImportSessionsOverrideStore: @unchecked Sendable {
         let importSessions: (BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo]
+        private let lock = NSLock()
+        private var cachedSessions: [SessionInfo]?
 
         init(importSessions: @escaping (BrowserDetection, ((String) -> Void)?) throws -> [SessionInfo]) {
             self.importSessions = importSessions
+        }
+
+        func sessions(
+            browserDetection: BrowserDetection,
+            logger: ((String) -> Void)?) throws -> [SessionInfo]
+        {
+            try self.lock.withLock {
+                if let cachedSessions = self.cachedSessions {
+                    return cachedSessions
+                }
+                let sessions = try self.importSessions(browserDetection, logger)
+                self.cachedSessions = sessions
+                return sessions
+            }
         }
     }
 
@@ -72,22 +104,17 @@ public enum PerplexityCookieImporter {
         browserDetection: BrowserDetection = BrowserDetection(),
         logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
     {
+        #if DEBUG
+        if let overrideStore = self.taskImportSessionsOverrideStore {
+            return try overrideStore.sessions(browserDetection: browserDetection, logger: logger)
+        }
+        if let overrideStore = self.taskImportSessionOverrideStore {
+            return try overrideStore.sessions(browserDetection: browserDetection, logger: logger)
+        }
+        #endif
         if let cached = self.cachedImportSessions() {
             return cached
         }
-        #if DEBUG
-        if let override = self.taskImportSessionsOverrideStore?.importSessions {
-            let sessions = try override(browserDetection, logger)
-            self.storeImportSessions(sessions)
-            return sessions
-        }
-        if let override = self.taskImportSessionOverrideStore?.importSession {
-            let session = try override(browserDetection, logger)
-            let sessions = [session]
-            self.storeImportSessions(sessions)
-            return sessions
-        }
-        #endif
 
         var sessions: [SessionInfo] = []
         let candidates = self.cookieImportOrder.cookieImportCandidates(using: browserDetection)

--- a/Sources/CodexBarCore/Providers/Windsurf/WindsurfDevinSessionImporter.swift
+++ b/Sources/CodexBarCore/Providers/Windsurf/WindsurfDevinSessionImporter.swift
@@ -5,12 +5,50 @@ import SweetCookieKit
 
 #if os(macOS)
 enum WindsurfDevinSessionImporter {
-    nonisolated(unsafe) static var importSessionsOverrideForTesting:
-        ((BrowserDetection, ((String) -> Void)?) -> [SessionInfo])?
-    nonisolated(unsafe) static var importPreferredSessionsOverrideForTesting:
-        ((BrowserDetection, ((String) -> Void)?) -> [SessionInfo])?
-    nonisolated(unsafe) static var importFallbackSessionsOverrideForTesting:
-        ((BrowserDetection, ((String) -> Void)?) -> [SessionInfo])?
+    #if DEBUG
+    final class ImportSessionsOverrideStore: @unchecked Sendable {
+        let importSessions: (BrowserDetection, ((String) -> Void)?) -> [SessionInfo]
+
+        init(importSessions: @escaping (BrowserDetection, ((String) -> Void)?) -> [SessionInfo]) {
+            self.importSessions = importSessions
+        }
+    }
+
+    @TaskLocal private static var taskImportSessionsOverrideStore: ImportSessionsOverrideStore?
+    @TaskLocal private static var taskImportPreferredSessionsOverrideStore: ImportSessionsOverrideStore?
+    @TaskLocal private static var taskImportFallbackSessionsOverrideStore: ImportSessionsOverrideStore?
+
+    static func withImportSessionsOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) -> [SessionInfo])?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskImportSessionsOverrideStore.withValue(override.map(ImportSessionsOverrideStore.init)) {
+            try await operation()
+        }
+    }
+
+    static func withImportPreferredSessionsOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) -> [SessionInfo])?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskImportPreferredSessionsOverrideStore.withValue(
+            override.map(ImportSessionsOverrideStore.init))
+        {
+            try await operation()
+        }
+    }
+
+    static func withImportFallbackSessionsOverrideForTesting<T>(
+        _ override: ((BrowserDetection, ((String) -> Void)?) -> [SessionInfo])?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskImportFallbackSessionsOverrideStore.withValue(
+            override.map(ImportSessionsOverrideStore.init))
+        {
+            try await operation()
+        }
+    }
+    #endif
     static let defaultPreferredBrowsers: [Browser] = [.chrome]
     static let fallbackBrowsers: [Browser] = [
         .chromeBeta,
@@ -40,9 +78,11 @@ enum WindsurfDevinSessionImporter {
         browserDetection: BrowserDetection,
         logger: ((String) -> Void)? = nil) -> [SessionInfo]
     {
-        if let override = self.importSessionsOverrideForTesting {
+        #if DEBUG
+        if let override = self.taskImportSessionsOverrideStore?.importSessions {
             return override(browserDetection, logger)
         }
+        #endif
 
         let log: (String) -> Void = { msg in logger?("[windsurf-storage] \(msg)") }
         let preferredSessions = self.importSessions(
@@ -70,9 +110,11 @@ enum WindsurfDevinSessionImporter {
         browserDetection: BrowserDetection,
         logger: ((String) -> Void)? = nil) -> [SessionInfo]
     {
-        if let override = self.importPreferredSessionsOverrideForTesting {
+        #if DEBUG
+        if let override = self.taskImportPreferredSessionsOverrideStore?.importSessions {
             return override(browserDetection, logger)
         }
+        #endif
         let log: (String) -> Void = { msg in logger?("[windsurf-storage] \(msg)") }
         return self.importSessions(
             browserDetection: browserDetection,
@@ -84,9 +126,11 @@ enum WindsurfDevinSessionImporter {
         browserDetection: BrowserDetection,
         logger: ((String) -> Void)? = nil) -> [SessionInfo]
     {
-        if let override = self.importFallbackSessionsOverrideForTesting {
+        #if DEBUG
+        if let override = self.taskImportFallbackSessionsOverrideStore?.importSessions {
             return override(browserDetection, logger)
         }
+        #endif
         let log: (String) -> Void = { msg in logger?("[windsurf-storage] \(msg)") }
         return self.importSessions(
             browserDetection: browserDetection,

--- a/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
@@ -667,7 +667,7 @@ struct AlibabaCodingPlanFallbackTests {
     }
 
     @Test
-    func `auto mode does not borrow manual cookie authority when browser import fails`() {
+    func `auto mode does not borrow manual cookie authority when browser import fails`() throws {
         let strategy = AlibabaCodingPlanWebFetchStrategy()
         let settings = ProviderSettingsSnapshot.make(
             alibaba: ProviderSettingsSnapshot.AlibabaCodingPlanProviderSettings(
@@ -677,12 +677,9 @@ struct AlibabaCodingPlanFallbackTests {
         let context = self.makeContext(sourceMode: .auto, settings: settings)
 
         CookieHeaderCache.clear(provider: .alibaba)
-        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
-                throw AlibabaCodingPlanSettingsError.missingCookie()
-            }
-
-        try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+        try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting { _, _ in
+            throw AlibabaCodingPlanSettingsError.missingCookie()
+        } operation: {
             do {
                 _ = try AlibabaCodingPlanWebFetchStrategy.resolveCookieHeader(context: context, allowCached: false)
                 Issue.record("Expected auto mode to fail instead of borrowing the manual cookie header")
@@ -699,7 +696,7 @@ struct AlibabaCodingPlanFallbackTests {
     }
 
     @Test
-    func `auto mode skips web when no alibaba session is available`() async {
+    func `auto mode skips web when no alibaba session is available`() async throws {
         let strategy = AlibabaCodingPlanWebFetchStrategy()
         let settings = ProviderSettingsSnapshot.make(
             alibaba: ProviderSettingsSnapshot.AlibabaCodingPlanProviderSettings(
@@ -712,12 +709,9 @@ struct AlibabaCodingPlanFallbackTests {
             env: [AlibabaCodingPlanSettingsReader.apiTokenKey: "token-abc"])
 
         CookieHeaderCache.clear(provider: .alibaba)
-        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
-                throw AlibabaCodingPlanSettingsError.missingCookie()
-            }
-
-        await AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+        try await AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting { _, _ in
+            throw AlibabaCodingPlanSettingsError.missingCookie()
+        } operation: {
             #expect(await strategy.isAvailable(context) == false)
         }
     }

--- a/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
@@ -677,24 +677,24 @@ struct AlibabaCodingPlanFallbackTests {
         let context = self.makeContext(sourceMode: .auto, settings: settings)
 
         CookieHeaderCache.clear(provider: .alibaba)
-        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
-            throw AlibabaCodingPlanSettingsError.missingCookie()
-        }
-        defer {
-            AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil
-        }
-
-        do {
-            _ = try AlibabaCodingPlanWebFetchStrategy.resolveCookieHeader(context: context, allowCached: false)
-            Issue.record("Expected auto mode to fail instead of borrowing the manual cookie header")
-        } catch let error as AlibabaCodingPlanSettingsError {
-            guard case .missingCookie = error else {
-                Issue.record("Expected missingCookie, got \(error)")
-                return
+        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+                throw AlibabaCodingPlanSettingsError.missingCookie()
             }
-            #expect(strategy.shouldFallback(on: error, context: context))
-        } catch {
-            Issue.record("Expected AlibabaCodingPlanSettingsError, got \(error)")
+
+        try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            do {
+                _ = try AlibabaCodingPlanWebFetchStrategy.resolveCookieHeader(context: context, allowCached: false)
+                Issue.record("Expected auto mode to fail instead of borrowing the manual cookie header")
+            } catch let error as AlibabaCodingPlanSettingsError {
+                guard case .missingCookie = error else {
+                    Issue.record("Expected missingCookie, got \(error)")
+                    return
+                }
+                #expect(strategy.shouldFallback(on: error, context: context))
+            } catch {
+                Issue.record("Expected AlibabaCodingPlanSettingsError, got \(error)")
+            }
         }
     }
 
@@ -712,14 +712,14 @@ struct AlibabaCodingPlanFallbackTests {
             env: [AlibabaCodingPlanSettingsReader.apiTokenKey: "token-abc"])
 
         CookieHeaderCache.clear(provider: .alibaba)
-        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
-            throw AlibabaCodingPlanSettingsError.missingCookie()
-        }
-        defer {
-            AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil
-        }
+        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+                throw AlibabaCodingPlanSettingsError.missingCookie()
+            }
 
-        #expect(await strategy.isAvailable(context) == false)
+        await AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            #expect(await strategy.isAvailable(context) == false)
+        }
     }
 }
 

--- a/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
@@ -612,76 +612,75 @@ struct AlibabaTokenPlanWebStrategyTests {
 
     @Test
     func `auto web strategy surfaces cookie import errors`() async throws {
-        let strategy = AlibabaTokenPlanWebFetchStrategy()
-        let settings = ProviderSettingsSnapshot.make(
-            alibabaTokenPlan: ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings(
-                cookieSource: .auto,
-                manualCookieHeader: nil))
-        let context = ProviderFetchContext(
-            runtime: .cli,
-            sourceMode: .web,
-            includeCredits: false,
-            webTimeout: 1,
-            webDebugDumpHTML: false,
-            verbose: false,
-            env: [:],
-            settings: settings,
-            fetcher: UsageFetcher(environment: [:]),
-            claudeFetcher: StubClaudeFetcher(),
-            browserDetection: BrowserDetection(cacheTTL: 0))
+        try await self.withIsolatedCookieCache {
+            let strategy = AlibabaTokenPlanWebFetchStrategy()
+            let settings = ProviderSettingsSnapshot.make(
+                alibabaTokenPlan: ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings(
+                    cookieSource: .auto,
+                    manualCookieHeader: nil))
+            let context = ProviderFetchContext(
+                runtime: .cli,
+                sourceMode: .web,
+                includeCredits: false,
+                webTimeout: 1,
+                webDebugDumpHTML: false,
+                verbose: false,
+                env: [:],
+                settings: settings,
+                fetcher: UsageFetcher(environment: [:]),
+                claudeFetcher: StubClaudeFetcher(),
+                browserDetection: BrowserDetection(cacheTTL: 0))
 
-        self.clearCookieCaches()
-        defer { self.clearCookieCaches() }
+            self.clearCookieCaches()
+            defer { self.clearCookieCaches() }
 
-        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+            try await AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting { _, _ in
                 throw AlibabaCodingPlanSettingsError.missingCookie(
                     details: "macOS Keychain denied access to Chrome Safe Storage.")
-            }
+            } operation: {
+                #expect(await strategy.isAvailable(context))
 
-        try await AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
-            #expect(await strategy.isAvailable(context))
-
-            do {
-                _ = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeader(context: context, allowCached: false)
-                Issue.record("Expected cookie import failure to be surfaced")
-            } catch let error as AlibabaTokenPlanSettingsError {
-                guard case let .missingCookie(details) = error else {
-                    Issue.record("Expected missingCookie, got \(error)")
-                    return
+                do {
+                    _ = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeader(context: context, allowCached: false)
+                    Issue.record("Expected cookie import failure to be surfaced")
+                } catch let error as AlibabaTokenPlanSettingsError {
+                    guard case let .missingCookie(details) = error else {
+                        Issue.record("Expected missingCookie, got \(error)")
+                        return
+                    }
+                    #expect(details == "macOS Keychain denied access to Chrome Safe Storage.")
+                    #expect(error.localizedDescription.contains("Alibaba Token Plan"))
+                    #expect(!error.localizedDescription.contains("Alibaba Coding Plan"))
                 }
-                #expect(details == "macOS Keychain denied access to Chrome Safe Storage.")
-                #expect(error.localizedDescription.contains("Alibaba Token Plan"))
-                #expect(!error.localizedDescription.contains("Alibaba Coding Plan"))
             }
         }
     }
 
     @Test
     func `auto web strategy imports subscription scoped token plan cookies`() throws {
-        let strategy = AlibabaTokenPlanWebFetchStrategy()
-        let settings = ProviderSettingsSnapshot.make(
-            alibabaTokenPlan: ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings(
-                cookieSource: .auto,
-                manualCookieHeader: nil))
-        let context = ProviderFetchContext(
-            runtime: .cli,
-            sourceMode: .web,
-            includeCredits: false,
-            webTimeout: 1,
-            webDebugDumpHTML: false,
-            verbose: false,
-            env: [:],
-            settings: settings,
-            fetcher: UsageFetcher(environment: [:]),
-            claudeFetcher: StubClaudeFetcher(),
-            browserDetection: BrowserDetection(cacheTTL: 0))
+        try self.withIsolatedCookieCache {
+            let strategy = AlibabaTokenPlanWebFetchStrategy()
+            let settings = ProviderSettingsSnapshot.make(
+                alibabaTokenPlan: ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings(
+                    cookieSource: .auto,
+                    manualCookieHeader: nil))
+            let context = ProviderFetchContext(
+                runtime: .cli,
+                sourceMode: .web,
+                includeCredits: false,
+                webTimeout: 1,
+                webDebugDumpHTML: false,
+                verbose: false,
+                env: [:],
+                settings: settings,
+                fetcher: UsageFetcher(environment: [:]),
+                claudeFetcher: StubClaudeFetcher(),
+                browserDetection: BrowserDetection(cacheTTL: 0))
 
-        self.clearCookieCaches()
-        defer { self.clearCookieCaches() }
+            self.clearCookieCaches()
+            defer { self.clearCookieCaches() }
 
-        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+            let headers = try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting { _, _ in
                 AlibabaCodingPlanCookieImporter.SessionInfo(
                     cookies: [
                         self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".alibabacloud.com"),
@@ -697,64 +696,59 @@ struct AlibabaTokenPlanWebStrategyTests {
                         self.cookie(name: "aliyun_only", value: "aliyun", domain: ".aliyun.com"),
                     ],
                     sourceLabel: "Chrome Default")
+            } operation: {
+                try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
             }
 
-        let headers = try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
-            try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
-        }
+            #expect(headers.apiCookieHeader == headers.dashboardCookieHeader)
+            #expect(headers.apiCookieHeader.contains("dashboard_only=dashboard"))
+            #expect(!headers.apiCookieHeader.contains("bailian_only=bailian"))
+            #expect(!headers.apiCookieHeader.contains("aliyun_only=aliyun"))
+            #expect(headers.dashboardCookieHeader.contains("dashboard_only=dashboard"))
+            #expect(!headers.dashboardCookieHeader.contains("bailian_only=bailian"))
+            #expect(!headers.dashboardCookieHeader.contains("aliyun_only=aliyun"))
 
-        #expect(headers.apiCookieHeader == headers.dashboardCookieHeader)
-        #expect(headers.apiCookieHeader.contains("dashboard_only=dashboard"))
-        #expect(!headers.apiCookieHeader.contains("bailian_only=bailian"))
-        #expect(!headers.apiCookieHeader.contains("aliyun_only=aliyun"))
-        #expect(headers.dashboardCookieHeader.contains("dashboard_only=dashboard"))
-        #expect(!headers.dashboardCookieHeader.contains("bailian_only=bailian"))
-        #expect(!headers.dashboardCookieHeader.contains("aliyun_only=aliyun"))
-
-        let missingImportOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+            let cachedHeaders = try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting { _, _ in
                 throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected import")
-            }
-
-        let cachedHeaders = try AlibabaCodingPlanCookieImporter
-            .withImportSessionOverrideForTesting(missingImportOverride) {
+            } operation: {
                 try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
                     context: context,
                     allowCached: true)
             }
-        #expect(cachedHeaders.apiCookieHeader == headers.apiCookieHeader)
-        #expect(cachedHeaders.dashboardCookieHeader == headers.dashboardCookieHeader)
-        #expect(strategy.id == "alibaba-token-plan.web")
+            #expect(cachedHeaders.apiCookieHeader == headers.apiCookieHeader)
+            #expect(cachedHeaders.dashboardCookieHeader == headers.dashboardCookieHeader)
+            #expect(strategy.id == "alibaba-token-plan.web")
+        }
     }
 
     @Test
     func `auto web strategy scopes imported cookies to environment overrides`() throws {
-        let settings = ProviderSettingsSnapshot.make(
-            alibabaTokenPlan: ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings(
-                cookieSource: .auto,
-                manualCookieHeader: nil))
-        let environment = [
-            AlibabaTokenPlanSettingsReader.quotaURLKey: "https://quota.token-plan.test/data/api.json",
-            AlibabaTokenPlanSettingsReader.hostKey: "https://dashboard.token-plan.test",
-        ]
-        let context = ProviderFetchContext(
-            runtime: .cli,
-            sourceMode: .web,
-            includeCredits: false,
-            webTimeout: 1,
-            webDebugDumpHTML: false,
-            verbose: false,
-            env: environment,
-            settings: settings,
-            fetcher: UsageFetcher(environment: environment),
-            claudeFetcher: StubClaudeFetcher(),
-            browserDetection: BrowserDetection(cacheTTL: 0))
+        try self.withIsolatedCookieCache {
+            let settings = ProviderSettingsSnapshot.make(
+                alibabaTokenPlan: ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings(
+                    cookieSource: .auto,
+                    manualCookieHeader: nil))
+            let environment = [
+                AlibabaTokenPlanSettingsReader.quotaURLKey: "https://quota.token-plan.test/data/api.json",
+                AlibabaTokenPlanSettingsReader.hostKey: "https://dashboard.token-plan.test",
+            ]
+            let context = ProviderFetchContext(
+                runtime: .cli,
+                sourceMode: .web,
+                includeCredits: false,
+                webTimeout: 1,
+                webDebugDumpHTML: false,
+                verbose: false,
+                env: environment,
+                settings: settings,
+                fetcher: UsageFetcher(environment: environment),
+                claudeFetcher: StubClaudeFetcher(),
+                browserDetection: BrowserDetection(cacheTTL: 0))
 
-        self.clearCookieCaches()
-        defer { self.clearCookieCaches() }
+            self.clearCookieCaches()
+            defer { self.clearCookieCaches() }
 
-        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+            let headers = try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting { _, _ in
                 AlibabaCodingPlanCookieImporter.SessionInfo(
                     cookies: [
                         self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".token-plan.test"),
@@ -767,66 +761,64 @@ struct AlibabaTokenPlanWebStrategyTests {
                             domain: "bailian.console.aliyun.com"),
                     ],
                     sourceLabel: "Chrome Default")
+            } operation: {
+                try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
             }
 
-        let headers = try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
-            try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
+            #expect(headers.apiCookieHeader.contains("api_only=api"))
+            #expect(!headers.apiCookieHeader.contains("prod_api_only=prod-api"))
+            #expect(headers.dashboardCookieHeader.contains("dashboard_only=dashboard"))
+            #expect(!headers.dashboardCookieHeader.contains("prod_dashboard_only=prod-dashboard"))
         }
-
-        #expect(headers.apiCookieHeader.contains("api_only=api"))
-        #expect(!headers.apiCookieHeader.contains("prod_api_only=prod-api"))
-        #expect(headers.dashboardCookieHeader.contains("dashboard_only=dashboard"))
-        #expect(!headers.dashboardCookieHeader.contains("prod_dashboard_only=prod-dashboard"))
     }
 
     @Test
     func `cached browser cookies stay isolated by gateway region`() throws {
-        self.clearCookieCaches()
-        defer { self.clearCookieCaches() }
-        CookieHeaderCache.store(
-            provider: .alibabatokenplan,
-            scope: AlibabaTokenPlanAPIRegion.international.cookieCacheScope,
-            cookieHeader: "login_aliyunid_ticket=intl-ticket; gateway=intl",
-            sourceLabel: "International fixture")
-        CookieHeaderCache.store(
-            provider: .alibabatokenplan,
-            scope: AlibabaTokenPlanAPIRegion.chinaMainland.cookieCacheScope,
-            cookieHeader: "login_aliyunid_ticket=cn-ticket; gateway=cn",
-            sourceLabel: "China fixture")
-        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+        try self.withIsolatedCookieCache {
+            self.clearCookieCaches()
+            defer { self.clearCookieCaches() }
+            CookieHeaderCache.store(
+                provider: .alibabatokenplan,
+                scope: AlibabaTokenPlanAPIRegion.international.cookieCacheScope,
+                cookieHeader: "login_aliyunid_ticket=intl-ticket; gateway=intl",
+                sourceLabel: "International fixture")
+            CookieHeaderCache.store(
+                provider: .alibabatokenplan,
+                scope: AlibabaTokenPlanAPIRegion.chinaMainland.cookieCacheScope,
+                cookieHeader: "login_aliyunid_ticket=cn-ticket; gateway=cn",
+                sourceLabel: "China fixture")
+            try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting { _, _ in
                 throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected import")
+            } operation: {
+                let context = self.context(region: .international)
+                let international = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+                    context: context,
+                    allowCached: true,
+                    region: .international)
+                let china = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+                    context: context,
+                    allowCached: true,
+                    region: .chinaMainland)
+
+                #expect(international.apiCookieHeader.contains("gateway=intl"))
+                #expect(!international.apiCookieHeader.contains("gateway=cn"))
+                #expect(china.apiCookieHeader.contains("gateway=cn"))
+                #expect(!china.apiCookieHeader.contains("gateway=intl"))
             }
-
-        try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
-            let context = self.context(region: .international)
-            let international = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
-                context: context,
-                allowCached: true,
-                region: .international)
-            let china = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
-                context: context,
-                allowCached: true,
-                region: .chinaMainland)
-
-            #expect(international.apiCookieHeader.contains("gateway=intl"))
-            #expect(!international.apiCookieHeader.contains("gateway=cn"))
-            #expect(china.apiCookieHeader.contains("gateway=cn"))
-            #expect(!china.apiCookieHeader.contains("gateway=intl"))
         }
     }
 
     @Test
     func `legacy unscoped cache migrates only to China gateway`() throws {
-        self.clearCookieCaches()
-        defer { self.clearCookieCaches() }
-        CookieHeaderCache.store(
-            provider: .alibabatokenplan,
-            cookieHeader: "login_aliyunid_ticket=legacy; gateway=legacy-cn",
-            sourceLabel: "Legacy fixture")
-        let context = self.context(region: .international)
-        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+        try self.withIsolatedCookieCache {
+            self.clearCookieCaches()
+            defer { self.clearCookieCaches() }
+            CookieHeaderCache.store(
+                provider: .alibabatokenplan,
+                cookieHeader: "login_aliyunid_ticket=legacy; gateway=legacy-cn",
+                sourceLabel: "Legacy fixture")
+            let context = self.context(region: .international)
+            let international = try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting { _, _ in
                 AlibabaCodingPlanCookieImporter.SessionInfo(
                     cookies: [
                         self.cookie(
@@ -839,36 +831,46 @@ struct AlibabaTokenPlanWebStrategyTests {
                             domain: "modelstudio.console.alibabacloud.com"),
                     ],
                     sourceLabel: "International fixture")
-            }
-
-        let international = try AlibabaCodingPlanCookieImporter
-            .withImportSessionOverrideForTesting(importSessionOverride) {
+            } operation: {
                 try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
                     context: context,
                     allowCached: true,
                     region: .international)
             }
 
-        let missingChinaImportOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+            let china = try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting { _, _ in
                 throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected China import")
-            }
-
-        let china = try AlibabaCodingPlanCookieImporter
-            .withImportSessionOverrideForTesting(missingChinaImportOverride) {
+            } operation: {
                 try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
                     context: context,
                     allowCached: true,
                     region: .chinaMainland)
             }
 
-        #expect(international.apiCookieHeader.contains("gateway=intl"))
-        #expect(!international.apiCookieHeader.contains("gateway=legacy-cn"))
-        #expect(china.apiCookieHeader.contains("gateway=legacy-cn"))
-        #expect(CookieHeaderCache.load(provider: .alibabatokenplan) == nil)
-        #expect(CookieHeaderCache.load(
-            provider: .alibabatokenplan,
-            scope: AlibabaTokenPlanAPIRegion.chinaMainland.cookieCacheScope) != nil)
+            #expect(international.apiCookieHeader.contains("gateway=intl"))
+            #expect(!international.apiCookieHeader.contains("gateway=legacy-cn"))
+            #expect(china.apiCookieHeader.contains("gateway=legacy-cn"))
+            #expect(CookieHeaderCache.load(provider: .alibabatokenplan) == nil)
+            #expect(CookieHeaderCache.load(
+                provider: .alibabatokenplan,
+                scope: AlibabaTokenPlanAPIRegion.chinaMainland.cookieCacheScope) != nil)
+        }
+    }
+
+    private func withIsolatedCookieCache<T>(_ operation: () throws -> T) rethrows -> T {
+        try KeychainCacheStore.withServiceOverrideForTesting(
+            "alibaba-token-plan-web-strategy-tests-\(UUID().uuidString)",
+            operation: {
+                try KeychainCacheStore.withImplicitTestStoreForTesting(operation: operation)
+            })
+    }
+
+    private func withIsolatedCookieCache<T>(_ operation: () async throws -> T) async rethrows -> T {
+        try await KeychainCacheStore.withServiceOverrideForTesting(
+            "alibaba-token-plan-web-strategy-tests-\(UUID().uuidString)",
+            operation: {
+                try await KeychainCacheStore.withImplicitTestStoreForTesting(operation: operation)
+            })
     }
 
     private func context(region: AlibabaTokenPlanAPIRegion) -> ProviderFetchContext {

--- a/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
@@ -631,28 +631,29 @@ struct AlibabaTokenPlanWebStrategyTests {
             browserDetection: BrowserDetection(cacheTTL: 0))
 
         self.clearCookieCaches()
-        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
-            throw AlibabaCodingPlanSettingsError.missingCookie(
-                details: "macOS Keychain denied access to Chrome Safe Storage.")
-        }
-        defer {
-            AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil
-            self.clearCookieCaches()
-        }
+        defer { self.clearCookieCaches() }
 
-        #expect(await strategy.isAvailable(context))
-
-        do {
-            _ = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeader(context: context, allowCached: false)
-            Issue.record("Expected cookie import failure to be surfaced")
-        } catch let error as AlibabaTokenPlanSettingsError {
-            guard case let .missingCookie(details) = error else {
-                Issue.record("Expected missingCookie, got \(error)")
-                return
+        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+                throw AlibabaCodingPlanSettingsError.missingCookie(
+                    details: "macOS Keychain denied access to Chrome Safe Storage.")
             }
-            #expect(details == "macOS Keychain denied access to Chrome Safe Storage.")
-            #expect(error.localizedDescription.contains("Alibaba Token Plan"))
-            #expect(!error.localizedDescription.contains("Alibaba Coding Plan"))
+
+        try await AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            #expect(await strategy.isAvailable(context))
+
+            do {
+                _ = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeader(context: context, allowCached: false)
+                Issue.record("Expected cookie import failure to be surfaced")
+            } catch let error as AlibabaTokenPlanSettingsError {
+                guard case let .missingCookie(details) = error else {
+                    Issue.record("Expected missingCookie, got \(error)")
+                    return
+                }
+                #expect(details == "macOS Keychain denied access to Chrome Safe Storage.")
+                #expect(error.localizedDescription.contains("Alibaba Token Plan"))
+                #expect(!error.localizedDescription.contains("Alibaba Coding Plan"))
+            }
         }
     }
 
@@ -677,29 +678,30 @@ struct AlibabaTokenPlanWebStrategyTests {
             browserDetection: BrowserDetection(cacheTTL: 0))
 
         self.clearCookieCaches()
-        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
-            AlibabaCodingPlanCookieImporter.SessionInfo(
-                cookies: [
-                    self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".alibabacloud.com"),
-                    self.cookie(name: "login_current_pk", value: "account", domain: ".alibabacloud.com"),
-                    self.cookie(
-                        name: "dashboard_only",
-                        value: "dashboard",
-                        domain: "modelstudio.console.alibabacloud.com"),
-                    self.cookie(
-                        name: "bailian_only",
-                        value: "bailian",
-                        domain: "bailian.console.aliyun.com"),
-                    self.cookie(name: "aliyun_only", value: "aliyun", domain: ".aliyun.com"),
-                ],
-                sourceLabel: "Chrome Default")
-        }
-        defer {
-            AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil
-            self.clearCookieCaches()
-        }
+        defer { self.clearCookieCaches() }
 
-        let headers = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
+        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+                AlibabaCodingPlanCookieImporter.SessionInfo(
+                    cookies: [
+                        self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".alibabacloud.com"),
+                        self.cookie(name: "login_current_pk", value: "account", domain: ".alibabacloud.com"),
+                        self.cookie(
+                            name: "dashboard_only",
+                            value: "dashboard",
+                            domain: "modelstudio.console.alibabacloud.com"),
+                        self.cookie(
+                            name: "bailian_only",
+                            value: "bailian",
+                            domain: "bailian.console.aliyun.com"),
+                        self.cookie(name: "aliyun_only", value: "aliyun", domain: ".aliyun.com"),
+                    ],
+                    sourceLabel: "Chrome Default")
+            }
+
+        let headers = try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
+        }
 
         #expect(headers.apiCookieHeader == headers.dashboardCookieHeader)
         #expect(headers.apiCookieHeader.contains("dashboard_only=dashboard"))
@@ -709,12 +711,17 @@ struct AlibabaTokenPlanWebStrategyTests {
         #expect(!headers.dashboardCookieHeader.contains("bailian_only=bailian"))
         #expect(!headers.dashboardCookieHeader.contains("aliyun_only=aliyun"))
 
-        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
-            throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected import")
-        }
-        let cachedHeaders = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
-            context: context,
-            allowCached: true)
+        let missingImportOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+                throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected import")
+            }
+
+        let cachedHeaders = try AlibabaCodingPlanCookieImporter
+            .withImportSessionOverrideForTesting(missingImportOverride) {
+                try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+                    context: context,
+                    allowCached: true)
+            }
         #expect(cachedHeaders.apiCookieHeader == headers.apiCookieHeader)
         #expect(cachedHeaders.dashboardCookieHeader == headers.dashboardCookieHeader)
         #expect(strategy.id == "alibaba-token-plan.web")
@@ -744,26 +751,27 @@ struct AlibabaTokenPlanWebStrategyTests {
             browserDetection: BrowserDetection(cacheTTL: 0))
 
         self.clearCookieCaches()
-        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
-            AlibabaCodingPlanCookieImporter.SessionInfo(
-                cookies: [
-                    self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".token-plan.test"),
-                    self.cookie(name: "api_only", value: "api", domain: "quota.token-plan.test"),
-                    self.cookie(name: "dashboard_only", value: "dashboard", domain: "dashboard.token-plan.test"),
-                    self.cookie(name: "prod_api_only", value: "prod-api", domain: "bailian.console.aliyun.com"),
-                    self.cookie(
-                        name: "prod_dashboard_only",
-                        value: "prod-dashboard",
-                        domain: "bailian.console.aliyun.com"),
-                ],
-                sourceLabel: "Chrome Default")
-        }
-        defer {
-            AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil
-            self.clearCookieCaches()
-        }
+        defer { self.clearCookieCaches() }
 
-        let headers = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
+        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+                AlibabaCodingPlanCookieImporter.SessionInfo(
+                    cookies: [
+                        self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".token-plan.test"),
+                        self.cookie(name: "api_only", value: "api", domain: "quota.token-plan.test"),
+                        self.cookie(name: "dashboard_only", value: "dashboard", domain: "dashboard.token-plan.test"),
+                        self.cookie(name: "prod_api_only", value: "prod-api", domain: "bailian.console.aliyun.com"),
+                        self.cookie(
+                            name: "prod_dashboard_only",
+                            value: "prod-dashboard",
+                            domain: "bailian.console.aliyun.com"),
+                    ],
+                    sourceLabel: "Chrome Default")
+            }
+
+        let headers = try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
+        }
 
         #expect(headers.apiCookieHeader.contains("api_only=api"))
         #expect(!headers.apiCookieHeader.contains("prod_api_only=prod-api"))
@@ -785,65 +793,74 @@ struct AlibabaTokenPlanWebStrategyTests {
             scope: AlibabaTokenPlanAPIRegion.chinaMainland.cookieCacheScope,
             cookieHeader: "login_aliyunid_ticket=cn-ticket; gateway=cn",
             sourceLabel: "China fixture")
-        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
-            throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected import")
+        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+                throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected import")
+            }
+
+        try AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            let context = self.context(region: .international)
+            let international = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+                context: context,
+                allowCached: true,
+                region: .international)
+            let china = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+                context: context,
+                allowCached: true,
+                region: .chinaMainland)
+
+            #expect(international.apiCookieHeader.contains("gateway=intl"))
+            #expect(!international.apiCookieHeader.contains("gateway=cn"))
+            #expect(china.apiCookieHeader.contains("gateway=cn"))
+            #expect(!china.apiCookieHeader.contains("gateway=intl"))
         }
-        defer { AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil }
-
-        let context = self.context(region: .international)
-        let international = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
-            context: context,
-            allowCached: true,
-            region: .international)
-        let china = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
-            context: context,
-            allowCached: true,
-            region: .chinaMainland)
-
-        #expect(international.apiCookieHeader.contains("gateway=intl"))
-        #expect(!international.apiCookieHeader.contains("gateway=cn"))
-        #expect(china.apiCookieHeader.contains("gateway=cn"))
-        #expect(!china.apiCookieHeader.contains("gateway=intl"))
     }
 
     @Test
     func `legacy unscoped cache migrates only to China gateway`() throws {
         self.clearCookieCaches()
-        defer {
-            AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = nil
-            self.clearCookieCaches()
-        }
+        defer { self.clearCookieCaches() }
         CookieHeaderCache.store(
             provider: .alibabatokenplan,
             cookieHeader: "login_aliyunid_ticket=legacy; gateway=legacy-cn",
             sourceLabel: "Legacy fixture")
-        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
-            AlibabaCodingPlanCookieImporter.SessionInfo(
-                cookies: [
-                    self.cookie(
-                        name: "login_aliyunid_ticket",
-                        value: "intl",
-                        domain: ".alibabacloud.com"),
-                    self.cookie(
-                        name: "gateway",
-                        value: "intl",
-                        domain: "modelstudio.console.alibabacloud.com"),
-                ],
-                sourceLabel: "International fixture")
-        }
         let context = self.context(region: .international)
+        let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+                AlibabaCodingPlanCookieImporter.SessionInfo(
+                    cookies: [
+                        self.cookie(
+                            name: "login_aliyunid_ticket",
+                            value: "intl",
+                            domain: ".alibabacloud.com"),
+                        self.cookie(
+                            name: "gateway",
+                            value: "intl",
+                            domain: "modelstudio.console.alibabacloud.com"),
+                    ],
+                    sourceLabel: "International fixture")
+            }
 
-        let international = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
-            context: context,
-            allowCached: true,
-            region: .international)
-        AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
-            throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected China import")
-        }
-        let china = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
-            context: context,
-            allowCached: true,
-            region: .chinaMainland)
+        let international = try AlibabaCodingPlanCookieImporter
+            .withImportSessionOverrideForTesting(importSessionOverride) {
+                try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+                    context: context,
+                    allowCached: true,
+                    region: .international)
+            }
+
+        let missingChinaImportOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> AlibabaCodingPlanCookieImporter.SessionInfo = { _, _ in
+                throw AlibabaCodingPlanSettingsError.missingCookie(details: "unexpected China import")
+            }
+
+        let china = try AlibabaCodingPlanCookieImporter
+            .withImportSessionOverrideForTesting(missingChinaImportOverride) {
+                try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(
+                    context: context,
+                    allowCached: true,
+                    region: .chinaMainland)
+            }
 
         #expect(international.apiCookieHeader.contains("gateway=intl"))
         #expect(!international.apiCookieHeader.contains("gateway=legacy-cn"))

--- a/Tests/CodexBarTests/CookieImporterOverrideIsolationTests.swift
+++ b/Tests/CodexBarTests/CookieImporterOverrideIsolationTests.swift
@@ -1,0 +1,53 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+private actor CookieImporterOverrideBarrier {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            self.continuations.append(continuation)
+            guard self.continuations.count == 2 else { return }
+
+            let continuations = self.continuations
+            self.continuations.removeAll()
+            continuations.forEach { $0.resume() }
+        }
+    }
+}
+
+struct CookieImporterOverrideIsolationTests {
+    @Test
+    func `cookie importer overrides stay isolated across concurrent tasks`() async throws {
+        let expectedLabels = ["first", "second"]
+        let barrier = CookieImporterOverrideBarrier()
+
+        let observedLabels = try await withThrowingTaskGroup(
+            of: String.self,
+            returning: Set<String>.self)
+        { group in
+            for label in expectedLabels {
+                group.addTask {
+                    try await AlibabaCodingPlanCookieImporter.withImportSessionOverrideForTesting { _, _ in
+                        AlibabaCodingPlanCookieImporter.SessionInfo(cookies: [], sourceLabel: label)
+                    } operation: {
+                        await barrier.wait()
+                        return try AlibabaCodingPlanCookieImporter.importSession(
+                            browserDetection: BrowserDetection()).sourceLabel
+                    }
+                }
+            }
+
+            var labels: Set<String> = []
+            for try await label in group {
+                labels.insert(label)
+            }
+            return labels
+        }
+
+        #expect(observedLabels == Set(expectedLabels))
+    }
+}
+#endif

--- a/Tests/CodexBarTests/CookieImporterOverrideIsolationTests.swift
+++ b/Tests/CodexBarTests/CookieImporterOverrideIsolationTests.swift
@@ -1,4 +1,4 @@
-#if os(macOS)
+#if DEBUG && os(macOS)
 import Foundation
 import Testing
 @testable import CodexBarCore

--- a/Tests/CodexBarTests/CookieImporterOverrideIsolationTests.swift
+++ b/Tests/CodexBarTests/CookieImporterOverrideIsolationTests.swift
@@ -49,5 +49,25 @@ struct CookieImporterOverrideIsolationTests {
 
         #expect(observedLabels == Set(expectedLabels))
     }
+
+    @Test
+    func `perplexity overrides bypass the shared import cache`() async throws {
+        PerplexityCookieImporter.invalidateImportSessionCache()
+        defer { PerplexityCookieImporter.invalidateImportSessionCache() }
+
+        let first = try await PerplexityCookieImporter.withImportSessionsOverrideForTesting { _, _ in
+            [PerplexityCookieImporter.SessionInfo(cookies: [], sourceLabel: "first")]
+        } operation: {
+            try PerplexityCookieImporter.importSessions().map(\.sourceLabel)
+        }
+        let second = try await PerplexityCookieImporter.withImportSessionsOverrideForTesting { _, _ in
+            [PerplexityCookieImporter.SessionInfo(cookies: [], sourceLabel: "second")]
+        } operation: {
+            try PerplexityCookieImporter.importSessions().map(\.sourceLabel)
+        }
+
+        #expect(first == ["first"])
+        #expect(second == ["second"])
+    }
 }
 #endif

--- a/Tests/CodexBarTests/DevinUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DevinUsageFetcherTests.swift
@@ -314,17 +314,14 @@ struct DevinUsageFetcherTests {
     #if os(macOS)
     @Test
     func `empty app organization setting preserves imported organization`() async throws {
-        let importSessionOverride: (BrowserDetection, String?, ((String) -> Void)?) -> DevinSessionImporter
-            .SessionInfo? = { _, organizationOverride, _ in
-                #expect(organizationOverride == nil)
-                return DevinSessionImporter.SessionInfo(
-                    accessToken: "auth1_abcdefghijklmnopqrstuvwxyz0123456789",
-                    organization: "org/example-org",
-                    internalOrganizationID: "org_GQ6LhcfkW1TSinM6",
-                    sourceLabel: "Chrome Default")
-            }
-
-        try await DevinSessionImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+        try await DevinSessionImporter.withImportSessionOverrideForTesting { _, organizationOverride, _ in
+            #expect(organizationOverride == nil)
+            return DevinSessionImporter.SessionInfo(
+                accessToken: "auth1_abcdefghijklmnopqrstuvwxyz0123456789",
+                organization: "org/example-org",
+                internalOrganizationID: "org_GQ6LhcfkW1TSinM6",
+                sourceLabel: "Chrome Default")
+        } operation: {
             let stub = ProviderHTTPTransportStub { request in
                 #expect(request.url?.path == "/api/org_GQ6LhcfkW1TSinM6/billing/quota/usage")
                 let response = HTTPURLResponse(

--- a/Tests/CodexBarTests/DevinUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DevinUsageFetcherTests.swift
@@ -314,33 +314,36 @@ struct DevinUsageFetcherTests {
     #if os(macOS)
     @Test
     func `empty app organization setting preserves imported organization`() async throws {
-        defer { DevinSessionImporter.importSessionOverrideForTesting = nil }
-        DevinSessionImporter.importSessionOverrideForTesting = { _, organizationOverride, _ in
-            #expect(organizationOverride == nil)
-            return DevinSessionImporter.SessionInfo(
-                accessToken: "auth1_abcdefghijklmnopqrstuvwxyz0123456789",
-                organization: "org/example-org",
-                internalOrganizationID: "org_GQ6LhcfkW1TSinM6",
-                sourceLabel: "Chrome Default")
-        }
-        let stub = ProviderHTTPTransportStub { request in
-            #expect(request.url?.path == "/api/org_GQ6LhcfkW1TSinM6/billing/quota/usage")
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil)!
-            return (Data(#"{"daily_percentage":0,"weekly_percentage":0}"#.utf8), response)
-        }
+        let importSessionOverride: (BrowserDetection, String?, ((String) -> Void)?) -> DevinSessionImporter
+            .SessionInfo? = { _, organizationOverride, _ in
+                #expect(organizationOverride == nil)
+                return DevinSessionImporter.SessionInfo(
+                    accessToken: "auth1_abcdefghijklmnopqrstuvwxyz0123456789",
+                    organization: "org/example-org",
+                    internalOrganizationID: "org_GQ6LhcfkW1TSinM6",
+                    sourceLabel: "Chrome Default")
+            }
 
-        let snapshot = try await DevinUsageFetcher(browserDetection: BrowserDetection(cacheTTL: 0)).fetch(
-            organizationOverride: "",
-            now: Self.now,
-            transport: stub)
+        try await DevinSessionImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            let stub = ProviderHTTPTransportStub { request in
+                #expect(request.url?.path == "/api/org_GQ6LhcfkW1TSinM6/billing/quota/usage")
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil)!
+                return (Data(#"{"daily_percentage":0,"weekly_percentage":0}"#.utf8), response)
+            }
 
-        #expect(snapshot.organization == "example-org")
-        #expect(snapshot.daily?.usedPercent == 0)
-        #expect(snapshot.weekly?.usedPercent == 0)
+            let snapshot = try await DevinUsageFetcher(browserDetection: BrowserDetection(cacheTTL: 0)).fetch(
+                organizationOverride: "",
+                now: Self.now,
+                transport: stub)
+
+            #expect(snapshot.organization == "example-org")
+            #expect(snapshot.daily?.usedPercent == 0)
+            #expect(snapshot.weekly?.usedPercent == 0)
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/DevinUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DevinUsageFetcherTests.swift
@@ -317,7 +317,7 @@ struct DevinUsageFetcherTests {
         try await DevinSessionImporter.withImportSessionOverrideForTesting { _, organizationOverride, _ in
             #expect(organizationOverride == nil)
             return DevinSessionImporter.SessionInfo(
-                accessToken: "auth1_abcdefghijklmnopqrstuvwxyz0123456789",
+                accessToken: "test-access-token",
                 organization: "org/example-org",
                 internalOrganizationID: "org_GQ6LhcfkW1TSinM6",
                 sourceLabel: "Chrome Default")

--- a/Tests/CodexBarTests/KeychainCacheStoreTests.swift
+++ b/Tests/CodexBarTests/KeychainCacheStoreTests.swift
@@ -29,6 +29,27 @@ struct KeychainCacheStoreTests {
     }
 
     @Test
+    func `implicit test store override stays isolated from explicit test store`() {
+        let service = "implicit-test-store-\(UUID().uuidString)"
+        let key = KeychainCacheStore.Key(category: "test", identifier: UUID().uuidString)
+        let explicitEntry = TestEntry(value: "explicit", storedAt: Date(timeIntervalSince1970: 1))
+        let implicitEntry = TestEntry(value: "implicit", storedAt: Date(timeIntervalSince1970: 2))
+
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+        KeychainCacheStore.withServiceOverrideForTesting(service) {
+            KeychainCacheStore.store(key: key, entry: explicitEntry)
+            KeychainCacheStore.withImplicitTestStoreForTesting {
+                #expect(self.loadedEntry(for: key) == nil)
+                KeychainCacheStore.store(key: key, entry: implicitEntry)
+                #expect(self.loadedEntry(for: key) == implicitEntry)
+            }
+            #expect(self.loadedEntry(for: key) == explicitEntry)
+        }
+    }
+
+    @Test
     func `background interaction keeps real keychain cache available for no UI reads writes and deletes`() {
         KeychainAccessGate.withTaskOverrideForTesting(false) {
             ProviderInteractionContext.$current.withValue(.background) {
@@ -36,6 +57,11 @@ struct KeychainCacheStoreTests {
                 #expect(KeychainCacheStore.canEnumerateOrDeleteRealKeychainForTesting == true)
             }
         }
+    }
+
+    private func loadedEntry(for key: KeychainCacheStore.Key) -> TestEntry? {
+        guard case let .found(entry) = KeychainCacheStore.load(key: key, as: TestEntry.self) else { return nil }
+        return entry
     }
 
     @Test

--- a/Tests/CodexBarTests/ManusProviderTests.swift
+++ b/Tests/CodexBarTests/ManusProviderTests.swift
@@ -123,7 +123,7 @@ struct ManusProviderTests {
     @Test
     func `environment token does not populate browser cache`() async throws {
         try await self.withIsolatedCacheStore {
-            let runFetch = {
+            let operation: () async throws -> Void = {
                 let strategy = ManusWebFetchStrategy()
                 let settings = ProviderSettingsSnapshot.make(
                     manus: ProviderSettingsSnapshot.ManusProviderSettings(
@@ -143,18 +143,14 @@ struct ManusProviderTests {
 
                 #expect(CookieHeaderCache.load(provider: .manus) == nil)
             }
-
             #if os(macOS)
-            let importSessionsOverride: (BrowserDetection, ((String) -> Void)?) throws
-                -> [ManusCookieImporter.SessionInfo] = { _, _ in
-                    throw ManusCookieImportError.noCookies
-                }
-
-            try await ManusCookieImporter.withImportSessionsOverrideForTesting(importSessionsOverride) {
-                try await runFetch()
+            try await ManusCookieImporter.withImportSessionsOverrideForTesting { _, _ in
+                throw ManusCookieImportError.noCookies
+            } operation: {
+                try await operation()
             }
             #else
-            try await runFetch()
+            try await operation()
             #endif
         }
     }
@@ -170,12 +166,9 @@ struct ManusProviderTests {
                 .value: "browser-token",
                 .secure: "TRUE",
             ]))
-            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-                -> ManusCookieImporter.SessionInfo = { _, _ in
-                    ManusCookieImporter.SessionInfo(cookies: [browserCookie], sourceLabel: "Chrome")
-                }
-
-            try await ManusCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            try await ManusCookieImporter.withImportSessionOverrideForTesting { _, _ in
+                ManusCookieImporter.SessionInfo(cookies: [browserCookie], sourceLabel: "Chrome")
+            } operation: {
                 let attempts = LockedArray<String>()
                 let strategy = ManusWebFetchStrategy()
                 let settings = ProviderSettingsSnapshot.make(
@@ -214,12 +207,9 @@ struct ManusProviderTests {
                 .value: "browser-token",
                 .secure: "TRUE",
             ]))
-            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-                -> ManusCookieImporter.SessionInfo = { _, _ in
-                    ManusCookieImporter.SessionInfo(cookies: [browserCookie], sourceLabel: "Chrome")
-                }
-
-            try await ManusCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            try await ManusCookieImporter.withImportSessionOverrideForTesting { _, _ in
+                ManusCookieImporter.SessionInfo(cookies: [browserCookie], sourceLabel: "Chrome")
+            } operation: {
                 let strategy = ManusWebFetchStrategy()
                 let settings = ProviderSettingsSnapshot.make(
                     manus: ProviderSettingsSnapshot.ManusProviderSettings(

--- a/Tests/CodexBarTests/ManusProviderTests.swift
+++ b/Tests/CodexBarTests/ManusProviderTests.swift
@@ -123,35 +123,39 @@ struct ManusProviderTests {
     @Test
     func `environment token does not populate browser cache`() async throws {
         try await self.withIsolatedCacheStore {
+            let runFetch = {
+                let strategy = ManusWebFetchStrategy()
+                let settings = ProviderSettingsSnapshot.make(
+                    manus: ProviderSettingsSnapshot.ManusProviderSettings(
+                        cookieSource: .auto,
+                        manualCookieHeader: nil))
+                let context = self.makeContext(
+                    settings: settings,
+                    env: ["MANUS_SESSION_TOKEN": "env-token"])
+                let fetchOverride: @Sendable (String, Date) async throws -> ManusCreditsResponse = { token, _ in
+                    #expect(token == "env-token")
+                    return self.stubResponse()
+                }
+
+                _ = try await ManusUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
+                    try await strategy.fetch(context)
+                })
+
+                #expect(CookieHeaderCache.load(provider: .manus) == nil)
+            }
+
             #if os(macOS)
-            ManusCookieImporter.importSessionsOverrideForTesting = { _, _ in
-                throw ManusCookieImportError.noCookies
+            let importSessionsOverride: (BrowserDetection, ((String) -> Void)?) throws
+                -> [ManusCookieImporter.SessionInfo] = { _, _ in
+                    throw ManusCookieImportError.noCookies
+                }
+
+            try await ManusCookieImporter.withImportSessionsOverrideForTesting(importSessionsOverride) {
+                try await runFetch()
             }
-            ManusCookieImporter.importSessionOverrideForTesting = nil
-            defer {
-                ManusCookieImporter.importSessionsOverrideForTesting = nil
-                ManusCookieImporter.importSessionOverrideForTesting = nil
-            }
+            #else
+            try await runFetch()
             #endif
-
-            let strategy = ManusWebFetchStrategy()
-            let settings = ProviderSettingsSnapshot.make(
-                manus: ProviderSettingsSnapshot.ManusProviderSettings(
-                    cookieSource: .auto,
-                    manualCookieHeader: nil))
-            let context = self.makeContext(
-                settings: settings,
-                env: ["MANUS_SESSION_TOKEN": "env-token"])
-            let fetchOverride: @Sendable (String, Date) async throws -> ManusCreditsResponse = { token, _ in
-                #expect(token == "env-token")
-                return self.stubResponse()
-            }
-
-            _ = try await ManusUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
-                try await strategy.fetch(context)
-            })
-
-            #expect(CookieHeaderCache.load(provider: .manus) == nil)
         }
     }
 
@@ -166,39 +170,37 @@ struct ManusProviderTests {
                 .value: "browser-token",
                 .secure: "TRUE",
             ]))
-            ManusCookieImporter.importSessionOverrideForTesting = { _, _ in
-                ManusCookieImporter.SessionInfo(cookies: [browserCookie], sourceLabel: "Chrome")
-            }
-            ManusCookieImporter.importSessionsOverrideForTesting = nil
-            defer {
-                ManusCookieImporter.importSessionOverrideForTesting = nil
-                ManusCookieImporter.importSessionsOverrideForTesting = nil
-            }
-
-            let attempts = LockedArray<String>()
-            let strategy = ManusWebFetchStrategy()
-            let settings = ProviderSettingsSnapshot.make(
-                manus: ProviderSettingsSnapshot.ManusProviderSettings(
-                    cookieSource: .auto,
-                    manualCookieHeader: nil))
-            let context = self.makeContext(
-                settings: settings,
-                env: ["MANUS_SESSION_TOKEN": "env-token"])
-            let fetchOverride: @Sendable (String, Date) async throws -> ManusCreditsResponse = { token, _ in
-                attempts.append(token)
-                if token == "browser-token" {
-                    throw ManusAPIError.invalidToken
+            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+                -> ManusCookieImporter.SessionInfo = { _, _ in
+                    ManusCookieImporter.SessionInfo(cookies: [browserCookie], sourceLabel: "Chrome")
                 }
-                #expect(token == "env-token")
-                return self.stubResponse()
+
+            try await ManusCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+                let attempts = LockedArray<String>()
+                let strategy = ManusWebFetchStrategy()
+                let settings = ProviderSettingsSnapshot.make(
+                    manus: ProviderSettingsSnapshot.ManusProviderSettings(
+                        cookieSource: .auto,
+                        manualCookieHeader: nil))
+                let context = self.makeContext(
+                    settings: settings,
+                    env: ["MANUS_SESSION_TOKEN": "env-token"])
+                let fetchOverride: @Sendable (String, Date) async throws -> ManusCreditsResponse = { token, _ in
+                    attempts.append(token)
+                    if token == "browser-token" {
+                        throw ManusAPIError.invalidToken
+                    }
+                    #expect(token == "env-token")
+                    return self.stubResponse()
+                }
+
+                _ = try await ManusUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
+                    try await strategy.fetch(context)
+                })
+
+                #expect(attempts.snapshot() == ["browser-token", "env-token"])
+                #expect(CookieHeaderCache.load(provider: .manus) == nil)
             }
-
-            _ = try await ManusUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
-                try await strategy.fetch(context)
-            })
-
-            #expect(attempts.snapshot() == ["browser-token", "env-token"])
-            #expect(CookieHeaderCache.load(provider: .manus) == nil)
         }
     }
 
@@ -212,32 +214,30 @@ struct ManusProviderTests {
                 .value: "browser-token",
                 .secure: "TRUE",
             ]))
-            ManusCookieImporter.importSessionOverrideForTesting = { _, _ in
-                ManusCookieImporter.SessionInfo(cookies: [browserCookie], sourceLabel: "Chrome")
-            }
-            ManusCookieImporter.importSessionsOverrideForTesting = nil
-            defer {
-                ManusCookieImporter.importSessionOverrideForTesting = nil
-                ManusCookieImporter.importSessionsOverrideForTesting = nil
-            }
+            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+                -> ManusCookieImporter.SessionInfo = { _, _ in
+                    ManusCookieImporter.SessionInfo(cookies: [browserCookie], sourceLabel: "Chrome")
+                }
 
-            let strategy = ManusWebFetchStrategy()
-            let settings = ProviderSettingsSnapshot.make(
-                manus: ProviderSettingsSnapshot.ManusProviderSettings(
-                    cookieSource: .auto,
-                    manualCookieHeader: nil))
-            let context = self.makeContext(settings: settings)
-            let fetchOverride: @Sendable (String, Date) async throws -> ManusCreditsResponse = { token, _ in
-                #expect(token == "browser-token")
-                return self.stubResponse()
+            try await ManusCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+                let strategy = ManusWebFetchStrategy()
+                let settings = ProviderSettingsSnapshot.make(
+                    manus: ProviderSettingsSnapshot.ManusProviderSettings(
+                        cookieSource: .auto,
+                        manualCookieHeader: nil))
+                let context = self.makeContext(settings: settings)
+                let fetchOverride: @Sendable (String, Date) async throws -> ManusCreditsResponse = { token, _ in
+                    #expect(token == "browser-token")
+                    return self.stubResponse()
+                }
+
+                _ = try await ManusUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
+                    try await strategy.fetch(context)
+                })
+
+                let cached = CookieHeaderCache.load(provider: .manus)
+                #expect(cached?.cookieHeader == "session_id=browser-token")
             }
-
-            _ = try await ManusUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
-                try await strategy.fetch(context)
-            })
-
-            let cached = CookieHeaderCache.load(provider: .manus)
-            #expect(cached?.cookieHeader == "session_id=browser-token")
         }
     }
     #endif

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -924,19 +924,16 @@ extension MiMoProviderTests {
         CookieHeaderCache.clear(provider: .mimo)
         CookieHeaderCache.store(provider: .mimo, cookieHeader: "invalid", sourceLabel: "invalid")
 
-        let importSessionsOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> [MiMoCookieImporter.SessionInfo] = { _, _ in
-                [
-                    .init(
-                        cookieHeader: "api-platform_serviceToken=expired-token; userId=111",
-                        sourceLabel: "Expired Chrome"),
-                    .init(
-                        cookieHeader: "api-platform_serviceToken=valid-token; userId=222",
-                        sourceLabel: "Active Chrome"),
-                ]
-            }
-
-        try await MiMoCookieImporter.withImportSessionsOverrideForTesting(importSessionsOverride) {
+        try await MiMoCookieImporter.withImportSessionsOverrideForTesting { _, _ in
+            [
+                .init(
+                    cookieHeader: "api-platform_serviceToken=expired-token; userId=111",
+                    sourceLabel: "Expired Chrome"),
+                .init(
+                    cookieHeader: "api-platform_serviceToken=valid-token; userId=222",
+                    sourceLabel: "Active Chrome"),
+            ]
+        } operation: {
             let lock = NSLock()
             var requestedCookies: [String] = []
             MiMoStubURLProtocol.handler = { request in
@@ -999,19 +996,16 @@ extension MiMoProviderTests {
             cookieHeader: "api-platform_serviceToken=stale-chrome-token; userId=111",
             sourceLabel: "Chrome")
 
-        let importSessionsOverride: (BrowserDetection, ((String) -> Void)?) throws
-            -> [MiMoCookieImporter.SessionInfo] = { _, _ in
-                [
-                    .init(
-                        cookieHeader: "api-platform_serviceToken=stale-chrome-token; userId=111",
-                        sourceLabel: "Chrome"),
-                    .init(
-                        cookieHeader: "api-platform_serviceToken=valid-safari-token; userId=222",
-                        sourceLabel: "Safari"),
-                ]
-            }
-
-        try await MiMoCookieImporter.withImportSessionsOverrideForTesting(importSessionsOverride) {
+        try await MiMoCookieImporter.withImportSessionsOverrideForTesting { _, _ in
+            [
+                .init(
+                    cookieHeader: "api-platform_serviceToken=stale-chrome-token; userId=111",
+                    sourceLabel: "Chrome"),
+                .init(
+                    cookieHeader: "api-platform_serviceToken=valid-safari-token; userId=222",
+                    sourceLabel: "Safari"),
+            ]
+        } operation: {
             let lock = NSLock()
             var requestedCookies: [String] = []
             MiMoStubURLProtocol.handler = { request in

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -918,64 +918,66 @@ extension MiMoProviderTests {
                 URLProtocol.unregisterClass(MiMoStubURLProtocol.self)
             }
             MiMoStubURLProtocol.handler = nil
-            MiMoCookieImporter.importSessionsOverrideForTesting = nil
             CookieHeaderCache.clear(provider: .mimo)
         }
 
         CookieHeaderCache.clear(provider: .mimo)
         CookieHeaderCache.store(provider: .mimo, cookieHeader: "invalid", sourceLabel: "invalid")
 
-        MiMoCookieImporter.importSessionsOverrideForTesting = { _, _ in
-            [
-                .init(
-                    cookieHeader: "api-platform_serviceToken=expired-token; userId=111",
-                    sourceLabel: "Expired Chrome"),
-                .init(
-                    cookieHeader: "api-platform_serviceToken=valid-token; userId=222",
-                    sourceLabel: "Active Chrome"),
-            ]
+        let importSessionsOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> [MiMoCookieImporter.SessionInfo] = { _, _ in
+                [
+                    .init(
+                        cookieHeader: "api-platform_serviceToken=expired-token; userId=111",
+                        sourceLabel: "Expired Chrome"),
+                    .init(
+                        cookieHeader: "api-platform_serviceToken=valid-token; userId=222",
+                        sourceLabel: "Active Chrome"),
+                ]
+            }
+
+        try await MiMoCookieImporter.withImportSessionsOverrideForTesting(importSessionsOverride) {
+            let lock = NSLock()
+            var requestedCookies: [String] = []
+            MiMoStubURLProtocol.handler = { request in
+                guard let url = request.url else { throw URLError(.badURL) }
+                let cookie = request.value(forHTTPHeaderField: "Cookie") ?? ""
+                lock.withLock {
+                    requestedCookies.append(cookie)
+                }
+
+                if cookie.contains("expired-token") {
+                    let response = HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: "HTTP/1.1",
+                        headerFields: ["Content-Type": "text/html"])!
+                    return (response, Data("<html>login</html>".utf8))
+                }
+
+                let body = """
+                {
+                  "code": 0,
+                  "message": "",
+                  "data": {
+                    "balance": "25.51",
+                    "currency": "USD"
+                  }
+                }
+                """
+                return Self.makeResponse(url: url, body: body)
+            }
+
+            let strategy = MiMoWebFetchStrategy()
+            let result = try await strategy
+                .fetch(self.makeContext(environment: ["MIMO_API_URL": "https://mimo.test/api/v1"]))
+
+            #expect(requestedCookies.count == 6)
+            #expect(requestedCookies.contains(where: { $0.contains("expired-token") }))
+            #expect(requestedCookies.contains(where: { $0.contains("valid-token") }))
+            #expect(result.usage.mimoUsage?.balanceDetail == "$25.51")
+            #expect(CookieHeaderCache.load(provider: .mimo)?.sourceLabel == "Active Chrome")
         }
-
-        let lock = NSLock()
-        var requestedCookies: [String] = []
-        MiMoStubURLProtocol.handler = { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            let cookie = request.value(forHTTPHeaderField: "Cookie") ?? ""
-            lock.withLock {
-                requestedCookies.append(cookie)
-            }
-
-            if cookie.contains("expired-token") {
-                let response = HTTPURLResponse(
-                    url: url,
-                    statusCode: 200,
-                    httpVersion: "HTTP/1.1",
-                    headerFields: ["Content-Type": "text/html"])!
-                return (response, Data("<html>login</html>".utf8))
-            }
-
-            let body = """
-            {
-              "code": 0,
-              "message": "",
-              "data": {
-                "balance": "25.51",
-                "currency": "USD"
-              }
-            }
-            """
-            return Self.makeResponse(url: url, body: body)
-        }
-
-        let strategy = MiMoWebFetchStrategy()
-        let result = try await strategy
-            .fetch(self.makeContext(environment: ["MIMO_API_URL": "https://mimo.test/api/v1"]))
-
-        #expect(requestedCookies.count == 6)
-        #expect(requestedCookies.contains(where: { $0.contains("expired-token") }))
-        #expect(requestedCookies.contains(where: { $0.contains("valid-token") }))
-        #expect(result.usage.mimoUsage?.balanceDetail == "$25.51")
-        #expect(CookieHeaderCache.load(provider: .mimo)?.sourceLabel == "Active Chrome")
     }
 
     @Test
@@ -988,7 +990,6 @@ extension MiMoProviderTests {
                 URLProtocol.unregisterClass(MiMoStubURLProtocol.self)
             }
             MiMoStubURLProtocol.handler = nil
-            MiMoCookieImporter.importSessionsOverrideForTesting = nil
             CookieHeaderCache.clear(provider: .mimo)
         }
 
@@ -998,51 +999,54 @@ extension MiMoProviderTests {
             cookieHeader: "api-platform_serviceToken=stale-chrome-token; userId=111",
             sourceLabel: "Chrome")
 
-        MiMoCookieImporter.importSessionsOverrideForTesting = { _, _ in
-            [
-                .init(
-                    cookieHeader: "api-platform_serviceToken=stale-chrome-token; userId=111",
-                    sourceLabel: "Chrome"),
-                .init(
-                    cookieHeader: "api-platform_serviceToken=valid-safari-token; userId=222",
-                    sourceLabel: "Safari"),
-            ]
+        let importSessionsOverride: (BrowserDetection, ((String) -> Void)?) throws
+            -> [MiMoCookieImporter.SessionInfo] = { _, _ in
+                [
+                    .init(
+                        cookieHeader: "api-platform_serviceToken=stale-chrome-token; userId=111",
+                        sourceLabel: "Chrome"),
+                    .init(
+                        cookieHeader: "api-platform_serviceToken=valid-safari-token; userId=222",
+                        sourceLabel: "Safari"),
+                ]
+            }
+
+        try await MiMoCookieImporter.withImportSessionsOverrideForTesting(importSessionsOverride) {
+            let lock = NSLock()
+            var requestedCookies: [String] = []
+            MiMoStubURLProtocol.handler = { request in
+                guard let url = request.url else { throw URLError(.badURL) }
+                let cookie = request.value(forHTTPHeaderField: "Cookie") ?? ""
+                lock.withLock {
+                    requestedCookies.append(cookie)
+                }
+
+                if cookie.contains("stale-chrome-token") {
+                    return Self.makeResponse(url: url, body: "", statusCode: 302)
+                }
+
+                let body = """
+                {
+                  "code": 0,
+                  "message": "",
+                  "data": {
+                    "balance": "25.51",
+                    "currency": "USD"
+                  }
+                }
+                """
+                return Self.makeResponse(url: url, body: body)
+            }
+
+            let strategy = MiMoWebFetchStrategy()
+            let result = try await strategy
+                .fetch(self.makeContext(environment: ["MIMO_API_URL": "https://mimo.test/api/v1"]))
+
+            #expect(requestedCookies.contains(where: { $0.contains("stale-chrome-token") }))
+            #expect(requestedCookies.contains(where: { $0.contains("valid-safari-token") }))
+            #expect(result.usage.mimoUsage?.balanceDetail == "$25.51")
+            #expect(CookieHeaderCache.load(provider: .mimo)?.sourceLabel == "Safari")
         }
-
-        let lock = NSLock()
-        var requestedCookies: [String] = []
-        MiMoStubURLProtocol.handler = { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            let cookie = request.value(forHTTPHeaderField: "Cookie") ?? ""
-            lock.withLock {
-                requestedCookies.append(cookie)
-            }
-
-            if cookie.contains("stale-chrome-token") {
-                return Self.makeResponse(url: url, body: "", statusCode: 302)
-            }
-
-            let body = """
-            {
-              "code": 0,
-              "message": "",
-              "data": {
-                "balance": "25.51",
-                "currency": "USD"
-              }
-            }
-            """
-            return Self.makeResponse(url: url, body: body)
-        }
-
-        let strategy = MiMoWebFetchStrategy()
-        let result = try await strategy
-            .fetch(self.makeContext(environment: ["MIMO_API_URL": "https://mimo.test/api/v1"]))
-
-        #expect(requestedCookies.contains(where: { $0.contains("stale-chrome-token") }))
-        #expect(requestedCookies.contains(where: { $0.contains("valid-safari-token") }))
-        #expect(result.usage.mimoUsage?.balanceDetail == "$25.51")
-        #expect(CookieHeaderCache.load(provider: .mimo)?.sourceLabel == "Safari")
     }
 
     #if os(macOS)

--- a/Tests/CodexBarTests/PerplexityProviderTests.swift
+++ b/Tests/CodexBarTests/PerplexityProviderTests.swift
@@ -149,12 +149,9 @@ struct PerplexityProviderTests {
                 PerplexityCookieImporter.invalidateImportSessionCache()
             }
 
-            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-                -> PerplexityCookieImporter.SessionInfo = { _, _ in
-                    throw PerplexityCookieImportError.noCookies
-                }
-
-            try await PerplexityCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            try await PerplexityCookieImporter.withImportSessionOverrideForTesting { _, _ in
+                throw PerplexityCookieImportError.noCookies
+            } operation: {
                 let strategy = PerplexityWebFetchStrategy()
                 let settings = ProviderSettingsSnapshot.make(
                     perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
@@ -206,12 +203,9 @@ struct PerplexityProviderTests {
                 PerplexityCookieImporter.invalidateImportSessionCache()
             }
 
-            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-                -> PerplexityCookieImporter.SessionInfo = { _, _ in
-                    throw PerplexityCookieImportError.noCookies
-                }
-
-            try await PerplexityCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            try await PerplexityCookieImporter.withImportSessionOverrideForTesting { _, _ in
+                throw PerplexityCookieImportError.noCookies
+            } operation: {
                 let attemptedCookieNames = LockedArray<String>()
                 let strategy = PerplexityWebFetchStrategy()
                 let settings = ProviderSettingsSnapshot.make(
@@ -251,19 +245,16 @@ struct PerplexityProviderTests {
                 PerplexityCookieImporter.invalidateImportSessionCache()
             }
 
-            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-                -> PerplexityCookieImporter.SessionInfo = { _, _ in
-                    let cookie = try #require(HTTPCookie(properties: [
-                        .domain: "www.perplexity.ai",
-                        .path: "/",
-                        .name: PerplexityCookieHeader.defaultSessionCookieName,
-                        .value: "browser-token",
-                        .secure: "TRUE",
-                    ]))
-                    return PerplexityCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")
-                }
-
-            try await PerplexityCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            try await PerplexityCookieImporter.withImportSessionOverrideForTesting { _, _ in
+                let cookie = try #require(HTTPCookie(properties: [
+                    .domain: "www.perplexity.ai",
+                    .path: "/",
+                    .name: PerplexityCookieHeader.defaultSessionCookieName,
+                    .value: "browser-token",
+                    .secure: "TRUE",
+                ]))
+                return PerplexityCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")
+            } operation: {
                 let attemptedTokens = LockedArray<String>()
                 let strategy = PerplexityWebFetchStrategy()
                 let settings = ProviderSettingsSnapshot.make(
@@ -303,29 +294,26 @@ struct PerplexityProviderTests {
                 PerplexityCookieImporter.invalidateImportSessionCache()
             }
 
-            let importSessionsOverride: (BrowserDetection, ((String) -> Void)?) throws
-                -> [PerplexityCookieImporter.SessionInfo] = { _, _ in
-                    let staleCookie = try #require(HTTPCookie(properties: [
-                        .domain: "www.perplexity.ai",
-                        .path: "/",
-                        .name: "__Secure-authjs.session-token",
-                        .value: "stale-browser-token",
-                        .secure: "TRUE",
-                    ]))
-                    let liveCookie = try #require(HTTPCookie(properties: [
-                        .domain: "www.perplexity.ai",
-                        .path: "/",
-                        .name: "__Secure-authjs.session-token",
-                        .value: "live-browser-token",
-                        .secure: "TRUE",
-                    ]))
-                    return [
-                        PerplexityCookieImporter.SessionInfo(cookies: [staleCookie], sourceLabel: "Chrome"),
-                        PerplexityCookieImporter.SessionInfo(cookies: [liveCookie], sourceLabel: "Safari"),
-                    ]
-                }
-
-            try await PerplexityCookieImporter.withImportSessionsOverrideForTesting(importSessionsOverride) {
+            try await PerplexityCookieImporter.withImportSessionsOverrideForTesting { _, _ in
+                let staleCookie = try #require(HTTPCookie(properties: [
+                    .domain: "www.perplexity.ai",
+                    .path: "/",
+                    .name: "__Secure-authjs.session-token",
+                    .value: "stale-browser-token",
+                    .secure: "TRUE",
+                ]))
+                let liveCookie = try #require(HTTPCookie(properties: [
+                    .domain: "www.perplexity.ai",
+                    .path: "/",
+                    .name: "__Secure-authjs.session-token",
+                    .value: "live-browser-token",
+                    .secure: "TRUE",
+                ]))
+                return [
+                    PerplexityCookieImporter.SessionInfo(cookies: [staleCookie], sourceLabel: "Chrome"),
+                    PerplexityCookieImporter.SessionInfo(cookies: [liveCookie], sourceLabel: "Safari"),
+                ]
+            } operation: {
                 let attemptedTokens = LockedArray<String>()
                 let strategy = PerplexityWebFetchStrategy()
                 let settings = ProviderSettingsSnapshot.make(
@@ -364,20 +352,17 @@ struct PerplexityProviderTests {
                 PerplexityCookieImporter.invalidateImportSessionCache()
             }
 
-            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
-                -> PerplexityCookieImporter.SessionInfo = { _, _ in
-                    importCount.increment()
-                    let cookie = try #require(HTTPCookie(properties: [
-                        .domain: "www.perplexity.ai",
-                        .path: "/",
-                        .name: PerplexityCookieHeader.defaultSessionCookieName,
-                        .value: "browser-token",
-                        .secure: "TRUE",
-                    ]))
-                    return PerplexityCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")
-                }
-
-            try await PerplexityCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+            try await PerplexityCookieImporter.withImportSessionOverrideForTesting { _, _ in
+                importCount.increment()
+                let cookie = try #require(HTTPCookie(properties: [
+                    .domain: "www.perplexity.ai",
+                    .path: "/",
+                    .name: PerplexityCookieHeader.defaultSessionCookieName,
+                    .value: "browser-token",
+                    .secure: "TRUE",
+                ]))
+                return PerplexityCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")
+            } operation: {
                 let strategy = PerplexityWebFetchStrategy()
                 let settings = ProviderSettingsSnapshot.make(
                     perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(

--- a/Tests/CodexBarTests/PerplexityProviderTests.swift
+++ b/Tests/CodexBarTests/PerplexityProviderTests.swift
@@ -145,33 +145,35 @@ struct PerplexityProviderTests {
     func `environment token does not populate browser cookie cache`() async throws {
         try await self.withIsolatedCacheStore {
             PerplexityCookieImporter.invalidateImportSessionCache()
-            PerplexityCookieImporter.importSessionsOverrideForTesting = nil
-            PerplexityCookieImporter.importSessionOverrideForTesting = { _, _ in
-                throw PerplexityCookieImportError.noCookies
-            }
             defer {
-                PerplexityCookieImporter.importSessionsOverrideForTesting = nil
-                PerplexityCookieImporter.importSessionOverrideForTesting = nil
                 PerplexityCookieImporter.invalidateImportSessionCache()
             }
 
-            let strategy = PerplexityWebFetchStrategy()
-            let settings = ProviderSettingsSnapshot.make(
-                perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
-                    cookieSource: .auto,
-                    manualCookieHeader: nil))
-            let context = self.makeContext(
-                settings: settings,
-                env: ["PERPLEXITY_COOKIE": "authjs.session-token=env-token"])
-            let fetchOverride: @Sendable (String, String, Date) async throws -> PerplexityUsageSnapshot = { _, _, _ in
-                self.stubSnapshot()
+            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+                -> PerplexityCookieImporter.SessionInfo = { _, _ in
+                    throw PerplexityCookieImportError.noCookies
+                }
+
+            try await PerplexityCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+                let strategy = PerplexityWebFetchStrategy()
+                let settings = ProviderSettingsSnapshot.make(
+                    perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
+                        cookieSource: .auto,
+                        manualCookieHeader: nil))
+                let context = self.makeContext(
+                    settings: settings,
+                    env: ["PERPLEXITY_COOKIE": "authjs.session-token=env-token"])
+                let fetchOverride: @Sendable (String, String, Date) async throws
+                    -> PerplexityUsageSnapshot = { _, _, _ in
+                        self.stubSnapshot()
+                    }
+
+                _ = try await PerplexityUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
+                    try await strategy.fetch(context)
+                })
+
+                #expect(CookieHeaderCache.load(provider: .perplexity) == nil)
             }
-
-            _ = try await PerplexityUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
-                try await strategy.fetch(context)
-            })
-
-            #expect(CookieHeaderCache.load(provider: .perplexity) == nil)
         }
     }
 
@@ -200,43 +202,44 @@ struct PerplexityProviderTests {
     func `bare environment token falls back to auth JS cookie name`() async throws {
         try await self.withIsolatedCacheStore {
             PerplexityCookieImporter.invalidateImportSessionCache()
-            PerplexityCookieImporter.importSessionsOverrideForTesting = nil
-            PerplexityCookieImporter.importSessionOverrideForTesting = { _, _ in
-                throw PerplexityCookieImportError.noCookies
-            }
             defer {
-                PerplexityCookieImporter.importSessionsOverrideForTesting = nil
-                PerplexityCookieImporter.importSessionOverrideForTesting = nil
                 PerplexityCookieImporter.invalidateImportSessionCache()
             }
 
-            let attemptedCookieNames = LockedArray<String>()
-            let strategy = PerplexityWebFetchStrategy()
-            let settings = ProviderSettingsSnapshot.make(
-                perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
-                    cookieSource: .auto,
-                    manualCookieHeader: nil))
-            let context = self.makeContext(
-                settings: settings,
-                env: ["PERPLEXITY_SESSION_TOKEN": "env-token"])
-            let fetchOverride: @Sendable (String, String, Date) async throws
-                -> PerplexityUsageSnapshot = { token, cookieName, _ in
-                    #expect(token == "env-token")
-                    attemptedCookieNames.append(cookieName)
-                    if cookieName == "authjs.session-token" {
-                        return self.stubSnapshot()
-                    }
-                    throw PerplexityAPIError.invalidToken
+            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+                -> PerplexityCookieImporter.SessionInfo = { _, _ in
+                    throw PerplexityCookieImportError.noCookies
                 }
 
-            _ = try await PerplexityUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
-                try await strategy.fetch(context)
-            })
+            try await PerplexityCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+                let attemptedCookieNames = LockedArray<String>()
+                let strategy = PerplexityWebFetchStrategy()
+                let settings = ProviderSettingsSnapshot.make(
+                    perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
+                        cookieSource: .auto,
+                        manualCookieHeader: nil))
+                let context = self.makeContext(
+                    settings: settings,
+                    env: ["PERPLEXITY_SESSION_TOKEN": "env-token"])
+                let fetchOverride: @Sendable (String, String, Date) async throws
+                    -> PerplexityUsageSnapshot = { token, cookieName, _ in
+                        #expect(token == "env-token")
+                        attemptedCookieNames.append(cookieName)
+                        if cookieName == "authjs.session-token" {
+                            return self.stubSnapshot()
+                        }
+                        throw PerplexityAPIError.invalidToken
+                    }
 
-            #expect(attemptedCookieNames.snapshot() == [
-                "__Secure-authjs.session-token",
-                "authjs.session-token",
-            ])
+                _ = try await PerplexityUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
+                    try await strategy.fetch(context)
+                })
+
+                #expect(attemptedCookieNames.snapshot() == [
+                    "__Secure-authjs.session-token",
+                    "authjs.session-token",
+                ])
+            }
         }
     }
 
@@ -244,50 +247,51 @@ struct PerplexityProviderTests {
     func `valid environment cookie wins after invalid browser session`() async throws {
         try await self.withIsolatedCacheStore {
             PerplexityCookieImporter.invalidateImportSessionCache()
-            PerplexityCookieImporter.importSessionsOverrideForTesting = nil
-            PerplexityCookieImporter.importSessionOverrideForTesting = { _, _ in
-                let cookie = try #require(HTTPCookie(properties: [
-                    .domain: "www.perplexity.ai",
-                    .path: "/",
-                    .name: PerplexityCookieHeader.defaultSessionCookieName,
-                    .value: "browser-token",
-                    .secure: "TRUE",
-                ]))
-                return PerplexityCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")
-            }
             defer {
-                PerplexityCookieImporter.importSessionsOverrideForTesting = nil
-                PerplexityCookieImporter.importSessionOverrideForTesting = nil
                 PerplexityCookieImporter.invalidateImportSessionCache()
             }
 
-            let attemptedTokens = LockedArray<String>()
-            let strategy = PerplexityWebFetchStrategy()
-            let settings = ProviderSettingsSnapshot.make(
-                perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
-                    cookieSource: .auto,
-                    manualCookieHeader: nil))
-            let context = self.makeContext(
-                settings: settings,
-                env: ["PERPLEXITY_COOKIE": "authjs.session-token=env-token"])
-            let fetchOverride: @Sendable (String, String, Date) async throws
-                -> PerplexityUsageSnapshot = { token, _, _ in
-                    attemptedTokens.append(token)
-                    if token == "browser-token" {
-                        throw PerplexityAPIError.invalidToken
-                    }
-                    if token == "env-token" {
-                        return self.stubSnapshot()
-                    }
-                    Issue.record("Unexpected token \(token)")
-                    throw PerplexityAPIError.invalidToken
+            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+                -> PerplexityCookieImporter.SessionInfo = { _, _ in
+                    let cookie = try #require(HTTPCookie(properties: [
+                        .domain: "www.perplexity.ai",
+                        .path: "/",
+                        .name: PerplexityCookieHeader.defaultSessionCookieName,
+                        .value: "browser-token",
+                        .secure: "TRUE",
+                    ]))
+                    return PerplexityCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")
                 }
 
-            _ = try await PerplexityUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
-                try await strategy.fetch(context)
-            })
+            try await PerplexityCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+                let attemptedTokens = LockedArray<String>()
+                let strategy = PerplexityWebFetchStrategy()
+                let settings = ProviderSettingsSnapshot.make(
+                    perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
+                        cookieSource: .auto,
+                        manualCookieHeader: nil))
+                let context = self.makeContext(
+                    settings: settings,
+                    env: ["PERPLEXITY_COOKIE": "authjs.session-token=env-token"])
+                let fetchOverride: @Sendable (String, String, Date) async throws
+                    -> PerplexityUsageSnapshot = { token, _, _ in
+                        attemptedTokens.append(token)
+                        if token == "browser-token" {
+                            throw PerplexityAPIError.invalidToken
+                        }
+                        if token == "env-token" {
+                            return self.stubSnapshot()
+                        }
+                        Issue.record("Unexpected token \(token)")
+                        throw PerplexityAPIError.invalidToken
+                    }
 
-            #expect(attemptedTokens.snapshot() == ["browser-token", "env-token"])
+                _ = try await PerplexityUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
+                    try await strategy.fetch(context)
+                })
+
+                #expect(attemptedTokens.snapshot() == ["browser-token", "env-token"])
+            }
         }
     }
 
@@ -295,58 +299,59 @@ struct PerplexityProviderTests {
     func `later browser session wins after earlier imported session fails auth`() async throws {
         try await self.withIsolatedCacheStore {
             PerplexityCookieImporter.invalidateImportSessionCache()
-            PerplexityCookieImporter.importSessionOverrideForTesting = nil
-            PerplexityCookieImporter.importSessionsOverrideForTesting = { _, _ in
-                let staleCookie = try #require(HTTPCookie(properties: [
-                    .domain: "www.perplexity.ai",
-                    .path: "/",
-                    .name: "__Secure-authjs.session-token",
-                    .value: "stale-browser-token",
-                    .secure: "TRUE",
-                ]))
-                let liveCookie = try #require(HTTPCookie(properties: [
-                    .domain: "www.perplexity.ai",
-                    .path: "/",
-                    .name: "__Secure-authjs.session-token",
-                    .value: "live-browser-token",
-                    .secure: "TRUE",
-                ]))
-                return [
-                    PerplexityCookieImporter.SessionInfo(cookies: [staleCookie], sourceLabel: "Chrome"),
-                    PerplexityCookieImporter.SessionInfo(cookies: [liveCookie], sourceLabel: "Safari"),
-                ]
-            }
             defer {
-                PerplexityCookieImporter.importSessionsOverrideForTesting = nil
-                PerplexityCookieImporter.importSessionOverrideForTesting = nil
                 PerplexityCookieImporter.invalidateImportSessionCache()
             }
 
-            let attemptedTokens = LockedArray<String>()
-            let strategy = PerplexityWebFetchStrategy()
-            let settings = ProviderSettingsSnapshot.make(
-                perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
-                    cookieSource: .auto,
-                    manualCookieHeader: nil))
-            let context = self.makeContext(settings: settings)
-            let fetchOverride: @Sendable (String, String, Date) async throws
-                -> PerplexityUsageSnapshot = { token, _, _ in
-                    attemptedTokens.append(token)
-                    if token == "stale-browser-token" {
-                        throw PerplexityAPIError.invalidToken
-                    }
-                    if token == "live-browser-token" {
-                        return self.stubSnapshot()
-                    }
-                    Issue.record("Unexpected token \(token)")
-                    throw PerplexityAPIError.invalidToken
+            let importSessionsOverride: (BrowserDetection, ((String) -> Void)?) throws
+                -> [PerplexityCookieImporter.SessionInfo] = { _, _ in
+                    let staleCookie = try #require(HTTPCookie(properties: [
+                        .domain: "www.perplexity.ai",
+                        .path: "/",
+                        .name: "__Secure-authjs.session-token",
+                        .value: "stale-browser-token",
+                        .secure: "TRUE",
+                    ]))
+                    let liveCookie = try #require(HTTPCookie(properties: [
+                        .domain: "www.perplexity.ai",
+                        .path: "/",
+                        .name: "__Secure-authjs.session-token",
+                        .value: "live-browser-token",
+                        .secure: "TRUE",
+                    ]))
+                    return [
+                        PerplexityCookieImporter.SessionInfo(cookies: [staleCookie], sourceLabel: "Chrome"),
+                        PerplexityCookieImporter.SessionInfo(cookies: [liveCookie], sourceLabel: "Safari"),
+                    ]
                 }
 
-            _ = try await PerplexityUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
-                try await strategy.fetch(context)
-            })
+            try await PerplexityCookieImporter.withImportSessionsOverrideForTesting(importSessionsOverride) {
+                let attemptedTokens = LockedArray<String>()
+                let strategy = PerplexityWebFetchStrategy()
+                let settings = ProviderSettingsSnapshot.make(
+                    perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
+                        cookieSource: .auto,
+                        manualCookieHeader: nil))
+                let context = self.makeContext(settings: settings)
+                let fetchOverride: @Sendable (String, String, Date) async throws
+                    -> PerplexityUsageSnapshot = { token, _, _ in
+                        attemptedTokens.append(token)
+                        if token == "stale-browser-token" {
+                            throw PerplexityAPIError.invalidToken
+                        }
+                        if token == "live-browser-token" {
+                            return self.stubSnapshot()
+                        }
+                        Issue.record("Unexpected token \(token)")
+                        throw PerplexityAPIError.invalidToken
+                    }
 
-            #expect(attemptedTokens.snapshot() == ["stale-browser-token", "live-browser-token"])
+                _ = try await PerplexityUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
+                    try await strategy.fetch(context)
+                })
+
+                #expect(attemptedTokens.snapshot() == ["stale-browser-token", "live-browser-token"])
+            }
         }
     }
 
@@ -355,43 +360,44 @@ struct PerplexityProviderTests {
         try await self.withIsolatedCacheStore {
             let importCount = LockedCounter()
             PerplexityCookieImporter.invalidateImportSessionCache()
-            PerplexityCookieImporter.importSessionsOverrideForTesting = nil
-            PerplexityCookieImporter.importSessionOverrideForTesting = { _, _ in
-                importCount.increment()
-                let cookie = try #require(HTTPCookie(properties: [
-                    .domain: "www.perplexity.ai",
-                    .path: "/",
-                    .name: PerplexityCookieHeader.defaultSessionCookieName,
-                    .value: "browser-token",
-                    .secure: "TRUE",
-                ]))
-                return PerplexityCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")
-            }
             defer {
-                PerplexityCookieImporter.importSessionsOverrideForTesting = nil
-                PerplexityCookieImporter.importSessionOverrideForTesting = nil
                 PerplexityCookieImporter.invalidateImportSessionCache()
             }
 
-            let strategy = PerplexityWebFetchStrategy()
-            let settings = ProviderSettingsSnapshot.make(
-                perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
-                    cookieSource: .auto,
-                    manualCookieHeader: nil))
-            let context = self.makeContext(settings: settings)
-            let fetchOverride: @Sendable (String, String, Date) async throws
-                -> PerplexityUsageSnapshot = { token, _, _ in
-                    #expect(token == "browser-token")
-                    return self.stubSnapshot()
+            let importSessionOverride: (BrowserDetection, ((String) -> Void)?) throws
+                -> PerplexityCookieImporter.SessionInfo = { _, _ in
+                    importCount.increment()
+                    let cookie = try #require(HTTPCookie(properties: [
+                        .domain: "www.perplexity.ai",
+                        .path: "/",
+                        .name: PerplexityCookieHeader.defaultSessionCookieName,
+                        .value: "browser-token",
+                        .secure: "TRUE",
+                    ]))
+                    return PerplexityCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")
                 }
 
-            #expect(await strategy.isAvailable(context))
+            try await PerplexityCookieImporter.withImportSessionOverrideForTesting(importSessionOverride) {
+                let strategy = PerplexityWebFetchStrategy()
+                let settings = ProviderSettingsSnapshot.make(
+                    perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
+                        cookieSource: .auto,
+                        manualCookieHeader: nil))
+                let context = self.makeContext(settings: settings)
+                let fetchOverride: @Sendable (String, String, Date) async throws
+                    -> PerplexityUsageSnapshot = { token, _, _ in
+                        #expect(token == "browser-token")
+                        return self.stubSnapshot()
+                    }
 
-            _ = try await PerplexityUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
-                try await strategy.fetch(context)
-            })
+                #expect(await strategy.isAvailable(context))
 
-            #expect(importCount.snapshot() == 1)
+                _ = try await PerplexityUsageFetcher.$fetchCreditsOverride.withValue(fetchOverride, operation: {
+                    try await strategy.fetch(context)
+                })
+
+                #expect(importCount.snapshot() == 1)
+            }
         }
     }
 }

--- a/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
+++ b/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
@@ -32,9 +32,11 @@ struct WindsurfWebFetcherTests {
     }
 
     private func withWindsurfSessionOverrides<T>(
-        importSessions: SessionOverride? = nil,
-        preferredSessions: SessionOverride? = nil,
-        fallbackSessions: SessionOverride? = nil,
+        importSessions: ((BrowserDetection, ((String) -> Void)?) -> [WindsurfDevinSessionImporter.SessionInfo])? = nil,
+        preferredSessions: ((BrowserDetection, ((String) -> Void)?) -> [WindsurfDevinSessionImporter.SessionInfo])? =
+            nil,
+        fallbackSessions: ((BrowserDetection, ((String) -> Void)?) -> [WindsurfDevinSessionImporter.SessionInfo])? =
+            nil,
         operation: () async throws -> T) async rethrows -> T
     {
         try await WindsurfDevinSessionImporter.withImportSessionsOverrideForTesting(importSessions) {
@@ -115,24 +117,25 @@ struct WindsurfWebFetcherTests {
             WindsurfWebFetcherStubURLProtocol.handler = nil
         }
 
-        let preferredSessions: SessionOverride = { _, _ in
-            [
-                WindsurfDevinSessionImporter.SessionInfo(
-                    session: WindsurfDevinSessionAuth(
-                        sessionToken: "stale-token",
-                        auth1Token: "stale-auth1",
-                        accountID: "stale-account",
-                        primaryOrgID: "stale-org"),
-                    sourceLabel: "Chrome Default"),
-                WindsurfDevinSessionImporter.SessionInfo(
-                    session: WindsurfDevinSessionAuth(
-                        sessionToken: "fresh-token",
-                        auth1Token: "fresh-auth1",
-                        accountID: "fresh-account",
-                        primaryOrgID: "fresh-org"),
-                    sourceLabel: "Chrome Profile 1"),
-            ]
-        }
+        let preferredSessions: (BrowserDetection, ((String) -> Void)?)
+            -> [WindsurfDevinSessionImporter.SessionInfo] = { _, _ in
+                [
+                    WindsurfDevinSessionImporter.SessionInfo(
+                        session: WindsurfDevinSessionAuth(
+                            sessionToken: "stale-token",
+                            auth1Token: "stale-auth1",
+                            accountID: "stale-account",
+                            primaryOrgID: "stale-org"),
+                        sourceLabel: "Chrome Default"),
+                    WindsurfDevinSessionImporter.SessionInfo(
+                        session: WindsurfDevinSessionAuth(
+                            sessionToken: "fresh-token",
+                            auth1Token: "fresh-auth1",
+                            accountID: "fresh-account",
+                            primaryOrgID: "fresh-org"),
+                        sourceLabel: "Chrome Profile 1"),
+                ]
+            }
 
         WindsurfWebFetcherStubURLProtocol.requests = []
         WindsurfWebFetcherStubURLProtocol.handler = { request in
@@ -182,28 +185,30 @@ struct WindsurfWebFetcherTests {
             WindsurfWebFetcherStubURLProtocol.handler = nil
         }
 
-        let preferredSessions: SessionOverride = { _, _ in
-            [
-                WindsurfDevinSessionImporter.SessionInfo(
-                    session: WindsurfDevinSessionAuth(
-                        sessionToken: "stale-chrome-token",
-                        auth1Token: "stale-auth1",
-                        accountID: "stale-account",
-                        primaryOrgID: "stale-org"),
-                    sourceLabel: "Chrome Default"),
-            ]
-        }
-        let fallbackSessions: SessionOverride = { _, _ in
-            [
-                WindsurfDevinSessionImporter.SessionInfo(
-                    session: WindsurfDevinSessionAuth(
-                        sessionToken: "fresh-edge-token",
-                        auth1Token: "fresh-auth1",
-                        accountID: "fresh-account",
-                        primaryOrgID: "fresh-org"),
-                    sourceLabel: "Microsoft Edge Default"),
-            ]
-        }
+        let preferredSessions: (BrowserDetection, ((String) -> Void)?)
+            -> [WindsurfDevinSessionImporter.SessionInfo] = { _, _ in
+                [
+                    WindsurfDevinSessionImporter.SessionInfo(
+                        session: WindsurfDevinSessionAuth(
+                            sessionToken: "stale-chrome-token",
+                            auth1Token: "stale-auth1",
+                            accountID: "stale-account",
+                            primaryOrgID: "stale-org"),
+                        sourceLabel: "Chrome Default"),
+                ]
+            }
+        let fallbackSessions: (BrowserDetection, ((String) -> Void)?)
+            -> [WindsurfDevinSessionImporter.SessionInfo] = { _, _ in
+                [
+                    WindsurfDevinSessionImporter.SessionInfo(
+                        session: WindsurfDevinSessionAuth(
+                            sessionToken: "fresh-edge-token",
+                            auth1Token: "fresh-auth1",
+                            accountID: "fresh-account",
+                            primaryOrgID: "fresh-org"),
+                        sourceLabel: "Microsoft Edge Default"),
+                ]
+            }
 
         WindsurfWebFetcherStubURLProtocol.requests = []
         WindsurfWebFetcherStubURLProtocol.handler = { request in
@@ -304,22 +309,22 @@ struct WindsurfWebFetcherTests {
                 statusCode: 200)
         }
 
-        let preferredSessions: SessionOverride = { _, _ in sessionInfos }
+        try await self.withWindsurfSessionOverrides(
+            preferredSessions: { _, _ in sessionInfos },
+            operation: {
+                let snapshot = try await WindsurfWebFetcher.fetchUsage(
+                    browserDetection: BrowserDetection(cacheTTL: 0),
+                    cookieSource: .auto,
+                    timeout: 2,
+                    session: self.makeSession())
 
-        try await self.withWindsurfSessionOverrides(preferredSessions: preferredSessions) {
-            let snapshot = try await WindsurfWebFetcher.fetchUsage(
-                browserDetection: BrowserDetection(cacheTTL: 0),
-                cookieSource: .auto,
-                timeout: 2,
-                session: self.makeSession())
-
-            #expect(snapshots.count == 1)
-            #expect(sessionInfos.map(\.sourceLabel) == ["Chrome Default (windsurf.com)"])
-            #expect(WindsurfWebFetcherStubURLProtocol.requests.count == 1)
-            #expect(snapshot.identity?.loginMethod == "Pro")
-            #expect(snapshot.primary?.usedPercent == 30)
-            #expect(snapshot.secondary?.usedPercent == 15)
-        }
+                #expect(snapshots.count == 1)
+                #expect(sessionInfos.map(\.sourceLabel) == ["Chrome Default (windsurf.com)"])
+                #expect(WindsurfWebFetcherStubURLProtocol.requests.count == 1)
+                #expect(snapshot.identity?.loginMethod == "Pro")
+                #expect(snapshot.primary?.usedPercent == 30)
+                #expect(snapshot.secondary?.usedPercent == 15)
+            })
     }
 
     @Test
@@ -329,17 +334,18 @@ struct WindsurfWebFetcherTests {
             WindsurfWebFetcherStubURLProtocol.handler = nil
         }
 
-        let importedSessions: SessionOverride = { _, _ in
-            [
-                WindsurfDevinSessionImporter.SessionInfo(
-                    session: WindsurfDevinSessionAuth(
-                        sessionToken: "auto-token",
-                        auth1Token: "auto-auth1",
-                        accountID: "auto-account",
-                        primaryOrgID: "auto-org"),
-                    sourceLabel: "Chrome Default"),
-            ]
-        }
+        let importedSessions: (BrowserDetection, ((String) -> Void)?)
+            -> [WindsurfDevinSessionImporter.SessionInfo] = { _, _ in
+                [
+                    WindsurfDevinSessionImporter.SessionInfo(
+                        session: WindsurfDevinSessionAuth(
+                            sessionToken: "auto-token",
+                            auth1Token: "auto-auth1",
+                            accountID: "auto-account",
+                            primaryOrgID: "auto-org"),
+                        sourceLabel: "Chrome Default"),
+                ]
+            }
         WindsurfWebFetcherStubURLProtocol.requests = []
 
         await self.withWindsurfSessionOverrides(importSessions: importedSessions) {

--- a/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
+++ b/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
@@ -5,9 +5,6 @@ import Testing
 
 @Suite(.serialized)
 struct WindsurfWebFetcherTests {
-    private typealias SessionOverride = (BrowserDetection, ((String) -> Void)?)
-        -> [WindsurfDevinSessionImporter.SessionInfo]
-
     @Test
     func `missing session guidance names current and legacy origins`() {
         let message = WindsurfWebFetcherError.noSessionData.errorDescription

--- a/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
+++ b/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
@@ -345,7 +345,7 @@ struct WindsurfWebFetcherTests {
             }
         WindsurfWebFetcherStubURLProtocol.requests = []
 
-        await self.withWindsurfSessionOverrides(importSessions: importedSessions) {
+        _ = await self.withWindsurfSessionOverrides(importSessions: importedSessions) {
             await #expect {
                 _ = try await WindsurfWebFetcher.fetchUsage(
                     browserDetection: BrowserDetection(cacheTTL: 0),

--- a/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
+++ b/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
@@ -5,6 +5,9 @@ import Testing
 
 @Suite(.serialized)
 struct WindsurfWebFetcherTests {
+    private typealias SessionOverride = (BrowserDetection, ((String) -> Void)?)
+        -> [WindsurfDevinSessionImporter.SessionInfo]
+
     @Test
     func `missing session guidance names current and legacy origins`() {
         let message = WindsurfWebFetcherError.noSessionData.errorDescription
@@ -26,6 +29,21 @@ struct WindsurfWebFetcherTests {
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [WindsurfWebFetcherStubURLProtocol.self]
         return URLSession(configuration: config)
+    }
+
+    private func withWindsurfSessionOverrides<T>(
+        importSessions: SessionOverride? = nil,
+        preferredSessions: SessionOverride? = nil,
+        fallbackSessions: SessionOverride? = nil,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await WindsurfDevinSessionImporter.withImportSessionsOverrideForTesting(importSessions) {
+            try await WindsurfDevinSessionImporter.withImportPreferredSessionsOverrideForTesting(preferredSessions) {
+                try await WindsurfDevinSessionImporter.withImportFallbackSessionsOverrideForTesting(fallbackSessions) {
+                    try await operation()
+                }
+            }
+        }
     }
 
     @Test
@@ -93,14 +111,11 @@ struct WindsurfWebFetcherTests {
     @Test
     func `auto session import retries next profile after auth failure`() async throws {
         defer {
-            WindsurfDevinSessionImporter.importSessionsOverrideForTesting = nil
-            WindsurfDevinSessionImporter.importPreferredSessionsOverrideForTesting = nil
-            WindsurfDevinSessionImporter.importFallbackSessionsOverrideForTesting = nil
             WindsurfWebFetcherStubURLProtocol.requests = []
             WindsurfWebFetcherStubURLProtocol.handler = nil
         }
 
-        WindsurfDevinSessionImporter.importPreferredSessionsOverrideForTesting = { _, _ in
+        let preferredSessions: SessionOverride = { _, _ in
             [
                 WindsurfDevinSessionImporter.SessionInfo(
                     session: WindsurfDevinSessionAuth(
@@ -146,29 +161,28 @@ struct WindsurfWebFetcherTests {
                 statusCode: 200)
         }
 
-        let snapshot = try await WindsurfWebFetcher.fetchUsage(
-            browserDetection: BrowserDetection(cacheTTL: 0),
-            cookieSource: .auto,
-            timeout: 2,
-            session: self.makeSession())
+        try await self.withWindsurfSessionOverrides(preferredSessions: preferredSessions) {
+            let snapshot = try await WindsurfWebFetcher.fetchUsage(
+                browserDetection: BrowserDetection(cacheTTL: 0),
+                cookieSource: .auto,
+                timeout: 2,
+                session: self.makeSession())
 
-        #expect(WindsurfWebFetcherStubURLProtocol.requests.count == 2)
-        #expect(snapshot.identity?.loginMethod == "Teams")
-        #expect(snapshot.primary?.usedPercent == 25)
-        #expect(snapshot.secondary?.usedPercent == 10)
+            #expect(WindsurfWebFetcherStubURLProtocol.requests.count == 2)
+            #expect(snapshot.identity?.loginMethod == "Teams")
+            #expect(snapshot.primary?.usedPercent == 25)
+            #expect(snapshot.secondary?.usedPercent == 10)
+        }
     }
 
     @Test
     func `auto session import tries fallback browsers after preferred sessions fail`() async throws {
         defer {
-            WindsurfDevinSessionImporter.importSessionsOverrideForTesting = nil
-            WindsurfDevinSessionImporter.importPreferredSessionsOverrideForTesting = nil
-            WindsurfDevinSessionImporter.importFallbackSessionsOverrideForTesting = nil
             WindsurfWebFetcherStubURLProtocol.requests = []
             WindsurfWebFetcherStubURLProtocol.handler = nil
         }
 
-        WindsurfDevinSessionImporter.importPreferredSessionsOverrideForTesting = { _, _ in
+        let preferredSessions: SessionOverride = { _, _ in
             [
                 WindsurfDevinSessionImporter.SessionInfo(
                     session: WindsurfDevinSessionAuth(
@@ -179,7 +193,7 @@ struct WindsurfWebFetcherTests {
                     sourceLabel: "Chrome Default"),
             ]
         }
-        WindsurfDevinSessionImporter.importFallbackSessionsOverrideForTesting = { _, _ in
+        let fallbackSessions: SessionOverride = { _, _ in
             [
                 WindsurfDevinSessionImporter.SessionInfo(
                     session: WindsurfDevinSessionAuth(
@@ -218,24 +232,26 @@ struct WindsurfWebFetcherTests {
                 statusCode: 200)
         }
 
-        let snapshot = try await WindsurfWebFetcher.fetchUsage(
-            browserDetection: BrowserDetection(cacheTTL: 0),
-            cookieSource: .auto,
-            timeout: 2,
-            session: self.makeSession())
+        try await self.withWindsurfSessionOverrides(
+            preferredSessions: preferredSessions,
+            fallbackSessions: fallbackSessions)
+        {
+            let snapshot = try await WindsurfWebFetcher.fetchUsage(
+                browserDetection: BrowserDetection(cacheTTL: 0),
+                cookieSource: .auto,
+                timeout: 2,
+                session: self.makeSession())
 
-        #expect(WindsurfWebFetcherStubURLProtocol.requests.count == 2)
-        #expect(snapshot.identity?.loginMethod == "Teams")
-        #expect(snapshot.primary?.usedPercent == 36)
-        #expect(snapshot.secondary?.usedPercent == 20)
+            #expect(WindsurfWebFetcherStubURLProtocol.requests.count == 2)
+            #expect(snapshot.identity?.loginMethod == "Teams")
+            #expect(snapshot.primary?.usedPercent == 36)
+            #expect(snapshot.secondary?.usedPercent == 20)
+        }
     }
 
     @Test
     func `auto import uses complete legacy origin when app origin is partial`() async throws {
         defer {
-            WindsurfDevinSessionImporter.importSessionsOverrideForTesting = nil
-            WindsurfDevinSessionImporter.importPreferredSessionsOverrideForTesting = nil
-            WindsurfDevinSessionImporter.importFallbackSessionsOverrideForTesting = nil
             WindsurfWebFetcherStubURLProtocol.requests = []
             WindsurfWebFetcherStubURLProtocol.handler = nil
         }
@@ -264,8 +280,6 @@ struct WindsurfWebFetcherTests {
                 from: snapshot.storage,
                 sourceLabel: "Chrome Default (\(snapshot.sourceSuffix ?? "unknown"))")
         }
-        WindsurfDevinSessionImporter.importPreferredSessionsOverrideForTesting = { _, _ in sessionInfos }
-
         WindsurfWebFetcherStubURLProtocol.requests = []
         WindsurfWebFetcherStubURLProtocol.handler = { request in
             let url = try #require(request.url)
@@ -290,31 +304,32 @@ struct WindsurfWebFetcherTests {
                 statusCode: 200)
         }
 
-        let snapshot = try await WindsurfWebFetcher.fetchUsage(
-            browserDetection: BrowserDetection(cacheTTL: 0),
-            cookieSource: .auto,
-            timeout: 2,
-            session: self.makeSession())
+        let preferredSessions: SessionOverride = { _, _ in sessionInfos }
 
-        #expect(snapshots.count == 1)
-        #expect(sessionInfos.map(\.sourceLabel) == ["Chrome Default (windsurf.com)"])
-        #expect(WindsurfWebFetcherStubURLProtocol.requests.count == 1)
-        #expect(snapshot.identity?.loginMethod == "Pro")
-        #expect(snapshot.primary?.usedPercent == 30)
-        #expect(snapshot.secondary?.usedPercent == 15)
+        try await self.withWindsurfSessionOverrides(preferredSessions: preferredSessions) {
+            let snapshot = try await WindsurfWebFetcher.fetchUsage(
+                browserDetection: BrowserDetection(cacheTTL: 0),
+                cookieSource: .auto,
+                timeout: 2,
+                session: self.makeSession())
+
+            #expect(snapshots.count == 1)
+            #expect(sessionInfos.map(\.sourceLabel) == ["Chrome Default (windsurf.com)"])
+            #expect(WindsurfWebFetcherStubURLProtocol.requests.count == 1)
+            #expect(snapshot.identity?.loginMethod == "Pro")
+            #expect(snapshot.primary?.usedPercent == 30)
+            #expect(snapshot.secondary?.usedPercent == 15)
+        }
     }
 
     @Test
     func `manual mode with empty session does not fall back to imported session`() async {
         defer {
-            WindsurfDevinSessionImporter.importSessionsOverrideForTesting = nil
-            WindsurfDevinSessionImporter.importPreferredSessionsOverrideForTesting = nil
-            WindsurfDevinSessionImporter.importFallbackSessionsOverrideForTesting = nil
             WindsurfWebFetcherStubURLProtocol.requests = []
             WindsurfWebFetcherStubURLProtocol.handler = nil
         }
 
-        WindsurfDevinSessionImporter.importSessionsOverrideForTesting = { _, _ in
+        let importedSessions: SessionOverride = { _, _ in
             [
                 WindsurfDevinSessionImporter.SessionInfo(
                     session: WindsurfDevinSessionAuth(
@@ -327,16 +342,18 @@ struct WindsurfWebFetcherTests {
         }
         WindsurfWebFetcherStubURLProtocol.requests = []
 
-        await #expect {
-            _ = try await WindsurfWebFetcher.fetchUsage(
-                browserDetection: BrowserDetection(cacheTTL: 0),
-                cookieSource: .manual,
-                manualSessionInput: "   \n",
-                timeout: 2,
-                session: self.makeSession())
-        } throws: { error in
-            guard case let WindsurfWebFetcherError.invalidManualSession(message) = error else { return false }
-            return message == "empty input"
+        await self.withWindsurfSessionOverrides(importSessions: importedSessions) {
+            await #expect {
+                _ = try await WindsurfWebFetcher.fetchUsage(
+                    browserDetection: BrowserDetection(cacheTTL: 0),
+                    cookieSource: .manual,
+                    manualSessionInput: "   \n",
+                    timeout: 2,
+                    session: self.makeSession())
+            } throws: { error in
+                guard case let WindsurfWebFetcherError.invalidManualSession(message) = error else { return false }
+                return message == "empty input"
+            }
         }
         #expect(WindsurfWebFetcherStubURLProtocol.requests.isEmpty)
     }


### PR DESCRIPTION
## Summary
- replace remaining cookie/session importer process-global test overrides with task-local scoped helpers
- isolate Perplexity override imports and Keychain-backed cookie test storage across concurrent tasks
- repair migrated provider tests for Swift 6 closure syntax and conditional compilation
- add regression coverage for concurrent override and cache isolation

Part of #2204.

## Tests
- `make check`
- focused concurrent provider/cache suite: 185 tests passed
- `make test`: 654 selections, 55/55 groups passed, 0 retries
- autoreview: clean, no accepted/actionable findings
