### PR TITLE
Fix Command Code progress contrast

### DIFF
--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
@@ -28,7 +28,7 @@ public enum CommandCodeProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .commandcode,
                 iconResourceName: "ProviderIcon-commandcode",
-                color: ProviderColor(red: 0 / 255, green: 0 / 255, blue: 0 / 255),
+                color: ProviderColor(hex: 0xA04DFD),
                 confettiPalette: [
                     ProviderColor(hex: 0x000000),
                     ProviderColor(hex: 0xFFFFFF),

--- a/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
+++ b/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
@@ -28,6 +28,20 @@ struct MenuCardProviderRegressionTests {
     }
 
     @Test
+    func `command code progress color uses its contrasting brand accent`() {
+        let branding = ProviderDescriptorRegistry.descriptor(for: .commandcode).branding.color
+        let expected = ProviderColor(hex: 0xA04DFD)
+
+        #expect(branding == expected)
+        #expect(UsageMenuCardView.Model.progressColor(for: .commandcode) == Color(
+            red: expected.red,
+            green: expected.green,
+            blue: expected.blue))
+        #expect(Self.contrastRatio(expected, againstLuminance: 0) >= 3)
+        #expect(Self.contrastRatio(expected, againstLuminance: 1) >= 3)
+    }
+
+    @Test
     func `open router model shows daily and weekly key spend`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.openrouter])
@@ -64,6 +78,16 @@ struct MenuCardProviderRegressionTests {
             now: now))
 
         #expect(model.usageNotes == ["Today: $0.12 · This week: $0.74"])
+    }
+
+    private static func contrastRatio(_ color: ProviderColor, againstLuminance background: Double) -> Double {
+        let components = [color.red, color.green, color.blue].map { component in
+            component <= 0.04045
+                ? component / 12.92
+                : pow((component + 0.055) / 1.055, 2.4)
+        }
+        let foreground = 0.2126 * components[0] + 0.7152 * components[1] + 0.0722 * components[2]
+        return (max(foreground, background) + 0.05) / (min(foreground, background) + 0.05)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace Command Code's black branding color with its `#A04DFD` accent
- keep the shared provider-branding resolver as the single progress-bar color source
- cover the exact menu-card mapping and 3:1 contrast against black and white backgrounds

## Root cause

The shared menu-card progress bar correctly used the provider descriptor's branding color, but Command Code's descriptor defined that color as pure black. The fill therefore blended into the dark menu-card track.

## Visual proof

Before (reporter capture):

![Black Command Code progress fill blending into the dark card](https://github.com/user-attachments/assets/383fe029-178f-4da3-a119-55d8e0acc758)

After: a fresh 308 x 169 synthetic dark-theme render using the production progress-bar view is attached in the verification comment below. It contains no account data.

## Verification

- `swift test --filter MenuCardProviderRegressionTests` — 7 passed
- `swift test --filter CommandCodeProviderTests` — 5 passed
- `make check` — format, lint, package, docs, locale, and repository checks passed; SwiftLint reported 0 violations
- artifact-only behavior contract — dark-theme fill visible, labels legible and unclipped, synthetic data only
- autoreview — clean, no accepted/actionable findings

Closes #2323
