### PR TITLE
Allow single-account claude-swap cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 0.44.1 — Unreleased
 
-### Added
-- Claude: add an opt-in setting to show claude-swap cards when only one account is available, while preserving the
-  ambient Claude presentation by default.
-
 ### Fixed
 
 ## 0.44.0 — 2026-07-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.44.1 — Unreleased
 
+### Added
+- Claude: add an opt-in setting to show claude-swap cards when only one account is available, while preserving the
+  ambient Claude presentation by default.
+
 ### Fixed
 
 ## 0.44.0 — 2026-07-17

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -26,6 +26,7 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         _ = settings.claudeOAuthKeychainReadStrategy
         _ = settings.claudeWebExtrasEnabled
         _ = settings.claudeSwapEnabled
+        _ = settings.claudeSwapShowSingleAccount
         _ = settings.claudeSwapExecutablePath
     }
 
@@ -86,6 +87,9 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         let claudeSwapBinding = Binding(
             get: { context.settings.claudeSwapEnabled },
             set: { context.settings.claudeSwapEnabled = $0 })
+        let claudeSwapShowSingleAccountBinding = Binding(
+            get: { context.settings.claudeSwapShowSingleAccount },
+            set: { context.settings.claudeSwapShowSingleAccount = $0 })
 
         return [
             ProviderSettingsToggleDescriptor(
@@ -109,6 +113,18 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                 statusText: { Self.claudeSwapStatusText(store: context.store, settings: context.settings) },
                 actions: [],
                 isVisible: nil,
+                isEnabled: nil,
+                onChange: nil,
+                onAppDidBecomeActive: nil,
+                onAppearWhenEnabled: nil),
+            ProviderSettingsToggleDescriptor(
+                id: "claude-swap-show-single-account",
+                title: "Show account card when only one account is available",
+                subtitle: "Prefer claude-swap over the ambient Claude account presentation.",
+                binding: claudeSwapShowSingleAccountBinding,
+                statusText: nil,
+                actions: [],
+                isVisible: { context.settings.claudeSwapEnabled },
                 isEnabled: nil,
                 onChange: nil,
                 onAppDidBecomeActive: nil,

--- a/Sources/CodexBar/Providers/Claude/ClaudeSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeSettingsStore.swift
@@ -67,6 +67,19 @@ extension SettingsStore {
         }
     }
 
+    var claudeSwapShowSingleAccount: Bool {
+        get { self.configSnapshot.providerConfig(for: .claude)?.claudeSwapShowSingleAccount ?? false }
+        set {
+            self.updateProviderConfig(provider: .claude) { entry in
+                entry.claudeSwapShowSingleAccount = newValue
+            }
+            self.logProviderModeChange(
+                provider: .claude,
+                field: "claudeSwapShowSingleAccount",
+                value: String(newValue))
+        }
+    }
+
     var claudeSwapExecutablePath: String {
         get { self.configSnapshot.providerConfig(for: .claude)?.sanitizedClaudeSwapExecutablePath ?? "" }
         set {

--- a/Sources/CodexBar/StatusItemController+AccountMenuDisplay.swift
+++ b/Sources/CodexBar/StatusItemController+AccountMenuDisplay.swift
@@ -2,8 +2,14 @@ import AppKit
 import CodexBarCore
 
 enum ClaudeSwapMenuPrecedence {
-    static func prefersClaudeSwap(provider: UsageProvider, accountCount: Int) -> Bool {
-        provider == .claude && accountCount > 1
+    static func prefersClaudeSwap(
+        provider: UsageProvider,
+        accountCount: Int,
+        showSingleAccount: Bool) -> Bool
+    {
+        provider == .claude && ClaudeSwapAccountProjection.shouldPresentAccounts(
+            accountCount: accountCount,
+            showSingleAccount: showSingleAccount)
     }
 }
 
@@ -36,11 +42,12 @@ extension StatusItemController {
         guard TokenAccountSupportCatalog.support(for: provider) != nil else { return nil }
         // Retained Cursor manual accounts are dormant while Automatic browser discovery owns the live snapshot.
         guard self.settings.effectiveSelectedTokenAccount(for: provider) != nil else { return nil }
-        // Multiple claude-swap rows are the selected Claude account source, so do not mix them
+        // Eligible claude-swap rows are the selected Claude account source, so do not mix them
         // with token-account cards or the segmented token-account switcher.
         if ClaudeSwapMenuPrecedence.prefersClaudeSwap(
             provider: provider,
-            accountCount: self.store.claudeSwapAccountSnapshots.count)
+            accountCount: self.store.claudeSwapAccountSnapshots.count,
+            showSingleAccount: self.settings.claudeSwapShowSingleAccount)
         {
             return nil
         }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -614,11 +614,12 @@ extension StatusItemController {
             return false
         }
 
-        // Multiple claude-swap rows take precedence over Claude token-account cards; otherwise
+        // Eligible claude-swap rows take precedence over Claude token-account cards; otherwise
         // the stacked token-account branch below would return before rendering the adapter rows.
         if ClaudeSwapMenuPrecedence.prefersClaudeSwap(
             provider: context.currentProvider,
-            accountCount: self.store.claudeSwapAccountSnapshots.count)
+            accountCount: self.store.claudeSwapAccountSnapshots.count,
+            showSingleAccount: self.settings.claudeSwapShowSingleAccount)
         {
             self.addClaudeSwapMenuCards(to: menu, captureMenu: captureMenu ?? menu, context: context)
             return false

--- a/Sources/CodexBarCLI/CLICardsCommand.swift
+++ b/Sources/CodexBarCLI/CLICardsCommand.swift
@@ -196,9 +196,7 @@ extension CodexBarCLI {
                             command: command)
                     }
                 })
-            if result.exitCode != .success {
-                exitCode = result.exitCode
-            }
+            if result.exitCode != .success { exitCode = result.exitCode }
             cards.append(contentsOf: result.cards)
             failures.append(contentsOf: result.cardFailures)
         }

--- a/Sources/CodexBarCLI/CLICardsCommand.swift
+++ b/Sources/CodexBarCLI/CLICardsCommand.swift
@@ -180,6 +180,7 @@ extension CodexBarCLI {
             let result = await CLIClaudeSwapCards.fetch(
                 eligible: claudeSwapEligible,
                 executablePath: CLIClaudeSwapCards.executablePath(from: claudeConfig),
+                showSingleAccount: claudeConfig?.claudeSwapShowSingleAccount == true,
                 renderOptions: CLIClaudeSwapCardsRenderOptions(
                     status: status,
                     useColor: useColor,

--- a/Sources/CodexBarCLI/CLIClaudeSwapCards.swift
+++ b/Sources/CodexBarCLI/CLIClaudeSwapCards.swift
@@ -103,12 +103,14 @@ enum CLIClaudeSwapCards {
     static func fetch(
         eligible: Bool,
         executablePath: String,
+        showSingleAccount: Bool = false,
         renderOptions: CLIClaudeSwapCardsRenderOptions,
         ambientFetch: @escaping AmbientFetch) async -> UsageCommandOutput
     {
         await self.fetch(
             eligible: eligible,
             executablePath: executablePath,
+            showSingleAccount: showSingleAccount,
             renderOptions: renderOptions,
             ambientFetch: ambientFetch,
             accountListReader: { path in
@@ -119,6 +121,7 @@ enum CLIClaudeSwapCards {
     static func fetch(
         eligible: Bool,
         executablePath: String,
+        showSingleAccount: Bool = false,
         renderOptions: CLIClaudeSwapCardsRenderOptions,
         ambientFetch: @escaping AmbientFetch,
         accountListReader: @escaping AccountListReader) async -> UsageCommandOutput
@@ -128,7 +131,10 @@ enum CLIClaudeSwapCards {
         do {
             let list = try await accountListReader(executablePath)
             let accounts = ClaudeSwapAccountProjection.accountSnapshots(from: list, now: renderOptions.now)
-            guard accounts.count > 1 else { return await ambientFetch() }
+            guard ClaudeSwapAccountProjection.shouldPresentAccounts(
+                accountCount: accounts.count,
+                showSingleAccount: showSingleAccount)
+            else { return await ambientFetch() }
 
             var output = UsageCommandOutput()
             output.cards = accounts.map { account in

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -18,8 +18,8 @@ extension CodexBarCLI {
           Print a one-shot usage snapshot as a responsive card grid in the terminal.
           Honors enabled providers from config and reuses the same fetch flags as codexbar usage.
           Failed providers are summarized in a footer instead of error cards.
-          Enabled claude-swap lists with 2+ accounts replace Claude cards unless an account or
-          explicit non-auto `--source` CLI flag is selected.
+          Enabled claude-swap lists with 2+ accounts—or one account when `claudeSwapShowSingleAccount`
+          is enabled—replace Claude cards unless an account or explicit non-auto `--source` CLI flag is selected.
           Sentinel accounts remain visible without metrics; claude-swap adapter failures use a separate footer entry.
           Use --brief for a compact table layout (Provider / Usage / Reset).
           Stdout is always the rendered card/table text; --json-output only affects stderr logs.

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -162,6 +162,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var enterpriseHost: String?
     public var tokenAccounts: ProviderTokenAccountData?
     public var claudeSwapEnabled: Bool?
+    public var claudeSwapShowSingleAccount: Bool?
     public var claudeSwapExecutablePath: String?
     public var codexActiveSource: CodexActiveSource?
     public var codexProfileHomePaths: [String]?
@@ -188,6 +189,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         enterpriseHost: String? = nil,
         tokenAccounts: ProviderTokenAccountData? = nil,
         claudeSwapEnabled: Bool? = nil,
+        claudeSwapShowSingleAccount: Bool? = nil,
         claudeSwapExecutablePath: String? = nil,
         codexActiveSource: CodexActiveSource? = nil,
         codexProfileHomePaths: [String]? = nil,
@@ -213,6 +215,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.enterpriseHost = enterpriseHost
         self.tokenAccounts = tokenAccounts
         self.claudeSwapEnabled = claudeSwapEnabled
+        self.claudeSwapShowSingleAccount = claudeSwapShowSingleAccount
         self.claudeSwapExecutablePath = claudeSwapExecutablePath
         self.codexActiveSource = codexActiveSource
         self.codexProfileHomePaths = codexProfileHomePaths

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
@@ -9,6 +9,10 @@ public enum ClaudeSwapAccountProjection {
     static let fiveHourWindowMinutes = 5 * 60
     static let sevenDayWindowMinutes = 7 * 24 * 60
 
+    public static func shouldPresentAccounts(accountCount: Int, showSingleAccount: Bool) -> Bool {
+        accountCount >= (showSingleAccount ? 1 : 2)
+    }
+
     public static func accountSnapshots(
         from list: ClaudeSwapAccountList,
         now: Date = Date()) -> [ProviderAccountUsageSnapshot]

--- a/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
+++ b/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
@@ -73,6 +73,18 @@ struct CLICardsClaudeSwapTests {
     }
 
     @Test
+    func `single account config is backward compatible and round trips opt in`() throws {
+        let legacyData = Data(#"{"id":"claude"}"#.utf8)
+        let legacy = try JSONDecoder().decode(ProviderConfig.self, from: legacyData)
+        #expect(legacy.claudeSwapShowSingleAccount != true)
+
+        let enabled = ProviderConfig(id: .claude, claudeSwapShowSingleAccount: true)
+        let encoded = try JSONEncoder().encode(enabled)
+        let decoded = try JSONDecoder().decode(ProviderConfig.self, from: encoded)
+        #expect(decoded.claudeSwapShowSingleAccount == true)
+    }
+
+    @Test
     func `eligibility preserves explicit account and source intent`() {
         let eligibleSourceModes: [ProviderSourceMode?] = [nil, .auto]
         for sourceMode in eligibleSourceModes {
@@ -109,12 +121,13 @@ struct CLICardsClaudeSwapTests {
     }
 
     @Test
-    func `bypass does not invoke the adapter`() async {
+    func `bypass does not invoke the adapter when single account cards are enabled`() async {
         let counter = InvocationCounter()
         let ambient = self.ambientOutput()
         let output = await CLIClaudeSwapCards.fetch(
             eligible: false,
             executablePath: "/unused/cswap",
+            showSingleAccount: true,
             renderOptions: self.renderOptions(),
             ambientFetch: { ambient },
             accountListReader: { _ in
@@ -146,6 +159,38 @@ struct CLICardsClaudeSwapTests {
             #expect(output.cardFailures.isEmpty)
         }
         #expect(await ambientCounter.value == 2)
+    }
+
+    @Test
+    func `single account option renders sentinel account instead of ambient output`() async {
+        let ambientCounter = InvocationCounter()
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "/fake/cswap",
+            showSingleAccount: true,
+            renderOptions: self.renderOptions(),
+            ambientFetch: {
+                await ambientCounter.increment()
+                return self.ambientOutput(failed: true)
+            },
+            accountListReader: { _ in
+                ClaudeSwapAccountList(activeAccountNumber: 1, accounts: [
+                    self.row(
+                        number: 1,
+                        active: true,
+                        status: .tokenExpired,
+                        email: "single@example.com",
+                        hasUsage: false),
+                ])
+            })
+
+        #expect(await ambientCounter.value == 0)
+        #expect(output.exitCode == .success)
+        #expect(output.cards.count == 1)
+        #expect(output.cards.first?.accountLine == "single@example.com")
+        #expect(output.cards.first?.isActive == true)
+        #expect(output.cards.first?.accountProblem ==
+            "Token expired. Switch to this account in claude-swap to refresh it.")
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeSwapMenuPrecedenceTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapMenuPrecedenceTests.swift
@@ -4,14 +4,34 @@ import Testing
 
 struct ClaudeSwapMenuPrecedenceTests {
     @Test
-    func `multiple Claude swap accounts take precedence`() {
-        #expect(ClaudeSwapMenuPrecedence.prefersClaudeSwap(provider: .claude, accountCount: 2))
+    func `multiple Claude swap accounts take precedence by default`() {
+        #expect(ClaudeSwapMenuPrecedence.prefersClaudeSwap(
+            provider: .claude,
+            accountCount: 2,
+            showSingleAccount: false))
     }
 
     @Test
-    func `precedence requires Claude and multiple swap accounts`() {
-        #expect(!ClaudeSwapMenuPrecedence.prefersClaudeSwap(provider: .claude, accountCount: 0))
-        #expect(!ClaudeSwapMenuPrecedence.prefersClaudeSwap(provider: .claude, accountCount: 1))
-        #expect(!ClaudeSwapMenuPrecedence.prefersClaudeSwap(provider: .openai, accountCount: 2))
+    func `single Claude swap account requires opt in`() {
+        #expect(!ClaudeSwapMenuPrecedence.prefersClaudeSwap(
+            provider: .claude,
+            accountCount: 1,
+            showSingleAccount: false))
+        #expect(ClaudeSwapMenuPrecedence.prefersClaudeSwap(
+            provider: .claude,
+            accountCount: 1,
+            showSingleAccount: true))
+    }
+
+    @Test
+    func `precedence requires Claude and at least one swap account`() {
+        #expect(!ClaudeSwapMenuPrecedence.prefersClaudeSwap(
+            provider: .claude,
+            accountCount: 0,
+            showSingleAccount: true))
+        #expect(!ClaudeSwapMenuPrecedence.prefersClaudeSwap(
+            provider: .openai,
+            accountCount: 2,
+            showSingleAccount: true))
     }
 }

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -140,6 +140,26 @@ struct ProviderSettingsDescriptorTests {
     }
 
     @Test
+    func `claude single swap account toggle persists and follows integration visibility`() throws {
+        let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-claude-swap-single")
+        let context = fixture.settingsContext(provider: .claude)
+        let toggles = ClaudeProviderImplementation().settingsToggles(context: context)
+        let singleAccountToggle = try #require(toggles.first {
+            $0.id == "claude-swap-show-single-account"
+        })
+
+        #expect(singleAccountToggle.binding.wrappedValue == false)
+        #expect(singleAccountToggle.isVisible?() == false)
+
+        fixture.settings.claudeSwapEnabled = true
+        #expect(singleAccountToggle.isVisible?() == true)
+        singleAccountToggle.binding.wrappedValue = true
+
+        #expect(fixture.settings.claudeSwapShowSingleAccount)
+        #expect(fixture.settings.configSnapshot.providerConfig(for: .claude)?.claudeSwapShowSingleAccount == true)
+    }
+
+    @Test
     func `claude prompt policy picker remains visible for prompt free toggle`() throws {
         let fixture = try self.makeSettingsFixture(
             suite: "ProviderSettingsDescriptorTests-claude-prompt-visible-prompt-free")

--- a/TestsLinux/CLICardsClaudeSwapTests.swift
+++ b/TestsLinux/CLICardsClaudeSwapTests.swift
@@ -73,6 +73,18 @@ struct CLICardsClaudeSwapTests {
     }
 
     @Test
+    func `single account config is backward compatible and round trips opt in`() throws {
+        let legacyData = Data(#"{"id":"claude"}"#.utf8)
+        let legacy = try JSONDecoder().decode(ProviderConfig.self, from: legacyData)
+        #expect(legacy.claudeSwapShowSingleAccount != true)
+
+        let enabled = ProviderConfig(id: .claude, claudeSwapShowSingleAccount: true)
+        let encoded = try JSONEncoder().encode(enabled)
+        let decoded = try JSONDecoder().decode(ProviderConfig.self, from: encoded)
+        #expect(decoded.claudeSwapShowSingleAccount == true)
+    }
+
+    @Test
     func `eligibility preserves explicit account and source intent`() {
         let eligibleSourceModes: [ProviderSourceMode?] = [nil, .auto]
         for sourceMode in eligibleSourceModes {
@@ -109,12 +121,13 @@ struct CLICardsClaudeSwapTests {
     }
 
     @Test
-    func `bypass does not invoke the adapter`() async {
+    func `bypass does not invoke the adapter when single account cards are enabled`() async {
         let counter = InvocationCounter()
         let ambient = self.ambientOutput()
         let output = await CLIClaudeSwapCards.fetch(
             eligible: false,
             executablePath: "/unused/cswap",
+            showSingleAccount: true,
             renderOptions: self.renderOptions(),
             ambientFetch: { ambient },
             accountListReader: { _ in
@@ -146,6 +159,38 @@ struct CLICardsClaudeSwapTests {
             #expect(output.cardFailures.isEmpty)
         }
         #expect(await ambientCounter.value == 2)
+    }
+
+    @Test
+    func `single account option renders sentinel account instead of ambient output`() async {
+        let ambientCounter = InvocationCounter()
+        let output = await CLIClaudeSwapCards.fetch(
+            eligible: true,
+            executablePath: "/fake/cswap",
+            showSingleAccount: true,
+            renderOptions: self.renderOptions(),
+            ambientFetch: {
+                await ambientCounter.increment()
+                return self.ambientOutput(failed: true)
+            },
+            accountListReader: { _ in
+                ClaudeSwapAccountList(activeAccountNumber: 1, accounts: [
+                    self.row(
+                        number: 1,
+                        active: true,
+                        status: .tokenExpired,
+                        email: "single@example.com",
+                        hasUsage: false),
+                ])
+            })
+
+        #expect(await ambientCounter.value == 0)
+        #expect(output.exitCode == .success)
+        #expect(output.cards.count == 1)
+        #expect(output.cards.first?.accountLine == "single@example.com")
+        #expect(output.cards.first?.isActive == true)
+        #expect(output.cards.first?.accountProblem ==
+            "Token expired. Switch to this account in claude-swap to refresh it.")
     }
 
     @Test

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -126,8 +126,12 @@ The accepted multi-account design in
   shell, fixed arguments, bounded runtime and output), requires `schemaVersion == 1`, and parses only slot number,
   active state, usage status, email (display only), and the 5-hour/7-day windows.
 - Display: when claude-swap reports more than one account, the Claude menu and `codexbar cards` show one card per
-  account (active account first, then numeric slot) instead of ambient/token-account Claude cards; with zero or one
-  account those views are unchanged. Account identity is `claude-swap:<slot>`, never the display email.
+  account (active account first, then numeric slot) instead of ambient/token-account Claude cards. To use this
+  presentation with one account, enable “Show account card when only one account is available” or set
+  `claudeSwapShowSingleAccount: true` on the Claude provider in the resolved config file (normally
+  `~/.config/codexbar/config.json`; legacy installs may use `~/.codexbar/config.json`). The option defaults off,
+  zero accounts still use the ambient presentation, and account identity is `claude-swap:<slot>`, never the display
+  email.
 - Terminal scope: this automatic precedence is cards-only and works on every supported CLI platform. An explicit
   Claude provider or `--source auto` remains eligible, while `--account`, `--account-index`, `--all-accounts`, and
   explicit non-auto source flags bypass the adapter. `codexbar usage` and `codexbar serve` are unchanged.
@@ -145,7 +149,7 @@ The accepted multi-account design in
 - Expired, missing, unknown, or Keychain-inaccessible credentials stay non-actionable. A failed switch remains visible
   on that account without discarding its last successful usage. A running Claude Code process can take up to the
   claude-swap Keychain cache interval to observe the new account.
-- When multiple claude-swap accounts are available, they take explicit precedence over Claude
+- Multiple claude-swap accounts—and a single account when explicitly enabled—take precedence over Claude
   token-account presentation (stacked cards and the segmented switcher).
 
 Packaged synthetic proof (fake `cswap` executable, no real accounts or credentials):

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,11 +55,13 @@ See `docs/configuration.md` for the schema.
   - `--brief` renders a compact table (Provider / Usage / Reset) instead of the card grid.
   - Stdout is always rendered text; `--json-output` only affects stderr logs (no JSON card payload).
   - Failed providers are summarized in a footer (not rendered as error cards).
-  - When the opt-in Claude claude-swap integration returns two or more accounts, cards renders every account in
-    active-first/slot order instead of the ambient or token-account Claude cards. This applies on macOS and Linux,
-    including an explicit `--provider claude`; `--source auto` remains eligible.
+  - When the opt-in Claude claude-swap integration returns two or more accounts—or one account with
+    `claudeSwapShowSingleAccount` enabled—cards renders every account in active-first/slot order instead of the
+    ambient or token-account Claude cards. This applies on macOS and Linux, including an explicit
+    `--provider claude`; `--source auto` remains eligible.
   - `--account`, `--account-index`, `--all-accounts`, and explicit non-auto source flags preserve their requested
-    ambient behavior and do not invoke claude-swap. Zero/one-account lists likewise retain ambient Claude output.
+    ambient behavior and do not invoke claude-swap. Zero-account lists always retain ambient Claude output;
+    one-account lists do so unless `claudeSwapShowSingleAccount` is enabled.
   - claude-swap sentinel accounts remain successful cards with their problem text and no fabricated usage metrics.
     A list adapter, parser, or timeout failure retains useful ambient Claude output, adds a distinct
     `Claude (claude-swap)` failure footer entry, and makes the command exit non-zero.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,10 @@ All provider fields are optional unless noted.
 - `workspaceID`: provider-specific workspace/deployment/project ID (e.g. Azure OpenAI deployment, OpenAI API project,
   `opencode`).
 - `tokenAccounts`: multi-account tokens for providers in `TokenAccountSupportCatalog`.
+- `claudeSwapEnabled`: allow the Claude provider to read account usage from claude-swap.
+- `claudeSwapExecutablePath`: path to the `cswap` executable.
+- `claudeSwapShowSingleAccount`: prefer a claude-swap card when exactly one account is available. Defaults to
+  `false`; multiple claude-swap accounts retain their existing precedence.
 
 ## Manual cookies
 Use manual cookies when automatic browser import is unavailable, disabled, or too noisy for your setup.


### PR DESCRIPTION
## Summary

- add `claudeSwapShowSingleAccount`, an opt-in Claude provider setting that prefers claude-swap cards when exactly one account is available
- apply the same account-count precedence to the menu-bar app and `codexbar cards`, while retaining the existing 2+ account default
- preserve zero-account fallback and explicit CLI account/source overrides; document and test config compatibility on macOS and Linux

## Why

The claude-swap integration currently requires at least two rows before it replaces the ambient Claude presentation. Users who intentionally manage a single account through claude-swap therefore cannot use its valid quota snapshot when the ambient Claude account is unavailable or different.

Changing the existing threshold globally would risk replacing ambient presentation for users with stale or sentinel-only single rows. This keeps that behavior backward-compatible and makes the alternate precedence explicit.

Follow-up to #2188 and the claude-swap precedence introduced in #1909.

## Testing

- `swift build --product CodexBarCLI`
- [redacted live proof](https://github.com/steipete/CodexBar/pull/2280#issuecomment-5009539899): a real one-account setup renders `[claude-swap]`, the active account marker, and both quota windows
- synthetic `cswap --list --json` fixture renders `@ synthetic@example.com [active]` from a one-account config without invoking ambient Claude
- focused macOS/Linux tests added for disabled/enabled single-account behavior, sentinel rows, explicit bypass, and config Codable compatibility
- `make check` portable, documentation, locale, and SwiftFormat checks pass locally; local SwiftLint cannot load SourceKit under the Command Line Tools-only environment
- the Command Line Tools-only installation also lacks Swift `Testing` and the SwiftUI `PreviewsMacros` plugin, so focused tests and the app target are delegated to CI
