### PR TITLE
Normalize session equivalent forecasts

### DIFF
--- a/Sources/CodexBar/SessionEquivalentForecast.swift
+++ b/Sources/CodexBar/SessionEquivalentForecast.swift
@@ -151,12 +151,18 @@ struct SessionEquivalentForecast: Equatable, Sendable {
 enum SessionEquivalentBurnEstimator {
     static let defaultSampleLimit = 7
     static let minimumSampleCount = 3
-    private static let boundaryTolerance: TimeInterval = 75 * 60
+    private static let observationAlignmentTolerance: TimeInterval = 0
     private static let resetEquivalenceTolerance = SessionEquivalentForecast.resetTolerance
 
     private struct SessionGroup {
         let resetsAt: Date
+        var entries: [PlanUtilizationHistoryEntry]
         var maximumUsedPercent: Double
+    }
+
+    private struct BurnObservation {
+        let sessionUsedPercent: Double
+        let weeklyEntry: PlanUtilizationHistoryEntry
     }
 
     static func estimate(
@@ -208,11 +214,13 @@ enum SessionEquivalentBurnEstimator {
             if let lastIndex = groups.indices.last,
                abs(groups[lastIndex].resetsAt.timeIntervalSince(resetsAt)) <= Self.resetEquivalenceTolerance
             {
+                groups[lastIndex].entries.append(entry)
                 groups[lastIndex].maximumUsedPercent = max(groups[lastIndex].maximumUsedPercent, entry.usedPercent)
             } else {
                 guard groups.last.map({ $0.resetsAt <= resetsAt }) ?? true else { return nil }
                 groups.append(SessionGroup(
                     resetsAt: resetsAt,
+                    entries: [entry],
                     maximumUsedPercent: entry.usedPercent))
             }
         }
@@ -240,20 +248,11 @@ enum SessionEquivalentBurnEstimator {
         let candidateGroups = completedActiveGroups.prefix(sampleLimit)
         burns.reserveCapacity(candidateGroups.count)
         for group in candidateGroups {
-            let windowStart = group.resetsAt.addingTimeInterval(-sessionDuration)
-            guard let start = Self.nearestEntry(to: windowStart, entries: weeklyEntries),
-                  let end = Self.nearestEntry(to: group.resetsAt, entries: weeklyEntries),
-                  start.capturedAt < end.capturedAt,
-                  let startReset = start.resetsAt,
-                  let endReset = end.resetsAt,
-                  abs(startReset.timeIntervalSince(endReset)) <= Self.resetEquivalenceTolerance
-            else {
-                continue
-            }
-            let burn = end.usedPercent - start.usedPercent
-            guard burn.isFinite, burn > 0 else { continue }
-            let fullAllowanceBurn = 100 * burn / group.maximumUsedPercent
-            guard fullAllowanceBurn.isFinite, fullAllowanceBurn > 0 else { continue }
+            guard let fullAllowanceBurn = Self.normalizedBurn(
+                for: group,
+                weeklyEntries: weeklyEntries,
+                sessionDuration: sessionDuration)
+            else { continue }
             burns.append(fullAllowanceBurn)
         }
 
@@ -269,9 +268,87 @@ enum SessionEquivalentBurnEstimator {
             sampleCount: burns.count)
     }
 
+    private static func normalizedBurn(
+        for group: SessionGroup,
+        weeklyEntries: [PlanUtilizationHistoryEntry],
+        sessionDuration: TimeInterval) -> Double?
+    {
+        guard let firstSessionEntry = group.entries.first,
+              let lastSessionEntry = group.entries.last
+        else {
+            return nil
+        }
+
+        var observations: [BurnObservation] = []
+        let windowStart = group.resetsAt.addingTimeInterval(-sessionDuration)
+        if let weeklyStart = Self.nearestEntry(
+            to: windowStart,
+            entries: weeklyEntries,
+            tolerance: Self.resetEquivalenceTolerance),
+            weeklyStart.capturedAt <= windowStart,
+            weeklyStart.capturedAt < firstSessionEntry.capturedAt
+        {
+            observations.append(BurnObservation(sessionUsedPercent: 0, weeklyEntry: weeklyStart))
+        }
+
+        for sessionEntry in group.entries {
+            guard let weeklyEntry = Self.nearestEntry(
+                to: sessionEntry.capturedAt,
+                entries: weeklyEntries,
+                tolerance: Self.observationAlignmentTolerance)
+            else {
+                continue
+            }
+            observations.append(BurnObservation(
+                sessionUsedPercent: sessionEntry.usedPercent,
+                weeklyEntry: weeklyEntry))
+        }
+
+        if group.maximumUsedPercent >= 100,
+           let weeklyEnd = Self.nearestEntry(
+               to: group.resetsAt,
+               entries: weeklyEntries,
+               tolerance: Self.resetEquivalenceTolerance),
+           weeklyEnd.capturedAt <= group.resetsAt,
+           lastSessionEntry.capturedAt < weeklyEnd.capturedAt
+        {
+            observations.append(BurnObservation(sessionUsedPercent: 100, weeklyEntry: weeklyEnd))
+        }
+
+        observations.sort { lhs, rhs in
+            if lhs.weeklyEntry.capturedAt != rhs.weeklyEntry.capturedAt {
+                return lhs.weeklyEntry.capturedAt < rhs.weeklyEntry.capturedAt
+            }
+            return lhs.sessionUsedPercent < rhs.sessionUsedPercent
+        }
+        guard let start = observations.first,
+              let end = observations.last,
+              start.weeklyEntry.capturedAt < end.weeklyEntry.capturedAt,
+              let startReset = start.weeklyEntry.resetsAt,
+              let endReset = end.weeklyEntry.resetsAt,
+              abs(startReset.timeIntervalSince(endReset)) <= Self.resetEquivalenceTolerance
+        else {
+            return nil
+        }
+
+        let sessionConsumption = end.sessionUsedPercent - start.sessionUsedPercent
+        let weeklyBurn = end.weeklyEntry.usedPercent - start.weeklyEntry.usedPercent
+        guard sessionConsumption.isFinite,
+              sessionConsumption > 0,
+              weeklyBurn.isFinite,
+              weeklyBurn > 0
+        else {
+            return nil
+        }
+        let fullAllowanceBurn = 100 * weeklyBurn / sessionConsumption
+        guard fullAllowanceBurn.isFinite, fullAllowanceBurn > 0 else { return nil }
+        return fullAllowanceBurn
+    }
+
     private static func nearestEntry(
         to target: Date,
-        entries: [PlanUtilizationHistoryEntry]) -> PlanUtilizationHistoryEntry?
+        entries: [PlanUtilizationHistoryEntry],
+        tolerance: TimeInterval) -> PlanUtilizationHistoryEntry?
     {
         var lower = 0
         var upper = entries.count
@@ -292,7 +369,7 @@ enum SessionEquivalentBurnEstimator {
             candidates.append(entries[lower - 1])
         }
         return candidates
-            .filter { abs($0.capturedAt.timeIntervalSince(target)) <= Self.boundaryTolerance }
+            .filter { abs($0.capturedAt.timeIntervalSince(target)) <= tolerance }
             .min { lhs, rhs in
                 abs(lhs.capturedAt.timeIntervalSince(target)) < abs(rhs.capturedAt.timeIntervalSince(target))
             }

--- a/Sources/CodexBar/SessionEquivalentForecast.swift
+++ b/Sources/CodexBar/SessionEquivalentForecast.swift
@@ -284,7 +284,8 @@ enum SessionEquivalentBurnEstimator {
         if let weeklyStart = Self.nearestEntry(
             to: windowStart,
             entries: weeklyEntries,
-            tolerance: Self.resetEquivalenceTolerance),
+            tolerance: Self.resetEquivalenceTolerance,
+            requireNotAfterTarget: true),
             weeklyStart.capturedAt <= windowStart,
             weeklyStart.capturedAt < firstSessionEntry.capturedAt
         {
@@ -308,7 +309,8 @@ enum SessionEquivalentBurnEstimator {
            let weeklyEnd = Self.nearestEntry(
                to: group.resetsAt,
                entries: weeklyEntries,
-               tolerance: Self.resetEquivalenceTolerance),
+               tolerance: Self.resetEquivalenceTolerance,
+               requireNotAfterTarget: true),
            weeklyEnd.capturedAt <= group.resetsAt,
            lastSessionEntry.capturedAt < weeklyEnd.capturedAt
         {
@@ -348,7 +350,8 @@ enum SessionEquivalentBurnEstimator {
     private static func nearestEntry(
         to target: Date,
         entries: [PlanUtilizationHistoryEntry],
-        tolerance: TimeInterval) -> PlanUtilizationHistoryEntry?
+        tolerance: TimeInterval,
+        requireNotAfterTarget: Bool = false) -> PlanUtilizationHistoryEntry?
     {
         var lower = 0
         var upper = entries.count
@@ -369,6 +372,7 @@ enum SessionEquivalentBurnEstimator {
             candidates.append(entries[lower - 1])
         }
         return candidates
+            .filter { !requireNotAfterTarget || $0.capturedAt <= target }
             .filter { abs($0.capturedAt.timeIntervalSince(target)) <= tolerance }
             .min { lhs, rhs in
                 abs(lhs.capturedAt.timeIntervalSince(target)) < abs(rhs.capturedAt.timeIntervalSince(target))

--- a/Sources/CodexBar/SessionEquivalentForecast.swift
+++ b/Sources/CodexBar/SessionEquivalentForecast.swift
@@ -252,7 +252,9 @@ enum SessionEquivalentBurnEstimator {
             }
             let burn = end.usedPercent - start.usedPercent
             guard burn.isFinite, burn > 0 else { continue }
-            burns.append(burn)
+            let fullAllowanceBurn = 100 * burn / group.maximumUsedPercent
+            guard fullAllowanceBurn.isFinite, fullAllowanceBurn > 0 else { continue }
+            burns.append(fullAllowanceBurn)
         }
 
         guard burns.count >= Self.minimumSampleCount else { return nil }

--- a/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
+++ b/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
@@ -20,12 +20,8 @@ struct SessionEquivalentForecastTests {
     }
 
     @Test
-    func `normalizes partial session burn to a full allowance`() throws {
-        let fixture = Self.historyFixture(samples: [
-            (sessionUsedPercent: 20, weeklyBurnPercent: 2),
-            (sessionUsedPercent: 40, weeklyBurnPercent: 4),
-            (sessionUsedPercent: 100, weeklyBurnPercent: 10),
-        ])
+    func `normalizes aligned partial session observations to a full allowance`() throws {
+        let fixture = Self.alignedPartialHistoryFixture()
 
         let estimate = try #require(SessionEquivalentBurnEstimator.estimate(
             histories: fixture.histories,
@@ -34,6 +30,20 @@ struct SessionEquivalentForecastTests {
 
         #expect(estimate.sampleCount == 3)
         #expect(estimate.medianWeeklyPercentPerWindow == 10)
+    }
+
+    @Test
+    func `rejects partial sessions whose weekly burn cannot be aligned`() {
+        let fixture = Self.historyFixture(samples: [
+            (sessionUsedPercent: 20, weeklyBurnPercent: 2),
+            (sessionUsedPercent: 40, weeklyBurnPercent: 4),
+            (sessionUsedPercent: 60, weeklyBurnPercent: 6),
+        ])
+
+        #expect(SessionEquivalentBurnEstimator.estimate(
+            histories: fixture.histories,
+            currentSessionResetsAt: fixture.currentSessionReset,
+            now: fixture.currentSessionReset.addingTimeInterval(-3600)) == nil)
     }
 
     @Test
@@ -1409,5 +1419,55 @@ extension SessionEquivalentForecastTests {
                 planSeries(name: .weekly, windowMinutes: 10080, entries: weeklyEntries),
             ],
             currentSessionReset: start.addingTimeInterval(Double(samples.count + 1) * duration))
+    }
+
+    private static func alignedPartialHistoryFixture()
+        -> (histories: [PlanUtilizationSeriesHistory], currentSessionReset: Date)
+    {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let duration: TimeInterval = 5 * 3600
+        let weeklyReset = start.addingTimeInterval(7 * 24 * 3600)
+        let fullAllowanceBurn = 10.0
+        var sessionEntries: [PlanUtilizationHistoryEntry] = []
+        var weeklyEntries: [PlanUtilizationHistoryEntry] = []
+        var weeklyUsed = 0.0
+
+        for (index, sessionUsedPercent) in [20.0, 40.0, 100.0].enumerated() {
+            let windowStart = start.addingTimeInterval(Double(index) * duration)
+            let reset = windowStart.addingTimeInterval(duration)
+            let firstSessionUsedPercent = sessionUsedPercent / 4
+            let firstCapturedAt = windowStart.addingTimeInterval(30 * 60)
+            let lastCapturedAt = reset.addingTimeInterval(-30 * 60)
+            let firstWeeklyUsedPercent = weeklyUsed + fullAllowanceBurn * firstSessionUsedPercent / 100
+            let lastWeeklyUsedPercent = weeklyUsed + fullAllowanceBurn * sessionUsedPercent / 100
+
+            sessionEntries.append(planEntry(
+                at: firstCapturedAt,
+                usedPercent: firstSessionUsedPercent,
+                resetsAt: reset))
+            weeklyEntries.append(planEntry(
+                at: firstCapturedAt,
+                usedPercent: firstWeeklyUsedPercent,
+                resetsAt: weeklyReset))
+            sessionEntries.append(planEntry(
+                at: lastCapturedAt,
+                usedPercent: sessionUsedPercent,
+                resetsAt: reset))
+            weeklyEntries.append(planEntry(
+                at: lastCapturedAt,
+                usedPercent: lastWeeklyUsedPercent,
+                resetsAt: weeklyReset))
+            weeklyUsed = lastWeeklyUsedPercent
+        }
+
+        let histories = UsageStore._updatedPlanUtilizationHistoriesForTesting(
+            existingHistories: [],
+            samples: [
+                planSeries(name: .session, windowMinutes: 300, entries: sessionEntries),
+                planSeries(name: .weekly, windowMinutes: 10080, entries: weeklyEntries),
+            ]) ?? []
+        return (
+            histories: histories,
+            currentSessionReset: start.addingTimeInterval(4 * duration))
     }
 }

--- a/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
+++ b/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
@@ -47,6 +47,19 @@ struct SessionEquivalentForecastTests {
     }
 
     @Test
+    func `uses eligible boundary samples when a closer sample follows the boundary`() throws {
+        let fixture = Self.straddledBoundaryHistoryFixture()
+
+        let estimate = try #require(SessionEquivalentBurnEstimator.estimate(
+            histories: fixture.histories,
+            currentSessionResetsAt: fixture.currentSessionReset,
+            now: fixture.currentSessionReset.addingTimeInterval(-3600)))
+
+        #expect(estimate.sampleCount == 3)
+        #expect(estimate.medianWeeklyPercentPerWindow == 10)
+    }
+
+    @Test
     func `requires three completed windows with measurable burn`() {
         let fixture = Self.historyFixture(burns: [8, 12])
 
@@ -1469,5 +1482,54 @@ extension SessionEquivalentForecastTests {
         return (
             histories: histories,
             currentSessionReset: start.addingTimeInterval(4 * duration))
+    }
+
+    private static func straddledBoundaryHistoryFixture()
+        -> (histories: [PlanUtilizationSeriesHistory], currentSessionReset: Date)
+    {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let duration: TimeInterval = 5 * 3600
+        let stride: TimeInterval = 6 * 3600
+        let weeklyReset = start.addingTimeInterval(7 * 24 * 3600)
+        var sessionEntries: [PlanUtilizationHistoryEntry] = []
+        var weeklyEntries: [PlanUtilizationHistoryEntry] = []
+        var weeklyUsed = 0.0
+
+        for index in 0..<3 {
+            let windowStart = start.addingTimeInterval(Double(index) * stride)
+            let reset = windowStart.addingTimeInterval(duration)
+            sessionEntries.append(planEntry(
+                at: windowStart.addingTimeInterval(30 * 60),
+                usedPercent: 20,
+                resetsAt: reset))
+            sessionEntries.append(planEntry(
+                at: reset.addingTimeInterval(-30 * 60),
+                usedPercent: 100,
+                resetsAt: reset))
+            weeklyEntries.append(planEntry(
+                at: windowStart.addingTimeInterval(-90),
+                usedPercent: weeklyUsed,
+                resetsAt: weeklyReset))
+            weeklyEntries.append(planEntry(
+                at: windowStart.addingTimeInterval(30),
+                usedPercent: weeklyUsed,
+                resetsAt: weeklyReset))
+            weeklyUsed += 10
+            weeklyEntries.append(planEntry(
+                at: reset.addingTimeInterval(-90),
+                usedPercent: weeklyUsed,
+                resetsAt: weeklyReset))
+            weeklyEntries.append(planEntry(
+                at: reset.addingTimeInterval(30),
+                usedPercent: weeklyUsed,
+                resetsAt: weeklyReset))
+        }
+
+        return (
+            histories: [
+                planSeries(name: .session, windowMinutes: 300, entries: sessionEntries),
+                planSeries(name: .weekly, windowMinutes: 10080, entries: weeklyEntries),
+            ],
+            currentSessionReset: start.addingTimeInterval(3 * stride + duration))
     }
 }

--- a/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
+++ b/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
@@ -20,6 +20,23 @@ struct SessionEquivalentForecastTests {
     }
 
     @Test
+    func `normalizes partial session burn to a full allowance`() throws {
+        let fixture = Self.historyFixture(samples: [
+            (sessionUsedPercent: 20, weeklyBurnPercent: 2),
+            (sessionUsedPercent: 40, weeklyBurnPercent: 4),
+            (sessionUsedPercent: 100, weeklyBurnPercent: 10),
+        ])
+
+        let estimate = try #require(SessionEquivalentBurnEstimator.estimate(
+            histories: fixture.histories,
+            currentSessionResetsAt: fixture.currentSessionReset,
+            now: fixture.currentSessionReset.addingTimeInterval(-3600)))
+
+        #expect(estimate.sampleCount == 3)
+        #expect(estimate.medianWeeklyPercentPerWindow == 10)
+    }
+
+    @Test
     func `requires three completed windows with measurable burn`() {
         let fixture = Self.historyFixture(burns: [8, 12])
 
@@ -1354,6 +1371,15 @@ extension SessionEquivalentForecastTests {
     private static func historyFixture(burns: [Double])
         -> (histories: [PlanUtilizationSeriesHistory], currentSessionReset: Date)
     {
+        self.historyFixture(samples: burns.map {
+            (sessionUsedPercent: 100, weeklyBurnPercent: $0)
+        })
+    }
+
+    private static func historyFixture(
+        samples: [(sessionUsedPercent: Double, weeklyBurnPercent: Double)])
+        -> (histories: [PlanUtilizationSeriesHistory], currentSessionReset: Date)
+    {
         let start = Date(timeIntervalSince1970: 1_800_000_000)
         let duration: TimeInterval = 5 * 3600
         let weeklyReset = start.addingTimeInterval(7 * 24 * 3600)
@@ -1361,19 +1387,19 @@ extension SessionEquivalentForecastTests {
         var weeklyEntries: [PlanUtilizationHistoryEntry] = []
         var weeklyUsed = 0.0
 
-        for (index, burn) in burns.enumerated() {
+        for (index, sample) in samples.enumerated() {
             let windowStart = start.addingTimeInterval(Double(index) * duration)
             let reset = windowStart.addingTimeInterval(duration)
             sessionEntries.append(planEntry(
                 at: windowStart.addingTimeInterval(30 * 60),
-                usedPercent: 20,
+                usedPercent: min(20, sample.sessionUsedPercent),
                 resetsAt: reset))
             sessionEntries.append(planEntry(
                 at: reset.addingTimeInterval(-30 * 60),
-                usedPercent: 100,
+                usedPercent: sample.sessionUsedPercent,
                 resetsAt: reset))
             weeklyEntries.append(planEntry(at: windowStart, usedPercent: weeklyUsed, resetsAt: weeklyReset))
-            weeklyUsed += burn
+            weeklyUsed += sample.weeklyBurnPercent
             weeklyEntries.append(planEntry(at: reset, usedPercent: weeklyUsed, resetsAt: weeklyReset))
         }
 
@@ -1382,6 +1408,6 @@ extension SessionEquivalentForecastTests {
                 planSeries(name: .session, windowMinutes: 300, entries: sessionEntries),
                 planSeries(name: .weekly, windowMinutes: 10080, entries: weeklyEntries),
             ],
-            currentSessionReset: start.addingTimeInterval(Double(burns.count + 1) * duration))
+            currentSessionReset: start.addingTimeInterval(Double(samples.count + 1) * duration))
     }
 }


### PR DESCRIPTION
## Summary

- Measure weekly burn and session consumption over the same stored observation interval.
- Normalize aligned partial-session samples to a full five-hour allowance.
- Reject partial histories whose denominator cannot be established safely.
- Keep the existing provider/account/history isolation and median aggregation unchanged.

## Why

The merged estimator treated raw weekly burn from a partially used five-hour window as the cost of a full allowance. The first patch normalized by the window's maximum session usage, but that could cover a different time interval from the weekly delta.

The revised estimator pairs session and weekly observations captured by the same refresh, calculates both deltas over that shared interval, and then scales the result to a full allowance. Exact 0% and 100% boundary anchors remain supported; ambiguous partial samples are ignored.

The regression fixture passes 20%, 40%, and 100% partial-session histories through `UsageStore`'s hourly storage canonicalization. The previous implementation reported 12.5% weekly burn per full allowance; the interval-aligned implementation reports the expected 10% for all three samples.

## Validation

- `swift test --filter SessionEquivalentForecastTests` — 37 tests passed.
- `make check` — passed.
- `make test` — reached unrelated failures in untouched Claude OAuth/keychain ownership suites; the estimator suite passes independently.

Related: #2261
Follow-up to: #2274
