### PR TITLE
Verify development Sparkle bundle integrity

### DIFF
--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -13,6 +13,25 @@ resolve_package_signing_mode() {
   SIGNING_MODE="$requested"
 }
 
+verify_no_quarantine_attribute() {
+  local bundle="$1"
+  local quarantined
+  quarantined="$(xattr -r -p com.apple.quarantine "$bundle" 2>/dev/null || true)"
+  if [[ -n "$quarantined" ]]; then
+    echo "ERROR: Packaged app still has com.apple.quarantine: ${bundle}" >&2
+    return 1
+  fi
+}
+
+verify_packaged_app_integrity() {
+  local bundle="$1"
+  local sparkle="$bundle/Contents/Frameworks/Sparkle.framework"
+
+  verify_no_quarantine_attribute "$bundle" || return 1
+  codesign --verify --deep --strict --verbose=2 "$sparkle" || return 1
+  codesign --verify --deep --strict --verbose=2 "$bundle" || return 1
+}
+
 CONF=${1:-release}
 ALLOW_LLDB=${CODEXBAR_ALLOW_LLDB:-0}
 SIGNING_MODE=
@@ -538,4 +557,5 @@ codesign "${CODESIGN_ARGS[@]}" \
 rm -rf "$APP_FINAL"
 mv "$APP" "$APP_FINAL"
 APP="$APP_FINAL"
+verify_packaged_app_integrity "$APP"
 echo "Created $APP"

--- a/Scripts/test_package_signing.sh
+++ b/Scripts/test_package_signing.sh
@@ -12,9 +12,16 @@ import sys
 from pathlib import Path
 
 script = Path(sys.argv[1]).read_text()
-start = script.index('resolve_package_signing_mode() {')
-end = script.index('\n}\n', start) + 3
-Path(sys.argv[2]).write_text(script[start:end])
+functions = []
+for name in (
+    'resolve_package_signing_mode',
+    'verify_no_quarantine_attribute',
+    'verify_packaged_app_integrity',
+):
+    start = script.index(f'{name}() {{')
+    end = script.index('\n}\n', start) + 3
+    functions.append(script[start:end])
+Path(sys.argv[2]).write_text('\n\n'.join(functions))
 PY
 
 source "$FUNCTIONS_FILE"
@@ -35,5 +42,38 @@ if resolve_package_signing_mode 2>/dev/null; then
 fi
 
 grep -Fq 'CODEXBAR_SIGNING=identity ./Scripts/package_app.sh release' "$RELEASE_SCRIPT"
+
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexbar-package-signing.XXXXXX")
+trap 'rm -f "$FUNCTIONS_FILE"; rm -rf "$TEMP_DIR"' EXIT
+APP="$TEMP_DIR/CodexBar.app"
+mkdir -p "$APP/Contents/Frameworks/Sparkle.framework"
+
+xattr() {
+  if [[ "${MOCK_QUARANTINE:-0}" == "1" ]]; then
+    printf '0081;fake;Safari;https://example.invalid\n'
+    return 0
+  fi
+  return 1
+}
+
+codesign() {
+  return "${MOCK_CODESIGN_STATUS:-0}"
+}
+
+verify_packaged_app_integrity "$APP"
+
+export MOCK_QUARANTINE=1
+if verify_packaged_app_integrity "$APP" 2>/dev/null; then
+  echo "Quarantined app unexpectedly passed integrity verification" >&2
+  exit 1
+fi
+unset MOCK_QUARANTINE
+
+export MOCK_CODESIGN_STATUS=1
+if verify_packaged_app_integrity "$APP" 2>/dev/null; then
+  echo "App with an invalid signature unexpectedly passed integrity verification" >&2
+  exit 1
+fi
+unset MOCK_CODESIGN_STATUS
 
 echo "Package signing tests passed."


### PR DESCRIPTION
## Summary

- verify the finished development app bundle has no `com.apple.quarantine` attribute before launch
- strictly verify the embedded `Sparkle.framework` and the final `CodexBar.app` code signatures
- add behavior tests for quarantine and signature-verification failures

## Why

The local development loop can otherwise reach `open` with a Gatekeeper-rejected embedded Sparkle framework. The failure surfaces as a macOS dialog instead of an actionable packaging error, interrupting every rebuild.

## Reproduction evidence

The attached screenshot shows the pre-fix Gatekeeper dialog: macOS cannot verify `Sparkle.framework` when launching a development build.

## Validation

- `bash -n Scripts/package_app.sh Scripts/test_package_signing.sh`
- `./Scripts/test_package_signing.sh`
- `make check`

`make check` passes; it reports the repository's existing localization-coverage warnings.
