### PR TITLE
fix(ProcessPipeCapture): close read handle and defend against EMFILE on Linux (#2234)

### DIFF
--- a/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if os(Linux)
+import Glibc
+#endif
 
 package final class ProcessPipeCapture: @unchecked Sendable {
     package static let defaultMaxBytes = 1 * 1024 * 1024
@@ -13,6 +16,7 @@ package final class ProcessPipeCapture: @unchecked Sendable {
     private var didReachEOF = false
     private var isStopping = false
     private var continuation: CheckedContinuation<Void, Never>?
+    private var usesReadableHandler = true
 
     package init(
         pipe: Pipe,
@@ -25,6 +29,22 @@ package final class ProcessPipeCapture: @unchecked Sendable {
     }
 
     package func start() {
+        #if os(Linux)
+        // swift-corelibs-foundation's readabilityHandler setter duplicates the
+        // underlying fd to create a dispatch source. If the process is already at
+        // EMFILE, that dup fails and the setter traps with precondition(_fd >= 0),
+        // producing the SIGILL reported in issue #2234. Defensively probe whether
+        // we can duplicate the fd ourselves; if not, fall back to synchronous
+        // reading in stopAndSnapshot() instead of installing the handler.
+        let fd = self.handle.fileDescriptor
+        let probe = Glibc.dup(fd)
+        guard probe != -1 else {
+            self.usesReadableHandler = false
+            return
+        }
+        Glibc.close(probe)
+        #endif
+
         self.handle.readabilityHandler = { [weak self] handle in
             self?.handleReadableData(from: handle)
         }
@@ -115,6 +135,27 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         continuation?.resume()
     }
 
+    private func drainSynchronously() {
+        while !self.isStopping {
+            let chunk = self.handle.availableData
+            self.condition.lock()
+            if chunk.isEmpty {
+                self.isFinished = true
+                self.didReachEOF = true
+                self.condition.broadcast()
+                self.condition.unlock()
+                return
+            }
+            let remainingBytes = max(0, self.maxBytes - self.data.count)
+            if remainingBytes > 0 {
+                self.data.append(chunk.prefix(remainingBytes))
+            }
+            self.onData?()
+            self.condition.broadcast()
+            self.condition.unlock()
+        }
+    }
+
     private func waitUntilFinished() async {
         await withCheckedContinuation { continuation in
             self.condition.lock()
@@ -131,6 +172,12 @@ package final class ProcessPipeCapture: @unchecked Sendable {
     private func stopAndSnapshot() -> Data {
         self.handle.readabilityHandler = nil
 
+        // If we could not install the readability handler (e.g. EMFILE on Linux),
+        // read whatever data is available synchronously before closing the fd.
+        if !self.usesReadableHandler {
+            self.drainSynchronously()
+        }
+
         let continuation: CheckedContinuation<Void, Never>?
         let snapshot: Data
         self.condition.lock()
@@ -143,6 +190,13 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         self.continuation = nil
         snapshot = self.data
         self.condition.unlock()
+
+        // Explicitly close the read-end file descriptor. On Linux
+        // swift-corelibs-foundation, clearing readabilityHandler does not
+        // release the underlying dup'd monitor fd, so the pipe read end leaks
+        // if we rely solely on closeOnDealloc. Closing here prevents the
+        // long-running fd growth that leads to EMFILE/SIGILL (issue #2234).
+        try? self.handle.close()
 
         continuation?.resume()
         return snapshot

--- a/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
@@ -16,7 +16,15 @@ package final class ProcessPipeCapture: @unchecked Sendable {
     private var didReachEOF = false
     private var isStopping = false
     private var continuation: CheckedContinuation<Void, Never>?
-    private var usesReadableHandler = true
+    #if os(Linux)
+    private let readerQueue = DispatchQueue(label: "com.steipete.CodexBar.process-pipe-capture.reader")
+    private let callbackQueue = DispatchQueue(label: "com.steipete.CodexBar.process-pipe-capture.callback")
+    private var readSource: DispatchSourceRead?
+    private var sourceStarted = false
+    private var sourceCancelled = false
+    private var callbackScheduled = false
+    private var callbackRequested = false
+    #endif
 
     package init(
         pipe: Pipe,
@@ -30,25 +38,37 @@ package final class ProcessPipeCapture: @unchecked Sendable {
 
     package func start() {
         #if os(Linux)
-        // swift-corelibs-foundation's readabilityHandler setter duplicates the
-        // underlying fd to create a dispatch source. If the process is already at
-        // EMFILE, that dup fails and the setter traps with precondition(_fd >= 0),
-        // producing the SIGILL reported in issue #2234. Defensively probe whether
-        // we can duplicate the fd ourselves; if not, fall back to synchronous
-        // reading in stopAndSnapshot() instead of installing the handler.
-        let fd = self.handle.fileDescriptor
-        let probe = Glibc.dup(fd)
-        guard probe != -1 else {
-            self.usesReadableHandler = false
+        self.start(linuxDescriptorSetup: Self.makeNonBlocking)
+        #else
+        self.installReadabilityHandler()
+        #endif
+    }
+
+    #if os(Linux)
+    package func start(linuxDescriptorSetup: @Sendable (Int32) -> Bool) {
+        let fileDescriptor = self.handle.fileDescriptor
+        guard linuxDescriptorSetup(fileDescriptor) else {
+            self.finishFailedLinuxStart()
             return
         }
-        Glibc.close(probe)
-        #endif
 
-        self.handle.readabilityHandler = { [weak self] handle in
-            self?.handleReadableData(from: handle)
+        // FileHandle.readabilityHandler duplicates the descriptor on Linux and traps if dup(2) returns EMFILE.
+        // A dispatch read source monitors the pipe's existing descriptor, so descriptor exhaustion cannot trigger
+        // Foundation's precondition failure.
+        let source = DispatchSource.makeReadSource(fileDescriptor: fileDescriptor, queue: self.readerQueue)
+        source.setEventHandler { [weak self] in
+            self?.handleLinuxReadableData(fileDescriptor: fileDescriptor)
         }
+        source.setCancelHandler { [weak self] in
+            self?.finishLinuxSourceCancellation()
+        }
+        self.condition.lock()
+        self.readSource = source
+        self.sourceStarted = true
+        self.condition.unlock()
+        source.resume()
     }
+    #endif
 
     package func finish(timeout: Duration) async -> Data {
         let drainTask = Task<Void, Error> {
@@ -135,24 +155,128 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         continuation?.resume()
     }
 
-    private func drainSynchronously() {
-        while !self.isStopping {
-            let chunk = self.handle.availableData
-            self.condition.lock()
-            if chunk.isEmpty {
-                self.isFinished = true
-                self.didReachEOF = true
+    #if os(Linux)
+    private func handleLinuxReadableData(fileDescriptor: Int32) {
+        self.condition.lock()
+        guard !self.isStopping else {
+            self.condition.unlock()
+            return
+        }
+        self.activeCallbacks += 1
+        self.condition.unlock()
+
+        var receivedData = false
+        var reachedEnd = false
+        var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+        while true {
+            let bytesRead = buffer.withUnsafeMutableBytes { bytes in
+                Glibc.read(fileDescriptor, bytes.baseAddress, bytes.count)
+            }
+            if bytesRead > 0 {
+                receivedData = true
+                self.condition.lock()
+                let remainingBytes = max(0, self.maxBytes - self.data.count)
+                if remainingBytes > 0 {
+                    self.data.append(contentsOf: buffer.prefix(min(remainingBytes, Int(bytesRead))))
+                }
+                let shouldStop = self.isStopping
                 self.condition.broadcast()
+                self.condition.unlock()
+                if shouldStop {
+                    break
+                }
+                continue
+            }
+            if bytesRead == 0 {
+                reachedEnd = true
+                break
+            }
+            if errno == EINTR {
+                continue
+            }
+            if errno != EAGAIN, errno != EWOULDBLOCK {
+                reachedEnd = true
+            }
+            break
+        }
+
+        var continuation: CheckedContinuation<Void, Never>?
+        var sourceToCancel: DispatchSourceRead?
+        self.condition.lock()
+        if reachedEnd {
+            self.isFinished = true
+            self.didReachEOF = true
+            continuation = self.continuation
+            self.continuation = nil
+            sourceToCancel = self.readSource
+        }
+        self.activeCallbacks -= 1
+        if self.activeCallbacks == 0 || reachedEnd {
+            self.condition.broadcast()
+        }
+        self.condition.unlock()
+
+        sourceToCancel?.cancel()
+        if receivedData {
+            self.scheduleLinuxDataCallback()
+        }
+        continuation?.resume()
+    }
+
+    private func scheduleLinuxDataCallback() {
+        guard self.onData != nil else { return }
+        self.condition.lock()
+        self.callbackRequested = true
+        guard !self.callbackScheduled else {
+            self.condition.unlock()
+            return
+        }
+        self.callbackScheduled = true
+        self.condition.unlock()
+
+        self.callbackQueue.async {
+            self.deliverLinuxDataCallbacks()
+        }
+    }
+
+    private func deliverLinuxDataCallbacks() {
+        while true {
+            self.condition.lock()
+            guard self.callbackRequested else {
+                self.callbackScheduled = false
                 self.condition.unlock()
                 return
             }
-            let remainingBytes = max(0, self.maxBytes - self.data.count)
-            if remainingBytes > 0 {
-                self.data.append(chunk.prefix(remainingBytes))
-            }
-            self.onData?()
-            self.condition.broadcast()
+            self.callbackRequested = false
             self.condition.unlock()
+            self.onData?()
+        }
+    }
+
+    private func finishFailedLinuxStart() {
+        try? self.handle.close()
+        self.condition.lock()
+        self.isFinished = true
+        let continuation = self.continuation
+        self.continuation = nil
+        self.condition.broadcast()
+        self.condition.unlock()
+        continuation?.resume()
+    }
+
+    private func finishLinuxSourceCancellation() {
+        try? self.handle.close()
+        self.condition.lock()
+        self.sourceCancelled = true
+        self.readSource = nil
+        self.condition.broadcast()
+        self.condition.unlock()
+    }
+    #endif
+
+    private func installReadabilityHandler() {
+        self.handle.readabilityHandler = { [weak self] handle in
+            self?.handleReadableData(from: handle)
         }
     }
 
@@ -170,21 +294,31 @@ package final class ProcessPipeCapture: @unchecked Sendable {
     }
 
     private func stopAndSnapshot() -> Data {
-        self.handle.readabilityHandler = nil
-
-        // If we could not install the readability handler (e.g. EMFILE on Linux),
-        // read whatever data is available synchronously before closing the fd.
-        if !self.usesReadableHandler {
-            self.drainSynchronously()
-        }
-
         let continuation: CheckedContinuation<Void, Never>?
         let snapshot: Data
+        #if os(Linux)
+        let source: DispatchSourceRead?
         self.condition.lock()
         self.isStopping = true
+        source = self.readSource
+        self.readSource = nil
+        self.condition.unlock()
+        source?.cancel()
+        #else
+        self.handle.readabilityHandler = nil
+        #endif
+
+        self.condition.lock()
+        self.isStopping = true
+        #if os(Linux)
+        while self.activeCallbacks > 0 || (self.sourceStarted && !self.sourceCancelled) {
+            self.condition.wait()
+        }
+        #else
         while self.activeCallbacks > 0 {
             self.condition.wait()
         }
+        #endif
         self.isFinished = true
         continuation = self.continuation
         self.continuation = nil
@@ -196,9 +330,20 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         // release the underlying dup'd monitor fd, so the pipe read end leaks
         // if we rely solely on closeOnDealloc. Closing here prevents the
         // long-running fd growth that leads to EMFILE/SIGILL (issue #2234).
+        #if !os(Linux)
         try? self.handle.close()
+        #endif
 
         continuation?.resume()
         return snapshot
     }
+
+    #if os(Linux)
+    private static func makeNonBlocking(fileDescriptor: Int32) -> Bool {
+        guard fileDescriptor >= 0 else { return false }
+        let flags = Glibc.fcntl(fileDescriptor, F_GETFL)
+        guard flags >= 0 else { return false }
+        return Glibc.fcntl(fileDescriptor, F_SETFL, flags | O_NONBLOCK) == 0
+    }
+    #endif
 }

--- a/TestsLinux/ProcessPipeCaptureLinuxTests.swift
+++ b/TestsLinux/ProcessPipeCaptureLinuxTests.swift
@@ -57,7 +57,14 @@ struct ProcessPipeCaptureLinuxTests {
             Glibc.sigemptyset(&blockedSignals)
             Glibc.sigaddset(&blockedSignals, SIGPIPE)
             _ = Glibc.pthread_sigmask(SIG_BLOCK, &blockedSignals, &previousSignals)
-            defer { _ = Glibc.pthread_sigmask(SIG_SETMASK, &previousSignals, nil) }
+            defer {
+                var pendingSignals = sigset_t()
+                if Glibc.sigpending(&pendingSignals) == 0, Glibc.sigismember(&pendingSignals, SIGPIPE) == 1 {
+                    var noWait = timespec(tv_sec: 0, tv_nsec: 0)
+                    _ = Glibc.sigtimedwait(&blockedSignals, nil, &noWait)
+                }
+                _ = Glibc.pthread_sigmask(SIG_SETMASK, &previousSignals, nil)
+            }
 
             var bytes = [UInt8](repeating: 0x41, count: 16 * 1024)
             while stopWriter.wait(timeout: .now()) == .timedOut {

--- a/TestsLinux/ProcessPipeCaptureLinuxTests.swift
+++ b/TestsLinux/ProcessPipeCaptureLinuxTests.swift
@@ -1,10 +1,132 @@
 import Foundation
+#if os(Linux)
+import Glibc
+#endif
 import Testing
 @testable import CodexBarCore
 
 #if os(Linux)
 @Suite(.serialized)
 struct ProcessPipeCaptureLinuxTests {
+    private static let emfileChildEnvironmentKey = "CODEXBAR_PROCESS_PIPE_EMFILE_CHILD"
+
+    @Test
+    func `blocked onData callback does not block capture close`() throws {
+        let callbackStarted = DispatchSemaphore(value: 0)
+        let releaseCallback = DispatchSemaphore(value: 0)
+        let captureFinished = DispatchSemaphore(value: 0)
+        let pipe = Pipe()
+        let capture = ProcessPipeCapture(pipe: pipe, onData: {
+            callbackStarted.signal()
+            releaseCallback.wait()
+        })
+        capture.start()
+
+        try pipe.fileHandleForWriting.write(contentsOf: Data("hello".utf8))
+        #expect(callbackStarted.wait(timeout: .now() + 1) == .success)
+
+        DispatchQueue.global().async {
+            _ = capture.finishSynchronously(timeout: 0.05)
+            captureFinished.signal()
+        }
+        let finishResult = captureFinished.wait(timeout: .now() + 0.5)
+        releaseCallback.signal()
+        #expect(finishResult == .success)
+        if finishResult != .success {
+            _ = captureFinished.wait(timeout: .now() + 1)
+        }
+        try pipe.fileHandleForWriting.close()
+    }
+
+    @Test
+    func `continuous output does not defeat the capture timeout`() throws {
+        let writerStarted = DispatchSemaphore(value: 0)
+        let stopWriter = DispatchSemaphore(value: 0)
+        let writerFinished = DispatchSemaphore(value: 0)
+        let pipe = Pipe()
+        let writerDescriptor = pipe.fileHandleForWriting.fileDescriptor
+        let writerFlags = Glibc.fcntl(writerDescriptor, F_GETFL)
+        #expect(writerFlags >= 0)
+        #expect(Glibc.fcntl(writerDescriptor, F_SETFL, writerFlags | O_NONBLOCK) == 0)
+
+        let capture = ProcessPipeCapture(pipe: pipe, maxBytes: 1024)
+        capture.start()
+        DispatchQueue.global().async {
+            var blockedSignals = sigset_t()
+            var previousSignals = sigset_t()
+            Glibc.sigemptyset(&blockedSignals)
+            Glibc.sigaddset(&blockedSignals, SIGPIPE)
+            _ = Glibc.pthread_sigmask(SIG_BLOCK, &blockedSignals, &previousSignals)
+            defer { _ = Glibc.pthread_sigmask(SIG_SETMASK, &previousSignals, nil) }
+
+            var bytes = [UInt8](repeating: 0x41, count: 16 * 1024)
+            while stopWriter.wait(timeout: .now()) == .timedOut {
+                let count = bytes.withUnsafeMutableBytes { buffer in
+                    Glibc.write(writerDescriptor, buffer.baseAddress, buffer.count)
+                }
+                if count < 0, errno == EPIPE {
+                    break
+                }
+                if count > 0 {
+                    writerStarted.signal()
+                }
+            }
+            writerFinished.signal()
+        }
+        #expect(writerStarted.wait(timeout: .now() + 1) == .success)
+
+        let startedAt = ContinuousClock.now
+        _ = capture.finishSynchronously(timeout: 0.01)
+        let elapsed = startedAt.duration(to: .now)
+        stopWriter.signal()
+
+        #expect(elapsed < .milliseconds(500))
+        #expect(writerFinished.wait(timeout: .now() + 1) == .success)
+        try pipe.fileHandleForWriting.close()
+    }
+
+    @Test
+    func `Linux descriptor setup failure closes the read end immediately`() throws {
+        let pipe = Pipe()
+        let readFileDescriptor = pipe.fileHandleForReading.fileDescriptor
+        let capture = ProcessPipeCapture(pipe: pipe)
+        capture.start(linuxDescriptorSetup: { descriptor in
+            errno = EMFILE
+            return descriptor < 0
+        })
+
+        let startedAt = ContinuousClock.now
+        let data = capture.finishSynchronously(timeout: 5)
+        let elapsed = startedAt.duration(to: .now)
+
+        #expect(data.isEmpty)
+        #expect(elapsed < .milliseconds(500))
+        #expect(Glibc.fcntl(readFileDescriptor, F_GETFD) == -1)
+        #expect(errno == EBADF)
+        try pipe.fileHandleForWriting.close()
+    }
+
+    @Test
+    func `capture starts while the process is at EMFILE`() throws {
+        if ProcessInfo.processInfo.environment[Self.emfileChildEnvironmentKey] == "1" {
+            try Self.runEMFILEChildScenario()
+            return
+        }
+
+        let process = Process()
+        let testExecutable = try FileManager.default.destinationOfSymbolicLink(atPath: "/proc/self/exe")
+        process.executableURL = URL(fileURLWithPath: testExecutable)
+        process.arguments = ["--filter", "ProcessPipeCaptureLinuxTests", "--testing-library", "swift-testing"]
+        var environment = ProcessInfo.processInfo.environment
+        environment[Self.emfileChildEnvironmentKey] = "1"
+        process.environment = environment
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(process.terminationReason == .exit)
+        #expect(process.terminationStatus == 0)
+    }
+
     @Test
     func `ProcessPipeCapture releases its pipe read end after capture`() throws {
         let initialFDs = try countOpenFDs()
@@ -19,14 +141,54 @@ struct ProcessPipeCaptureLinuxTests {
             let capture = ProcessPipeCapture(pipe: out)
             capture.start()
             try proc.run()
+            try out.fileHandleForWriting.close()
             proc.waitUntilExit()
-            _ = capture.finishSynchronously(timeout: 0.25)
+            let data = capture.finishSynchronously(timeout: 0.25)
+            #expect(String(decoding: data, as: UTF8.self) == "hello\n")
         }
         let finalFDs = try countOpenFDs()
 
         // Allow a small tolerance for unrelated fd churn, but ensure we are
         // not leaking pipe read ends (which would show as ~100 extra fds).
         #expect(finalFDs - initialFDs <= 15)
+    }
+
+    private static func runEMFILEChildScenario() throws {
+        var originalLimit = rlimit()
+        let noFileResource = Int32(RLIMIT_NOFILE.rawValue)
+        #expect(Glibc.getrlimit(noFileResource, &originalLimit) == 0)
+
+        let pipe = Pipe()
+        let capture = ProcessPipeCapture(pipe: pipe)
+        let highestOpenFileDescriptor = try FileManager.default.contentsOfDirectory(atPath: "/proc/self/fd")
+            .compactMap(Int.init)
+            .max() ?? 32
+        var constrainedLimit = originalLimit
+        constrainedLimit.rlim_cur = min(originalLimit.rlim_cur, rlim_t(highestOpenFileDescriptor + 32))
+        #expect(Glibc.setrlimit(noFileResource, &constrainedLimit) == 0)
+
+        var heldFileDescriptors: [Int32] = []
+        defer {
+            for descriptor in heldFileDescriptors {
+                Glibc.close(descriptor)
+            }
+            _ = Glibc.setrlimit(noFileResource, &originalLimit)
+        }
+        while true {
+            let descriptor = Glibc.dup(STDIN_FILENO)
+            if descriptor < 0 {
+                #expect(errno == EMFILE)
+                break
+            }
+            heldFileDescriptors.append(descriptor)
+        }
+
+        capture.start()
+        try pipe.fileHandleForWriting.write(contentsOf: Data("hello".utf8))
+        try pipe.fileHandleForWriting.close()
+        let data = capture.finishSynchronously(timeout: 1)
+        #expect(String(decoding: data, as: UTF8.self) == "hello")
+        #expect(capture.reachedEOF)
     }
 }
 

--- a/TestsLinux/ProcessPipeCaptureLinuxTests.swift
+++ b/TestsLinux/ProcessPipeCaptureLinuxTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if os(Linux)
+@Suite(.serialized)
+struct ProcessPipeCaptureLinuxTests {
+    @Test
+    func `ProcessPipeCapture releases its pipe read end after capture`() throws {
+        let initialFDs = try countOpenFDs()
+        for _ in 0..<100 {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/bin/echo")
+            proc.arguments = ["hello"]
+            let out = Pipe()
+            proc.standardOutput = out
+            proc.standardError = FileHandle.nullDevice
+
+            let capture = ProcessPipeCapture(pipe: out)
+            capture.start()
+            try proc.run()
+            proc.waitUntilExit()
+            _ = capture.finishSynchronously(timeout: 0.25)
+        }
+        let finalFDs = try countOpenFDs()
+
+        // Allow a small tolerance for unrelated fd churn, but ensure we are
+        // not leaking pipe read ends (which would show as ~100 extra fds).
+        #expect(finalFDs - initialFDs <= 15)
+    }
+}
+
+private func countOpenFDs() throws -> Int {
+    let entries = try FileManager.default.contentsOfDirectory(atPath: "/proc/self/fd")
+    return entries.count
+}
+#endif


### PR DESCRIPTION
## Summary

- Fixes the file descriptor leak in `ProcessPipeCapture` on Linux that leads to `RLIMIT_NOFILE` exhaustion and the subsequent SIGILL crash described in #2234.
- In `stopAndSnapshot()`, explicitly `close()` the read-end `FileHandle` after capturing output. On swift-corelibs-foundation, clearing `readabilityHandler` alone does not release the internal dup'd monitor fd, so the pipe read end leaks over time.
- In `start()`, defensively probe whether another fd can be duplicated before installing `readabilityHandler`. If the process is already at EMFILE, the Foundation setter traps with `precondition(_fd >= 0)` and SIGILL. When the dup probe fails, fall back to synchronous draining in `stopAndSnapshot()` instead.
- Adds a Linux regression test `ProcessPipeCaptureLinuxTests` that spawns 100 child processes and asserts the process does not leak pipe read-end fds.

## Test plan

- [x] Reproduced SIGILL with the standalone reproducer on `issue2241-repro`.
- [x] Verified the fd-leak regression test passes on Ubuntu 24.04 (`swift test --filter ProcessPipeCaptureLinuxTests`).
- [x] The repro workflow now reports the (unfixed) baseline `Repro emfile` still crashes as expected, while the real `ProcessPipeCapture` test passes.

Closes #2234

Made with [Cursor](https://cursor.com)