### PR TITLE
Claude: preserve Enterprise seat labels

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudePlan.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudePlan.swift
@@ -116,13 +116,18 @@ public enum ClaudePlan: String, CaseIterable, Sendable {
     }
 
     public static func webLoginMethod(rateLimitTier: String?, billingType: String?, seatTier: String?) -> String? {
-        switch self.normalized(seatTier) {
+        let plan = self.fromWebAccount(rateLimitTier: rateLimitTier, billingType: billingType)
+        if let plan, plan != .team {
+            return plan.brandedLoginMethod(rateLimitTier: rateLimitTier)
+        }
+
+        return switch self.normalized(seatTier) {
         case "team_standard":
             "Claude Team Standard"
         case "team_tier_1":
             "Claude Team Premium"
         default:
-            self.webLoginMethod(rateLimitTier: rateLimitTier, billingType: billingType)
+            plan?.brandedLoginMethod(rateLimitTier: rateLimitTier)
         }
     }
 

--- a/Tests/CodexBarTests/ClaudePlanResolverTests.swift
+++ b/Tests/CodexBarTests/ClaudePlanResolverTests.swift
@@ -61,6 +61,12 @@ struct ClaudePlanResolverTests {
                 billingType: "stripe_subscription",
                 seatTier: "team_tier_1")
                 == "Claude Team Premium")
+        #expect(
+            ClaudePlan.webLoginMethod(
+                rateLimitTier: nil,
+                billingType: nil,
+                seatTier: "team_standard")
+                == "Claude Team Standard")
     }
 
     @Test
@@ -77,6 +83,22 @@ struct ClaudePlanResolverTests {
                 billingType: "stripe_subscription",
                 seatTier: "team_standard_plus")
                 == "Claude Team")
+    }
+
+    @Test
+    func `web enterprise seat tiers preserve the enterprise label`() {
+        #expect(
+            ClaudePlan.webLoginMethod(
+                rateLimitTier: "claude_enterprise",
+                billingType: "stripe_subscription",
+                seatTier: "team_standard")
+                == "Claude Enterprise")
+        #expect(
+            ClaudePlan.webLoginMethod(
+                rateLimitTier: "claude_enterprise",
+                billingType: "stripe_subscription",
+                seatTier: "team_tier_1")
+                == "Claude Enterprise")
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeWebAccountInfoTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebAccountInfoTests.swift
@@ -36,4 +36,26 @@ struct ClaudeWebAccountInfoTests {
         #expect(premium?.loginMethod == "Claude Team Premium")
         #expect(standard?.loginMethod == "Claude Team Standard")
     }
+
+    @Test
+    func `enterprise membership preserves its plan when it has a legacy seat tier`() {
+        let json = """
+        {
+          "email_address": "enterprise@example.com",
+          "memberships": [
+            {
+              "seat_tier": "team_tier_1",
+              "organization": {
+                "uuid": "org-enterprise",
+                "name": "Enterprise Org",
+                "rate_limit_tier": "claude_enterprise",
+                "billing_type": "stripe_subscription"
+              }
+            }
+          ]
+        }
+        """
+        let account = ClaudeWebAPIFetcher._parseAccountInfoForTesting(Data(json.utf8), orgId: "org-enterprise")
+        #expect(account?.loginMethod == "Claude Enterprise")
+    }
 }


### PR DESCRIPTION
## Summary

- preserve Claude Enterprise plan labels when legacy Enterprise memberships expose Standard or Premium seat tiers
- keep Team Standard/Premium labels when the base plan is Team or unresolved
- cover both plan resolution and selected `/api/account` membership parsing

Follow-up to #1965. Anthropic documents Standard and Premium seats for legacy seat-based Enterprise plans, so `seat_tier` cannot override an already-resolved Enterprise plan.

## Validation

- `swift test --filter 'Claude(PlanResolver|WebAccountInfo)Tests'` — 13 tests across 2 suites passed
- `make check` — SwiftFormat, SwiftLint, repository checks, scripts, docs, and locale checks passed
- autoreview — clean after preserving the unresolved-plan seat-tier fallback

Live Team Standard and legacy Enterprise accounts were not available. No browser cookies, Keychain data, or real-account probes were accessed.
