### PR TITLE
Isolate Claude CLI gating tests

### DIFF
--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -8,101 +8,159 @@ import Musl
 import Foundation
 
 private enum TTYCommandRunnerActiveProcessRegistry {
-    private static let condition = NSCondition()
-    private nonisolated(unsafe) static var processes: [pid_t: ProcessInfo] = [:]
-    private nonisolated(unsafe) static var isShuttingDown = false
-    private nonisolated(unsafe) static var launchesInProgress = 0
-
     private struct ProcessInfo {
         let binary: String
         var processGroup: pid_t?
     }
 
-    @discardableResult
+    private final class State: @unchecked Sendable {
+        private let condition = NSCondition()
+        private var processes: [pid_t: ProcessInfo] = [:]
+        private var isShuttingDown = false
+        private var launchesInProgress = 0
+
+        @discardableResult
+        func register(pid: pid_t, binary: String) -> Bool {
+            guard pid > 0 else { return false }
+            self.condition.lock()
+            defer { self.condition.unlock() }
+            guard !self.isShuttingDown else { return false }
+            self.processes[pid] = ProcessInfo(binary: binary, processGroup: nil)
+            return true
+        }
+
+        func beginLaunch() -> Bool {
+            self.condition.lock()
+            defer { self.condition.unlock() }
+            guard !self.isShuttingDown else { return false }
+            self.launchesInProgress += 1
+            return true
+        }
+
+        func endLaunch() {
+            self.condition.lock()
+            self.launchesInProgress = max(0, self.launchesInProgress - 1)
+            if self.launchesInProgress == 0 {
+                self.condition.broadcast()
+            }
+            self.condition.unlock()
+        }
+
+        func updateProcessGroup(pid: pid_t, processGroup: pid_t?) {
+            guard pid > 0 else { return }
+            self.condition.lock()
+            guard var existing = self.processes[pid] else {
+                self.condition.unlock()
+                return
+            }
+            existing.processGroup = processGroup
+            self.processes[pid] = existing
+            self.condition.unlock()
+        }
+
+        func unregister(pid: pid_t) {
+            guard pid > 0 else { return }
+            self.condition.lock()
+            self.processes.removeValue(forKey: pid)
+            self.condition.unlock()
+        }
+
+        func drainForShutdown(
+            onFenceSet: (() -> Void)? = nil)
+            -> [(pid: pid_t, binary: String, processGroup: pid_t?)]
+        {
+            self.condition.lock()
+            self.isShuttingDown = true
+            onFenceSet?()
+            while self.launchesInProgress > 0 {
+                self.condition.wait()
+            }
+            let drained = self.processes.map {
+                (pid: $0.key, binary: $0.value.binary, processGroup: $0.value.processGroup)
+            }
+            self.processes.removeAll()
+            self.condition.unlock()
+            return drained
+        }
+
+        func reset() {
+            self.condition.lock()
+            self.processes.removeAll()
+            self.isShuttingDown = false
+            self.launchesInProgress = 0
+            self.condition.broadcast()
+            self.condition.unlock()
+        }
+
+        func count() -> Int {
+            self.condition.lock()
+            let count = self.processes.count
+            self.condition.unlock()
+            return count
+        }
+
+        func testTrackProcess(pid: pid_t, binary: String, processGroup: pid_t?) {
+            guard pid > 0 else { return }
+            self.condition.lock()
+            self.processes[pid] = ProcessInfo(binary: binary, processGroup: processGroup)
+            self.condition.unlock()
+        }
+    }
+
+    private static let shared = State()
+    @TaskLocal private static var stateOverrideForTesting: State?
+
+    private static var current: State {
+        self.stateOverrideForTesting ?? self.shared
+    }
+
     static func register(pid: pid_t, binary: String) -> Bool {
-        guard pid > 0 else { return false }
-        self.condition.lock()
-        defer { self.condition.unlock() }
-        guard !self.isShuttingDown else { return false }
-        self.processes[pid] = ProcessInfo(binary: binary, processGroup: nil)
-        return true
+        self.current.register(pid: pid, binary: binary)
     }
 
     static func beginLaunch() -> Bool {
-        self.condition.lock()
-        defer { self.condition.unlock() }
-        guard !self.isShuttingDown else { return false }
-        self.launchesInProgress += 1
-        return true
+        self.current.beginLaunch()
     }
 
     static func endLaunch() {
-        self.condition.lock()
-        self.launchesInProgress = max(0, self.launchesInProgress - 1)
-        if self.launchesInProgress == 0 {
-            self.condition.broadcast()
-        }
-        self.condition.unlock()
+        self.current.endLaunch()
     }
 
     static func updateProcessGroup(pid: pid_t, processGroup: pid_t?) {
-        guard pid > 0 else { return }
-        self.condition.lock()
-        guard var existing = self.processes[pid] else {
-            self.condition.unlock()
-            return
-        }
-        existing.processGroup = processGroup
-        self.processes[pid] = existing
-        self.condition.unlock()
+        self.current.updateProcessGroup(pid: pid, processGroup: processGroup)
     }
 
     static func unregister(pid: pid_t) {
-        guard pid > 0 else { return }
-        self.condition.lock()
-        self.processes.removeValue(forKey: pid)
-        self.condition.unlock()
+        self.current.unregister(pid: pid)
     }
 
-    static func drainForShutdown(
-        onFenceSet: (() -> Void)? = nil)
+    static func drainForShutdown(onFenceSet: (() -> Void)? = nil)
         -> [(pid: pid_t, binary: String, processGroup: pid_t?)]
     {
-        self.condition.lock()
-        self.isShuttingDown = true
-        onFenceSet?()
-        while self.launchesInProgress > 0 {
-            self.condition.wait()
-        }
-        let drained = self.processes.map {
-            (pid: $0.key, binary: $0.value.binary, processGroup: $0.value.processGroup)
-        }
-        self.processes.removeAll()
-        self.condition.unlock()
-        return drained
+        self.current.drainForShutdown(onFenceSet: onFenceSet)
     }
 
     static func reset() {
-        self.condition.lock()
-        self.processes.removeAll()
-        self.isShuttingDown = false
-        self.launchesInProgress = 0
-        self.condition.broadcast()
-        self.condition.unlock()
+        self.current.reset()
     }
 
     static func count() -> Int {
-        self.condition.lock()
-        let count = self.processes.count
-        self.condition.unlock()
-        return count
+        self.current.count()
     }
 
     static func testTrackProcess(pid: pid_t, binary: String, processGroup: pid_t?) {
-        guard pid > 0 else { return }
-        self.condition.lock()
-        self.processes[pid] = ProcessInfo(binary: binary, processGroup: processGroup)
-        self.condition.unlock()
+        self.current.testTrackProcess(pid: pid, binary: binary, processGroup: processGroup)
+    }
+
+    static func withIsolatedStateForTesting<T>(_ operation: () throws -> T) rethrows -> T {
+        try self.$stateOverrideForTesting.withValue(State(), operation: operation)
+    }
+
+    static func makeDrainOperationForTesting(onFenceSet: (@Sendable () -> Void)? = nil)
+        -> @Sendable () -> [(pid: pid_t, binary: String, processGroup: pid_t?)]
+    {
+        let state = self.current
+        return { state.drainForShutdown(onFenceSet: onFenceSet) }
     }
 }
 
@@ -204,6 +262,10 @@ enum TTYProcessTreeTerminator {
         }
         signalSender(rootPID, signal)
     }
+}
+
+private enum TTYCommandRunnerTestingOverrides {
+    @TaskLocal static var postDeadlineDrainDuration: TimeInterval?
 }
 
 /// Executes an interactive CLI inside a pseudo-terminal and returns all captured text.
@@ -910,7 +972,9 @@ public struct TTYCommandRunner {
             } else {
                 // PTY-backed scripts can exit before their final echo becomes readable on the parent side.
                 // Give the kernel a brief non-blocking drain window so we don't lose the last line of output.
-                drainNonCodexOutput(for: min(0.5, max(0.2, options.settleAfterStop)))
+                let defaultDrainDuration = min(0.5, max(0.2, options.settleAfterStop))
+                let drainDuration = TTYCommandRunnerTestingOverrides.postDeadlineDrainDuration ?? defaultDrainDuration
+                drainNonCodexOutput(for: drainDuration)
             }
 
             try checkOutputLimit()
@@ -1102,6 +1166,17 @@ public struct TTYCommandRunner {
 }
 
 extension TTYCommandRunner {
+    static func withIsolatedActiveProcessRegistryForTesting<T>(_ operation: () throws -> T) rethrows -> T {
+        try TTYCommandRunnerActiveProcessRegistry.withIsolatedStateForTesting(operation)
+    }
+
+    static func withPostDeadlineDrainDurationOverrideForTesting<T>(
+        _ duration: TimeInterval,
+        operation: () throws -> T) rethrows -> T
+    {
+        try TTYCommandRunnerTestingOverrides.$postDeadlineDrainDuration.withValue(duration, operation: operation)
+    }
+
     public static func which(_ tool: String) -> String? {
         if tool == "codex", let located = BinaryLocator.resolveCodexBinary() {
             return located
@@ -1252,6 +1327,13 @@ extension TTYCommandRunner {
         -> [(pid: pid_t, binary: String, processGroup: pid_t?)]
     {
         TTYCommandRunnerActiveProcessRegistry.drainForShutdown(onFenceSet: onFenceSet)
+    }
+
+    static func _test_makeDrainTrackedProcessesForShutdownOperation(
+        onFenceSet: (@Sendable () -> Void)? = nil)
+        -> @Sendable () -> [(pid: pid_t, binary: String, processGroup: pid_t?)]
+    {
+        TTYCommandRunnerActiveProcessRegistry.makeDrainOperationForTesting(onFenceSet: onFenceSet)
     }
 
     static func _test_resolveShutdownTargets(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLIAuthStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLIAuthStatusProbe.swift
@@ -6,12 +6,22 @@ enum ClaudeCLIAuthStatusProbe {
     }
 
     @TaskLocal private static var resultOverrideForTesting: Bool?
+    @TaskLocal private static var timeoutOverrideForTesting: TimeInterval?
 
     static func withResultOverrideForTesting<T>(
         _ result: Bool?,
         operation: () async throws -> T) async rethrows -> T
     {
         try await self.$resultOverrideForTesting.withValue(result) {
+            try await operation()
+        }
+    }
+
+    static func withTimeoutOverrideForTesting<T>(
+        _ timeout: TimeInterval,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$timeoutOverrideForTesting.withValue(timeout) {
             try await operation()
         }
     }
@@ -29,7 +39,7 @@ enum ClaudeCLIAuthStatusProbe {
                 binary: binary,
                 arguments: ["auth", "status", "--json"],
                 environment: ClaudeCLISession.launchEnvironment(baseEnv: environment),
-                timeout: timeout,
+                timeout: self.timeoutOverrideForTesting ?? timeout,
                 standardInput: FileHandle.nullDevice,
                 label: "claude-auth-status")
             return self.parseLoggedIn(result.stdout)

--- a/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
@@ -207,17 +207,19 @@ struct ClaudeBaselineCharacterizationTests {
         let stubCLIPath = try self.makeStubClaudeCLI(loggedIn: false, invocationLog: invocationLog)
         let env = ["CLAUDE_CLI_PATH": stubCLIPath]
 
-        await self.withBackgroundKeychainAccess {
-            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
-                await self.withNoOAuthCredentials {
-                    let outcome = await self.fetchOutcome(
-                        runtime: .app,
-                        sourceMode: .auto,
-                        env: env,
-                        settings: settings)
+        await ClaudeCLIAuthStatusProbe.withTimeoutOverrideForTesting(20) {
+            await self.withBackgroundKeychainAccess {
+                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                    await self.withNoOAuthCredentials {
+                        let outcome = await self.fetchOutcome(
+                            runtime: .app,
+                            sourceMode: .auto,
+                            env: env,
+                            settings: settings)
 
-                    #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli", "claude.web"])
-                    #expect(outcome.attempts.map(\.wasAvailable) == [false, false, false])
+                        #expect(outcome.attempts.map(\.strategyID) == ["claude.oauth", "claude.cli", "claude.web"])
+                        #expect(outcome.attempts.map(\.wasAvailable) == [false, false, false])
+                    }
                 }
             }
         }
@@ -323,11 +325,13 @@ struct ClaudeBaselineCharacterizationTests {
                 rawText: nil)
         }
 
-        let outcome = await self.withBackgroundKeychainAccess {
-            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
-                await self.withNoOAuthCredentials {
-                    await ClaudeWebFetchStrategy.$usageLoaderOverrideForTesting.withValue(usageLoader) {
-                        await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
+        let outcome = await ClaudeCLIAuthStatusProbe.withTimeoutOverrideForTesting(20) {
+            await self.withBackgroundKeychainAccess {
+                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                    await self.withNoOAuthCredentials {
+                        await ClaudeWebFetchStrategy.$usageLoaderOverrideForTesting.withValue(usageLoader) {
+                            await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env, settings: settings)
+                        }
                     }
                 }
             }

--- a/Tests/CodexBarTests/ClaudeLoginRunnerTests.swift
+++ b/Tests/CodexBarTests/ClaudeLoginRunnerTests.swift
@@ -17,13 +17,14 @@ struct ClaudeLoginRunnerTests {
         defer { fixture.remove() }
 
         let result = await ClaudeLoginRunner.run(
-            timeout: 2,
+            timeout: 10,
             binary: fixture.executable.path,
             environment: fixture.environment,
             onPhaseChange: { _ in })
 
         guard case .success = result.outcome else {
-            Issue.record("Expected success, got \(String(describing: result.outcome))")
+            Issue.record(
+                "Expected success, got \(String(describing: result.outcome)); output=\(result.output.debugDescription)")
             return
         }
         #expect(result.output.contains("args:auth login --claudeai"))
@@ -40,13 +41,15 @@ struct ClaudeLoginRunnerTests {
         defer { fixture.remove() }
 
         let result = await ClaudeLoginRunner.run(
-            timeout: 1,
+            timeout: 3,
             binary: fixture.executable.path,
             environment: fixture.environment,
             onPhaseChange: { _ in })
 
         guard case .timedOut = result.outcome else {
-            Issue.record("Expected timeout, got \(String(describing: result.outcome))")
+            let message = "Expected timeout, got \(String(describing: result.outcome)); "
+                + "output=\(result.output.debugDescription)"
+            Issue.record(Comment(rawValue: message))
             return
         }
         #expect(result.authLink == "https://claude.ai/oauth/authorize?test=1")
@@ -62,13 +65,15 @@ struct ClaudeLoginRunnerTests {
         defer { fixture.remove() }
 
         let result = await ClaudeLoginRunner.run(
-            timeout: 2,
+            timeout: 10,
             binary: fixture.executable.path,
             environment: fixture.environment,
             onPhaseChange: { _ in })
 
         guard case .failed(status: 7) = result.outcome else {
-            Issue.record("Expected status 7, got \(String(describing: result.outcome))")
+            let message = "Expected status 7, got \(String(describing: result.outcome)); "
+                + "output=\(result.output.debugDescription)"
+            Issue.record(Comment(rawValue: message))
             return
         }
         #expect(result.output.contains("login failed"))

--- a/Tests/CodexBarTests/CodexLoginRunnerTests.swift
+++ b/Tests/CodexBarTests/CodexLoginRunnerTests.swift
@@ -60,11 +60,11 @@ struct CodexLoginRunnerTests {
         let codex = binDir.appendingPathComponent("codex")
         let script = """
         #!/bin/sh
-        /bin/sh -c 'trap "" TERM; /bin/sleep 5' &
+        /bin/sh -c 'trap "" TERM; /bin/sleep 20' &
         child_pid=$!
         printf '%s\\n' "$child_pid" > "$CODEXBAR_TEST_CHILD_PID_FILE"
         printf 'login-started\\n'
-        /bin/sleep 5
+        /bin/sleep 20
         """
         try script.write(to: codex, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: codex.path)
@@ -72,8 +72,8 @@ struct CodexLoginRunnerTests {
         let start = Date()
         let result = await CodexLoginRunner.run(
             homePath: homeDir.path,
-            timeout: 1,
-            outputDrainTimeout: 0.2,
+            timeout: 5,
+            outputDrainTimeout: 0.5,
             environment: [
                 "CODEXBAR_TEST_CHILD_PID_FILE": childPIDFile.path,
                 "PATH": binDir.path,
@@ -83,6 +83,6 @@ struct CodexLoginRunnerTests {
 
         #expect(result.outcome == .timedOut)
         #expect(result.output.contains("login-started"))
-        #expect(elapsed < 3.0, "Output drain should stay bounded, took \(elapsed)s")
+        #expect(elapsed < 8.0, "Output drain should stay bounded, took \(elapsed)s")
     }
 }

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -136,8 +136,8 @@ struct KiroStatusProbeTests {
         let startedAt = clock.now
         let probe = KiroStatusProbe(
             cliBinaryResolver: { cliURL.path },
-            usageProbeTimeout: 0.8,
-            pipeTimeoutCap: 0.4)
+            usageProbeTimeout: 4,
+            pipeTimeoutCap: 2)
 
         await #expect {
             _ = try await probe.fetch()
@@ -146,7 +146,7 @@ struct KiroStatusProbeTests {
             return true
         }
 
-        #expect(startedAt.duration(to: clock.now) < .seconds(2))
+        #expect(startedAt.duration(to: clock.now) < .seconds(7))
         #expect(!FileManager.default.fileExists(atPath: ptyMarker.path))
         let pipePIDText = try String(contentsOf: pipePIDFile, encoding: .utf8)
         let pipePID = try #require(pid_t(pipePIDText.trimmingCharacters(in: .whitespacesAndNewlines)))

--- a/Tests/CodexBarTests/TTYCommandRunnerTests.swift
+++ b/Tests/CodexBarTests/TTYCommandRunnerTests.swift
@@ -25,73 +25,84 @@ struct TTYCommandRunnerEnvTests {
 
     @Test
     func `shutdown fence drains tracked TTY processes`() {
-        TTYCommandRunner._test_resetTrackedProcesses()
-        defer { TTYCommandRunner._test_resetTrackedProcesses() }
+        TTYCommandRunner.withIsolatedActiveProcessRegistryForTesting {
+            TTYCommandRunner._test_resetTrackedProcesses()
+            defer { TTYCommandRunner._test_resetTrackedProcesses() }
 
-        #expect(TTYCommandRunner._test_registerTrackedProcess(pid: 1001, binary: "codex"))
-        #expect(TTYCommandRunner._test_trackedProcessCount() == 1)
+            #expect(TTYCommandRunner._test_registerTrackedProcess(pid: 1001, binary: "codex"))
+            #expect(TTYCommandRunner._test_trackedProcessCount() == 1)
 
-        let drained = TTYCommandRunner._test_drainTrackedProcessesForShutdown()
-        #expect(drained.count == 1)
-        #expect(drained[0].pid == 1001)
-        #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
+            let drained = TTYCommandRunner._test_drainTrackedProcessesForShutdown()
+            #expect(drained.count == 1)
+            #expect(drained[0].pid == 1001)
+            #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
+        }
     }
 
     @Test
     func `cached CLI sessions share shutdown tracking`() {
-        TTYCommandRunner._test_resetTrackedProcesses()
-        defer { TTYCommandRunner._test_resetTrackedProcesses() }
+        TTYCommandRunner.withIsolatedActiveProcessRegistryForTesting {
+            TTYCommandRunner._test_resetTrackedProcesses()
+            defer { TTYCommandRunner._test_resetTrackedProcesses() }
 
-        #expect(TTYCommandRunner.registerActiveProcessForAppShutdown(pid: 3001, binary: "codex"))
-        TTYCommandRunner.updateActiveProcessGroupForAppShutdown(pid: 3001, processGroup: 3001)
-        #expect(TTYCommandRunner._test_trackedProcessCount() == 1)
+            #expect(TTYCommandRunner.registerActiveProcessForAppShutdown(pid: 3001, binary: "codex"))
+            TTYCommandRunner.updateActiveProcessGroupForAppShutdown(pid: 3001, processGroup: 3001)
+            #expect(TTYCommandRunner._test_trackedProcessCount() == 1)
 
-        TTYCommandRunner.unregisterActiveProcessForAppShutdown(pid: 3001)
-        #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
+            TTYCommandRunner.unregisterActiveProcessForAppShutdown(pid: 3001)
+            #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
+        }
     }
 
     @Test
     func `tracked process helpers ignore invalid PID`() {
-        TTYCommandRunner._test_resetTrackedProcesses()
-        defer { TTYCommandRunner._test_resetTrackedProcesses() }
+        TTYCommandRunner.withIsolatedActiveProcessRegistryForTesting {
+            TTYCommandRunner._test_resetTrackedProcesses()
+            defer { TTYCommandRunner._test_resetTrackedProcesses() }
 
-        TTYCommandRunner._test_trackProcess(pid: 0, binary: "codex", processGroup: nil)
-        #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
+            TTYCommandRunner._test_trackProcess(pid: 0, binary: "codex", processGroup: nil)
+            #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
+        }
     }
 
     @Test
     func `shutdown fence rejects new registrations`() {
-        TTYCommandRunner._test_resetTrackedProcesses()
-        defer { TTYCommandRunner._test_resetTrackedProcesses() }
+        TTYCommandRunner.withIsolatedActiveProcessRegistryForTesting {
+            TTYCommandRunner._test_resetTrackedProcesses()
+            defer { TTYCommandRunner._test_resetTrackedProcesses() }
 
-        #expect(TTYCommandRunner._test_registerTrackedProcess(pid: 2001, binary: "codex"))
-        let drained = TTYCommandRunner._test_drainTrackedProcessesForShutdown()
-        #expect(drained.count == 1)
+            #expect(TTYCommandRunner._test_registerTrackedProcess(pid: 2001, binary: "codex"))
+            let drained = TTYCommandRunner._test_drainTrackedProcessesForShutdown()
+            #expect(drained.count == 1)
 
-        #expect(TTYCommandRunner._test_registerTrackedProcess(pid: 2002, binary: "codex") == false)
-        #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
+            #expect(TTYCommandRunner._test_registerTrackedProcess(pid: 2002, binary: "codex") == false)
+            #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
+        }
     }
 
     @Test
     func `shutdown waits for launch cleanup before draining`() {
-        TTYCommandRunner._test_resetTrackedProcesses()
-        defer { TTYCommandRunner._test_resetTrackedProcesses() }
+        TTYCommandRunner.withIsolatedActiveProcessRegistryForTesting {
+            TTYCommandRunner._test_resetTrackedProcesses()
+            defer { TTYCommandRunner._test_resetTrackedProcesses() }
 
-        #expect(TTYCommandRunner._test_beginTrackedProcessLaunch())
-        let fenceSet = DispatchSemaphore(value: 0)
-        let completed = DispatchSemaphore(value: 0)
-        Thread.detachNewThread {
-            _ = TTYCommandRunner._test_drainTrackedProcessesForShutdown {
+            #expect(TTYCommandRunner._test_beginTrackedProcessLaunch())
+            let fenceSet = DispatchSemaphore(value: 0)
+            let completed = DispatchSemaphore(value: 0)
+            let drain = TTYCommandRunner._test_makeDrainTrackedProcessesForShutdownOperation {
                 fenceSet.signal()
             }
-            completed.signal()
-        }
+            Thread.detachNewThread {
+                _ = drain()
+                completed.signal()
+            }
 
-        #expect(fenceSet.wait(timeout: .now() + 1) == .success)
-        #expect(completed.wait(timeout: .now() + 0.05) == .timedOut)
-        #expect(!TTYCommandRunner._test_registerTrackedProcess(pid: 2002, binary: "codex"))
-        TTYCommandRunner._test_endTrackedProcessLaunch()
-        #expect(completed.wait(timeout: .now() + 1) == .success)
+            #expect(fenceSet.wait(timeout: .now() + 1) == .success)
+            #expect(completed.wait(timeout: .now() + 0.05) == .timedOut)
+            #expect(!TTYCommandRunner._test_registerTrackedProcess(pid: 2002, binary: "codex"))
+            TTYCommandRunner._test_endTrackedProcessLaunch()
+            #expect(completed.wait(timeout: .now() + 1) == .success)
+        }
     }
 
     @Test
@@ -435,10 +446,12 @@ struct TTYCommandRunnerEnvTests {
         try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
 
         let runner = TTYCommandRunner()
-        let result = try runner.run(
-            binary: scriptURL.path,
-            send: "",
-            options: .init(timeout: 0.01, initialDelay: 0, settleAfterStop: 0.5))
+        let result = try TTYCommandRunner.withPostDeadlineDrainDurationOverrideForTesting(10) {
+            try runner.run(
+                binary: scriptURL.path,
+                send: "",
+                options: .init(timeout: 0.01, initialDelay: 0, settleAfterStop: 0.5))
+        }
 
         #expect(result.completion == .deadlineExceeded)
         #expect(result.text.contains("https://claude.ai/oauth/authorize?test=late"))
@@ -465,7 +478,7 @@ struct TTYCommandRunnerEnvTests {
         let result = try runner.run(
             binary: scriptURL.path,
             send: "",
-            options: .init(timeout: 4, initialDelay: 0, returnOnEmptyProcessExit: true))
+            options: .init(timeout: 10, initialDelay: 0, returnOnEmptyProcessExit: true))
 
         #expect(result.completion == .processExited(status: 0))
         #expect(result.text.isEmpty)

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import CodexBarCLI
 @testable import CodexBarCore
 
-@Suite
+@Suite(.serialized)
 struct PlatformGatingTests {
     @Test
     func `shell probe requests a detached Linux session`() {
@@ -85,7 +85,7 @@ struct PlatformGatingTests {
         #endif
     }
 
-    @Test(.serialized, arguments: [ProviderSourceMode.auto, .cli])
+    @Test(arguments: [ProviderSourceMode.auto, .cli])
     func `Claude CLI runtime skips logged out interactive fallback`(sourceMode: ProviderSourceMode) async throws {
         #if os(Linux)
         let invocationLog = FileManager.default.temporaryDirectory
@@ -103,10 +103,12 @@ struct PlatformGatingTests {
             return Self.makeClaudeStatus()
         }
 
-        let outcome = await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
-            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
-                context: context,
-                provider: .claude)
+        let outcome = await ClaudeCLIAuthStatusProbe.withTimeoutOverrideForTesting(20) {
+            await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
+                await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                    context: context,
+                    provider: .claude)
+            }
         }
 
         switch outcome.result {
@@ -125,7 +127,8 @@ struct PlatformGatingTests {
         let expectedStrategyIDs = sourceMode == .auto ? ["claude.web", "claude.cli"] : ["claude.cli"]
         #expect(outcome.attempts.map(\.strategyID) == expectedStrategyIDs)
         #expect(outcome.attempts.allSatisfy { !$0.wasAvailable })
-        #expect(try String(contentsOf: invocationLog, encoding: .utf8) == "auth status --json\n")
+        let invocations = try String(contentsOf: invocationLog, encoding: .utf8)
+        #expect(invocations == "auth status --json\n")
         #else
         #expect(Bool(true))
         #endif


### PR DESCRIPTION
## Summary

- isolate `TTYCommandRunnerActiveProcessRegistry` behind a task-local state override so shutdown-fence tests cannot reject unrelated concurrent Claude login launches
- serialize the complete Linux `PlatformGatingTests` suite, completing the partial Claude CLI gating serialization from #2311
- make Claude auth-status timeout overrides task-local and widen only test fixture deadlines that proved load-sensitive; production defaults and behavior are unchanged
- harden the named Kiro pipe-deadline assertion without changing the probe implementation

## Root cause

`TTYCommandRunnerEnvTests` is serialized only within its own suite. Its shutdown-fence cases mutate the process-global `TTYCommandRunnerActiveProcessRegistry.isShuttingDown` flag, while `ClaudeLoginRunnerTests` concurrently call `TTYCommandRunner.run`. When the fence wins, `beginLaunch()` rejects the Claude fixture launch and all three login tests receive `launchFailed`/empty output instead of their expected auth link or exit result.

The exact concurrent reproducer was:

```
swift test --filter 'ClaudeLoginRunnerTests|TTYCommandRunnerEnvTests'
```

It failed before the fix and now passes all 31 tests. The isolated registry state is task-local; the one test that crosses to a detached `Thread` explicitly captures its scoped state.

The Linux gating failure is a neighboring isolation class: #2311 serialized only the parameterized logged-out test's argument cases, not that test against the rest of `PlatformGatingTests`. Suite-level serialization closes that gap, while task-local auth timeout control keeps slow arm64 fake-CLI fixtures inside a test-only budget.

## Verification

- `swift test --filter ClaudeLoginRunnerTests`
- `swift test --filter 'ClaudeLoginRunnerTests|TTYCommandRunnerEnvTests'` — 31 tests passed
- arm64 Docker `PlatformGatingTests` — 10 consecutive focused runs passed
- `swift build -c release` — passed in 218.64s
- `make check` — SwiftFormat clean; SwiftLint 0 violations in 1,577 files
- three consecutive `make test` runs on the final debug implementation:
  - 60/60 first-pass groups, 719 selections, 0 retries/timeouts, 692.8s
  - 60/60 first-pass groups, 719 selections, 0 retries/timeouts, 575.6s
  - 60/60 first-pass groups, 719 selections, 0 retries/timeouts, 477.9s
- autoreview: no accepted/actionable findings

`swift test -c release` was also attempted after making the new seams configuration-independent. It compiled past this patch and then hit existing unrelated DEBUG-only OAuth test seams in `ClaudeOAuthDelegatedRefreshLinuxTests`; the production release build is green.

No changelog edit here; this is an internal test-infrastructure fix.
