### PR TITLE
Fix menu bar layout palette drag

### DIFF
--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -29,6 +29,10 @@ check_package_signing() {
   "${ROOT_DIR}/Scripts/test_package_signing.sh"
 }
 
+check_package_info_plist() {
+  "${ROOT_DIR}/Scripts/test_package_info_plist.sh"
+}
+
 check_release_dsym_paths() {
   "${ROOT_DIR}/Scripts/test_release_dsym_paths.sh"
 }
@@ -84,6 +88,7 @@ run_portable_checks() {
   check_package_product_paths
   check_package_strip
   check_package_signing
+  check_package_info_plist
   check_release_dsym_paths
   check_sparkle_signing_paths
   check_swift_test_sharding

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -294,6 +294,19 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>CodexBuildTimestamp</key><string>${BUILD_TIMESTAMP}</string>
     <key>CodexGitCommit</key><string>${GIT_COMMIT}</string>
     <key>CodexBarTeamID</key><string>${APP_TEAM_ID}</string>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key><string>com.steipete.codexbar.menu-layout-item</string>
+            <key>UTTypeDescription</key><string>CodexBar menu bar layout token</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+            </array>
+            <key>UTTypeTagSpecification</key>
+            <dict/>
+        </dict>
+    </array>
 </dict>
 </plist>
 PLIST

--- a/Scripts/test_package_info_plist.sh
+++ b/Scripts/test_package_info_plist.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+PACKAGE_SCRIPT="$ROOT/Scripts/package_app.sh"
+PLIST_SCRIPT=$(mktemp "${TMPDIR:-/tmp}/codexbar-package-info-plist-script.XXXXXX")
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexbar-package-info-plist.XXXXXX")
+trap 'rm -f "$PLIST_SCRIPT"; rm -rf "$TEMP_DIR"' EXIT
+
+python3 - "$PACKAGE_SCRIPT" "$PLIST_SCRIPT" <<'PY'
+import sys
+from pathlib import Path
+
+script = Path(sys.argv[1]).read_text()
+start = script.index('cat > "$APP/Contents/Info.plist" <<PLIST')
+end = script.index('\nPLIST\n', start) + len('\nPLIST\n')
+Path(sys.argv[2]).write_text(script[start:end])
+PY
+
+APP="$TEMP_DIR/CodexBar.app"
+mkdir -p "$APP/Contents"
+BUNDLE_ID=com.steipete.codexbar.test
+MARKETING_VERSION=0.0.0
+BUILD_NUMBER=0
+FEED_URL=https://example.invalid/appcast.xml
+AUTO_CHECKS=false
+BUILD_TIMESTAMP=2026-01-01T00:00:00Z
+GIT_COMMIT=test
+APP_TEAM_ID=TESTTEAM
+source "$PLIST_SCRIPT"
+
+plutil -lint "$APP/Contents/Info.plist"
+python3 - "$APP/Contents/Info.plist" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+plist = plistlib.loads(Path(sys.argv[1]).read_bytes())
+declarations = plist.get("UTExportedTypeDeclarations")
+assert declarations == [{
+    "UTTypeIdentifier": "com.steipete.codexbar.menu-layout-item",
+    "UTTypeDescription": "CodexBar menu bar layout token",
+    "UTTypeConformsTo": ["public.data"],
+    "UTTypeTagSpecification": {},
+}]
+PY
+
+echo "Package Info.plist tests passed."

--- a/Scripts/test_package_info_plist.sh
+++ b/Scripts/test_package_info_plist.sh
@@ -29,7 +29,9 @@ GIT_COMMIT=test
 APP_TEAM_ID=TESTTEAM
 source "$PLIST_SCRIPT"
 
-plutil -lint "$APP/Contents/Info.plist"
+if command -v plutil >/dev/null 2>&1; then
+  plutil -lint "$APP/Contents/Info.plist"
+fi
 python3 - "$APP/Contents/Info.plist" <<'PY'
 import plistlib
 import sys

--- a/Tests/CodexBarTests/MenuBarLayoutEditorTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutEditorTests.swift
@@ -1,5 +1,7 @@
+import CoreTransferable
 import Foundation
 import Testing
+import UniformTypeIdentifiers
 @testable import CodexBar
 
 struct MenuBarLayoutEditorTests {
@@ -136,5 +138,20 @@ struct MenuBarLayoutEditorTests {
 
         let data = try JSONEncoder().encode(payload)
         #expect(try JSONDecoder().decode(MenuBarLayoutDragItem.self, from: data) == payload)
+    }
+
+    @Test
+    @available(macOS 15.2, *)
+    func `palette drag transfer representation round trips`() async throws {
+        let payload = MenuBarLayoutDragItem.palette(.percent(window: .weekly))
+
+        #expect(MenuBarLayoutDragItem.exportedContentTypes() == [.codexBarMenuLayoutItem])
+        #expect(MenuBarLayoutDragItem.importedContentTypes() == [.codexBarMenuLayoutItem])
+
+        let data = try await payload.exported(as: .codexBarMenuLayoutItem)
+        let decoded = try await MenuBarLayoutDragItem(
+            importing: data,
+            contentType: .codexBarMenuLayoutItem)
+        #expect(decoded == payload)
     }
 }


### PR DESCRIPTION
## Summary

- Register `com.steipete.codexbar.menu-layout-item` as an exported `public.data` UTType in the packaged main app.
- Add a real CoreTransferable palette-item export/import round-trip test and retain mutation coverage for palette insertion, placed-token reordering, removal, and line breaks.
- Add a portable packaging assertion that parses the generated Info.plist and checks the exact exported declaration.

Follow-up to #2275.

## Root cause

The layout editor uses `CodableRepresentation` with a custom exported UTType, but the generated main-app Info.plist did not declare that type. Apple requires matching Info.plist entries for custom Transferable UTTypes. The Settings UI is hosted by the main app, so the declaration belongs there; the widget extension does not need it.

The mutation path itself is healthy: palette insertion and placed-token reorder/remove tests pass, and the new CoreTransferable test proves a palette payload exports and imports as the declared content type.

## Verification

- `swift test --filter MenuBarLayoutEditorTests`: 9 tests passed.
- `Scripts/test_package_info_plist.sh`: generated plist linted and exact declaration matched.
- `make check`: all packaging, locale, docs, SwiftFormat, and strict SwiftLint checks passed; 0 lint violations.
- `CODEXBAR_SIGNING=identity ./Scripts/package_app.sh debug`: signed bundle built successfully; `codesign --verify --deep --strict` passed; packaged main Info.plist contains the declaration.
- Autoreview: final full-branch pass clean, no accepted/actionable findings.

## Live verification

Live drag verification follows after merge per the owner gate. Both available local UI automation routes failed before a drag could be performed: Peekaboo lacked Screen Recording and Accessibility grants, and Computer Use closed its native pipe whenever Settings opened. Please verify palette-to-strip insertion, placed-token reordering, drag-to-remove, click-to-append, and line-break behavior against the freshly built bundle.
