### PR TITLE
ci(repo-hygiene): isolate release write permissions

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -435,11 +435,11 @@ jobs:
             printf '%s\n' "${assets[@]:-<none>}" >&2
             exit 1
           fi
-          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber --repo "$GITHUB_REPOSITORY"
 
   update-homebrew-tap:
     runs-on: ubuntu-24.04
-    needs: build-cli
+    needs: publish-release-assets
     if: github.event_name == 'release'
     permissions: {}
     steps:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -11,10 +11,12 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-cli:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -396,20 +398,7 @@ jobs:
           echo "out_dir=$OUT_DIR" >> "$GITHUB_OUTPUT"
           echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
 
-      - name: Upload release assets
-        if: github.event_name == 'release'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG="${RELEASE_TAG}"
-          OUT_DIR="${{ steps.pkg.outputs.out_dir }}"
-          ASSET="${{ steps.pkg.outputs.asset }}"
-          gh release upload "$TAG" "$OUT_DIR/$ASSET" "$OUT_DIR/$ASSET.sha256" --clobber
-
-      - name: Upload workflow artifact (manual runs)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Upload packaged artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codexbar-cli-${{ matrix.name }}
@@ -417,10 +406,42 @@ jobs:
             ${{ steps.pkg.outputs.out_dir }}/${{ steps.pkg.outputs.asset }}
             ${{ steps.pkg.outputs.out_dir }}/${{ steps.pkg.outputs.asset }}.sha256
 
+  publish-release-assets:
+    runs-on: ubuntu-24.04
+    needs: build-cli
+    if: github.event_name == 'release'
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: codexbar-cli-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Upload release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t assets < <(find release-assets -maxdepth 1 -type f \
+            \( -name 'CodexBarCLI-*.tar.gz' -o -name 'CodexBarCLI-*.tar.gz.sha256' \) -print | sort)
+          if [[ "${#assets[@]}" -ne 12 ]]; then
+            printf 'Expected 12 CLI release files, found %s.\n' "${#assets[@]}" >&2
+            printf '%s\n' "${assets[@]:-<none>}" >&2
+            exit 1
+          fi
+          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+
   update-homebrew-tap:
     runs-on: ubuntu-24.04
     needs: build-cli
     if: github.event_name == 'release'
+    permissions: {}
     steps:
       - name: Resolve release tag
         id: release

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -79,6 +79,10 @@ check_documentation_links() {
   node "${ROOT_DIR}/Scripts/check-documentation-links.mjs"
 }
 
+check_release_cli_permissions() {
+  "${ROOT_DIR}/Scripts/test_release_cli_permissions.sh"
+}
+
 check_llms_index() {
   node "${ROOT_DIR}/Scripts/generate-llms.mjs" --check
 }
@@ -93,10 +97,12 @@ run_portable_checks() {
   check_sparkle_signing_paths
   check_swift_test_sharding
   check_ci_path_gate
+  check_release_cli_permissions
   check_repository_size
   check_shell_scripts
   check_documentation_links
   check_llms_index
+  check_release_cli_permissions
   check_site_locales
 }
 

--- a/Scripts/test_release_cli_permissions.sh
+++ b/Scripts/test_release_cli_permissions.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/release-cli.yml"
+
+python3 - "$WORKFLOW" <<'PY'
+import pathlib
+import re
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text()
+
+if not re.search(r"(?ms)^permissions:\n  contents: read\n", workflow):
+    raise SystemExit("release workflow must default to read-only repository contents")
+
+
+def job(name: str) -> str:
+    match = re.search(rf"(?ms)^  {re.escape(name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:|\Z)", workflow)
+    if match is None:
+        raise SystemExit(f"missing {name} job")
+    return match.group("body")
+
+
+build = job("build-cli")
+if not re.search(r"(?ms)^    permissions:\n      contents: read\n", build):
+    raise SystemExit("build-cli must receive only read access to repository contents")
+if "contents: write" in build:
+    raise SystemExit("build-cli must not receive repository write access")
+if "Upload packaged artifact" not in build or "if: github.event_name" in build.split("Upload packaged artifact", 1)[1].split("\n  ", 1)[0]:
+    raise SystemExit("build-cli must upload its packaged artifact for every run")
+
+publisher = job("publish-release-assets")
+for required in (
+    "needs: build-cli",
+    "if: github.event_name == 'release'",
+    "actions: read",
+    "contents: write",
+    "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+    "pattern: codexbar-cli-*",
+    "merge-multiple: true",
+    'gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber',
+):
+    if required not in publisher:
+        raise SystemExit(f"release publisher is missing: {required}")
+
+tap = job("update-homebrew-tap")
+if "permissions: {}" not in tap:
+    raise SystemExit("tap updater must not receive the repository token")
+
+print("Release CLI permissions workflow tests passed.")
+PY

--- a/Scripts/test_release_cli_permissions.sh
+++ b/Scripts/test_release_cli_permissions.sh
@@ -40,12 +40,14 @@ for required in (
     "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
     "pattern: codexbar-cli-*",
     "merge-multiple: true",
-    'gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber',
+    'gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber --repo "$GITHUB_REPOSITORY"',
 ):
     if required not in publisher:
         raise SystemExit(f"release publisher is missing: {required}")
 
 tap = job("update-homebrew-tap")
+if "needs: publish-release-assets" not in tap:
+    raise SystemExit("tap updater must wait for release assets to upload")
 if "permissions: {}" not in tap:
     raise SystemExit("tap updater must not receive the repository token")
 

--- a/Sources/CodexBar/Localization.swift
+++ b/Sources/CodexBar/Localization.swift
@@ -214,7 +214,22 @@ func L(_ key: String, language: String) -> String {
 }
 
 func codexBarLocalizedLocale() -> Locale {
-    let language = resolvedAppLanguage()
+    codexBarLocale(forLanguage: resolvedAppLanguage())
+}
+
+/// Returns the locale of the resource bundle currently selected by `L`.
+///
+/// This can differ from `Locale.current` when the app falls back to a supported language. Plural
+/// formatting must use this locale so it follows the same language as the resolved strings.
+func codexBarLocalizedResourceLocale() -> Locale {
+    let bundleURL = localizedBundle().bundleURL
+    guard bundleURL.pathExtension == "lproj" else {
+        return codexBarLocalizedLocale()
+    }
+    return codexBarLocale(forLanguage: bundleURL.deletingPathExtension().lastPathComponent)
+}
+
+private func codexBarLocale(forLanguage language: String) -> Locale {
     guard !language.isEmpty else { return .current }
     let normalized = language.lowercased()
     if normalized == "ar" || normalized.hasPrefix("ar-") {

--- a/Sources/CodexBar/UsagePaceText.swift
+++ b/Sources/CodexBar/UsagePaceText.swift
@@ -39,19 +39,21 @@ enum UsagePaceText {
 
     static func sessionEquivalentDetail(forecast: SessionEquivalentForecast) -> SessionEquivalentDetail {
         let displayedEstimate = Self.boundedFullWindowCount(forecast.estimatedWindowsToExhaustWeekly)
-        let numberText = String.localizedStringWithFormat(
-            L("≈%d full 5h windows of weekly left · %d windows until reset"),
-            displayedEstimate,
-            forecast.windowsUntilReset)
+        let formattingLocale = codexBarLocalizedResourceLocale()
+        let numberText = String(
+            format: L("≈%d full 5h windows of weekly left · %d windows until reset"),
+            locale: formattingLocale,
+            arguments: [displayedEstimate, forecast.windowsUntilReset])
         let verdictText: String
         if forecast.estimatedWindowsToExhaustWeekly >= forecast.availableWindowsUntilReset {
             verdictText = L("Weekly cannot run out before reset at this pace")
         } else {
             let windowsEarly = Self.boundedWindowCount(
                 forecast.availableWindowsUntilReset - forecast.estimatedWindowsToExhaustWeekly)
-            verdictText = String.localizedStringWithFormat(
-                L("Weekly can run out ≈%d windows early"),
-                max(1, windowsEarly))
+            verdictText = String(
+                format: L("Weekly can run out ≈%d windows early"),
+                locale: formattingLocale,
+                arguments: [max(1, windowsEarly)])
         }
         return SessionEquivalentDetail(
             verdictText: verdictText,

--- a/Tests/CodexBarTests/LocalizationBundleCacheTests.swift
+++ b/Tests/CodexBarTests/LocalizationBundleCacheTests.swift
@@ -55,6 +55,19 @@ struct LocalizationBundleCacheTests {
     }
 
     @Test
+    func `format locale follows the resolved resource bundle`() {
+        let english = CodexBarLocalizationOverride.$appLanguage.withValue("en") {
+            codexBarLocalizedResourceLocale()
+        }
+        #expect(english.language.languageCode?.identifier == "en")
+
+        let fallback = CodexBarLocalizationOverride.$appLanguage.withValue("zz-unknown") {
+            codexBarLocalizedResourceLocale()
+        }
+        #expect(fallback.language.languageCode?.identifier == "en")
+    }
+
+    @Test
     func `resolution survives an explicit cache reset`() {
         let first = CodexBarLocalizationOverride.$appLanguage.withValue("uk") {
             codexBarLocalizedBundleForTesting()

--- a/Tests/CodexBarTests/LocalizationBundleCacheTests.swift
+++ b/Tests/CodexBarTests/LocalizationBundleCacheTests.swift
@@ -68,6 +68,18 @@ struct LocalizationBundleCacheTests {
     }
 
     @Test
+    func `resource locale expands English stringsdict singular forms`() {
+        let rendered = CodexBarLocalizationOverride.$appLanguage.withValue("en") {
+            String(
+                format: L("≈%d full 5h windows of weekly left · %d windows until reset"),
+                locale: codexBarLocalizedResourceLocale(),
+                arguments: [1, 1])
+        }
+
+        #expect(rendered == "≈1 full 5h window of weekly left · 1 window until reset")
+    }
+
+    @Test
     func `resolution survives an explicit cache reset`() {
         let first = CodexBarLocalizationOverride.$appLanguage.withValue("uk") {
             codexBarLocalizedBundleForTesting()

--- a/Tests/CodexBarTests/SpendDashboardControllerTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardControllerTests.swift
@@ -4,6 +4,7 @@ import Testing
 @testable import CodexBar
 
 @MainActor
+@Suite(.serialized)
 struct SpendDashboardControllerTests {
     @Test
     func `empty codex history loads as successful inactive source`() async {

--- a/Tests/CodexBarTests/SpendDashboardControllerTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardControllerTests.swift
@@ -289,7 +289,7 @@ struct SpendDashboardControllerTests {
         let snapshot = Self.input(id: "claude", provider: .claude, cost: 3).snapshot
         store._setTokenSnapshotForTesting(snapshot, provider: .claude)
         store._test_tokenUsageRefreshOverride = { _, _ in }
-        let controller = SpendDashboardController(requestBuilder: { mode in
+        let controller = SpendDashboardController(userDefaults: settings.userDefaults, requestBuilder: { mode in
             await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
         })
 
@@ -409,9 +409,11 @@ struct SpendDashboardControllerTests {
             environmentBase: [:])
         store._setTokenSnapshotForTesting(Self.input(provider: .claude, cost: 3).snapshot, provider: .claude)
         store._test_tokenUsageRefreshOverride = { _, _ in }
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
+            })
 
         let firstConfiguration = SpendDashboardSource.configuration(settings: settings, store: store)
         controller.update(configuration: firstConfiguration)
@@ -432,9 +434,11 @@ struct SpendDashboardControllerTests {
         #expect(controller.failedSourceCount == 1)
         #expect(store.tokenSnapshot(for: .claude)?.last30DaysCostUSD == 3)
 
-        let reopenedController = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let reopenedController = SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
+            })
         reopenedController.update(configuration: replacementConfiguration)
         await Self.waitUntil { !reopenedController.isRefreshing }
         #expect(reopenedController.model.groups.isEmpty)
@@ -488,9 +492,11 @@ struct SpendDashboardControllerTests {
 
         store._setTokenSnapshotForTesting(Self.input(provider: .mistral, cost: 3).snapshot, provider: .mistral)
         store._test_providerRefreshOverride = { _ in }
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
+            })
         controller.update(configuration: selectedBackupConfiguration)
         await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.model.groups.first?.totalCost == 3)
@@ -528,9 +534,11 @@ struct SpendDashboardControllerTests {
             environmentBase: [:])
         store._setTokenSnapshotForTesting(Self.input(provider: .claude, cost: 4).snapshot, provider: .claude)
         store._test_tokenUsageRefreshOverride = { _, _ in }
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
+            })
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.model.groups.first?.totalCost == 4)
@@ -558,9 +566,11 @@ struct SpendDashboardControllerTests {
             environmentBase: [:])
         store._setTokenSnapshotForTesting(Self.input(provider: .claude, cost: 5).snapshot, provider: .claude)
         store._test_tokenUsageRefreshOverride = { _, _ in }
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
+            })
         let firstConfiguration = SpendDashboardSource.configuration(settings: settings, store: store)
         controller.update(configuration: firstConfiguration)
         await Self.waitUntil { !controller.isRefreshing }
@@ -627,9 +637,11 @@ struct SpendDashboardControllerTests {
             environmentBase: [:])
         store._setTokenSnapshotForTesting(Self.input(provider: .claude, cost: 5).snapshot, provider: .claude)
         store._test_tokenUsageRefreshOverride = { _, _ in }
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
+            })
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.model.groups.first?.totalCost == 5)
@@ -645,9 +657,11 @@ struct SpendDashboardControllerTests {
         #expect(controller.model.groups.isEmpty)
         #expect(controller.failedSourceCount == 1)
 
-        let reopenedController = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let reopenedController = SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
+            })
         reopenedController.update(configuration: reenabledConfiguration)
         await Self.waitUntil { !reopenedController.isRefreshing }
         #expect(reopenedController.model.groups.isEmpty)

--- a/Tests/CodexBarTests/SpendDashboardTokenProvenanceTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardTokenProvenanceTests.swift
@@ -124,9 +124,11 @@ struct SpendDashboardTokenProvenanceTests {
         store.activateCachedTokenAccountSnapshot(provider: .mistral, accountID: account.id)
         #expect(store.tokenSnapshotPublicationRevision(for: .mistral) == baselineRevision)
         store._test_providerRefreshOverride = { _ in }
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
+            })
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.model.groups.first?.totalCost == 3)
@@ -148,9 +150,11 @@ struct SpendDashboardTokenProvenanceTests {
             return loadCount == 1 ? Self.tokenSnapshot(cost: 4) : Self.emptyTokenSnapshot()
         }
         await store.refreshTokenUsageNow(for: .bedrock, force: true)
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
+            })
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.model.groups.first?.totalCost == 4)
@@ -177,9 +181,11 @@ struct SpendDashboardTokenProvenanceTests {
         }
         await store.refreshTokenUsageNow(for: .bedrock, force: true)
         let publicationRevision = store.tokenSnapshotPublicationRevision(for: .bedrock)
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
+            })
 
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }


### PR DESCRIPTION
> **Repository-hygiene review stack · child of #2418**
>
> Part of #2439. Review #2418 first. After it merges, rebase this branch onto `main`; the temporary baseline merge will disappear, leaving only release-workflow permissions and ordering changes to review.
>
> **Sibling PRs:** #2383 · #2384 · #2420  
> **Tracking issue:** #2439

## Summary

- keep build jobs read-only and retain `contents: write` solely in the release-asset publisher
- make the Homebrew tap updater wait for the publisher, so it cannot resolve CLI assets before they are attached to the release
- pass `--repo "$GITHUB_REPOSITORY"` to `gh release upload`, because the publisher intentionally has no checkout
- add regression assertions for both release ordering and explicit repository selection
- temporarily merge the already-validated macOS test-baseline repair from #2418 so this PR can validate against the current CI baseline

## Why

The permission split should not change release behavior. Once asset upload moved out of the build matrix, the tap updater needed to wait for the new publisher, and the checkout-free publisher needed an explicit GitHub repository target.

## Linked issue or maintainer sign-off

No linked issue: maintainer sign-off is requested because this changes release workflow execution boundaries.

## CI baseline dependency

This branch temporarily merges #2418, the tested repair for an unrelated macOS test baseline. It does not alter the release-workflow behavior in this PR. After #2418 merges to `main`, GitHub's comparison will naturally omit that already-merged ancestor from this PR's diff.

## Merge order

Merge #2418 first. Until it lands, do not merge this PR even if its checks are green; otherwise the unrelated test-baseline repair would enter `main` through this PR and obscure its functional scope.

## Validation

- `git diff --check`
- Ruby YAML parse of `.github/workflows/release-cli.yml`
- `Scripts/test_release_cli_permissions.sh`
- `make check` — passed (SwiftFormat and SwiftLint)
- `make test` — passed: 722 selections, 61/61 first-pass groups, with no failures, retries, or timeouts
- fresh GitHub CI: passed on the current head

## UI proof

Not applicable: release CI configuration only.

## Provider and privacy impact

None to runtime providers. Build jobs remain read-only; only the post-build publisher can write release assets. The tap updater continues to use only its dedicated tap token.

## Checklist

- [x] This PR is functionally focused; the temporary CI-baseline dependency is documented above.
- [x] I ran `make check` and the relevant focused tests.
- [x] I ran `make test`.
- [x] UI changes include visual proof; logic changes include reproducible evidence.
- [x] I did not include credentials, cookies, Authorization headers, account files, or unredacted personal data.
- [x] Provider data remains siloed and this change does not create an unbounded network, PTY, or UI wait.

## Release-owner verification

Before marking ready, exercise a non-production release workflow or inspect a release-event run to confirm all six CLI archives plus checksums are published before the tap dispatch starts.