### PR TITLE
Gate provider version probes to enabled providers

### DIFF
--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -70,6 +70,11 @@ extension UsageStore {
                 guard self.startupBehavior.automaticallyStartsBackgroundWork else { return }
                 self.startTimer()
                 self.updateProviderRuntimes()
+                let enabledNow = Set(self.settings.enabledProvidersOrdered(
+                    metadataByProvider: self.providerMetadata))
+                if enabledNow != self.versionDetectionProviders {
+                    self.detectVersions()
+                }
                 await self.refreshHistoricalDatasetIfNeeded()
                 await self.refreshForSettingsChange()
             }
@@ -184,6 +189,7 @@ final class UsageStore {
     var openAIDashboardCookieImportStatus: String?
     var openAIDashboardCookieImportDebugLog: String?
     var versions: [UsageProvider: String] = [:]
+    @ObservationIgnored var versionDetectionProviders: Set<UsageProvider> = []
     var isRefreshing = false
     var hasForcedRefreshEnrichmentInFlight = false
     var refreshingProviders: Set<UsageProvider> = []
@@ -1261,8 +1267,19 @@ extension UsageStore {
         }
     }
 
-    private func detectVersions() {
-        let implementations = ProviderCatalog.all
+    /// Version probes can spawn subprocesses (Antigravity's `ps` scan trips a TCC
+    /// prompt, CLI providers exec their binaries), so disabled providers must not
+    /// be probed (#2267). Settings changes re-run this when the enabled set changes.
+    static func versionDetectionImplementations(
+        enabled: Set<UsageProvider>) -> [any ProviderImplementation]
+    {
+        ProviderCatalog.all.filter { enabled.contains($0.id) }
+    }
+
+    func detectVersions() {
+        let enabled = Set(self.settings.enabledProvidersOrdered(metadataByProvider: self.providerMetadata))
+        self.versionDetectionProviders = enabled
+        let implementations = Self.versionDetectionImplementations(enabled: enabled)
         let browserDetection = self.browserDetection
         Task { @MainActor [weak self] in
             let resolved = await Task.detached { () -> [UsageProvider: String] in

--- a/Tests/CodexBarTests/ProviderVersionDetectionGatingTests.swift
+++ b/Tests/CodexBarTests/ProviderVersionDetectionGatingTests.swift
@@ -1,0 +1,28 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite("Provider version detection gating")
+@MainActor
+struct ProviderVersionDetectionGatingTests {
+    @Test
+    func `disabled providers are excluded from version probes`() {
+        let implementations = UsageStore.versionDetectionImplementations(enabled: [.codex, .claude])
+        let ids = Set(implementations.map(\.id))
+        #expect(ids == [.codex, .claude])
+        #expect(!ids.contains(.antigravity))
+    }
+
+    @Test
+    func `empty enabled set probes nothing`() {
+        #expect(UsageStore.versionDetectionImplementations(enabled: []).isEmpty)
+    }
+
+    @Test
+    func `enabling a provider includes it in version probes`() {
+        let ids = Set(UsageStore.versionDetectionImplementations(
+            enabled: [.codex, .antigravity]).map(\.id))
+        #expect(ids.contains(.antigravity))
+    }
+}


### PR DESCRIPTION
Fixes #2267.

`UsageStore.detectVersions()` iterated `ProviderCatalog.all`, probing every provider implementation regardless of enablement. Antigravity's `detectVersion` runs the `ps -ax` process scan (label `antigravity-ps`), which trips the macOS "access data from other apps" (kTCCServiceSystemPolicyAppData) prompt on every relaunch even with the provider disabled, exactly as reported. Disabled CLI providers similarly spawned version probes.

Change:
- `detectVersions()` filters the catalog to the enabled provider set (new testable seam `versionDetectionImplementations(enabled:)`).
- The existing settings observation hook re-runs detection when the enabled set changes, so enabling a provider later populates its version without relaunch.

Verification:
- New `ProviderVersionDetectionGatingTests` (3 tests: disabled excluded, empty set probes nothing, enabling includes).
- `make check` clean, focused tests green; CI on this PR.
- Behavior: with Antigravity disabled, no `antigravity-ps` subprocess at launch; reporter asked to confirm the TCC prompt stops on the next release.
