### PR TITLE
Show DeepSeek Platform usage with cost summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.44.1 — Unreleased
 
 ### Fixed
+- DeepSeek: show detailed Platform cost and token history whenever Cost summary is enabled, including an inline fallback for Submenu, without tying balance guidance to credits and extras.
 
 ## 0.44.0 — 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.44.1 — Unreleased
 
 ### Fixed
-- DeepSeek: show detailed Platform cost and token history whenever Cost summary is enabled, including an inline fallback for Submenu, without tying balance guidance to credits and extras.
 
 ## 0.44.0 — 2026-07-17
 

--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -98,7 +98,9 @@ extension UsageMenuCardView.Model {
                     return [L("Select a DeepSeek Chrome profile in Settings.")]
                 }
             }
-            guard input.tokenCostInlineDashboardEnabled else { return nil }
+            guard input.tokenCostInlineDashboardEnabled,
+                  input.showOptionalCreditsAndExtraUsage
+            else { return nil }
             guard let usage = input.snapshot?.deepseekUsage else {
                 if input.snapshot?.deepseekDetailedUsageState == .webSessionRequired {
                     return [L("Sign in to DeepSeek Platform in Chrome for detailed usage.")]
@@ -241,6 +243,7 @@ extension UsageMenuCardView.Model {
         if input.provider == .deepseek,
            !input.isRefreshing,
            input.tokenCostInlineDashboardEnabled,
+           input.showOptionalCreditsAndExtraUsage,
            let usage = input.snapshot?.deepseekUsage,
            !usage.daily.isEmpty
         {

--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -98,7 +98,7 @@ extension UsageMenuCardView.Model {
                     return [L("Select a DeepSeek Chrome profile in Settings.")]
                 }
             }
-            guard input.showOptionalCreditsAndExtraUsage else { return nil }
+            guard input.tokenCostInlineDashboardEnabled else { return nil }
             guard let usage = input.snapshot?.deepseekUsage else {
                 if input.snapshot?.deepseekDetailedUsageState == .webSessionRequired {
                     return [L("Sign in to DeepSeek Platform in Chrome for detailed usage.")]
@@ -240,7 +240,7 @@ extension UsageMenuCardView.Model {
         }
         if input.provider == .deepseek,
            !input.isRefreshing,
-           input.showOptionalCreditsAndExtraUsage,
+           input.tokenCostInlineDashboardEnabled,
            let usage = input.snapshot?.deepseekUsage,
            !usage.daily.isEmpty
         {

--- a/Sources/CodexBar/Providers/Shared/ProviderTokenAccountSelection.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderTokenAccountSelection.swift
@@ -23,11 +23,9 @@ enum ProviderTokenAccountSelection {
         settings: SettingsStore,
         override: TokenAccountOverride?) -> Bool
     {
-        guard settings.showOptionalCreditsAndExtraUsage else { return false }
-        guard provider == .deepseek,
-              let override,
-              override.provider == provider
-        else { return true }
+        guard provider == .deepseek else { return settings.showOptionalCreditsAndExtraUsage }
+        guard settings.costUsageEnabled else { return false }
+        guard let override, override.provider == provider else { return true }
         return settings.selectedTokenAccount(for: provider)?.id == override.account.id
     }
 }

--- a/Sources/CodexBar/Providers/Shared/ProviderTokenAccountSelection.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderTokenAccountSelection.swift
@@ -13,7 +13,9 @@ enum ProviderTokenAccountSelection {
         settings: SettingsStore,
         override: TokenAccountOverride?) -> ProviderTokenAccount?
     {
-        if let override, override.provider == provider { return override.account }
+        if let override, override.provider == provider {
+            return override.account
+        }
         return settings.effectiveSelectedTokenAccount(for: provider)
     }
 
@@ -24,7 +26,7 @@ enum ProviderTokenAccountSelection {
         override: TokenAccountOverride?) -> Bool
     {
         guard provider == .deepseek else { return settings.showOptionalCreditsAndExtraUsage }
-        guard settings.costUsageEnabled else { return false }
+        guard settings.costUsageEnabled, settings.showOptionalCreditsAndExtraUsage else { return false }
         guard let override, override.provider == provider else { return true }
         return settings.selectedTokenAccount(for: provider)?.id == override.account.id
     }

--- a/Sources/CodexBar/SettingsStore+TokenCost.swift
+++ b/Sources/CodexBar/SettingsStore+TokenCost.swift
@@ -3,7 +3,9 @@ import Foundation
 
 extension SettingsStore {
     func costSummaryShowsInlineDashboard(for provider: UsageProvider) -> Bool {
-        self.isCostUsageEffectivelyEnabled(for: provider) &&
+        // DeepSeek has no cost submenu, so any enabled cost-summary style falls back to inline.
+        if provider == .deepseek { return self.costUsageEnabled }
+        return self.isCostUsageEffectivelyEnabled(for: provider) &&
             self.costSummaryDisplayStyle.showsInlineSummary
     }
 

--- a/Sources/CodexBar/SettingsStore+TokenCost.swift
+++ b/Sources/CodexBar/SettingsStore+TokenCost.swift
@@ -4,7 +4,9 @@ import Foundation
 extension SettingsStore {
     func costSummaryShowsInlineDashboard(for provider: UsageProvider) -> Bool {
         // DeepSeek has no cost submenu, so any enabled cost-summary style falls back to inline.
-        if provider == .deepseek { return self.costUsageEnabled }
+        if provider == .deepseek {
+            return self.costUsageEnabled
+        }
         return self.isCostUsageEffectivelyEnabled(for: provider) &&
             self.costSummaryDisplayStyle.showsInlineSummary
     }
@@ -69,8 +71,12 @@ extension SettingsStore {
                 .appendingPathComponent("archived_sessions", isDirectory: true)
         }()
 
-        if hasAnyJsonl(in: codexRoot) { return true }
-        if let archivedCodexRoot, hasAnyJsonl(in: archivedCodexRoot) { return true }
+        if hasAnyJsonl(in: codexRoot) {
+            return true
+        }
+        if let archivedCodexRoot, hasAnyJsonl(in: archivedCodexRoot) {
+            return true
+        }
 
         let claudeRoots: [URL] = {
             if let env = env["CLAUDE_CONFIG_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Tests/CodexBarTests/MenuCardDeepSeekTests.swift
+++ b/Tests/CodexBarTests/MenuCardDeepSeekTests.swift
@@ -90,7 +90,7 @@ struct MenuCardDeepSeekTests {
     }
 
     @Test
-    func `model hides optional deepseek usage when extras disabled`() throws {
+    func `model shows deepseek usage with cost summary enabled and extras disabled`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.deepseek])
         let snapshot = Self.makeSnapshot(now: now, usageSummary: Self.sampleDeepSeekSummary(now: now))
@@ -110,17 +110,17 @@ struct MenuCardDeepSeekTests {
             lastError: nil,
             usageBarsShowUsed: false,
             resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
+            tokenCostUsageEnabled: true,
             showOptionalCreditsAndExtraUsage: false,
             hidePersonalInfo: false,
             now: now))
 
-        #expect(model.inlineUsageDashboard == nil)
-        #expect(model.usageNotes.isEmpty)
+        #expect(model.inlineUsageDashboard?.accessibilityLabel == "DeepSeek this month token usage trend")
+        #expect(model.usageNotes.contains { $0.contains("Today:") })
     }
 
     @Test
-    func `model explains unavailable optional deepseek usage`() throws {
+    func `model explains unavailable deepseek usage when cost summary is enabled`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.deepseek])
         let snapshot = Self.makeSnapshot(now: now)
@@ -140,7 +140,7 @@ struct MenuCardDeepSeekTests {
             lastError: nil,
             usageBarsShowUsed: false,
             resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
+            tokenCostUsageEnabled: true,
             showOptionalCreditsAndExtraUsage: true,
             hidePersonalInfo: false,
             now: now))
@@ -170,7 +170,7 @@ struct MenuCardDeepSeekTests {
             lastError: nil,
             usageBarsShowUsed: false,
             resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
+            tokenCostUsageEnabled: true,
             showOptionalCreditsAndExtraUsage: true,
             hidePersonalInfo: false,
             now: now))
@@ -203,7 +203,7 @@ struct MenuCardDeepSeekTests {
             lastError: nil,
             usageBarsShowUsed: false,
             resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
+            tokenCostUsageEnabled: true,
             showOptionalCreditsAndExtraUsage: true,
             hidePersonalInfo: false,
             now: now))
@@ -213,7 +213,7 @@ struct MenuCardDeepSeekTests {
     }
 
     @Test
-    func `browser only sign in remains visible when optional usage is hidden`() throws {
+    func `browser only sign in remains visible when cost summary is disabled`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.deepseek])
         let snapshot = DeepSeekUsageSnapshot(
@@ -272,7 +272,7 @@ struct MenuCardDeepSeekTests {
             lastError: nil,
             usageBarsShowUsed: false,
             resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
+            tokenCostUsageEnabled: true,
             showOptionalCreditsAndExtraUsage: true,
             hidePersonalInfo: false,
             now: now))
@@ -282,7 +282,7 @@ struct MenuCardDeepSeekTests {
     }
 
     @Test
-    func `model shows optional deepseek usage when extras enabled`() throws {
+    func `model hides deepseek usage when cost summary is disabled despite extras enabled`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.deepseek])
         let snapshot = Self.makeSnapshot(now: now, usageSummary: Self.sampleDeepSeekSummary(now: now))
@@ -307,7 +307,7 @@ struct MenuCardDeepSeekTests {
             hidePersonalInfo: false,
             now: now))
 
-        #expect(model.inlineUsageDashboard?.accessibilityLabel == "DeepSeek this month token usage trend")
-        #expect(model.usageNotes.contains { $0.contains("Today:") })
+        #expect(model.inlineUsageDashboard == nil)
+        #expect(model.usageNotes.isEmpty)
     }
 }

--- a/Tests/CodexBarTests/MenuCardDeepSeekTests.swift
+++ b/Tests/CodexBarTests/MenuCardDeepSeekTests.swift
@@ -90,7 +90,7 @@ struct MenuCardDeepSeekTests {
     }
 
     @Test
-    func `model shows deepseek usage with cost summary enabled and extras disabled`() throws {
+    func `model hides deepseek usage when extras are disabled despite cost summary enabled`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.deepseek])
         let snapshot = Self.makeSnapshot(now: now, usageSummary: Self.sampleDeepSeekSummary(now: now))
@@ -112,6 +112,36 @@ struct MenuCardDeepSeekTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: true,
             showOptionalCreditsAndExtraUsage: false,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.inlineUsageDashboard == nil)
+        #expect(model.usageNotes.isEmpty)
+    }
+
+    @Test
+    func `model shows deepseek usage when cost summary and extras are enabled`() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.deepseek])
+        let snapshot = Self.makeSnapshot(now: now, usageSummary: Self.sampleDeepSeekSummary(now: now))
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .deepseek,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: true,
+            showOptionalCreditsAndExtraUsage: true,
             hidePersonalInfo: false,
             now: now))
 

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -789,6 +789,9 @@ extension ProviderSettingsDescriptorTests {
     @Test
     func `deepseek detailed usage runs only for the active api token account`() throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-deepseek-account-usage")
+        fixture.settings.showOptionalCreditsAndExtraUsage = false
+        fixture.settings.costSummaryOption = .inlineSummary
+        #expect(fixture.settings.costSummaryShowsInlineDashboard(for: .deepseek))
         fixture.settings.addTokenAccount(provider: .deepseek, label: "Personal", token: "token-1")
         fixture.settings.addTokenAccount(provider: .deepseek, label: "Work", token: "token-2")
         let accounts = fixture.settings.tokenAccounts(for: .deepseek)
@@ -803,6 +806,24 @@ extension ProviderSettingsDescriptorTests {
             provider: .deepseek,
             settings: fixture.settings,
             override: TokenAccountOverride(provider: .deepseek, account: inactive)))
+        fixture.settings.costSummaryOption = .costSubmenu
+        #expect(fixture.settings.costSummaryShowsInlineDashboard(for: .deepseek))
+        #expect(ProviderTokenAccountSelection.shouldIncludeOptionalUsage(
+            provider: .deepseek,
+            settings: fixture.settings,
+            override: TokenAccountOverride(provider: .deepseek, account: active)))
+        fixture.settings.costSummaryOption = .both
+        #expect(fixture.settings.costSummaryShowsInlineDashboard(for: .deepseek))
+        fixture.settings.costSummaryOption = .off
+        #expect(!fixture.settings.costSummaryShowsInlineDashboard(for: .deepseek))
+        #expect(!ProviderTokenAccountSelection.shouldIncludeOptionalUsage(
+            provider: .deepseek,
+            settings: fixture.settings,
+            override: TokenAccountOverride(provider: .deepseek, account: active)))
+        #expect(!ProviderTokenAccountSelection.shouldIncludeOptionalUsage(
+            provider: .codex,
+            settings: fixture.settings,
+            override: nil))
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -787,9 +787,9 @@ extension ProviderSettingsDescriptorTests {
     }
 
     @Test
-    func `deepseek detailed usage runs only for the active api token account`() throws {
+    func `deepseek detailed usage requires cost extras and active api token account`() throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-deepseek-account-usage")
-        fixture.settings.showOptionalCreditsAndExtraUsage = false
+        fixture.settings.showOptionalCreditsAndExtraUsage = true
         fixture.settings.costSummaryOption = .inlineSummary
         #expect(fixture.settings.costSummaryShowsInlineDashboard(for: .deepseek))
         fixture.settings.addTokenAccount(provider: .deepseek, label: "Personal", token: "token-1")
@@ -820,10 +820,16 @@ extension ProviderSettingsDescriptorTests {
             provider: .deepseek,
             settings: fixture.settings,
             override: TokenAccountOverride(provider: .deepseek, account: active)))
+        fixture.settings.showOptionalCreditsAndExtraUsage = false
         #expect(!ProviderTokenAccountSelection.shouldIncludeOptionalUsage(
             provider: .codex,
             settings: fixture.settings,
             override: nil))
+        fixture.settings.costSummaryOption = .inlineSummary
+        #expect(!ProviderTokenAccountSelection.shouldIncludeOptionalUsage(
+            provider: .deepseek,
+            settings: fixture.settings,
+            override: TokenAccountOverride(provider: .deepseek, account: active)))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- show DeepSeek Platform cost and token history with **Cost summary**
- show DeepSeek details inline for Inline, Submenu, and Both because DeepSeek has no cost submenu
- preserve **Show credits & extra usage** as the existing opt-in for Chrome-backed Platform probes
- keep balance and browser sign-in guidance independent, while limiting detailed usage to the active token account

## Why

DeepSeek detailed Platform data is cost and token usage, but its rendering did not follow the Cost summary setting. Users could authenticate successfully and see their balance while the available usage chart remained hidden.

This is a follow-up to #2135.

## Consent boundary

DeepSeek detailed usage continues to use the existing selected Chrome session. Both a non-Off **Cost summary** option and **Show credits & extra usage** are required to run that Platform usage probe and show its cost and token data inline. Turning either setting off disables detailed usage. Balance and sign-in guidance remain independent.

## Validation

- `swift test --filter MenuCardDeepSeekTests` (9 tests passed)
- `swift test --filter ProviderSettingsDescriptorTests` (36 tests passed)
- `make check` (format and lint clean)
- maintainer autoreview: no findings

Live DeepSeek account verification was unavailable for the maintainer review. Endpoint and source audit confirmed the existing official `api.deepseek.com` and `platform.deepseek.com` surfaces remain unchanged.
