### PR TITLE
fix: don't rescale computed OpenCode/OpenCodeGo usage percent below 1%

### DIFF
--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeUsageFetcher.swift
@@ -730,6 +730,9 @@ public struct OpenCodeUsageFetcher: Sendable {
 
     private static func parseWindow(_ dict: [String: Any], now: Date) -> (percent: Double, resetInSec: Int)? {
         var percent = self.doubleValue(from: dict, keys: self.percentKeys)
+        // A direct percent field may arrive as a fraction (0...1) or a percent (0...100), so it goes
+        // through the `<= 1` heuristic below. A computed used/limit percent is already 0...100 and must not.
+        let percentIsDirect = percent != nil
 
         if percent == nil {
             let used = self.doubleValue(from: dict, keys: ["used", "usage", "consumed", "count", "usedTokens"])
@@ -740,7 +743,7 @@ public struct OpenCodeUsageFetcher: Sendable {
         }
 
         guard var resolvedPercent = percent else { return nil }
-        if resolvedPercent <= 1.0, resolvedPercent >= 0 {
+        if percentIsDirect, resolvedPercent <= 1.0, resolvedPercent >= 0 {
             resolvedPercent *= 100
         }
         resolvedPercent = max(0, min(100, resolvedPercent))

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -749,6 +749,9 @@ extension OpenCodeGoUsageFetcher {
                 break
             }
         }
+        // A direct percent field may arrive as a fraction (0...1) or a percent (0...100), so it goes
+        // through the `<= 1` heuristic below. A computed used/limit percent is already 0...100 and must not.
+        let percentIsDirect = percent != nil
 
         if percent == nil {
             let usedKeys = ["used", "usage", "consumed", "count", "usedTokens"]
@@ -773,7 +776,7 @@ extension OpenCodeGoUsageFetcher {
         }
 
         guard var resolvedPercent = percent else { return nil }
-        if resolvedPercent <= 1.0, resolvedPercent >= 0 {
+        if percentIsDirect, resolvedPercent <= 1.0, resolvedPercent >= 0 {
             resolvedPercent *= 100
         }
         resolvedPercent = max(0, min(100, resolvedPercent))

--- a/TestsLinux/OpenCodeGoPercentUnitLinuxTests.swift
+++ b/TestsLinux/OpenCodeGoPercentUnitLinuxTests.swift
@@ -1,0 +1,41 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct OpenCodeGoPercentUnitLinuxTests {
+    private func rollingPercent(used: Int, limit: Int) throws -> Double {
+        let payload: [String: Any] = [
+            "usage": ["rollingUsage": ["used": used, "limit": limit, "resetInSec": 600]],
+        ]
+        let text = try String(data: JSONSerialization.data(withJSONObject: payload), encoding: .utf8) ?? ""
+        return try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: Date(timeIntervalSince1970: 0))
+            .rollingUsagePercent
+    }
+
+    @Test
+    func `sub-one-percent computed usage is not rescaled to 100`() throws {
+        // 1/100 = 1% used. The direct-fraction heuristic (<= 1 => * 100) must NOT touch a
+        // computed used/limit percent, which is already 0...100 — else 1.0 becomes 100.
+        #expect(try abs(self.rollingPercent(used: 1, limit: 100) - 1) < 0.0001)
+        // 1/200 = 0.5% used (was wrongly rescaled to 50).
+        #expect(try abs(self.rollingPercent(used: 1, limit: 200) - 0.5) < 0.0001)
+    }
+
+    @Test
+    func `normal computed usage is unchanged`() throws {
+        #expect(try abs(self.rollingPercent(used: 25, limit: 100) - 25) < 0.0001)
+    }
+
+    @Test
+    func `direct fractional percent is still scaled to percent`() throws {
+        // A direct percent field given as a 0...1 fraction keeps the existing behavior.
+        let payload: [String: Any] = [
+            "usage": ["rollingUsage": ["usagePercent": 0.25, "resetInSec": 600]],
+        ]
+        let text = try String(data: JSONSerialization.data(withJSONObject: payload), encoding: .utf8) ?? ""
+        let snapshot = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: Date(timeIntervalSince1970: 0))
+        #expect(snapshot.rollingUsagePercent == 25)
+    }
+}
+#endif

--- a/TestsLinux/OpenCodePercentUnitLinuxTests.swift
+++ b/TestsLinux/OpenCodePercentUnitLinuxTests.swift
@@ -1,0 +1,44 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct OpenCodePercentUnitLinuxTests {
+    private func rollingPercent(used: Int, limit: Int) throws -> Double {
+        let payload: [String: Any] = [
+            "rollingUsage": ["used": used, "limit": limit, "resetInSec": 600],
+            "weeklyUsage": ["used": used, "limit": limit, "resetInSec": 3600],
+        ]
+        let text = try String(data: JSONSerialization.data(withJSONObject: payload), encoding: .utf8) ?? ""
+        return try OpenCodeUsageFetcher.parseSubscription(text: text, now: Date(timeIntervalSince1970: 0))
+            .rollingUsagePercent
+    }
+
+    @Test
+    func `sub-one-percent computed usage is not rescaled to 100`() throws {
+        // 1/100 = 1% used. The direct-fraction heuristic (<= 1 => * 100) must NOT touch a
+        // computed used/limit percent, which is already 0...100 — else 1.0 becomes 100.
+        #expect(try abs(self.rollingPercent(used: 1, limit: 100) - 1) < 0.0001)
+        // 1/200 = 0.5% used (was wrongly rescaled to 50).
+        #expect(try abs(self.rollingPercent(used: 1, limit: 200) - 0.5) < 0.0001)
+    }
+
+    @Test
+    func `normal computed usage is unchanged`() throws {
+        #expect(try abs(self.rollingPercent(used: 25, limit: 100) - 25) < 0.0001)
+    }
+
+    @Test
+    func `direct fractional percent is still scaled to percent`() throws {
+        // A direct percent field given as a 0...1 fraction keeps the existing behavior.
+        let payload: [String: Any] = [
+            "rollingUsage": ["usagePercent": 0.25, "resetInSec": 600],
+            "weeklyUsage": ["usagePercent": 0.5, "resetInSec": 3600],
+        ]
+        let text = try String(data: JSONSerialization.data(withJSONObject: payload), encoding: .utf8) ?? ""
+        let snapshot = try OpenCodeUsageFetcher.parseSubscription(text: text, now: Date(timeIntervalSince1970: 0))
+        #expect(snapshot.rollingUsagePercent == 25)
+        #expect(snapshot.weeklyUsagePercent == 50)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

`OpenCode` and `OpenCodeGo` resolve a window percent one of two ways in `parseWindow`:

- a **direct** percent field, which may arrive as a fraction (`0…1`) or a percent (`0…100`), or
- a **computed** `(used / limit) * 100`, which is **already** `0…100`.

A fraction heuristic — `if resolvedPercent <= 1.0 { resolvedPercent *= 100 }` — is meant only for the direct field (to promote a `0.25` fraction to `25%`). But it ran after **both** branches, so it also re-scaled the computed percent whenever an account was **≤ 1 % used**:

- `used = 1, limit = 100` → `(1/100)*100 = 1.0` → `<= 1.0` → `*100` → **100 %** (false "quota exhausted")
- `used = 5, limit = 750` → `0.667 %` → **66.7 %**

Sibling providers (Devin, Synthetic) apply the `<= 1` heuristic only to their raw-fraction branch and use the computed `used/limit*100` directly. These two are the outliers. Same percent-normalization family as #2255 / #2265 / #2293.

## Fix

```diff
  var percent = self.doubleValue(from: dict, keys: self.percentKeys)
+ let percentIsDirect = percent != nil
  ...
  guard var resolvedPercent = percent else { return nil }
- if resolvedPercent <= 1.0, resolvedPercent >= 0 {
+ if percentIsDirect, resolvedPercent <= 1.0, resolvedPercent >= 0 {
      resolvedPercent *= 100
  }
```

Applied to both `OpenCodeUsageFetcher` and its twin `OpenCodeGoUsageFetcher`. The direct-percent path (fraction ≤ 1 still scaled, percent > 1 unchanged) and the normal ≥ 1 % computed path are byte-for-byte unchanged.

## Test

`TestsLinux/OpenCode{,Go}PercentUnitLinuxTests.swift` — for each provider: sub-1 % computed (`1/100 → 1`, `1/200 → 0.5`; were `100` / `50`), normal computed unchanged (`25/100 → 25`), direct fractional still scaled (`0.25 → 25`). The existing `computes usage percent from totals` tests only use ≥ 1 % inputs, so this case was uncovered.

## Proof (real run)

These suites run on CI in the **`build-linux-cli`** job's "Swift Test (Linux only)" step (`swift test --parallel`). Local red→green in `swift:6.3.3`, same inputs, only the two-line gate differs:

**Before the fix** — heuristic reverted, sub-1 % computed usage inflates:
```
✘ "sub-one-percent computed usage is not rescaled to 100" (OpenCode):   abs(rollingPercent(1,100) - 1) < 0.0001   FAILED  (got 100)
✘ "sub-one-percent computed usage is not rescaled to 100" (OpenCodeGo): abs(rollingPercent(1,200) - 0.5) < 0.0001 FAILED  (got 50)
✘ Test run with 6 tests in 2 suites failed with 4 issues.
```

**After the fix** — all pass:
```
✔ Suite OpenCodePercentUnitLinuxTests passed
✔ Suite OpenCodeGoPercentUnitLinuxTests passed
✔ Test run with 6 tests in 2 suites passed
```

Build clean, `swiftlint --strict` 0 violations, `swiftformat --lint` clean.

Small and self-contained — happy to adjust or close if the behavior isn't wanted.
