### PR TITLE
Prefer weekly windows in switcher progress

### DIFF
--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -467,6 +467,13 @@ public struct UsageSnapshot: Codable, Sendable {
     }
 
     public func switcherWeeklyWindow(for provider: UsageProvider, showUsed: Bool) -> RateWindow? {
+        // This surface is labelled "Weekly progress", so prefer a real 7-day lane when one is
+        // available. Some providers publish model-specific weekly lanes in extraRateWindows.
+        if let weekly = self.mostConstrainedSwitcherWeeklyWindow() {
+            return weekly
+        }
+
+        // Keep the existing provider-specific fallback for providers without a weekly allowance.
         switch provider {
         case .factory:
             // Factory prefers secondary window
@@ -494,6 +501,16 @@ public struct UsageSnapshot: Codable, Sendable {
         default:
             return self.primary ?? self.secondary
         }
+    }
+
+    private func mostConstrainedSwitcherWeeklyWindow() -> RateWindow? {
+        let standardWindows = [self.primary, self.secondary, self.tertiary].compactMap(\.self)
+        let namedWindows = self.extraRateWindows?
+            .filter(\.usageKnown)
+            .map(\.window) ?? []
+        return (standardWindows + namedWindows)
+            .filter { $0.windowMinutes == 7 * 24 * 60 }
+            .max { $0.usedPercent < $1.usedPercent }
     }
 
     public func accountEmail(for provider: UsageProvider) -> String? {

--- a/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
@@ -29,6 +29,7 @@ struct StatusItemControllerMenuTests {
         primary: RateWindow?,
         secondary: RateWindow?,
         tertiary: RateWindow? = nil,
+        extraRateWindows: [NamedRateWindow]? = nil,
         providerCost: ProviderCostSnapshot? = nil)
         -> UsageSnapshot
     {
@@ -36,8 +37,85 @@ struct StatusItemControllerMenuTests {
             primary: primary,
             secondary: secondary,
             tertiary: tertiary,
+            extraRateWindows: extraRateWindows,
             providerCost: providerCost,
             updatedAt: Date())
+    }
+
+    @Test
+    func `switcher prefers weekly allowance over primary session allowance`() {
+        let session = RateWindow(
+            usedPercent: 20,
+            windowMinutes: 5 * 60,
+            resetsAt: nil,
+            resetDescription: nil)
+        let weekly = RateWindow(
+            usedPercent: 65,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: nil,
+            resetDescription: nil)
+        let snapshot = self.makeSnapshot(primary: session, secondary: weekly)
+
+        let percent = StatusItemController.switcherWeeklyMetricPercent(
+            for: .claude,
+            snapshot: snapshot,
+            showUsed: false)
+
+        #expect(percent == 35)
+    }
+
+    @Test
+    func `switcher uses most constrained named weekly allowance`() {
+        let session = RateWindow(
+            usedPercent: 10,
+            windowMinutes: 5 * 60,
+            resetsAt: nil,
+            resetDescription: nil)
+        let snapshot = self.makeSnapshot(
+            primary: session,
+            secondary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-weekly",
+                    title: "Gemini weekly",
+                    window: RateWindow(
+                        usedPercent: 40,
+                        windowMinutes: 7 * 24 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-claude-weekly",
+                    title: "Claude/GPT weekly",
+                    window: RateWindow(
+                        usedPercent: 75,
+                        windowMinutes: 7 * 24 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+            ])
+
+        let percent = StatusItemController.switcherWeeklyMetricPercent(
+            for: .antigravity,
+            snapshot: snapshot,
+            showUsed: false)
+
+        #expect(percent == 25)
+    }
+
+    @Test
+    func `switcher preserves provider quota when no weekly allowance exists`() {
+        let monthly = RateWindow(
+            usedPercent: 28,
+            windowMinutes: nil,
+            resetsAt: nil,
+            resetDescription: nil)
+        let snapshot = self.makeSnapshot(primary: monthly, secondary: nil)
+
+        let percent = StatusItemController.switcherWeeklyMetricPercent(
+            for: .copilot,
+            snapshot: snapshot,
+            showUsed: false)
+
+        #expect(percent == 72)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- prefer an actual 7-day quota for the combined switcher's `Weekly progress` line
- choose the most constrained weekly lane when a provider publishes several model-specific limits
- preserve the existing provider-specific fallback when no weekly quota exists

## Why

The current selector generally uses `primary ?? secondary`. Codex can therefore appear correct only when its primary window is absent, while Claude selects its 5-hour primary window even when a 7-day secondary window is available. That makes the same switcher row compare different time horizons across providers.

This is a draft because commit `11f4cc8d` deliberately changed the switcher toward primary quotas. The patch implements the behavior promised by the current `Weekly progress` label, but the maintainer should confirm that product contract before merge.

## Tests

- `swift test --filter StatusItemControllerMenuTests`: 12 tests passed
- `make check`: passed, including SwiftFormat and SwiftLint with 0 violations
- `make test`: ran all 60 groups; the only failure was the unrelated locale-sensitive `ZenMuxProviderTests` date assertion (`12 Apr 2026` on this UK-locale machine versus expected `Apr 12, 2026`)

Fixes #2324
