### PR TITLE
Stabilize Antigravity deadline assertion

### DIFF
--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -708,7 +708,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         let timeouts = timeoutRecorder.snapshot()
         #expect(result == "ok")
         #expect(timeouts.count == 2)
-        #expect(timeouts.allSatisfy { $0 < 10 })
+        #expect(timeouts.allSatisfy { $0 <= 10 })
         #expect((timeouts.last ?? 10) < (timeouts.first ?? 0))
     }
 


### PR DESCRIPTION
## Summary

- accept the legal equality boundary when the shared deadline and per-request timeout are both 10 seconds
- keep the decreasing second-attempt assertion that proves the shared deadline is recomputed

## Proof

- exact affected 12-suite group: 105 tests passed
- `make check`
- full no-retry suite: 665 selections, 56 groups, zero failures or retries
- autoreview: clean, 0.99 confidence

Test-only change; no changelog entry.
