### PR TITLE
Fix Command Code Vivaldi session selection

### DIFF
--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
@@ -48,8 +48,23 @@ public enum CommandCodeProviderDescriptor {
 }
 
 struct CommandCodeWebFetchStrategy: ProviderFetchStrategy {
+    typealias UsageLoader = @Sendable (String) async throws -> CommandCodeUsageSnapshot
+    typealias SessionLoader = @Sendable () throws -> [CommandCodeResolvedSession]
+
     let id: String = "commandcode.web"
     let kind: ProviderFetchKind = .web
+    private let usageLoader: UsageLoader
+    private let sessionLoader: SessionLoader
+
+    init(
+        usageLoader: @escaping UsageLoader = { cookieHeader in
+            try await CommandCodeUsageFetcher.fetchUsage(cookieHeader: cookieHeader)
+        },
+        sessionLoader: @escaping SessionLoader = CommandCodeWebFetchStrategy.loadAutomaticSessions)
+    {
+        self.usageLoader = usageLoader
+        self.sessionLoader = sessionLoader
+    }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         guard context.settings?.commandcode?.cookieSource != .off else { return false }
@@ -64,32 +79,32 @@ struct CommandCodeWebFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let cookieHeader: String
-        let sourceLabel: String
         if let manual = Self.manualCookieHeader(from: context) {
-            cookieHeader = manual
-            sourceLabel = "manual"
-        } else {
-            #if os(macOS)
-            let session: CommandCodeCookieImporter.SessionInfo
-            do {
-                session = try CommandCodeCookieImporter.importSession()
-            } catch {
-                throw CommandCodeUsageError.missingCredentials
-            }
-            guard !session.cookies.isEmpty else {
-                throw CommandCodeUsageError.missingCredentials
-            }
-            cookieHeader = session.cookieHeader
-            sourceLabel = session.sourceLabel
-            #else
-            throw CommandCodeUsageError.missingCredentials
-            #endif
+            let snapshot = try await self.usageLoader(manual)
+            return self.makeResult(usage: snapshot.toUsageSnapshot(), sourceLabel: "manual")
         }
-        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(cookieHeader: cookieHeader)
-        return self.makeResult(
-            usage: snapshot.toUsageSnapshot(),
-            sourceLabel: sourceLabel)
+
+        let sessions: [CommandCodeResolvedSession]
+        do {
+            sessions = try self.sessionLoader()
+        } catch {
+            throw CommandCodeUsageError.missingCredentials
+        }
+
+        let candidates = sessions.filter { !$0.cookieHeader.isEmpty }
+        guard !candidates.isEmpty else { throw CommandCodeUsageError.missingCredentials }
+
+        return try await ProviderCandidateRetryRunner.run(
+            candidates,
+            shouldRetry: { error in
+                (error as? CommandCodeUsageError) == .invalidCredentials
+            },
+            attempt: { session in
+                let snapshot = try await self.usageLoader(session.cookieHeader)
+                return self.makeResult(
+                    usage: snapshot.toUsageSnapshot(),
+                    sourceLabel: session.sourceLabel)
+            })
     }
 
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
@@ -100,4 +115,21 @@ struct CommandCodeWebFetchStrategy: ProviderFetchStrategy {
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
         false
     }
+
+    private static func loadAutomaticSessions() throws -> [CommandCodeResolvedSession] {
+        #if os(macOS)
+        try CommandCodeCookieImporter.importSessions().map { session in
+            CommandCodeResolvedSession(
+                cookieHeader: session.cookieHeader,
+                sourceLabel: session.sourceLabel)
+        }
+        #else
+        []
+        #endif
+    }
+}
+
+struct CommandCodeResolvedSession: Sendable {
+    let cookieHeader: String
+    let sourceLabel: String
 }

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -187,6 +187,27 @@ struct BrowserDetectionTests {
     }
 
     @Test
+    func `Vivaldi uses its Chromium profile and Safe Storage metadata`() throws {
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let profile = temp
+            .appendingPathComponent("Library")
+            .appendingPathComponent("Application Support")
+            .appendingPathComponent("Vivaldi")
+            .appendingPathComponent("Default")
+            .appendingPathComponent("Network")
+        try FileManager.default.createDirectory(at: profile, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: profile.appendingPathComponent("Cookies").path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let detection = self.detection(homeDirectory: temp.path, installedBrowsers: [.vivaldi])
+
+        #expect(Browser.vivaldi.chromiumProfileRelativePath == "Vivaldi")
+        #expect(Self.labelIDs(for: .vivaldi).contains("Vivaldi Safe Storage|Vivaldi"))
+        #expect(Browser.defaultImportOrder.contains(.vivaldi))
+        #expect(detection.isCookieSourceAvailable(.vivaldi))
+    }
+
+    @Test
     func `process filters chromium candidates despite false global keychain override`() throws {
         guard ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1" else { return }
         KeychainAccessGate.resetOverrideForTesting()

--- a/Tests/CodexBarTests/CommandCodeProviderTests.swift
+++ b/Tests/CodexBarTests/CommandCodeProviderTests.swift
@@ -1,8 +1,24 @@
+import Foundation
 import Testing
 @testable import CodexBar
 @testable import CodexBarCore
 
 struct CommandCodeProviderTests {
+    private final class CookieAttemptRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var cookieHeaders: [String] = []
+
+        func append(_ cookieHeader: String) {
+            self.lock.withLock {
+                self.cookieHeaders.append(cookieHeader)
+            }
+        }
+
+        func snapshot() -> [String] {
+            self.lock.withLock { self.cookieHeaders }
+        }
+    }
+
     @Test
     func `descriptor metadata is correct`() {
         let descriptor = ProviderDescriptorRegistry.descriptor(for: .commandcode)
@@ -17,10 +33,81 @@ struct CommandCodeProviderTests {
 
     @Test
     func `manual cookie makes web strategy available`() async {
+        let context = self.makeContext(cookieSource: .manual, manualCookieHeader: "session=manual")
+
+        #expect(await CommandCodeWebFetchStrategy().isAvailable(context))
+    }
+
+    @Test
+    func `automatic cookie fetch retries Vivaldi after stale earlier browser session`() async throws {
+        let recorder = CookieAttemptRecorder()
+        let strategy = CommandCodeWebFetchStrategy(
+            usageLoader: { cookieHeader in
+                recorder.append(cookieHeader)
+                guard cookieHeader == "session=vivaldi" else {
+                    throw CommandCodeUsageError.invalidCredentials
+                }
+                return Self.snapshot()
+            },
+            sessionLoader: {
+                [
+                    CommandCodeResolvedSession(cookieHeader: "session=stale", sourceLabel: "Chrome Default"),
+                    CommandCodeResolvedSession(cookieHeader: "session=vivaldi", sourceLabel: "Vivaldi Default"),
+                ]
+            })
+
+        let result = try await strategy.fetch(self.makeContext(cookieSource: .auto))
+
+        #expect(recorder.snapshot() == ["session=stale", "session=vivaldi"])
+        #expect(result.sourceLabel == "Vivaldi Default")
+    }
+
+    @Test
+    func `automatic cookie fetch does not hide non-auth failure with later session`() async {
+        let recorder = CookieAttemptRecorder()
+        let strategy = CommandCodeWebFetchStrategy(
+            usageLoader: { cookieHeader in
+                recorder.append(cookieHeader)
+                throw CommandCodeUsageError.networkError("offline")
+            },
+            sessionLoader: {
+                [
+                    CommandCodeResolvedSession(cookieHeader: "session=first", sourceLabel: "Chrome Default"),
+                    CommandCodeResolvedSession(cookieHeader: "session=vivaldi", sourceLabel: "Vivaldi Default"),
+                ]
+            })
+
+        await #expect(throws: CommandCodeUsageError.networkError("offline")) {
+            try await strategy.fetch(self.makeContext(cookieSource: .auto))
+        }
+        #expect(recorder.snapshot() == ["session=first"])
+    }
+
+    @MainActor
+    @Test
+    func `implementation is registered`() {
+        #expect(ProviderCatalog.implementation(for: .commandcode) != nil)
+    }
+
+    private static func snapshot() -> CommandCodeUsageSnapshot {
+        CommandCodeUsageSnapshot(
+            monthlyCreditsRemaining: 10,
+            purchasedCredits: 0,
+            premiumMonthlyCredits: 0,
+            opensourceMonthlyCredits: 0,
+            plan: nil,
+            billingPeriodEnd: nil,
+            subscriptionStatus: nil)
+    }
+
+    private func makeContext(
+        cookieSource: ProviderCookieSource,
+        manualCookieHeader: String? = nil) -> ProviderFetchContext
+    {
         let browserDetection = BrowserDetection(cacheTTL: 0)
         let settings = ProviderSettingsSnapshot.make(
-            commandcode: .init(cookieSource: .manual, manualCookieHeader: "session=manual"))
-        let context = ProviderFetchContext(
+            commandcode: .init(cookieSource: cookieSource, manualCookieHeader: manualCookieHeader))
+        return ProviderFetchContext(
             runtime: .cli,
             sourceMode: .web,
             includeCredits: true,
@@ -32,13 +119,5 @@ struct CommandCodeProviderTests {
             fetcher: UsageFetcher(),
             claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
             browserDetection: browserDetection)
-
-        #expect(await CommandCodeWebFetchStrategy().isAvailable(context))
-    }
-
-    @MainActor
-    @Test
-    func `implementation is registered`() {
-        #expect(ProviderCatalog.implementation(for: .commandcode) != nil)
     }
 }

--- a/docs/command-code.md
+++ b/docs/command-code.md
@@ -28,8 +28,10 @@ Command Code support uses browser cookies or a manually pasted cookie header.
    and paste a `Cookie:` header/cURL capture from Command Code.
 
 Automatic import looks for better-auth session cookies from `commandcode.ai`
-and `www.commandcode.ai`. If automatic import cannot find a session, use the
-manual cookie field.
+and `www.commandcode.ai`. It tries each detected browser profile in order until
+one authenticates, so stale cookies in an earlier browser do not mask a later
+active session. If automatic import cannot find a session, use the manual cookie
+field.
 
 On Linux, browser import is unavailable. Set `cookieSource` to `manual` and
 provide the Command Code `Cookie` header in `cookieHeader`; both `auto` and


### PR DESCRIPTION
## Summary

- keep Command Code browser discovery on SweetCookieKit's full Chromium-family list, including Vivaldi
- retry later discovered browser sessions when an earlier session is rejected as unauthorized
- preserve immediate failure for network, decoding, cancellation, and other non-authentication errors
- document automatic multi-profile selection behavior

The Vivaldi metadata was already correct: `~/Library/Application Support/Vivaldi`, `Vivaldi Safe Storage`, and the `Vivaldi` account label. The bug was selection: Command Code used only the first discovered browser session, so a stale earlier Chrome/Safari-family cookie could mask a valid later Vivaldi session.

Refs #1155.

## Security review

- full contributor issue context and current importer path reviewed
- no new hosts, dependencies, credential storage, logging, or browser access boundaries
- only authentication rejection retries; other failures remain fail-fast

## Verification

- `swift test --filter 'CommandCodeProviderTests|BrowserDetectionTests|CommandCodeUsageFetcherTests'` — 55 tests, 3 suites passed
- `make check` — SwiftFormat clean; SwiftLint 0 violations; repository gates passed
- `make test` — 713 selections in 60 groups; 60 successful, 0 failed, 0 retries
- autoreview — one rejected false positive claiming a compile error; both focused and full Swift builds compiled the cited initializer successfully
