### PR TITLE
Test adaptive refresh CPU budget

### DIFF
--- a/Sources/CodexBar/AgentSessionsStore.swift
+++ b/Sources/CodexBar/AgentSessionsStore.swift
@@ -32,8 +32,10 @@ struct AgentSessionRemoteRefreshGate {
 @MainActor
 @Observable
 final class AgentSessionsStore {
+    typealias LocalScan = @Sendable (_ includeFileOnlySessions: Bool) async -> [AgentSession]
+
     private let settings: SettingsStore
-    private let localScanner: LocalAgentSessionScanner
+    private let localScan: LocalScan
     private let remoteFetcher: RemoteSessionFetcher
     @ObservationIgnored private var localRefreshTask: Task<Void, Never>?
     @ObservationIgnored private var remoteRefreshTask: Task<Void, Never>?
@@ -52,7 +54,19 @@ final class AgentSessionsStore {
         remoteFetcher: RemoteSessionFetcher = RemoteSessionFetcher())
     {
         self.settings = settings
-        self.localScanner = localScanner
+        self.localScan = { includeFileOnlySessions in
+            await localScanner.scan(includeFileOnlySessions: includeFileOnlySessions)
+        }
+        self.remoteFetcher = remoteFetcher
+    }
+
+    init(
+        settings: SettingsStore,
+        localScan: @escaping LocalScan,
+        remoteFetcher: RemoteSessionFetcher = RemoteSessionFetcher())
+    {
+        self.settings = settings
+        self.localScan = localScan
         self.remoteFetcher = remoteFetcher
     }
 
@@ -150,7 +164,7 @@ final class AgentSessionsStore {
         }
     }
 
-    private func refreshLocal() async {
+    func refreshLocal() async {
         guard self.localMonitoringEnabled, !self.localRefreshInFlight else { return }
         let processInfo = ProcessInfo.processInfo
         guard Self.shouldScanLocally(
@@ -160,7 +174,7 @@ final class AgentSessionsStore {
             thermalState: processInfo.thermalState)
         else { return }
         self.localRefreshInFlight = true
-        let sessions = await self.localScanner.scan(includeFileOnlySessions: self.settings.agentSessionsEnabled)
+        let sessions = await self.localScan(self.settings.agentSessionsEnabled)
         self.localRefreshInFlight = false
         guard !Task.isCancelled, self.localMonitoringEnabled else { return }
         self.applyLocalScanResult(sessions)

--- a/Sources/CodexBarCore/AgentSession.swift
+++ b/Sources/CodexBarCore/AgentSession.swift
@@ -66,6 +66,7 @@ public struct SessionScanConfig: Equatable, Sendable {
     public var maxDirectoryEntryCount: Int
     public var maxDirectoryDepth: Int
     public var directoryScanBudget: TimeInterval
+    public var adaptiveDirectoryScanBudget: TimeInterval
 
     public init(
         activeWindow: TimeInterval = 120,
@@ -75,7 +76,8 @@ public struct SessionScanConfig: Equatable, Sendable {
         maxClaudeTranscriptCountPerProject: Int = 64,
         maxDirectoryEntryCount: Int = 512,
         maxDirectoryDepth: Int = 1,
-        directoryScanBudget: TimeInterval = 0.25)
+        directoryScanBudget: TimeInterval = 0.25,
+        adaptiveDirectoryScanBudget: TimeInterval = 0.15)
     {
         self.activeWindow = activeWindow
         self.fileOnlyWindow = fileOnlyWindow
@@ -85,6 +87,7 @@ public struct SessionScanConfig: Equatable, Sendable {
         self.maxDirectoryEntryCount = maxDirectoryEntryCount
         self.maxDirectoryDepth = maxDirectoryDepth
         self.directoryScanBudget = directoryScanBudget
+        self.adaptiveDirectoryScanBudget = adaptiveDirectoryScanBudget
     }
 
     public func state(lastActivityAt: Date?, now: Date, hasLiveProcess: Bool) -> AgentSession.State {
@@ -97,16 +100,19 @@ struct DirectoryMetadataScanBudget {
     private var remainingEntryCount: Int
     let maxDepth: Int
     private let deadline: Date
+    private let didVisitEntry: (@Sendable () -> Void)?
 
     init(
         maxEntryCount: Int,
         maxDepth: Int,
         timeLimit: TimeInterval,
-        startedAt: Date = Date())
+        startedAt: Date = Date(),
+        didVisitEntry: (@Sendable () -> Void)? = nil)
     {
         self.remainingEntryCount = max(0, maxEntryCount)
         self.maxDepth = max(0, maxDepth)
         self.deadline = startedAt.addingTimeInterval(max(0, timeLimit))
+        self.didVisitEntry = didVisitEntry
     }
 
     mutating func files(
@@ -127,6 +133,10 @@ struct DirectoryMetadataScanBudget {
             .compactMap { entry in entry.isDirectory ? entry.url : nil }
     }
 
+    func hasTimeRemaining(clock: () -> Date = Date.init) -> Bool {
+        clock() < self.deadline
+    }
+
     private mutating func entries(
         in directory: URL,
         fileManager: FileManager,
@@ -145,6 +155,7 @@ struct DirectoryMetadataScanBudget {
         while self.remainingEntryCount > 0, clock() < self.deadline {
             guard let url = enumerator.nextObject() as? URL else { break }
             self.remainingEntryCount -= 1
+            self.didVisitEntry?()
             let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
             entries.append((url, isDirectory))
         }
@@ -384,7 +395,8 @@ public enum ClaudeSessionProjectMapper {
             budget: &budget)
             .flatMap { directory in budget.files(in: directory, fileManager: fileManager) }
             .compactMap { file -> (URL, Date)? in
-                guard file.pathExtension == "jsonl",
+                guard budget.hasTimeRemaining(),
+                      file.pathExtension == "jsonl",
                       let modifiedAt = try? file.resourceValues(
                           forKeys: [.contentModificationDateKey]).contentModificationDate
                 else { return nil }

--- a/Sources/CodexBarCore/LocalAgentSessionScanner.swift
+++ b/Sources/CodexBarCore/LocalAgentSessionScanner.swift
@@ -21,6 +21,9 @@ final class FutureModificationDateClamp: @unchecked Sendable {
 }
 
 public struct LocalAgentSessionScanner: Sendable {
+    typealias ProcessOutputProvider = @Sendable ([String: String]) async -> String
+    typealias CWDProvider = @Sendable ([Int32], [String: String]) async -> [Int32: String]
+
     private struct Rollout: Sendable {
         let url: URL
         let modifiedAt: Date
@@ -37,9 +40,27 @@ public struct LocalAgentSessionScanner: Sendable {
 
     public let config: SessionScanConfig
     private let futureModificationDateClamp = FutureModificationDateClamp()
+    private let processOutputProvider: ProcessOutputProvider?
+    private let cwdProvider: CWDProvider?
+    private let didVisitDirectoryEntry: (@Sendable () -> Void)?
 
     public init(config: SessionScanConfig = SessionScanConfig()) {
         self.config = config
+        self.processOutputProvider = nil
+        self.cwdProvider = nil
+        self.didVisitDirectoryEntry = nil
+    }
+
+    init(
+        config: SessionScanConfig = SessionScanConfig(),
+        processOutputProvider: @escaping ProcessOutputProvider,
+        cwdProvider: @escaping CWDProvider,
+        didVisitDirectoryEntry: (@Sendable () -> Void)? = nil)
+    {
+        self.config = config
+        self.processOutputProvider = processOutputProvider
+        self.cwdProvider = cwdProvider
+        self.didVisitDirectoryEntry = didVisitDirectoryEntry
     }
 
     @concurrent
@@ -48,7 +69,11 @@ public struct LocalAgentSessionScanner: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         includeFileOnlySessions: Bool = true) async -> [AgentSession]
     {
-        let processOutput = await self.processOutput(environment: environment)
+        let processOutput = if let processOutputProvider = self.processOutputProvider {
+            await processOutputProvider(environment)
+        } else {
+            await self.processOutput(environment: environment)
+        }
         let allProcesses = AgentPSOutputParser.parse(processOutput)
         let processes = Array(AgentSessionCorrelation.newestProcessesFirst(
             AgentPSOutputParser.agentProcesses(from: allProcesses))
@@ -58,18 +83,34 @@ public struct LocalAgentSessionScanner: Sendable {
             includeFileOnlySessions: includeFileOnlySessions)
         else { return [] }
         let codexAppServerPresent = AgentPSOutputParser.hasCodexAppServer(in: allProcesses)
-        let cwdByPID = await self.cwdByPID(processes.map(\ .pid), environment: environment)
+        let cwdByPID = if let cwdProvider = self.cwdProvider {
+            await cwdProvider(processes.map(\ .pid), environment)
+        } else {
+            await self.cwdByPID(processes.map(\ .pid), environment: environment)
+        }
+        let codexCWDs = processes.compactMap { process -> String? in
+            guard AgentPSOutputParser.provider(for: process) == .codex else { return nil }
+            return cwdByPID[process.pid]
+        }
         let homeDirectory = URL(fileURLWithPath: environment["HOME"] ?? NSHomeDirectory(), isDirectory: true)
         let host = ProcessInfo.processInfo.hostName
         var directoryBudget = DirectoryMetadataScanBudget(
             maxEntryCount: self.config.maxDirectoryEntryCount,
             maxDepth: self.config.maxDirectoryDepth,
-            timeLimit: self.config.directoryScanBudget)
-        let rollouts = self.codexRollouts(
-            now: now,
-            environment: environment,
-            homeDirectory: homeDirectory,
-            directoryBudget: &directoryBudget)
+            timeLimit: includeFileOnlySessions
+                ? self.config.directoryScanBudget
+                : min(self.config.directoryScanBudget, self.config.adaptiveDirectoryScanBudget),
+            didVisitEntry: self.didVisitDirectoryEntry)
+        let rollouts: [Rollout] = if includeFileOnlySessions || !codexCWDs.isEmpty {
+            self.codexRollouts(
+                now: now,
+                environment: environment,
+                homeDirectory: homeDirectory,
+                matchingCWDs: includeFileOnlySessions ? nil : codexCWDs,
+                directoryBudget: &directoryBudget)
+        } else {
+            []
+        }
         return self.sessions(
             processes: processes,
             cwdByPID: cwdByPID,
@@ -237,6 +278,7 @@ public struct LocalAgentSessionScanner: Sendable {
         now: Date,
         environment: [String: String],
         homeDirectory: URL,
+        matchingCWDs: [String]?,
         directoryBudget: inout DirectoryMetadataScanBudget) -> [Rollout]
     {
         let root = URL(
@@ -264,12 +306,22 @@ public struct LocalAgentSessionScanner: Sendable {
             }
         }.sorted { $0.modifiedAt > $1.modifiedAt }
 
-        return candidates
-            .prefix(max(0, self.config.maxCodexRolloutCount))
-            .compactMap { candidate in
-                guard let metadata = CodexRolloutFirstLineParser.read(from: candidate.url) else { return nil }
-                return Rollout(url: candidate.url, modifiedAt: candidate.modifiedAt, metadata: metadata)
+        var remainingCWDs = matchingCWDs ?? []
+        var rollouts: [Rollout] = []
+        for candidate in candidates.prefix(max(0, self.config.maxCodexRolloutCount)) {
+            guard directoryBudget.hasTimeRemaining() else { break }
+            guard let metadata = CodexRolloutFirstLineParser.read(from: candidate.url) else { continue }
+            rollouts.append(Rollout(url: candidate.url, modifiedAt: candidate.modifiedAt, metadata: metadata))
+            if let index = remainingCWDs.firstIndex(where: {
+                AgentSessionCorrelation.codexWorkingDirectoriesMatch(metadata.cwd, $0)
+            }) {
+                remainingCWDs.remove(at: index)
+                if matchingCWDs != nil, remainingCWDs.isEmpty {
+                    break
+                }
             }
+        }
+        return rollouts
     }
 
     private func findExecutable(_ name: String, environment: [String: String]) -> String? {

--- a/Tests/CodexBarTests/AdaptiveRefreshPerformanceTests.swift
+++ b/Tests/CodexBarTests/AdaptiveRefreshPerformanceTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+private final class DirectoryEntryVisitCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        self.lock.withLock { self.value += 1 }
+    }
+
+    var count: Int {
+        self.lock.withLock { self.value }
+    }
+}
+
+private actor AdaptiveLocalScanSpy {
+    private(set) var callCount = 0
+
+    func scan(includeFileOnlySessions _: Bool) -> [AgentSession] {
+        self.callCount += 1
+        return []
+    }
+}
+
+@MainActor
+struct AdaptiveRefreshPerformanceTests {
+    @Test
+    func `agent aware detection stays within the bounded scan budget`() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("AdaptiveRefreshPerformanceTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let config = SessionScanConfig()
+        #expect(config.maxDirectoryEntryCount == 512)
+        #expect(config.maxDirectoryDepth == 1)
+        #expect(config.adaptiveDirectoryScanBudget == 0.15)
+
+        let now = Date()
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy/MM/dd"
+        let codexHome = root.appendingPathComponent("codex-home", isDirectory: true)
+        let sessionDirectory = codexHome
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(formatter.string(from: now), isDirectory: true)
+        try fileManager.createDirectory(at: sessionDirectory, withIntermediateDirectories: true)
+
+        let fixtureURL = try AgentSessionParserTests.fixtureURL("agent-session-rollout", extension: "jsonl")
+        let fixture = try Data(contentsOf: fixtureURL)
+        for index in 0..<config.maxDirectoryEntryCount {
+            try fixture.write(to: sessionDirectory.appendingPathComponent("rollout-budget-\(index).jsonl"))
+        }
+        let nested = sessionDirectory.appendingPathComponent("past-depth-cap", isDirectory: true)
+        try fileManager.createDirectory(at: nested, withIntermediateDirectories: true)
+        try fixture.write(to: nested.appendingPathComponent("rollout-must-not-be-visited.jsonl"))
+
+        let visits = DirectoryEntryVisitCounter()
+        let scanner = LocalAgentSessionScanner(
+            config: config,
+            processOutputProvider: { _ in
+                "201 1 Mon Jul 6 09:03:00 2026 /usr/local/bin/codex exec"
+            },
+            cwdProvider: { _, _ in [201: "/Users/test/Projects/alpha"] },
+            didVisitDirectoryEntry: { visits.increment() })
+
+        let startedAt = ContinuousClock.now
+        let sessions = await scanner.scan(
+            now: now,
+            environment: [
+                "CODEX_HOME": codexHome.path,
+                "HOME": root.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            ],
+            includeFileOnlySessions: false)
+        let elapsed = startedAt.duration(to: .now)
+
+        #expect(!sessions.isEmpty)
+        #expect(visits.count <= config.maxDirectoryEntryCount)
+        #expect(
+            elapsed < .milliseconds(250),
+            "Bounded agent scan exceeded 250 ms: \(elapsed), visited \(visits.count) entries")
+    }
+
+    @Test
+    func `plain adaptive and missing consent perform zero local scans`() async {
+        let settings = testSettingsStore(suiteName: "AdaptiveRefreshPerformanceTests-zero-scan")
+        settings.agentSessionsEnabled = false
+        settings.adaptiveActivityScanConsent = .allowed
+        settings.refreshFrequency = .adaptive
+        let spy = AdaptiveLocalScanSpy()
+        let store = AgentSessionsStore(
+            settings: settings,
+            localScan: { includeFileOnlySessions in
+                await spy.scan(includeFileOnlySessions: includeFileOnlySessions)
+            })
+
+        await store.refreshLocal()
+        #expect(await spy.callCount == 0)
+
+        settings.refreshFrequency = .adaptiveAgentAware
+        settings.adaptiveActivityScanConsent = .undecided
+        await store.refreshLocal()
+        #expect(await spy.callCount == 0)
+
+        settings.adaptiveActivityScanConsent = .declined
+        await store.refreshLocal()
+        #expect(await spy.callCount == 0)
+    }
+}

--- a/docs/predictive-refresh-policy.md
+++ b/docs/predictive-refresh-policy.md
@@ -186,7 +186,8 @@ Adaptive stores no persistent interaction history.
   metadata scan, not a provider request. Pause agent-aware scans under Low Power Mode or serious/critical thermal
   pressure; keep scanning when the user explicitly enables Agent Sessions presentation.
 - Bound each scan to the newest 64 agent processes, 128 Codex rollout metadata records, and 64 Claude transcript
-  candidates per project. Share a 512-entry, depth-1, 250 ms budget across Codex and Claude directory enumeration, and
+  candidates per project. Share a 512-entry, depth-1, 150 ms budget across agent-aware Codex and Claude directory
+  enumeration, and
   clamp future transcript mtimes to the scan time. Keep the first clamped value for an unchanged future-dated file so
   repeated scans cannot synthesize newer activity.
 - When Agent Sessions presentation is disabled, discard the full scan result after deriving the newest `Date`. Do not

--- a/docs/refresh-loop.md
+++ b/docs/refresh-loop.md
@@ -54,7 +54,8 @@ read_when:
   recent Codex rollouts, reads rollout first-line metadata and mtimes, and inspects Claude transcript metadata. When
   the Agent Sessions UI is off, CodexBar discards the resulting session records and retains only the latest `Date`.
   Each scan considers at most 64 agent processes, parses at most 128 Codex rollout metadata records, keeps at most 64
-  Claude transcript candidates per project, and shares a 512-entry, depth-1, 250 ms directory metadata budget. Future
+  Claude transcript candidates per project, and shares a 512-entry, depth-1, 150 ms agent-aware directory metadata
+  budget. Future
   transcript mtimes are clamped to one scanner-lifetime timestamp. The clamp retains no file paths, and unchanged
   future-dated files cannot manufacture newer activity every 30 seconds.
   Agent-aware scans pause under Low Power Mode and serious/critical thermal pressure. Explicitly enabling Agent


### PR DESCRIPTION
## Summary

- enforce a 250 ms wall-clock ceiling for an agent-aware scan over the capped 512-entry, depth-1 synthetic session tree
- verify plain Adaptive and missing-consent refresh attempts make zero local scan calls
- reduce adaptive metadata enumeration to 150 ms and stop Codex parsing once live working directories are matched

Follow-up coverage for #2111.

## Verification

- `swift test --filter AdaptiveRefreshPerformanceTests` (2 passed)
- `swift test --filter AgentSessionMenuDescriptorTests` (13 passed)
- `swift test --filter ClaudeSessionMappingTests` (4 passed)
- `swift test --filter CodexSessionRolloutTests` (5 passed)
- `make check` (passed; SwiftFormat clean, SwiftLint 0 violations)
- `make test` exercised all 60 normal groups; unrelated Claude group 15 failed twice, then passed unchanged on direct rerun
- autoreview: no accepted actionable findings
