### PR TITLE
Block background Chromium Keychain access

### DIFF
--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -82,6 +82,12 @@ public enum BrowserCookieAccessGate {
     public static func shouldAttempt(_ browser: Browser, now: Date = Date()) -> Bool {
         guard browser.usesKeychainForCookieDecryption else { return true }
         guard !KeychainAccessGate.isDisabled else { return false }
+        guard ProviderInteractionContext.current == .userInitiated else {
+            self.log.info(
+                "Skipping background Chromium cookie import to avoid a Keychain prompt",
+                metadata: ["browser": browser.displayName])
+            return false
+        }
         if self.deniedBrowsersForTesting?.contains(browser) == true {
             return self.isExplicitRetryAllowed(for: browser)
         }

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -247,7 +247,7 @@ struct BrowserDetectionTests {
     }
 
     @Test
-    func `background cookie import allows authorized chromium keychain sources`() {
+    func `background cookie import skips chromium before keychain preflight`() {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 
@@ -259,17 +259,17 @@ struct BrowserDetectionTests {
                 return .allowed
             } operation: {
                 ProviderInteractionContext.$current.withValue(.background) {
-                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == true)
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == false)
                     #expect(BrowserCookieAccessGate.shouldAttempt(.safari) == true)
                 }
             }
         }
 
-        #expect(preflightCount == 1)
+        #expect(preflightCount == 0)
     }
 
     @Test
-    func `background cookie import suppresses chromium keychain sources requiring interaction`() {
+    func `background cookie import skips chromium without probing keychain interaction`() {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 
@@ -287,7 +287,7 @@ struct BrowserDetectionTests {
             }
         }
 
-        #expect(preflightCount == 1)
+        #expect(preflightCount == 0)
     }
 
     @Test

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -130,7 +130,9 @@ struct BrowserDetectionTests {
         let client = BrowserCookieClient(configuration: .init(homeDirectories: [temp]))
         let stores = try KeychainAccessGate.withTaskOverrideForTesting(false) {
             try KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in .allowed } operation: {
-                try client.codexBarStores(for: .chrome)
+                try ProviderInteractionContext.$current.withValue(.userInitiated) {
+                    try client.codexBarStores(for: .chrome)
+                }
             }
         }
         #expect(stores.count == 1)
@@ -221,7 +223,7 @@ struct BrowserDetectionTests {
         var preflightCount = 0
 
         KeychainAccessGate.withTaskOverrideForTesting(false) {
-            ProviderInteractionContext.$current.withValue(.background) {
+            ProviderInteractionContext.$current.withValue(.userInitiated) {
                 KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in
                     preflightCount += 1
                     return .interactionRequired
@@ -320,7 +322,7 @@ struct BrowserDetectionTests {
                         BrowserCookieAccessGate.recordAllowed(for: .arc)
                     }
                 }
-                ProviderInteractionContext.$current.withValue(.background) {
+                ProviderInteractionContext.$current.withValue(.userInitiated) {
                     #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(3)) == true)
                 }
             }
@@ -367,7 +369,9 @@ struct BrowserDetectionTests {
                 queriedLabels.append(label)
                 return .notFound
             } operation: {
-                #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == true)
+                ProviderInteractionContext.$current.withValue(.userInitiated) {
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == true)
+                }
             }
         }
 
@@ -390,7 +394,9 @@ struct BrowserDetectionTests {
                 queriedLabels.append(label)
                 return .notFound
             } operation: {
-                #expect(BrowserCookieAccessGate.shouldAttempt(.dia) == true)
+                ProviderInteractionContext.$current.withValue(.userInitiated) {
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.dia) == true)
+                }
             }
         }
 
@@ -419,7 +425,7 @@ struct BrowserDetectionTests {
                 if label == firstDiaLabel { return .interactionRequired }
                 return .notFound
             } operation: {
-                ProviderInteractionContext.$current.withValue(.background) {
+                ProviderInteractionContext.$current.withValue(.userInitiated) {
                     #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start) == true)
                     #expect(BrowserCookieAccessGate.shouldAttempt(.dia, now: start.addingTimeInterval(1)) == false)
                     #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(60)) == false)


### PR DESCRIPTION
## Summary

- block Chromium browser-cookie imports during background provider refreshes
- preserve browser-cookie access for user-initiated refreshes and the existing Keychain pre-alert flow
- update gate tests to prove background paths do not even perform the Keychain preflight

## Root cause

Chromium cookie decryption reads `Chrome Safe Storage` from Keychain. The previous background path could proceed into the browser importer whenever an attribute-only preflight appeared allowed, even though the later password-data read could require user interaction.

## Impact

Automatic refreshes no longer initiate the Chromium Keychain path. A user-initiated refresh remains the consent boundary for browser-cookie authentication.

## Validation

- targeted test changes use `KeychainAccessPreflight` test overrides and do not touch a real Keychain item
- `git diff --check`
- the full local SwiftPM test executable was blocked by unrelated auxiliary-target timestamp churn after the modified core module compiled; this is recorded rather than treated as a passing test

## Follow-up

SweetCookieKit is being hardened separately so no host can implicitly promote a no-UI Safe Storage read to an interactive one. Once released, CodexBar should bump that dependency.

Fixes #2213
Related: #2214
