### PR TITLE
fix: clamp ElevenLabs usage percent to 100%

### DIFF
--- a/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsUsageFetcher.swift
@@ -75,7 +75,7 @@ public struct ElevenLabsUsageSnapshot: Codable, Sendable, Equatable {
 
     public var usedPercent: Double {
         guard self.characterLimit > 0 else { return 0 }
-        return max(0, Double(self.characterCount) / Double(self.characterLimit) * 100)
+        return min(100, max(0, Double(self.characterCount) / Double(self.characterLimit) * 100))
     }
 
     public var remainingCharacters: Int {
@@ -127,7 +127,7 @@ public struct ElevenLabsUsageSnapshot: Codable, Sendable, Equatable {
                 id: "voice-slots",
                 title: "Voice slots",
                 window: RateWindow(
-                    usedPercent: Double(used) / Double(limit) * 100,
+                    usedPercent: min(100, max(0, Double(used) / Double(limit) * 100)),
                     windowMinutes: nil,
                     resetsAt: nil,
                     resetDescription: "\(used) / \(limit)")))
@@ -137,7 +137,7 @@ public struct ElevenLabsUsageSnapshot: Codable, Sendable, Equatable {
                 id: "professional-voices",
                 title: "Professional voices",
                 window: RateWindow(
-                    usedPercent: Double(used) / Double(limit) * 100,
+                    usedPercent: min(100, max(0, Double(used) / Double(limit) * 100)),
                     windowMinutes: nil,
                     resetsAt: nil,
                     resetDescription: "\(used) / \(limit)")))

--- a/TestsLinux/ElevenLabsUsageSnapshotLinuxTests.swift
+++ b/TestsLinux/ElevenLabsUsageSnapshotLinuxTests.swift
@@ -1,0 +1,53 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ElevenLabsUsageSnapshotLinuxTests {
+    private func snapshot(
+        characterCount: Int,
+        characterLimit: Int,
+        voiceSlotsUsed: Int? = nil,
+        voiceLimit: Int? = nil) -> ElevenLabsUsageSnapshot
+    {
+        ElevenLabsUsageSnapshot(
+            tier: "creator",
+            characterCount: characterCount,
+            characterLimit: characterLimit,
+            voiceSlotsUsed: voiceSlotsUsed,
+            professionalVoiceSlotsUsed: nil,
+            voiceLimit: voiceLimit,
+            professionalVoiceLimit: nil,
+            currentOverage: nil,
+            status: "active",
+            resetsAt: nil,
+            updatedAt: Date(timeIntervalSince1970: 0))
+    }
+
+    @Test
+    func `in-range character usage maps to its percent`() {
+        let usage = self.snapshot(characterCount: 25000, characterLimit: 100_000).toUsageSnapshot()
+        #expect(abs((usage.primary?.usedPercent ?? 0) - 25) < 0.01)
+    }
+
+    @Test
+    func `character overage clamps used percent to 100`() {
+        // ElevenLabs models overage explicitly (currentOverage), so characterCount > characterLimit
+        // is a real state. The percent must cap at 100 like sibling credit providers instead of
+        // flowing 150 into RateWindow.usedPercent (which does not clamp).
+        let usage = self.snapshot(characterCount: 150_000, characterLimit: 100_000).toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 100)
+    }
+
+    @Test
+    func `voice slot overage clamps used percent to 100`() {
+        let usage = self.snapshot(
+            characterCount: 0,
+            characterLimit: 100_000,
+            voiceSlotsUsed: 12,
+            voiceLimit: 10).toUsageSnapshot()
+        let voice = usage.extraRateWindows?.first { $0.id == "voice-slots" }
+        #expect(voice?.window.usedPercent == 100)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

`ElevenLabsUsageSnapshot` computes three `usedPercent` values **without** the `min(100, max(0, …))` clamp that every sibling credit provider applies — `OpenAIAPICreditBalanceFetcher`, `CommandCodeUsageSnapshot`, `CodebuffUsageSnapshot`, and the recently merged `AbacusUsageSnapshot` (#2265):

- `usedPercent` (character usage) applies a `max(0, …)` floor but **no ceiling** (`ElevenLabsUsageFetcher.swift:78`)
- both voice-slot windows apply **neither** bound (`:130`, `:140`)

ElevenLabs models overage explicitly via its `current_overage` field, so `characterCount > characterLimit` is a real, documented state. It flows e.g. `150000/100000 → 150` (and voice `12/10 → 120`) straight into `RateWindow.usedPercent`, which does not clamp — so the bar reads past full.

Same class as the merged #2255 (Cursor) and #2265 (Abacus) percent clamps.

## Fix

```diff
- return max(0, Double(self.characterCount) / Double(self.characterLimit) * 100)
+ return min(100, max(0, Double(self.characterCount) / Double(self.characterLimit) * 100))

- usedPercent: Double(used) / Double(limit) * 100,      // voice-slots  (x2)
+ usedPercent: min(100, max(0, Double(used) / Double(limit) * 100)),
```

Matches the sibling idiom. No behavior change for in-range values. The `characterLimit > 0` / `limit > 0` guards are untouched.

## Test

`TestsLinux/ElevenLabsUsageSnapshotLinuxTests.swift`:
- character overage `150000/100000 → 100` (was `150`)
- voice-slot overage `12/10 → 100` (was `120`)
- in-range guard `25000/100000 → 25`

## Proof (real run)

The suite runs on CI in the **`build-linux-cli`** job's "Swift Test (Linux only)" step (`swift test --parallel`). Local red→green run in `swift:6.3.3` (`x86_64-unknown-linux-gnu`), same inputs, clamp is the only difference:

**Before the fix** — clamps removed, overage flows through as `150` / `120`:
```
>>> line 78:  return max(0, Double(self.characterCount) / Double(self.characterLimit) * 100)
>>> line 130/140:  usedPercent: Double(used) / Double(limit) * 100,
✘ "character overage clamps used percent to 100": Expectation failed: (usage.primary?.usedPercent → 150.0) == 100
✘ "voice slot overage clamps used percent to 100": Expectation failed: (voice?.window.usedPercent → 120.0) == 100
✘ Test run with 3 tests in 1 suite failed with 2 issues.
```

**After the fix** — clamps applied (this PR):
```
✔ "voice slot overage clamps used percent to 100" passed
✔ "character overage clamps used percent to 100" passed
✔ "in-range character usage maps to its percent" passed
✔ Test run with 3 tests in 1 suite passed
```

Build clean, `swiftlint --strict` 0 violations, `swiftformat --lint` clean.

Small and self-contained — happy to adjust or close if the clamp-on-overage behavior isn't wanted.
