### PR TITLE
Fix custom reset layout refresh

### DIFF
--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -1236,10 +1236,10 @@ extension StatusItemController {
         if !layoutResolution.usesLegacyRendering,
            self.settings.menuBarIconStyle == .iconAndPercent
         {
-            let showsCountdown = layoutResolution.layout.lines
+            let showsReset = layoutResolution.layout.lines
                 .joined()
-                .contains(.resetCountdown)
-            guard showsCountdown else { return [] }
+                .contains { $0 == .resetCountdown || $0 == .resetAbsolute }
+            guard showsReset else { return [] }
             let window = self.menuBarLayoutWindows(provider: provider, snapshot: snapshot, now: now).automatic
             return window?.resetsAt.map { [$0] } ?? []
         }

--- a/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
@@ -15,31 +15,45 @@ extension StatusItemController {
             && self.settings.menuBarShowsResetTimeWhenExhausted
             && displayMode != .resetTime
 
-        /// Reset dates for every lane whose menu-bar text is currently a reset time — including both
-        /// combined session/weekly lanes when the smart option surfaces reset text for each of them.
-        func resetDrivenResetDates() -> [Date] {
-            providers.flatMap { self.menuBarDisplayedResetDates(for: $0, now: now) }
+        var countdownResetDates: [Date] = []
+        var absoluteResetDates: [Date] = []
+        for provider in providers {
+            let resetDates = self.menuBarDisplayedResetDates(for: provider, now: now)
+            let resolution = self.settings.menuBarLayoutResolution(for: provider)
+            if !resolution.usesLegacyRendering,
+               self.settings.menuBarIconStyle == .iconAndPercent
+            {
+                let tokens = resolution.layout.lines.joined()
+                if tokens.contains(.resetCountdown) {
+                    countdownResetDates.append(contentsOf: resetDates)
+                }
+                if tokens.contains(.resetAbsolute) {
+                    absoluteResetDates.append(contentsOf: resetDates)
+                }
+                continue
+            }
+
+            guard self.settings.menuBarShowsBrandIconWithPercent,
+                  displayMode == .resetTime || smartExhaustedActive
+            else { continue }
+            switch self.settings.resetTimeDisplayStyle {
+            case .countdown:
+                countdownResetDates.append(contentsOf: resetDates)
+            case .absolute:
+                absoluteResetDates.append(contentsOf: resetDates)
+            }
         }
 
-        if self.settings.menuBarShowsBrandIconWithPercent,
-           self.settings.resetTimeDisplayStyle == .countdown,
-           displayMode == .resetTime || smartExhaustedActive
-        {
+        if let delay = Self.menuBarCountdownRefreshDelay(resetDates: countdownResetDates, now: now) {
             // Countdown text ticks every minute; refresh on each displayed-minute boundary (the last of
             // which lands at the reset, flipping a smart-exhausted lane back to the percentage).
-            if let delay = Self.menuBarCountdownRefreshDelay(resetDates: resetDrivenResetDates(), now: now) {
-                delays.append(delay)
-            }
-        } else if self.settings.menuBarShowsBrandIconWithPercent,
-                  self.settings.resetTimeDisplayStyle == .absolute,
-                  displayMode == .resetTime || smartExhaustedActive
-        {
+            delays.append(delay)
+        }
+        if let delay = Self.menuBarAbsoluteRefreshDelay(resetDates: absoluteResetDates, now: now) {
             // Absolute clocks don't tick each minute, but their human-friendly date label can change at
             // local midnight (for example, "tomorrow" becomes a same-day time). Wake at that boundary or
             // the reset itself, whichever comes first; the next icon update schedules any later boundary.
-            if let delay = Self.menuBarAbsoluteRefreshDelay(resetDates: resetDrivenResetDates(), now: now) {
-                delays.append(delay)
-            }
+            delays.append(delay)
         }
 
         if self.menuBarObservesCodexReset(providers: providers) {

--- a/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
+++ b/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
@@ -73,10 +73,7 @@ struct MenuBarCountdownRefreshTests {
 
     @Test
     func `status item schedules countdown and exhausted lane refreshes`() {
-        let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: "MenuBarCountdownRefreshTests-scheduling"),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+        let settings = testSettingsStore(suiteName: "MenuBarCountdownRefreshTests-scheduling")
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.menuBarShowsBrandIconWithPercent = true
@@ -196,6 +193,22 @@ struct MenuBarCountdownRefreshTests {
 
         controller.prepareForAppShutdown()
         #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+    }
+
+    @Test
+    func `custom countdown schedules independently of legacy reset settings`() throws {
+        try self.expectCustomResetTokenSchedules(
+            .resetCountdown,
+            legacyAbsoluteReset: true,
+            suiteName: "MenuBarCountdownRefreshTests-custom-countdown")
+    }
+
+    @Test
+    func `custom absolute reset schedules independently of legacy reset settings`() throws {
+        try self.expectCustomResetTokenSchedules(
+            .resetAbsolute,
+            legacyAbsoluteReset: false,
+            suiteName: "MenuBarCountdownRefreshTests-custom-absolute")
     }
 
     @Test
@@ -440,10 +453,7 @@ struct MenuBarCountdownRefreshTests {
 
     @Test
     func `merged highest usage observes reset for noncurrent Codex candidate`() throws {
-        let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: "MenuBarCountdownRefreshTests-merged-highest"),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+        let settings = testSettingsStore(suiteName: "MenuBarCountdownRefreshTests-merged-highest")
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
@@ -500,6 +510,63 @@ struct MenuBarCountdownRefreshTests {
 
         controller.updateIcons()
         #expect(controller.primaryProviderForUnifiedIcon() == .claude)
+        #expect(controller._test_isMenuBarCountdownRefreshScheduled())
+    }
+
+    private func expectCustomResetTokenSchedules(
+        _ token: MenuBarLayoutToken,
+        legacyAbsoluteReset: Bool,
+        suiteName: String) throws
+    {
+        let settings = testSettingsStore(suiteName: suiteName)
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.selectedMenuProvider = .claude
+        settings.menuBarIconStyle = .iconAndPercent
+        settings.menuBarDisplayMode = .percent
+        settings.menuBarShowsResetTimeWhenExhausted = false
+        settings.resetTimesShowAbsolute = legacyAbsoluteReset
+        settings.setMenuBarLayout(MenuBarLayout(lines: [[.icon, token]]), for: .claude)
+
+        let registry = ProviderRegistry.shared
+        try settings.setProviderEnabled(
+            provider: .codex,
+            metadata: #require(registry.metadata[.codex]),
+            enabled: false)
+        try settings.setProviderEnabled(
+            provider: .claude,
+            metadata: #require(registry.metadata[.claude]),
+            enabled: true)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let now = Date()
+        let reset = now.addingTimeInterval(90)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 42,
+                    windowMinutes: 300,
+                    resetsAt: reset,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now),
+            provider: .claude)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        #expect(controller.menuBarDisplayedResetDates(for: .claude, now: now) == [reset])
         #expect(controller._test_isMenuBarCountdownRefreshScheduled())
     }
 }

--- a/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
+++ b/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
@@ -514,7 +514,7 @@ struct MenuBarCountdownRefreshTests {
     }
 
     private func expectCustomResetTokenSchedules(
-        _ token: MenuBarLayoutToken,
+        _ layoutElement: MenuBarLayoutToken,
         legacyAbsoluteReset: Bool,
         suiteName: String) throws
     {
@@ -527,7 +527,7 @@ struct MenuBarCountdownRefreshTests {
         settings.menuBarDisplayMode = .percent
         settings.menuBarShowsResetTimeWhenExhausted = false
         settings.resetTimesShowAbsolute = legacyAbsoluteReset
-        settings.setMenuBarLayout(MenuBarLayout(lines: [[.icon, token]]), for: .claude)
+        settings.setMenuBarLayout(MenuBarLayout(lines: [[.icon, layoutElement]]), for: .claude)
 
         let registry = ProviderRegistry.shared
         try settings.setProviderEnabled(


### PR DESCRIPTION
## Summary

- schedule menu-bar refreshes from the active custom layout's reset tokens instead of unused legacy display settings
- handle both Reset Countdown minute boundaries and Reset Time absolute/reset boundaries
- add focused regression coverage and isolate scheduler tests from shared user defaults

## Root cause

Custom layouts rendered reset tokens directly, but refresh scheduling remained gated by the legacy menu-bar display mode and reset-time style. The displayed-reset-date helper also recognized only the countdown token, so an absolute reset token could remain stale.

## Impact

Custom reset labels now refresh at the boundaries required by the token that is actually displayed, while legacy rendering behavior remains unchanged.

## Validation

- `swift test --no-parallel --filter MenuBarCountdownRefreshTests`
- neighboring 12-suite batch: 147 tests passed
- `make check`
- `make test`: 716 selections across 60 groups passed on the first attempt with zero retries

Closes #2299