### PR TITLE
Refresh custom Account labels after account changes

### DIFF
--- a/Sources/CodexBar/StatusItemController+IconObservation.swift
+++ b/Sources/CodexBar/StatusItemController+IconObservation.swift
@@ -47,6 +47,9 @@ extension StatusItemController {
         let layoutCostSignature = showBrandPercent
             ? self.storedMenuBarLayoutCostSignature(for: provider)
             : nil
+        let layoutAccountSignature = showBrandPercent
+            ? self.storedMenuBarLayoutAccountSignature(for: provider, snapshot: snapshot)
+            : nil
 
         return [
             provider.rawValue,
@@ -60,7 +63,24 @@ extension StatusItemController {
             "refreshing=\(self.store.refreshingProviders.contains(provider) ? "1" : "0")",
             "text=\(displayText ?? "nil")",
             "layoutCost=\(layoutCostSignature ?? "nil")",
+            "layoutAccount=\(layoutAccountSignature ?? "nil")",
         ].joined(separator: "|")
+    }
+
+    private func storedMenuBarLayoutAccountSignature(
+        for provider: UsageProvider,
+        snapshot: UsageSnapshot?)
+        -> String?
+    {
+        let resolution = self.settings.menuBarLayoutResolution(for: provider)
+        guard !resolution.usesLegacyRendering,
+              resolution.layout.lines.joined().contains(.accountLabel),
+              let accountLabel = self.menuBarLayoutAccountLabel(provider: provider, snapshot: snapshot)
+        else { return nil }
+
+        var hasher = Hasher()
+        hasher.combine(accountLabel)
+        return String(hasher.finalize())
     }
 
     private func storedMenuBarLayoutCostSignature(for provider: UsageProvider) -> String? {

--- a/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
+++ b/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
@@ -62,11 +62,7 @@ extension StatusItemController {
             .flatMap { UsagePaceText.weeklyDetail(provider: provider, pace: $0, now: now).rightLabel }
         let costStrings = self.menuBarLayoutCostStrings(provider: provider, now: now)
         let providerName = L(self.store.metadata(for: provider).displayName)
-        let rawAccountLabel = snapshot?.accountEmail(for: provider)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let accountLabel = self.settings.hidePersonalInfo || rawAccountLabel?.isEmpty != false
-            ? nil
-            : rawAccountLabel
+        let accountLabel = self.menuBarLayoutAccountLabel(provider: provider, snapshot: snapshot)
 
         return MenuBarLayoutRenderData(
             iconKey: "\(provider.rawValue):\(warningFlash ? "warning" : "normal")",
@@ -78,6 +74,14 @@ extension StatusItemController {
             runsOut: runsOut,
             costToday: costStrings.today,
             cost30d: costStrings.last30Days)
+    }
+
+    func menuBarLayoutAccountLabel(provider: UsageProvider, snapshot: UsageSnapshot?) -> String? {
+        let rawAccountLabel = snapshot?.accountEmail(for: provider)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return self.settings.hidePersonalInfo || rawAccountLabel?.isEmpty != false
+            ? nil
+            : rawAccountLabel
     }
 
     func menuBarLayoutCostStrings(

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -87,6 +87,52 @@ struct StatusItemIconObservationSignatureTests {
         defer { controller.releaseStatusItemsForTesting() }
 
         let baseline = controller.storeIconObservationSignature()
+        #expect(!baseline.contains("icon@example.com"))
+
+        store._setSnapshotForTesting(
+            Self.makeSnapshot(
+                provider: .codex,
+                email: "rotated-account@example.com",
+                updatedAt: Date(timeIntervalSince1970: 200)),
+            provider: .codex)
+
+        let signature = controller.storeIconObservationSignature()
+
+        #expect(signature == baseline)
+        #expect(!signature.contains("rotated-account@example.com"))
+    }
+
+    @Test
+    func `custom account label changes the store icon observation signature`() {
+        let (_, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-custom-account-label",
+            menuBarLayout: MenuBarLayout(lines: [[.accountLabel]]))
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let baseline = controller.storeIconObservationSignature()
+        #expect(!baseline.contains("icon@example.com"))
+
+        store._setSnapshotForTesting(
+            Self.makeSnapshot(
+                provider: .codex,
+                email: "rotated-account@example.com",
+                updatedAt: Date(timeIntervalSince1970: 200)),
+            provider: .codex)
+
+        let signature = controller.storeIconObservationSignature()
+
+        #expect(signature != baseline)
+        #expect(!signature.contains("rotated-account@example.com"))
+    }
+
+    @Test
+    func `hidden custom account label ignores account changes`() {
+        let (settings, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-hidden-custom-account-label",
+            menuBarLayout: MenuBarLayout(lines: [[.accountLabel]]))
+        defer { controller.releaseStatusItemsForTesting() }
+        settings.hidePersonalInfo = true
+        let baseline = controller.storeIconObservationSignature()
 
         store._setSnapshotForTesting(
             Self.makeSnapshot(


### PR DESCRIPTION
## Summary

- refresh stored custom layouts when the rendered Account value changes
- keep account-only snapshot churn ignored when Account is absent or personal info is hidden
- hash the displayed label in the observation signature so it does not retain account text

## Root cause

Custom Account tokens render from the snapshot account email, but icon observation intentionally ignored email-only snapshot churn. A stored layout containing Account could therefore keep showing the previous label until another visual field changed.

## Verification

- regression test failed before the fix because the before/after signatures were identical
- `swift test --filter StatusItemIconObservationSignatureTests` — 20 tests passed
- `swift test --skip-build --no-parallel --filter '(MenuBarLayoutRendererTests|StatusItemIconObservationSignatureTests)'` — 29 tests passed
- `make check` — passed, including SwiftFormat and SwiftLint with zero violations
- `git diff --check` — passed

### Exact-head runtime proof

I packaged and ran a fresh debug bundle from `5f9cffffbaf40388b90300d9ba1250b6d662cb78` (`CodexGitCommit=5f9cffff`). The app used a stored custom layout containing only **Account**, with personal-info hiding off. A local fixture exercised CodexBar's supported Amp CLI provider path and kept usage constant at 20% used while changing only the synthetic account address. The same app process remained running, and I selected **Refresh** from its status menu after the identity change.

Redacted terminal/live-capture transcript:

```text
bundle_head=5f9cffffbaf40388b90300d9ba1250b6d662cb78
layout_tokens=Account
process_restart_between_captures=no
usage_before=20.0% used
usage_after=20.0% used

before_account=proof-alpha@example.invalid
before_status_item_frame={x:889, y:4, width:201, height:24}
before_capture_ocr="proof-alpha@example.invalid D"
before_capture_sha256=d5aff685e9210f88fda4e98fe1c4fd4bf350fd62f123b667b06c76deb51f20ad

after_refresh_account=proof-beta@example.invalid
after_status_item_frame={x:857, y:4, width:195, height:24}
after_capture_ocr="proof-beta@example.invalid D"
after_capture_sha256=649dca42978002869181260ec4a71bf09f4fdb493827fd39e14fd54eab315ce0
```

The `D` suffix is CodexBar's debug-build marker. OCR was run locally against tight status-item captures with macOS Vision. No production account data or credentials were used.

`make test` was also run. It stopped in group 4 after both the initial run and automatic retry because two untouched `AdaptiveRefreshTimerTests` hit their 30-second wait deadline:

- `menu open advances a long idle timer during refresh without postponing an earlier tick`
- `coding activity advances a long idle timer without postponing an earlier tick`

No adaptive-refresh source or test files are changed here; hosted CI can provide clean-environment confirmation.

## Risk

Low. Only stored custom layouts containing Account gain an additional render trigger. Other layouts and privacy-hidden account labels keep the previous observation behavior.

## Review focus

Please sanity-check the render-aware observation boundary and the account-text hashing.
