### PR TITLE
Scope startup version probes to enabled providers

### DIFF
--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -1262,7 +1262,9 @@ extension UsageStore {
     }
 
     private func detectVersions() {
-        let implementations = ProviderCatalog.all
+        let implementations = Self.implementationsForVersionDetection(
+            enabledProviders: self.enabledProvidersForDisplay(),
+            implementations: ProviderCatalog.all)
         let browserDetection = self.browserDetection
         Task { @MainActor [weak self] in
             let resolved = await Task.detached { () -> [UsageProvider: String] in
@@ -1285,6 +1287,14 @@ extension UsageStore {
             }.value
             self?.versions = resolved
         }
+    }
+
+    nonisolated static func implementationsForVersionDetection(
+        enabledProviders: [UsageProvider],
+        implementations: [any ProviderImplementation]) -> [any ProviderImplementation]
+    {
+        let implementationsByID = Dictionary(uniqueKeysWithValues: implementations.map { ($0.id, $0) })
+        return enabledProviders.compactMap { implementationsByID[$0] }
     }
 
     @MainActor

--- a/Tests/CodexBarTests/UsageStoreVersionDetectionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreVersionDetectionTests.swift
@@ -1,0 +1,16 @@
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+struct UsageStoreVersionDetectionTests {
+    @Test
+    func `version detection only probes enabled providers`() {
+        let implementations = UsageStore.implementationsForVersionDetection(
+            enabledProviders: [.claude, .codex],
+            implementations: ProviderCatalog.all)
+
+        let ids = implementations.map(\.id)
+        #expect(ids == [.claude, .codex])
+        #expect(!ids.contains(.antigravity))
+    }
+}


### PR DESCRIPTION
## Summary
- Scope startup version detection to enabled/display providers instead of every registered provider.
- Keeps disabled providers from running version probes at launch; for Antigravity this avoids the `detectVersion -> isRunning -> antigravity-ps` path when the provider is disabled.
- Add a regression test for the provider selection helper.

Fixes #2267.

## Tests
- `make check`
- `git diff --check`
- `swiftc -parse Sources/CodexBar/UsageStore.swift`
- `swiftc -parse Tests/CodexBarTests/UsageStoreVersionDetectionTests.swift`
- Attempted: `swift test --skip-update --filter UsageStoreVersionDetectionTests` (stalled before test execution while downloading the Sparkle 2.9.3 binary artifact)