### PR TITLE
refactor: centralize usage percent clamping

### DIFF
--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageSnapshot.swift
@@ -22,7 +22,7 @@ public struct AbacusUsageSnapshot: Sendable {
 
     public func toUsageSnapshot() -> UsageSnapshot {
         let percentUsed: Double = if let used = self.creditsUsed, let total = self.creditsTotal, total > 0 {
-            min(100, max(0, (used / total) * 100.0))
+            UsagePercent(used: used, limit: total).displayClamped
         } else {
             0
         }

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageSnapshot.swift
@@ -81,7 +81,7 @@ public struct CodebuffUsageSnapshot: Sendable {
             return nil
         }
         let used = self.resolvedUsed
-        let percent = min(100, max(0, (used / total) * 100))
+        let percent = UsagePercent(used: used, limit: total).displayClamped
         // Note: do not stuff the credit balance ("X/Y credits") into `resetDescription` —
         // generic renderers (UsageFormatter.resetLine) prepend "Resets " when `resetsAt`
         // is absent, which would surface misleading text like "Resets 250/1,000 credits".
@@ -96,7 +96,7 @@ public struct CodebuffUsageSnapshot: Sendable {
     private func makeWeeklyWindow() -> RateWindow? {
         guard let limit = self.weeklyLimit, limit > 0 else { return nil }
         let used = max(0, self.weeklyUsed ?? 0)
-        let percent = min(100, max(0, (used / limit) * 100))
+        let percent = UsagePercent(used: used, limit: limit).displayClamped
         // Same reasoning as above: avoid encoding non-reset detail in `resetDescription`.
         return RateWindow(
             usedPercent: percent,
@@ -106,7 +106,9 @@ public struct CodebuffUsageSnapshot: Sendable {
     }
 
     private var resolvedTotal: Double? {
-        if let creditsTotal { return max(0, creditsTotal) }
+        if let creditsTotal {
+            return max(0, creditsTotal)
+        }
         if let creditsUsed, let creditsRemaining {
             return max(0, creditsUsed + creditsRemaining)
         }

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageSnapshot.swift
@@ -87,7 +87,7 @@ public struct CommandCodeUsageSnapshot: Sendable {
             return nil
         }
         let used = self.monthlyCreditsUsed ?? 0
-        let percent = min(100, max(0, (used / total) * 100))
+        let percent = UsagePercent(used: used, limit: total).displayClamped
         return RateWindow(
             usedPercent: percent,
             windowMinutes: nil,

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -1578,17 +1578,7 @@ public struct CursorStatusProbe: Sendable {
         let planLimitRaw = Double(summary.individualUsage?.plan?.limit ?? 0)
         func normPct(_ value: Double?) -> Double? {
             guard let v = value else { return nil }
-            if v < 0 {
-                return 0
-            }
-            if v > 100 {
-                return 100
-            }
-            return v
-        }
-
-        func normalizeTotalPercent(_ v: Double) -> Double {
-            max(0, min(100, v))
+            return UsagePercent(raw: v).displayClamped
         }
 
         // Cursor's usage-summary percent fields are already in percentage units, even when they are fractional
@@ -1614,19 +1604,19 @@ public struct CursorStatusProbe: Sendable {
         //   5. NEW: `individualUsage.overall` ratio (Enterprise/Team personal cap)
         //   6. NEW: `teamUsage.pooled` ratio (last resort when no individual data is reported)
         let planPercentUsed: Double = if let totalPercentUsed = summary.individualUsage?.plan?.totalPercentUsed {
-            normalizeTotalPercent(totalPercentUsed)
+            UsagePercent(raw: totalPercentUsed).displayClamped
         } else if let autoUsed = autoPercent, let apiUsed = apiPercent {
-            max(0, min(100, (autoUsed + apiUsed) / 2))
+            UsagePercent(raw: (autoUsed + apiUsed) / 2).displayClamped
         } else if let apiUsed = apiPercent {
-            max(0, min(100, apiUsed))
+            UsagePercent(raw: apiUsed).displayClamped
         } else if let autoUsed = autoPercent {
-            max(0, min(100, autoUsed))
+            UsagePercent(raw: autoUsed).displayClamped
         } else if planLimitRaw > 0 {
-            normalizeTotalPercent((planUsedRaw / planLimitRaw) * 100)
+            UsagePercent(used: planUsedRaw, limit: planLimitRaw).displayClamped
         } else if let used = overallUsedRaw, let limit = overallLimitRaw, limit > 0 {
-            normalizeTotalPercent((used / limit) * 100)
+            UsagePercent(used: used, limit: limit).displayClamped
         } else if let used = pooledUsedRaw, let limit = pooledLimitRaw, limit > 0 {
-            normalizeTotalPercent((used / limit) * 100)
+            UsagePercent(used: used, limit: limit).displayClamped
         } else {
             0
         }

--- a/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsUsageFetcher.swift
@@ -75,7 +75,9 @@ public struct ElevenLabsUsageSnapshot: Codable, Sendable, Equatable {
 
     public var usedPercent: Double {
         guard self.characterLimit > 0 else { return 0 }
-        return min(100, max(0, Double(self.characterCount) / Double(self.characterLimit) * 100))
+        return UsagePercent(
+            used: Double(self.characterCount),
+            limit: Double(self.characterLimit)).displayClamped
     }
 
     public var remainingCharacters: Int {
@@ -127,7 +129,7 @@ public struct ElevenLabsUsageSnapshot: Codable, Sendable, Equatable {
                 id: "voice-slots",
                 title: "Voice slots",
                 window: RateWindow(
-                    usedPercent: min(100, max(0, Double(used) / Double(limit) * 100)),
+                    usedPercent: UsagePercent(used: Double(used), limit: Double(limit)).displayClamped,
                     windowMinutes: nil,
                     resetsAt: nil,
                     resetDescription: "\(used) / \(limit)")))
@@ -137,7 +139,7 @@ public struct ElevenLabsUsageSnapshot: Codable, Sendable, Equatable {
                 id: "professional-voices",
                 title: "Professional voices",
                 window: RateWindow(
-                    usedPercent: min(100, max(0, Double(used) / Double(limit) * 100)),
+                    usedPercent: UsagePercent(used: Double(used), limit: Double(limit)).displayClamped,
                     windowMinutes: nil,
                     resetsAt: nil,
                     resetDescription: "\(used) / \(limit)")))

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPICreditBalanceFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPICreditBalanceFetcher.swift
@@ -84,7 +84,7 @@ public struct OpenAIAPICreditBalanceSnapshot: Sendable {
 
     public func toUsageSnapshot() -> UsageSnapshot {
         let usedPercent: Double = if self.totalGranted > 0 {
-            min(100, max(0, (self.totalUsed / self.totalGranted) * 100))
+            UsagePercent(used: self.totalUsed, limit: self.totalGranted).displayClamped
         } else {
             self.totalAvailable > 0 ? 0 : 100
         }

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public struct RateWindow: Codable, Equatable, Sendable {
+    /// Provider usage value, intentionally not normalized globally. Pace and provider-specific diagnostics may
+    /// preserve raw over-quota values; display-only projections should use `UsagePercent.displayClamped`.
     public let usedPercent: Double
     public let windowMinutes: Int?
     public let resetsAt: Date?

--- a/Sources/CodexBarCore/UsagePercent.swift
+++ b/Sources/CodexBarCore/UsagePercent.swift
@@ -1,0 +1,24 @@
+/// A provider-reported usage percentage before and after display normalization.
+///
+/// Keep `raw` when over-quota values carry meaning for provider-specific details or pace diagnostics.
+/// Use `displayClamped` when projecting a percentage into a headline or `RateWindow` display value.
+/// `RateWindow` itself intentionally remains raw-capable so callers must choose the appropriate contract.
+public struct UsagePercent: Equatable, Sendable {
+    public let raw: Double
+
+    public init(raw: Double) {
+        self.raw = raw
+    }
+
+    /// Computes an unbounded percentage from a numeric quota ratio.
+    ///
+    /// Callers must resolve the provider-specific fallback for a missing or non-positive limit first.
+    public init(used: Double, limit: Double) {
+        precondition(limit > 0, "Usage percent requires a positive limit")
+        self.raw = (used / limit) * 100
+    }
+
+    public var displayClamped: Double {
+        self.raw.clamped(to: 0...100)
+    }
+}

--- a/Tests/CodexBarTests/UsagePercentTests.swift
+++ b/Tests/CodexBarTests/UsagePercentTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import CodexBarCore
+
+struct UsagePercentTests {
+    @Test
+    func `display normalization preserves boundaries and small percentages`() {
+        #expect(UsagePercent(raw: 0).displayClamped == 0)
+        #expect(UsagePercent(raw: 0.25).displayClamped == 0.25)
+        #expect(UsagePercent(raw: 100).displayClamped == 100)
+    }
+
+    @Test
+    func `display normalization clamps overage while preserving the raw percentage`() {
+        let percent = UsagePercent(used: 150, limit: 100)
+
+        #expect(percent.raw == 150)
+        #expect(percent.displayClamped == 100)
+    }
+
+    @Test
+    func `display normalization guards negative usage`() {
+        let percent = UsagePercent(used: -1, limit: 100)
+
+        #expect(percent.raw == -1)
+        #expect(percent.displayClamped == 0)
+    }
+}


### PR DESCRIPTION
## Summary

- add a raw-capable `UsagePercent` value with an explicit `displayClamped` projection
- migrate Abacus, Codebuff, Command Code, Cursor, ElevenLabs, and OpenAI API credits from hand-rolled ratio clamps
- keep `RateWindow.usedPercent` intentionally raw-capable so pace, deficit, and provider-specific over-quota diagnostics retain their existing semantics

This is behavior-preserving: each provider keeps its existing missing/zero-limit fallback, performs the same ratio arithmetic, and projects the same `0...100` display value. The Cursor #2255, Abacus #2265, and ElevenLabs #2293 overage regressions remain covered.

## Verification

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer make check` (SwiftFormat clean; SwiftLint 0 violations across 1,580 files)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --skip-build --no-parallel --filter 'UsagePercentTests|AbacusUsageSnapshotTests|CodebuffUsageFetcherTests|CommandCodeUsageFetcherTests|CursorStatusProbeTests|CursorEnterpriseUsageTests|ElevenLabsUsageFetcherTests|OpenAIAPICreditBalanceTests'` (116 tests passed)
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean; no accepted/actionable findings)

Local full `make test` reached the unrelated `BoundedChildProcessProofTests` suite, where the synthetic PTY overflow proof is deterministic on this macOS/Xcode 27 host because the child no longer exceeds the output limit before its ten-second deadline. The same exact `main` head is green in CI; PR CI is the full-suite gate for this branch.

## Follow-up candidates

- ratio-based numeric providers: Bedrock, ClawRouter, Doubao, JetBrains, Kilo, LiteLLM, NeuralWatt, OpenRouter, Perplexity, Sub2API, and Warp
- already-percent normalization: ClinePass, Devin, Factory, Kimi, MiniMax, Qoder, T3 Chat, and Zai
- remaining inverse/derived percentage paths should be migrated only after their raw overage and deficit contracts are characterized

## Changelog

Internal only: centralize display-clamped provider usage percentage calculations. No user-facing behavior change.
