### PR TITLE
Fix custom layout provider icon rendering

### DIFF
--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -94,6 +94,8 @@ final class MenuBarLayoutRenderer {
 
     private struct TokenStyle {
         let font: NSFont
+        let foregroundColor: NSColor
+        let iconHeight: CGFloat
         let attributes: [NSAttributedString.Key: Any]
     }
 
@@ -129,6 +131,7 @@ final class MenuBarLayoutRenderer {
     {
         let isStacked = layout.lines.count == 2
         let font = NSFont.systemFont(ofSize: Self.fontSize(size: options.size, isStacked: isStacked))
+        let foregroundColor = options.highContrast ? NSColor.labelColor : NSColor.controlTextColor
         let paragraphStyle = NSMutableParagraphStyle()
         if isStacked {
             paragraphStyle.minimumLineHeight = 9.5
@@ -137,7 +140,7 @@ final class MenuBarLayoutRenderer {
         }
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
-            .foregroundColor: options.highContrast ? NSColor.labelColor : NSColor.controlTextColor,
+            .foregroundColor: foregroundColor,
             .paragraphStyle: paragraphStyle,
         ]
         let result = NSMutableAttributedString()
@@ -156,7 +159,11 @@ final class MenuBarLayoutRenderer {
                     token,
                     data: data,
                     icon: icon,
-                    style: TokenStyle(font: font, attributes: attributes),
+                    style: TokenStyle(
+                        font: font,
+                        foregroundColor: foregroundColor,
+                        iconHeight: Self.iconHeight(size: options.size, isStacked: isStacked),
+                        attributes: attributes),
                     options: options)
                 result.append(renderedItem.value)
                 if let accessibilityText = renderedItem.accessibilityText {
@@ -195,10 +202,8 @@ final class MenuBarLayoutRenderer {
                     attributes: style.attributes)
             }
             let attachment = NSTextAttachment()
-            attachment.image = icon
-            let height = options.size == .small
-                ? min(style.font.capHeight + 2, 12)
-                : min(style.font.capHeight + 3, 15)
+            attachment.image = Self.attachmentImage(icon, tint: style.foregroundColor)
+            let height = style.iconHeight
             let width = icon.size.height > 0 ? icon.size.width * height / icon.size.height : height
             attachment.bounds = NSRect(
                 x: 0,
@@ -288,6 +293,22 @@ final class MenuBarLayoutRenderer {
         }
     }
 
+    private static func attachmentImage(_ image: NSImage, tint: NSColor) -> NSImage {
+        guard image.isTemplate else { return image }
+
+        // NSTextAttachment draws an NSImage directly instead of through an image cell, so AppKit does not
+        // apply template tinting here. Keep a template image for status-item semantics while drawing its mask
+        // with the same dynamic foreground color as the surrounding title.
+        let tintedImage = NSImage(size: image.size, flipped: false) { rect in
+            image.draw(in: rect)
+            tint.setFill()
+            rect.fill(using: .sourceAtop)
+            return true
+        }
+        tintedImage.isTemplate = true
+        return tintedImage
+    }
+
     private static func resetToken(
         _ value: String?,
         unavailableLabel: String,
@@ -347,5 +368,12 @@ final class MenuBarLayoutRenderer {
             return size == .small ? 8 : 9
         }
         return size == .small ? 11 : NSFont.systemFontSize
+    }
+
+    private static func iconHeight(size: MenuBarLayoutSize, isStacked: Bool) -> CGFloat {
+        if isStacked {
+            return size == .small ? 8 : 9
+        }
+        return size == .small ? 14 : 16
     }
 }

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -54,6 +54,31 @@ struct MenuBarLayoutRendererTests {
     }
 
     @Test
+    func `icon attachment matches the default template size and appearance`() throws {
+        let renderer = MenuBarLayoutRenderer()
+        let icon = NSImage(size: NSSize(width: 16, height: 16))
+        icon.lockFocus()
+        NSColor.white.setFill()
+        NSBezierPath(ovalIn: NSRect(x: 1, y: 1, width: 14, height: 14)).fill()
+        icon.unlockFocus()
+        icon.isTemplate = true
+
+        let output = renderer.render(
+            layout: MenuBarLayout(lines: [[.icon]]),
+            data: self.data(),
+            icon: icon,
+            options: self.options())
+        let attachment = try #require(
+            output.attributedTitle.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment)
+        let attachmentImage = try #require(attachment.image)
+
+        #expect(attachment.bounds.size == NSSize(width: 16, height: 16))
+        #expect(attachmentImage.isTemplate)
+        #expect(try self.averageBrightness(of: output.attributedTitle, appearance: .aqua) < 0.25)
+        #expect(try self.averageBrightness(of: output.attributedTitle, appearance: .darkAqua) > 0.75)
+    }
+
+    @Test
     func `missing token data keeps every sibling visible as a placeholder`() {
         let renderer = MenuBarLayoutRenderer()
         let missingData = MenuBarLayoutRenderData(
@@ -249,5 +274,33 @@ struct MenuBarLayoutRendererTests {
             appearanceName: "aqua",
             isDebugApp: false,
             now: self.now)
+    }
+
+    private func averageBrightness(
+        of title: NSAttributedString,
+        appearance: NSAppearance.Name) throws
+        -> CGFloat
+    {
+        let canvas = NSImage(size: NSSize(width: 24, height: 24))
+        try #require(NSAppearance(named: appearance)).performAsCurrentDrawingAppearance {
+            canvas.lockFocus()
+            NSColor.clear.setFill()
+            NSRect(origin: .zero, size: canvas.size).fill()
+            title.draw(at: NSPoint(x: 4, y: 4))
+            canvas.unlockFocus()
+        }
+
+        let data = try #require(canvas.tiffRepresentation)
+        let bitmap = try #require(NSBitmapImageRep(data: data))
+        var totalBrightness: CGFloat = 0
+        var visiblePixelCount = 0
+        for y in 0..<bitmap.pixelsHigh {
+            for x in 0..<bitmap.pixelsWide {
+                guard let color = bitmap.colorAt(x: x, y: y), color.alphaComponent > 0.1 else { continue }
+                totalBrightness += color.brightnessComponent
+                visiblePixelCount += 1
+            }
+        }
+        return try totalBrightness / CGFloat(#require(visiblePixelCount > 0 ? visiblePixelCount : nil))
     }
 }


### PR DESCRIPTION
## Summary

- render custom-layout provider icons at the same 16-point regular size as the default Icon & percent path
- preserve template-image semantics while applying the surrounding dynamic status-item foreground color inside `NSTextAttachment`
- cover the actual Aqua and Dark Aqua raster output, attachment size, and template flag

## Root cause

`NSTextAttachment` draws its `NSImage` directly rather than through the image cell used by `NSStatusBarButton`. The provider SVGs contain white artwork, so the attachment rendered that white artwork literally even though the image was marked as a template. The custom renderer also reduced regular icons to a font-cap-height-derived size instead of the default path's 16-point footprint.

## Verification

- `swift test --filter MenuBarLayoutRendererTests` — 9 tests passed
- `make check` — SwiftFormat clean; SwiftLint found 0 violations in 1,577 files; all repository checks passed
- `make test` — all 719 discovered selections passed; one unrelated group recovered on the runner's automatic full-group retry
- structured autoreview — clean, no accepted/actionable findings

The focused AppKit regression test renders the attachment under both Aqua and Dark Aqua and checks the resulting pixel brightness. A human will still live-verify the freshly built app on a light menu bar before release.

Closes #2325.
