### PR TITLE
Prevent duplicate Claude weekly reset confetti

### DIFF
--- a/Sources/CodexBar/UsageStore+LimitResetCelebration.swift
+++ b/Sources/CodexBar/UsageStore+LimitResetCelebration.swift
@@ -1,0 +1,187 @@
+import CodexBarCore
+import Foundation
+
+extension UsageStore {
+    private nonisolated static let limitResetThreshold = 1.0
+    private nonisolated static let claudeWeeklyRecoveryObservationCount = 2
+
+    struct LimitResetDetectorState: Codable, Equatable {
+        let wasAboveThreshold: Bool
+        let lastObservedAt: Date
+        let sourceRawValue: String?
+        var resetBoundary: Date?
+        var recoveryAboveThresholdCount: Int?
+
+        init(
+            wasAboveThreshold: Bool,
+            lastObservedAt: Date,
+            sourceRawValue: String?,
+            resetBoundary: Date? = nil,
+            recoveryAboveThresholdCount: Int? = nil)
+        {
+            self.wasAboveThreshold = wasAboveThreshold
+            self.lastObservedAt = lastObservedAt
+            self.sourceRawValue = sourceRawValue
+            self.resetBoundary = resetBoundary
+            self.recoveryAboveThresholdCount = recoveryAboveThresholdCount
+        }
+    }
+
+    struct LimitResetDetectionContext {
+        let provider: UsageProvider
+        let account: ProviderTokenAccount?
+        let snapshot: UsageSnapshot
+        let accountKey: String?
+        let capturedAt: Date
+        let codexLimitResetOwnerKey: CodexLimitResetOwnerKey?
+    }
+
+    struct LimitResetObservation {
+        let usedPercent: Double
+        let observedAt: Date
+        let resetBoundary: Date?
+        let source: SessionQuotaWindowSource?
+    }
+
+    struct LimitResetDetectionDescriptor {
+        let seriesName: PlanUtilizationSeriesName
+        let defaultsKey: String
+        let resetKind: String
+    }
+
+    func postLimitResetCelebrationIfNeeded(
+        states: inout [String: LimitResetDetectorState],
+        context: LimitResetDetectionContext,
+        descriptor: LimitResetDetectionDescriptor,
+        observation: LimitResetObservation?)
+    {
+        guard let observation else { return }
+
+        guard let accountIdentifier = self.limitResetAccountIdentifier(
+            provider: context.provider,
+            account: context.account,
+            snapshot: context.snapshot,
+            accountKey: context.accountKey,
+            codexLimitResetOwnerKey: context.codexLimitResetOwnerKey)
+        else {
+            return
+        }
+        let detectorKey = Self.limitResetDetectorStateKey(
+            provider: context.provider,
+            accountIdentifier: accountIdentifier)
+        let currentUsed = observation.usedPercent
+        let currentObservedAt = observation.observedAt
+        let wasAboveThreshold = currentUsed > Self.limitResetThreshold
+        if let existingState = states[detectorKey],
+           currentObservedAt <= existingState.lastObservedAt
+        {
+            return
+        }
+
+        let previousState = states[detectorKey]
+        let isClaudeWeekly = context.provider == .claude && descriptor.seriesName == .weekly
+        let claudeWeeklyRecoveryPending = isClaudeWeekly
+            && previousState?.recoveryAboveThresholdCount != nil
+        let sourceRawValue = observation.source?.rawValue
+        let sourceChanged = descriptor.seriesName == .session && previousState?.sourceRawValue != nil
+            && previousState?.sourceRawValue != sourceRawValue
+        let resetBoundaryAllowsPost = if descriptor.seriesName == .session {
+            Self.limitResetBoundaryAdvanced(
+                previous: previousState?.resetBoundary,
+                current: observation.resetBoundary)
+        } else if context.provider == .codex, descriptor.seriesName == .weekly {
+            Self.limitResetBoundaryAdvanced(
+                previous: previousState?.resetBoundary,
+                current: observation.resetBoundary,
+                requiresPreviousBoundary: true)
+        } else {
+            true
+        }
+        let crossedBelowThreshold = !sourceChanged && previousState?.wasAboveThreshold == true && !wasAboveThreshold
+        let shouldPost = crossedBelowThreshold && resetBoundaryAllowsPost && !claudeWeeklyRecoveryPending
+        let suppressedGuardedCrossing = crossedBelowThreshold && !resetBoundaryAllowsPost
+        // Sessions retain the last non-regressed boundary on every guarded sample. Codex weekly crossings
+        // adopt a newly appearing boundary so a later genuine advance can still trigger once.
+        let shouldPreserveBoundary = !sourceChanged && !resetBoundaryAllowsPost
+            && (descriptor.seriesName == .session || previousState?.resetBoundary != nil)
+        let shouldPreserveBaseline = suppressedGuardedCrossing
+        let previousRecoveryCount = previousState?.recoveryAboveThresholdCount ?? 0
+        let nextRecoveryCount = if claudeWeeklyRecoveryPending {
+            wasAboveThreshold ? previousRecoveryCount + 1 : 0
+        } else {
+            0
+        }
+        let claudeWeeklyRecoveryConfirmed = claudeWeeklyRecoveryPending
+            && nextRecoveryCount >= Self.claudeWeeklyRecoveryObservationCount
+        let nextWasAboveThreshold = if claudeWeeklyRecoveryPending {
+            claudeWeeklyRecoveryConfirmed
+        } else if shouldPreserveBaseline {
+            true
+        } else {
+            wasAboveThreshold
+        }
+        let persistedRecoveryCount: Int? = if shouldPost {
+            0
+        } else if claudeWeeklyRecoveryPending, !claudeWeeklyRecoveryConfirmed {
+            nextRecoveryCount
+        } else {
+            nil
+        }
+        states[detectorKey] = LimitResetDetectorState(
+            // A transient zero must not erase the baseline needed to recognize the real reset that follows.
+            wasAboveThreshold: nextWasAboveThreshold,
+            lastObservedAt: currentObservedAt,
+            sourceRawValue: sourceRawValue,
+            resetBoundary: shouldPreserveBoundary ? previousState?.resetBoundary : observation.resetBoundary,
+            recoveryAboveThresholdCount: persistedRecoveryCount)
+        self.persistLimitResetDetectorStates(
+            states,
+            defaultsKey: descriptor.defaultsKey,
+            logName: descriptor.resetKind)
+
+        if claudeWeeklyRecoveryPending, wasAboveThreshold {
+            CodexBarLog.logger(LogCategories.confetti).debug(
+                "Confirming Claude weekly usage recovery after celebration",
+                metadata: [
+                    "accountIdentifier": accountIdentifier,
+                    "confirmationCount": String(nextRecoveryCount),
+                    "observedAt": String(format: "%.0f", currentObservedAt.timeIntervalSince1970),
+                ])
+        }
+
+        guard shouldPost else { return }
+        let accountLabel = self.limitResetAccountLabel(
+            provider: context.provider,
+            account: context.account,
+            snapshot: context.snapshot)
+
+        CodexBarLog.logger(LogCategories.confetti).info(
+            "\(descriptor.resetKind.capitalized) limit reset",
+            metadata: [
+                "provider": context.provider.rawValue,
+                "accountIdentifier": accountIdentifier,
+                "accountLabel": accountLabel ?? "",
+                "resetKind": descriptor.resetKind,
+                "usedPercent": String(format: "%.2f", currentUsed),
+                "observedAt": String(format: "%.0f", currentObservedAt.timeIntervalSince1970),
+            ])
+        switch descriptor.seriesName {
+        case .session:
+            let event = SessionLimitResetEvent(
+                provider: context.provider,
+                accountIdentifier: accountIdentifier,
+                accountLabel: accountLabel,
+                usedPercent: currentUsed)
+            NotificationCenter.default.post(name: .codexbarSessionLimitReset, object: event)
+        case .weekly:
+            let event = WeeklyLimitResetEvent(
+                provider: context.provider,
+                accountIdentifier: accountIdentifier,
+                accountLabel: accountLabel,
+                usedPercent: currentUsed)
+            NotificationCenter.default.post(name: .codexbarWeeklyLimitReset, object: event)
+        default:
+            return
+        }
+    }
+}

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -2,7 +2,6 @@ import CodexBarCore
 import Foundation
 
 extension UsageStore {
-    private nonisolated static let limitResetThreshold = 1.0
     nonisolated static let sessionLimitResetDetectorDefaultsKey = "sessionLimitResetDetectorStates"
     private nonisolated static let weeklyLimitResetDetectorDefaultsKey = "weeklyLimitResetDetectorStates"
     private nonisolated static let claudeOAuthAccountUuidMapDefaultsKey = "ClaudeOAuthHistoryOwnerAccountUuidMapV1"
@@ -30,13 +29,6 @@ extension UsageStore {
         let keychainCredentialUnavailable: Bool
         let activeAccountObservation: ClaudeOAuthActiveAccountObservation
         let observedAt: Date
-    }
-
-    struct LimitResetDetectorState: Codable, Equatable {
-        let wasAboveThreshold: Bool
-        let lastObservedAt: Date
-        let sourceRawValue: String?
-        var resetBoundary: Date?
     }
 
     func supportsPlanUtilizationHistory(for provider: UsageProvider) -> Bool {
@@ -70,28 +62,6 @@ extension UsageStore {
         let name: PlanUtilizationSeriesName
         let windowMinutes: Int
         let entry: PlanUtilizationHistoryEntry
-    }
-
-    private struct LimitResetDetectionContext {
-        let provider: UsageProvider
-        let account: ProviderTokenAccount?
-        let snapshot: UsageSnapshot
-        let accountKey: String?
-        let capturedAt: Date
-        let codexLimitResetOwnerKey: CodexLimitResetOwnerKey?
-    }
-
-    private struct LimitResetObservation {
-        let usedPercent: Double
-        let observedAt: Date
-        let resetBoundary: Date?
-        let source: SessionQuotaWindowSource?
-    }
-
-    private struct LimitResetDetectionDescriptor {
-        let seriesName: PlanUtilizationSeriesName
-        let defaultsKey: String
-        let resetKind: String
     }
 
     func planUtilizationHistory(for provider: UsageProvider) -> [PlanUtilizationSeriesHistory] {
@@ -418,6 +388,7 @@ extension UsageStore {
     nonisolated static var _planUtilizationMaxSamplesForTesting: Int {
         self.planUtilizationMaxSamples
     }
+
     #endif
 
     private nonisolated static func clampedPercent(_ value: Double?) -> Double? {
@@ -488,106 +459,6 @@ extension UsageStore {
             return minutes > 0 && minutes <= 6 * 60
         case .copilotSecondaryFallback, .zaiTertiary, .antigravityQuotaSummary, .antigravityLegacy:
             return true
-        }
-    }
-
-    private func postLimitResetCelebrationIfNeeded(
-        states: inout [String: LimitResetDetectorState],
-        context: LimitResetDetectionContext,
-        descriptor: LimitResetDetectionDescriptor,
-        observation: LimitResetObservation?)
-    {
-        guard let observation else { return }
-
-        guard let accountIdentifier = self.limitResetAccountIdentifier(
-            provider: context.provider,
-            account: context.account,
-            snapshot: context.snapshot,
-            accountKey: context.accountKey,
-            codexLimitResetOwnerKey: context.codexLimitResetOwnerKey)
-        else {
-            return
-        }
-        let detectorKey = Self.limitResetDetectorStateKey(
-            provider: context.provider,
-            accountIdentifier: accountIdentifier)
-        let currentUsed = observation.usedPercent
-        let currentObservedAt = observation.observedAt
-        let wasAboveThreshold = currentUsed > Self.limitResetThreshold
-        if let existingState = states[detectorKey],
-           currentObservedAt <= existingState.lastObservedAt
-        {
-            return
-        }
-
-        let previousState = states[detectorKey]
-        let sourceRawValue = observation.source?.rawValue
-        let sourceChanged = descriptor.seriesName == .session && previousState?.sourceRawValue != nil
-            && previousState?.sourceRawValue != sourceRawValue
-        let resetBoundaryAllowsPost = if descriptor.seriesName == .session {
-            Self.limitResetBoundaryAdvanced(
-                previous: previousState?.resetBoundary,
-                current: observation.resetBoundary)
-        } else if context.provider == .codex, descriptor.seriesName == .weekly {
-            Self.limitResetBoundaryAdvanced(
-                previous: previousState?.resetBoundary,
-                current: observation.resetBoundary,
-                requiresPreviousBoundary: true)
-        } else {
-            true
-        }
-        let crossedBelowThreshold = !sourceChanged && previousState?.wasAboveThreshold == true && !wasAboveThreshold
-        let shouldPost = crossedBelowThreshold && resetBoundaryAllowsPost
-        let suppressedGuardedCrossing = crossedBelowThreshold && !resetBoundaryAllowsPost
-        // Sessions retain the last non-regressed boundary on every guarded sample. Codex weekly crossings
-        // adopt a newly appearing boundary so a later genuine advance can still trigger once.
-        let shouldPreserveBoundary = !sourceChanged && !resetBoundaryAllowsPost
-            && (descriptor.seriesName == .session || previousState?.resetBoundary != nil)
-        let shouldPreserveBaseline = suppressedGuardedCrossing
-        states[detectorKey] = LimitResetDetectorState(
-            // A transient zero must not erase the baseline needed to recognize the real reset that follows.
-            wasAboveThreshold: shouldPreserveBaseline ? true : wasAboveThreshold,
-            lastObservedAt: currentObservedAt,
-            sourceRawValue: sourceRawValue,
-            resetBoundary: shouldPreserveBoundary ? previousState?.resetBoundary : observation.resetBoundary)
-        self.persistLimitResetDetectorStates(
-            states,
-            defaultsKey: descriptor.defaultsKey,
-            logName: descriptor.resetKind)
-
-        guard shouldPost else { return }
-        let accountLabel = self.limitResetAccountLabel(
-            provider: context.provider,
-            account: context.account,
-            snapshot: context.snapshot)
-
-        CodexBarLog.logger(LogCategories.confetti).info(
-            "\(descriptor.resetKind.capitalized) limit reset",
-            metadata: [
-                "provider": context.provider.rawValue,
-                "accountIdentifier": accountIdentifier,
-                "accountLabel": accountLabel ?? "",
-                "resetKind": descriptor.resetKind,
-                "usedPercent": String(format: "%.2f", currentUsed),
-                "observedAt": String(format: "%.0f", currentObservedAt.timeIntervalSince1970),
-            ])
-        switch descriptor.seriesName {
-        case .session:
-            let event = SessionLimitResetEvent(
-                provider: context.provider,
-                accountIdentifier: accountIdentifier,
-                accountLabel: accountLabel,
-                usedPercent: currentUsed)
-            NotificationCenter.default.post(name: .codexbarSessionLimitReset, object: event)
-        case .weekly:
-            let event = WeeklyLimitResetEvent(
-                provider: context.provider,
-                accountIdentifier: accountIdentifier,
-                accountLabel: accountLabel,
-                usedPercent: currentUsed)
-            NotificationCenter.default.post(name: .codexbarWeeklyLimitReset, object: event)
-        default:
-            return
         }
     }
 
@@ -909,7 +780,7 @@ extension UsageStore {
         provider == .claude && self.shouldHidePlanUtilizationMenuItem(for: .claude)
     }
 
-    private nonisolated static func limitResetDetectorStateKey(
+    nonisolated static func limitResetDetectorStateKey(
         provider: UsageProvider,
         accountIdentifier: String) -> String
     {
@@ -919,10 +790,23 @@ extension UsageStore {
     nonisolated static func loadWeeklyLimitResetDetectorStates(from userDefaults: UserDefaults)
         -> [String: LimitResetDetectorState]
     {
-        self.loadLimitResetDetectorStates(
+        var states = self.loadLimitResetDetectorStates(
             from: userDefaults,
             defaultsKey: self.weeklyLimitResetDetectorDefaultsKey,
             logName: "weekly")
+        let legacyClaudeLowStateKeys = states.compactMap { key, state in
+            key.hasPrefix("\(UsageProvider.claude.rawValue):")
+                && !state.wasAboveThreshold
+                && state.recoveryAboveThresholdCount == nil
+                ? key
+                : nil
+        }
+        for key in legacyClaudeLowStateKeys {
+            guard var migratedState = states[key] else { continue }
+            migratedState.recoveryAboveThresholdCount = 0
+            states[key] = migratedState
+        }
+        return states
     }
 
     nonisolated static func loadLimitResetDetectorStates(
@@ -941,7 +825,7 @@ extension UsageStore {
         }
     }
 
-    private func persistLimitResetDetectorStates(
+    func persistLimitResetDetectorStates(
         _ states: [String: LimitResetDetectorState],
         defaultsKey: String,
         logName: String)

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeWeeklyDedupTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeWeeklyDedupTests.swift
@@ -1,0 +1,324 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+extension UsageStorePlanUtilizationTests {
+    @MainActor
+    @Test
+    func `Claude weekly celebration ignores a stale high and duplicate low after reset`() async throws {
+        let store = Self.makeStore()
+        let accountLabel = "claude-weekly-dedup@example.com"
+        let recorder = ClaudeWeeklyResetEventRecorder(accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let start = Date(timeIntervalSince1970: 1_784_174_200)
+        let boundary = start.addingTimeInterval(4 * 24 * 60 * 60)
+        let snapshots = [
+            claudeWeeklyDedupSnapshot(
+                accountLabel: accountLabel,
+                usedPercent: 73,
+                resetsAt: boundary,
+                updatedAt: start),
+            claudeWeeklyDedupSnapshot(
+                accountLabel: accountLabel,
+                usedPercent: 0,
+                resetsAt: boundary,
+                updatedAt: start.addingTimeInterval(10)),
+            claudeWeeklyDedupSnapshot(
+                accountLabel: accountLabel,
+                usedPercent: 73,
+                resetsAt: boundary,
+                updatedAt: start.addingTimeInterval(20)),
+            claudeWeeklyDedupSnapshot(
+                accountLabel: accountLabel,
+                usedPercent: 0,
+                resetsAt: boundary,
+                updatedAt: start.addingTimeInterval(25)),
+        ]
+
+        for snapshot in snapshots {
+            await store.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: snapshot,
+                now: snapshot.updatedAt)
+        }
+
+        #expect(recorder.count == 1)
+        let state = try #require(store.weeklyLimitResetDetectorStates.values.first)
+        #expect(state.wasAboveThreshold == false)
+        #expect(state.recoveryAboveThresholdCount == 0)
+    }
+
+    @MainActor
+    @Test
+    func `Claude weekly recovery confirmation persists and later permits a new reset`() async throws {
+        let firstStore = Self.makeStore()
+        let accountLabel = "claude-weekly-persisted-dedup@example.com"
+        let recorder = ClaudeWeeklyResetEventRecorder(accountLabel: accountLabel)
+        defer { recorder.invalidate() }
+
+        let start = Date(timeIntervalSince1970: 1_784_200_000)
+        let boundary = start.addingTimeInterval(4 * 24 * 60 * 60)
+        let firstHigh = claudeWeeklyDedupSnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 65,
+            resetsAt: boundary,
+            updatedAt: start)
+        let firstReset = claudeWeeklyDedupSnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: boundary,
+            updatedAt: start.addingTimeInterval(10))
+
+        for snapshot in [firstHigh, firstReset] {
+            await firstStore.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: snapshot,
+                now: snapshot.updatedAt)
+        }
+        #expect(recorder.count == 1)
+
+        let persistedStates = UsageStore.loadWeeklyLimitResetDetectorStates(
+            from: firstStore.settings.userDefaults)
+        let restartedStore = Self.makeStore()
+        restartedStore.weeklyLimitResetDetectorStates = persistedStates
+
+        let delayedStaleHigh = claudeWeeklyDedupSnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 65,
+            resetsAt: boundary,
+            updatedAt: firstReset.updatedAt.addingTimeInterval(30 * 60))
+        let duplicateLow = claudeWeeklyDedupSnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: boundary,
+            updatedAt: firstReset.updatedAt.addingTimeInterval(31 * 60))
+
+        for snapshot in [delayedStaleHigh, duplicateLow] {
+            await restartedStore.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: snapshot,
+                now: snapshot.updatedAt)
+        }
+        #expect(recorder.count == 1)
+        var state = try #require(restartedStore.weeklyLimitResetDetectorStates.values.first)
+        #expect(state.wasAboveThreshold == false)
+        #expect(state.recoveryAboveThresholdCount == 0)
+
+        let firstRecoveryHigh = claudeWeeklyDedupSnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 40,
+            resetsAt: boundary,
+            updatedAt: firstReset.updatedAt.addingTimeInterval(60 * 60))
+        await restartedStore.recordPlanUtilizationHistorySample(
+            provider: .claude,
+            snapshot: firstRecoveryHigh,
+            now: firstRecoveryHigh.updatedAt)
+        #expect(recorder.count == 1)
+        state = try #require(restartedStore.weeklyLimitResetDetectorStates.values.first)
+        #expect(state.wasAboveThreshold == false)
+        #expect(state.recoveryAboveThresholdCount == 1)
+
+        let recoveryStates = UsageStore.loadWeeklyLimitResetDetectorStates(
+            from: restartedStore.settings.userDefaults)
+        let secondRestartedStore = Self.makeStore()
+        secondRestartedStore.weeklyLimitResetDetectorStates = recoveryStates
+
+        let secondRecoveryHigh = claudeWeeklyDedupSnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 45,
+            resetsAt: boundary,
+            updatedAt: firstReset.updatedAt.addingTimeInterval(65 * 60))
+        let laterReset = claudeWeeklyDedupSnapshot(
+            accountLabel: accountLabel,
+            usedPercent: 0,
+            resetsAt: boundary,
+            updatedAt: firstReset.updatedAt.addingTimeInterval(70 * 60))
+
+        for snapshot in [secondRecoveryHigh, laterReset] {
+            await secondRestartedStore.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: snapshot,
+                now: snapshot.updatedAt)
+        }
+        #expect(recorder.count == 2)
+    }
+
+    @MainActor
+    @Test
+    func `Claude weekly recovery confirmation is isolated by account`() async {
+        let store = Self.makeStore()
+        let firstAccount = "claude-weekly-dedup-a@example.com"
+        let secondAccount = "claude-weekly-dedup-b@example.com"
+        let firstRecorder = ClaudeWeeklyResetEventRecorder(accountLabel: firstAccount)
+        let secondRecorder = ClaudeWeeklyResetEventRecorder(accountLabel: secondAccount)
+        defer {
+            firstRecorder.invalidate()
+            secondRecorder.invalidate()
+        }
+
+        let start = Date(timeIntervalSince1970: 1_784_300_000)
+        let boundary = start.addingTimeInterval(4 * 24 * 60 * 60)
+        let snapshots = [
+            claudeWeeklyDedupSnapshot(
+                accountLabel: firstAccount,
+                usedPercent: 65,
+                resetsAt: boundary,
+                updatedAt: start),
+            claudeWeeklyDedupSnapshot(
+                accountLabel: firstAccount,
+                usedPercent: 0,
+                resetsAt: boundary,
+                updatedAt: start.addingTimeInterval(1)),
+            claudeWeeklyDedupSnapshot(
+                accountLabel: firstAccount,
+                usedPercent: 65,
+                resetsAt: boundary,
+                updatedAt: start.addingTimeInterval(30 * 60)),
+            claudeWeeklyDedupSnapshot(
+                accountLabel: secondAccount,
+                usedPercent: 60,
+                resetsAt: boundary,
+                updatedAt: start.addingTimeInterval(31 * 60)),
+            claudeWeeklyDedupSnapshot(
+                accountLabel: secondAccount,
+                usedPercent: 0,
+                resetsAt: boundary,
+                updatedAt: start.addingTimeInterval(32 * 60)),
+            claudeWeeklyDedupSnapshot(
+                accountLabel: firstAccount,
+                usedPercent: 0,
+                resetsAt: boundary,
+                updatedAt: start.addingTimeInterval(33 * 60)),
+        ]
+
+        for snapshot in snapshots {
+            await store.recordPlanUtilizationHistorySample(
+                provider: .claude,
+                snapshot: snapshot,
+                now: snapshot.updatedAt)
+        }
+
+        #expect(firstRecorder.count == 1)
+        #expect(secondRecorder.count == 1)
+        #expect(store.weeklyLimitResetDetectorStates.count == 2)
+        #expect(store.weeklyLimitResetDetectorStates.values.allSatisfy { !$0.wasAboveThreshold })
+        #expect(store.weeklyLimitResetDetectorStates.values.allSatisfy {
+            $0.recoveryAboveThresholdCount == 0
+        })
+    }
+
+    @Test
+    func `legacy reset detector state decodes without recovery state`() throws {
+        let suiteName = "ClaudeWeeklyResetDedupLegacy-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let data = Data(
+            #"{"claude:legacy":{"wasAboveThreshold":true,"lastObservedAt":0}}"#.utf8)
+        defaults.set(data, forKey: "legacyWeeklyResetStates")
+
+        let states = UsageStore.loadLimitResetDetectorStates(
+            from: defaults,
+            defaultsKey: "legacyWeeklyResetStates",
+            logName: "weekly")
+
+        let state = try #require(states["claude:legacy"])
+        #expect(state.wasAboveThreshold)
+        #expect(state.recoveryAboveThresholdCount == nil)
+    }
+
+    @Test
+    func `legacy Claude weekly low state migrates into recovery confirmation`() throws {
+        let suiteName = "ClaudeWeeklyResetDedupLowMigration-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let data = Data(
+            """
+            {
+              "claude:legacy-low": {"wasAboveThreshold":false,"lastObservedAt":0},
+              "codex:legacy-low": {"wasAboveThreshold":false,"lastObservedAt":0}
+            }
+            """.utf8)
+        defaults.set(data, forKey: "weeklyLimitResetDetectorStates")
+
+        let states = UsageStore.loadWeeklyLimitResetDetectorStates(from: defaults)
+
+        #expect(states["claude:legacy-low"]?.recoveryAboveThresholdCount == 0)
+        #expect(states["codex:legacy-low"]?.recoveryAboveThresholdCount == nil)
+    }
+}
+
+private func claudeWeeklyDedupSnapshot(
+    accountLabel: String,
+    usedPercent: Double,
+    resetsAt: Date,
+    updatedAt: Date) -> UsageSnapshot
+{
+    UsageSnapshot(
+        primary: RateWindow(
+            usedPercent: 14,
+            windowMinutes: 300,
+            resetsAt: updatedAt.addingTimeInterval(5 * 60 * 60),
+            resetDescription: nil),
+        secondary: RateWindow(
+            usedPercent: usedPercent,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: resetsAt,
+            resetDescription: nil),
+        updatedAt: updatedAt,
+        identity: ProviderIdentitySnapshot(
+            providerID: .claude,
+            accountEmail: accountLabel,
+            accountOrganization: nil,
+            loginMethod: "web"))
+}
+
+private final class ClaudeWeeklyResetEventRecorder: @unchecked Sendable {
+    private let accountLabel: String
+    private let lock = NSLock()
+    private var eventCount = 0
+    private var token: NSObjectProtocol?
+
+    init(accountLabel: String) {
+        self.accountLabel = accountLabel
+        self.token = NotificationCenter.default.addObserver(
+            forName: .codexbarWeeklyLimitReset,
+            object: nil,
+            queue: nil)
+        { [weak self] notification in
+            guard let self,
+                  let event = notification.object as? WeeklyLimitResetEvent
+            else {
+                return
+            }
+
+            let matches = MainActor.assumeIsolated {
+                event.provider == .claude && event.accountLabel == self.accountLabel
+            }
+            guard matches else { return }
+
+            self.lock.lock()
+            self.eventCount += 1
+            self.lock.unlock()
+        }
+    }
+
+    var count: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.eventCount
+    }
+
+    func invalidate() {
+        guard let token else { return }
+        NotificationCenter.default.removeObserver(token)
+        self.token = nil
+    }
+
+    deinit {
+        self.invalidate()
+    }
+}

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeWeeklyDedupTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationClaudeWeeklyDedupTests.swift
@@ -8,7 +8,7 @@ extension UsageStorePlanUtilizationTests {
     @Test
     func `Claude weekly celebration ignores a stale high and duplicate low after reset`() async throws {
         let store = Self.makeStore()
-        let accountLabel = "claude-weekly-dedup@example.com"
+        let accountLabel = "claude-weekly-dedup-account"
         let recorder = ClaudeWeeklyResetEventRecorder(accountLabel: accountLabel)
         defer { recorder.invalidate() }
 
@@ -54,7 +54,7 @@ extension UsageStorePlanUtilizationTests {
     @Test
     func `Claude weekly recovery confirmation persists and later permits a new reset`() async throws {
         let firstStore = Self.makeStore()
-        let accountLabel = "claude-weekly-persisted-dedup@example.com"
+        let accountLabel = "claude-weekly-persisted-dedup-account"
         let recorder = ClaudeWeeklyResetEventRecorder(accountLabel: accountLabel)
         defer { recorder.invalidate() }
 
@@ -149,8 +149,8 @@ extension UsageStorePlanUtilizationTests {
     @Test
     func `Claude weekly recovery confirmation is isolated by account`() async {
         let store = Self.makeStore()
-        let firstAccount = "claude-weekly-dedup-a@example.com"
-        let secondAccount = "claude-weekly-dedup-b@example.com"
+        let firstAccount = "claude-weekly-dedup-account-a"
+        let secondAccount = "claude-weekly-dedup-account-b"
         let firstRecorder = ClaudeWeeklyResetEventRecorder(accountLabel: firstAccount)
         let secondRecorder = ClaudeWeeklyResetEventRecorder(accountLabel: secondAccount)
         defer {
@@ -280,11 +280,11 @@ private final class ClaudeWeeklyResetEventRecorder: @unchecked Sendable {
     private let accountLabel: String
     private let lock = NSLock()
     private var eventCount = 0
-    private var token: NSObjectProtocol?
+    private var observer: NSObjectProtocol?
 
     init(accountLabel: String) {
         self.accountLabel = accountLabel
-        self.token = NotificationCenter.default.addObserver(
+        self.observer = NotificationCenter.default.addObserver(
             forName: .codexbarWeeklyLimitReset,
             object: nil,
             queue: nil)
@@ -313,9 +313,9 @@ private final class ClaudeWeeklyResetEventRecorder: @unchecked Sendable {
     }
 
     func invalidate() {
-        guard let token else { return }
-        NotificationCenter.default.removeObserver(token)
-        self.token = nil
+        guard let observer else { return }
+        NotificationCenter.default.removeObserver(observer)
+        self.observer = nil
     }
 
     deinit {


### PR DESCRIPTION
## Summary

- prevent a stale Claude weekly usage rebound from rearming duplicate reset confetti
- require two consecutive above-threshold observations before rearming, persisted separately per account
- migrate legacy Claude weekly low states into the new recovery-confirmation state
- preserve Claude's existing behavior where a genuine refill may occur without changing the weekly boundary

## Root cause

After a genuine refill, a stale pre-refill sample could immediately rearm the threshold detector:

`73% → 0% (event posted) → 73% → 0% (duplicate event posted)`

The detector now remains disarmed until two consecutive readings confirm that weekly usage has genuinely resumed. A low reading interrupts that confirmation.

## Tests

- `swift test --filter UsageStorePlanUtilizationTests` — 76 passed
- `make check` — passed with 0 violations
- `make test` — the full suite remains blocked by eight failures in the untouched `ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests` suite; the same failures reproduce when that suite is run independently

Regression coverage includes the exact observed sequence, a stale rebound delayed by 30 minutes, restart persistence, multiple-account isolation, a genuine later reset, and legacy-state migration.

Fixes #2230.

Related to #2222, but does not address its false first celebration.
