### PR TITLE
fix: clamp z.ai raw-percentage usedPercent fallback to 0...100

### DIFF
--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -84,7 +84,9 @@ extension ZaiLimitEntry {
         if let computed = self.computedUsedPercent {
             return computed
         }
-        return self.percentage
+        // The raw API percentage can fall outside 0...100 (z.ai omits/misreports quota fields);
+        // clamp it like computedUsedPercent and every sibling provider instead of surfacing it raw.
+        return min(100, max(0, self.percentage))
     }
 
     public var windowMinutes: Int? {

--- a/TestsLinux/ZaiUsedPercentLinuxTests.swift
+++ b/TestsLinux/ZaiUsedPercentLinuxTests.swift
@@ -1,0 +1,52 @@
+#if os(Linux)
+import CodexBarCore
+import Foundation
+import Testing
+
+struct ZaiUsedPercentLinuxTests {
+    /// usage == nil forces computedUsedPercent to return nil, exercising the raw-percentage fallback.
+    private func fallbackUsedPercent(_ percentage: Double) -> Double {
+        ZaiLimitEntry(
+            type: .tokensLimit,
+            unit: .hours,
+            number: 5,
+            usage: nil,
+            currentValue: nil,
+            remaining: nil,
+            percentage: percentage,
+            usageDetails: [],
+            nextResetTime: nil).usedPercent
+    }
+
+    @Test
+    func `raw percentage fallback clamps above 100`() {
+        #expect(self.fallbackUsedPercent(150) == 100)
+    }
+
+    @Test
+    func `raw percentage fallback clamps below 0`() {
+        #expect(self.fallbackUsedPercent(-5) == 0)
+    }
+
+    @Test
+    func `raw percentage fallback preserves an in-range value`() {
+        #expect(self.fallbackUsedPercent(42) == 42)
+    }
+
+    @Test
+    func `computed path takes precedence and ignores the raw percentage`() {
+        // usage(limit)=100, currentValue(used)=25 -> computed 25%, so the raw 999 must not leak.
+        let entry = ZaiLimitEntry(
+            type: .tokensLimit,
+            unit: .hours,
+            number: 5,
+            usage: 100,
+            currentValue: 25,
+            remaining: nil,
+            percentage: 999,
+            usageDetails: [],
+            nextResetTime: nil)
+        #expect(entry.usedPercent == 25)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

`ZaiLimitEntry.usedPercent` returns `computedUsedPercent` (which already clamps `min(100, max(0, …))`) when z.ai reports quota fields. But when those fields are absent it falls back to `return self.percentage` — the **raw API percentage, unclamped**:

```swift
public var usedPercent: Double {
    if let computed = self.computedUsedPercent { return computed }
    return self.percentage            // raw, can be < 0 or > 100
}
```

z.ai is known to omit/misreport quota fields (see #1855), so an out-of-range `percentage` flows straight into `RateWindow.usedPercent` and the menu bar — every other provider, and this struct's own computed branch, clamp to `0…100`.

## Fix

```diff
- return self.percentage
+ return min(100, max(0, self.percentage))
```

Matches `computedUsedPercent` (line 150) and sibling providers. No change for in-range values.

## Test

`TestsLinux/ZaiUsedPercentLinuxTests.swift` (usage `== nil` forces the fallback path):
- `150 → 100`, `-5 → 0` (clamped)
- `42 → 42` (in-range unchanged)
- computed-path precedence: `usage 100 / used 25 / percentage 999 → 25` (raw 999 does not leak)

## Proof (real run)

Runs on CI in the **`build-linux-cli`** "Swift Test (Linux only)" step. Local red→green in `swift:6.3.3`:

**Before the fix** — fallback returns the raw value:
```
✘ "raw percentage fallback clamps above 100":  fallbackUsedPercent(150) → 150.0 == 100   FAILED
✘ "raw percentage fallback clamps below 0":     fallbackUsedPercent(-5)  → -5.0  == 0     FAILED
✔ in-range + computed-path tests pass
✘ Test run with 4 tests in 1 suite failed with 2 issues.
```

**After the fix** — all pass:
```
✔ Suite ZaiUsedPercentLinuxTests passed
✔ Test run with 4 tests in 1 suite passed
```

Build clean, `swiftlint --strict` 0 violations, `swiftformat --lint` clean.

Small and self-contained — happy to adjust or close if not wanted.
