### PR TITLE
Fix macOS 14 TaskLocal launch crash

### DIFF
--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -163,7 +163,7 @@ extension UsageStore {
                     allowDisabled: allowDisabled)
                 snapshotUpdatedAtBeforeRefresh = self.snapshot(for: provider)?.updatedAt
                 didStartRefresh = true
-                await ProviderRefreshRequestContext.$id.withValue(UUID()) {
+                await ProviderRefreshRequestContext.withNewRequest {
                     await self.refreshProviderTracked(
                         provider,
                         allowDisabled: allowDisabled,

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -431,7 +431,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                         ])
                 }
 
-                let refreshedRecord = try await ProviderRefreshRequestContext.$id.withValue(UUID()) {
+                let refreshedRecord = try await ProviderRefreshRequestContext.withNewRequest {
                     try await ClaudeUsageFetcher.loadOAuthCredentialRecord(
                         environment: self.fetcher.environment,
                         allowKeychainPrompt: retryAllowKeychainPrompt,

--- a/Sources/CodexBarCore/Providers/ProviderInteractionContext.swift
+++ b/Sources/CodexBarCore/Providers/ProviderInteractionContext.swift
@@ -20,4 +20,14 @@ public enum ProviderRefreshContext {
 
 public enum ProviderRefreshRequestContext {
     @TaskLocal public static var id: UUID?
+
+    public static func withNewRequest<T>(
+        isolation _: isolated (any Actor)? = #isolation,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        // Keep the nontrivial UUID value in the async frame. Passing UUID() directly to
+        // TaskLocal.withValue mis-nests task allocations in the macOS 14 backdeployment thunk.
+        let requestID: UUID? = UUID()
+        return try await self.$id.withValue(requestID, operation: operation)
+    }
 }

--- a/Tests/CodexBarTests/ProviderRefreshRequestContextTests.swift
+++ b/Tests/CodexBarTests/ProviderRefreshRequestContextTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ProviderRefreshRequestContextTests {
+    @Test
+    func `new request stays bound for the full awaited operation`() async throws {
+        #expect(ProviderRefreshRequestContext.id == nil)
+
+        let firstRequestID = try await ProviderRefreshRequestContext.withNewRequest {
+            let requestID = try #require(ProviderRefreshRequestContext.id)
+            await Task.yield()
+            #expect(ProviderRefreshRequestContext.id == requestID)
+            return requestID
+        }
+
+        let secondRequestID = await ProviderRefreshRequestContext.withNewRequest {
+            ProviderRefreshRequestContext.id
+        }
+        #expect(secondRequestID != nil)
+        #expect(secondRequestID != firstRequestID)
+        #expect(ProviderRefreshRequestContext.id == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- keep the exact `UUID?` refresh-request value in an async frame before binding the TaskLocal
- route both the launch refresh and post-delegation Claude retry through the safe helper
- cover suspension, fresh request IDs, and restoration of the outer TaskLocal value

## Root cause

Both reports contain the same arm64 CodexBar image UUID (`947DF872-55B6-39D5-8C6A-EDEDC690D30E`) and the same app fault offset (`0x5cf644`). The frame is the Swift macOS 14 backdeployment implementation of `TaskLocal.withValue`, not provider code: the shipped lowering allocates a nontrivial temporary, pushes the TaskLocal, then deallocates the earlier temporary before entering the operation. That violates the task allocator's LIFO contract and aborts with either `swift_task_dealloc` or `freed pointer was not the last allocation`.

This patch binds a concrete `UUID?` local in the helper's async frame and awaits the complete `withValue` scope. In the signed optimized build (`0ED1C8DB-98FB-34FA-8C40-75034E27E3C1`), the macOS 14 path now performs the safe sequence: allocate value buffer, push TaskLocal, allocate/await/deallocate operation frame, pop TaskLocal, deallocate value buffer.

## Verification

- `swift test --filter ProviderRefreshRequestContextTests` — 1 test passed
- `swift test --filter ClaudeOAuthPromptCoalescingTests` — 5 tests passed
- `swift test --filter ClaudeOAuthDelegatedRefreshEpochTests` — 1 test passed
- `make check` — SwiftFormat clean; SwiftLint found 0 violations in 1,578 files; all repository checks passed
- `make test` pass 1 — 720 selections, 60/60 first-pass groups, 0 retries/timeouts, 615.3s
- `make test` pass 2 — 720 selections, 59 first-pass groups plus 1 recovered group, 0 timeouts, 639.8s
- `make test` pass 3 — 720 selections, 60/60 first-pass groups, 0 retries/timeouts, 437.8s
- Developer ID signed release package passed `codesign --verify --deep --strict`
- optimized arm64 disassembly verified the corrected allocator/push/pop/deallocator nesting on the macOS 14 fallback path
- autoreview clean with no actionable findings

An interactive Sonoma launch was not available: the disposable Sonoma VM lacks Parallels Guest Tools and was locked at its login screen. The crash signature and the before/after optimized machine code provide deterministic evidence for the affected fallback path.

Fixes #2319
Fixes #2326
