### PR TITLE
fix: don't rescale computed OpenCode usage below 1%

### DIFF
--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeUsageFetcher.swift
@@ -730,6 +730,9 @@ public struct OpenCodeUsageFetcher: Sendable {
 
     private static func parseWindow(_ dict: [String: Any], now: Date) -> (percent: Double, resetInSec: Int)? {
         var percent = self.doubleValue(from: dict, keys: self.percentKeys)
+        // A direct percent field may arrive as a fraction (0...1) or a percent (0...100), so it goes
+        // through the `<= 1` heuristic below. A computed used/limit percent is already 0...100 and must not.
+        let percentIsDirect = percent != nil
 
         if percent == nil {
             let used = self.doubleValue(from: dict, keys: ["used", "usage", "consumed", "count", "usedTokens"])
@@ -740,7 +743,7 @@ public struct OpenCodeUsageFetcher: Sendable {
         }
 
         guard var resolvedPercent = percent else { return nil }
-        if resolvedPercent <= 1.0, resolvedPercent >= 0 {
+        if percentIsDirect, resolvedPercent <= 1.0, resolvedPercent >= 0 {
             resolvedPercent *= 100
         }
         resolvedPercent = max(0, min(100, resolvedPercent))

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -749,6 +749,9 @@ extension OpenCodeGoUsageFetcher {
                 break
             }
         }
+        // A direct percent field may arrive as a fraction (0...1) or a percent (0...100), so it goes
+        // through the `<= 1` heuristic below. A computed used/limit percent is already 0...100 and must not.
+        let percentIsDirect = percent != nil
 
         if percent == nil {
             let usedKeys = ["used", "usage", "consumed", "count", "usedTokens"]
@@ -773,7 +776,7 @@ extension OpenCodeGoUsageFetcher {
         }
 
         guard var resolvedPercent = percent else { return nil }
-        if resolvedPercent <= 1.0, resolvedPercent >= 0 {
+        if percentIsDirect, resolvedPercent <= 1.0, resolvedPercent >= 0 {
             resolvedPercent *= 100
         }
         resolvedPercent = max(0, min(100, resolvedPercent))

--- a/TestsLinux/OpenCodeGoPercentUnitLinuxTests.swift
+++ b/TestsLinux/OpenCodeGoPercentUnitLinuxTests.swift
@@ -1,0 +1,41 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct OpenCodeGoPercentUnitLinuxTests {
+    private func rollingPercent(used: Int, limit: Int) throws -> Double {
+        let payload: [String: Any] = [
+            "usage": ["rollingUsage": ["used": used, "limit": limit, "resetInSec": 600]],
+        ]
+        let text = try String(data: JSONSerialization.data(withJSONObject: payload), encoding: .utf8) ?? ""
+        return try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: Date(timeIntervalSince1970: 0))
+            .rollingUsagePercent
+    }
+
+    @Test
+    func `sub-one-percent computed usage is not rescaled to 100`() throws {
+        // 1/100 = 1% used. The direct-fraction heuristic (<= 1 => * 100) must NOT touch a
+        // computed used/limit percent, which is already 0...100 — else 1.0 becomes 100.
+        #expect(try abs(self.rollingPercent(used: 1, limit: 100) - 1) < 0.0001)
+        // 1/200 = 0.5% used (was wrongly rescaled to 50).
+        #expect(try abs(self.rollingPercent(used: 1, limit: 200) - 0.5) < 0.0001)
+    }
+
+    @Test
+    func `normal computed usage is unchanged`() throws {
+        #expect(try abs(self.rollingPercent(used: 25, limit: 100) - 25) < 0.0001)
+    }
+
+    @Test
+    func `direct fractional percent is still scaled to percent`() throws {
+        // A direct percent field given as a 0...1 fraction keeps the existing behavior.
+        let payload: [String: Any] = [
+            "usage": ["rollingUsage": ["usagePercent": 0.25, "resetInSec": 600]],
+        ]
+        let text = try String(data: JSONSerialization.data(withJSONObject: payload), encoding: .utf8) ?? ""
+        let snapshot = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: Date(timeIntervalSince1970: 0))
+        #expect(snapshot.rollingUsagePercent == 25)
+    }
+}
+#endif

--- a/TestsLinux/OpenCodePercentUnitLinuxTests.swift
+++ b/TestsLinux/OpenCodePercentUnitLinuxTests.swift
@@ -1,0 +1,44 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct OpenCodePercentUnitLinuxTests {
+    private func rollingPercent(used: Int, limit: Int) throws -> Double {
+        let payload: [String: Any] = [
+            "rollingUsage": ["used": used, "limit": limit, "resetInSec": 600],
+            "weeklyUsage": ["used": used, "limit": limit, "resetInSec": 3600],
+        ]
+        let text = try String(data: JSONSerialization.data(withJSONObject: payload), encoding: .utf8) ?? ""
+        return try OpenCodeUsageFetcher.parseSubscription(text: text, now: Date(timeIntervalSince1970: 0))
+            .rollingUsagePercent
+    }
+
+    @Test
+    func `sub-one-percent computed usage is not rescaled to 100`() throws {
+        // 1/100 = 1% used. The direct-fraction heuristic (<= 1 => * 100) must NOT touch a
+        // computed used/limit percent, which is already 0...100 — else 1.0 becomes 100.
+        #expect(try abs(self.rollingPercent(used: 1, limit: 100) - 1) < 0.0001)
+        // 1/200 = 0.5% used (was wrongly rescaled to 50).
+        #expect(try abs(self.rollingPercent(used: 1, limit: 200) - 0.5) < 0.0001)
+    }
+
+    @Test
+    func `normal computed usage is unchanged`() throws {
+        #expect(try abs(self.rollingPercent(used: 25, limit: 100) - 25) < 0.0001)
+    }
+
+    @Test
+    func `direct fractional percent is still scaled to percent`() throws {
+        // A direct percent field given as a 0...1 fraction keeps the existing behavior.
+        let payload: [String: Any] = [
+            "rollingUsage": ["usagePercent": 0.25, "resetInSec": 600],
+            "weeklyUsage": ["usagePercent": 0.5, "resetInSec": 3600],
+        ]
+        let text = try String(data: JSONSerialization.data(withJSONObject: payload), encoding: .utf8) ?? ""
+        let snapshot = try OpenCodeUsageFetcher.parseSubscription(text: text, now: Date(timeIntervalSince1970: 0))
+        #expect(snapshot.rollingUsagePercent == 25)
+        #expect(snapshot.weeklyUsagePercent == 50)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- Preserve computed OpenCode and OpenCode Go usage percentages at their native 0...100 scale.
- Keep the existing fraction-to-percent normalization only for directly supplied percentage fields.
- Add Linux regression coverage for 1%, sub-1%, ordinary computed, and direct fractional inputs.

Replacement for #2321 because GitHub rejected maintainer writes to the contributor fork. The original commit and authorship from @OfficialAbhinavSingh are preserved exactly on top of current `main`.

## Verification

- `swift test --filter OpenCodeUsageParserTests` — 14 tests passed.
- `swift test --filter OpenCodeGoUsageParserTests` — 28 tests passed.
- `make check` — formatting, lint, repository, packaging, and documentation checks passed; SwiftLint reported 0 violations.
- Structured autoreview against current `origin/main` — no accepted/actionable findings.
- Source-blind live-provider proof was not run because no disposable public fixture/account surface was available; no real provider credentials were touched.

Closes #2321.
