### PR TITLE
Center stacked menu bar titles

### DIFF
--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -91,6 +91,7 @@ final class MenuBarLayoutTitleCache {
 @MainActor
 final class MenuBarLayoutRenderer {
     private static let missingValue = "–"
+    private static let stackedBaselineOffset: CGFloat = -3 // Center multi-line NSStatusBarButton titles.
 
     private struct TokenStyle {
         let font: NSFont
@@ -138,11 +139,14 @@ final class MenuBarLayoutRenderer {
             paragraphStyle.maximumLineHeight = 9.5
             paragraphStyle.lineSpacing = -1
         }
-        let attributes: [NSAttributedString.Key: Any] = [
+        var attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: foregroundColor,
             .paragraphStyle: paragraphStyle,
         ]
+        if isStacked {
+            attributes[.baselineOffset] = Self.stackedBaselineOffset
+        }
         let result = NSMutableAttributedString()
         var accessibilityLines: [String] = []
 

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -130,6 +130,29 @@ struct MenuBarLayoutRendererTests {
     }
 
     @Test
+    func `stacked titles apply a vertical centering offset`() throws {
+        let renderer = MenuBarLayoutRenderer()
+        let stacked = renderer.render(
+            layout: MenuBarLayout(lines: [
+                [.percent(window: .automatic)],
+                [.resetCountdown],
+            ]),
+            data: self.data(),
+            icon: nil,
+            options: self.options())
+        let resetIndex = (stacked.attributedTitle.string as NSString).range(of: "in 2h").location
+        let singleLine = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic), .resetCountdown]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options())
+
+        #expect(try #require(self.baselineOffset(in: stacked.attributedTitle, at: 0)) == -3)
+        #expect(try #require(self.baselineOffset(in: stacked.attributedTitle, at: resetIndex)) == -3)
+        #expect(self.baselineOffset(in: singleLine.attributedTitle, at: 0) == nil)
+    }
+
+    @Test
     func `two line icon uses compact paragraph metrics`() {
         let renderer = MenuBarLayoutRenderer()
         let icon = NSImage(size: NSSize(width: 16, height: 16))
@@ -302,5 +325,16 @@ struct MenuBarLayoutRendererTests {
             }
         }
         return try totalBrightness / CGFloat(#require(visiblePixelCount > 0 ? visiblePixelCount : nil))
+    }
+
+    private func baselineOffset(in title: NSAttributedString, at index: Int) -> CGFloat? {
+        let value = title.attribute(.baselineOffset, at: index, effectiveRange: nil)
+        if let value = value as? CGFloat {
+            return value
+        }
+        if let value = value as? NSNumber {
+            return CGFloat(truncating: value)
+        }
+        return nil
     }
 }


### PR DESCRIPTION
Fixes #2345.

## Summary
- Adds a stacked-only baseline offset when rendering two-line menu bar titles so NSStatusBarButton centers the block instead of anchoring it high.
- Leaves single-line menu bar layouts unchanged.
- Adds renderer coverage for the stacked baseline attribute and the single-line no-offset contract.

## Verification
- `swiftc -parse Sources/CodexBar/MenuBarLayoutRenderer.swift`
- `swiftc -parse Tests/CodexBarTests/MenuBarLayoutRendererTests.swift`
- `git diff --check`
- `make check`

Not completed locally: `swift test --filter MenuBarLayoutRendererTests` and `swift test --skip-update --filter MenuBarLayoutRendererTests` both stalled before compilation while downloading Sparkle 2.9.3 from SwiftPM. I stopped both after retries.

Compatibility risk: low; the attribute is only applied when a custom layout has exactly two lines.

Review focus: please sanity-check whether the -3pt offset matches the reported Regular stacked menu-bar capture across the supported menu-bar sizes.

## Native UI proof

Fresh native menu bar proof was captured from this exact PR head on macOS 26.3. It includes the signed 0.45.2 baseline, the corrected Regular stacked layout, an adjacent single line control, and 2x pixel measurements.

Evidence: https://github.com/steipete/CodexBar/pull/2347#issuecomment-5020429069
