### PR TITLE
fix: clamp Abacus credit usage percent to 100%

### DIFF
--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageSnapshot.swift
@@ -22,7 +22,7 @@ public struct AbacusUsageSnapshot: Sendable {
 
     public func toUsageSnapshot() -> UsageSnapshot {
         let percentUsed: Double = if let used = self.creditsUsed, let total = self.creditsTotal, total > 0 {
-            (used / total) * 100.0
+            min(100, max(0, (used / total) * 100.0))
         } else {
             0
         }

--- a/TestsLinux/AbacusUsageSnapshotLinuxTests.swift
+++ b/TestsLinux/AbacusUsageSnapshotLinuxTests.swift
@@ -1,0 +1,24 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct AbacusUsageSnapshotLinuxTests {
+    @Test
+    func `in-range credit usage maps to its percent`() {
+        let snapshot = AbacusUsageSnapshot(creditsUsed: 250, creditsTotal: 1000)
+        let usage = snapshot.toUsageSnapshot()
+        #expect(abs((usage.primary?.usedPercent ?? 0) - 25) < 0.01)
+    }
+
+    @Test
+    func `credit overage clamps used percent to 100`() {
+        // A usage-based plan in overage (or a shrunk grant) reports used > total.
+        // The percent must cap at 100 like every sibling credit provider, instead
+        // of flowing 150 into RateWindow.usedPercent (which does not clamp).
+        let snapshot = AbacusUsageSnapshot(creditsUsed: 15000, creditsTotal: 10000)
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 100)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

`AbacusUsageSnapshot.toUsageSnapshot()` computes the credit percent as `(used / total) * 100` **without** the `min(100, max(0, …))` clamp that every sibling credit provider applies — `OpenAIAPICreditBalanceFetcher`, `CommandCodeUsageSnapshot`, `CodebuffUsageSnapshot`. On an overage / shrunk-grant state (`creditsUsed > creditsTotal`) it flows e.g. `15000/10000 → 150` straight into `RateWindow.usedPercent`, which does not clamp — so the headline bar reads past full.

Same class as the recently merged #2255 (Cursor plan-percent clamp).

## Fix

```diff
-            (used / total) * 100.0
+            min(100, max(0, (used / total) * 100.0))
```

One line, matching the sibling idiom. No behavior change for in-range plans.

## Test

`TestsLinux/AbacusUsageSnapshotLinuxTests.swift`:
- overage `creditsUsed 15000 / creditsTotal 10000 → 100` (was `150`)
- in-range guard `250 / 1000 → 25`

Red before the source change (`150 ≠ 100`), green after.

## Verification

Built and tested on Linux (`swift:6.3.3`) — `AbacusUsageSnapshot` is in cross-platform `CodexBarCore`, so the test runs in the Linux shard. Build clean, `swiftlint --strict` + `swiftformat --lint` clean.

## Proof (real run)

The `AbacusUsageSnapshotLinuxTests` suite is executed on CI by the **`build-linux-cli`** job's "Swift Test (Linux only)" step (`swift test --parallel`) — both `linux-x64` and `linux-arm64` passed on this PR.

Below is a local red→green run in `swift:6.3.3` (`x86_64-unknown-linux-gnu`) with the exact same input (`creditsUsed: 15000, creditsTotal: 10000`); the one-line clamp is the only difference between the two runs.

**Before the fix** — clamp removed, overage flows through as `150`:
```
>>> line 25:  (used / total) * 100.0
✘ Test "credit overage clamps used percent to 100" recorded an issue at AbacusUsageSnapshotLinuxTests.swift:21:9:
  Expectation failed: (usage.primary?.usedPercent → 150.0) == (100 → 100.0)
✘ Test run with 2 tests in 1 suite failed with 1 issue.
```

**After the fix** — clamp applied (this PR, `c70597b`), overage caps at `100`:
```
>>> line 25:  min(100, max(0, (used / total) * 100.0))
✔ Test "credit overage clamps used percent to 100" passed after 0.001 seconds.
✔ Test "in-range credit usage maps to its percent" passed after 0.001 seconds.
✔ Test run with 2 tests in 1 suite passed after 0.003 seconds.
```


Small and self-contained — happy to adjust or close if the clamp-on-overage behavior isn't wanted.
