### PR TITLE
ci: add Linux musl build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       macos-tests-deferred: ${{ steps.macos-tests.outputs.macos-tests-deferred }}
       macos-tests-reason: ${{ steps.macos-tests.outputs.macos-tests-reason }}
       changed-path-count: ${{ steps.macos-tests.outputs.changed-path-count }}
+      linux-musl-build: ${{ steps.linux-musl-build.outputs.linux-musl-build }}
+      linux-musl-build-reason: ${{ steps.linux-musl-build.outputs.linux-musl-build-reason }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -57,23 +59,34 @@ jobs:
           sed 's/^/- /' "$changed_paths"
           ./Scripts/ci_macos_test_gate.sh "$changed_paths"
 
-      - name: Summarize macOS test gate
+      - name: Detect Linux musl build impact
+        id: linux-musl-build
+        shell: bash
+        run: ./Scripts/ci_linux_musl_build_gate.sh "$RUNNER_TEMP/changed-paths.txt"
+
+      - name: Summarize CI path gates
         if: ${{ always() }}
         shell: bash
         env:
           MACOS_TESTS: ${{ steps.macos-tests.outputs.macos-tests }}
           MACOS_TESTS_REASON: ${{ steps.macos-tests.outputs.macos-tests-reason }}
           CHANGED_PATH_COUNT: ${{ steps.macos-tests.outputs.changed-path-count }}
+          LINUX_MUSL_BUILD: ${{ steps.linux-musl-build.outputs.linux-musl-build }}
+          LINUX_MUSL_BUILD_REASON: ${{ steps.linux-musl-build.outputs.linux-musl-build-reason }}
         run: |
           set -euo pipefail
           reason="${MACOS_TESTS_REASON:-<unset>}"
           reason="${reason//|/\\|}"
+          musl_reason="${LINUX_MUSL_BUILD_REASON:-<unset>}"
+          musl_reason="${musl_reason//|/\\|}"
           {
-            printf '### macOS test gate\n\n'
+            printf '### CI path gates\n\n'
             printf '| Field | Value |\n'
             printf '| --- | --- |\n'
             printf '| macOS Swift tests required | `%s` |\n' "${MACOS_TESTS:-<unset>}"
-            printf '| Reason | %s |\n' "$reason"
+            printf '| macOS reason | %s |\n' "$reason"
+            printf '| Linux musl build required | `%s` |\n' "${LINUX_MUSL_BUILD:-<unset>}"
+            printf '| Linux musl reason | %s |\n' "$musl_reason"
             printf '| Changed path entries | `%s` |\n' "${CHANGED_PATH_COUNT:-<unset>}"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -167,18 +180,21 @@ jobs:
       - changes
       - lint
       - swift-test-macos
+      - build-linux-musl-cli
     if: ${{ always() && !cancelled() }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Verify lint and macOS test jobs
+      - name: Verify required CI jobs
         run: |
           ./Scripts/ci_verify_test_jobs.sh \
             "${{ needs.lint.result }}" \
             "${{ needs.changes.result }}" \
             "${{ needs.changes.outputs.macos-tests }}" \
             "${{ needs.swift-test-macos.result }}" \
-            "${{ needs.changes.outputs.macos-tests-deferred }}"
+            "${{ needs.changes.outputs.macos-tests-deferred }}" \
+            "${{ needs.changes.outputs.linux-musl-build }}" \
+            "${{ needs.build-linux-musl-cli.result }}"
 
       - name: Summarize aggregate CI gate
         if: ${{ always() }}
@@ -190,10 +206,15 @@ jobs:
           MACOS_TESTS_DEFERRED: ${{ needs.changes.outputs.macos-tests-deferred }}
           MACOS_TESTS_REASON: ${{ needs.changes.outputs.macos-tests-reason }}
           MACOS_RESULT: ${{ needs.swift-test-macos.result }}
+          LINUX_MUSL_BUILD: ${{ needs.changes.outputs.linux-musl-build }}
+          LINUX_MUSL_BUILD_REASON: ${{ needs.changes.outputs.linux-musl-build-reason }}
+          LINUX_MUSL_RESULT: ${{ needs.build-linux-musl-cli.result }}
         run: |
           set -euo pipefail
           reason="${MACOS_TESTS_REASON:-<unset>}"
           reason="${reason//|/\\|}"
+          musl_reason="${LINUX_MUSL_BUILD_REASON:-<unset>}"
+          musl_reason="${musl_reason//|/\\|}"
           {
             printf '### Aggregate CI gate\n\n'
             printf '| Field | Value |\n'
@@ -204,7 +225,184 @@ jobs:
             printf '| macOS Swift tests deferred | `%s` |\n' "${MACOS_TESTS_DEFERRED:-<unset>}"
             printf '| macOS gate reason | %s |\n' "$reason"
             printf '| swift-test-macos result | `%s` |\n' "$MACOS_RESULT"
+            printf '| Linux musl build required | `%s` |\n' "${LINUX_MUSL_BUILD:-<unset>}"
+            printf '| Linux musl gate reason | %s |\n' "$musl_reason"
+            printf '| build-linux-musl-cli result | `%s` |\n' "$LINUX_MUSL_RESULT"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  build-linux-musl-cli:
+    needs: changes
+    if: ${{ needs.changes.outputs.linux-musl-build == 'true' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      SWIFT_VERSION: 6.2.1
+      SWIFT_STATIC_LINUX_SDK: swift-6.2.1-RELEASE_static-linux-0.0.1
+      SWIFT_STATIC_LINUX_SDK_TRIPLE: x86_64-swift-linux-musl
+      SWIFT_STATIC_LINUX_SDK_ARCH: x86_64
+      SWIFT_STATIC_LINUX_SDK_URL: https://download.swift.org/swift-6.2.1-release/static-sdk/swift-6.2.1-RELEASE/swift-6.2.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz
+      SWIFT_STATIC_LINUX_SDK_CHECKSUM: 08e1939a504e499ec871b36826569173103e4562769e12b9b8c2a50f098374ad
+      SQLITE_AMALGAMATION_VERSION: "3530300"
+      SQLITE_AMALGAMATION_SHA3_256: d45c688a8cb23f68611a894a756a12d7eb6ab6e9e2468ca70adbeab3808b5ab9
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Runner info
+        run: |
+          set -euo pipefail
+          uname -a
+          uname -m
+          swift --version
+
+      - name: Install Swift ${{ env.SWIFT_VERSION }} via swiftly
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! command -v gpg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y ca-certificates gpg
+          fi
+
+          SWIFTLY_ARCH="$(uname -m)"
+          SWIFTLY_ARCHIVE="$RUNNER_TEMP/swiftly-${SWIFTLY_VERSION}-${SWIFTLY_ARCH}.tar.gz"
+          SWIFTLY_SIGNATURE="${SWIFTLY_ARCHIVE}.sig"
+          SWIFTLY_HOME_DIR="$HOME/.local/share/swiftly"
+          SWIFTLY_BIN_DIR="$HOME/.local/bin"
+          SWIFT_GNUPGHOME="$(mktemp -d)"
+          SWIFT_KEYS="$RUNNER_TEMP/swift-signing-keys.asc"
+          POST_INSTALL_SCRIPT="$(mktemp)"
+
+          mkdir -p "$SWIFTLY_BIN_DIR"
+          chmod 700 "$SWIFT_GNUPGHOME"
+          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${SWIFTLY_VERSION}-${SWIFTLY_ARCH}.tar.gz" -o "$SWIFTLY_ARCHIVE"
+          curl -fsSL "https://download.swift.org/swiftly/linux/swiftly-${SWIFTLY_VERSION}-${SWIFTLY_ARCH}.tar.gz.sig" -o "$SWIFTLY_SIGNATURE"
+          curl -fsSL --compressed "https://www.swift.org/keys/all-keys.asc" -o "$SWIFT_KEYS"
+          GNUPGHOME="$SWIFT_GNUPGHOME" gpg --batch --import "$SWIFT_KEYS"
+          SIGNATURE_STATUS="$(GNUPGHOME="$SWIFT_GNUPGHOME" gpg --batch --status-fd=1 \
+            --verify "$SWIFTLY_SIGNATURE" "$SWIFTLY_ARCHIVE" 2>&1)"
+          printf '%s\n' "$SIGNATURE_STATUS"
+          grep -Fq "[GNUPG:] VALIDSIG ${SWIFTLY_SIGNING_FINGERPRINT} " <<< "$SIGNATURE_STATUS"
+          tar -xzf "$SWIFTLY_ARCHIVE" -C /tmp
+          /tmp/swiftly init --assume-yes --skip-install
+
+          . "$SWIFTLY_HOME_DIR/env.sh"
+          echo "$SWIFTLY_BIN_DIR" >> "$GITHUB_PATH"
+          echo "SWIFTLY_HOME_DIR=$SWIFTLY_HOME_DIR" >> "$GITHUB_ENV"
+          echo "SWIFTLY_BIN_DIR=$SWIFTLY_BIN_DIR" >> "$GITHUB_ENV"
+
+          swiftly install "$SWIFT_VERSION" --use --assume-yes --verify --post-install-file "$POST_INSTALL_SCRIPT"
+          if [[ -s "$POST_INSTALL_SCRIPT" ]]; then
+            sudo apt-get update
+            sudo bash "$POST_INSTALL_SCRIPT"
+          fi
+
+          hash -r
+          swift --version
+
+      - name: Install Swift Static Linux SDK
+        shell: bash
+        run: |
+          set -euo pipefail
+          swift sdk install "$SWIFT_STATIC_LINUX_SDK_URL" --checksum "$SWIFT_STATIC_LINUX_SDK_CHECKSUM"
+          swift sdk list | grep -Fx "$SWIFT_STATIC_LINUX_SDK"
+
+          sdk_root="$(
+            find "$HOME" -type d -path "*/${SWIFT_STATIC_LINUX_SDK}.artifactbundle/${SWIFT_STATIC_LINUX_SDK}/swift-linux-musl" | head -n1
+          )"
+          if [[ -z "$sdk_root" ]]; then
+            echo "Swift SDK root not found." >&2
+            exit 1
+          fi
+
+          python3 - "$sdk_root/swift-sdk.json" "$SWIFT_STATIC_LINUX_SDK_TRIPLE" <<'PY'
+          import json
+          import sys
+
+          sdk_json_path, target_triple = sys.argv[1], sys.argv[2]
+          with open(sdk_json_path, encoding="utf-8") as handle:
+              sdk_json = json.load(handle)
+
+          target_triples = sdk_json.get("targetTriples", {})
+          if target_triple not in target_triples:
+              raise SystemExit(f"Swift SDK target triple not found: {target_triple}")
+
+          sdk_json["targetTriples"] = {target_triple: target_triples[target_triple]}
+          with open(sdk_json_path, "w", encoding="utf-8") as handle:
+              json.dump(sdk_json, handle, indent=2)
+              handle.write("\n")
+          PY
+
+          for sdk_arch in "$sdk_root"/musl-1.2.5.sdk/*; do
+            if [[ "$(basename "$sdk_arch")" != "$SWIFT_STATIC_LINUX_SDK_ARCH" ]]; then
+              rm -rf "$sdk_arch"
+            fi
+          done
+
+      - name: Build static SQLite for musl SDK
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing_packages=()
+          for tool in clang openssl unzip; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              missing_packages+=("$tool")
+            fi
+          done
+          if [[ "${#missing_packages[@]}" -gt 0 ]]; then
+            sudo apt-get update
+            sudo apt-get install -y "${missing_packages[@]}"
+          fi
+
+          sqlite_zip="$RUNNER_TEMP/sqlite-amalgamation-${SQLITE_AMALGAMATION_VERSION}.zip"
+          sqlite_src="$RUNNER_TEMP/sqlite-src"
+          sqlite_out="$RUNNER_TEMP/sqlite-${SWIFT_STATIC_LINUX_SDK_TRIPLE}"
+
+          curl -fsSL "https://www.sqlite.org/2026/sqlite-amalgamation-${SQLITE_AMALGAMATION_VERSION}.zip" -o "$sqlite_zip"
+          actual_sha3="$(openssl dgst -sha3-256 "$sqlite_zip" | awk '{print $NF}')"
+          if [[ "$actual_sha3" != "$SQLITE_AMALGAMATION_SHA3_256" ]]; then
+            echo "SQLite amalgamation checksum mismatch: $actual_sha3" >&2
+            exit 1
+          fi
+
+          rm -rf "$sqlite_src" "$sqlite_out"
+          mkdir -p "$sqlite_src" "$sqlite_out/build" "$sqlite_out/lib"
+          unzip -q "$sqlite_zip" -d "$sqlite_src"
+
+          sdk_bundle="$(
+            find "$HOME" -type d -name "${SWIFT_STATIC_LINUX_SDK}.artifactbundle" | head -n1
+          )"
+          if [[ -z "$sdk_bundle" ]]; then
+            echo "Swift SDK artifact bundle not found." >&2
+            exit 1
+          fi
+          sysroot="$sdk_bundle/$SWIFT_STATIC_LINUX_SDK/swift-linux-musl/musl-1.2.5.sdk/$SWIFT_STATIC_LINUX_SDK_ARCH"
+          if [[ ! -d "$sysroot" ]]; then
+            echo "Swift SDK sysroot not found: $sysroot" >&2
+            exit 1
+          fi
+
+          sqlite_amalgamation="$sqlite_src/sqlite-amalgamation-${SQLITE_AMALGAMATION_VERSION}"
+          mkdir -p "$sysroot/usr/include"
+          install -m 0644 "$sqlite_amalgamation/sqlite3.h" "$sysroot/usr/include/sqlite3.h"
+
+          clang \
+            -target "$SWIFT_STATIC_LINUX_SDK_TRIPLE" \
+            --sysroot="$sysroot" \
+            -O2 \
+            -DSQLITE_OMIT_LOAD_EXTENSION=1 \
+            -c "$sqlite_amalgamation/sqlite3.c" \
+            -o "$sqlite_out/build/sqlite3.o"
+          llvm-ar crs "$sqlite_out/lib/libsqlite3.a" "$sqlite_out/build/sqlite3.o"
+
+          echo "CODEXBAR_SQLITE3_LIB_DIR=$sqlite_out/lib" >> "$GITHUB_ENV"
+
+      - name: Build CodexBarCLI (release, Linux musl x86_64)
+        run: >-
+          swift build -c release --product CodexBarCLI
+          --swift-sdk "$SWIFT_STATIC_LINUX_SDK"
+          --triple "$SWIFT_STATIC_LINUX_SDK_TRIPLE"
 
   build-linux-cli:
     timeout-minutes: 20

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
     ],
     targets: {
         var targets: [Target] = [
-            // Host pkg-config paths contaminate cross-musl links; the module map supplies sqlite3 linkage.
+            // Both glibc and static-musl CLI builds use this target; the module map supplies sqlite3 linkage.
             .systemLibrary(
                 name: "CSQLite3",
                 providers: [

--- a/Scripts/ci_linux_musl_build_gate.sh
+++ b/Scripts/ci_linux_musl_build_gate.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+changed_paths_file="${1:-}"
+
+if [[ -z "$changed_paths_file" || ! -f "$changed_paths_file" ]]; then
+  printf 'Usage: %s <changed-paths-file>\n' "$(basename "$0")" >&2
+  exit 2
+fi
+
+linux_musl_build=false
+linux_musl_build_reason=""
+path_count=0
+
+require_linux_musl_build() {
+  local path="$1"
+  local reason="$2"
+
+  linux_musl_build=true
+  if [[ -z "$linux_musl_build_reason" ]]; then
+    linux_musl_build_reason="${path}: ${reason}"
+  fi
+}
+
+classify_path() {
+  local path="$1"
+  [[ -z "$path" ]] && return
+
+  path_count=$((path_count + 1))
+
+  case "$path" in
+    Package.swift)
+      require_linux_musl_build "$path" "changes the Swift package manifest"
+      ;;
+    Sources/*.swift)
+      require_linux_musl_build "$path" "changes Swift source code"
+      ;;
+  esac
+}
+
+invalid_row=false
+while IFS=$'\t' read -r status first_path second_path extra_path \
+  || [[ -n "${status:-}${first_path:-}${second_path:-}${extra_path:-}" ]]
+do
+  [[ -z "${status}${first_path:-}${second_path:-}${extra_path:-}" ]] && continue
+
+  case "$status" in
+    R*|C*)
+      if ! [[ "$status" =~ ^[RC][0-9]{1,3}$ ]] \
+        || ((10#${status:1} > 100)) \
+        || [[ -z "${first_path:-}" || -z "${second_path:-}" || -n "${extra_path:-}" ]]
+      then
+        invalid_row=true
+        break
+      fi
+      classify_path "$first_path"
+      classify_path "$second_path"
+      ;;
+    A|D|M|T|U|X|B)
+      if [[ -z "${first_path:-}" || -n "${second_path:-}" || -n "${extra_path:-}" ]]; then
+        invalid_row=true
+        break
+      fi
+      classify_path "$first_path"
+      ;;
+    *)
+      invalid_row=true
+      break
+      ;;
+  esac
+done < "$changed_paths_file"
+
+if [[ "$invalid_row" == true ]]; then
+  printf 'Invalid git name-status row; refusing to skip the Linux musl build.\n' >&2
+  exit 2
+fi
+
+if [[ "$path_count" -eq 0 ]]; then
+  require_linux_musl_build '<empty diff>' 'no changed paths were reported'
+fi
+
+if [[ "$linux_musl_build" == true ]]; then
+  summary_reason="$linux_musl_build_reason"
+else
+  summary_reason="no Swift source or Package.swift changes"
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  printf 'linux-musl-build=%s\n' "$linux_musl_build" >> "$GITHUB_OUTPUT"
+  printf 'linux-musl-build-reason=%s\n' "$summary_reason" >> "$GITHUB_OUTPUT"
+fi
+
+if [[ "$linux_musl_build" == true ]]; then
+  printf 'Linux musl build required for this change set: %s.\n' "$linux_musl_build_reason"
+else
+  printf 'Skipping Linux musl build: %s.\n' "$summary_reason"
+fi

--- a/Scripts/ci_verify_test_jobs.sh
+++ b/Scripts/ci_verify_test_jobs.sh
@@ -7,6 +7,8 @@ changes_result="${2:-}"
 macos_tests_required="${3:-}"
 macos_test_result="${4:-}"
 macos_tests_deferred="${5:-}"
+linux_musl_build_required="${6:-}"
+linux_musl_build_result="${7:-}"
 
 if [[ "$lint_result" != "success" ]]; then
   printf 'lint job finished with %s\n' "${lint_result:-<empty>}" >&2
@@ -33,6 +35,20 @@ case "${macos_tests_required}:${macos_tests_deferred}:${macos_test_result}" in
     printf 'macOS test gate/result mismatch: required=%s deferred=%s result=%s\n' \
       "${macos_tests_required:-<empty>}" "${macos_tests_deferred:-<empty>}" \
       "${macos_test_result:-<empty>}" >&2
+    exit 1
+    ;;
+esac
+
+case "${linux_musl_build_required}:${linux_musl_build_result}" in
+  true:success)
+    printf 'Linux musl CLI build passed.\n'
+    ;;
+  false:skipped)
+    printf 'Linux musl CLI build skipped by its path gate.\n'
+    ;;
+  *)
+    printf 'Linux musl build gate/result mismatch: required=%s result=%s\n' \
+      "${linux_musl_build_required:-<empty>}" "${linux_musl_build_result:-<empty>}" >&2
     exit 1
     ;;
 esac

--- a/Scripts/test_ci_path_gate.sh
+++ b/Scripts/test_ci_path_gate.sh
@@ -69,6 +69,41 @@ assert_gate true source-to-docs $'R100\tSources/CodexBar/App.swift\tdocs/App.md'
 assert_gate true docs-to-source $'R100\tdocs/App.md\tSources/CodexBar/App.swift'
 assert_gate false docs-to-site $'R100\tdocs/old.md\tdocs/site.css'
 
+assert_linux_musl_gate() {
+  local expected="$1"
+  local name="$2"
+  local paths_file="${tmp_dir}/linux-musl-${name}.paths"
+  local output_file="${tmp_dir}/linux-musl-${name}.output"
+  shift 2
+
+  printf '%s\n' "$@" > "$paths_file"
+  GITHUB_OUTPUT="$output_file" "${ROOT_DIR}/Scripts/ci_linux_musl_build_gate.sh" "$paths_file" >/dev/null
+  local actual
+  actual="$(sed -n 's/^linux-musl-build=//p' "$output_file")"
+  if [[ "$actual" != "$expected" ]]; then
+    printf '%s: expected linux-musl-build=%s, got %s\n' "$name" "$expected" "${actual:-<empty>}" >&2
+    exit 1
+  fi
+
+  local reason
+  reason="$(sed -n 's/^linux-musl-build-reason=//p' "$output_file")"
+  if [[ -z "$reason" ]]; then
+    printf '%s: expected linux-musl-build-reason output\n' "$name" >&2
+    exit 1
+  fi
+}
+
+assert_linux_musl_gate true package-manifest $'M\tPackage.swift'
+assert_linux_musl_gate true swift-source $'M\tSources/CodexBarCore/Process.swift'
+assert_linux_musl_gate true nested-swift-source $'M\tSources/CodexBarCore/Host/Process/Process.swift'
+assert_linux_musl_gate true rename-from-swift $'R100\tSources/CodexBarCore/Old.swift\tdocs/Old.md'
+assert_linux_musl_gate true rename-to-swift $'R100\tdocs/New.md\tSources/CodexBarCore/New.swift'
+assert_linux_musl_gate false tests-only $'M\tTests/CodexBarTests/ProcessTests.swift'
+assert_linux_musl_gate false workflow-only $'M\t.github/workflows/ci.yml'
+assert_linux_musl_gate false script-only $'M\tScripts/ci_verify_test_jobs.sh'
+assert_linux_musl_gate false package-resolved $'M\tPackage.resolved'
+assert_linux_musl_gate true empty-diff
+
 draft_paths="${tmp_dir}/draft-source.paths"
 draft_output="${tmp_dir}/draft-source.output"
 printf '%s\n' $'M\tSources/CodexBar/App.swift' > "$draft_paths"
@@ -122,6 +157,23 @@ assert_gate_fails missing-rename-score $'R\tREADME.md\tdocs/README.md'
 assert_gate_fails invalid-rename-score $'Rfoo\tREADME.md\tdocs/README.md'
 assert_gate_fails out-of-range-rename-score $'R101\tREADME.md\tdocs/README.md'
 
+for malformed_case in missing-rename-target extra-modified-path missing-rename-score \
+  invalid-rename-score out-of-range-rename-score
+do
+  paths_file="${tmp_dir}/${malformed_case}.paths"
+  output_file="${tmp_dir}/linux-musl-${malformed_case}.output"
+  if GITHUB_OUTPUT="$output_file" \
+    "${ROOT_DIR}/Scripts/ci_linux_musl_build_gate.sh" "$paths_file" >/dev/null 2>&1
+  then
+    printf '%s: malformed Linux musl gate input unexpectedly succeeded\n' "$malformed_case" >&2
+    exit 1
+  fi
+  if [[ -s "$output_file" ]]; then
+    printf '%s: malformed Linux musl gate input emitted an output\n' "$malformed_case" >&2
+    exit 1
+  fi
+done
+
 if CI_PULL_REQUEST_DRAFT=maybe GITHUB_OUTPUT="${tmp_dir}/invalid-draft.output" \
   "${ROOT_DIR}/Scripts/ci_macos_test_gate.sh" "${tmp_dir}/docs-only.paths" >/dev/null 2>&1
 then
@@ -144,8 +196,10 @@ if [[ -s "$unterminated_output" ]]; then
 fi
 
 verify="${ROOT_DIR}/Scripts/ci_verify_test_jobs.sh"
-"$verify" success success true success false >/dev/null
-"$verify" success success false skipped false >/dev/null
+"$verify" success success true success false true success >/dev/null
+"$verify" success success true success false false skipped >/dev/null
+"$verify" success success false skipped false true success >/dev/null
+"$verify" success success false skipped false false skipped >/dev/null
 
 assert_verify_fails() {
   if "$verify" "$@" >/dev/null 2>&1; then
@@ -154,13 +208,16 @@ assert_verify_fails() {
   fi
 }
 
-assert_verify_fails success success true skipped false
-assert_verify_fails success success true skipped true
-assert_verify_fails success success false skipped true
-assert_verify_fails success success true success true
-assert_verify_fails success success false success false
-assert_verify_fails success success "" skipped false
-assert_verify_fails failure success true success false
-assert_verify_fails success failure true success false
+assert_verify_fails success success true skipped false true success
+assert_verify_fails success success true skipped true true success
+assert_verify_fails success success false skipped true true success
+assert_verify_fails success success true success true true success
+assert_verify_fails success success false success false true success
+assert_verify_fails success success "" skipped false true success
+assert_verify_fails failure success true success false true success
+assert_verify_fails success failure true success false true success
+assert_verify_fails success success true success false true skipped
+assert_verify_fails success success true success false false success
+assert_verify_fails success success true success false "" skipped
 
-printf 'CI macOS path gate tests passed.\n'
+printf 'CI path gate tests passed.\n'

--- a/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
@@ -1,8 +1,6 @@
 import Foundation
-#if canImport(Glibc)
+#if os(Linux)
 import Glibc
-#elseif canImport(Musl)
-import Musl
 #endif
 
 package final class ProcessPipeCapture: @unchecked Sendable {

--- a/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
@@ -1,6 +1,8 @@
 import Foundation
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 package final class ProcessPipeCapture: @unchecked Sendable {

--- a/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
@@ -172,7 +172,11 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         var buffer = [UInt8](repeating: 0, count: 16 * 1024)
         while true {
             let bytesRead = buffer.withUnsafeMutableBytes { bytes in
+                #if canImport(Glibc)
                 Glibc.read(fileDescriptor, bytes.baseAddress, bytes.count)
+                #elseif canImport(Musl)
+                Musl.read(fileDescriptor, bytes.baseAddress, bytes.count)
+                #endif
             }
             if bytesRead > 0 {
                 receivedData = true
@@ -343,9 +347,17 @@ package final class ProcessPipeCapture: @unchecked Sendable {
     #if os(Linux)
     private static func makeNonBlocking(fileDescriptor: Int32) -> Bool {
         guard fileDescriptor >= 0 else { return false }
+        #if canImport(Glibc)
         let flags = Glibc.fcntl(fileDescriptor, F_GETFL)
+        #elseif canImport(Musl)
+        let flags = Musl.fcntl(fileDescriptor, F_GETFL)
+        #endif
         guard flags >= 0 else { return false }
+        #if canImport(Glibc)
         return Glibc.fcntl(fileDescriptor, F_SETFL, flags | O_NONBLOCK) == 0
+        #elseif canImport(Musl)
+        return Musl.fcntl(fileDescriptor, F_SETFL, flags | O_NONBLOCK) == 0
+        #endif
     }
     #endif
 }


### PR DESCRIPTION
## Summary

- add a build-only x86_64 Linux musl job to pull-request CI
- reuse the release CLI workflow's pinned Swift 6.2.1 static Linux SDK and static SQLite preparation
- run the job only for Swift source or Package.swift changes
- include the required-or-skipped result in the aggregate CI verifier
- use Musl-qualified process calls where the new check exposed remaining Glibc-only syscall references

## Why

Linux glibc builds do not catch imports or other compile paths that are unavailable under musl. This moves that compatibility check before release publication.

## Validation

- `make check`
- `./Scripts/test_ci_path_gate.sh`
- `actionlint .github/workflows/ci.yml`
- autoreview: clean, no accepted or actionable findings

## Negative control

- Deliberate Glibc-only head `79d3a163d`: [CI run 29651741449](https://github.com/steipete/CodexBar/actions/runs/29651741449). `build-linux-musl-cli` failed at `ProcessPipeCapture.swift:3:8` with `no such module 'Glibc'`.
- Clean fixed head `3183d563e`: [CI run 29652360695](https://github.com/steipete/CodexBar/actions/runs/29652360695). The Linux musl build, both glibc Linux builds, both macOS test shards, lint, path gate, and aggregate verifier all passed.
