### PR TITLE
Fix Claude probe session pollution

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
@@ -10,6 +10,8 @@ import Foundation
 actor ClaudeCLISession {
     static let shared = ClaudeCLISession()
     private static let log = CodexBarLog.logger(LogCategories.claudeCLI)
+    private static let probeSessionIDFilename = ".codexbar-session-id"
+    private static let fallbackProbeSessionID = UUID()
     #if DEBUG
     @TaskLocal private static var sessionOverrideForTesting: ClaudeCLISession?
 
@@ -297,22 +299,27 @@ actor ClaudeCLISession {
 
         let proc = Process()
         let resolvedURL = URL(fileURLWithPath: binary)
+        let workingDirectory = ClaudeStatusProbe.preparedProbeWorkingDirectoryURL()
+        // A crashed probe can leave a JSONL behind. Claude treats `--session-id` as creation-only when that local
+        // transcript exists, so clear the probe-owned artifact before reusing the account-side identifier.
+        ClaudeProbeSessionArtifactCleaner.cleanupProbeSessionArtifacts(probeDirectory: workingDirectory)
+        let sessionID = Self.loadOrCreateProbeSessionID(in: workingDirectory)
+        let claudeArguments = Self.launchArguments(sessionID: sessionID)
         let disableWatchdog = ProcessInfo.processInfo.environment["CODEXBAR_DISABLE_CLAUDE_WATCHDOG"] == "1"
         if !disableWatchdog,
            resolvedURL.lastPathComponent == "claude",
            let watchdog = TTYCommandRunner.locateBundledHelper("CodexBarClaudeWatchdog")
         {
             proc.executableURL = URL(fileURLWithPath: watchdog)
-            proc.arguments = ["--", binary, "--allowed-tools", ""]
+            proc.arguments = ["--", binary] + claudeArguments
         } else {
             proc.executableURL = resolvedURL
-            proc.arguments = ["--allowed-tools", ""]
+            proc.arguments = claudeArguments
         }
         proc.standardInput = secondaryHandle
         proc.standardOutput = secondaryHandle
         proc.standardError = secondaryHandle
 
-        let workingDirectory = ClaudeStatusProbe.preparedProbeWorkingDirectoryURL()
         proc.currentDirectoryURL = workingDirectory
         var env = Self.launchEnvironment()
         env["PWD"] = workingDirectory.path
@@ -362,6 +369,54 @@ actor ClaudeCLISession {
         self.processGroup = processGroup
         self.binaryPath = binary
         self.startedAt = Date()
+    }
+
+    static func launchArguments(sessionID: UUID) -> [String] {
+        // `/usage` is interactive, while Claude's no-persistence option is print-only. Reusing one explicit ID keeps
+        // repeated probe launches from registering a fresh empty account session every time.
+        ["--allowed-tools", "", "--session-id", sessionID.uuidString.lowercased()]
+    }
+
+    static func loadOrCreateProbeSessionID(
+        in directory: URL,
+        fileManager fm: FileManager = .default) -> UUID
+    {
+        let url = directory.appendingPathComponent(self.probeSessionIDFilename, isDirectory: false)
+        if let existing = self.readProbeSessionID(from: url) {
+            return existing
+        }
+
+        let sessionID = UUID()
+        do {
+            try fm.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+            try sessionID.uuidString.lowercased().write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            Self.log.warning(
+                "Claude probe session identity persistence failed",
+                metadata: ["error": error.localizedDescription])
+            return self.fallbackProbeSessionID
+        }
+
+        #if os(macOS) || os(Linux)
+        do {
+            try fm.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o600))],
+                ofItemAtPath: url.path)
+        } catch {
+            Self.log.warning(
+                "Claude probe session identity permission hardening failed",
+                metadata: ["error": error.localizedDescription])
+        }
+        #endif
+        return sessionID
+    }
+
+    private static func readProbeSessionID(from url: URL) -> UUID? {
+        guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        return UUID(uuidString: raw.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
     static func launchEnvironment(baseEnv: [String: String] = ProcessInfo.processInfo.environment) -> [String: String] {

--- a/Tests/CodexBarTests/ClaudeCLISessionTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLISessionTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeCLISessionTests {
+    @Test
+    func `probe launch reuses one persisted session identifier`() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-claude-session-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let first = ClaudeCLISession.loadOrCreateProbeSessionID(in: directory)
+        let second = ClaudeCLISession.loadOrCreateProbeSessionID(in: directory)
+
+        #expect(first == second)
+        #expect(ClaudeCLISession.launchArguments(sessionID: first) == [
+            "--allowed-tools",
+            "",
+            "--session-id",
+            first.uuidString.lowercased(),
+        ])
+
+        let file = directory.appendingPathComponent(".codexbar-session-id")
+        let persisted = try String(contentsOf: file, encoding: .utf8)
+        #expect(persisted == first.uuidString.lowercased())
+        #if os(macOS) || os(Linux)
+        let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
+        let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+        #expect(permissions.intValue == 0o600)
+        #endif
+    }
+
+    @Test
+    func `invalid persisted probe session identifier is replaced`() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-claude-session-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let file = directory.appendingPathComponent(".codexbar-session-id")
+        try "invalid".write(to: file, atomically: true, encoding: .utf8)
+
+        let sessionID = ClaudeCLISession.loadOrCreateProbeSessionID(in: directory)
+        let persisted = try String(contentsOf: file, encoding: .utf8)
+
+        #expect(persisted == sessionID.uuidString.lowercased())
+    }
+
+    @Test
+    func `unwritable probe directory keeps one process local fallback identifier`() {
+        let directory = URL(fileURLWithPath: "/dev/null/CodexBar-ClaudeProbe", isDirectory: true)
+
+        let first = ClaudeCLISession.loadOrCreateProbeSessionID(in: directory)
+        let second = ClaudeCLISession.loadOrCreateProbeSessionID(in: directory)
+
+        #expect(first == second)
+    }
+}


### PR DESCRIPTION
## Summary

- persist one installation-local Claude probe UUID in the existing `ClaudeProbe` working directory
- pass that UUID through `--session-id` for both direct and watchdog-backed Claude CLI launches
- remove stale probe-owned transcripts before launch and keep the identifier file permission-restricted

## Root cause

The CLI usage source starts an interactive Claude session so it can invoke `/usage` and `/status`. It previously launched without a session identity, causing every cold probe launch to register another empty account-side session.

Claude CLI 2.1.212 still has no non-interactive quota command. Its `--no-session-persistence` flag is print-mode-only, so it cannot drive the interactive `/usage` panel. Reusing an explicit session ID preserves every field the existing probe collects without creating a new identity per refresh.

Background delegated refresh is already policy-gated after #2191, so this currently affects user-initiated CLI refreshes rather than scheduled background probes. Repeated refreshes and cold launches still polluted the account session list.

## Verification

- `swift test --filter ClaudeCLISessionTests` — 3 passed
- `swift test --filter ClaudeDirectUsageFallbackTests` — 3 passed
- `swift test --filter ClaudeProbeWorkingDirectoryTests` — 6 passed
- `make check` — SwiftFormat clean; SwiftLint 0 violations; repository checks passed
- autoreview — clean, no accepted/actionable findings

Live account-side counting was unavailable: the working local Claude CLI 2.1.206 is logged out, while the global 2.1.212 wrapper is missing its native optional dependency. No credentialed probe was attempted.

Closes #2251
