### PR TITLE
Keep draft macOS test requirements visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
 
   swift-test-macos:
     needs: changes
-    if: ${{ needs.changes.outputs.macos-tests == 'true' }}
+    if: ${{ needs.changes.outputs.macos-tests == 'true' && needs.changes.outputs.macos-tests-deferred != 'true' }}
     runs-on: macos-15-intel
     timeout-minutes: 60
     strategy:

--- a/Scripts/ci_macos_test_gate.sh
+++ b/Scripts/ci_macos_test_gate.sh
@@ -98,7 +98,6 @@ if [[ "$path_count" -eq 0 ]]; then
 fi
 
 if [[ "$macos_tests" == true && "$draft_pull_request" == true ]]; then
-  macos_tests=false
   macos_tests_deferred=true
   summary_reason="draft pull request: macOS Swift tests deferred until ready for review"
 elif [[ "$macos_tests" == true ]]; then
@@ -114,7 +113,9 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   printf 'changed-path-count=%s\n' "$path_count" >> "$GITHUB_OUTPUT"
 fi
 
-if [[ "$macos_tests" == true ]]; then
+if [[ "$macos_tests_deferred" == true ]]; then
+  printf 'macOS Swift tests required but deferred until ready for review: %s.\n' "$macos_tests_reason"
+elif [[ "$macos_tests" == true ]]; then
   printf 'macOS Swift tests required for this change set: %s.\n' "$macos_tests_reason"
 else
   printf 'Skipping macOS Swift tests: %s.\n' "$summary_reason"

--- a/Scripts/ci_verify_test_jobs.sh
+++ b/Scripts/ci_verify_test_jobs.sh
@@ -18,29 +18,21 @@ if [[ "$changes_result" != "success" ]]; then
   exit 1
 fi
 
-case "${macos_tests_required}:${macos_test_result}" in
-  true:success)
-    if [[ "$macos_tests_deferred" != false ]]; then
-      printf 'macOS test gate marked a required test as deferred\n' >&2
-      exit 1
-    fi
+case "${macos_tests_required}:${macos_tests_deferred}:${macos_test_result}" in
+  true:false:success)
     printf 'Lint and macOS Swift test shards passed.\n'
     ;;
-  false:skipped)
-    if [[ "$macos_tests_deferred" == true ]]; then
-      printf 'Lint passed; macOS Swift tests are deferred until the pull request is ready for review.\n'
-      exit 0
-    fi
-    if [[ "$macos_tests_deferred" != false ]]; then
-      printf 'macOS test gate returned invalid deferred state: %s\n' \
-        "${macos_tests_deferred:-<empty>}" >&2
-      exit 1
-    fi
+  false:false:skipped)
     printf 'Lint passed; macOS Swift tests skipped by the macOS test gate.\n'
     ;;
+  true:true:skipped)
+    printf 'macOS Swift tests are required but deferred; aggregate CI remains incomplete\n' >&2
+    exit 1
+    ;;
   *)
-    printf 'macOS test gate/result mismatch: required=%s result=%s\n' \
-      "${macos_tests_required:-<empty>}" "${macos_test_result:-<empty>}" >&2
+    printf 'macOS test gate/result mismatch: required=%s deferred=%s result=%s\n' \
+      "${macos_tests_required:-<empty>}" "${macos_tests_deferred:-<empty>}" \
+      "${macos_test_result:-<empty>}" >&2
     exit 1
     ;;
 esac

--- a/Scripts/test_ci_path_gate.sh
+++ b/Scripts/test_ci_path_gate.sh
@@ -74,8 +74,8 @@ draft_output="${tmp_dir}/draft-source.output"
 printf '%s\n' $'M\tSources/CodexBar/App.swift' > "$draft_paths"
 CI_PULL_REQUEST_DRAFT=true GITHUB_OUTPUT="$draft_output" \
   "${ROOT_DIR}/Scripts/ci_macos_test_gate.sh" "$draft_paths" >/dev/null
-if [[ "$(sed -n 's/^macos-tests=//p' "$draft_output")" != false ]]; then
-  printf 'draft source: expected macOS tests to be deferred\n' >&2
+if [[ "$(sed -n 's/^macos-tests=//p' "$draft_output")" != true ]]; then
+  printf 'draft source: expected macOS tests to remain required while deferred\n' >&2
   exit 1
 fi
 if [[ "$(sed -n 's/^macos-tests-reason=//p' "$draft_output")" != \
@@ -86,6 +86,16 @@ then
 fi
 if [[ "$(sed -n 's/^macos-tests-deferred=//p' "$draft_output")" != true ]]; then
   printf 'draft source: expected macOS tests to be marked deferred\n' >&2
+  exit 1
+fi
+
+draft_docs_output="${tmp_dir}/draft-docs.output"
+CI_PULL_REQUEST_DRAFT=true GITHUB_OUTPUT="$draft_docs_output" \
+  "${ROOT_DIR}/Scripts/ci_macos_test_gate.sh" "${tmp_dir}/docs-only.paths" >/dev/null
+if [[ "$(sed -n 's/^macos-tests=//p' "$draft_docs_output")" != false ]] \
+  || [[ "$(sed -n 's/^macos-tests-deferred=//p' "$draft_docs_output")" != false ]]
+then
+  printf 'draft docs: expected required=false and deferred=false\n' >&2
   exit 1
 fi
 
@@ -136,7 +146,6 @@ fi
 verify="${ROOT_DIR}/Scripts/ci_verify_test_jobs.sh"
 "$verify" success success true success false >/dev/null
 "$verify" success success false skipped false >/dev/null
-"$verify" success success false skipped true >/dev/null
 
 assert_verify_fails() {
   if "$verify" "$@" >/dev/null 2>&1; then
@@ -146,6 +155,9 @@ assert_verify_fails() {
 }
 
 assert_verify_fails success success true skipped false
+assert_verify_fails success success true skipped true
+assert_verify_fails success success false skipped true
+assert_verify_fails success success true success true
 assert_verify_fails success success false success false
 assert_verify_fails success success "" skipped false
 assert_verify_fails failure success true success false

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -114,6 +114,12 @@ if not job_match:
     raise SystemExit("swift-test-macos job not found in CI workflow")
 
 job = job_match.group("body")
+required_not_deferred = (
+    "if: ${{ needs.changes.outputs.macos-tests == 'true' && "
+    "needs.changes.outputs.macos-tests-deferred != 'true' }}"
+)
+if required_not_deferred not in job:
+    raise SystemExit("swift-test-macos must skip only required tests explicitly deferred for drafts")
 if not re.search(r"(?m)^\s+shard-index:\s+\[0,\s*1\]\s*$", job):
     raise SystemExit("swift-test-macos must run exactly two shard indexes: [0, 1]")
 if not re.search(r"(?m)^\s+shard-count:\s+\[2\]\s*$", job):


### PR DESCRIPTION
## Summary

- keep macOS tests marked required for code-changing draft pull requests while recording their explicit deferred state
- skip the macOS job only when that required work is deferred
- fail the aggregate gate until the pull request becomes ready and the required shards pass
- reject inconsistent required/deferred/result combinations in the gate tests

Follow-up hardening for #2161. Internal CI behavior only; no changelog entry.

## Proof

- `bash Scripts/test_ci_path_gate.sh`
- `bash Scripts/test_swift_test_sharding.sh`
- `make check`
- autoreview: clean, 0.93 confidence
