### PR TITLE
Show local Codex credit fallback as remaining percent

### DIFF
--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -986,9 +986,11 @@ extension StatusItemController {
     {
         guard let remaining = credits?.remaining, remaining > 0 else { return nil }
         if isLocalRecoveryBuild,
-           let remainingPercent = credits?.codexCreditLimit?.remainingPercent
+           let creditLimit = credits?.codexCreditLimit,
+           creditLimit.limit > 0,
+           creditLimit.remainingPercent > 0
         {
-            return UsageFormatter.percentString(remainingPercent)
+            return UsageFormatter.percentString(creditLimit.remainingPercent)
         }
         return UsageFormatter
             .creditsString(from: remaining)

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -946,13 +946,11 @@ extension StatusItemController {
         if mode == .percent,
            !self.settings.usageBarsShowUsed,
            codexProjection?.menuBarFallback == .creditsBalance,
-           let creditsRemaining = codexProjection?.credits?.remaining,
-           creditsRemaining > 0
+           let fallbackText = Self.codexCreditsFallbackDisplayText(
+               credits: codexProjection?.credits?.snapshot,
+               isLocalRecoveryBuild: Bundle.main.bundleIdentifier == "com.steipete.codexbar.localrecovery")
         {
-            return
-                UsageFormatter
-                    .creditsString(from: creditsRemaining)
-                    .replacingOccurrences(of: " left", with: "")
+            return fallbackText
         }
         if let combinedLanes, mode == .percent {
             if let combinedText = MenuBarDisplayText.combinedSessionWeeklyPercentText(
@@ -980,6 +978,21 @@ extension StatusItemController {
             resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
             showsResetTimeWhenExhausted: self.settings.menuBarShowsResetTimeWhenExhausted,
             now: now)
+    }
+
+    nonisolated static func codexCreditsFallbackDisplayText(
+        credits: CreditsSnapshot?,
+        isLocalRecoveryBuild: Bool) -> String?
+    {
+        guard let remaining = credits?.remaining, remaining > 0 else { return nil }
+        if isLocalRecoveryBuild,
+           let remainingPercent = credits?.codexCreditLimit?.remainingPercent
+        {
+            return UsageFormatter.percentString(remainingPercent)
+        }
+        return UsageFormatter
+            .creditsString(from: remaining)
+            .replacingOccurrences(of: " left", with: "")
     }
 
     nonisolated static func deepSeekBalanceDisplayText(snapshot: UsageSnapshot?) -> String? {

--- a/Tests/CodexBarTests/CodexConsumerProjectionCharacterizationTests.swift
+++ b/Tests/CodexBarTests/CodexConsumerProjectionCharacterizationTests.swift
@@ -212,6 +212,32 @@ struct CodexConsumerProjectionCharacterizationTests {
 
     @Test
     func `menu bar combined codex percent falls back to credits when no percent lanes are available`() {
+        let creditLimit = CodexCreditLimitSnapshot(
+            used: 7_324.4,
+            limit: 50_000,
+            remainingPercent: 85.3512,
+            resetsAt: nil,
+            updatedAt: Date())
+        let creditsWithLimit = CreditsSnapshot(
+            remaining: 42_675.6,
+            events: [],
+            updatedAt: Date(),
+            codexCreditLimit: creditLimit)
+        let creditsWithoutLimit = CreditsSnapshot(remaining: 42.5, events: [], updatedAt: Date())
+
+        #expect(
+            StatusItemController.codexCreditsFallbackDisplayText(
+                credits: creditsWithLimit,
+                isLocalRecoveryBuild: true) == "85%")
+        #expect(
+            StatusItemController.codexCreditsFallbackDisplayText(
+                credits: creditsWithLimit,
+                isLocalRecoveryBuild: false) == "42675.6")
+        #expect(
+            StatusItemController.codexCreditsFallbackDisplayText(
+                credits: creditsWithoutLimit,
+                isLocalRecoveryBuild: true) == "42.5")
+
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/CodexConsumerProjectionCharacterizationTests.swift
+++ b/Tests/CodexBarTests/CodexConsumerProjectionCharacterizationTests.swift
@@ -238,6 +238,23 @@ struct CodexConsumerProjectionCharacterizationTests {
                 credits: creditsWithoutLimit,
                 isLocalRecoveryBuild: true) == "42.5")
 
+        let unusableCreditLimit = CodexCreditLimitSnapshot(
+            used: 0,
+            limit: 0,
+            remainingPercent: 0,
+            resetsAt: nil,
+            updatedAt: Date())
+        let creditsWithUnusableLimit = CreditsSnapshot(
+            remaining: 42.5,
+            events: [],
+            updatedAt: Date(),
+            codexCreditLimit: unusableCreditLimit)
+
+        #expect(
+            StatusItemController.codexCreditsFallbackDisplayText(
+                credits: creditsWithUnusableLimit,
+                isLocalRecoveryBuild: true) == "42.5")
+
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual


### PR DESCRIPTION
## Summary

- In the local recovery bundle only, render a positive Codex credits fallback as a whole remaining percentage when a valid credit limit is available.
- Preserve raw credit values for the upstream bundle and for missing, zero, or otherwise invalid limits.
- Add characterization coverage for the local-only and fallback paths.

## Why

When Codex returns only a credits balance, the menu bar previously showed a raw number (for example, `42675.6`) while other quota sources use percentages. The local recovery build can safely calculate and display the remaining percentage only when its limit is known.

## Validation

- `swift test --filter CodexConsumerProjectionCharacterizationTests` (7 tests passed)

## Scope

The changed rendering behavior is deliberately gated to `com.steipete.codexbar.localrecovery`; the upstream bundle retains its existing behavior.
