### PR TITLE
fix: skip elapsed reset times when picking LLMProxy next reset

### DIFF
--- a/Sources/CodexBarCore/Providers/LLMProxy/LLMProxyUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/LLMProxy/LLMProxyUsageFetcher.swift
@@ -264,7 +264,12 @@ public struct LLMProxyUsageFetcher: Sendable {
 
             let quotaGroups = providers.values.flatMap { $0.quotaGroups ?? [] }
             let minRemaining = quotaGroups.compactMap(\.remainingPercent).min()
-            let reset = quotaGroups.compactMap { Self.parseDate($0.resetTime) }.min()
+            // Ignore already-elapsed reset times so a stale past reset can't win over the real
+            // upcoming one; mirrors GrokWebBillingFetcher and ClaudeStatusProbe.
+            let reset = quotaGroups
+                .compactMap { Self.parseDate($0.resetTime) }
+                .filter { $0 > updatedAt }
+                .min()
 
             return LLMProxyUsageSnapshot(
                 providerCount: providers.count,

--- a/TestsLinux/LLMProxyResetLinuxTests.swift
+++ b/TestsLinux/LLMProxyResetLinuxTests.swift
@@ -1,0 +1,53 @@
+#if os(Linux)
+import CodexBarCore
+import Foundation
+import Testing
+
+struct LLMProxyResetLinuxTests {
+    // 2023-11-14T22:13:20Z — the snapshot time treated as "now".
+    private static let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func nextReset(resetTimes: [String]) throws -> Date? {
+        let groups = resetTimes
+            .map { "{ \"remaining_percent\": 50, \"reset_time\": \"\($0)\" }" }
+            .joined(separator: ", ")
+        let json = "{ \"providers\": { \"p\": { \"quota_groups\": [ \(groups) ] } } }"
+        return try LLMProxyUsageFetcher
+            ._parseSnapshotForTesting(Data(json.utf8), updatedAt: Self.now)
+            .nextResetAt
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) throws -> Date {
+        try #require(DateComponents(
+            calendar: Calendar(identifier: .gregorian),
+            timeZone: TimeZone(secondsFromGMT: 0),
+            year: year, month: month, day: day, hour: 0, minute: 0, second: 0).date)
+    }
+
+    @Test
+    func `next reset skips already-elapsed reset times`() throws {
+        // A past reset (stale until the API refreshes) must not be chosen over the soonest upcoming one.
+        let reset = try self.nextReset(resetTimes: [
+            "2023-11-01T00:00:00Z", // past (before now)
+            "2023-11-20T00:00:00Z", // soonest future
+            "2023-12-25T00:00:00Z", // later future
+        ])
+        #expect(try abs(#require(reset).timeIntervalSince(self.date(2023, 11, 20))) < 0.001)
+    }
+
+    @Test
+    func `all-past reset times yield no next reset`() throws {
+        let reset = try self.nextReset(resetTimes: [
+            "2023-11-01T00:00:00Z",
+            "2023-10-15T00:00:00Z",
+        ])
+        #expect(reset == nil)
+    }
+
+    @Test
+    func `future reset time is preserved`() throws {
+        let reset = try self.nextReset(resetTimes: ["2023-11-20T00:00:00Z"])
+        #expect(try abs(#require(reset).timeIntervalSince(self.date(2023, 11, 20))) < 0.001)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

`LLMProxyUsageFetcher.parseSnapshot(data:updatedAt:)` computes the displayed next reset as the **globally earliest** reset across all quota groups:

```swift
let reset = quotaGroups.compactMap { Self.parseDate($0.resetTime) }.min()
```

There is no future filter, so if any quota group carries an **already-elapsed** `reset_time` (a group that rolled over and is momentarily stale until the next refresh), that past date wins the `.min()` and is surfaced as `nextResetAt` → `RateWindow.resetsAt`. A user then sees a "next reset" that is in the past.

Concrete: reset times `[2023-11-01 (past), 2023-11-20 (soon), 2023-12-25 (later)]` with a snapshot time of `2023-11-14` → shows `2023-11-01`; correct is `2023-11-20`.

## Fix

Ignore reset times at or before the snapshot time (`updatedAt`) before taking the minimum:

```diff
- let reset = quotaGroups.compactMap { Self.parseDate($0.resetTime) }.min()
+ let reset = quotaGroups
+     .compactMap { Self.parseDate($0.resetTime) }
+     .filter { $0 > updatedAt }
+     .min()
```

This mirrors the existing convention in `GrokWebBillingFetcher` (`filter { $0.date > now }`) and `ClaudeStatusProbe` (`first(where: { $0 >= now })`). When every reset is in the past, `nextResetAt` becomes `nil` (honestly "unknown") rather than a stale past date; downstream (`RateWindow.resetsAt`) already accepts `Date?`. Normal all-future data is unchanged.

## Test

`TestsLinux/LLMProxyResetLinuxTests.swift` (via the existing `_parseSnapshotForTesting` hook):
- past + two future → picks the **soonest future** (`2023-11-20`), not the past one
- all-past → `nextResetAt == nil`
- single future → preserved

## Proof (real run)

Runs on CI in the **`build-linux-cli`** "Swift Test (Linux only)" step (`swift test --parallel`). Local red→green in `swift:6.3.3`, only the `.filter` line differs:

**Before the fix** — filter removed, the past reset wins:
```
✘ "next reset skips already-elapsed reset times":  #require(reset) == 2023-11-20  FAILED  (got 2023-11-01)
✘ "all-past reset times yield no next reset":       reset == nil                  FAILED  (got 2023-10-15)
✔ "future reset time is preserved"                                                passed
✘ Test run with 3 tests in 1 suite failed with 2 issues.
```

**After the fix** — all pass:
```
✔ "all-past reset times yield no next reset" passed
✔ "future reset time is preserved" passed
✔ "next reset skips already-elapsed reset times" passed
✔ Test run with 3 tests in 1 suite passed
```

Build clean, `swiftlint --strict` 0 violations, `swiftformat --lint` clean.

Small and self-contained — happy to adjust or close if the behavior isn't wanted.
