### PR TITLE
fix: allow Alibaba/Qwen Token Plan usage on Linux with a manual cookie

### DIFF
--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -694,6 +694,13 @@ extension CodexBarCLI {
         {
             return false
         }
+        if provider == .alibabatokenplan,
+           settings?.alibabaTokenPlan?.cookieSource == .manual
+        {
+            // The Alibaba/Qwen Token Plan fetch is plain URLSession + cookies; only browser
+            // cookie auto-import needs macOS, so a manual cookie header works off macOS too.
+            return false
+        }
         #if os(Linux)
         if provider == .cursor,
            settings?.cursor?.cookieSource != .off

--- a/TestsLinux/AlibabaTokenPlanLinuxTests.swift
+++ b/TestsLinux/AlibabaTokenPlanLinuxTests.swift
@@ -1,0 +1,30 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCLI
+@testable import CodexBarCore
+
+struct AlibabaTokenPlanLinuxTests {
+    @Test
+    func `manual cookie source does not require macOS web support`() {
+        // The Alibaba/Qwen Token Plan fetch is plain URLSession + cookies, so a manually
+        // configured cookie header must be usable off macOS (matches qoder/commandcode).
+        #expect(!CodexBarCLI.sourceModeRequiresWebSupport(
+            .web,
+            provider: .alibabatokenplan,
+            settings: ProviderSettingsSnapshot.make(
+                alibabaTokenPlan: .init(
+                    cookieSource: .manual,
+                    manualCookieHeader: "login_qwencloud_ticket=t"))))
+    }
+
+    @Test
+    func `auto cookie source still requires web support off macOS`() {
+        #expect(CodexBarCLI.sourceModeRequiresWebSupport(
+            .web,
+            provider: .alibabatokenplan,
+            settings: ProviderSettingsSnapshot.make(
+                alibabaTokenPlan: .init(cookieSource: .auto, manualCookieHeader: nil))))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

`sourceModeRequiresWebSupport` blanket-rejects web-source providers off macOS, but it already carries per-provider escape hatches for `opencodego`, `commandcode`, `cursor`, and `qoder` when their cookie source is **manual** — those fetches are plain `URLSession` + cookies, and only browser cookie *auto-import* actually needs macOS.

`alibabatokenplan` (Alibaba / Qwen Cloud Token Plan) was missing this exemption, so on Linux:

```
$ codexbar usage --provider alibaba-token-plan
Error: selected source requires web support and is only supported on macOS.
```

…even with `cookieSource: "manual"` + a configured cookie header. `AlibabaTokenPlanProviderSettings` already conforms to `ProviderCookieSettings`, so the same exemption applies cleanly.

This is the "Blocker on Linux" from #2328 (the full Qwen Cloud Personal API variant is a separate, larger follow-up).

## Fix

```swift
if provider == .alibabatokenplan,
   settings?.alibabaTokenPlan?.cookieSource == .manual
{
    return false
}
```

Placed alongside the existing `commandcode` / `qoder` exemptions (not `#if os(Linux)`-gated, since a manual cookie works on any platform; only `cursor`'s app-auth path is Linux-specific). No effect on macOS (already supports web). Only `.manual` is exempted — `.auto` / `.off` still require web support.

## Test

`TestsLinux/AlibabaTokenPlanLinuxTests.swift`:
- `cookieSource == .manual` → does **not** require web support (reachable on Linux)
- `cookieSource == .auto` → still requires web support (unchanged)

## Proof (real run)

Runs on CI in the **`build-linux-cli`** "Swift Test (Linux only)" step. Local red→green in `swift:6.3.3`:

**Before the fix** (exemption removed) — manual cookie is still gated:
```
✘ "manual cookie source does not require macOS web support"  FAILED  (sourceModeRequiresWebSupport → true)
✔ "auto cookie source still requires web support off macOS"  passed
✘ Test run with 2 tests failed with 1 issue.
```

**After the fix** — both pass:
```
✔ "manual cookie source does not require macOS web support" passed
✔ "auto cookie source still requires web support off macOS" passed
✔ Test run with 2 tests in 1 suite passed
```

Build clean, `swiftlint --strict` 0 violations, `swiftformat --lint` clean.

Small and self-contained — happy to adjust or close if not wanted.
