### PR TITLE
Harden Linux Claude swap invocation proof

### DIFF
--- a/TestsLinux/CLICardsClaudeSwapTests.swift
+++ b/TestsLinux/CLICardsClaudeSwapTests.swift
@@ -308,10 +308,17 @@ struct CLICardsClaudeSwapTests {
             .appendingPathComponent("cards-claude-swap-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let executable = directory.appendingPathComponent("cswap")
-        let arguments = directory.appendingPathComponent("arguments")
+        let invocationMarker = directory.appendingPathComponent("invoked", isDirectory: true)
+        let duplicateMarker = directory.appendingPathComponent("duplicate")
         let script = """
         #!/bin/sh
-        printf '%s\\n' "$@" >> '\(arguments.path)'
+        mkdir '\(invocationMarker.path)' || {
+          touch '\(duplicateMarker.path)'
+          exit 2
+        }
+        [ "$#" -eq 2 ] || exit 2
+        [ "$1" = "--list" ] || exit 2
+        [ "$2" = "--json" ] || exit 2
         cat <<'JSON'
         {"schemaVersion":1,"activeAccountNumber":2,"accounts":[
           {"number":1,"email":"one@example.com","active":false,"usageStatus":"api_key"},
@@ -327,11 +334,12 @@ struct CLICardsClaudeSwapTests {
             executablePath: executable.path,
             renderOptions: self.renderOptions(),
             ambientFetch: { self.ambientOutput() })
-        let invokedArguments = try String(contentsOf: arguments, encoding: .utf8)
 
-        #expect(invokedArguments == "--list\n--json\n")
-        #expect(!invokedArguments.contains("switch"))
+        #expect(output.exitCode == .success)
+        #expect(output.cardFailures.isEmpty)
         #expect(output.cards.count == 2)
+        #expect(FileManager.default.fileExists(atPath: invocationMarker.path))
+        #expect(!FileManager.default.fileExists(atPath: duplicateMarker.path))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- port the hardened claude-swap invocation proof to the Linux test copy
- verify the fake executable sees exactly one read-only list call by validating argv inside the script and using marker files for invocation/duplicate detection
- keep the change scoped to the Linux CI test that failed on current main

## Context
Current main CI run https://github.com/steipete/CodexBar/actions/runs/29632108080 failed in Linux x64 Swift Test (Linux only) with CLICardsClaudeSwapTests: the test expected the /tmp/.../arguments file to exist, but it was missing. The macOS/main test copy was already hardened in commit 7b63ab4f; this applies the same proof shape to TestsLinux/CLICardsClaudeSwapTests.swift.

## Tests
- swiftc -parse TestsLinux/CLICardsClaudeSwapTests.swift
- git diff --check
- make check
- Hosted CI on head f832115ba2ec9bec94a1c8c926183e6a2e2afe7a: build-linux-cli (linux-x64, ubuntu-24.04) passed: https://github.com/steipete/CodexBar/actions/runs/29632695641/job/88049381436
- Hosted CI on head f832115ba2ec9bec94a1c8c926183e6a2e2afe7a: build-linux-cli (linux-arm64, ubuntu-24.04-arm) passed: https://github.com/steipete/CodexBar/actions/runs/29632695641/job/88049381444
- Hosted CI on head f832115ba2ec9bec94a1c8c926183e6a2e2afe7a: aggregate lint-build-test passed: https://github.com/steipete/CodexBar/actions/runs/29632695641/job/88052085071

Not completed locally: swift test --filter CLICardsClaudeSwapTests stalled while downloading the Sparkle 2.9.3 SwiftPM binary artifact before tests executed. The touched target is Linux-only, so the green hosted Linux shards above are the execution proof for the failing shard.