### PR TITLE
Fix widget cost row wrapping

### DIFF
--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -928,8 +928,16 @@ private struct ValueLine: View {
             Text(self.title)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
             Text(self.value)
                 .font(.caption)
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .allowsTightening(true)
+                .layoutPriority(1)
         }
     }
 }
@@ -1175,11 +1183,7 @@ enum WidgetFormat {
     }
 
     static func tokenCount(_ value: Int) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 0
-        let raw = formatter.string(from: NSNumber(value: value)) ?? "\(value)"
-        return "\(raw) tokens"
+        "\(UsageFormatter.tokenCountString(value)) tokens"
     }
 
     static func relativeDate(_ date: Date) -> String {

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -5,6 +5,14 @@ import Testing
 
 struct CodexBarWidgetProviderTests {
     @Test
+    func `widget token counts use compact shared formatting`() {
+        #expect(WidgetFormat.tokenCount(999) == "999 tokens")
+        #expect(WidgetFormat.tokenCount(9_400_000) == "9.4M tokens")
+        #expect(WidgetFormat.tokenCount(94_500_000) == "94M tokens")
+        #expect(WidgetFormat.tokenCount(10_600_000_000) == "11B tokens")
+    }
+
+    @Test
     func `usage display follows remaining and used preference`() {
         #expect(WidgetUsageDisplay.percent(fromRemaining: 48, showUsed: false) == 48)
         #expect(WidgetUsageDisplay.percent(fromRemaining: 48, showUsed: true) == 52)


### PR DESCRIPTION
## Summary

- format widget token totals with CodexBar's shared compact K/M/B formatter
- keep cost rows on one line, prioritizing the value while tail-truncating the lower-priority label
- allow oversized values to tighten and scale within the row instead of clipping

## Root cause

The widget's shared `ValueLine` allowed its title and value texts to wrap independently, while `WidgetFormat.tokenCount` expanded every token total with decimal separators. Large history values therefore consumed multiple lines and broke the row alignment.

## Visual proof

Before (reporter capture):

![Wrapped widget cost rows](https://github.com/user-attachments/assets/97af83a2-9e21-4451-9e75-2063fc6e52fe)

After: a fresh synthetic 338 × 158 dark widget render using the production history view is attached in the verification comment below. It uses the issue's long labels plus 94.5M and 10.6B token fixtures and contains no account data.

## Verification

- `swift test --filter CodexBarWidgetProviderTests` — 47 passed
- `make check` — format, lint, package, docs, locale, and repository checks passed; SwiftLint reported 0 violations
- production-view behavior render — both values remain fully visible on one line; labels truncate at the tail
- autoreview — accepted one accessibility-width finding, removed unbounded horizontal fixed sizing, then reran clean with no accepted/actionable findings

Closes #2317
