### PR TITLE
Add universal quota planning estimates

### DIFF
--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -83,6 +83,7 @@ extension UsageMenuCardView.Model.Metric {
             "percentStyle=\(self.percentStyle.rawValue)",
             MenuCardHeightFingerprint.field("status", self.statusText),
             MenuCardHeightFingerprint.field("reset", self.resetText),
+            MenuCardHeightFingerprint.field("quotaPlanning", self.quotaPlanningText),
             MenuCardHeightFingerprint.field("detail", self.detailText),
             MenuCardHeightFingerprint.field("detailLeft", self.detailLeftText),
             MenuCardHeightFingerprint.field("detailRight", self.detailRightText),

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -9,6 +9,39 @@ extension UsageMenuCardView.Model {
         let paceOnTop: Bool
     }
 
+    static func metricsByAddingQuotaPlanning(
+        _ metrics: [Metric],
+        estimates: [String: QuotaPlanningEstimate]) -> [Metric]
+    {
+        guard !estimates.isEmpty else { return metrics }
+        return metrics.map { metric in
+            guard let estimate = estimates[metric.id] else { return metric }
+            var decorated = metric
+            decorated.quotaPlanningText = Self.quotaPlanningText(for: estimate)
+            return decorated
+        }
+    }
+
+    static func quotaPlanningText(for estimate: QuotaPlanningEstimate) -> String? {
+        let value = estimate.fundableFullSessionEquivalents
+        guard value.isFinite, value >= 0 else { return nil }
+        return L("Available full sessions: ≈%@", Self.quotaPlanningNumber(value))
+    }
+
+    private static func quotaPlanningNumber(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.locale = codexBarLocalizedLocale()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 1
+        formatter.roundingMode = .halfUp
+        let oneTenth = formatter.string(from: NSNumber(value: 0.1)) ?? "0.1"
+        if value > 0, value < 0.1 {
+            return "<\(oneTenth)"
+        }
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.1f", value)
+    }
+
     static func redactedMetricDetail(_ detail: String?, provider: UsageProvider, metricID: String) -> String? {
         guard let detail else { return nil }
         guard provider == .litellm,
@@ -178,6 +211,7 @@ extension UsageMenuCardView.Model {
             current.percentStyle == candidate.percentStyle &&
             (current.statusText == nil) == (candidate.statusText == nil) &&
             (current.resetText == nil) == (candidate.resetText == nil) &&
+            current.quotaPlanningText == candidate.quotaPlanningText &&
             (current.detailText == nil) == (candidate.detailText == nil) &&
             (current.detailLeftText == nil) == (candidate.detailLeftText == nil) &&
             (current.detailRightText == nil) == (candidate.detailRightText == nil) &&

--- a/Sources/CodexBar/MenuCardView+ModelInput.swift
+++ b/Sources/CodexBar/MenuCardView+ModelInput.swift
@@ -33,6 +33,7 @@ extension UsageMenuCardView.Model {
         let kiloAutoMode: Bool
         let hidePersonalInfo: Bool
         let weeklyPace: UsagePace?
+        let quotaPlanningEstimates: [String: QuotaPlanningEstimate]
         let quotaWarningThresholds: [QuotaWarningWindow: [Int]]
         let workDaysPerWeek: Int?
         let usesLiveSubtitle: Bool
@@ -69,6 +70,7 @@ extension UsageMenuCardView.Model {
             kiloAutoMode: Bool = false,
             hidePersonalInfo: Bool,
             weeklyPace: UsagePace? = nil,
+            quotaPlanningEstimates: [String: QuotaPlanningEstimate] = [:],
             quotaWarningThresholds: [QuotaWarningWindow: [Int]] = [:],
             workDaysPerWeek: Int? = nil,
             usesLiveSubtitle: Bool = false,
@@ -104,6 +106,7 @@ extension UsageMenuCardView.Model {
             self.kiloAutoMode = kiloAutoMode
             self.hidePersonalInfo = hidePersonalInfo
             self.weeklyPace = weeklyPace
+            self.quotaPlanningEstimates = quotaPlanningEstimates
             self.quotaWarningThresholds = quotaWarningThresholds
             self.workDaysPerWeek = workDaysPerWeek
             self.usesLiveSubtitle = usesLiveSubtitle

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -31,6 +31,7 @@ struct UsageMenuCardView: View {
             let percentStyle: PercentStyle
             let statusText: String?
             let resetText: String?
+            var quotaPlanningText: String?
             let detailText: String?
             let detailLeftText: String?
             let detailRightText: String?
@@ -47,6 +48,7 @@ struct UsageMenuCardView: View {
                 percentStyle: PercentStyle,
                 statusText: String? = nil,
                 resetText: String?,
+                quotaPlanningText: String? = nil,
                 detailText: String?,
                 detailLeftText: String?,
                 detailRightText: String?,
@@ -62,6 +64,7 @@ struct UsageMenuCardView: View {
                 self.percentStyle = percentStyle
                 self.statusText = statusText
                 self.resetText = resetText
+                self.quotaPlanningText = quotaPlanningText
                 self.detailText = detailText
                 self.detailLeftText = detailLeftText
                 self.detailRightText = detailRightText
@@ -526,6 +529,12 @@ private struct MetricRow: View {
                                 .lineLimit(1)
                         }
                     }
+                    if let quotaPlanningText = self.metric.quotaPlanningText {
+                        Text(quotaPlanningText)
+                            .font(.footnote)
+                            .foregroundStyle(MenuHighlightStyle.primary(self.isHighlighted))
+                            .lineLimit(2)
+                    }
                     if self.metric.detailLeftText != nil || self.metric.detailRightText != nil {
                         HStack(alignment: .firstTextBaseline) {
                             if let detailLeft = self.metric.detailLeftText {
@@ -841,10 +850,13 @@ extension UsageMenuCardView.Model {
             account: input.account,
             override: input.planOverride,
             metadata: input.metadata)
-        let metrics = Self.redactedMetrics(
+        let redactedMetrics = Self.redactedMetrics(
             Self.metrics(input: input),
             provider: input.provider,
             hidePersonalInfo: input.hidePersonalInfo)
+        let metrics = Self.metricsByAddingQuotaPlanning(
+            redactedMetrics,
+            estimates: input.quotaPlanningEstimates)
         let openAIAPIUsage = input.snapshot?.openAIAPIUsage
         let inlineUsageDashboard = Self.inlineUsageDashboard(input: input)
         let usageNotes = Self.usageNotes(input: input)

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -529,6 +529,12 @@ private struct ProviderMetricInlineRow: View {
                         .frame(maxWidth: .infinity, alignment: .trailing)
                 }
 
+                if let quotaPlanningText = self.metric.quotaPlanningText {
+                    Text(quotaPlanningText)
+                        .font(.footnote)
+                        .foregroundStyle(.primary)
+                }
+
                 if let detail = self.metric.detailText, !detail.isEmpty {
                     Text(detail)
                         .font(.footnote)

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -696,6 +696,7 @@ struct ProvidersPane: View {
             copilotBudgetExtrasEnabled: self.settings.copilotBudgetExtrasEnabled,
             hidePersonalInfo: self.settings.hidePersonalInfo,
             weeklyPace: weeklyPace,
+            quotaPlanningEstimates: self.store.quotaPlanningEstimates[provider] ?? [:],
             quotaWarningThresholds: [
                 .session: self.quotaWarningMarkerThresholds(provider: provider, window: .session),
                 .weekly: self.quotaWarningMarkerThresholds(provider: provider, window: .weekly),

--- a/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
@@ -375,15 +375,13 @@ struct CodexConsumerProjection {
 
     private static func rateWindowsByLane(snapshot: UsageSnapshot?) -> [RateLane: RateWindow] {
         guard let snapshot else { return [:] }
-
+        let semanticWindows = CodexSemanticRateWindows(snapshot: snapshot)
         var windowsByLane: [RateLane: RateWindow] = [:]
-        let slottedWindows: [(RateLane, RateWindow)] = [
-            self.classifyRateWindow(snapshot.primary, slot: .primary),
-            self.classifyRateWindow(snapshot.secondary, slot: .secondary),
-        ].compactMap(\.self)
-
-        for (lane, window) in slottedWindows {
-            windowsByLane[lane] = window
+        if let session = semanticWindows.window(for: .session) {
+            windowsByLane[.session] = session
+        }
+        if let weekly = semanticWindows.window(for: .weekly) {
+            windowsByLane[.weekly] = weekly
         }
         return windowsByLane
     }
@@ -394,10 +392,12 @@ struct CodexConsumerProjection {
     {
         guard let snapshot else { return [] }
 
-        let slottedLanes = [
-            self.classifyRateWindow(snapshot.primary, slot: .primary)?.0,
-            self.classifyRateWindow(snapshot.secondary, slot: .secondary)?.0,
-        ].compactMap(\.self)
+        let slottedLanes = CodexSemanticRateWindows(snapshot: snapshot).sourceOrder.map { role in
+            switch role {
+            case .session: RateLane.session
+            case .weekly: RateLane.weekly
+            }
+        }
 
         var visible: [RateLane] = []
         for lane in slottedLanes where rateWindowsByLane[lane] != nil && !visible.contains(lane) {
@@ -421,31 +421,6 @@ struct CodexConsumerProjection {
         case .weekly:
             .weekly
         }
-    }
-
-    private enum SnapshotSlot {
-        case primary
-        case secondary
-    }
-
-    private static func classifyRateWindow(_ window: RateWindow?, slot: SnapshotSlot) -> (RateLane, RateWindow)? {
-        guard let window else { return nil }
-
-        let lane: RateLane = switch window.windowMinutes {
-        case 300:
-            .session
-        case 10080:
-            .weekly
-        default:
-            switch slot {
-            case .primary:
-                .session
-            case .secondary:
-                .weekly
-            }
-        }
-
-        return (lane, window)
     }
 
     /// When Codex's weekly lane is exhausted, it is the binding cap: session quota cannot be used until

--- a/Sources/CodexBar/QuotaPlanningLifecycle.swift
+++ b/Sources/CodexBar/QuotaPlanningLifecycle.swift
@@ -1,0 +1,355 @@
+import CodexBarCore
+import CryptoKit
+import Foundation
+
+struct QuotaPlanningStrategyScope: Hashable {
+    let provider: UsageProvider
+    let accountDiscriminator: String
+    let strategyID: String
+    let strategyKind: ProviderFetchKind
+
+    init?(
+        provider: UsageProvider,
+        accountDiscriminator: String?,
+        strategyID: String,
+        strategyKind: ProviderFetchKind)
+    {
+        guard let accountDiscriminator = Self.normalized(accountDiscriminator),
+              let strategyID = Self.normalized(strategyID)
+        else {
+            return nil
+        }
+        self.provider = provider
+        self.accountDiscriminator = accountDiscriminator
+        self.strategyID = strategyID
+        self.strategyKind = strategyKind
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else {
+            return nil
+        }
+        return value
+    }
+}
+
+struct QuotaPlanningScopeKey: Hashable {
+    let strategyScope: QuotaPlanningStrategyScope
+    let pairID: String
+}
+
+struct QuotaPlanningPublicationState: Equatable {
+    let estimate: QuotaPlanningEstimate
+    let monotonicExpiresAt: ContinuousClock.Instant
+}
+
+struct QuotaPlanningReceipt {
+    let wallNow: Date
+    let monotonicNow: ContinuousClock.Instant
+}
+
+struct QuotaPlanningLifecycle {
+    static let presentationTTL: Duration = .seconds(60 * 60)
+
+    private(set) var calibrations: [QuotaPlanningScopeKey: QuotaPlanningCalibrationState] = [:]
+    private(set) var activeScopes: [UsageProvider: QuotaPlanningStrategyScope] = [:]
+    private(set) var publications: [UsageProvider: [String: QuotaPlanningPublicationState]] = [:]
+
+    mutating func recordSuccessfulFetch(
+        provider: UsageProvider,
+        accountDiscriminator: String?,
+        result: ProviderFetchResult,
+        resolvedPairs: [QuotaPlanningPairSnapshot],
+        receipt: QuotaPlanningReceipt)
+    {
+        let wallNow = receipt.wallNow
+        let monotonicNow = receipt.monotonicNow
+        self.expire(wallNow: wallNow, monotonicNow: monotonicNow)
+        guard let scope = QuotaPlanningStrategyScope(
+            provider: provider,
+            accountDiscriminator: accountDiscriminator,
+            strategyID: result.strategyID,
+            strategyKind: result.strategyKind)
+        else {
+            self.activeScopes.removeValue(forKey: provider)
+            self.hidePublications(for: provider)
+            return
+        }
+
+        let scopeChanged = self.activeScopes[provider] != scope
+        self.activeScopes[provider] = scope
+        if scopeChanged {
+            self.hidePublications(for: provider)
+        }
+
+        guard result.observationFreshness == .live else {
+            return
+        }
+
+        self.publications.removeValue(forKey: provider)
+        var nextPublications: [String: QuotaPlanningPublicationState] = [:]
+        let monotonicExpiresAt = monotonicNow.advanced(by: Self.presentationTTL)
+
+        for pair in resolvedPairs {
+            let pairID = pair.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !pairID.isEmpty,
+                  let observation = QuotaPlanningEstimator.observation(for: pair, now: wallNow)
+            else {
+                continue
+            }
+
+            let key = QuotaPlanningScopeKey(strategyScope: scope, pairID: pairID)
+            let calibration = QuotaPlanningCalibrationReducer.reduce(
+                state: self.calibrations[key],
+                observation: observation)
+            self.calibrations[key] = calibration
+
+            guard let estimate = QuotaPlanningEstimator.estimate(
+                for: pair,
+                calibration: calibration,
+                now: wallNow)
+            else {
+                continue
+            }
+            nextPublications[estimate.longMetricID] = QuotaPlanningPublicationState(
+                estimate: estimate,
+                monotonicExpiresAt: monotonicExpiresAt)
+        }
+
+        if !nextPublications.isEmpty {
+            self.publications[provider] = nextPublications
+        }
+    }
+
+    @discardableResult
+    mutating func activateAccount(
+        provider: UsageProvider,
+        accountDiscriminator: String?) -> Bool
+    {
+        guard let current = self.activeScopes[provider],
+              current.accountDiscriminator != accountDiscriminator?
+                  .trimmingCharacters(in: .whitespacesAndNewlines)
+        else {
+            return false
+        }
+        self.activeScopes.removeValue(forKey: provider)
+        return self.hidePublications(for: provider)
+    }
+
+    mutating func expire(
+        wallNow: Date,
+        monotonicNow: ContinuousClock.Instant)
+    {
+        for provider in Array(self.publications.keys) {
+            guard let providerPublications = self.publications[provider] else { continue }
+            let active = providerPublications.filter { _, publication in
+                publication.monotonicExpiresAt > monotonicNow &&
+                    publication.estimate.shortResetAt > wallNow &&
+                    publication.estimate.longResetAt > wallNow
+            }
+            if active != providerPublications {
+                if active.isEmpty {
+                    self.publications.removeValue(forKey: provider)
+                } else {
+                    self.publications[provider] = active
+                }
+            }
+        }
+
+        let unexpiredCalibrations = self.calibrations.filter { _, calibration in
+            calibration.canonicalLongResetAt > wallNow
+        }
+        if unexpiredCalibrations.count != self.calibrations.count {
+            self.calibrations = unexpiredCalibrations
+        }
+    }
+
+    func estimatesByProvider() -> [UsageProvider: [String: QuotaPlanningEstimate]] {
+        self.publications.reduce(into: [:]) { result, entry in
+            result[entry.key] = entry.value.mapValues(\.estimate)
+        }
+    }
+
+    func nextExpiryDelay(
+        wallNow: Date,
+        monotonicNow: ContinuousClock.Instant) -> Duration?
+    {
+        self.publications.values
+            .flatMap(\.values)
+            .flatMap { publication in
+                [
+                    monotonicNow.duration(to: publication.monotonicExpiresAt),
+                    .seconds(publication.estimate.shortResetAt.timeIntervalSince(wallNow)),
+                    .seconds(publication.estimate.longResetAt.timeIntervalSince(wallNow)),
+                ]
+            }
+            .map { max(.zero, $0) }
+            .min()
+    }
+
+    @discardableResult
+    private mutating func hidePublications(for provider: UsageProvider) -> Bool {
+        self.publications.removeValue(forKey: provider) != nil
+    }
+}
+
+@MainActor
+extension UsageStore {
+    func quotaPlanningEstimate(
+        provider: UsageProvider,
+        longMetricID: String) -> QuotaPlanningEstimate?
+    {
+        self.quotaPlanningEstimates[provider]?[longMetricID]
+    }
+
+    func recordQuotaPlanningSuccess(
+        provider: UsageProvider,
+        result: ProviderFetchResult,
+        accountDiscriminator: String?)
+    {
+        guard let capability = ProviderDescriptorRegistry.descriptor(for: provider).quotaPlanning else {
+            return
+        }
+        let wallNow = Date()
+        let monotonicNow = self.quotaPlanningClock.now
+        self.quotaPlanningLifecycle.recordSuccessfulFetch(
+            provider: provider,
+            accountDiscriminator: accountDiscriminator,
+            result: result,
+            resolvedPairs: capability.resolvePairs(for: result),
+            receipt: QuotaPlanningReceipt(
+                wallNow: wallNow,
+                monotonicNow: monotonicNow))
+        self.publishQuotaPlanningState()
+        self.rescheduleQuotaPlanningExpiry(wallNow: wallNow, monotonicNow: monotonicNow)
+    }
+
+    func activateQuotaPlanningAccount(
+        provider: UsageProvider,
+        accountDiscriminator: String?)
+    {
+        guard ProviderDescriptorRegistry.descriptor(for: provider).quotaPlanning != nil else { return }
+        guard self.quotaPlanningLifecycle.activateAccount(
+            provider: provider,
+            accountDiscriminator: accountDiscriminator)
+        else {
+            return
+        }
+        self.publishQuotaPlanningState()
+        self.rescheduleQuotaPlanningExpiry()
+    }
+
+    func activateQuotaPlanningTokenAccount(_ provider: UsageProvider, accountID: UUID) {
+        self.activateQuotaPlanningAccount(
+            provider: provider,
+            accountDiscriminator: "token-account:\(accountID.uuidString.lowercased())")
+    }
+
+    func activateQuotaPlanningCodexOwner(_ ownerKey: CodexSessionQuotaOwnerKey?) {
+        self.activateQuotaPlanningAccount(
+            provider: .codex,
+            accountDiscriminator: ownerKey?.rawValue)
+    }
+
+    func recordQuotaPlanningTokenAccountSuccess(
+        _ provider: UsageProvider,
+        result: ProviderFetchResult,
+        account: ProviderTokenAccount?)
+    {
+        self.recordQuotaPlanningSuccess(
+            provider: provider,
+            result: result,
+            accountDiscriminator: Self.warningTokenAccountDiscriminator(account)
+                ?? Self.quotaPlanningIdentityDiscriminator(provider: provider, usage: result.usage))
+    }
+
+    func recordQuotaPlanningCodexSuccess(
+        result: ProviderFetchResult,
+        ownerKey: CodexSessionQuotaOwnerKey?)
+    {
+        self.recordQuotaPlanningSuccess(
+            provider: .codex,
+            result: result,
+            accountDiscriminator: ownerKey?.rawValue)
+    }
+
+    func handleQuotaPlanningTimeEnvironmentChange() {
+        let wallNow = Date()
+        let monotonicNow = self.quotaPlanningClock.now
+        self.quotaPlanningLifecycle.expire(
+            wallNow: wallNow,
+            monotonicNow: monotonicNow)
+        self.publishQuotaPlanningState()
+        self.rescheduleQuotaPlanningExpiry(wallNow: wallNow, monotonicNow: monotonicNow)
+    }
+
+    private func publishQuotaPlanningState() {
+        let estimates = self.quotaPlanningLifecycle.estimatesByProvider()
+        if estimates != self.quotaPlanningEstimates {
+            self.quotaPlanningEstimates = estimates
+        }
+    }
+
+    private func rescheduleQuotaPlanningExpiry(
+        wallNow: Date = Date(),
+        monotonicNow: ContinuousClock.Instant? = nil)
+    {
+        self.quotaPlanningExpiryTask?.cancel()
+        self.quotaPlanningExpiryGeneration &+= 1
+        let generation = self.quotaPlanningExpiryGeneration
+        let monotonicNow = monotonicNow ?? self.quotaPlanningClock.now
+        guard let delay = self.quotaPlanningLifecycle.nextExpiryDelay(
+            wallNow: wallNow,
+            monotonicNow: monotonicNow)
+        else {
+            self.quotaPlanningExpiryTask = nil
+            return
+        }
+
+        self.quotaPlanningExpiryTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            guard let self, self.quotaPlanningExpiryGeneration == generation else { return }
+            self.handleQuotaPlanningTimeEnvironmentChange()
+        }
+    }
+
+    nonisolated static func quotaPlanningIdentityDiscriminator(
+        provider: UsageProvider,
+        usage: UsageSnapshot) -> String?
+    {
+        guard let identity = usage.identity, identity.providerID == provider else { return nil }
+        if let accountID = identity.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !accountID.isEmpty
+        {
+            return self.hashedQuotaPlanningIdentity(
+                provider: provider,
+                kind: "account",
+                value: accountID.lowercased())
+        }
+        guard let email = identity.accountEmail?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !email.isEmpty
+        else {
+            return nil
+        }
+        return self.hashedQuotaPlanningIdentity(
+            provider: provider,
+            kind: "email",
+            value: email)
+    }
+
+    private nonisolated static func hashedQuotaPlanningIdentity(
+        provider: UsageProvider,
+        kind: String,
+        value: String) -> String
+    {
+        let input = "quota-planning-owner:v1\0\(provider.rawValue)\0\(kind)\0\(value)"
+        let digest = SHA256.hash(data: Data(input.utf8))
+        return "provider-identity:" + digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -810,6 +810,7 @@
 "Pace: %@ · %@" = "الوتيرة: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% خطر الانتهاء";
+"Available full sessions: ≈%@" = "الجلسات الكاملة المتاحة: ≈%@";
 "%d%% in deficit" = "%d%% في العجز";
 "%d%% in reserve" = "%d%% في الاحتياط";
 "usage_percent_suffix_left" = "متبقٍ";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1210,6 +1210,7 @@
 "Weekly" = "Setmanal";
 "z.ai API token not found. Set apiKey in ~/.codexbar/config.json or Z_AI_API_KEY." = "No s'ha trobat el token d'API de z.ai. Definiu apiKey a ~/.codexbar/config.json o Z_AI_API_KEY.";
 "≈ %d%% run-out risk" = "≈ %d%% risc d'esgotament";
+"Available full sessions: ≈%@" = "Sessions completes disponibles: ≈%@";
 
 /* Settings sidebar redesign */
 "Enable" = "Activa";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -802,6 +802,7 @@
 "Pace: %@ · %@" = "Tempo: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% Auslaufrisiko";
+"Available full sessions: ≈%@" = "Verfügbare volle Sitzungen: ≈%@";
 "%d%% in deficit" = "%d%% im Defizit";
 "%d%% in reserve" = "%d%% in Reserve";
 "usage_percent_suffix_left" = "übrig";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -810,6 +810,7 @@
 "Pace: %@ · %@" = "Pace: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% run-out risk";
+"Available full sessions: ≈%@" = "Available full sessions: ≈%@";
 "%d%% in deficit" = "%d%% in deficit";
 "%d%% in reserve" = "%d%% in reserve";
 "usage_percent_suffix_left" = "left";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1097,6 +1097,7 @@
 "%d%% in reserve" = "%d%% de reserva";
 "%dd" = "%d d";
 "≈ %d%% run-out risk" = "≈ %d%% de riesgo de agotamiento";
+"Available full sessions: ≈%@" = "Sesiones completas disponibles: ≈%@";
 "About CodexBar" = "Acerca de CodexBar";
 "Add Account..." = "Añadir cuenta...";
 "Add accounts via GitHub OAuth Device Flow on the selected host." = "Añade cuentas mediante el flujo de dispositivo OAuth de GitHub en el host seleccionado.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -810,6 +810,7 @@
 "Pace: %@ · %@" = "سرعت: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% خطر تمام شدن";
+"Available full sessions: ≈%@" = "نشست‌های کامل موجود: ≈%@";
 "%d%% in deficit" = "%d%% در کسری بودجه";
 "%d%% in reserve" = "%d%% در ذخیره";
 "usage_percent_suffix_left" = "باقی مانده";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -804,6 +804,7 @@
 "Pace: %@ · %@" = "Rythme : %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% risque d'épuisement";
+"Available full sessions: ≈%@" = "Sessions complètes disponibles : ≈%@";
 "%d%% in deficit" = "%d%% en déficit";
 "%d%% in reserve" = "%d%% en réserve";
 "usage_percent_suffix_left" = "restant";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1217,6 +1217,7 @@
 "usage_percent_suffix_used" = "usado";
 "z.ai API token not found. Set apiKey in ~/.codexbar/config.json or Z_AI_API_KEY." = "Non se atopou o token da API de z.ai. Define apiKey en ~/.codexbar/config.json ou Z_AI_API_KEY.";
 "≈ %d%% run-out risk" = "≈ %d%% de risco de esgotamento";
+"Available full sessions: ≈%@" = "Sesións completas dispoñibles: ≈%@";
 "Show Codex Spark usage" = "Amosar o uso de Codex Spark";
 "Shows Codex Spark quota rows in the menu and provider preview. Requires optional credits and extra usage in Display settings." = "Amosa as filas de cota de Codex Spark no menú e na previsualización do provedor. Require activar «Amosar créditos + uso adicional» nos axustes de Pantalla.";
 "Scroll to see more models" = "Desprázate para ver máis modelos";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -812,6 +812,7 @@
 "Pace: %@ · %@" = "Pace: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% risiko habis";
+"Available full sessions: ≈%@" = "Sesi penuh tersedia: ≈%@";
 "%d%% in deficit" = "%d%% defisit";
 "%d%% in reserve" = "%d%% cadangan";
 "usage_percent_suffix_left" = "tersisa";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -812,6 +812,7 @@
 "Pace: %@ · %@" = "Andamento: %@ · %@";
 "%@ · %@" = "%@ • %@";
 "≈ %d%% run-out risk" = "≈ %d%% rischio di esaurimento";
+"Available full sessions: ≈%@" = "Sessioni complete disponibili: ≈%@";
 "%d%% in deficit" = "deficit del %d%%";
 "%d%% in reserve" = "%d%% di riserva";
 "usage_percent_suffix_left" = "rimasto";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -801,6 +801,7 @@
 "Pace: %@ · %@" = "ペース: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "枯渇リスク ≈ %d%%";
+"Available full sessions: ≈%@" = "利用可能なフルセッション：≈%@";
 "%d%% in deficit" = "%d%% 不足";
 "%d%% in reserve" = "%d%% 余裕";
 "usage_percent_suffix_left" = "残り";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -775,6 +775,7 @@
 "Pace: %@ · %@" = "사용 속도: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% 소진 위험";
+"Available full sessions: ≈%@" = "사용 가능한 전체 세션: ≈%@";
 "%d%% in deficit" = "%d%% 부족";
 "%d%% in reserve" = "%d%% 여유";
 "usage_percent_suffix_left" = "남음";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -804,6 +804,7 @@
 "Pace: %@ · %@" = "Tempo: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% uitlooprisico";
+"Available full sessions: ≈%@" = "Beschikbare volledige sessies: ≈%@";
 "%d%% in deficit" = "%d%% tekort";
 "%d%% in reserve" = "%d%% in reserve";
 "usage_percent_suffix_left" = "over";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -812,6 +812,7 @@
 "Pace: %@ · %@" = "Tempo: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% ryzyka wyczerpania";
+"Available full sessions: ≈%@" = "Dostępne pełne sesje: ≈%@";
 "%d%% in deficit" = "%d%% deficytu";
 "%d%% in reserve" = "%d%% rezerwy";
 "usage_percent_suffix_left" = "pozostało";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -801,6 +801,7 @@
 "Pace: %@ · %@" = "Ritmo: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% de risco de esgotar";
+"Available full sessions: ≈%@" = "Sessões completas disponíveis: ≈%@";
 "%d%% in deficit" = "%d%% em déficit";
 "%d%% in reserve" = "%d%% em reserva";
 "usage_percent_suffix_left" = "restante";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -805,6 +805,7 @@
 "1.5× headroom" = "Запас 1,5×";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% риск исчерпания";
+"Available full sessions: ≈%@" = "Доступно полных сессий: ≈%@";
 "%d%% in deficit" = "%d%% в дефиците";
 "%d%% in reserve" = "%d%% в резерве";
 "usage_percent_suffix_left" = "осталось";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -803,6 +803,7 @@
 "Pace: %@ · %@" = "Takt: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d %% risk att ta slut";
+"Available full sessions: ≈%@" = "Tillgängliga fullständiga sessioner: ≈%@";
 "%d%% in deficit" = "%d %% underskott";
 "%d%% in reserve" = "%d %% reserv";
 "usage_percent_suffix_left" = "kvar";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -810,6 +810,7 @@
 "Pace: %@ · %@" = "เพซ: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% ความเสี่ยงในการหมด";
+"Available full sessions: ≈%@" = "เซสชันเต็มที่ใช้ได้: ≈%@";
 "%d%% in deficit" = "%d%% ขาดดุล";
 "%d%% in reserve" = "%d%% สํารอง";
 "usage_percent_suffix_left" = "คงเหลือ";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -806,6 +806,7 @@
 "Pace: %@ · %@" = "Hız: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %%%d tükenme riski";
+"Available full sessions: ≈%@" = "Kullanılabilir tam oturumlar: ≈%@";
 "%d%% in deficit" = "%%%d açıkta";
 "%d%% in reserve" = "%%%d rezervde";
 "usage_percent_suffix_left" = "kaldı";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -804,6 +804,7 @@
 "Pace: %@ · %@" = "Темп: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% ризик вичерпання";
+"Available full sessions: ≈%@" = "Доступні повні сесії: ≈%@";
 "%d%% in deficit" = "%d%% в дефіциті";
 "%d%% in reserve" = "%d%% в резерві";
 "usage_percent_suffix_left" = "зліва";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -800,6 +800,7 @@
 "Pace: %@ · %@" = "Pace: %@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d %% rủi ro cạn kiệt";
+"Available full sessions: ≈%@" = "Số phiên đầy đủ khả dụng: ≈%@";
 "%d%% in deficit" = "%d %% thâm hụt";
 "%d%% in reserve" = "%d %% dự trữ";
 "usage_percent_suffix_left" = "left";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -767,6 +767,7 @@
 "Pace: %@ · %@" = "节奏：%@ · %@";
 "%@ · %@" = "%@ · %@";
 "≈ %d%% run-out risk" = "≈ %d%% 耗尽风险";
+"Available full sessions: ≈%@" = "可用完整会话：≈%@";
 "%d%% in deficit" = "超额 %d%%";
 "%d%% in reserve" = "余量 %d%%";
 "usage_percent_suffix_left" = "剩余";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1128,6 +1128,7 @@
 "minimax_used_percent_format" = "已使用 %@";
 "minimax_service_coding_plan_vlm" = "Coding Plan VLM";
 "≈ %d%% run-out risk" = "約 %d%% 機率會用完";
+"Available full sessions: ≈%@" = "可用完整工作階段：≈%@";
 "No available fetch strategy for %@." = "%@ 沒有可用的取得策略。";
 "%@ left" = "剩餘 %@";
 "Manual cleanup: cache" = "手動清理：快取";

--- a/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
@@ -139,6 +139,7 @@ extension StatusItemController {
     }
 
     func handleMenuBarTimeEnvironmentChange() {
+        self.store.handleQuotaPlanningTimeEnvironmentChange()
         self.updateIcons()
     }
 

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -139,6 +139,9 @@ extension StatusItemController {
             kiloAutoMode: kiloAutoMode,
             hidePersonalInfo: self.settings.hidePersonalInfo,
             weeklyPace: weeklyPace,
+            quotaPlanningEstimates: surface == .liveCard
+                ? self.store.quotaPlanningEstimates[target] ?? [:]
+                : [:],
             quotaWarningThresholds: [
                 .session: self.quotaWarningMarkerThresholds(provider: target, window: .session),
                 .weekly: self.quotaWarningMarkerThresholds(provider: target, window: .weekly),

--- a/Sources/CodexBar/UsageStore+CodexResetCredits.swift
+++ b/Sources/CodexBar/UsageStore+CodexResetCredits.swift
@@ -117,6 +117,7 @@ extension ProviderFetchOutcome {
                 sourceLabel: result.sourceLabel,
                 strategyID: result.strategyID,
                 strategyKind: result.strategyKind,
+                observationFreshness: result.observationFreshness,
                 diagnostic: result.diagnostic,
                 claudeOAuthKeychainPersistentRefHash: result.claudeOAuthKeychainPersistentRefHash,
                 claudeOAuthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier,

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -61,6 +61,45 @@ extension UsageStore {
             oauthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier)
     }
 
+    private static func quotaPlanningAccountDiscriminator(
+        provider: UsageProvider,
+        tokenAccount: ProviderTokenAccount?,
+        result: ProviderFetchResult,
+        context: ProviderRefreshOutcomeContext) -> String?
+    {
+        if let tokenAccount {
+            return self.warningTokenAccountDiscriminator(tokenAccount)
+        }
+        if provider == .codex {
+            return context.codexSessionQuotaOwnerKey?.rawValue
+        }
+        if provider == .claude,
+           let discriminator = self.warningClaudeAccountDiscriminator(
+               strategyKind: result.strategyKind,
+               observation: context.claudeOAuthActiveAccountObservation,
+               oauthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier)
+        {
+            return discriminator
+        }
+        return self.quotaPlanningIdentityDiscriminator(provider: provider, usage: result.usage)
+    }
+
+    private func recordQuotaPlanningSuccess(
+        _ provider: UsageProvider,
+        _ result: ProviderFetchResult,
+        _ tokenAccount: ProviderTokenAccount?,
+        _ context: ProviderRefreshOutcomeContext)
+    {
+        self.recordQuotaPlanningSuccess(
+            provider: provider,
+            result: result,
+            accountDiscriminator: Self.quotaPlanningAccountDiscriminator(
+                provider: provider,
+                tokenAccount: tokenAccount,
+                result: result,
+                context: context))
+    }
+
     static func commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
         current: UsageSnapshot,
         previous: UsageSnapshot?) -> UsageSnapshot
@@ -232,6 +271,7 @@ extension UsageStore {
     private func prepareCodexRefreshPublication() -> CodexRefreshPublicationPreparation {
         let previousGuard = self.lastCodexUsagePublicationGuard
         let expectedGuard = self.freshCodexAccountScopedRefreshGuard()
+        self.activateQuotaPlanningCodexOwner(Self.codexSessionQuotaOwnerKey(for: expectedGuard))
         let hydrationCandidates = self.codexAccountSnapshots
         let projection = self.settings.codexVisibleAccountProjection
         let visibleAccounts = projection.visibleAccounts
@@ -556,6 +596,7 @@ extension UsageStore {
             }
             self.lastKnownResetSnapshots[provider] = backfilled
             self.snapshots[provider] = backfilled
+            self.recordQuotaPlanningSuccess(provider, result, currentTokenAccount, context)
             if provider == .deepseek {
                 self.clearDeepSeekProfileTransition()
             }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -45,6 +45,7 @@ struct CodexAccountUsageSnapshot: Identifiable {
 extension UsageStore {
     func activateCachedTokenAccountSnapshot(provider: UsageProvider, accountID: UUID) {
         guard self.settings.effectiveSelectedTokenAccount(for: provider)?.id == accountID else { return }
+        self.activateQuotaPlanningTokenAccount(provider, accountID: accountID)
         self.tokenAccountLiveStateProviders.insert(provider)
         guard let account = self.uniqueTokenAccount(provider: provider, accountID: accountID),
               let cached = self.accountSnapshots[provider]?.first(where: {
@@ -579,7 +580,6 @@ extension UsageStore {
             return
         }
         let limitedAccounts = self.limitedTokenAccounts(accounts, selected: selectedAccount)
-        let effectiveSelected = selectedAccount
 
         // Capture the prior per-account snapshot state so we can preserve last-good
         // data when an in-flight refresh is cancelled (e.g. menu tab switches). Without
@@ -587,7 +587,7 @@ extension UsageStore {
         // misleading cards for accounts that previously had valid data.
         let priorSnapshots = await MainActor.run {
             self.pruneTokenAccountSnapshots(provider: provider, accounts: accounts)
-            self.activateCachedTokenAccountSnapshot(provider: provider, accountID: effectiveSelected.id)
+            self.activateCachedTokenAccountSnapshot(provider: provider, accountID: selectedAccount.id)
             return self.accountSnapshots[provider] ?? []
         }
         let priorByAccountID = Dictionary(uniqueKeysWithValues: priorSnapshots.map { ($0.account.id, $0) })
@@ -621,7 +621,7 @@ extension UsageStore {
             if let usage = resolved.freshUsage {
                 historySamples.append((account: account, snapshot: usage))
             }
-            if account.id == effectiveSelected.id {
+            if account.id == selectedAccount.id {
                 selectedOutcome = outcome
                 resolvedSelectedAccount = account
                 selectedSnapshot = resolved.usage
@@ -654,7 +654,7 @@ extension UsageStore {
         await self.recordFetchedTokenAccountPlanUtilizationHistory(
             provider: provider,
             samples: historySamples,
-            selectedAccount: effectiveSelected)
+            selectedAccount: selectedAccount)
     }
 
     private static func outcomeIsCancellation(_ outcome: ProviderFetchOutcome) -> Bool {
@@ -1457,11 +1457,12 @@ extension UsageStore {
         generation: UInt64? = nil) async
     {
         guard self.isCurrentProviderRefreshGeneration(.codex, generation: generation) else { return }
+        let publicationGuard = Self.codexScopedRefreshGuard(for: account)
+        let codexOwnerKey = Self.codexSessionQuotaOwnerKey(for: publicationGuard)
+        self.activateQuotaPlanningCodexOwner(codexOwnerKey)
         switch outcome.result {
-        case .success:
+        case let .success(result):
             guard let snapshot else { return }
-            let publicationGuard = Self.codexScopedRefreshGuard(for: account)
-            let codexOwnerKey = Self.codexSessionQuotaOwnerKey(for: publicationGuard)
             self.lastFetchAttempts[.codex] = outcome.attempts
             self.handleCodexResetCreditNotifications(snapshot: snapshot)
             self.handleQuotaWarningTransitions(
@@ -1477,6 +1478,7 @@ extension UsageStore {
             self.lastCodexUsagePublicationGuard = publicationGuard
             self.lastCodexAccountScopedRefreshGuard = publicationGuard
             self.snapshots[.codex] = snapshot
+            self.recordQuotaPlanningCodexSuccess(result: result, ownerKey: codexOwnerKey)
             if let sourceLabel {
                 self.lastSourceLabels[.codex] = sourceLabel
             }
@@ -1495,7 +1497,6 @@ extension UsageStore {
                 self.errors[.codex] = nil
                 return
             }
-            let publicationGuard = Self.codexScopedRefreshGuard(for: account)
             self.lastCodexUsagePublicationGuard = publicationGuard
             self.lastCodexAccountScopedRefreshGuard = publicationGuard
             self.lastFetchAttempts[.codex] = outcome.attempts
@@ -1554,6 +1555,7 @@ extension UsageStore {
                     accountDiscriminatorOverride: provider == .claude ? warningAccountDiscriminator : nil)
                 self.lastKnownResetSnapshots[provider] = backfilled
                 self.snapshots[provider] = backfilled
+                self.recordQuotaPlanningTokenAccountSuccess(provider, result: result, account: account)
                 if provider == .deepseek {
                     self.clearDeepSeekProfileTransition()
                 }

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -38,6 +38,7 @@ extension UsageStore {
         _ = self.probeLogs
         _ = self.historicalPaceRevision
         _ = self.planUtilizationHistoryRevision
+        _ = self.quotaPlanningEstimates
         _ = self.providerStorageFootprints
         return 0
     }
@@ -194,6 +195,7 @@ final class UsageStore {
     var probeLogs: [UsageProvider: String] = [:]
     var historicalPaceRevision: Int = 0
     var planUtilizationHistoryRevision: Int = 0
+    var quotaPlanningEstimates: [UsageProvider: [String: QuotaPlanningEstimate]] = [:]
     var providerStorageFootprints: [UsageProvider: ProviderStorageFootprint] = [:]
     @ObservationIgnored var lastCreditsSnapshot: CreditsSnapshot?
     @ObservationIgnored var lastCreditsSnapshotAccountKey: String?
@@ -347,6 +349,10 @@ final class UsageStore {
     @ObservationIgnored var lastTokenFetchAt: [UsageProvider: Date] = [:]
     @ObservationIgnored var lastTokenFetchScope: [UsageProvider: String] = [:]
     @ObservationIgnored var planUtilizationHistory: [UsageProvider: PlanUtilizationHistoryBuckets] = [:]
+    @ObservationIgnored var quotaPlanningLifecycle = QuotaPlanningLifecycle()
+    @ObservationIgnored let quotaPlanningClock = ContinuousClock()
+    @ObservationIgnored var quotaPlanningExpiryTask: Task<Void, Never>?
+    @ObservationIgnored var quotaPlanningExpiryGeneration: UInt64 = 0
 
     /// Background load task; cleared on deinit and on the cancel test seam.
     @ObservationIgnored var planUtilizationHistoryLoadTask: Task<Void, Never>?
@@ -827,6 +833,7 @@ final class UsageStore {
         self.storageRefreshTask?.cancel()
         self.codexPlanHistoryBackfillTask?.cancel()
         self.resetBoundaryRefreshTask?.cancel()
+        self.quotaPlanningExpiryTask?.cancel()
         self.planUtilizationHistoryLoadTask?.cancel()
     }
 

--- a/Sources/CodexBarCore/ProviderQuotaPlanning.swift
+++ b/Sources/CodexBarCore/ProviderQuotaPlanning.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+public struct QuotaPlanningResolutionInput: Sendable {
+    public let usage: UsageSnapshot
+    public let strategyID: String
+    public let strategyKind: ProviderFetchKind
+    public let observationFreshness: ProviderObservationFreshness
+
+    public init(
+        usage: UsageSnapshot,
+        strategyID: String,
+        strategyKind: ProviderFetchKind,
+        observationFreshness: ProviderObservationFreshness)
+    {
+        self.usage = usage
+        self.strategyID = strategyID
+        self.strategyKind = strategyKind
+        self.observationFreshness = observationFreshness
+    }
+
+    public init(result: ProviderFetchResult) {
+        self.init(
+            usage: result.usage,
+            strategyID: result.strategyID,
+            strategyKind: result.strategyKind,
+            observationFreshness: result.observationFreshness)
+    }
+}
+
+public struct ProviderQuotaPlanningCapability: Sendable {
+    public typealias Resolver = @Sendable (QuotaPlanningResolutionInput) -> [QuotaPlanningPairSnapshot]
+
+    private let resolver: Resolver
+
+    public init(resolve: @escaping Resolver) {
+        self.resolver = resolve
+    }
+
+    public func resolvePairs(for result: ProviderFetchResult) -> [QuotaPlanningPairSnapshot] {
+        self.resolvePairs(input: QuotaPlanningResolutionInput(result: result))
+    }
+
+    public func resolvePairs(input: QuotaPlanningResolutionInput) -> [QuotaPlanningPairSnapshot] {
+        guard input.observationFreshness == .live,
+              !input.strategyID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return []
+        }
+
+        let candidates = self.resolver(input).filter(Self.isInitialRolloutEligible)
+        guard !candidates.isEmpty else { return [] }
+
+        let pairIDCounts = Dictionary(grouping: candidates, by: { Self.normalized($0.id) })
+            .mapValues(\.count)
+        let metricIDCounts = Dictionary(
+            grouping: candidates.flatMap { [Self.normalized($0.short.metricID), Self.normalized($0.long.metricID)] },
+            by: { $0 })
+            .mapValues(\.count)
+
+        return candidates.filter { pair in
+            let pairID = Self.normalized(pair.id)
+            let shortMetricID = Self.normalized(pair.short.metricID)
+            let longMetricID = Self.normalized(pair.long.metricID)
+            return !pairID.isEmpty &&
+                !shortMetricID.isEmpty &&
+                !longMetricID.isEmpty &&
+                shortMetricID != longMetricID &&
+                pairIDCounts[pairID] == 1 &&
+                metricIDCounts[shortMetricID] == 1 &&
+                metricIDCounts[longMetricID] == 1
+        }
+    }
+
+    public static func primarySecondaryPairs(
+        usage: UsageSnapshot,
+        pairID: String = "primary-secondary") -> [QuotaPlanningPairSnapshot]
+    {
+        guard let primary = usage.primary, let secondary = usage.secondary else { return [] }
+        return [QuotaPlanningPairSnapshot(
+            id: pairID,
+            short: QuotaPlanningWindowSnapshot(metricID: "primary", window: primary),
+            long: QuotaPlanningWindowSnapshot(metricID: "secondary", window: secondary))]
+    }
+
+    private static func isInitialRolloutEligible(_ pair: QuotaPlanningPairSnapshot) -> Bool {
+        let short = pair.short
+        let long = pair.long
+        guard short.usageKnown,
+              long.usageKnown,
+              !short.window.isSyntheticPlaceholder,
+              !long.window.isSyntheticPlaceholder,
+              short.window.nextRegenPercent == nil,
+              long.window.nextRegenPercent == nil,
+              short.window.usedPercent.isFinite,
+              long.window.usedPercent.isFinite,
+              (0...100).contains(short.window.usedPercent),
+              (0..<100).contains(long.window.usedPercent),
+              let shortMinutes = short.window.windowMinutes,
+              let longMinutes = long.window.windowMinutes,
+              (240...360).contains(shortMinutes),
+              longMinutes == 10080,
+              short.window.resetsAt != nil,
+              long.window.resetsAt != nil
+        else {
+            return false
+        }
+        return true
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -41,7 +41,53 @@ public enum AntigravityProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "antigravity",
-                versionDetector: nil))
+                versionDetector: nil),
+            quotaPlanning: ProviderQuotaPlanningCapability(resolve: self.resolveQuotaPlanningPairs))
+    }
+
+    private static func resolveQuotaPlanningPairs(
+        input: QuotaPlanningResolutionInput) -> [QuotaPlanningPairSnapshot]
+    {
+        struct Group {
+            var short: [NamedRateWindow] = []
+            var long: [NamedRateWindow] = []
+        }
+
+        var groups: [String: Group] = [:]
+        for namedWindow in input.usage.extraRateWindows ?? [] {
+            guard let groupID = AntigravityStatusSnapshot.quotaPlanningGroupID(forWindowID: namedWindow.id) else {
+                continue
+            }
+            switch namedWindow.window.windowMinutes {
+            case 300:
+                groups[groupID, default: Group()].short.append(namedWindow)
+            case 10080:
+                groups[groupID, default: Group()].long.append(namedWindow)
+            default:
+                continue
+            }
+        }
+
+        return groups.keys.sorted().compactMap { groupID in
+            guard let group = groups[groupID],
+                  group.short.count == 1,
+                  group.long.count == 1,
+                  let short = group.short.first,
+                  let long = group.long.first
+            else {
+                return nil
+            }
+            return QuotaPlanningPairSnapshot(
+                id: "quota-summary-\(groupID)",
+                short: QuotaPlanningWindowSnapshot(
+                    metricID: short.id,
+                    window: short.window,
+                    usageKnown: short.usageKnown),
+                long: QuotaPlanningWindowSnapshot(
+                    metricID: long.id,
+                    window: long.window,
+                    usageKnown: long.usageKnown))
+        }
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
@@ -130,7 +176,8 @@ struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
         try AntigravitySelectedAccountGuard.validate(usage, context: context)
         return self.makeResult(
             usage: usage,
-            sourceLabel: self.source.sourceLabel)
+            sourceLabel: self.source.sourceLabel,
+            observationFreshness: .live)
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
@@ -435,7 +482,8 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
             let warmUsage = try warmSnapshot.toUsageSnapshot()
             return self.makeResult(
                 usage: warmUsage,
-                sourceLabel: Self.sourceLabel)
+                sourceLabel: Self.sourceLabel,
+                observationFreshness: .live)
         }
 
         try Task.checkCancellation()
@@ -484,7 +532,8 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
 
         return self.makeResult(
             usage: usage,
-            sourceLabel: Self.sourceLabel)
+            sourceLabel: Self.sourceLabel,
+            observationFreshness: .live)
     }
 
     static func shouldResetSessionAfterFetch(_ context: ProviderFetchContext) -> Bool {
@@ -624,7 +673,8 @@ struct AntigravityOAuthFetchStrategy: ProviderFetchStrategy {
         let usage = try Self.usageSnapshot(from: snapshot)
         return self.makeResult(
             usage: usage,
-            sourceLabel: "oauth")
+            sourceLabel: "oauth",
+            observationFreshness: .live)
     }
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -277,7 +277,7 @@ public struct AntigravityStatusSnapshot: Sendable {
                     id: Self.quotaSummaryWindowID(for: bucket),
                     title: "\(groupTitle) \(bucketTitle)",
                     window: window,
-                    usageKnown: !bucket.disabled && bucket.remainingFraction != nil)
+                    usageKnown: !bucket.disabled && remainingPercent != nil)
             }
         }
     }
@@ -288,13 +288,37 @@ public struct AntigravityStatusSnapshot: Sendable {
 
     private static let quotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
 
+    static func quotaPlanningGroupID(forWindowID id: String) -> String? {
+        guard id.hasPrefix(self.quotaSummaryWindowIDPrefix) else { return nil }
+        var bucketID = String(id.dropFirst(self.quotaSummaryWindowIDPrefix.count))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        if bucketID.hasSuffix(" limit") {
+            bucketID.removeLast(" limit".count)
+        }
+
+        let cadenceAliases = self.sessionCadenceAliases.union(["weekly"])
+            .sorted { $0.count > $1.count }
+        guard let cadence = cadenceAliases.first(where: { bucketID.hasSuffix("-\($0)") }) else {
+            return nil
+        }
+        bucketID.removeLast(cadence.count + 1)
+        return bucketID.isEmpty ? nil : bucketID
+    }
+
     private static func quotaSummaryWindowID(for bucket: AntigravityQuotaSummaryBucket) -> String {
         self.quotaSummaryWindowIDPrefix + bucket.bucketId
     }
 
     private static func remainingPercent(from remainingFraction: Double?) -> Double? {
-        guard let remainingFraction else { return nil }
-        return max(0, min(100, remainingFraction * 100))
+        guard let remainingFraction,
+              remainingFraction.isFinite,
+              (0...1).contains(remainingFraction)
+        else {
+            return nil
+        }
+        return remainingFraction * 100
     }
 
     private static func displayTitle(forQuotaGroup group: AntigravityQuotaSummaryGroup) -> String {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -44,7 +44,12 @@ public enum ClaudeProviderDescriptor {
                 name: "claude",
                 versionDetector: { browserDetection in
                     ClaudeUsageFetcher(browserDetection: browserDetection).detectVersion()
-                }))
+                }),
+            quotaPlanning: ProviderQuotaPlanningCapability { input in
+                ProviderQuotaPlanningCapability.primarySecondaryPairs(
+                    usage: input.usage,
+                    pairID: "session-weekly")
+            })
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
@@ -392,6 +397,7 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
             sourceLabel: "oauth",
             strategyID: self.id,
             strategyKind: self.kind,
+            observationFreshness: .live,
             claudeOAuthKeychainPersistentRefHash: usage.oauthKeychainPersistentRefHash,
             claudeOAuthHistoryOwnerIdentifier: usage.oauthHistoryOwnerIdentifier,
             claudeOAuthKeychainCredentialMismatch: usage.oauthKeychainCredentialMismatch,
@@ -509,7 +515,8 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
         let usage = try await self.loadUsage(before: context.webTimeout, context: context)
         return self.makeResult(
             usage: ClaudeOAuthFetchStrategy.snapshot(from: usage),
-            sourceLabel: "web")
+            sourceLabel: "web",
+            observationFreshness: .live)
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
@@ -677,7 +684,8 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
         let usage = try await fetcher.loadLatestUsage(model: "sonnet")
         return self.makeResult(
             usage: ClaudeOAuthFetchStrategy.snapshot(from: usage),
-            sourceLabel: "claude")
+            sourceLabel: "claude",
+            observationFreshness: .live)
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -42,7 +42,23 @@ public enum CodexProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "codex",
-                versionDetector: { _ in ProviderVersionDetector.codexVersion() }))
+                versionDetector: { _ in ProviderVersionDetector.codexVersion() }),
+            quotaPlanning: ProviderQuotaPlanningCapability(resolve: self.resolveQuotaPlanningPairs))
+    }
+
+    private static func resolveQuotaPlanningPairs(
+        input: QuotaPlanningResolutionInput) -> [QuotaPlanningPairSnapshot]
+    {
+        let windows = CodexSemanticRateWindows(snapshot: input.usage)
+        guard let session = windows.window(for: .session),
+              let weekly = windows.window(for: .weekly)
+        else {
+            return []
+        }
+        return [QuotaPlanningPairSnapshot(
+            id: "session-weekly",
+            short: QuotaPlanningWindowSnapshot(metricID: "primary", window: session),
+            long: QuotaPlanningWindowSnapshot(metricID: "secondary", window: weekly))]
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
@@ -131,13 +147,15 @@ struct CodexCLIUsageStrategy: ProviderFetchStrategy {
                     updatedAt: credits.updatedAt,
                     identity: snapshot.identity),
                 credits: credits,
-                sourceLabel: "codex-cli")
+                sourceLabel: "codex-cli",
+                observationFreshness: .live)
         }
         let credits = context.includeCredits ? snapshot.credits : nil
         return self.makeResult(
             usage: usage,
             credits: credits,
-            sourceLabel: "codex-cli")
+            sourceLabel: "codex-cli",
+            observationFreshness: .live)
     }
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
@@ -269,7 +287,8 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
                     .withCodexResetCredits(resetCredits)
                     .withDataConfidence(dataConfidence),
                 credits: credits,
-                sourceLabel: "oauth")
+                sourceLabel: "oauth",
+                observationFreshness: .live)
         }
 
         guard credits != nil
@@ -292,7 +311,8 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
                     response: usageResponse,
                     credentials: credentials)),
             credits: credits,
-            sourceLabel: "oauth")
+            sourceLabel: "oauth",
+            observationFreshness: .live)
     }
 
     private static func replacingWithCLIMonthlyLimitIfAvailable(
@@ -327,6 +347,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             sourceLabel: oauthResult.sourceLabel,
             strategyID: oauthResult.strategyID,
             strategyKind: oauthResult.strategyKind,
+            observationFreshness: oauthResult.observationFreshness,
             diagnostic: oauthResult.diagnostic)
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexSemanticRateWindows.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexSemanticRateWindows.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public enum CodexSemanticRateWindowRole: String, Hashable, Sendable {
+    case session
+    case weekly
+}
+
+public struct CodexSemanticRateWindows: Sendable {
+    public let sourceOrder: [CodexSemanticRateWindowRole]
+
+    private let windowsByRole: [CodexSemanticRateWindowRole: RateWindow]
+
+    public init(snapshot: UsageSnapshot) {
+        let slottedWindows = [
+            Self.classify(snapshot.primary, fallback: .session),
+            Self.classify(snapshot.secondary, fallback: .weekly),
+        ].compactMap(\.self)
+
+        var windowsByRole: [CodexSemanticRateWindowRole: RateWindow] = [:]
+        var sourceOrder: [CodexSemanticRateWindowRole] = []
+        for (role, window) in slottedWindows {
+            windowsByRole[role] = window
+            if !sourceOrder.contains(role) {
+                sourceOrder.append(role)
+            }
+        }
+        self.windowsByRole = windowsByRole
+        self.sourceOrder = sourceOrder
+    }
+
+    public func window(for role: CodexSemanticRateWindowRole) -> RateWindow? {
+        self.windowsByRole[role]
+    }
+
+    private static func classify(
+        _ window: RateWindow?,
+        fallback: CodexSemanticRateWindowRole) -> (CodexSemanticRateWindowRole, RateWindow)?
+    {
+        guard let window else { return nil }
+        let role: CodexSemanticRateWindowRole = switch window.windowMinutes {
+        case 300:
+            .session
+        case 10080:
+            .weekly
+        default:
+            fallback
+        }
+        return (role, window)
+    }
+}

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -17,6 +17,7 @@ public struct ProviderDescriptor: Sendable {
     public let tokenCost: ProviderTokenCostConfig
     public let fetchPlan: ProviderFetchPlan
     public let cli: ProviderCLIConfig
+    public let quotaPlanning: ProviderQuotaPlanningCapability?
 
     public init(
         id: UsageProvider,
@@ -24,7 +25,8 @@ public struct ProviderDescriptor: Sendable {
         branding: ProviderBranding,
         tokenCost: ProviderTokenCostConfig,
         fetchPlan: ProviderFetchPlan,
-        cli: ProviderCLIConfig)
+        cli: ProviderCLIConfig,
+        quotaPlanning: ProviderQuotaPlanningCapability? = nil)
     {
         self.id = id
         self.metadata = metadata
@@ -32,6 +34,7 @@ public struct ProviderDescriptor: Sendable {
         self.tokenCost = tokenCost
         self.fetchPlan = fetchPlan
         self.cli = cli
+        self.quotaPlanning = quotaPlanning
     }
 
     public func fetchOutcome(context: ProviderFetchContext) async -> ProviderFetchOutcome {

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -191,7 +191,7 @@ public enum ProviderFetchError: LocalizedError, Sendable {
     }
 }
 
-public enum ProviderFetchKind: Sendable {
+public enum ProviderFetchKind: Hashable, Sendable {
     case cli
     case web
     case oauth

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -5,6 +5,12 @@ public enum ProviderRuntime: Sendable {
     case cli
 }
 
+public enum ProviderObservationFreshness: String, Equatable, Sendable {
+    case live
+    case cached
+    case unknown
+}
+
 public enum ProviderSourceMode: String, CaseIterable, Sendable, Codable {
     case auto
     case web
@@ -101,6 +107,9 @@ public struct ProviderFetchResult: Sendable {
     public let sourceLabel: String
     public let strategyID: String
     public let strategyKind: ProviderFetchKind
+    /// Whether the quota facts were observed by this successful fetch.
+    /// This is transient fetch provenance and is never persisted with `UsageSnapshot`.
+    public let observationFreshness: ProviderObservationFreshness
     /// Optional live diagnostic retained alongside an otherwise usable snapshot.
     public let diagnostic: String?
     /// Transient account ownership evidence for plan-utilization history.
@@ -123,6 +132,7 @@ public struct ProviderFetchResult: Sendable {
         sourceLabel: String,
         strategyID: String,
         strategyKind: ProviderFetchKind,
+        observationFreshness: ProviderObservationFreshness = .unknown,
         diagnostic: String? = nil,
         claudeOAuthKeychainPersistentRefHash: String? = nil,
         claudeOAuthHistoryOwnerIdentifier: String? = nil,
@@ -136,6 +146,7 @@ public struct ProviderFetchResult: Sendable {
         self.sourceLabel = sourceLabel
         self.strategyID = strategyID
         self.strategyKind = strategyKind
+        self.observationFreshness = observationFreshness
         self.diagnostic = diagnostic
         self.claudeOAuthKeychainPersistentRefHash = claudeOAuthKeychainPersistentRefHash
         self.claudeOAuthHistoryOwnerIdentifier = claudeOAuthHistoryOwnerIdentifier
@@ -203,6 +214,7 @@ extension ProviderFetchStrategy {
         credits: CreditsSnapshot? = nil,
         dashboard: OpenAIDashboardSnapshot? = nil,
         sourceLabel: String,
+        observationFreshness: ProviderObservationFreshness = .unknown,
         diagnostic: String? = nil) -> ProviderFetchResult
     {
         ProviderFetchResult(
@@ -212,6 +224,7 @@ extension ProviderFetchStrategy {
             sourceLabel: sourceLabel,
             strategyID: self.id,
             strategyKind: self.kind,
+            observationFreshness: observationFreshness,
             diagnostic: diagnostic)
     }
 }

--- a/Sources/CodexBarCore/QuotaPlanning.swift
+++ b/Sources/CodexBarCore/QuotaPlanning.swift
@@ -1,0 +1,500 @@
+import Foundation
+
+public enum QuotaPlanningConstants {
+    public static let resetEquivalenceTolerance: TimeInterval = 120
+    public static let percentageJitterTolerance = 0.5
+    public static let minimumShortDelta = 20.0
+    public static let minimumLongDelta = 1.0
+    public static let minimumSingleCandidateLongDelta = 3.0
+    public static let longSaturationThreshold = 99.5
+    public static let maximumRelativeDeviation = 0.30
+    public static let maximumCompletedCandidates = 5
+}
+
+public struct QuotaPlanningWindowSnapshot: Equatable, Sendable {
+    public let metricID: String
+    public let window: RateWindow
+    public let usageKnown: Bool
+
+    public init(metricID: String, window: RateWindow, usageKnown: Bool = true) {
+        self.metricID = metricID
+        self.window = window
+        self.usageKnown = usageKnown
+    }
+}
+
+public struct QuotaPlanningPairSnapshot: Equatable, Sendable {
+    public let id: String
+    public let short: QuotaPlanningWindowSnapshot
+    public let long: QuotaPlanningWindowSnapshot
+
+    public init(id: String, short: QuotaPlanningWindowSnapshot, long: QuotaPlanningWindowSnapshot) {
+        self.id = id
+        self.short = short
+        self.long = long
+    }
+}
+
+public struct QuotaPlanningObservation: Equatable, Sendable {
+    public let capturedAt: Date
+    public let shortUsedPercent: Double
+    public let longUsedPercent: Double
+    public let shortResetAt: Date
+    public let longResetAt: Date
+
+    public init(
+        capturedAt: Date,
+        shortUsedPercent: Double,
+        longUsedPercent: Double,
+        shortResetAt: Date,
+        longResetAt: Date)
+    {
+        self.capturedAt = capturedAt
+        self.shortUsedPercent = shortUsedPercent
+        self.longUsedPercent = longUsedPercent
+        self.shortResetAt = shortResetAt
+        self.longResetAt = longResetAt
+    }
+}
+
+public struct QuotaPlanningCandidate: Equatable, Sendable {
+    public let longPercentPerFullShortAllowance: Double
+    public let sourceLongDelta: Double
+
+    public init(longPercentPerFullShortAllowance: Double, sourceLongDelta: Double) {
+        self.longPercentPerFullShortAllowance = longPercentPerFullShortAllowance
+        self.sourceLongDelta = sourceLongDelta
+    }
+}
+
+public struct QuotaPlanningCalibrationState: Equatable, Sendable {
+    public let baseline: QuotaPlanningObservation
+    public let latest: QuotaPlanningObservation
+    public let canonicalShortResetAt: Date
+    public let canonicalLongResetAt: Date
+    public let activeCandidate: QuotaPlanningCandidate?
+    public let completedCandidates: [QuotaPlanningCandidate]
+    public let requiresActiveRequalification: Bool
+
+    public init(
+        baseline: QuotaPlanningObservation,
+        latest: QuotaPlanningObservation,
+        canonicalShortResetAt: Date,
+        canonicalLongResetAt: Date,
+        activeCandidate: QuotaPlanningCandidate?,
+        completedCandidates: [QuotaPlanningCandidate],
+        requiresActiveRequalification: Bool)
+    {
+        self.baseline = baseline
+        self.latest = latest
+        self.canonicalShortResetAt = canonicalShortResetAt
+        self.canonicalLongResetAt = canonicalLongResetAt
+        self.activeCandidate = activeCandidate
+        self.completedCandidates = completedCandidates
+        self.requiresActiveRequalification = requiresActiveRequalification
+    }
+
+    public var candidates: [QuotaPlanningCandidate] {
+        self.completedCandidates + [self.activeCandidate].compactMap(\.self)
+    }
+}
+
+public enum QuotaPlanningReachability: Equatable, Sendable {
+    case insufficientEvidence
+    case theoreticallyReachable
+    case likelyStranded
+    case uncertain
+}
+
+public struct QuotaPlanningScheduleCapacity: Equatable, Sendable {
+    public let maximumFullSessionEquivalentsBeforeReset: Double
+    public let futureFullShortAllowanceCount: Int
+    public let shortResetAt: Date
+    public let longResetAt: Date
+
+    public init(
+        maximumFullSessionEquivalentsBeforeReset: Double,
+        futureFullShortAllowanceCount: Int,
+        shortResetAt: Date,
+        longResetAt: Date)
+    {
+        self.maximumFullSessionEquivalentsBeforeReset = maximumFullSessionEquivalentsBeforeReset
+        self.futureFullShortAllowanceCount = futureFullShortAllowanceCount
+        self.shortResetAt = shortResetAt
+        self.longResetAt = longResetAt
+    }
+}
+
+public struct QuotaPlanningEstimate: Equatable, Sendable {
+    public let pairID: String
+    public let longMetricID: String
+    public let fundableFullSessionEquivalents: Double
+    public let maximumFullSessionEquivalentsBeforeReset: Double
+    public let futureFullShortAllowanceCount: Int
+    public let longPercentPerFullShortAllowance: Double
+    public let reachability: QuotaPlanningReachability
+    public let shortResetAt: Date
+    public let longResetAt: Date
+
+    public init(
+        pairID: String,
+        longMetricID: String,
+        fundableFullSessionEquivalents: Double,
+        maximumFullSessionEquivalentsBeforeReset: Double,
+        futureFullShortAllowanceCount: Int,
+        longPercentPerFullShortAllowance: Double,
+        reachability: QuotaPlanningReachability,
+        shortResetAt: Date,
+        longResetAt: Date)
+    {
+        self.pairID = pairID
+        self.longMetricID = longMetricID
+        self.fundableFullSessionEquivalents = fundableFullSessionEquivalents
+        self.maximumFullSessionEquivalentsBeforeReset = maximumFullSessionEquivalentsBeforeReset
+        self.futureFullShortAllowanceCount = futureFullShortAllowanceCount
+        self.longPercentPerFullShortAllowance = longPercentPerFullShortAllowance
+        self.reachability = reachability
+        self.shortResetAt = shortResetAt
+        self.longResetAt = longResetAt
+    }
+}
+
+public enum QuotaPlanningEstimator {
+    public static func observation(
+        for pair: QuotaPlanningPairSnapshot,
+        now: Date = .init()) -> QuotaPlanningObservation?
+    {
+        guard let pair = self.validated(pair: pair, now: now) else { return nil }
+        return QuotaPlanningObservation(
+            capturedAt: now,
+            shortUsedPercent: pair.shortUsedPercent,
+            longUsedPercent: pair.longUsedPercent,
+            shortResetAt: pair.shortResetAt,
+            longResetAt: pair.longResetAt)
+    }
+
+    public static func scheduleCapacity(
+        for pair: QuotaPlanningPairSnapshot,
+        now: Date = .init()) -> QuotaPlanningScheduleCapacity?
+    {
+        guard let pair = self.validated(pair: pair, now: now) else { return nil }
+        return self.scheduleCapacity(
+            pair: pair,
+            shortResetAt: pair.shortResetAt,
+            longResetAt: pair.longResetAt)
+    }
+
+    public static func estimate(
+        for pair: QuotaPlanningPairSnapshot,
+        calibration: QuotaPlanningCalibrationState,
+        now: Date = .init()) -> QuotaPlanningEstimate?
+    {
+        guard !calibration.requiresActiveRequalification,
+              let pair = self.validated(pair: pair, now: now),
+              Self.equivalent(pair.shortResetAt, calibration.canonicalShortResetAt),
+              Self.equivalent(pair.longResetAt, calibration.canonicalLongResetAt),
+              calibration.canonicalShortResetAt > now,
+              calibration.canonicalLongResetAt > now
+        else {
+            return nil
+        }
+
+        let candidates = calibration.candidates
+        guard !candidates.isEmpty else { return nil }
+        if candidates.count == 1,
+           candidates[0].sourceLongDelta < QuotaPlanningConstants.minimumSingleCandidateLongDelta
+        {
+            return nil
+        }
+
+        let costs = candidates.map(\.longPercentPerFullShortAllowance).sorted()
+        guard let median = Self.median(costs), median.isFinite, median > 0 else { return nil }
+        if costs.count >= 2,
+           costs.contains(where: {
+               abs($0 - median) / median > QuotaPlanningConstants.maximumRelativeDeviation
+           })
+        {
+            return nil
+        }
+
+        guard let schedule = self.scheduleCapacity(
+            pair: pair,
+            shortResetAt: calibration.canonicalShortResetAt,
+            longResetAt: calibration.canonicalLongResetAt)
+        else {
+            return nil
+        }
+
+        let longRemainingPercent = 100 - pair.longUsedPercent
+        let fundable = longRemainingPercent / median
+        guard fundable.isFinite, fundable >= 0 else { return nil }
+
+        let reachability: QuotaPlanningReachability
+        if costs.count < 2 {
+            reachability = .insufficientEvidence
+        } else {
+            let lowerFundable = longRemainingPercent / (costs.last ?? median)
+            let upperFundable = longRemainingPercent / (costs.first ?? median)
+            if lowerFundable > schedule.maximumFullSessionEquivalentsBeforeReset {
+                reachability = .likelyStranded
+            } else if upperFundable <= schedule.maximumFullSessionEquivalentsBeforeReset {
+                reachability = .theoreticallyReachable
+            } else {
+                reachability = .uncertain
+            }
+        }
+
+        return QuotaPlanningEstimate(
+            pairID: pair.id,
+            longMetricID: pair.longMetricID,
+            fundableFullSessionEquivalents: fundable,
+            maximumFullSessionEquivalentsBeforeReset: schedule.maximumFullSessionEquivalentsBeforeReset,
+            futureFullShortAllowanceCount: schedule.futureFullShortAllowanceCount,
+            longPercentPerFullShortAllowance: median,
+            reachability: reachability,
+            shortResetAt: schedule.shortResetAt,
+            longResetAt: schedule.longResetAt)
+    }
+
+    private struct ValidatedPair {
+        let id: String
+        let longMetricID: String
+        let shortUsedPercent: Double
+        let longUsedPercent: Double
+        let shortDuration: TimeInterval
+        let shortResetAt: Date
+        let longResetAt: Date
+    }
+
+    private static func validated(pair: QuotaPlanningPairSnapshot, now: Date) -> ValidatedPair? {
+        let pairID = pair.id.trimmingCharacters(in: .whitespacesAndNewlines)
+        let shortMetricID = pair.short.metricID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let longMetricID = pair.long.metricID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !pairID.isEmpty,
+              !shortMetricID.isEmpty,
+              !longMetricID.isEmpty,
+              shortMetricID != longMetricID,
+              pair.short.usageKnown,
+              pair.long.usageKnown,
+              !pair.short.window.isSyntheticPlaceholder,
+              !pair.long.window.isSyntheticPlaceholder,
+              pair.short.window.nextRegenPercent == nil,
+              pair.long.window.nextRegenPercent == nil,
+              pair.short.window.usedPercent.isFinite,
+              pair.long.window.usedPercent.isFinite,
+              (0...100).contains(pair.short.window.usedPercent),
+              (0...100).contains(pair.long.window.usedPercent),
+              pair.long.window.usedPercent < 100,
+              let shortMinutes = pair.short.window.windowMinutes,
+              let longMinutes = pair.long.window.windowMinutes,
+              shortMinutes > 0,
+              longMinutes > shortMinutes,
+              let shortResetAt = pair.short.window.resetsAt,
+              let longResetAt = pair.long.window.resetsAt
+        else {
+            return nil
+        }
+
+        let shortDuration = TimeInterval(shortMinutes) * 60
+        let longDuration = TimeInterval(longMinutes) * 60
+        let shortRemaining = shortResetAt.timeIntervalSince(now)
+        let longRemaining = longResetAt.timeIntervalSince(now)
+        let tolerance = QuotaPlanningConstants.resetEquivalenceTolerance
+        guard shortRemaining > 0,
+              longRemaining > 0,
+              shortRemaining <= shortDuration + tolerance,
+              longRemaining <= longDuration + tolerance
+        else {
+            return nil
+        }
+
+        return ValidatedPair(
+            id: pairID,
+            longMetricID: longMetricID,
+            shortUsedPercent: pair.short.window.usedPercent,
+            longUsedPercent: pair.long.window.usedPercent,
+            shortDuration: shortDuration,
+            shortResetAt: shortResetAt,
+            longResetAt: longResetAt)
+    }
+
+    private static func scheduleCapacity(
+        pair: ValidatedPair,
+        shortResetAt: Date,
+        longResetAt: Date) -> QuotaPlanningScheduleCapacity?
+    {
+        let delta = longResetAt.timeIntervalSince(shortResetAt)
+        let tolerance = QuotaPlanningConstants.resetEquivalenceTolerance
+        let futureCount: Int
+        if delta <= tolerance {
+            futureCount = 0
+        } else {
+            let rawCount = ceil((delta - tolerance) / pair.shortDuration)
+            guard rawCount.isFinite, rawCount >= 0, rawCount <= Double(Int.max) else { return nil }
+            futureCount = Int(rawCount)
+        }
+
+        let shortRemainingFraction = (100 - pair.shortUsedPercent) / 100
+        let maximum = shortRemainingFraction + Double(futureCount)
+        guard maximum.isFinite, maximum >= 0 else { return nil }
+        return QuotaPlanningScheduleCapacity(
+            maximumFullSessionEquivalentsBeforeReset: maximum,
+            futureFullShortAllowanceCount: futureCount,
+            shortResetAt: shortResetAt,
+            longResetAt: longResetAt)
+    }
+
+    private static func equivalent(_ lhs: Date, _ rhs: Date) -> Bool {
+        abs(lhs.timeIntervalSince(rhs)) <= QuotaPlanningConstants.resetEquivalenceTolerance
+    }
+
+    private static func median(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let midpoint = values.count / 2
+        if values.count.isMultiple(of: 2) {
+            return (values[midpoint - 1] + values[midpoint]) / 2
+        }
+        return values[midpoint]
+    }
+}
+
+public enum QuotaPlanningCalibrationReducer {
+    public static func reduce(
+        state: QuotaPlanningCalibrationState?,
+        observation: QuotaPlanningObservation) -> QuotaPlanningCalibrationState
+    {
+        guard let state else { return self.freshState(observation: observation) }
+
+        guard self.equivalent(observation.longResetAt, state.canonicalLongResetAt) else {
+            return self.freshState(observation: observation)
+        }
+
+        let shortResetDelta = observation.shortResetAt.timeIntervalSince(state.canonicalShortResetAt)
+        let tolerance = QuotaPlanningConstants.resetEquivalenceTolerance
+        if shortResetDelta > tolerance {
+            var completed = state.completedCandidates
+            if let candidate = state.activeCandidate {
+                completed.append(candidate)
+                if completed.count > QuotaPlanningConstants.maximumCompletedCandidates {
+                    completed.removeFirst(completed.count - QuotaPlanningConstants.maximumCompletedCandidates)
+                }
+            }
+            let normalized = self.normalized(
+                observation,
+                shortResetAt: observation.shortResetAt,
+                longResetAt: state.canonicalLongResetAt)
+            return QuotaPlanningCalibrationState(
+                baseline: normalized,
+                latest: normalized,
+                canonicalShortResetAt: observation.shortResetAt,
+                canonicalLongResetAt: state.canonicalLongResetAt,
+                activeCandidate: nil,
+                completedCandidates: completed,
+                requiresActiveRequalification: state.requiresActiveRequalification)
+        }
+
+        if shortResetDelta < -tolerance {
+            return self.discontinuousState(
+                from: state,
+                observation: observation,
+                shortResetAt: observation.shortResetAt)
+        }
+
+        let jitter = QuotaPlanningConstants.percentageJitterTolerance
+        if observation.shortUsedPercent < state.latest.shortUsedPercent - jitter ||
+            observation.longUsedPercent < state.latest.longUsedPercent - jitter
+        {
+            return self.discontinuousState(
+                from: state,
+                observation: observation,
+                shortResetAt: state.canonicalShortResetAt)
+        }
+
+        let latest = QuotaPlanningObservation(
+            capturedAt: observation.capturedAt,
+            shortUsedPercent: max(state.latest.shortUsedPercent, observation.shortUsedPercent),
+            longUsedPercent: max(state.latest.longUsedPercent, observation.longUsedPercent),
+            shortResetAt: state.canonicalShortResetAt,
+            longResetAt: state.canonicalLongResetAt)
+        let candidate = self.candidate(baseline: state.baseline, latest: latest)
+        return QuotaPlanningCalibrationState(
+            baseline: state.baseline,
+            latest: latest,
+            canonicalShortResetAt: state.canonicalShortResetAt,
+            canonicalLongResetAt: state.canonicalLongResetAt,
+            activeCandidate: candidate ?? state.activeCandidate,
+            completedCandidates: state.completedCandidates,
+            requiresActiveRequalification: candidate == nil ? state.requiresActiveRequalification : false)
+    }
+
+    private static func freshState(observation: QuotaPlanningObservation) -> QuotaPlanningCalibrationState {
+        let normalized = self.normalized(
+            observation,
+            shortResetAt: observation.shortResetAt,
+            longResetAt: observation.longResetAt)
+        return QuotaPlanningCalibrationState(
+            baseline: normalized,
+            latest: normalized,
+            canonicalShortResetAt: observation.shortResetAt,
+            canonicalLongResetAt: observation.longResetAt,
+            activeCandidate: nil,
+            completedCandidates: [],
+            requiresActiveRequalification: false)
+    }
+
+    private static func discontinuousState(
+        from state: QuotaPlanningCalibrationState,
+        observation: QuotaPlanningObservation,
+        shortResetAt: Date) -> QuotaPlanningCalibrationState
+    {
+        let normalized = self.normalized(
+            observation,
+            shortResetAt: shortResetAt,
+            longResetAt: state.canonicalLongResetAt)
+        return QuotaPlanningCalibrationState(
+            baseline: normalized,
+            latest: normalized,
+            canonicalShortResetAt: shortResetAt,
+            canonicalLongResetAt: state.canonicalLongResetAt,
+            activeCandidate: nil,
+            completedCandidates: state.completedCandidates,
+            requiresActiveRequalification: true)
+    }
+
+    private static func candidate(
+        baseline: QuotaPlanningObservation,
+        latest: QuotaPlanningObservation) -> QuotaPlanningCandidate?
+    {
+        let shortDelta = latest.shortUsedPercent - baseline.shortUsedPercent
+        let longDelta = latest.longUsedPercent - baseline.longUsedPercent
+        guard shortDelta >= QuotaPlanningConstants.minimumShortDelta,
+              longDelta >= QuotaPlanningConstants.minimumLongDelta,
+              latest.longUsedPercent < QuotaPlanningConstants.longSaturationThreshold
+        else {
+            return nil
+        }
+
+        let cost = 100 * longDelta / shortDelta
+        guard cost.isFinite, cost > 0 else { return nil }
+        return QuotaPlanningCandidate(
+            longPercentPerFullShortAllowance: cost,
+            sourceLongDelta: longDelta)
+    }
+
+    private static func normalized(
+        _ observation: QuotaPlanningObservation,
+        shortResetAt: Date,
+        longResetAt: Date) -> QuotaPlanningObservation
+    {
+        QuotaPlanningObservation(
+            capturedAt: observation.capturedAt,
+            shortUsedPercent: observation.shortUsedPercent,
+            longUsedPercent: observation.longUsedPercent,
+            shortResetAt: shortResetAt,
+            longResetAt: longResetAt)
+    }
+
+    private static func equivalent(_ lhs: Date, _ rhs: Date) -> Bool {
+        abs(lhs.timeIntervalSince(rhs)) <= QuotaPlanningConstants.resetEquivalenceTolerance
+    }
+}

--- a/Sources/CodexBarCore/QuotaPlanning.swift
+++ b/Sources/CodexBarCore/QuotaPlanning.swift
@@ -191,8 +191,8 @@ public enum QuotaPlanningEstimator {
     {
         guard !calibration.requiresActiveRequalification,
               let pair = self.validated(pair: pair, now: now),
-              Self.equivalent(pair.shortResetAt, calibration.canonicalShortResetAt),
-              Self.equivalent(pair.longResetAt, calibration.canonicalLongResetAt),
+              equivalent(pair.shortResetAt, calibration.canonicalShortResetAt),
+              equivalent(pair.longResetAt, calibration.canonicalLongResetAt),
               calibration.canonicalShortResetAt > now,
               calibration.canonicalLongResetAt > now
         else {

--- a/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
@@ -84,6 +84,31 @@ struct AntigravityQuotaSummaryTests {
         #expect(usage.extraRateWindows?.first?.window.remainingPercent == 50)
     }
 
+    @Test
+    func `out of range quota summary fraction remains explicitly unknown`() throws {
+        let json = """
+        {
+          "groups": [
+            {
+              "displayName": "Gemini Models",
+              "buckets": [
+                {
+                  "bucketId": "gemini-weekly",
+                  "displayName": "Weekly Limit",
+                  "remainingFraction": 1.2
+                }
+              ]
+            }
+          ]
+        }
+        """
+
+        let snapshot = try AntigravityStatusProbe.parseQuotaSummaryResponse(Data(json.utf8))
+        let window = try #require(snapshot.toUsageSnapshot().extraRateWindows?.first)
+
+        #expect(!window.usageKnown)
+    }
+
     @Test(arguments: ["session", "5h", "5-hour", "five hour", "five-hour"])
     func `normalizes supported session cadence aliases without rewriting bucket IDs`(alias: String) throws {
         let bucketID = "gemini-\(alias)"

--- a/Tests/CodexBarTests/CodexResetCreditOutcomeTests.swift
+++ b/Tests/CodexBarTests/CodexResetCreditOutcomeTests.swift
@@ -169,11 +169,27 @@ struct CodexResetCreditOutcomeTests {
         #expect(await recorder.environments().isEmpty)
     }
 
+    @Test
+    func `supplemental inventory preserves live quota freshness`() async {
+        let now = Date(timeIntervalSince1970: 1_781_726_400)
+        let outcome = await UsageStore.attachingCodexResetCreditsIfNeeded(
+            to: Self.outcome(resetCredits: nil, now: now, observationFreshness: .live),
+            env: [:],
+            fetcher: { _ in Self.resetSnapshot(id: "supplemental", now: now) })
+
+        guard case let .success(result) = outcome.result else {
+            Issue.record("Expected successful enriched result")
+            return
+        }
+        #expect(result.observationFreshness == .live)
+    }
+
     private static func outcome(
         resetCredits: CodexRateLimitResetCreditsSnapshot?,
         now: Date,
         primary: RateWindow? = nil,
-        strategyID: String = "test") -> ProviderFetchOutcome
+        strategyID: String = "test",
+        observationFreshness: ProviderObservationFreshness = .unknown) -> ProviderFetchOutcome
     {
         let resolvedPrimary = strategyID == "codex.oauth" ? primary : primary ?? RateWindow(
             usedPercent: 25,
@@ -191,7 +207,8 @@ struct CodexResetCreditOutcomeTests {
                 dashboard: nil,
                 sourceLabel: "test",
                 strategyID: strategyID,
-                strategyKind: .cli)),
+                strategyKind: .cli,
+                observationFreshness: observationFreshness)),
             attempts: [])
     }
 

--- a/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
+++ b/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
@@ -48,10 +48,20 @@ struct MenuCardHeightFingerprintTests {
         #expect(one.heightFingerprint(section: "card") != two.heightFingerprint(section: "card"))
     }
 
+    @Test
+    func `height fingerprint tracks quota planning line`() {
+        let withoutPlanning = Self.model()
+        let withPlanning = Self.model(quotaPlanningText: "Available full sessions: ≈4")
+
+        #expect(withoutPlanning.heightFingerprint(section: "card") !=
+            withPlanning.heightFingerprint(section: "card"))
+    }
+
     private static func model(
         percent: Double = 42,
         percentStyle: UsageMenuCardView.Model.PercentStyle = .left,
-        resetCredits: CodexResetCreditsPresentation? = nil) -> UsageMenuCardView.Model
+        resetCredits: CodexResetCreditsPresentation? = nil,
+        quotaPlanningText: String? = nil) -> UsageMenuCardView.Model
     {
         UsageMenuCardView.Model(
             provider: .codex,
@@ -68,6 +78,7 @@ struct MenuCardHeightFingerprintTests {
                     percentStyle: percentStyle,
                     statusText: "Secret status",
                     resetText: nil,
+                    quotaPlanningText: quotaPlanningText,
                     detailText: nil,
                     detailLeftText: nil,
                     detailRightText: nil,

--- a/Tests/CodexBarTests/MenuCardOverrideIsolationTests.swift
+++ b/Tests/CodexBarTests/MenuCardOverrideIsolationTests.swift
@@ -7,6 +7,62 @@ import Testing
 @MainActor
 struct MenuCardOverrideIsolationTests {
     @Test
+    func `account override card does not inherit live quota planning`() throws {
+        let suite = "MenuCardOverrideIsolationTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 30,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(6 * 24 * 60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store.quotaPlanningEstimates[.claude] = [
+            "secondary": QuotaPlanningEstimate(
+                pairID: "session-weekly",
+                longMetricID: "secondary",
+                fundableFullSessionEquivalents: 4,
+                maximumFullSessionEquivalentsBeforeReset: 3,
+                futureFullShortAllowanceCount: 2,
+                longPercentPerFullShortAllowance: 5,
+                reachability: .insufficientEvidence,
+                shortResetAt: now.addingTimeInterval(4 * 60 * 60),
+                longResetAt: now.addingTimeInterval(6 * 24 * 60 * 60)),
+        ]
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+
+        let liveModel = try #require(controller.menuCardModel(for: .claude))
+        let overrideModel = try #require(controller.menuCardModel(
+            for: .claude,
+            snapshotOverride: snapshot,
+            accountOverride: AccountInfo(email: "other@example.com", plan: nil)))
+
+        #expect(liveModel.metrics.first(where: { $0.id == "secondary" })?.quotaPlanningText != nil)
+        #expect(overrideModel.metrics.allSatisfy { $0.quotaPlanningText == nil })
+    }
+
+    @Test
     func `nil snapshot account card does not inherit ambient Claude costs`() throws {
         let suite = "MenuCardOverrideIsolationTests-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suite))

--- a/Tests/CodexBarTests/QuotaPlanningLifecycleTests.swift
+++ b/Tests/CodexBarTests/QuotaPlanningLifecycleTests.swift
@@ -1,0 +1,375 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct QuotaPlanningLifecycleTests {
+    @Test
+    func `live observations publish an estimate keyed by long metric`() throws {
+        let fixture = Self.fixture()
+        var lifecycle = QuotaPlanningLifecycle()
+
+        Self.recordBaseline(in: &lifecycle, fixture: fixture)
+        Self.recordQualifiedObservation(in: &lifecycle, fixture: fixture)
+
+        let estimate = try #require(lifecycle.estimatesByProvider()[.claude]?["weekly"])
+        #expect(estimate.pairID == "session-weekly")
+        #expect(Self.close(estimate.longPercentPerFullShortAllowance, 5))
+    }
+
+    @Test(arguments: [ProviderObservationFreshness.cached, .unknown])
+    func `same scope non-live successes retain publication without extending ttl`(
+        freshness: ProviderObservationFreshness) throws
+    {
+        let fixture = Self.fixture()
+        var lifecycle = QuotaPlanningLifecycle()
+        Self.recordBaseline(in: &lifecycle, fixture: fixture)
+        Self.recordQualifiedObservation(in: &lifecycle, fixture: fixture)
+        let originalExpiry = try #require(
+            lifecycle.publications[.claude]?["weekly"]?.monotonicExpiresAt)
+
+        lifecycle.recordSuccessfulFetch(
+            provider: .claude,
+            accountDiscriminator: "account-a",
+            result: Self.result(freshness: freshness),
+            resolvedPairs: [],
+            receipt: QuotaPlanningReceipt(
+                wallNow: fixture.now.addingTimeInterval(20 * 60),
+                monotonicNow: fixture.monotonic.advanced(by: .seconds(20 * 60))))
+
+        #expect(lifecycle.publications[.claude]?["weekly"]?.monotonicExpiresAt == originalExpiry)
+        lifecycle.expire(
+            wallNow: fixture.now.addingTimeInterval(61 * 60),
+            monotonicNow: fixture.monotonic.advanced(by: .seconds(61 * 60)))
+        #expect(lifecycle.publications[.claude] == nil)
+        #expect(lifecycle.calibrations.count == 1)
+    }
+
+    @Test
+    func `live ineligible result hides publication but preserves calibration`() {
+        let fixture = Self.fixture()
+        var lifecycle = QuotaPlanningLifecycle()
+        Self.recordBaseline(in: &lifecycle, fixture: fixture)
+        Self.recordQualifiedObservation(in: &lifecycle, fixture: fixture)
+
+        lifecycle.recordSuccessfulFetch(
+            provider: .claude,
+            accountDiscriminator: "account-a",
+            result: Self.result(freshness: .live),
+            resolvedPairs: [],
+            receipt: QuotaPlanningReceipt(
+                wallNow: fixture.now.addingTimeInterval(120),
+                monotonicNow: fixture.monotonic.advanced(by: .seconds(120))))
+
+        #expect(lifecycle.publications[.claude] == nil)
+        #expect(lifecycle.calibrations.count == 1)
+    }
+
+    @Test
+    func `strategy change hides old publication and isolates calibration`() {
+        let fixture = Self.fixture()
+        var lifecycle = QuotaPlanningLifecycle()
+        Self.recordBaseline(in: &lifecycle, fixture: fixture)
+        Self.recordQualifiedObservation(in: &lifecycle, fixture: fixture)
+
+        lifecycle.recordSuccessfulFetch(
+            provider: .claude,
+            accountDiscriminator: "account-a",
+            result: Self.result(freshness: .live, strategyID: "claude.cli", kind: .cli),
+            resolvedPairs: [Self.pair(
+                fixture: fixture,
+                shortUsed: 0,
+                longUsed: 13)],
+            receipt: QuotaPlanningReceipt(
+                wallNow: fixture.now.addingTimeInterval(120),
+                monotonicNow: fixture.monotonic.advanced(by: .seconds(120))))
+
+        #expect(lifecycle.publications[.claude] == nil)
+        #expect(lifecycle.calibrations.count == 2)
+        #expect(lifecycle.activeScopes[.claude]?.strategyID == "claude.cli")
+    }
+
+    @Test
+    func `non-live strategy change hides without learning`() {
+        let fixture = Self.fixture()
+        var lifecycle = QuotaPlanningLifecycle()
+        Self.recordBaseline(in: &lifecycle, fixture: fixture)
+        Self.recordQualifiedObservation(in: &lifecycle, fixture: fixture)
+
+        lifecycle.recordSuccessfulFetch(
+            provider: .claude,
+            accountDiscriminator: "account-a",
+            result: Self.result(freshness: .cached, strategyID: "claude.cli", kind: .cli),
+            resolvedPairs: [],
+            receipt: QuotaPlanningReceipt(
+                wallNow: fixture.now.addingTimeInterval(120),
+                monotonicNow: fixture.monotonic.advanced(by: .seconds(120))))
+
+        #expect(lifecycle.publications[.claude] == nil)
+        #expect(lifecycle.calibrations.count == 1)
+    }
+
+    @Test
+    func `active account change hides publication before another success`() {
+        let fixture = Self.fixture()
+        var lifecycle = QuotaPlanningLifecycle()
+        Self.recordBaseline(in: &lifecycle, fixture: fixture)
+        Self.recordQualifiedObservation(in: &lifecycle, fixture: fixture)
+
+        let changed = lifecycle.activateAccount(
+            provider: .claude,
+            accountDiscriminator: "account-b")
+
+        #expect(changed)
+        #expect(lifecycle.publications[.claude] == nil)
+        #expect(lifecycle.calibrations.count == 1)
+    }
+
+    @Test
+    func `short reset expiry hides publication and retains calibration`() {
+        let fixture = Self.fixture(shortResetOffset: 30 * 60)
+        var lifecycle = QuotaPlanningLifecycle()
+        Self.recordBaseline(in: &lifecycle, fixture: fixture)
+        Self.recordQualifiedObservation(in: &lifecycle, fixture: fixture)
+
+        lifecycle.expire(
+            wallNow: fixture.shortReset.addingTimeInterval(1),
+            monotonicNow: fixture.monotonic.advanced(by: .seconds(31 * 60)))
+
+        #expect(lifecycle.publications[.claude] == nil)
+        #expect(lifecycle.calibrations.count == 1)
+    }
+
+    @Test
+    func `long reset expiry discards publication and calibration`() {
+        let fixture = Self.fixture(shortResetOffset: 30 * 60, longResetOffset: 40 * 60)
+        var lifecycle = QuotaPlanningLifecycle()
+        Self.recordBaseline(in: &lifecycle, fixture: fixture)
+        Self.recordQualifiedObservation(in: &lifecycle, fixture: fixture)
+
+        lifecycle.expire(
+            wallNow: fixture.longReset.addingTimeInterval(1),
+            monotonicNow: fixture.monotonic.advanced(by: .seconds(41 * 60)))
+
+        #expect(lifecycle.publications[.claude] == nil)
+        #expect(lifecycle.calibrations.isEmpty)
+    }
+
+    @Test
+    func `missing stable account never learns or publishes`() {
+        let fixture = Self.fixture()
+        var lifecycle = QuotaPlanningLifecycle()
+
+        lifecycle.recordSuccessfulFetch(
+            provider: .claude,
+            accountDiscriminator: nil,
+            result: Self.result(freshness: .live),
+            resolvedPairs: [Self.pair(
+                fixture: fixture,
+                shortUsed: 0,
+                longUsed: 10)],
+            receipt: QuotaPlanningReceipt(
+                wallNow: fixture.now,
+                monotonicNow: fixture.monotonic))
+
+        #expect(lifecycle.calibrations.isEmpty)
+        #expect(lifecycle.publications.isEmpty)
+    }
+
+    @Test
+    func `independent pairs publish by their own long metric ids`() throws {
+        let fixture = Self.fixture()
+        var lifecycle = QuotaPlanningLifecycle()
+
+        lifecycle.recordSuccessfulFetch(
+            provider: .antigravity,
+            accountDiscriminator: "account-a",
+            result: Self.result(freshness: .live, strategyID: "antigravity.local", kind: .localProbe),
+            resolvedPairs: [
+                Self.pair(
+                    fixture: fixture,
+                    pairID: "gemini",
+                    longMetricID: "gemini-weekly",
+                    shortUsed: 0,
+                    longUsed: 10),
+                Self.pair(
+                    fixture: fixture,
+                    pairID: "third-party",
+                    longMetricID: "third-party-weekly",
+                    shortUsed: 0,
+                    longUsed: 20),
+            ],
+            receipt: QuotaPlanningReceipt(
+                wallNow: fixture.now,
+                monotonicNow: fixture.monotonic))
+        lifecycle.recordSuccessfulFetch(
+            provider: .antigravity,
+            accountDiscriminator: "account-a",
+            result: Self.result(freshness: .live, strategyID: "antigravity.local", kind: .localProbe),
+            resolvedPairs: [
+                Self.pair(
+                    fixture: fixture,
+                    pairID: "gemini",
+                    longMetricID: "gemini-weekly",
+                    shortUsed: 60,
+                    longUsed: 13),
+                Self.pair(
+                    fixture: fixture,
+                    pairID: "third-party",
+                    longMetricID: "third-party-weekly",
+                    shortUsed: 50,
+                    longUsed: 23),
+            ],
+            receipt: QuotaPlanningReceipt(
+                wallNow: fixture.now.addingTimeInterval(60),
+                monotonicNow: fixture.monotonic.advanced(by: .seconds(60))))
+
+        let estimates = try #require(lifecycle.estimatesByProvider()[.antigravity])
+        #expect(Set(estimates.keys) == ["gemini-weekly", "third-party-weekly"])
+        #expect(try Self.close(
+            #require(estimates["gemini-weekly"])
+                .longPercentPerFullShortAllowance,
+            5))
+        #expect(try Self.close(
+            #require(estimates["third-party-weekly"])
+                .longPercentPerFullShortAllowance,
+            6))
+    }
+
+    @Test
+    func `identity discriminator is normalized and does not expose email`() throws {
+        let first = try #require(UsageStore.quotaPlanningIdentityDiscriminator(
+            provider: .antigravity,
+            usage: Self.usage(email: " Person@Example.com ")))
+        let second = try #require(UsageStore.quotaPlanningIdentityDiscriminator(
+            provider: .antigravity,
+            usage: Self.usage(email: "person@example.com")))
+
+        #expect(first == second)
+        #expect(!first.contains("person@example.com"))
+    }
+
+    @Test
+    func `earliest expiry uses monotonic ttl when resets are later`() throws {
+        let fixture = Self.fixture()
+        var lifecycle = QuotaPlanningLifecycle()
+        Self.recordBaseline(in: &lifecycle, fixture: fixture)
+        Self.recordQualifiedObservation(in: &lifecycle, fixture: fixture)
+
+        let delay = try #require(lifecycle.nextExpiryDelay(
+            wallNow: fixture.now.addingTimeInterval(60),
+            monotonicNow: fixture.monotonic.advanced(by: .seconds(60))))
+
+        #expect(delay == .seconds(60 * 60))
+    }
+
+    private struct Fixture {
+        let now: Date
+        let monotonic: ContinuousClock.Instant
+        let shortReset: Date
+        let longReset: Date
+    }
+
+    private static func fixture(
+        shortResetOffset: TimeInterval = 4 * 60 * 60,
+        longResetOffset: TimeInterval = 6 * 24 * 60 * 60) -> Fixture
+    {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        return Fixture(
+            now: now,
+            monotonic: ContinuousClock().now,
+            shortReset: now.addingTimeInterval(shortResetOffset),
+            longReset: now.addingTimeInterval(longResetOffset))
+    }
+
+    private static func recordBaseline(
+        in lifecycle: inout QuotaPlanningLifecycle,
+        fixture: Fixture)
+    {
+        lifecycle.recordSuccessfulFetch(
+            provider: .claude,
+            accountDiscriminator: "account-a",
+            result: self.result(freshness: .live),
+            resolvedPairs: [self.pair(
+                fixture: fixture,
+                shortUsed: 0,
+                longUsed: 10)],
+            receipt: QuotaPlanningReceipt(
+                wallNow: fixture.now,
+                monotonicNow: fixture.monotonic))
+    }
+
+    private static func recordQualifiedObservation(
+        in lifecycle: inout QuotaPlanningLifecycle,
+        fixture: Fixture)
+    {
+        let capturedAt = fixture.now.addingTimeInterval(60)
+        lifecycle.recordSuccessfulFetch(
+            provider: .claude,
+            accountDiscriminator: "account-a",
+            result: Self.result(freshness: .live),
+            resolvedPairs: [Self.pair(
+                fixture: fixture,
+                shortUsed: 60,
+                longUsed: 13)],
+            receipt: QuotaPlanningReceipt(
+                wallNow: capturedAt,
+                monotonicNow: fixture.monotonic.advanced(by: .seconds(60))))
+    }
+
+    private static func pair(
+        fixture: Fixture,
+        pairID: String = "session-weekly",
+        longMetricID: String = "weekly",
+        shortUsed: Double,
+        longUsed: Double) -> QuotaPlanningPairSnapshot
+    {
+        QuotaPlanningPairSnapshot(
+            id: pairID,
+            short: QuotaPlanningWindowSnapshot(
+                metricID: "\(pairID)-session",
+                window: RateWindow(
+                    usedPercent: shortUsed,
+                    windowMinutes: 300,
+                    resetsAt: fixture.shortReset,
+                    resetDescription: nil)),
+            long: QuotaPlanningWindowSnapshot(
+                metricID: longMetricID,
+                window: RateWindow(
+                    usedPercent: longUsed,
+                    windowMinutes: 10080,
+                    resetsAt: fixture.longReset,
+                    resetDescription: nil)))
+    }
+
+    private static func usage(email: String) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: .init(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .antigravity,
+                accountEmail: email,
+                accountOrganization: nil,
+                loginMethod: nil))
+    }
+
+    private static func result(
+        freshness: ProviderObservationFreshness,
+        strategyID: String = "claude.oauth",
+        kind: ProviderFetchKind = .oauth) -> ProviderFetchResult
+    {
+        ProviderFetchResult(
+            usage: UsageSnapshot(primary: nil, secondary: nil, updatedAt: .init()),
+            credits: nil,
+            dashboard: nil,
+            sourceLabel: "test",
+            strategyID: strategyID,
+            strategyKind: kind,
+            observationFreshness: freshness)
+    }
+
+    private static func close(_ lhs: Double, _ rhs: Double, tolerance: Double = 0.0001) -> Bool {
+        abs(lhs - rhs) <= tolerance
+    }
+}

--- a/Tests/CodexBarTests/QuotaPlanningMenuPresentationTests.swift
+++ b/Tests/CodexBarTests/QuotaPlanningMenuPresentationTests.swift
@@ -1,0 +1,112 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct QuotaPlanningMenuPresentationTests {
+    @Test
+    func `model decorates only the matching long window`() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let metadata = try #require(ProviderDefaults.metadata[.claude])
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .claude,
+            metadata: metadata,
+            snapshot: Self.snapshot(now: now),
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            quotaPlanningEstimates: ["secondary": Self.estimate(id: "secondary", value: 4)],
+            now: now))
+
+        #expect(model.metrics.first(where: { $0.id == "primary" })?.quotaPlanningText == nil)
+        #expect(model.metrics.first(where: { $0.id == "secondary" })?.quotaPlanningText ==
+            "Available full sessions: ≈4")
+    }
+
+    @Test
+    func `shared decoration supports independent named quota groups`() {
+        let metrics = [Self.metric(id: "group-a-weekly"), Self.metric(id: "group-b-weekly")]
+        let decorated = UsageMenuCardView.Model.metricsByAddingQuotaPlanning(
+            metrics,
+            estimates: [
+                "group-a-weekly": Self.estimate(id: "group-a-weekly", value: 1.25),
+                "group-b-weekly": Self.estimate(id: "group-b-weekly", value: 8),
+            ])
+
+        #expect(decorated[0].quotaPlanningText == "Available full sessions: ≈1.3")
+        #expect(decorated[1].quotaPlanningText == "Available full sessions: ≈8")
+    }
+
+    @Test
+    func `small positive estimates remain visible`() throws {
+        let estimate = Self.estimate(id: "secondary", value: 0.04)
+
+        let text = try #require(UsageMenuCardView.Model.quotaPlanningText(for: estimate))
+
+        #expect(text == "Available full sessions: ≈<0.1")
+    }
+
+    @Test
+    func `number formatting follows the selected locale`() throws {
+        try CodexBarLocalizationOverride.$appLanguage.withValue("de") {
+            let estimate = Self.estimate(id: "secondary", value: 1.25)
+
+            let text = try #require(UsageMenuCardView.Model.quotaPlanningText(for: estimate))
+
+            #expect(text == "Verfügbare volle Sitzungen: ≈1,3")
+        }
+    }
+
+    private static func snapshot(now: Date) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 40,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 60,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(6 * 24 * 60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+    }
+
+    private static func metric(id: String) -> UsageMenuCardView.Model.Metric {
+        .init(
+            id: id,
+            title: id,
+            percent: 50,
+            percentStyle: .left,
+            resetText: nil,
+            detailText: nil,
+            detailLeftText: nil,
+            detailRightText: nil,
+            pacePercent: nil,
+            paceOnTop: true)
+    }
+
+    private static func estimate(id: String, value: Double) -> QuotaPlanningEstimate {
+        QuotaPlanningEstimate(
+            pairID: "pair-\(id)",
+            longMetricID: id,
+            fundableFullSessionEquivalents: value,
+            maximumFullSessionEquivalentsBeforeReset: 3,
+            futureFullShortAllowanceCount: 2,
+            longPercentPerFullShortAllowance: 5,
+            reachability: .insufficientEvidence,
+            shortResetAt: Date(timeIntervalSince1970: 1_800_010_000),
+            longResetAt: Date(timeIntervalSince1970: 1_800_500_000))
+    }
+}

--- a/Tests/CodexBarTests/QuotaPlanningProviderResolutionTests.swift
+++ b/Tests/CodexBarTests/QuotaPlanningProviderResolutionTests.swift
@@ -1,0 +1,278 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct QuotaPlanningProviderResolutionTests {
+    @Test
+    func `only opted in descriptors expose quota planning`() {
+        #expect(CodexProviderDescriptor.descriptor.quotaPlanning != nil)
+        #expect(ClaudeProviderDescriptor.descriptor.quotaPlanning != nil)
+        #expect(AntigravityProviderDescriptor.descriptor.quotaPlanning != nil)
+        #expect(ProviderDescriptorRegistry.descriptor(for: .openai).quotaPlanning == nil)
+    }
+
+    @Test(arguments: [ProviderObservationFreshness.cached, .unknown])
+    func `non-live freshness never resolves pairs`(freshness: ProviderObservationFreshness) throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let capability = try #require(ClaudeProviderDescriptor.descriptor.quotaPlanning)
+        let pairs = capability.resolvePairs(for: Self.result(
+            usage: Self.primarySecondaryUsage(now: now),
+            provider: .claude,
+            freshness: freshness))
+
+        #expect(pairs.isEmpty)
+    }
+
+    @Test
+    func `result freshness defaults to unknown`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let result = ProviderFetchResult(
+            usage: Self.primarySecondaryUsage(now: now),
+            credits: nil,
+            dashboard: nil,
+            sourceLabel: "test",
+            strategyID: "test.strategy",
+            strategyKind: .oauth)
+
+        #expect(result.observationFreshness == .unknown)
+    }
+
+    @Test
+    func `codex resolves reversed source slots through shared semantic lanes`() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let session = Self.window(used: 20, minutes: 300, reset: now.addingTimeInterval(4 * 3600))
+        let weekly = Self.window(used: 30, minutes: 10080, reset: now.addingTimeInterval(6 * 24 * 3600))
+        let usage = UsageSnapshot(
+            primary: weekly,
+            secondary: session,
+            updatedAt: now)
+        let capability = try #require(CodexProviderDescriptor.descriptor.quotaPlanning)
+
+        let pair = try #require(capability.resolvePairs(for: Self.result(
+            usage: usage,
+            provider: .codex,
+            freshness: .live)).first)
+
+        #expect(pair.id == "session-weekly")
+        #expect(pair.short.metricID == "primary")
+        #expect(pair.short.window == session)
+        #expect(pair.long.metricID == "secondary")
+        #expect(pair.long.window == weekly)
+    }
+
+    @Test
+    func `claude accepts a real session and rejects a synthetic placeholder`() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let capability = try #require(ClaudeProviderDescriptor.descriptor.quotaPlanning)
+        let realResult = Self.result(
+            usage: Self.primarySecondaryUsage(now: now),
+            provider: .claude,
+            freshness: .live)
+        let placeholderUsage = UsageSnapshot(
+            primary: Self.window(
+                used: 0,
+                minutes: 300,
+                reset: now.addingTimeInterval(5 * 3600),
+                synthetic: true),
+            secondary: Self.window(
+                used: 30,
+                minutes: 10080,
+                reset: now.addingTimeInterval(6 * 24 * 3600)),
+            updatedAt: now)
+
+        #expect(capability.resolvePairs(for: realResult).count == 1)
+        #expect(capability.resolvePairs(for: Self.result(
+            usage: placeholderUsage,
+            provider: .claude,
+            freshness: .live)).isEmpty)
+    }
+
+    @Test
+    func `antigravity resolves every complete named group independent of order`() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let windows = [
+            Self.namedAntigravityWindow(group: "3p", cadence: "weekly", used: 40, now: now),
+            Self.namedAntigravityWindow(group: "gemini", cadence: "5h", used: 10, now: now),
+            Self.namedAntigravityWindow(group: "3p", cadence: "5h", used: 20, now: now),
+            Self.namedAntigravityWindow(group: "gemini", cadence: "weekly", used: 30, now: now),
+        ]
+        let usage = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: windows,
+            updatedAt: now)
+        let capability = try #require(AntigravityProviderDescriptor.descriptor.quotaPlanning)
+
+        let pairs = capability.resolvePairs(for: Self.result(
+            usage: usage,
+            provider: .antigravity,
+            freshness: .live))
+
+        #expect(pairs.map(\.id) == ["quota-summary-3p", "quota-summary-gemini"])
+        #expect(pairs.map(\.short.metricID) == [
+            "antigravity-quota-summary-3p-5h",
+            "antigravity-quota-summary-gemini-5h",
+        ])
+        #expect(pairs.map(\.long.metricID) == [
+            "antigravity-quota-summary-3p-weekly",
+            "antigravity-quota-summary-gemini-weekly",
+        ])
+    }
+
+    @Test
+    func `antigravity drops incomplete and ambiguous groups`() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let windows = [
+            Self.namedAntigravityWindow(group: "incomplete", cadence: "5h", used: 10, now: now),
+            Self.namedAntigravityWindow(group: "duplicate", cadence: "5h", used: 10, now: now),
+            Self.namedAntigravityWindow(group: "duplicate", cadence: "session", used: 11, now: now),
+            Self.namedAntigravityWindow(group: "duplicate", cadence: "weekly", used: 20, now: now),
+            Self.namedAntigravityWindow(group: "valid", cadence: "5h", used: 30, now: now),
+            Self.namedAntigravityWindow(group: "valid", cadence: "weekly", used: 40, now: now),
+        ]
+        let usage = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: windows,
+            updatedAt: now)
+        let capability = try #require(AntigravityProviderDescriptor.descriptor.quotaPlanning)
+
+        let pairs = capability.resolvePairs(for: Self.result(
+            usage: usage,
+            provider: .antigravity,
+            freshness: .live))
+
+        #expect(pairs.map(\.id) == ["quota-summary-valid"])
+    }
+
+    @Test
+    func `colliding pair and metric IDs drop every ambiguous pair`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let independent = Self.pair(id: "independent", shortID: "s3", longID: "l3", now: now)
+        let capability = ProviderQuotaPlanningCapability { _ in
+            [
+                Self.pair(id: "one", shortID: "s1", longID: "shared", now: now),
+                Self.pair(id: "two", shortID: "s2", longID: "shared", now: now),
+                Self.pair(id: "duplicate", shortID: "s4", longID: "l4", now: now),
+                Self.pair(id: "duplicate", shortID: "s5", longID: "l5", now: now),
+                independent,
+            ]
+        }
+
+        let pairs = capability.resolvePairs(input: QuotaPlanningResolutionInput(
+            usage: Self.primarySecondaryUsage(now: now),
+            strategyID: "test.strategy",
+            strategyKind: .oauth,
+            observationFreshness: .live))
+
+        #expect(pairs == [independent])
+    }
+
+    @Test
+    func `initial rollout requires supported cadence and strategy identity`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let unsupported = Self.pair(
+            id: "daily-monthly",
+            shortID: "daily",
+            longID: "monthly",
+            now: now,
+            shortMinutes: 1440,
+            longMinutes: 43200)
+        let capability = ProviderQuotaPlanningCapability { _ in [unsupported] }
+
+        #expect(capability.resolvePairs(input: QuotaPlanningResolutionInput(
+            usage: Self.primarySecondaryUsage(now: now),
+            strategyID: "test.strategy",
+            strategyKind: .oauth,
+            observationFreshness: .live)).isEmpty)
+        #expect(ProviderQuotaPlanningCapability { _ in
+            [Self.pair(id: "valid", shortID: "short", longID: "long", now: now)]
+        }.resolvePairs(input: QuotaPlanningResolutionInput(
+            usage: Self.primarySecondaryUsage(now: now),
+            strategyID: " ",
+            strategyKind: .oauth,
+            observationFreshness: .live)).isEmpty)
+    }
+
+    private static func result(
+        usage: UsageSnapshot,
+        provider: UsageProvider,
+        freshness: ProviderObservationFreshness) -> ProviderFetchResult
+    {
+        ProviderFetchResult(
+            usage: usage,
+            credits: nil,
+            dashboard: nil,
+            sourceLabel: "test",
+            strategyID: "\(provider.rawValue).test",
+            strategyKind: .oauth,
+            observationFreshness: freshness)
+    }
+
+    private static func primarySecondaryUsage(now: Date) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: Self.window(
+                used: 20,
+                minutes: 300,
+                reset: now.addingTimeInterval(4 * 3600)),
+            secondary: Self.window(
+                used: 30,
+                minutes: 10080,
+                reset: now.addingTimeInterval(6 * 24 * 3600)),
+            updatedAt: now)
+    }
+
+    private static func namedAntigravityWindow(
+        group: String,
+        cadence: String,
+        used: Double,
+        now: Date) -> NamedRateWindow
+    {
+        let isWeekly = cadence == "weekly"
+        return NamedRateWindow(
+            id: "antigravity-quota-summary-\(group)-\(cadence)",
+            title: "Fixture",
+            window: Self.window(
+                used: used,
+                minutes: isWeekly ? 10080 : 300,
+                reset: now.addingTimeInterval(isWeekly ? 6 * 24 * 3600 : 4 * 3600)))
+    }
+
+    private static func pair(
+        id: String,
+        shortID: String,
+        longID: String,
+        now: Date,
+        shortMinutes: Int = 300,
+        longMinutes: Int = 10080) -> QuotaPlanningPairSnapshot
+    {
+        QuotaPlanningPairSnapshot(
+            id: id,
+            short: QuotaPlanningWindowSnapshot(
+                metricID: shortID,
+                window: Self.window(
+                    used: 10,
+                    minutes: shortMinutes,
+                    reset: now.addingTimeInterval(TimeInterval(shortMinutes * 30)))),
+            long: QuotaPlanningWindowSnapshot(
+                metricID: longID,
+                window: Self.window(
+                    used: 20,
+                    minutes: longMinutes,
+                    reset: now.addingTimeInterval(TimeInterval(longMinutes * 30)))))
+    }
+
+    private static func window(
+        used: Double,
+        minutes: Int,
+        reset: Date,
+        synthetic: Bool = false) -> RateWindow
+    {
+        RateWindow(
+            usedPercent: used,
+            windowMinutes: minutes,
+            resetsAt: reset,
+            resetDescription: nil,
+            isSyntheticPlaceholder: synthetic)
+    }
+}

--- a/Tests/CodexBarTests/QuotaPlanningProviderResolutionTests.swift
+++ b/Tests/CodexBarTests/QuotaPlanningProviderResolutionTests.swift
@@ -211,11 +211,11 @@ struct QuotaPlanningProviderResolutionTests {
 
     private static func primarySecondaryUsage(now: Date) -> UsageSnapshot {
         UsageSnapshot(
-            primary: Self.window(
+            primary: self.window(
                 used: 20,
                 minutes: 300,
                 reset: now.addingTimeInterval(4 * 3600)),
-            secondary: Self.window(
+            secondary: self.window(
                 used: 30,
                 minutes: 10080,
                 reset: now.addingTimeInterval(6 * 24 * 3600)),
@@ -250,13 +250,13 @@ struct QuotaPlanningProviderResolutionTests {
             id: id,
             short: QuotaPlanningWindowSnapshot(
                 metricID: shortID,
-                window: Self.window(
+                window: self.window(
                     used: 10,
                     minutes: shortMinutes,
                     reset: now.addingTimeInterval(TimeInterval(shortMinutes * 30)))),
             long: QuotaPlanningWindowSnapshot(
                 metricID: longID,
-                window: Self.window(
+                window: self.window(
                     used: 20,
                     minutes: longMinutes,
                     reset: now.addingTimeInterval(TimeInterval(longMinutes * 30)))))

--- a/Tests/CodexBarTests/QuotaPlanningTests.swift
+++ b/Tests/CodexBarTests/QuotaPlanningTests.swift
@@ -1,0 +1,494 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct QuotaPlanningTests {
+    @Test
+    func `schedule capacity includes fractional current remainder and future refills`() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let pair = Self.pair(
+            now: now,
+            shortUsed: 60,
+            longUsed: 20,
+            shortResetOffset: 3600,
+            longResetOffset: 16 * 3600)
+
+        let capacity = try #require(QuotaPlanningEstimator.scheduleCapacity(for: pair, now: now))
+
+        #expect(capacity.futureFullShortAllowanceCount == 3)
+        #expect(Self.close(capacity.maximumFullSessionEquivalentsBeforeReset, 3.4))
+    }
+
+    @Test
+    func `schedule capacity honors tolerance and exact duration boundaries`() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let shortResetOffset: TimeInterval = 3600
+        let shortDuration: TimeInterval = 5 * 3600
+        let tolerance = QuotaPlanningConstants.resetEquivalenceTolerance
+
+        let simultaneous = Self.pair(
+            now: now,
+            shortUsed: 100,
+            shortResetOffset: shortResetOffset,
+            longResetOffset: shortResetOffset + tolerance)
+        let exactOne = Self.pair(
+            now: now,
+            shortUsed: 100,
+            shortResetOffset: shortResetOffset,
+            longResetOffset: shortResetOffset + shortDuration + tolerance)
+        let justTwo = Self.pair(
+            now: now,
+            shortUsed: 100,
+            shortResetOffset: shortResetOffset,
+            longResetOffset: shortResetOffset + shortDuration + tolerance + 0.001)
+
+        #expect(try #require(QuotaPlanningEstimator.scheduleCapacity(for: simultaneous, now: now))
+            .futureFullShortAllowanceCount == 0)
+        #expect(try #require(QuotaPlanningEstimator.scheduleCapacity(for: exactOne, now: now))
+            .futureFullShortAllowanceCount == 1)
+        #expect(try #require(QuotaPlanningEstimator.scheduleCapacity(for: justTwo, now: now))
+            .futureFullShortAllowanceCount == 2)
+    }
+
+    @Test
+    func `pair eligibility rejects malformed and unsupported windows`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let invalidPairs = [
+            Self.pair(now: now, shortUsed: -1),
+            Self.pair(now: now, longUsed: 100),
+            Self.pair(now: now, shortUsed: .nan),
+            Self.pair(now: now, shortUsageKnown: false),
+            Self.pair(now: now, shortSynthetic: true),
+            Self.pair(now: now, shortNextRegenPercent: 1),
+            Self.pair(now: now, shortMinutes: nil),
+            Self.pair(now: now, shortResetOffset: -1),
+            Self.pair(now: now, longResetOffset: 8 * 24 * 3600),
+        ]
+
+        for pair in invalidPairs {
+            #expect(QuotaPlanningEstimator.observation(for: pair, now: now) == nil)
+            #expect(QuotaPlanningEstimator.scheduleCapacity(for: pair, now: now) == nil)
+        }
+    }
+
+    @Test
+    func `single candidate requires three long points for presentation`() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let shortReset = now.addingTimeInterval(5 * 3600)
+        let longReset = now.addingTimeInterval(7 * 24 * 3600)
+        var state = QuotaPlanningCalibrationReducer.reduce(
+            state: nil,
+            observation: Self.observation(
+                at: now,
+                short: 0,
+                long: 10,
+                shortReset: shortReset,
+                longReset: longReset))
+
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: now.addingTimeInterval(60),
+                short: 20,
+                long: 11,
+                shortReset: shortReset,
+                longReset: longReset))
+
+        #expect(state.activeCandidate?.longPercentPerFullShortAllowance == 5)
+        #expect(QuotaPlanningEstimator.estimate(
+            for: Self.pair(
+                now: now.addingTimeInterval(60),
+                shortUsed: 20,
+                longUsed: 11,
+                shortResetAt: shortReset,
+                longResetAt: longReset),
+            calibration: state,
+            now: now.addingTimeInterval(60)) == nil)
+
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: now.addingTimeInterval(120),
+                short: 60,
+                long: 13,
+                shortReset: shortReset,
+                longReset: longReset))
+        let estimate = try #require(QuotaPlanningEstimator.estimate(
+            for: Self.pair(
+                now: now.addingTimeInterval(120),
+                shortUsed: 60,
+                longUsed: 13,
+                shortResetAt: shortReset,
+                longResetAt: longReset),
+            calibration: state,
+            now: now.addingTimeInterval(120)))
+
+        #expect(Self.close(estimate.longPercentPerFullShortAllowance, 5))
+        #expect(Self.close(estimate.fundableFullSessionEquivalents, 17.4))
+        #expect(estimate.reachability == .insufficientEvidence)
+    }
+
+    @Test
+    func `two consistent low movement candidates qualify`() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let firstShortReset = now.addingTimeInterval(5 * 3600)
+        let secondShortReset = firstShortReset.addingTimeInterval(5 * 3600)
+        let longReset = now.addingTimeInterval(7 * 24 * 3600)
+        var state = QuotaPlanningCalibrationReducer.reduce(
+            state: nil,
+            observation: Self.observation(
+                at: now,
+                short: 0,
+                long: 10,
+                shortReset: firstShortReset,
+                longReset: longReset))
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: now.addingTimeInterval(60),
+                short: 20,
+                long: 11,
+                shortReset: firstShortReset,
+                longReset: longReset))
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: firstShortReset.addingTimeInterval(60),
+                short: 0,
+                long: 11,
+                shortReset: secondShortReset,
+                longReset: longReset))
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: firstShortReset.addingTimeInterval(120),
+                short: 20,
+                long: 12,
+                shortReset: secondShortReset,
+                longReset: longReset))
+
+        let estimate = try #require(QuotaPlanningEstimator.estimate(
+            for: Self.pair(
+                now: firstShortReset.addingTimeInterval(120),
+                shortUsed: 20,
+                longUsed: 12,
+                shortResetAt: secondShortReset,
+                longResetAt: longReset),
+            calibration: state,
+            now: firstShortReset.addingTimeInterval(120)))
+
+        #expect(state.candidates.count == 2)
+        #expect(Self.close(estimate.longPercentPerFullShortAllowance, 5))
+        #expect(estimate.reachability == .theoreticallyReachable)
+    }
+
+    @Test
+    func `verdict uses full candidate range`() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let shortReset = now.addingTimeInterval(3600)
+        let longReset = shortReset.addingTimeInterval(15 * 3600)
+        let pair = Self.pair(
+            now: now,
+            shortUsed: 100,
+            longUsed: 90,
+            shortResetAt: shortReset,
+            longResetAt: longReset)
+
+        let reachable = try #require(QuotaPlanningEstimator.estimate(
+            for: pair,
+            calibration: Self.calibration(
+                now: now,
+                shortReset: shortReset,
+                longReset: longReset,
+                costs: [4, 4.2],
+                longUsed: 90),
+            now: now))
+        let stranded = try #require(QuotaPlanningEstimator.estimate(
+            for: pair,
+            calibration: Self.calibration(
+                now: now,
+                shortReset: shortReset,
+                longReset: longReset,
+                costs: [2, 2.2],
+                longUsed: 90),
+            now: now))
+        let uncertain = try #require(QuotaPlanningEstimator.estimate(
+            for: pair,
+            calibration: Self.calibration(
+                now: now,
+                shortReset: shortReset,
+                longReset: longReset,
+                costs: [2.5, 4],
+                longUsed: 90),
+            now: now))
+
+        #expect(reachable.reachability == .theoreticallyReachable)
+        #expect(stranded.reachability == .likelyStranded)
+        #expect(uncertain.reachability == .uncertain)
+    }
+
+    @Test
+    func `dispersion suppresses estimate without deleting candidates`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let shortReset = now.addingTimeInterval(3600)
+        let longReset = now.addingTimeInterval(24 * 3600)
+        let calibration = Self.calibration(
+            now: now,
+            shortReset: shortReset,
+            longReset: longReset,
+            costs: [5, 10],
+            longUsed: 50)
+
+        let estimate = QuotaPlanningEstimator.estimate(
+            for: Self.pair(
+                now: now,
+                shortUsed: 50,
+                longUsed: 50,
+                shortResetAt: shortReset,
+                longResetAt: longReset),
+            calibration: calibration,
+            now: now)
+
+        #expect(estimate == nil)
+        #expect(calibration.candidates.count == 2)
+    }
+
+    @Test
+    func `material decrease requires active requalification`() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let shortReset = now.addingTimeInterval(5 * 3600)
+        let longReset = now.addingTimeInterval(7 * 24 * 3600)
+        var state = QuotaPlanningCalibrationReducer.reduce(
+            state: nil,
+            observation: Self.observation(
+                at: now,
+                short: 0,
+                long: 10,
+                shortReset: shortReset,
+                longReset: longReset))
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: now.addingTimeInterval(60),
+                short: 20,
+                long: 13,
+                shortReset: shortReset,
+                longReset: longReset))
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: now.addingTimeInterval(120),
+                short: 19.7,
+                long: 12.7,
+                shortReset: shortReset,
+                longReset: longReset))
+        #expect(state.activeCandidate != nil)
+        #expect(state.latest.shortUsedPercent == 20)
+        #expect(state.latest.longUsedPercent == 13)
+
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: now.addingTimeInterval(180),
+                short: 19,
+                long: 12,
+                shortReset: shortReset,
+                longReset: longReset))
+        #expect(state.activeCandidate == nil)
+        #expect(state.requiresActiveRequalification)
+
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: now.addingTimeInterval(240),
+                short: 39,
+                long: 15,
+                shortReset: shortReset,
+                longReset: longReset))
+        #expect(state.activeCandidate != nil)
+        #expect(!state.requiresActiveRequalification)
+    }
+
+    @Test
+    func `long reset clears prior candidates`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let shortReset = now.addingTimeInterval(5 * 3600)
+        let longReset = now.addingTimeInterval(7 * 24 * 3600)
+        var state = Self.calibration(
+            now: now,
+            shortReset: shortReset,
+            longReset: longReset,
+            costs: [5, 6],
+            longUsed: 30)
+        let nextLongReset = longReset.addingTimeInterval(7 * 24 * 3600)
+
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: now.addingTimeInterval(60),
+                short: 0,
+                long: 0,
+                shortReset: shortReset.addingTimeInterval(5 * 3600),
+                longReset: nextLongReset))
+
+        #expect(state.candidates.isEmpty)
+        #expect(state.canonicalLongResetAt == nextLongReset)
+    }
+
+    @Test
+    func `saturation retains earlier active candidate`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let shortReset = now.addingTimeInterval(5 * 3600)
+        let longReset = now.addingTimeInterval(7 * 24 * 3600)
+        var state = QuotaPlanningCalibrationReducer.reduce(
+            state: nil,
+            observation: Self.observation(
+                at: now,
+                short: 0,
+                long: 10,
+                shortReset: shortReset,
+                longReset: longReset))
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: now.addingTimeInterval(60),
+                short: 20,
+                long: 13,
+                shortReset: shortReset,
+                longReset: longReset))
+        let candidate = state.activeCandidate
+
+        state = QuotaPlanningCalibrationReducer.reduce(
+            state: state,
+            observation: Self.observation(
+                at: now.addingTimeInterval(120),
+                short: 80,
+                long: 99.6,
+                shortReset: shortReset,
+                longReset: longReset))
+
+        #expect(state.activeCandidate == candidate)
+        #expect(state.latest.longUsedPercent == 99.6)
+    }
+
+    @Test
+    func `completed candidate fifo keeps newest five`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let longReset = now.addingTimeInterval(7 * 24 * 3600)
+        var shortReset = now.addingTimeInterval(5 * 3600)
+        var longUsed = 0.0
+        var state = QuotaPlanningCalibrationReducer.reduce(
+            state: nil,
+            observation: Self.observation(
+                at: now,
+                short: 0,
+                long: longUsed,
+                shortReset: shortReset,
+                longReset: longReset))
+
+        for index in 0..<7 {
+            longUsed += Double(index + 1)
+            state = QuotaPlanningCalibrationReducer.reduce(
+                state: state,
+                observation: Self.observation(
+                    at: now.addingTimeInterval(Double(index * 120 + 60)),
+                    short: 20,
+                    long: longUsed,
+                    shortReset: shortReset,
+                    longReset: longReset))
+            shortReset = shortReset.addingTimeInterval(5 * 3600)
+            state = QuotaPlanningCalibrationReducer.reduce(
+                state: state,
+                observation: Self.observation(
+                    at: now.addingTimeInterval(Double(index * 120 + 120)),
+                    short: 0,
+                    long: longUsed,
+                    shortReset: shortReset,
+                    longReset: longReset))
+        }
+
+        #expect(state.completedCandidates.count == 5)
+        #expect(state.completedCandidates.map(\.sourceLongDelta) == [3, 4, 5, 6, 7])
+    }
+
+    private static func pair(
+        now: Date,
+        shortUsed: Double = 10,
+        longUsed: Double = 20,
+        shortResetOffset: TimeInterval = 5 * 3600,
+        longResetOffset: TimeInterval = 7 * 24 * 3600,
+        shortResetAt: Date? = nil,
+        longResetAt: Date? = nil,
+        shortMinutes: Int? = 300,
+        longMinutes: Int? = 10080,
+        shortUsageKnown: Bool = true,
+        shortSynthetic: Bool = false,
+        shortNextRegenPercent: Double? = nil) -> QuotaPlanningPairSnapshot
+    {
+        QuotaPlanningPairSnapshot(
+            id: "session-weekly",
+            short: QuotaPlanningWindowSnapshot(
+                metricID: "session",
+                window: RateWindow(
+                    usedPercent: shortUsed,
+                    windowMinutes: shortMinutes,
+                    resetsAt: shortResetAt ?? now.addingTimeInterval(shortResetOffset),
+                    resetDescription: nil,
+                    nextRegenPercent: shortNextRegenPercent,
+                    isSyntheticPlaceholder: shortSynthetic),
+                usageKnown: shortUsageKnown),
+            long: QuotaPlanningWindowSnapshot(
+                metricID: "weekly",
+                window: RateWindow(
+                    usedPercent: longUsed,
+                    windowMinutes: longMinutes,
+                    resetsAt: longResetAt ?? now.addingTimeInterval(longResetOffset),
+                    resetDescription: nil)))
+    }
+
+    private static func observation(
+        at capturedAt: Date,
+        short: Double,
+        long: Double,
+        shortReset: Date,
+        longReset: Date) -> QuotaPlanningObservation
+    {
+        QuotaPlanningObservation(
+            capturedAt: capturedAt,
+            shortUsedPercent: short,
+            longUsedPercent: long,
+            shortResetAt: shortReset,
+            longResetAt: longReset)
+    }
+
+    private static func calibration(
+        now: Date,
+        shortReset: Date,
+        longReset: Date,
+        costs: [Double],
+        longUsed: Double) -> QuotaPlanningCalibrationState
+    {
+        let observation = self.observation(
+            at: now,
+            short: 0,
+            long: longUsed,
+            shortReset: shortReset,
+            longReset: longReset)
+        return QuotaPlanningCalibrationState(
+            baseline: observation,
+            latest: observation,
+            canonicalShortResetAt: shortReset,
+            canonicalLongResetAt: longReset,
+            activeCandidate: nil,
+            completedCandidates: costs.map {
+                QuotaPlanningCandidate(
+                    longPercentPerFullShortAllowance: $0,
+                    sourceLongDelta: 3)
+            },
+            requiresActiveRequalification: false)
+    }
+
+    private static func close(_ lhs: Double, _ rhs: Double, tolerance: Double = 0.0001) -> Bool {
+        abs(lhs - rhs) <= tolerance
+    }
+}

--- a/Tests/CodexBarTests/QuotaPlanningTests.swift
+++ b/Tests/CodexBarTests/QuotaPlanningTests.swift
@@ -254,7 +254,7 @@ struct QuotaPlanningTests {
     }
 
     @Test
-    func `material decrease requires active requalification`() throws {
+    func `material decrease requires active requalification`() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let shortReset = now.addingTimeInterval(5 * 3600)
         let longReset = now.addingTimeInterval(7 * 24 * 3600)


### PR DESCRIPTION
## Summary

- add a provider-neutral estimator that learns how many full short-window sessions the remaining long-window quota can fund
- add transient fetch freshness plus descriptor-driven pair resolution for Codex, Claude, and Antigravity
- isolate in-memory calibration by provider, account, strategy, pair, and reset window, with monotonic expiry and fail-closed lifecycle handling
- show one concise localized line on the matching long-window row: `Available full sessions: ≈N`
- keep deterministic schedule capacity and reachability typed inside Core, but do not surface them in the UI following the latest product direction in #2261

## Status

Draft implementation following the architecture in #2268 and the later UI direction in #2261.

- [x] Core estimator and focused tests
- [x] provider capability, freshness, and pair resolvers
- [x] UsageStore scope, lifecycle, TTL, and expiry
- [x] localized menu presentation across all catalogs
- [x] `make check`
- [ ] clean full `make test` run (blocked by an unrelated local Claude credential/keychain ownership suite; details below)
- [ ] redacted live-provider/menu proof

## Validation

Passed:

- `swift test --filter QuotaPlanningTests`
- `swift test --filter QuotaPlanningProviderResolutionTests`
- `swift test --filter AntigravityQuotaSummaryTests`
- `swift test --filter CodexConsumerProjectionTests`
- `swift test --filter "QuotaPlanningLifecycleTests|QuotaPlanningProviderResolutionTests|QuotaPlanningTests|CodexResetCreditOutcomeTests"` — 42 tests
- `swift test --filter "QuotaPlanningMenuPresentationTests|MenuCardOverrideIsolationTests|MenuCardHeightFingerprintTests|QuotaPlanningLifecycleTests"` — 26 tests
- `make check` — 0 SwiftFormat changes, 0 SwiftLint violations, all 22 non-English catalogs match 1,221 English keys

`make test` discovered 702 selections in 59 groups. The first 10 groups passed. Group 11 failed twice only in the pre-existing `ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests` suite with eight local credential/keychain ownership errors (`.notFound`, `.decodeFailed`, and local credentials-file precedence); the sharded runner then stopped. No quota-planning test failed.

Real provider and account-sensitive menu proof was not run because repository policy requires an explicit request before live provider, cookie, or Keychain-backed probes.

Refs #2261
Design: #2268