### PR TITLE
Refactor provider pace capability into descriptors

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -518,7 +518,8 @@ extension UsageMenuCardView.Model {
         input: Input,
         pace: UsagePace? = nil) -> PaceDetail?
     {
-        guard self.supportsResetWindowPace(provider: input.provider, window: window, now: input.now),
+        let capability = ProviderDescriptorRegistry.descriptor(for: input.provider).pace
+        guard capability.supportsResetWindowPace(window: window, now: input.now),
               window.remainingPercent > 0
         else { return nil }
         let paceWindow = Self.resetWindowForPace(provider: input.provider, window: window)
@@ -536,34 +537,10 @@ extension UsageMenuCardView.Model {
             showUsed: input.usageBarsShowUsed)
     }
 
-    private static let weeklyWindowMinutes = 7 * 24 * 60
-    private static let monthlyWindowSentinelMinutes = 30 * 24 * 60
-
-    private static func supportsResetWindowPace(provider: UsageProvider, window: RateWindow, now: Date) -> Bool {
-        switch provider {
-        case .copilot:
-            return window.resetsAt != nil
-        case .cursor:
-            return window.windowMinutes != nil
-        case .grok:
-            guard GrokProviderDescriptor.primaryLabel(window: window, now: now) == "Weekly",
-                  let resetsAt = window.resetsAt
-            else { return false }
-            let windowMinutes = window.windowMinutes ?? self.weeklyWindowMinutes
-            let timeUntilReset = resetsAt.timeIntervalSince(now)
-            return windowMinutes > 0
-                && timeUntilReset > 0
-                && timeUntilReset <= TimeInterval(windowMinutes) * 60
-        case .alibaba, .alibabatokenplan, .doubao, .opencodego:
-            return window.windowMinutes == self.monthlyWindowSentinelMinutes
-        default:
-            return false
-        }
-    }
-
     private static func resetWindowForPace(provider: UsageProvider, window: RateWindow) -> RateWindow {
         // Provider snapshots use 30 days as a monthly sentinel; use the reset date for the real calendar-cycle length.
-        guard self.usesInferredMonthlyDuration(provider: provider, window: window),
+        let pace = ProviderDescriptorRegistry.descriptor(for: provider).pace
+        guard pace.usesInferredMonthlyDuration(window: window),
               let resetsAt = window.resetsAt,
               let minutes = self.inferredMonthlyWindowMinutes(endingAt: resetsAt)
         else { return window }
@@ -574,17 +551,6 @@ extension UsageMenuCardView.Model {
             resetDescription: window.resetDescription,
             nextRegenPercent: window.nextRegenPercent,
             isSyntheticPlaceholder: window.isSyntheticPlaceholder)
-    }
-
-    private static func usesInferredMonthlyDuration(provider: UsageProvider, window: RateWindow) -> Bool {
-        switch provider {
-        case .copilot:
-            window.windowMinutes == nil
-        case .alibaba, .alibabatokenplan, .doubao, .opencodego:
-            window.windowMinutes == self.monthlyWindowSentinelMinutes
-        default:
-            false
-        }
     }
 
     private static func inferredMonthlyWindowMinutes(endingAt resetsAt: Date) -> Int? {

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanProviderDescriptor.swift
@@ -54,6 +54,7 @@ public enum AlibabaCodingPlanProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Alibaba Coding Plan cost summary is not supported." }),
+            pace: .calendarMonthResetWindow,
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanProviderDescriptor.swift
@@ -54,6 +54,7 @@ public enum AlibabaTokenPlanProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Alibaba Token Plan cost summary is not supported." }),
+            pace: .calendarMonthResetWindow,
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
@@ -35,6 +35,9 @@ public enum CopilotProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Copilot cost summary is not supported." }),
+            pace: ProviderPaceCapability(
+                resetWindowPace: .resetDatePresent,
+                inferredMonthlyDuration: .windowDurationMissing),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [CopilotAPIFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
@@ -36,6 +36,7 @@ public enum CursorProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: true,
                 noDataMessage: { "No Cursor cost usage found. Sign in to Cursor in your browser or the Cursor app." }),
+            pace: ProviderPaceCapability(resetWindowPace: .windowDurationPresent),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .cli, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [CursorStatusFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Doubao/DoubaoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Doubao/DoubaoProviderDescriptor.swift
@@ -44,6 +44,7 @@ public enum DoubaoProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Doubao cost summary is not available." }),
+            pace: .calendarMonthResetWindow,
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .cli, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -37,6 +37,16 @@ public enum GrokProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Grok cost summary is not supported yet." }),
+            pace: ProviderPaceCapability(resetWindowPace: .custom { window, now in
+                guard Self.primaryLabel(window: window, now: now) == "Weekly",
+                      let resetsAt = window.resetsAt
+                else { return false }
+                let windowMinutes = window.windowMinutes ?? 7 * 24 * 60
+                let timeUntilReset = resetsAt.timeIntervalSince(now)
+                return windowMinutes > 0
+                    && timeUntilReset > 0
+                    && timeUntilReset <= TimeInterval(windowMinutes) * 60
+            }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .cli, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -37,6 +37,7 @@ public enum OpenCodeGoProviderDescriptor {
                 noDataMessage: {
                     "No OpenCode Go local usage history found in ~/.local/share/opencode/opencode.db."
                 }),
+            pace: .calendarMonthResetWindow,
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -10,11 +10,79 @@ public struct ProviderTokenCostConfig: Sendable {
     }
 }
 
+public enum ProviderPaceWindowRule: Sendable {
+    case unsupported
+    case resetDatePresent
+    case windowDurationPresent
+    case windowDuration(minutes: Int)
+    case custom(@Sendable (_ window: RateWindow, _ now: Date) -> Bool)
+
+    public func matches(window: RateWindow, now: Date) -> Bool {
+        switch self {
+        case .unsupported:
+            false
+        case .resetDatePresent:
+            window.resetsAt != nil
+        case .windowDurationPresent:
+            window.windowMinutes != nil
+        case let .windowDuration(minutes):
+            window.windowMinutes == minutes
+        case let .custom(predicate):
+            predicate(window, now)
+        }
+    }
+}
+
+public enum ProviderPaceDurationRule: Sendable {
+    case unsupported
+    case windowDurationMissing
+    case windowDuration(minutes: Int)
+
+    public func matches(window: RateWindow) -> Bool {
+        switch self {
+        case .unsupported:
+            false
+        case .windowDurationMissing:
+            window.windowMinutes == nil
+        case let .windowDuration(minutes):
+            window.windowMinutes == minutes
+        }
+    }
+}
+
+public struct ProviderPaceCapability: Sendable {
+    public static let monthlyWindowSentinelMinutes = 30 * 24 * 60
+    public static let unsupported = ProviderPaceCapability()
+    public static let calendarMonthResetWindow = ProviderPaceCapability(
+        resetWindowPace: .windowDuration(minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
+        inferredMonthlyDuration: .windowDuration(minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes))
+
+    public let resetWindowPace: ProviderPaceWindowRule
+    public let inferredMonthlyDuration: ProviderPaceDurationRule
+
+    public init(
+        resetWindowPace: ProviderPaceWindowRule = .unsupported,
+        inferredMonthlyDuration: ProviderPaceDurationRule = .unsupported)
+    {
+        self.resetWindowPace = resetWindowPace
+        self.inferredMonthlyDuration = inferredMonthlyDuration
+    }
+
+    public func supportsResetWindowPace(window: RateWindow, now: Date) -> Bool {
+        self.resetWindowPace.matches(window: window, now: now)
+    }
+
+    public func usesInferredMonthlyDuration(window: RateWindow) -> Bool {
+        self.inferredMonthlyDuration.matches(window: window)
+    }
+}
+
 public struct ProviderDescriptor: Sendable {
     public let id: UsageProvider
     public let metadata: ProviderMetadata
     public let branding: ProviderBranding
     public let tokenCost: ProviderTokenCostConfig
+    public let pace: ProviderPaceCapability
     public let fetchPlan: ProviderFetchPlan
     public let cli: ProviderCLIConfig
 
@@ -23,6 +91,7 @@ public struct ProviderDescriptor: Sendable {
         metadata: ProviderMetadata,
         branding: ProviderBranding,
         tokenCost: ProviderTokenCostConfig,
+        pace: ProviderPaceCapability = .unsupported,
         fetchPlan: ProviderFetchPlan,
         cli: ProviderCLIConfig)
     {
@@ -30,6 +99,7 @@ public struct ProviderDescriptor: Sendable {
         self.metadata = metadata
         self.branding = branding
         self.tokenCost = tokenCost
+        self.pace = pace
         self.fetchPlan = fetchPlan
         self.cli = cli
     }

--- a/Tests/CodexBarTests/BoundedChildProcessProofTests.swift
+++ b/Tests/CodexBarTests/BoundedChildProcessProofTests.swift
@@ -35,7 +35,7 @@ struct BoundedChildProcessProofTests {
             _ = try runner.run(
                 binary: scriptURL.path,
                 send: "",
-                options: .init(timeout: 10, baseEnvironment: environment, initialDelay: 0))
+                options: .init(timeout: 60, baseEnvironment: environment, initialDelay: 0))
             Issue.record("Expected the synthetic child to exceed the PTY output limit")
         } catch TTYCommandRunner.Error.outputTooLarge {
             // Expected: the production runner propagated the bounded-output error.

--- a/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
+++ b/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
@@ -1,0 +1,100 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct ProviderPaceCapabilityTests {
+    private static let weeklyWindowMinutes = 7 * 24 * 60
+    private static let monthlyWindowSentinelMinutes = 30 * 24 * 60
+
+    @Test
+    func `descriptor pace capabilities preserve the legacy provider mapping`() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let fixtures: [RateWindow] = [
+            Self.window(minutes: nil, resetsAt: nil),
+            Self.window(minutes: nil, resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60)),
+            Self.window(minutes: nil, resetsAt: now.addingTimeInterval(8 * 24 * 60 * 60)),
+            Self.window(minutes: nil, resetsAt: now.addingTimeInterval(30 * 24 * 60 * 60)),
+            Self.window(minutes: 60, resetsAt: now.addingTimeInterval(30 * 60)),
+            Self.window(minutes: Self.weeklyWindowMinutes, resetsAt: nil),
+            Self.window(minutes: Self.weeklyWindowMinutes, resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60)),
+            Self.window(minutes: Self.weeklyWindowMinutes, resetsAt: now.addingTimeInterval(8 * 24 * 60 * 60)),
+            Self.window(minutes: Self.monthlyWindowSentinelMinutes, resetsAt: nil),
+            Self.window(
+                minutes: Self.monthlyWindowSentinelMinutes,
+                resetsAt: now.addingTimeInterval(20 * 24 * 60 * 60)),
+            Self.window(minutes: 0, resetsAt: now.addingTimeInterval(60)),
+            Self.window(minutes: Self.weeklyWindowMinutes, resetsAt: now.addingTimeInterval(-60)),
+        ]
+
+        for provider in UsageProvider.allCases {
+            let capability = ProviderDescriptorRegistry.descriptor(for: provider).pace
+            for window in fixtures {
+                let actualResetWindowPace = capability.supportsResetWindowPace(window: window, now: now)
+                let legacyResetWindowPace = Self.legacySupportsResetWindowPace(
+                    provider: provider,
+                    window: window,
+                    now: now)
+                #expect(
+                    actualResetWindowPace == legacyResetWindowPace,
+                    "Reset-window pace changed for \(provider.rawValue), window=\(String(describing: window)).")
+
+                let actualMonthlyInference = capability.usesInferredMonthlyDuration(window: window)
+                let legacyMonthlyInference = Self.legacyUsesInferredMonthlyDuration(
+                    provider: provider,
+                    window: window)
+                #expect(
+                    actualMonthlyInference == legacyMonthlyInference,
+                    "Monthly inference changed for \(provider.rawValue), window=\(String(describing: window)).")
+            }
+        }
+    }
+
+    private static func window(minutes: Int?, resetsAt: Date?) -> RateWindow {
+        RateWindow(
+            usedPercent: 50,
+            windowMinutes: minutes,
+            resetsAt: resetsAt,
+            resetDescription: nil)
+    }
+
+    /// Snapshot of the switches removed from UsageMenuCardView.Model.
+    private static func legacySupportsResetWindowPace(
+        provider: UsageProvider,
+        window: RateWindow,
+        now: Date) -> Bool
+    {
+        switch provider {
+        case .copilot:
+            return window.resetsAt != nil
+        case .cursor:
+            return window.windowMinutes != nil
+        case .grok:
+            guard GrokProviderDescriptor.primaryLabel(window: window, now: now) == "Weekly",
+                  let resetsAt = window.resetsAt
+            else { return false }
+            let windowMinutes = window.windowMinutes ?? self.weeklyWindowMinutes
+            let timeUntilReset = resetsAt.timeIntervalSince(now)
+            return windowMinutes > 0
+                && timeUntilReset > 0
+                && timeUntilReset <= TimeInterval(windowMinutes) * 60
+        case .alibaba, .alibabatokenplan, .doubao, .opencodego:
+            return window.windowMinutes == self.monthlyWindowSentinelMinutes
+        default:
+            return false
+        }
+    }
+
+    private static func legacyUsesInferredMonthlyDuration(
+        provider: UsageProvider,
+        window: RateWindow) -> Bool
+    {
+        switch provider {
+        case .copilot:
+            window.windowMinutes == nil
+        case .alibaba, .alibabatokenplan, .doubao, .opencodego:
+            window.windowMinutes == self.monthlyWindowSentinelMinutes
+        default:
+            false
+        }
+    }
+}

--- a/Tests/CodexBarTests/ZenMuxProviderTests.swift
+++ b/Tests/CodexBarTests/ZenMuxProviderTests.swift
@@ -241,6 +241,11 @@ struct ZenMuxProviderTests {
     @Test @MainActor
     func `menu card uses compact flow expiry and USD PAYG labels`() async throws {
         let now = try #require(Self.date("2026-03-24T07:35:09.000Z"))
+        let expiresAt = try #require(Self.date("2026-04-12T08:26:56.000Z"))
+        let expiryFormatter = DateFormatter()
+        expiryFormatter.locale = .current
+        expiryFormatter.timeZone = .current
+        expiryFormatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
         let transport = ProviderHTTPTransportStub { request in
             let url = try #require(request.url)
             return Self.response(
@@ -280,7 +285,7 @@ struct ZenMuxProviderTests {
         #expect(primary.resetText == "Resets in 1h")
         #expect(secondary.detailLeftText == "416.11 / 6182 flows")
         #expect(secondary.detailRightText == nil)
-        #expect(model.usageNotes == ["Plan expires: Apr 12, 2026"])
+        #expect(model.usageNotes == ["Plan expires: \(expiryFormatter.string(from: expiresAt))"])
         #expect(model.creditsText == nil)
         #expect(model.providerCost?.title == "Pay-as-you-go")
         #expect(model.providerCost?.spendLine == "Balance: $482.74")


### PR DESCRIPTION
## Summary

- Move reset-window pace eligibility and inferred monthly duration from the menu model's provider switch into `ProviderDescriptor` capabilities.
- Declare the existing Copilot, Cursor, Grok, Alibaba, Doubao, and OpenCode Go rules beside their provider descriptors.
- Add an all-provider equivalence test that compares the descriptor-driven behavior with the removed legacy mapping.
- Stabilize two environment-sensitive tests exposed by the full suite: PTY overflow under host load and localized ZenMux expiry dates.

## Testing

- `make check`
- `swift test --filter ProviderPaceCapabilityTests`
- `swift test --filter BoundedChildProcessProofTests`
- `swift test --filter ZenMuxProviderTests`
- `make test` — 61/61 groups passed on the first attempt, with zero retries or timeouts
- structured autoreview — no accepted or actionable findings
