### PR TITLE
Prefer OpenCode Go local usage in Auto mode

### DIFF
--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -50,8 +50,8 @@ public enum OpenCodeGoProviderDescriptor {
             return [OpenCodeGoUsageFetchStrategy()]
         }
         return [
-            OpenCodeGoUsageFetchStrategy(),
             OpenCodeGoLocalUsageFetchStrategy(),
+            OpenCodeGoUsageFetchStrategy(),
         ]
     }
 }

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -49,10 +49,33 @@ public enum OpenCodeGoProviderDescriptor {
         if context.sourceMode == .web {
             return [OpenCodeGoUsageFetchStrategy()]
         }
+        if self.requiresScopedWebStrategy(context: context) {
+            return [
+                OpenCodeGoUsageFetchStrategy(),
+                OpenCodeGoLocalUsageFetchStrategy(),
+            ]
+        }
         return [
             OpenCodeGoLocalUsageFetchStrategy(),
             OpenCodeGoUsageFetchStrategy(),
         ]
+    }
+
+    private static func requiresScopedWebStrategy(context: ProviderFetchContext) -> Bool {
+        guard context.sourceMode == .auto else { return false }
+        if context.selectedTokenAccountID != nil { return true }
+        if context.settings?.opencodego?.cookieSource == .manual { return true }
+        if self.normalizedWorkspaceID(context.settings?.opencodego?.workspaceID) != nil { return true }
+        return self.normalizedWorkspaceID(context.env["CODEXBAR_OPENCODEGO_WORKSPACE_ID"]) != nil
+    }
+
+    private static func normalizedWorkspaceID(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+        return trimmed
     }
 }
 

--- a/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
@@ -34,11 +34,11 @@ struct OpenCodeGoProviderStrategyTests {
     }
 
     @Test
-    func `auto source prefers web before local fallback`() async {
+    func `auto source prefers local history before web fallback`() async {
         let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
         let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(self.makeContext())
 
-        #expect(strategies.map(\.id) == ["opencodego.web", "opencodego.local"])
+        #expect(strategies.map(\.id) == ["opencodego.local", "opencodego.web"])
     }
 
     @Test
@@ -50,7 +50,22 @@ struct OpenCodeGoProviderStrategyTests {
     }
 
     @Test
-    func `web strategy falls back to local only for auth setup failures in auto mode`() {
+    func `local strategy falls through to web when local history is unavailable`() {
+        let strategy = OpenCodeGoLocalUsageFetchStrategy()
+        let context = self.makeContext()
+
+        #expect(strategy.shouldFallback(on: OpenCodeGoLocalUsageError.notDetected, context: context))
+        #expect(strategy.shouldFallback(
+            on: OpenCodeGoLocalUsageError.historyUnavailable("database not found"),
+            context: context))
+        #expect(strategy.shouldFallback(
+            on: OpenCodeGoLocalUsageError.sqliteFailed("database is locked"),
+            context: context))
+        #expect(!strategy.shouldFallback(on: OpenCodeGoUsageError.networkError("timeout"), context: context))
+    }
+
+    @Test
+    func `web strategy falls through only for auth setup failures in auto mode`() {
         let strategy = OpenCodeGoUsageFetchStrategy()
         let autoContext = self.makeContext()
         let webContext = self.makeContext(sourceMode: .web)

--- a/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
@@ -91,6 +91,22 @@ struct OpenCodeGoProviderStrategyTests {
     }
 
     @Test
+    func `auto source treats blank workspace overrides as unscoped`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let settings = ProviderSettingsSnapshot.make(opencodego: .init(
+            cookieSource: .auto,
+            manualCookieHeader: nil,
+            workspaceID: " \n "))
+        let settingsStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(settings: settings))
+        let environmentStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(env: ["CODEXBAR_OPENCODEGO_WORKSPACE_ID": " \t "]))
+
+        #expect(settingsStrategies.map(\.id) == ["opencodego.local", "opencodego.web"])
+        #expect(environmentStrategies.map(\.id) == ["opencodego.local", "opencodego.web"])
+    }
+
+    @Test
     func `web source does not include local fallback`() async {
         let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
         let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(self.makeContext(sourceMode: .web))

--- a/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
@@ -17,9 +17,13 @@ struct OpenCodeGoProviderStrategyTests {
         }
     }
 
-    private func makeContext(sourceMode: ProviderSourceMode = .auto) -> ProviderFetchContext {
-        let env: [String: String] = [:]
-        return ProviderFetchContext(
+    private func makeContext(
+        sourceMode: ProviderSourceMode = .auto,
+        env: [String: String] = [:],
+        settings: ProviderSettingsSnapshot? = nil,
+        selectedTokenAccountID: UUID? = nil) -> ProviderFetchContext
+    {
+        ProviderFetchContext(
             runtime: .app,
             sourceMode: sourceMode,
             includeCredits: false,
@@ -27,18 +31,63 @@ struct OpenCodeGoProviderStrategyTests {
             webDebugDumpHTML: false,
             verbose: false,
             env: env,
-            settings: nil,
+            settings: settings,
             fetcher: UsageFetcher(environment: env),
             claudeFetcher: StubClaudeFetcher(),
-            browserDetection: BrowserDetection(cacheTTL: 0))
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            selectedTokenAccountID: selectedTokenAccountID)
     }
 
     @Test
-    func `auto source prefers local history before web fallback`() async {
+    func `unscoped auto source prefers local history before web fallback`() async {
         let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
         let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(self.makeContext())
 
         #expect(strategies.map(\.id) == ["opencodego.local", "opencodego.web"])
+    }
+
+    @Test
+    func `auto source tries web before local for selected token accounts`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(selectedTokenAccountID: UUID()))
+
+        #expect(strategies.map(\.id) == ["opencodego.web", "opencodego.local"])
+    }
+
+    @Test
+    func `auto source tries web before local for manual cookies`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let settings = ProviderSettingsSnapshot.make(opencodego: .init(
+            cookieSource: .manual,
+            manualCookieHeader: "auth=selected",
+            workspaceID: nil))
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(settings: settings))
+
+        #expect(strategies.map(\.id) == ["opencodego.web", "opencodego.local"])
+    }
+
+    @Test
+    func `auto source tries web before local for configured workspaces`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let settings = ProviderSettingsSnapshot.make(opencodego: .init(
+            cookieSource: .auto,
+            manualCookieHeader: nil,
+            workspaceID: "wrk_team"))
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(settings: settings))
+
+        #expect(strategies.map(\.id) == ["opencodego.web", "opencodego.local"])
+    }
+
+    @Test
+    func `auto source tries web before local for environment workspaces`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(env: ["CODEXBAR_OPENCODEGO_WORKSPACE_ID": "wrk_env"]))
+
+        #expect(strategies.map(\.id) == ["opencodego.web", "opencodego.local"])
     }
 
     @Test

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -29,8 +29,9 @@ read_when:
 - Workspace override accepts a raw `wrk_…` ID or a full `https://opencode.ai/workspace/...` URL.
 - Cached cookies: Keychain cache `com.steipete.codexbar.cache` (account `cookie.opencode`, source + timestamp). Browser
   import only runs when the cached cookie fails.
-- OpenCode Go auto mode tries web usage first. Authentication/setup failures fall back to quota windows and daily cost
-  history derived from local `opencode-go` assistant costs.
+- OpenCode Go unscoped Auto mode tries quota windows and daily cost history derived from local `opencode-go` assistant
+  costs first, then falls back to web usage when local history is unavailable. Auto stays web-first when a token account,
+  manual cookie, or workspace override scopes the request, because local history is device-wide.
 - OpenCode Go cost history chart: `opencode.ai` has no daily-granularity endpoint, so per-day cost/request buckets
   come from local `opencode-go` assistant costs in `opencode.db`, keyed by device-local calendar day. Successful web
   usage remains workspace-scoped and is never blended with device-wide local costs, so it does not show cost history.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -42,7 +42,7 @@ scan fails, while provider/account configuration changes replace obsolete result
 | Antigravity | Local LSP/HTTP probe (`local`). |
 | Cursor | Web API via cookies → legacy stored session → Cursor.app local auth (`web`). |
 | OpenCode | Web dashboard via cookies (`web`). |
-| OpenCode Go | Web dashboard via cookies (`web`) -> local SQLite usage (`local`) in auto mode; optional workspace ID. |
+| OpenCode Go | Unscoped Auto: local SQLite usage (`local`) → web dashboard (`web`). Scoped Auto (selected account/manual cookie/workspace): web → local. Explicit Web: web only. |
 | Alibaba Coding Plan | Console RPC via web cookies (auto/manual) with API key fallback (`web`, `api`). |
 | Alibaba Token Plan | Bailian subscription summary API via browser or manual cookies (`web`). |
 | Droid/Factory | API key (`FACTORY_API_KEY` / config) → web cookies → stored tokens → local storage → WorkOS cookies (`auto`, `api`, `web`). |
@@ -199,7 +199,10 @@ scan fails, while provider/account configuration changes replace obsolete result
 
 ## OpenCode Go
 - Web dashboard via browser or manual cookies (`opencode.ai`).
-- Auto mode falls back to local usage from `~/.local/share/opencode/opencode.db` on macOS and Linux.
+- Unscoped Auto mode prefers local usage from `~/.local/share/opencode/opencode.db` on macOS and Linux, then falls back
+  to web when local history is unavailable.
+- Auto mode stays web-first for selected token accounts, manual cookies, and workspace overrides; explicit Web mode does
+  not include local fallback.
 - Uses the workspace Go page/server data for rolling 5-hour, weekly, and optional monthly usage windows.
 - Optional workspace ID comes from `~/.codexbar/config.json` (`providers[].workspaceID`) or `CODEXBAR_OPENCODEGO_WORKSPACE_ID`.
 - Status: none yet.


### PR DESCRIPTION
## Summary
- prefer OpenCode Go local history before the web fetch only for unscoped Auto requests
- keep selected-token-account, manual-cookie, and workspace-scoped Auto requests web-first so scoped web resolution runs before local fallback
- keep explicit Web source web-only, and keep web fallback when local history is unavailable
- update strategy tests for unscoped local-first, scoped web-first, explicit Web, and fallback behavior

## Why
The OpenCode Go timing reported in #2117 shows `codexbar usage --provider opencodego` spending about 20 seconds. Auto previously ran the web strategy first, so a slow or missing web session could delay the fast local SQLite reader even when local history could satisfy an unscoped usage display.

The follow-up keeps that local-first optimization only for unscoped Auto requests. If the fetch context carries a selected token account, a manual cookie, or a workspace override from settings or `CODEXBAR_OPENCODEGO_WORKSPACE_ID`, Auto keeps the prior web-first order so the selected scope is applied before any local fallback.

## Tests
- `swiftc -parse Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift`
- `swiftc -parse Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift`
- `git diff --check`
- `swift test --filter OpenCodeGoProviderStrategyTests`
- `make check`

Not run: live OpenCode Go account/cookie probes. `AGENTS.md` says live provider probes, browser-cookie imports, `codexbar usage` against real accounts, and real SecItem reads require an explicit request; this PR uses focused strategy tests instead.

## Compatibility risk
Medium-low. This still changes OpenCode Go Auto precedence for unscoped requests, but selected token accounts, manual cookies, and workspace-scoped requests preserve the prior web-first behavior. `--source web` remains web-only, and Auto still falls through to web when local history is missing or unreadable.
