### PR TITLE
Keep full-session estimate visible while idle

### DIFF
--- a/Sources/CodexBar/SessionEquivalentForecast.swift
+++ b/Sources/CodexBar/SessionEquivalentForecast.swift
@@ -51,7 +51,6 @@ struct SessionEquivalentForecast: Equatable, Sendable {
               == self.sessionWindowMinutes,
               weeklyWindow.windowMinutes.map({ PlanUtilizationSeriesName.weekly.canonicalWindowMinutes($0) })
               == self.weeklyWindowMinutes,
-              let sessionResetsAt = sessionWindow.resetsAt,
               let weeklyResetsAt = weeklyWindow.resetsAt,
               weeklyWindow.usedPercent.isFinite,
               (0...100).contains(weeklyWindow.usedPercent),
@@ -64,12 +63,18 @@ struct SessionEquivalentForecast: Equatable, Sendable {
 
         let sessionSeconds = TimeInterval(Self.sessionWindowMinutes * 60)
         let weeklySeconds = TimeInterval(Self.weeklyWindowMinutes * 60)
-        let sessionRemaining = sessionResetsAt.timeIntervalSince(now)
+        if let sessionResetsAt = sessionWindow.resetsAt {
+            let sessionRemaining = sessionResetsAt.timeIntervalSince(now)
+            guard sessionRemaining.isFinite,
+                  sessionRemaining > 0,
+                  sessionRemaining <= sessionSeconds + Self.resetTolerance
+            else {
+                return nil
+            }
+        }
+
         let weeklyRemaining = weeklyResetsAt.timeIntervalSince(now)
-        guard sessionRemaining.isFinite,
-              sessionRemaining > 0,
-              sessionRemaining <= sessionSeconds + Self.resetTolerance,
-              weeklyRemaining.isFinite,
+        guard weeklyRemaining.isFinite,
               weeklyRemaining > 0,
               weeklyRemaining <= weeklySeconds + Self.resetTolerance
         else {
@@ -167,7 +172,7 @@ enum SessionEquivalentBurnEstimator {
 
     static func estimate(
         histories: [PlanUtilizationSeriesHistory],
-        currentSessionResetsAt: Date,
+        currentSessionResetsAt: Date?,
         now: Date,
         sampleLimit: Int = Self.defaultSampleLimit) -> SessionEquivalentBurnEstimate?
     {
@@ -188,14 +193,19 @@ enum SessionEquivalentBurnEstimator {
 
         let sessionDuration = TimeInterval(SessionEquivalentForecast.sessionWindowMinutes * 60)
         let weeklyDuration = TimeInterval(SessionEquivalentForecast.weeklyWindowMinutes * 60)
-        let currentSessionRemaining = currentSessionResetsAt.timeIntervalSince(now)
-        guard currentSessionRemaining.isFinite,
-              currentSessionRemaining > 0,
-              currentSessionRemaining <= sessionDuration + Self.resetEquivalenceTolerance,
-              Self.isChronologicallyOrdered(sessionHistory.entries),
+        guard Self.isChronologicallyOrdered(sessionHistory.entries),
               Self.isChronologicallyOrdered(weeklyHistory.entries)
         else {
             return nil
+        }
+        if let currentSessionResetsAt {
+            let currentSessionRemaining = currentSessionResetsAt.timeIntervalSince(now)
+            guard currentSessionRemaining.isFinite,
+                  currentSessionRemaining > 0,
+                  currentSessionRemaining <= sessionDuration + Self.resetEquivalenceTolerance
+            else {
+                return nil
+            }
         }
 
         var groups: [SessionGroup] = []
@@ -226,7 +236,10 @@ enum SessionEquivalentBurnEstimator {
         }
 
         let completedActiveGroups = groups.reversed().compactMap { group -> SessionGroup? in
-            guard group.resetsAt < currentSessionResetsAt.addingTimeInterval(-Self.resetEquivalenceTolerance),
+            let precedesCurrentSession = currentSessionResetsAt.map {
+                group.resetsAt < $0.addingTimeInterval(-Self.resetEquivalenceTolerance)
+            } ?? true
+            guard precedesCurrentSession,
                   group.resetsAt <= now,
                   group.maximumUsedPercent > 0
             else {
@@ -399,10 +412,13 @@ enum SessionEquivalentBurnEstimator {
 }
 
 private struct SessionEquivalentBurnCacheKey: Equatable {
+    static let idleTimeBucketSeconds: TimeInterval = 60
+
     let historyRevision: Int
     let historySelectionIdentity: String
-    let currentSessionResetsAt: Date
+    let currentSessionResetsAt: Date?
     let weeklyWindowID: String?
+    let idleTimeBucket: Int64?
 }
 
 struct SessionEquivalentBurnCacheEntry {
@@ -422,10 +438,12 @@ extension UsageStore {
         now: Date = .init()) -> SessionEquivalentForecast?
     {
         guard sessionWindow.windowMinutes.map({ PlanUtilizationSeriesName.session.canonicalWindowMinutes($0) })
-            == SessionEquivalentForecast.sessionWindowMinutes,
-            let currentSessionResetsAt = sessionWindow.resetsAt,
-            currentSessionResetsAt.timeIntervalSinceReferenceDate.isFinite
+            == SessionEquivalentForecast.sessionWindowMinutes
         else {
+            return nil
+        }
+        let currentSessionResetsAt = sessionWindow.resetsAt
+        guard currentSessionResetsAt?.timeIntervalSinceReferenceDate.isFinite ?? true else {
             return nil
         }
 
@@ -441,7 +459,11 @@ extension UsageStore {
             historyRevision: self.planUtilizationHistoryRevision,
             historySelectionIdentity: selection.cacheIdentity,
             currentSessionResetsAt: currentSessionResetsAt,
-            weeklyWindowID: weeklyWindowID)
+            weeklyWindowID: weeklyWindowID,
+            idleTimeBucket: currentSessionResetsAt == nil
+                ? Int64(floor(now.timeIntervalSinceReferenceDate /
+                        SessionEquivalentBurnCacheKey.idleTimeBucketSeconds))
+                : nil)
         let burnEstimate: SessionEquivalentBurnEstimate?
         if let cached = self.sessionEquivalentBurnCache[provider], cached.key == cacheKey {
             burnEstimate = cached.estimate

--- a/Tests/CodexBarTests/SessionEquivalentForecastIdleTests.swift
+++ b/Tests/CodexBarTests/SessionEquivalentForecastIdleTests.swift
@@ -1,0 +1,71 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+extension SessionEquivalentForecastTests {
+    @MainActor
+    @Test
+    func `usage store preserves learned forecast while current session is idle`() throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let fixture = Self.historyFixture(burns: [4, 8, 6, 10])
+        store.planUtilizationHistory[.claude] = PlanUtilizationHistoryBuckets(unscoped: fixture.histories)
+        let now = fixture.currentSessionReset.addingTimeInterval(-3600)
+        let session = RateWindow(
+            usedPercent: 0,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: nil)
+        let weekly = RateWindow(
+            usedPercent: 60,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(2 * 24 * 3600),
+            resetDescription: nil)
+
+        let forecast = try #require(store.sessionEquivalentForecast(
+            provider: .claude,
+            sessionWindow: session,
+            weeklyWindow: weekly,
+            now: now))
+
+        #expect(forecast.sampleCount == 4)
+        #expect(forecast.estimatedWindowsToExhaustWeekly > 0)
+    }
+
+    @MainActor
+    @Test
+    func `idle forecast cache refreshes after a historical session completes`() throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let fixture = Self.historyFixture(burns: [5, 5, 5])
+        store.planUtilizationHistory[.claude] = PlanUtilizationHistoryBuckets(unscoped: fixture.histories)
+        store.planUtilizationHistoryRevision = 1
+        let thirdReset = fixture.currentSessionReset.addingTimeInterval(-5 * 3600)
+        let beforeReset = thirdReset.addingTimeInterval(-61)
+        let afterReset = thirdReset.addingTimeInterval(61)
+        let session = RateWindow(
+            usedPercent: 0,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: nil)
+        let weekly = RateWindow(
+            usedPercent: 15,
+            windowMinutes: 10080,
+            resetsAt: afterReset.addingTimeInterval(2 * 24 * 3600),
+            resetDescription: nil)
+
+        #expect(store.sessionEquivalentForecast(
+            provider: .claude,
+            sessionWindow: session,
+            weeklyWindow: weekly,
+            now: beforeReset) == nil)
+        #expect(store._sessionEquivalentHistoryScanCountForTesting == 1)
+
+        let forecast = try #require(store.sessionEquivalentForecast(
+            provider: .claude,
+            sessionWindow: session,
+            weeklyWindow: weekly,
+            now: afterReset))
+        #expect(forecast.sampleCount == 3)
+        #expect(store._sessionEquivalentHistoryScanCountForTesting == 2)
+    }
+}

--- a/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
+++ b/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
@@ -440,7 +440,7 @@ struct SessionEquivalentForecastTests {
                 planSeries(name: .session, windowMinutes: 300, entries: sessionEntries),
                 planSeries(name: .weekly, windowMinutes: 10080, entries: weeklyEntries),
             ],
-            currentSessionResetsAt: fixture.currentSessionReset,
+            currentSessionResetsAt: nil,
             now: now) == nil)
     }
 
@@ -560,6 +560,71 @@ struct SessionEquivalentForecastTests {
         #expect(!forecast.applies(
             to: weekly,
             windowID: "antigravity-quota-summary-3p-weekly"))
+    }
+
+    @MainActor
+    @Test
+    func `usage store preserves learned forecast while current session is idle`() throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let fixture = Self.historyFixture(burns: [4, 8, 6, 10])
+        store.planUtilizationHistory[.claude] = PlanUtilizationHistoryBuckets(unscoped: fixture.histories)
+        let now = fixture.currentSessionReset.addingTimeInterval(-3600)
+        let session = RateWindow(
+            usedPercent: 0,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: nil)
+        let weekly = RateWindow(
+            usedPercent: 60,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(2 * 24 * 3600),
+            resetDescription: nil)
+
+        let forecast = try #require(store.sessionEquivalentForecast(
+            provider: .claude,
+            sessionWindow: session,
+            weeklyWindow: weekly,
+            now: now))
+
+        #expect(forecast.sampleCount == 4)
+        #expect(forecast.estimatedWindowsToExhaustWeekly > 0)
+    }
+
+    @MainActor
+    @Test
+    func `idle forecast cache refreshes after a historical session completes`() throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let fixture = Self.historyFixture(burns: [5, 5, 5])
+        store.planUtilizationHistory[.claude] = PlanUtilizationHistoryBuckets(unscoped: fixture.histories)
+        store.planUtilizationHistoryRevision = 1
+        let thirdReset = fixture.currentSessionReset.addingTimeInterval(-5 * 3600)
+        let beforeReset = thirdReset.addingTimeInterval(-61)
+        let afterReset = thirdReset.addingTimeInterval(61)
+        let session = RateWindow(
+            usedPercent: 0,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: nil)
+        let weekly = RateWindow(
+            usedPercent: 15,
+            windowMinutes: 10080,
+            resetsAt: afterReset.addingTimeInterval(2 * 24 * 3600),
+            resetDescription: nil)
+
+        #expect(store.sessionEquivalentForecast(
+            provider: .claude,
+            sessionWindow: session,
+            weeklyWindow: weekly,
+            now: beforeReset) == nil)
+        #expect(store._sessionEquivalentHistoryScanCountForTesting == 1)
+
+        let forecast = try #require(store.sessionEquivalentForecast(
+            provider: .claude,
+            sessionWindow: session,
+            weeklyWindow: weekly,
+            now: afterReset))
+        #expect(forecast.sampleCount == 3)
+        #expect(store._sessionEquivalentHistoryScanCountForTesting == 2)
     }
 
     @MainActor

--- a/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
+++ b/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
@@ -575,71 +575,6 @@ struct SessionEquivalentForecastTests {
 
     @MainActor
     @Test
-    func `usage store preserves learned forecast while current session is idle`() throws {
-        let store = UsageStorePlanUtilizationTests.makeStore()
-        let fixture = Self.historyFixture(burns: [4, 8, 6, 10])
-        store.planUtilizationHistory[.claude] = PlanUtilizationHistoryBuckets(unscoped: fixture.histories)
-        let now = fixture.currentSessionReset.addingTimeInterval(-3600)
-        let session = RateWindow(
-            usedPercent: 0,
-            windowMinutes: 300,
-            resetsAt: nil,
-            resetDescription: nil)
-        let weekly = RateWindow(
-            usedPercent: 60,
-            windowMinutes: 10080,
-            resetsAt: now.addingTimeInterval(2 * 24 * 3600),
-            resetDescription: nil)
-
-        let forecast = try #require(store.sessionEquivalentForecast(
-            provider: .claude,
-            sessionWindow: session,
-            weeklyWindow: weekly,
-            now: now))
-
-        #expect(forecast.sampleCount == 4)
-        #expect(forecast.estimatedWindowsToExhaustWeekly > 0)
-    }
-
-    @MainActor
-    @Test
-    func `idle forecast cache refreshes after a historical session completes`() throws {
-        let store = UsageStorePlanUtilizationTests.makeStore()
-        let fixture = Self.historyFixture(burns: [5, 5, 5])
-        store.planUtilizationHistory[.claude] = PlanUtilizationHistoryBuckets(unscoped: fixture.histories)
-        store.planUtilizationHistoryRevision = 1
-        let thirdReset = fixture.currentSessionReset.addingTimeInterval(-5 * 3600)
-        let beforeReset = thirdReset.addingTimeInterval(-61)
-        let afterReset = thirdReset.addingTimeInterval(61)
-        let session = RateWindow(
-            usedPercent: 0,
-            windowMinutes: 300,
-            resetsAt: nil,
-            resetDescription: nil)
-        let weekly = RateWindow(
-            usedPercent: 15,
-            windowMinutes: 10080,
-            resetsAt: afterReset.addingTimeInterval(2 * 24 * 3600),
-            resetDescription: nil)
-
-        #expect(store.sessionEquivalentForecast(
-            provider: .claude,
-            sessionWindow: session,
-            weeklyWindow: weekly,
-            now: beforeReset) == nil)
-        #expect(store._sessionEquivalentHistoryScanCountForTesting == 1)
-
-        let forecast = try #require(store.sessionEquivalentForecast(
-            provider: .claude,
-            sessionWindow: session,
-            weeklyWindow: weekly,
-            now: afterReset))
-        #expect(forecast.sampleCount == 3)
-        #expect(store._sessionEquivalentHistoryScanCountForTesting == 2)
-    }
-
-    @MainActor
-    @Test
     func `usage store memoizes the history scan until revision changes`() {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let fixture = Self.historyFixture(burns: [4, 8, 6, 10])
@@ -1518,7 +1453,7 @@ extension SessionEquivalentForecastTests {
             updatedAt: now)
     }
 
-    private static func historyFixture(burns: [Double])
+    static func historyFixture(burns: [Double])
         -> (histories: [PlanUtilizationSeriesHistory], currentSessionReset: Date)
     {
         self.historyFixture(samples: burns.map {


### PR DESCRIPTION
## Summary

- Keep a learned full-session forecast available when the current five-hour window is idle and has no reset timestamp.
- Continue validating a current reset when one is present.
- Continue excluding historical session windows whose reset is still in the future.
- Refresh the idle forecast cache on minute boundaries so newly completed history becomes eligible.
- Cover idle forecast persistence and cache invalidation with focused tests.

## Why

An idle Claude five-hour window can have no `resetsAt` value. The forecast pipeline treated that missing reset as a hard failure even when enough completed history already existed to calculate the weekly full-session estimate. As a result, a learned estimate disappeared while idle and returned as soon as the user consumed any session quota.

The current session reset is not needed for the estimate itself. Weekly remaining quota and the learned weekly burn per completed full session are sufficient, so this change makes the reset optional without weakening the weekly-window or historical-evidence guards.

Because historical eligibility depends on the current time, idle cache keys also include a minute bucket. This avoids indefinitely reusing a stale `nil` or older estimate after a recorded session reset passes.

## User impact

Once CodexBar has learned a full-session estimate, it remains visible during idle periods and picks up newly completed historical sessions within the menu's minute-level refresh cadence.

## Validation

- `swift test --filter SessionEquivalentForecastTests` — 40 tests passed.
- `make check` — passed with no formatting or lint violations.
- Independent review found no actionable issues.
- `make test` was attempted earlier in development; it stopped in unrelated Claude OAuth temporary-keychain-cache tests (`ClaudeOAuthCredentialsStoreTemporaryKeychainCacheTests`).