### PR TITLE
Fix custom menu bar cost refresh

### DIFF
--- a/Sources/CodexBar/StatusItemController+IconObservation.swift
+++ b/Sources/CodexBar/StatusItemController+IconObservation.swift
@@ -44,6 +44,9 @@ extension StatusItemController {
             showUsed: self.settings.usageBarsShowUsed)
         let creditsRemaining = self.menuBarCreditsRemainingForIcon(provider: provider, snapshot: snapshot)
         let displayText = showBrandPercent ? self.menuBarDisplayText(for: provider, snapshot: snapshot) : nil
+        let layoutCostSignature = showBrandPercent
+            ? self.storedMenuBarLayoutCostSignature(for: provider)
+            : nil
 
         return [
             provider.rawValue,
@@ -56,6 +59,23 @@ extension StatusItemController {
             "anim=\(self.shouldAnimate(provider: provider) ? "1" : "0")",
             "refreshing=\(self.store.refreshingProviders.contains(provider) ? "1" : "0")",
             "text=\(displayText ?? "nil")",
+            "layoutCost=\(layoutCostSignature ?? "nil")",
         ].joined(separator: "|")
+    }
+
+    private func storedMenuBarLayoutCostSignature(for provider: UsageProvider) -> String? {
+        let resolution = self.settings.menuBarLayoutResolution(for: provider)
+        guard !resolution.usesLegacyRendering else { return nil }
+
+        let tokens = resolution.layout.lines.joined()
+        let showsToday = tokens.contains(.costToday)
+        let showsLast30Days = tokens.contains(.cost30d)
+        guard showsToday || showsLast30Days else { return nil }
+
+        let costs = self.menuBarLayoutCostStrings(provider: provider)
+        return [
+            "today=\(showsToday ? costs.today ?? "nil" : "unused")",
+            "last30Days=\(showsLast30Days ? costs.last30Days ?? "nil" : "unused")",
+        ].joined(separator: ",")
     }
 }

--- a/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
+++ b/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
@@ -60,8 +60,7 @@ extension StatusItemController {
         let runsOut = paceWindow
             .flatMap { self.store.weeklyPace(provider: provider, window: $0, now: now) }
             .flatMap { UsagePaceText.weeklyDetail(provider: provider, pace: $0, now: now).rightLabel }
-        let costSnapshot = self.store.tokenSnapshotForCurrentProviderConfig(for: provider)?.snapshot
-        let costToday = MenuBarLayoutCostResolver.todayCostUSD(snapshot: costSnapshot, now: now)
+        let costStrings = self.menuBarLayoutCostStrings(provider: provider, now: now)
         let providerName = L(self.store.metadata(for: provider).displayName)
         let rawAccountLabel = snapshot?.accountEmail(for: provider)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -77,12 +76,24 @@ extension StatusItemController {
             weekly: MenuBarLayoutRenderWindow(windows.weekly),
             automatic: MenuBarLayoutRenderWindow(windows.automatic),
             runsOut: runsOut,
-            costToday: costToday.map {
-                UsageFormatter.currencyString($0, currencyCode: costSnapshot?.currencyCode ?? "USD")
-            },
-            cost30d: costSnapshot?.last30DaysCostUSD.map {
-                UsageFormatter.currencyString($0, currencyCode: costSnapshot?.currencyCode ?? "USD")
-            })
+            costToday: costStrings.today,
+            cost30d: costStrings.last30Days)
+    }
+
+    func menuBarLayoutCostStrings(
+        provider: UsageProvider,
+        now: Date = .init())
+        -> (today: String?, last30Days: String?)
+    {
+        let snapshot = self.store.tokenSnapshotForCurrentProviderConfig(for: provider)?.snapshot
+        let currencyCode = snapshot?.currencyCode ?? "USD"
+        let today = MenuBarLayoutCostResolver.todayCostUSD(snapshot: snapshot, now: now).map {
+            UsageFormatter.currencyString($0, currencyCode: currencyCode)
+        }
+        let last30Days = snapshot?.last30DaysCostUSD.map {
+            UsageFormatter.currencyString($0, currencyCode: currencyCode)
+        }
+        return (today, last30Days)
     }
 
     func menuBarLayoutWindows(

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -54,6 +54,7 @@ extension UsageStore {
         _ = self.openAIDashboardRequiresLogin
         _ = self.refreshingProviders
         _ = self.statuses
+        _ = self.tokenSnapshotPublications
         _ = self.historicalPaceRevision
         return 0
     }

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -251,10 +251,10 @@ struct StatusItemIconObservationSignatureTests {
     }
 
     @Test(arguments: [MenuBarLayoutToken.costToday, .cost30d])
-    func `custom cost token changes the store icon observation signature`(token: MenuBarLayoutToken) {
+    func `custom cost token changes the store icon observation signature`(layoutToken: MenuBarLayoutToken) {
         let (_, store, controller) = self.makeController(
-            suiteName: "StatusItemIconObservationSignatureTests-custom-cost-\(token)",
-            menuBarLayout: MenuBarLayout(lines: [[token]]))
+            suiteName: "StatusItemIconObservationSignatureTests-custom-cost-\(layoutToken)",
+            menuBarLayout: MenuBarLayout(lines: [[layoutToken]]))
         defer { controller.releaseStatusItemsForTesting() }
 
         let baseline = controller.storeIconObservationSignature()

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -251,10 +251,10 @@ struct StatusItemIconObservationSignatureTests {
     }
 
     @Test(arguments: [MenuBarLayoutToken.costToday, .cost30d])
-    func `custom cost token changes the store icon observation signature`(layoutToken: MenuBarLayoutToken) {
+    func `custom cost token changes the store icon observation signature`(layoutElement: MenuBarLayoutToken) {
         let (_, store, controller) = self.makeController(
-            suiteName: "StatusItemIconObservationSignatureTests-custom-cost-\(layoutToken)",
-            menuBarLayout: MenuBarLayout(lines: [[layoutToken]]))
+            suiteName: "StatusItemIconObservationSignatureTests-custom-cost-\(layoutElement)",
+            menuBarLayout: MenuBarLayout(lines: [[layoutElement]]))
         defer { controller.releaseStatusItemsForTesting() }
 
         let baseline = controller.storeIconObservationSignature()

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -6,11 +6,12 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct StatusItemIconObservationSignatureTests {
-    private func makeController(suiteName: String) -> (SettingsStore, UsageStore, StatusItemController) {
-        let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: suiteName),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+    private func makeController(
+        suiteName: String,
+        menuBarLayout: MenuBarLayout? = nil)
+        -> (SettingsStore, UsageStore, StatusItemController)
+    {
+        let settings = testSettingsStore(suiteName: suiteName)
         settings.statusChecksEnabled = true
         settings.refreshFrequency = .manual
         settings.usageBarsShowUsed = false
@@ -20,6 +21,10 @@ struct StatusItemIconObservationSignatureTests {
         settings.mergeIcons = true
         settings.mergedMenuLastSelectedWasOverview = false
         settings.selectedMenuProvider = .codex
+        if let menuBarLayout {
+            settings.menuBarShowsBrandIconWithPercent = true
+            settings.setMenuBarLayout(menuBarLayout, for: nil)
+        }
 
         let registry = ProviderRegistry.shared
         if let codexMeta = registry.metadata[.codex] {
@@ -245,6 +250,68 @@ struct StatusItemIconObservationSignatureTests {
         #expect(controller.storeIconObservationSignature() != baseline)
     }
 
+    @Test(arguments: [MenuBarLayoutToken.costToday, .cost30d])
+    func `custom cost token changes the store icon observation signature`(token: MenuBarLayoutToken) {
+        let (_, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-custom-cost-\(token)",
+            menuBarLayout: MenuBarLayout(lines: [[token]]))
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let baseline = controller.storeIconObservationSignature()
+
+        store._setTokenSnapshotForTesting(
+            Self.makeTokenSnapshot(todayCost: 1.25, last30DaysCost: 12.50),
+            provider: .codex)
+
+        #expect(controller.storeIconObservationSignature() != baseline)
+    }
+
+    @Test
+    func `custom cost layout ignores token fields it does not render`() {
+        let (_, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-custom-cost-irrelevant",
+            menuBarLayout: MenuBarLayout(lines: [[.cost30d]]))
+        defer { controller.releaseStatusItemsForTesting() }
+
+        store._setTokenSnapshotForTesting(
+            Self.makeTokenSnapshot(todayCost: 1.25, last30DaysCost: 12.50, sessionTokens: 100),
+            provider: .codex)
+        let baseline = controller.storeIconObservationSignature()
+
+        store._setTokenSnapshotForTesting(
+            Self.makeTokenSnapshot(todayCost: 9.99, last30DaysCost: 12.50, sessionTokens: 999),
+            provider: .codex)
+
+        #expect(controller.storeIconObservationSignature() == baseline)
+    }
+
+    @Test
+    func `token cost publication enters the icon refresh path without a usage change`() async {
+        let (_, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-custom-cost-title",
+            menuBarLayout: MenuBarLayout(lines: [[.cost30d]]))
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.updateIcons()
+        let baseline = controller.lastObservedStoreIconWorkSignature
+        let usageUpdatedAt = store.snapshot(for: .codex)?.updatedAt
+        let usagePrimaryPercent = store.snapshot(for: .codex)?.primary?.usedPercent
+
+        store._setTokenSnapshotForTesting(
+            Self.makeTokenSnapshot(todayCost: 1.25, last30DaysCost: 12.50),
+            provider: .codex)
+
+        for _ in 0..<100 where controller.lastObservedStoreIconWorkSignature == baseline {
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(store.snapshot(for: .codex)?.updatedAt == usageUpdatedAt)
+        #expect(store.snapshot(for: .codex)?.primary?.usedPercent == usagePrimaryPercent)
+        #expect(controller.lastObservedStoreIconWorkSignature != baseline)
+        #expect(
+            controller.menuBarLayoutCostStrings(provider: .codex).last30Days ==
+                UsageFormatter.currencyString(12.50, currencyCode: "USD"))
+    }
+
     @Test
     func `display settings persist cached widget snapshot`() async {
         let (settings, store, controller) = self.makeController(
@@ -360,5 +427,35 @@ struct StatusItemIconObservationSignatureTests {
                 accountEmail: "copilot@example.com",
                 accountOrganization: nil,
                 loginMethod: "individual"))
+    }
+
+    private static func makeTokenSnapshot(
+        todayCost: Double,
+        last30DaysCost: Double,
+        sessionTokens: Int? = nil,
+        now: Date = .init())
+        -> CostUsageTokenSnapshot
+    {
+        let formatter = DateFormatter()
+        formatter.calendar = .current
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd"
+        return CostUsageTokenSnapshot(
+            sessionTokens: sessionTokens,
+            sessionCostUSD: nil,
+            last30DaysTokens: nil,
+            last30DaysCostUSD: last30DaysCost,
+            daily: [
+                CostUsageDailyReport.Entry(
+                    date: formatter.string(from: now),
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: nil,
+                    costUSD: todayCost,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            updatedAt: now)
     }
 }


### PR DESCRIPTION
## Summary

- Observe token-cost snapshot publications in the menu-bar icon/title refresh path.
- Include only the formatted cost strings used by active custom `Cost Today` and `30d Cost` layout tokens in the icon observation signature.
- Share cost formatting between rendering and observation, and add focused regression coverage for cost-only publications and irrelevant token-data changes.

## Root cause

Custom menu-bar cost tokens render from token-cost snapshots, but the icon observer did not observe token snapshot publication state. Menu contents were invalidated, while the status-item title could remain stale until an unrelated usage or settings change triggered icon work.

## Impact

Custom cost tokens now update as soon as their rendered value changes. Token snapshot fields that are not displayed by the active layout do not trigger unnecessary title rendering.

Closes #2300.

## Validation

- `swift test --filter StatusItemIconObservationSignatureTests` — 17 tests passed on the rebased commit.
- `swift test --skip-build --filter MenuBarCountdownRefreshTests` — 10 tests passed.
- `make check` — formatting, strict lint, locale, documentation, packaging, and repository checks passed on the rebased commit.
- `make test` — all 716 selections passed; one 12-suite group exceeded the aggregate timeout and all 12 suites passed through the harness's isolated retries.
