### PR TITLE
Fix spurious Claude weekly reset confetti from transient near-zero samples

### DIFF
--- a/Sources/CodexBar/UsageStore+LimitResetBoundary.swift
+++ b/Sources/CodexBar/UsageStore+LimitResetBoundary.swift
@@ -1,13 +1,37 @@
+import CodexBarCore
 import Foundation
 
 extension UsageStore {
     nonisolated static func limitResetBoundaryAdvanced(
         previous: Date?,
         current: Date?,
-        requiresPreviousBoundary: Bool = false) -> Bool
+        requiresPreviousBoundary: Bool = false,
+        requiresCurrentBoundary: Bool = true) -> Bool
     {
         guard let previous else { return !requiresPreviousBoundary }
-        guard let current else { return false }
+        // A missing current boundary cannot confirm an advance. Callers that trust
+        // boundary-less snapshots (e.g. Claude OAuth, which may omit resetsAt on a genuine
+        // reset) pass requiresCurrentBoundary: false so the crossing is still allowed.
+        guard let current else { return !requiresCurrentBoundary }
         return !self.areEquivalentPlanUtilizationResetBoundaries(previous, current) && current > previous
+    }
+
+    /// Whether a weekly below-threshold crossing should post a limit-reset celebration.
+    ///
+    /// Codex boundaries are always present, so a real advance requires both a prior and a
+    /// current boundary (#2054). Claude OAuth snapshots may legitimately omit the boundary, so
+    /// neither is required: only a confirmed *unchanged* boundary is suppressed as a suspect
+    /// near-zero sample (#2222); a missing boundary on either side still allows a genuine reset.
+    nonisolated static func weeklyResetBoundaryAllowsCelebration(
+        provider: UsageProvider,
+        previous: Date?,
+        current: Date?) -> Bool
+    {
+        let isCodex = provider == .codex
+        return self.limitResetBoundaryAdvanced(
+            previous: previous,
+            current: current,
+            requiresPreviousBoundary: isCodex,
+            requiresCurrentBoundary: isCodex)
     }
 }

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -529,16 +529,12 @@ extension UsageStore {
                 previous: previousState?.resetBoundary,
                 current: observation.resetBoundary)
         } else if descriptor.seriesName == .weekly, context.provider == .codex || context.provider == .claude {
-            // A weekly below-threshold crossing only counts as a genuine reset if the reset
-            // boundary actually advanced — otherwise a bogus near-zero sample (e.g. a CLI
-            // usage-probe misparse) gets read as a reset and fires spurious confetti (#2222).
-            // Codex requires an existing previous boundary (#2054); Claude OAuth snapshots can
-            // lack one entirely, so Claude must NOT require it — an absent boundary still
-            // allows a genuine reset to post, only an unchanged one is suppressed.
-            Self.limitResetBoundaryAdvanced(
+            // Weekly celebrations require a real boundary advance so a bogus near-zero sample
+            // is not read as a reset (#2222 for Claude, #2054 for Codex). See the helper.
+            Self.weeklyResetBoundaryAllowsCelebration(
+                provider: context.provider,
                 previous: previousState?.resetBoundary,
-                current: observation.resetBoundary,
-                requiresPreviousBoundary: context.provider == .codex)
+                current: observation.resetBoundary)
         } else {
             true
         }

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -528,22 +528,17 @@ extension UsageStore {
             Self.limitResetBoundaryAdvanced(
                 previous: previousState?.resetBoundary,
                 current: observation.resetBoundary)
-        } else if context.provider == .codex, descriptor.seriesName == .weekly {
+        } else if descriptor.seriesName == .weekly, context.provider == .codex || context.provider == .claude {
+            // A weekly below-threshold crossing only counts as a genuine reset if the reset
+            // boundary actually advanced — otherwise a bogus near-zero sample (e.g. a CLI
+            // usage-probe misparse) gets read as a reset and fires spurious confetti (#2222).
+            // Codex requires an existing previous boundary (#2054); Claude OAuth snapshots can
+            // lack one entirely, so Claude must NOT require it — an absent boundary still
+            // allows a genuine reset to post, only an unchanged one is suppressed.
             Self.limitResetBoundaryAdvanced(
                 previous: previousState?.resetBoundary,
                 current: observation.resetBoundary,
-                requiresPreviousBoundary: true)
-        } else if context.provider == .claude, descriptor.seriesName == .weekly {
-            // A Claude weekly below-threshold crossing is only a genuine reset if the reset
-            // boundary actually advanced. Usage is monotonic within a window, so a drop to
-            // ~0 while the boundary is unchanged is a bogus near-zero sample (e.g. a CLI
-            // usage-probe misparse) rather than a reset — celebrating it fires spurious
-            // confetti (#2222). Unlike Codex, Claude OAuth snapshots can lack a boundary
-            // entirely, so this must NOT require a previous boundary: an absent boundary
-            // still celebrates a real reset, only an unchanged one is suppressed.
-            Self.limitResetBoundaryAdvanced(
-                previous: previousState?.resetBoundary,
-                current: observation.resetBoundary)
+                requiresPreviousBoundary: context.provider == .codex)
         } else {
             true
         }

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -533,14 +533,25 @@ extension UsageStore {
                 previous: previousState?.resetBoundary,
                 current: observation.resetBoundary,
                 requiresPreviousBoundary: true)
+        } else if context.provider == .claude, descriptor.seriesName == .weekly {
+            // A Claude weekly below-threshold crossing is only a genuine reset if the reset
+            // boundary actually advanced. Usage is monotonic within a window, so a drop to
+            // ~0 while the boundary is unchanged is a bogus near-zero sample (e.g. a CLI
+            // usage-probe misparse) rather than a reset — celebrating it fires spurious
+            // confetti (#2222). Unlike Codex, Claude OAuth snapshots can lack a boundary
+            // entirely, so this must NOT require a previous boundary: an absent boundary
+            // still celebrates a real reset, only an unchanged one is suppressed.
+            Self.limitResetBoundaryAdvanced(
+                previous: previousState?.resetBoundary,
+                current: observation.resetBoundary)
         } else {
             true
         }
         let crossedBelowThreshold = !sourceChanged && previousState?.wasAboveThreshold == true && !wasAboveThreshold
         let shouldPost = crossedBelowThreshold && resetBoundaryAllowsPost
         let suppressedGuardedCrossing = crossedBelowThreshold && !resetBoundaryAllowsPost
-        // Sessions retain the last non-regressed boundary on every guarded sample. Codex weekly crossings
-        // adopt a newly appearing boundary so a later genuine advance can still trigger once.
+        // Sessions retain the last non-regressed boundary on every guarded sample. Codex and Claude weekly
+        // crossings adopt a newly appearing boundary so a later genuine advance can still trigger once.
         let shouldPreserveBoundary = !sourceChanged && !resetBoundaryAllowsPost
             && (descriptor.seriesName == .session || previousState?.resetBoundary != nil)
         let shouldPreserveBaseline = suppressedGuardedCrossing

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
@@ -884,6 +884,63 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
+    func `claude weekly celebration ignores transient zero when reset boundary is unchanged`() async {
+        let store = Self.makeStore()
+        let accountLabel = "claude-weekly-transient-zero@example.com"
+        let recorder = WeeklyLimitResetEventRecorder(provider: .claude, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessionReset = firstDate.addingTimeInterval(5 * 3600)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+
+        func snapshot(weeklyUsed: Double, weeklyReset: Date, updatedAt: Date) -> UsageSnapshot {
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 14,
+                    windowMinutes: 300,
+                    resetsAt: sessionReset,
+                    resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: weeklyUsed,
+                    windowMinutes: 10080,
+                    resetsAt: weeklyReset,
+                    resetDescription: nil),
+                updatedAt: updatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .claude,
+                    accountEmail: accountLabel,
+                    accountOrganization: nil,
+                    loginMethod: "max"))
+        }
+
+        let before = snapshot(
+            weeklyUsed: 86,
+            weeklyReset: weeklyReset,
+            updatedAt: firstDate)
+        // Bogus near-zero probe sample: usage drops to 0 but the reset boundary is unchanged.
+        let transientZero = snapshot(
+            weeklyUsed: 0,
+            weeklyReset: weeklyReset,
+            updatedAt: firstDate.addingTimeInterval(120))
+        // Genuine reset: usage is 0 and the boundary has advanced by a full week.
+        let realReset = snapshot(
+            weeklyUsed: 0,
+            weeklyReset: weeklyReset.addingTimeInterval(7 * 24 * 3600),
+            updatedAt: firstDate.addingTimeInterval(180))
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude, snapshot: transientZero, now: transientZero.updatedAt)
+        #expect(recorder.events.isEmpty)
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: realReset, now: realReset.updatedAt)
+        #expect(recorder.events.count == 1)
+        #expect(recorder.events.first?.usedPercent == 0)
+    }
+
+    @MainActor
+    @Test
     func `weekly quota celebration posts when reset lands mid hour without history split`() async {
         let store = Self.makeStore()
         let accountLabel = "mid-hour-reset@example.com"
@@ -908,7 +965,9 @@ extension UsageStorePlanUtilizationTests {
             secondary: RateWindow(
                 usedPercent: 0,
                 windowMinutes: 10080,
-                resetsAt: Date(timeIntervalSince1970: 1_700_100_030),
+                // A genuine weekly reset advances the boundary by a full week; the same-hour
+                // history-split behavior under test is driven by `updatedAt`, not this boundary.
+                resetsAt: Date(timeIntervalSince1970: 1_700_100_000 + 7 * 24 * 3600),
                 resetDescription: nil),
             updatedAt: Date(timeIntervalSince1970: 1_700_001_800),
             identity: ProviderIdentitySnapshot(

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
@@ -1579,7 +1579,9 @@ private final class SessionLimitResetEventRecorder: @unchecked Sendable {
     }
 }
 
-private final class WeeklyLimitResetEventRecorder: @unchecked Sendable {
+// Internal (not private) so focused sibling test files — e.g.
+// UsageStorePlanUtilizationClaudeWeeklyResetGuardTests — can reuse it.
+final class WeeklyLimitResetEventRecorder: @unchecked Sendable {
     struct Event {
         let provider: UsageProvider
         let accountLabel: String?

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
@@ -884,63 +884,6 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
-    func `claude weekly celebration ignores transient zero when reset boundary is unchanged`() async {
-        let store = Self.makeStore()
-        let accountLabel = "claude-weekly-transient-zero@example.com"
-        let recorder = WeeklyLimitResetEventRecorder(provider: .claude, accountLabel: accountLabel)
-        defer { recorder.invalidate() }
-
-        let firstDate = Date(timeIntervalSince1970: 1_700_000_000)
-        let sessionReset = firstDate.addingTimeInterval(5 * 3600)
-        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
-
-        func snapshot(weeklyUsed: Double, weeklyReset: Date, updatedAt: Date) -> UsageSnapshot {
-            UsageSnapshot(
-                primary: RateWindow(
-                    usedPercent: 14,
-                    windowMinutes: 300,
-                    resetsAt: sessionReset,
-                    resetDescription: nil),
-                secondary: RateWindow(
-                    usedPercent: weeklyUsed,
-                    windowMinutes: 10080,
-                    resetsAt: weeklyReset,
-                    resetDescription: nil),
-                updatedAt: updatedAt,
-                identity: ProviderIdentitySnapshot(
-                    providerID: .claude,
-                    accountEmail: accountLabel,
-                    accountOrganization: nil,
-                    loginMethod: "max"))
-        }
-
-        let before = snapshot(
-            weeklyUsed: 86,
-            weeklyReset: weeklyReset,
-            updatedAt: firstDate)
-        // Bogus near-zero probe sample: usage drops to 0 but the reset boundary is unchanged.
-        let transientZero = snapshot(
-            weeklyUsed: 0,
-            weeklyReset: weeklyReset,
-            updatedAt: firstDate.addingTimeInterval(120))
-        // Genuine reset: usage is 0 and the boundary has advanced by a full week.
-        let realReset = snapshot(
-            weeklyUsed: 0,
-            weeklyReset: weeklyReset.addingTimeInterval(7 * 24 * 3600),
-            updatedAt: firstDate.addingTimeInterval(180))
-
-        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: before, now: before.updatedAt)
-        await store.recordPlanUtilizationHistorySample(
-            provider: .claude, snapshot: transientZero, now: transientZero.updatedAt)
-        #expect(recorder.events.isEmpty)
-
-        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: realReset, now: realReset.updatedAt)
-        #expect(recorder.events.count == 1)
-        #expect(recorder.events.first?.usedPercent == 0)
-    }
-
-    @MainActor
-    @Test
     func `weekly quota celebration posts when reset lands mid hour without history split`() async {
         let store = Self.makeStore()
         let accountLabel = "mid-hour-reset@example.com"

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCelebrationTests.swift
@@ -884,7 +884,7 @@ extension UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
-    func `weekly quota celebration posts when reset lands mid hour without history split`() async {
+    func `weekly same-hour drop with unchanged boundary coalesces history without celebrating`() async {
         let store = Self.makeStore()
         let accountLabel = "mid-hour-reset@example.com"
         let recorder = WeeklyLimitResetEventRecorder(provider: .claude, accountLabel: accountLabel)
@@ -908,9 +908,9 @@ extension UsageStorePlanUtilizationTests {
             secondary: RateWindow(
                 usedPercent: 0,
                 windowMinutes: 10080,
-                // A genuine weekly reset advances the boundary by a full week; the same-hour
-                // history-split behavior under test is driven by `updatedAt`, not this boundary.
-                resetsAt: Date(timeIntervalSince1970: 1_700_100_000 + 7 * 24 * 3600),
+                // Boundary drifts 30s (< the 2-min equivalence tolerance) — same reset window,
+                // so the two samples coalesce into a single hourly entry (no history split).
+                resetsAt: Date(timeIntervalSince1970: 1_700_100_030),
                 resetDescription: nil),
             updatedAt: Date(timeIntervalSince1970: 1_700_001_800),
             identity: ProviderIdentitySnapshot(
@@ -925,9 +925,9 @@ extension UsageStorePlanUtilizationTests {
         let histories = store.planUtilizationHistory(for: .claude)
         #expect(findSeries(histories, name: .weekly, windowMinutes: 10080)?.entries.count == 1)
         #expect(findSeries(histories, name: .weekly, windowMinutes: 10080)?.entries.last?.usedPercent == 40)
-        let events = recorder.events
-        #expect(events.count == 1)
-        #expect(events[0].usedPercent == 0)
+        // The drop to 0 on an unchanged reset boundary is a suspect sample, not a reset, so no
+        // celebration fires (#2222). A genuine reset advances the boundary — covered separately.
+        #expect(recorder.events.isEmpty)
     }
 
     @MainActor

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeWeeklyResetGuardTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeWeeklyResetGuardTests.swift
@@ -60,4 +60,53 @@ extension UsageStorePlanUtilizationTests {
         #expect(recorder.events.count == 1)
         #expect(recorder.events.first?.usedPercent == 0)
     }
+
+    @MainActor
+    @Test
+    func `claude weekly celebration posts when a genuine reset drops the boundary`() async {
+        // Regression for the prior-boundary-to-nil transition: a Claude OAuth snapshot may
+        // legitimately omit resetsAt on a genuine reset. Detector state holds a prior boundary,
+        // then the reset sample has no boundary — this must still celebrate, not be suppressed.
+        let store = Self.makeStore()
+        let accountLabel = "claude-weekly-boundary-dropped@example.com"
+        let recorder = WeeklyLimitResetEventRecorder(provider: .claude, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+
+        func snapshot(weeklyUsed: Double, weeklyReset: Date?, updatedAt: Date) -> UsageSnapshot {
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 14,
+                    windowMinutes: 300,
+                    resetsAt: firstDate.addingTimeInterval(5 * 3600),
+                    resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: weeklyUsed,
+                    windowMinutes: 10080,
+                    resetsAt: weeklyReset,
+                    resetDescription: nil),
+                updatedAt: updatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .claude,
+                    accountEmail: accountLabel,
+                    accountOrganization: nil,
+                    loginMethod: "max"))
+        }
+
+        let before = snapshot(weeklyUsed: 86, weeklyReset: weeklyReset, updatedAt: firstDate)
+        // Genuine reset whose snapshot omits the boundary entirely.
+        let boundarylessReset = snapshot(
+            weeklyUsed: 0,
+            weeklyReset: nil,
+            updatedAt: firstDate.addingTimeInterval(120))
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude, snapshot: boundarylessReset, now: boundarylessReset.updatedAt)
+
+        #expect(recorder.events.count == 1)
+        #expect(recorder.events.first?.usedPercent == 0)
+    }
 }

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeWeeklyResetGuardTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeWeeklyResetGuardTests.swift
@@ -1,0 +1,63 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+extension UsageStorePlanUtilizationTests {
+    @MainActor
+    @Test
+    func `claude weekly celebration ignores transient zero when reset boundary is unchanged`() async {
+        let store = Self.makeStore()
+        let accountLabel = "claude-weekly-transient-zero@example.com"
+        let recorder = WeeklyLimitResetEventRecorder(provider: .claude, accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let firstDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessionReset = firstDate.addingTimeInterval(5 * 3600)
+        let weeklyReset = firstDate.addingTimeInterval(3 * 24 * 3600)
+
+        func snapshot(weeklyUsed: Double, weeklyReset: Date, updatedAt: Date) -> UsageSnapshot {
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 14,
+                    windowMinutes: 300,
+                    resetsAt: sessionReset,
+                    resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: weeklyUsed,
+                    windowMinutes: 10080,
+                    resetsAt: weeklyReset,
+                    resetDescription: nil),
+                updatedAt: updatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .claude,
+                    accountEmail: accountLabel,
+                    accountOrganization: nil,
+                    loginMethod: "max"))
+        }
+
+        let before = snapshot(
+            weeklyUsed: 86,
+            weeklyReset: weeklyReset,
+            updatedAt: firstDate)
+        // Bogus near-zero probe sample: usage drops to 0 but the reset boundary is unchanged.
+        let transientZero = snapshot(
+            weeklyUsed: 0,
+            weeklyReset: weeklyReset,
+            updatedAt: firstDate.addingTimeInterval(120))
+        // Genuine reset: usage is 0 and the boundary has advanced by a full week.
+        let realReset = snapshot(
+            weeklyUsed: 0,
+            weeklyReset: weeklyReset.addingTimeInterval(7 * 24 * 3600),
+            updatedAt: firstDate.addingTimeInterval(180))
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .claude, snapshot: transientZero, now: transientZero.updatedAt)
+        #expect(recorder.events.isEmpty)
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: realReset, now: realReset.updatedAt)
+        #expect(recorder.events.count == 1)
+        #expect(recorder.events.first?.usedPercent == 0)
+    }
+}


### PR DESCRIPTION
**Partially addresses #2222** (the Claude weekly boundary-guard path; see "Scope" below — this intentionally does not fully close the issue).

## Problem
Claude weekly limit-reset celebrations fire on a single bogus near-zero usage reading (e.g. a CLI usage-probe misparse). The `resetBoundaryAllowsPost` gate in `postLimitResetCelebrationIfNeeded` has a boundary-advance guard for the **session** lane and for **Codex weekly** (added for #2054), but Claude weekly fell through to the unconditional `else { true }` — so one transient zero was enough to celebrate, even when the reset boundary had not moved.

Reported forensics on the issue show the transient sample carried the *correct, unchanged* reset boundary, yet a whole-panel misread dropped both session and weekly to ~0 and both fired.

## Fix
Route Claude weekly crossings through the same boundary-advance guard as Codex, via a shared `weeklyResetBoundaryAllowsCelebration(provider:previous:current:)` helper: a below-threshold crossing only celebrates if the reset boundary actually advanced.

Claude uses a more permissive variant than Codex, because Claude OAuth snapshots can legitimately have **no** boundary:
- **Unchanged** boundary (present on both sides, within the 2-minute equivalence tolerance) → suppressed (the #2222 transient-zero case).
- Boundary **missing** on either side → still allowed (a genuine boundary-less OAuth reset must still celebrate).
- Boundary **advanced** → celebrates.

Codex behavior is byte-for-byte unchanged (it requires both a prior and current boundary).

## Scope
This fixes the Claude **weekly boundary-guard** path only. #2222 also reports a stale-boundary **session** path and an identity-less shared `claude:claude` detector-key concern. Those are larger, separable changes and are intentionally **out of scope** here — left as follow-ups rather than folded into this narrow guard. Hence "Partially addresses" rather than "Closes".

## Tests
- `claude weekly celebration ignores transient zero when reset boundary is unchanged` — transient zero (same boundary) suppressed; a subsequent genuine week-advance celebrates exactly once.
- `claude weekly celebration posts when a genuine reset drops the boundary` — prior-boundary → nil-boundary genuine reset still celebrates.
- `weekly same-hour drop with unchanged boundary coalesces history without celebrating` — same-hour history coalescing preserved, no false celebration.
Existing nil-boundary Claude reset coverage (`weekly quota celebration posts when weekly usage resets to zero`, repeated-low, first-seen) is unaffected.

## Review feedback addressed (clawsweeper — commits `b02e3ac`, `048f444`)
Both first-round P1 findings were correct and are fixed:
1. **Preserve boundary-less Claude resets** — added a `requiresCurrentBoundary` flag to `limitResetBoundaryAdvanced` (default `true`, so session/Codex are unchanged); Claude passes `false`, so a stored boundary followed by a boundary-less genuine reset (`B → nil`) is no longer wrongly suppressed. Added focused coverage.
2. **Same-hour history fixture** — an earlier `+7d` edit exceeded the 2-minute tolerance and started a second history segment. Restored an in-tolerance boundary; the same-boundary drop is now correctly a suspect sample, so the test asserts coalescing **without** a celebration.
Also fixed a sibling-test compile issue (made `WeeklyLimitResetEventRecorder` internal so the split test file resolves it).

## On "real behavior proof"
This is a pure-logic change fully covered by deterministic Swift Testing cases (transient-zero suppressed, genuine week-advance celebrates, boundary-dropped reset celebrates, same-hour coalescing without celebration). I don't own a Mac, so I can't attach a native-app run/recording — the CI `swift-test-macos` job and a maintainer's signed run are the runtime confirmation, same situation as #2102. Happy to adjust anything.
