### PR TITLE
Prevent WidgetKit reload loop in BurnDownRefreshSchedule (fix #2369)

### DIFF
--- a/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
+++ b/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
@@ -147,6 +147,7 @@ struct BurnDownState {
 }
 
 enum BurnDownRefreshSchedule {
+    private static let minimumInterval: TimeInterval = 5 * 60
     private static let maximumInterval: TimeInterval = 30 * 60
 
     static func nextRefresh(
@@ -161,7 +162,12 @@ enum BurnDownRefreshSchedule {
             .filter { $0 > now }
             .min()?
             .addingTimeInterval(1)
-        return min(fallback, nextReset ?? fallback)
+        if let nextReset {
+            let target = min(fallback, nextReset)
+            let minimumDate = now.addingTimeInterval(self.minimumInterval)
+            return max(minimumDate, target)
+        }
+        return fallback
     }
 }
 

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -826,11 +826,25 @@ struct CodexBarWidgetProviderTests {
             provider: .codex,
             primaryUsed: 20,
             secondaryUsed: 30,
+            primaryReset: now.addingTimeInterval(360),
+            secondaryReset: now.addingTimeInterval(420))
+
+        #expect(BurnDownRefreshSchedule.nextRefresh(snapshot: snapshot, provider: .codex, now: now)
+            == now.addingTimeInterval(361))
+    }
+
+    @Test
+    func `burn down refresh clamps to minimum interval`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = Self.burnSnapshot(
+            provider: .codex,
+            primaryUsed: 20,
+            secondaryUsed: 30,
             primaryReset: now.addingTimeInterval(60),
             secondaryReset: now.addingTimeInterval(120))
 
         #expect(BurnDownRefreshSchedule.nextRefresh(snapshot: snapshot, provider: .codex, now: now)
-            == now.addingTimeInterval(61))
+            == now.addingTimeInterval(300))
     }
 
     @Test


### PR DESCRIPTION
This PR prevents a WidgetKit reload loop where the widget daemon `chronod` sustained high disk writes when a provider's rate limit reset time was calculated very close to `now` (e.g. within a few seconds).

To fix this, we've enforced a minimum 5-minute reload interval safety threshold (per Apple's recommendation) on all dynamic timeline refreshes.

### Changes
- Enforced `minimumInterval = 5 * 60` in `BurnDownRefreshSchedule.nextRefresh`.
- Added test coverage for clamping behavior in `CodexBarWidgetProviderTests.swift`.

### Verification
- Focused and sharded unit tests passed successfully.