### PR TITLE
Cache validated Ollama browser sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.45.3 — Unreleased
 
 ### Fixed
+- Ollama: skip inaccessible Safari cookies when another browser cookie store can be read.
 
 ## 0.45.2 — 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.45.3 — Unreleased
 
 ### Fixed
-- Ollama: skip inaccessible Safari cookies when another browser cookie store can be read.
+- Ollama: skip inaccessible Safari cookies during automatic browser fallback while preserving explicit Safari
+  permission guidance.
 
 ## 0.45.2 — 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 0.45.3 — Unreleased
 
 ### Fixed
-- Ollama: skip inaccessible Safari cookies during automatic browser fallback while preserving explicit Safari
-  permission guidance.
+- Ollama: reuse validated browser sessions across refreshes, and skip inaccessible Safari cookies during automatic
+  fallback while preserving explicit Safari permission guidance.
 
 ## 0.45.2 — 2026-07-19
 

--- a/Sources/CodexBar/Providers/Ollama/OllamaProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Ollama/OllamaProviderImplementation.swift
@@ -97,7 +97,21 @@ struct OllamaProviderImplementation: ProviderImplementation {
                 binding: cookieBinding,
                 options: cookieOptions,
                 isVisible: nil,
-                onChange: nil),
+                onChange: nil,
+                trailingText: {
+                    guard context.settings.ollamaUsageDataSource != .api else { return nil }
+                    return ProviderCookieRefreshAction.trailingText(
+                        provider: .ollama,
+                        cookieSource: context.settings.ollamaCookieSource,
+                        context: context)
+                },
+                trailingActions: [
+                    ProviderCookieRefreshAction.descriptor(
+                        provider: .ollama,
+                        cookieSource: { context.settings.ollamaCookieSource },
+                        additionalVisibility: { context.settings.ollamaUsageDataSource != .api },
+                        context: context),
+                ]),
         ]
     }
 

--- a/Sources/CodexBar/Providers/Shared/ProviderCookieRefreshAction.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderCookieRefreshAction.swift
@@ -11,13 +11,14 @@ enum ProviderCookieRefreshAction {
     static func descriptor(
         provider: UsageProvider,
         cookieSource: @escaping () -> ProviderCookieSource,
+        additionalVisibility: @escaping () -> Bool = { true },
         context: ProviderSettingsContext) -> ProviderSettingsActionDescriptor
     {
         ProviderSettingsActionDescriptor(
             id: "\(provider.rawValue)-reimport-cookie",
             title: "Refresh",
             style: .bordered,
-            isVisible: { cookieSource() == .auto },
+            isVisible: { cookieSource() == .auto && additionalVisibility() },
             perform: {
                 await self.perform(provider: provider, context: context)
             })

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -79,10 +79,33 @@ struct OllamaStatusFetchStrategy: ProviderFetchStrategy {
         let logger: ((String) -> Void)? = context.verbose
             ? { msg in CodexBarLog.logger(LogCategories.ollama).verbose(msg) }
             : nil
-        let snap = try await fetcher.fetch(
-            cookieHeaderOverride: manual,
-            manualCookieMode: isManualMode,
-            logger: logger)
+        let snap: OllamaUsageSnapshot = if isManualMode {
+            try await fetcher.fetch(
+                cookieHeaderOverride: manual,
+                manualCookieMode: true,
+                logger: logger)
+        } else {
+            try await Self.fetchAutomatic(
+                cached: CookieHeaderCache.load(provider: .ollama),
+                fetchCached: { cached in
+                    try await fetcher.fetchResolvedCookie(
+                        cookieHeaderOverride: cached.cookieHeader,
+                        cookieHeaderOverrideSourceLabel: "cached \(cached.sourceLabel)",
+                        logger: logger).snapshot
+                },
+                fetchBrowser: {
+                    try await fetcher.fetchResolvedCookie(logger: logger)
+                },
+                clearCached: { cached in
+                    _ = CookieHeaderCache.clearIfCurrent(provider: .ollama, expected: cached)
+                },
+                storeResolved: { resolved in
+                    CookieHeaderCache.store(
+                        provider: .ollama,
+                        cookieHeader: resolved.cookieHeader,
+                        sourceLabel: resolved.sourceLabel)
+                })
+        }
         return self.makeResult(
             usage: snap.toUsageSnapshot(),
             sourceLabel: "web")
@@ -96,6 +119,57 @@ struct OllamaStatusFetchStrategy: ProviderFetchStrategy {
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
         guard context.settings?.ollama?.cookieSource == .manual else { return nil }
         return CookieHeaderNormalizer.normalize(context.settings?.ollama?.manualCookieHeader)
+    }
+
+    static func fetchAutomatic(
+        cached: CookieHeaderCache.Entry?,
+        fetchCached: (CookieHeaderCache.Entry) async throws -> OllamaUsageSnapshot,
+        fetchBrowser: () async throws -> OllamaUsageFetcher.ResolvedCookieFetch,
+        clearCached: (CookieHeaderCache.Entry) -> Void,
+        storeResolved: (OllamaUsageFetcher.ResolvedCookieFetch) -> Void) async throws -> OllamaUsageSnapshot
+    {
+        if let cached {
+            do {
+                return try await fetchCached(cached)
+            } catch {
+                if self.shouldInvalidateCachedCookie(after: error) {
+                    clearCached(cached)
+                } else if self.shouldTryBrowserCandidates(afterCachedFailure: error) {
+                    let cachedError = error
+                    do {
+                        let resolved = try await fetchBrowser()
+                        storeResolved(resolved)
+                        return resolved.snapshot
+                    } catch {
+                        throw cachedError
+                    }
+                } else {
+                    throw error
+                }
+            }
+        }
+
+        let resolved = try await fetchBrowser()
+        storeResolved(resolved)
+        return resolved.snapshot
+    }
+
+    static func shouldInvalidateCachedCookie(after error: Error) -> Bool {
+        switch error {
+        case OllamaUsageError.invalidCredentials, OllamaUsageError.notLoggedIn:
+            true
+        default:
+            false
+        }
+    }
+
+    static func shouldTryBrowserCandidates(afterCachedFailure error: Error) -> Bool {
+        switch error {
+        case let OllamaUsageError.parseFailed(message):
+            message == "Missing Ollama usage data."
+        default:
+            false
+        }
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -102,41 +102,70 @@ public enum OllamaCookieImporter {
         allowFallbackBrowsers: Bool = false,
         logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
     {
-        let log: (String) -> Void = { msg in logger?("[ollama-cookie] \(msg)") }
         var accessError: OllamaUsageError?
         let preferredOrder = preferredBrowsers.isEmpty ? ollamaCookieImportOrder : preferredBrowsers
         let preferredSources = self.cookieSources(
             from: preferredOrder,
             browserDetection: browserDetection,
             accessError: &accessError)
-        let preferredCandidates = self.collectSessionInfo(
+        let canUseFallback = allowFallbackBrowsers && !preferredBrowsers.isEmpty
+        return try self.importSessions(
+            preferredSources: preferredSources,
+            allowFallbackBrowsers: canUseFallback,
+            initialAccessError: accessError,
+            logger: logger,
+            loadFallbackSources: { accessError in
+                let fallbackOrder = ollamaCookieImportOrder.filter { !preferredBrowsers.contains($0) }
+                return self.cookieSources(
+                    from: fallbackOrder,
+                    browserDetection: browserDetection,
+                    accessError: &accessError)
+            },
+            loadSessions: self.loadSessions)
+    }
+
+    static func importSessions(
+        preferredSources: [Browser],
+        allowFallbackBrowsers: Bool,
+        initialAccessError: OllamaUsageError? = nil,
+        logger: ((String) -> Void)? = nil,
+        loadFallbackSources: (inout OllamaUsageError?) -> [Browser],
+        loadSessions: (Browser, @escaping (String) -> Void) throws -> [SessionInfo]) throws -> [SessionInfo]
+    {
+        let log: (String) -> Void = { msg in logger?("[ollama-cookie] \(msg)") }
+        var accessError = initialAccessError
+        let preferredImport = self.collectSessionInfo(
             from: preferredSources,
             logger: log,
-            accessError: &accessError)
+            accessError: &accessError,
+            loadSessions: loadSessions)
+        var successfullyReadBrowsers = preferredImport.successfullyReadBrowsers
         do {
-            return try self.selectSessionInfos(from: preferredCandidates, logger: log)
+            return try self.selectSessionInfos(from: preferredImport.candidates, logger: log)
         } catch OllamaUsageError.noSessionCookie {
-            guard allowFallbackBrowsers, !preferredBrowsers.isEmpty else {
-                throw accessError ?? OllamaUsageError.noSessionCookie
+            guard allowFallbackBrowsers else {
+                throw self.surfacedAccessError(
+                    accessError,
+                    successfullyReadBrowsers: successfullyReadBrowsers) ?? OllamaUsageError.noSessionCookie
             }
         }
 
-        let fallbackOrder = ollamaCookieImportOrder.filter { !preferredBrowsers.contains($0) }
-        let fallbackSources = self.cookieSources(
-            from: fallbackOrder,
-            browserDetection: browserDetection,
-            accessError: &accessError)
+        let fallbackSources = loadFallbackSources(&accessError)
         if !fallbackSources.isEmpty {
             log("No recognized Ollama session in preferred browsers; trying fallback import order")
         }
-        let fallbackCandidates = self.collectSessionInfo(
+        let fallbackImport = self.collectSessionInfo(
             from: fallbackSources,
             logger: log,
-            accessError: &accessError)
+            accessError: &accessError,
+            loadSessions: loadSessions)
+        successfullyReadBrowsers.append(contentsOf: fallbackImport.successfullyReadBrowsers)
         do {
-            return try self.selectSessionInfos(from: fallbackCandidates, logger: log)
+            return try self.selectSessionInfos(from: fallbackImport.candidates, logger: log)
         } catch OllamaUsageError.noSessionCookie {
-            throw accessError ?? OllamaUsageError.noSessionCookie
+            throw self.surfacedAccessError(
+                accessError,
+                successfullyReadBrowsers: successfullyReadBrowsers) ?? OllamaUsageError.noSessionCookie
         }
     }
 
@@ -231,6 +260,15 @@ public enum OllamaCookieImporter {
         return .browserCookieDecryptionDenied(browser.displayName)
     }
 
+    static func surfacedAccessError(
+        _ error: OllamaUsageError?,
+        successfullyReadBrowsers: [Browser]) -> OllamaUsageError?
+    {
+        guard case .safariCookieAccessDenied = error else { return error }
+        guard successfullyReadBrowsers.contains(where: { $0 != .safari }) else { return error }
+        return nil
+    }
+
     static func suppressedAccessError(for browser: Browser, now: Date = Date()) -> OllamaUsageError? {
         guard browser.usesKeychainForCookieDecryption else { return nil }
         if KeychainAccessGate.isDisabled {
@@ -268,28 +306,41 @@ public enum OllamaCookieImporter {
     private static func collectSessionInfo(
         from browserSources: [Browser],
         logger: @escaping (String) -> Void,
-        accessError: inout OllamaUsageError?) -> [SessionInfo]
+        accessError: inout OllamaUsageError?,
+        loadSessions: (Browser, @escaping (String) -> Void) throws -> [SessionInfo])
+        -> (candidates: [SessionInfo], successfullyReadBrowsers: [Browser])
     {
         var candidates: [SessionInfo] = []
+        var successfullyReadBrowsers: [Browser] = []
         for browserSource in browserSources {
             do {
-                let query = BrowserCookieQuery(domains: self.cookieDomains)
-                let sources = try Self.cookieClient.codexBarRecords(
-                    matching: query,
-                    in: browserSource,
-                    logger: logger)
-                for source in sources where !source.records.isEmpty {
-                    let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
-                    guard !cookies.isEmpty else { continue }
-                    candidates.append(SessionInfo(cookies: cookies, sourceLabel: source.label))
-                }
+                let sessions = try loadSessions(browserSource, logger)
+                successfullyReadBrowsers.append(browserSource)
+                candidates.append(contentsOf: sessions)
             } catch {
                 BrowserCookieAccessGate.recordIfNeeded(error)
                 accessError = accessError ?? self.accessError(from: error)
                 logger("\(browserSource.displayName) cookie import failed: \(error.localizedDescription)")
             }
         }
-        return candidates
+        return (candidates, successfullyReadBrowsers)
+    }
+
+    private static func loadSessions(
+        from browserSource: Browser,
+        logger: @escaping (String) -> Void) throws -> [SessionInfo]
+    {
+        let query = BrowserCookieQuery(domains: self.cookieDomains)
+        let sources = try Self.cookieClient.codexBarRecords(
+            matching: query,
+            in: browserSource,
+            logger: logger)
+        return sources.compactMap { source in
+            guard !source.records.isEmpty else { return nil }
+            let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
+            guard !cookies.isEmpty else { return nil }
+            return SessionInfo(cookies: cookies, sourceLabel: source.label)
+        }
     }
 
     private static func containsRecognizedSessionCookie(in cookies: [HTTPCookie]) -> Bool {

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -373,6 +373,12 @@ public struct OllamaUsageFetcher: Sendable {
         let sourceLabel: String
     }
 
+    struct ResolvedCookieFetch: Sendable {
+        let snapshot: OllamaUsageSnapshot
+        let cookieHeader: String
+        let sourceLabel: String
+    }
+
     enum RetryableParseFailure: Error {
         case missingUsageData
     }
@@ -405,8 +411,23 @@ public struct OllamaUsageFetcher: Sendable {
         logger: ((String) -> Void)? = nil,
         now: Date = Date()) async throws -> OllamaUsageSnapshot
     {
+        try await self.fetchResolvedCookie(
+            cookieHeaderOverride: cookieHeaderOverride,
+            manualCookieMode: manualCookieMode,
+            logger: logger,
+            now: now).snapshot
+    }
+
+    func fetchResolvedCookie(
+        cookieHeaderOverride: String? = nil,
+        cookieHeaderOverrideSourceLabel: String? = nil,
+        manualCookieMode: Bool = false,
+        logger: ((String) -> Void)? = nil,
+        now: Date = Date()) async throws -> ResolvedCookieFetch
+    {
         let cookieCandidates = try await self.resolveCookieCandidates(
             override: cookieHeaderOverride,
+            overrideSourceLabel: cookieHeaderOverrideSourceLabel,
             manualCookieMode: manualCookieMode,
             logger: logger)
         return try await self.fetchUsingCookieCandidates(
@@ -429,7 +450,7 @@ public struct OllamaUsageFetcher: Sendable {
     private func fetchUsingCookieCandidates(
         _ candidates: [CookieCandidate],
         logger: ((String) -> Void)?,
-        now: Date) async throws -> OllamaUsageSnapshot
+        now: Date) async throws -> ResolvedCookieFetch
     {
         do {
             return try await ProviderCandidateRetryRunner.run(
@@ -456,7 +477,10 @@ public struct OllamaUsageFetcher: Sendable {
                             self.logDiagnostics(responseInfo: responseInfo, diagnostics: diagnostics, logger: logger)
                         }
                         do {
-                            return try Self.parseSnapshotForRetry(html: html, now: now)
+                            return try ResolvedCookieFetch(
+                                snapshot: Self.parseSnapshotForRetry(html: html, now: now),
+                                cookieHeader: candidate.cookieHeader,
+                                sourceLabel: candidate.sourceLabel)
                         } catch {
                             let surfacedError = Self.surfacedError(from: error)
                             if let logger {
@@ -501,6 +525,7 @@ public struct OllamaUsageFetcher: Sendable {
 
     private func resolveCookieCandidates(
         override: String?,
+        overrideSourceLabel: String? = nil,
         manualCookieMode: Bool,
         logger: ((String) -> Void)?) async throws -> [CookieCandidate]
     {
@@ -509,7 +534,9 @@ public struct OllamaUsageFetcher: Sendable {
             manualCookieMode: manualCookieMode,
             logger: logger)
         {
-            return [CookieCandidate(cookieHeader: manualHeader, sourceLabel: "manual cookie header")]
+            return [CookieCandidate(
+                cookieHeader: manualHeader,
+                sourceLabel: overrideSourceLabel ?? "manual cookie header")]
         }
         #if os(macOS)
         let sessions = try OllamaCookieImporter.importSessions(

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -150,16 +150,20 @@ public enum OllamaCookieImporter {
             }
         }
 
-        let fallbackSources = loadFallbackSources(&accessError)
+        var fallbackAccessError: OllamaUsageError?
+        let fallbackSources = loadFallbackSources(&fallbackAccessError)
+        fallbackAccessError = self.surfacedFallbackAccessError(fallbackAccessError)
         if !fallbackSources.isEmpty {
             log("No recognized Ollama session in preferred browsers; trying fallback import order")
         }
         let fallbackImport = self.collectSessionInfo(
             from: fallbackSources,
             logger: log,
-            accessError: &accessError,
+            accessError: &fallbackAccessError,
+            suppressSafariAccessErrors: true,
             loadSessions: loadSessions)
         successfullyReadBrowsers.append(contentsOf: fallbackImport.successfullyReadBrowsers)
+        accessError = accessError ?? self.surfacedFallbackAccessError(fallbackAccessError)
         do {
             return try self.selectSessionInfos(from: fallbackImport.candidates, logger: log)
         } catch OllamaUsageError.noSessionCookie {
@@ -269,6 +273,11 @@ public enum OllamaCookieImporter {
         return nil
     }
 
+    static func surfacedFallbackAccessError(_ error: OllamaUsageError?) -> OllamaUsageError? {
+        guard case .safariCookieAccessDenied = error else { return error }
+        return nil
+    }
+
     static func suppressedAccessError(for browser: Browser, now: Date = Date()) -> OllamaUsageError? {
         guard browser.usesKeychainForCookieDecryption else { return nil }
         if KeychainAccessGate.isDisabled {
@@ -307,6 +316,7 @@ public enum OllamaCookieImporter {
         from browserSources: [Browser],
         logger: @escaping (String) -> Void,
         accessError: inout OllamaUsageError?,
+        suppressSafariAccessErrors: Bool = false,
         loadSessions: (Browser, @escaping (String) -> Void) throws -> [SessionInfo])
         -> (candidates: [SessionInfo], successfullyReadBrowsers: [Browser])
     {
@@ -319,7 +329,10 @@ public enum OllamaCookieImporter {
                 candidates.append(contentsOf: sessions)
             } catch {
                 BrowserCookieAccessGate.recordIfNeeded(error)
-                accessError = accessError ?? self.accessError(from: error)
+                let importedAccessError = self.accessError(from: error)
+                accessError = accessError ?? (suppressSafariAccessErrors
+                    ? self.surfacedFallbackAccessError(importedAccessError)
+                    : importedAccessError)
                 logger("\(browserSource.displayName) cookie import failed: \(error.localizedDescription)")
             }
         }

--- a/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
@@ -84,6 +84,159 @@ struct OllamaUsageFetcherRetryMappingTests {
         #expect(strategy.shouldFallback(on: OllamaUsageError.parseFailed("missing"), context: context))
     }
 
+    @Test
+    func `automatic web fetch reuses validated cached cookie without browser import`() async throws {
+        let cached = CookieHeaderCache.Entry(
+            cookieHeader: "session=cached",
+            storedAt: Date(timeIntervalSince1970: 100),
+            sourceLabel: "Chrome")
+        var events: [String] = []
+
+        let snapshot = try await OllamaStatusFetchStrategy.fetchAutomatic(
+            cached: cached,
+            fetchCached: { entry in
+                events.append("cache:\(entry.sourceLabel)")
+                return Self.makeSnapshot(sessionUsedPercent: 12)
+            },
+            fetchBrowser: {
+                events.append("browser")
+                return OllamaUsageFetcher.ResolvedCookieFetch(
+                    snapshot: Self.makeSnapshot(sessionUsedPercent: 99),
+                    cookieHeader: "session=browser",
+                    sourceLabel: "Browser")
+            },
+            clearCached: { _ in events.append("clear") },
+            storeResolved: { _ in events.append("store") })
+
+        #expect(snapshot.sessionUsedPercent == 12)
+        #expect(events == ["cache:Chrome"])
+    }
+
+    @Test
+    func `automatic web fetch keeps cached cookie on offline failure`() async {
+        let cached = CookieHeaderCache.Entry(
+            cookieHeader: "session=cached",
+            storedAt: Date(timeIntervalSince1970: 100),
+            sourceLabel: "Chrome")
+        var events: [String] = []
+
+        await #expect(throws: URLError.self) {
+            _ = try await OllamaStatusFetchStrategy.fetchAutomatic(
+                cached: cached,
+                fetchCached: { _ in throw URLError(.notConnectedToInternet) },
+                fetchBrowser: {
+                    events.append("browser")
+                    return OllamaUsageFetcher.ResolvedCookieFetch(
+                        snapshot: Self.makeSnapshot(sessionUsedPercent: 99),
+                        cookieHeader: "session=browser",
+                        sourceLabel: "Browser")
+                },
+                clearCached: { _ in events.append("clear") },
+                storeResolved: { _ in events.append("store") })
+        }
+
+        #expect(events.isEmpty)
+    }
+
+    @Test
+    func `automatic web fetch replaces cached cookie only after authentication failure`() async throws {
+        let cached = CookieHeaderCache.Entry(
+            cookieHeader: "session=expired",
+            storedAt: Date(timeIntervalSince1970: 100),
+            sourceLabel: "Chrome")
+        var events: [String] = []
+
+        let snapshot = try await OllamaStatusFetchStrategy.fetchAutomatic(
+            cached: cached,
+            fetchCached: { _ in
+                events.append("cache")
+                throw OllamaUsageError.invalidCredentials
+            },
+            fetchBrowser: {
+                events.append("browser")
+                return OllamaUsageFetcher.ResolvedCookieFetch(
+                    snapshot: Self.makeSnapshot(sessionUsedPercent: 34),
+                    cookieHeader: "session=fresh",
+                    sourceLabel: "Brave")
+            },
+            clearCached: { entry in events.append("clear:\(entry.sourceLabel)") },
+            storeResolved: { resolved in events.append("store:\(resolved.sourceLabel)") })
+
+        #expect(snapshot.sessionUsedPercent == 34)
+        #expect(events == ["cache", "clear:Chrome", "browser", "store:Brave"])
+    }
+
+    @Test
+    func `cached cookie invalidation excludes network and parse errors`() {
+        #expect(OllamaStatusFetchStrategy.shouldInvalidateCachedCookie(
+            after: OllamaUsageError.invalidCredentials))
+        #expect(OllamaStatusFetchStrategy.shouldInvalidateCachedCookie(
+            after: OllamaUsageError.notLoggedIn))
+        #expect(!OllamaStatusFetchStrategy.shouldInvalidateCachedCookie(
+            after: URLError(.notConnectedToInternet)))
+        #expect(!OllamaStatusFetchStrategy.shouldInvalidateCachedCookie(
+            after: OllamaUsageError.parseFailed("changed page")))
+    }
+
+    @Test
+    func `cached session missing usage tries another browser without clearing cache`() async throws {
+        let cached = CookieHeaderCache.Entry(
+            cookieHeader: "session=cached",
+            storedAt: Date(timeIntervalSince1970: 100),
+            sourceLabel: "Chrome")
+        var events: [String] = []
+
+        let snapshot = try await OllamaStatusFetchStrategy.fetchAutomatic(
+            cached: cached,
+            fetchCached: { _ in
+                events.append("cache")
+                throw OllamaUsageError.parseFailed("Missing Ollama usage data.")
+            },
+            fetchBrowser: {
+                events.append("browser")
+                return OllamaUsageFetcher.ResolvedCookieFetch(
+                    snapshot: Self.makeSnapshot(sessionUsedPercent: 56),
+                    cookieHeader: "session=browser",
+                    sourceLabel: "Brave")
+            },
+            clearCached: { _ in events.append("clear") },
+            storeResolved: { resolved in events.append("store:\(resolved.sourceLabel)") })
+
+        #expect(snapshot.sessionUsedPercent == 56)
+        #expect(events == ["cache", "browser", "store:Brave"])
+    }
+
+    @Test
+    func `failed browser fallback preserves cached missing usage error`() async {
+        let cached = CookieHeaderCache.Entry(
+            cookieHeader: "session=cached",
+            storedAt: Date(timeIntervalSince1970: 100),
+            sourceLabel: "Chrome")
+        var events: [String] = []
+
+        do {
+            _ = try await OllamaStatusFetchStrategy.fetchAutomatic(
+                cached: cached,
+                fetchCached: { _ in
+                    events.append("cache")
+                    throw OllamaUsageError.parseFailed("Missing Ollama usage data.")
+                },
+                fetchBrowser: {
+                    events.append("browser")
+                    throw OllamaUsageError.noSessionCookie
+                },
+                clearCached: { _ in events.append("clear") },
+                storeResolved: { _ in events.append("store") })
+            Issue.record("Expected cached parse failure")
+        } catch let OllamaUsageError.parseFailed(message) {
+            #expect(message == "Missing Ollama usage data.")
+        } catch {
+            Issue.record("Expected cached parse failure, got \(error)")
+        }
+
+        #expect(events == ["cache", "browser"])
+    }
+
     @Test(arguments: [401, 403])
     func `api fetch sends bearer token and rejects unauthorized key`(statusCode: Int) async throws {
         let url = try #require(URL(string: "https://ollama.com/api/web_search"))
@@ -515,6 +668,17 @@ struct OllamaUsageFetcherRetryMappingTests {
             httpVersion: "HTTP/1.1",
             headerFields: ["Content-Type": "text/html"])!
         return (response, Data(body.utf8))
+    }
+
+    private static func makeSnapshot(sessionUsedPercent: Double) -> OllamaUsageSnapshot {
+        OllamaUsageSnapshot(
+            planName: nil,
+            accountEmail: nil,
+            sessionUsedPercent: sessionUsedPercent,
+            weeklyUsedPercent: nil,
+            sessionResetsAt: nil,
+            weeklyResetsAt: nil,
+            updatedAt: Date(timeIntervalSince1970: 200))
     }
 }
 

--- a/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
@@ -5,6 +5,7 @@ import Testing
 import SweetCookieKit
 #endif
 
+@Suite(.serialized)
 struct OllamaUsageFetcherTests {
     @Test
     func `session authentication errors point to current recovery page`() {
@@ -158,6 +159,78 @@ struct OllamaUsageFetcherTests {
             browser: .brave,
             details: "SQLite failed"))
         #expect(ambiguous == nil)
+    }
+
+    @Test
+    func `multi browser import skips safari access error after chrome was read`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+        var attemptedBrowsers: [Browser] = []
+
+        do {
+            _ = try OllamaCookieImporter.importSessions(
+                preferredSources: [.chrome],
+                allowFallbackBrowsers: true,
+                loadFallbackSources: { _ in [.safari] },
+                loadSessions: { browser, _ in
+                    attemptedBrowsers.append(browser)
+                    if browser == .safari {
+                        throw BrowserCookieError.accessDenied(
+                            browser: .safari,
+                            details: "Full Disk Access denied")
+                    }
+                    return []
+                })
+            Issue.record("Expected OllamaUsageError.noSessionCookie")
+        } catch OllamaUsageError.noSessionCookie {
+            #expect(attemptedBrowsers == [.chrome, .safari])
+        } catch {
+            Issue.record("Expected OllamaUsageError.noSessionCookie, got \(error)")
+        }
+    }
+
+    @Test
+    func `fallback browser gates stay lazy when chrome has a session`() throws {
+        var loadedFallbackSources = false
+        let sessions = try OllamaCookieImporter.importSessions(
+            preferredSources: [.chrome],
+            allowFallbackBrowsers: true,
+            loadFallbackSources: { _ in
+                loadedFallbackSources = true
+                return [.safari]
+            },
+            loadSessions: { browser, _ in
+                #expect(browser == .chrome)
+                return [OllamaCookieImporter.SessionInfo(
+                    cookies: [Self.makeCookie(name: "session", value: "auth")],
+                    sourceLabel: "Chrome Profile")]
+            })
+
+        #expect(sessions.map(\.sourceLabel) == ["Chrome Profile"])
+        #expect(!loadedFallbackSources)
+    }
+
+    @Test
+    func `safari only import surfaces safari access error`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        do {
+            _ = try OllamaCookieImporter.importSessions(
+                preferredSources: [.safari],
+                allowFallbackBrowsers: false,
+                loadFallbackSources: { _ in [] },
+                loadSessions: { browser, _ in
+                    throw BrowserCookieError.accessDenied(
+                        browser: browser,
+                        details: "Full Disk Access denied")
+                })
+            Issue.record("Expected Safari Full Disk Access error")
+        } catch OllamaUsageError.safariCookieAccessDenied {
+            // expected
+        } catch {
+            Issue.record("Expected Safari Full Disk Access error, got \(error)")
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
@@ -190,6 +190,57 @@ struct OllamaUsageFetcherTests {
     }
 
     @Test
+    func `automatic fallback skips safari access error when preferred browser is unavailable`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+        var attemptedBrowsers: [Browser] = []
+
+        do {
+            _ = try OllamaCookieImporter.importSessions(
+                preferredSources: [],
+                allowFallbackBrowsers: true,
+                loadFallbackSources: { _ in [.safari] },
+                loadSessions: { browser, _ in
+                    attemptedBrowsers.append(browser)
+                    throw BrowserCookieError.accessDenied(
+                        browser: browser,
+                        details: "Full Disk Access denied")
+                })
+            Issue.record("Expected OllamaUsageError.noSessionCookie")
+        } catch OllamaUsageError.noSessionCookie {
+            #expect(attemptedBrowsers == [.safari])
+        } catch {
+            Issue.record("Expected OllamaUsageError.noSessionCookie, got \(error)")
+        }
+    }
+
+    @Test
+    func `automatic fallback keeps non safari access error after safari denial`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        do {
+            _ = try OllamaCookieImporter.importSessions(
+                preferredSources: [.chrome],
+                allowFallbackBrowsers: true,
+                loadFallbackSources: { _ in [.safari, .brave] },
+                loadSessions: { browser, _ in
+                    if browser == .chrome {
+                        return []
+                    }
+                    throw BrowserCookieError.accessDenied(
+                        browser: browser,
+                        details: "Access denied")
+                })
+            Issue.record("Expected Brave Keychain denial")
+        } catch let OllamaUsageError.browserCookieDecryptionDenied(browserName) {
+            #expect(browserName == "Brave")
+        } catch {
+            Issue.record("Expected Brave Keychain denial, got \(error)")
+        }
+    }
+
+    @Test
     func `fallback browser gates stay lazy when chrome has a session`() throws {
         var loadedFallbackSources = false
         let sessions = try OllamaCookieImporter.importSessions(
@@ -211,7 +262,7 @@ struct OllamaUsageFetcherTests {
     }
 
     @Test
-    func `safari only import surfaces safari access error`() {
+    func `explicit safari import surfaces safari access error`() {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -93,6 +93,28 @@ struct ProviderSettingsDescriptorTests {
     }
 
     @Test
+    func `ollama automatic cookie source exposes validated refresh action`() throws {
+        let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-ollama-refresh")
+        let context = fixture.settingsContext(provider: .ollama)
+        let pickers = OllamaProviderImplementation().settingsPickers(context: context)
+        let picker = try #require(pickers.first { $0.id == "ollama-cookie-source" })
+        let action = try #require(picker.trailingActions.first)
+
+        #expect(action.id == "ollama-reimport-cookie")
+        #expect(action.title == "Refresh")
+        #expect(action.isVisible?() == true)
+
+        fixture.settings.ollamaCookieSource = .manual
+        #expect(action.isVisible?() == false)
+        #expect(picker.trailingText?() == nil)
+
+        fixture.settings.ollamaCookieSource = .auto
+        fixture.settings.ollamaUsageDataSource = .api
+        #expect(action.isVisible?() == false)
+        #expect(picker.trailingText?() == nil)
+    }
+
+    @Test
     func `open code go cookie refresh rejects local fallback cookie`() async throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-opencodego-validation")
         let context = fixture.settingsContext(provider: .opencodego)


### PR DESCRIPTION
## Summary

- reuse the last validated Ollama browser session instead of scanning every browser on each refresh
- keep the cached session on offline, transport, and general parse failures; only invalidate it on authentication failures
- preserve multi-browser fallback when a cached account is valid but does not expose quota data
- skip optional Safari Full Disk Access errors during automatic fallback while retaining explicit Safari recovery guidance
- add a staged Refresh action for automatic Cookie mode and hide it when Ollama is explicitly API-only

## Root cause

Ollama automatic refresh imported browser cookies on every poll. When the network was unavailable, no candidate could be validated and the final browser-import outcome could replace the real connectivity failure with a Safari permission or generic sign-in error.

## User impact

After one successful browser-cookie refresh, temporary network loss now reports the network failure without rescanning browsers or discarding the validated session. Authentication failures still trigger re-import, and users can explicitly refresh browser cookies from Settings.

## Validation

- `swift test --filter 'OllamaUsageFetcherTests|OllamaUsageFetcherRetryMappingTests|ProviderSettingsDescriptorTests'` (99 tests passed)\n- `make check`\n- structured Codex autoreview: clean, no accepted/actionable findings\n- release bundle built, ad-hoc signed, and deep-signature verified\n- `/Applications/CodexBar.app` launched with `CodexGitCommit=667beb1b`\n\n`make test` consistently stops in the unrelated existing `AdaptiveRefreshTimerTests` group: two timer cases time out after 30 seconds with `CancellationError`, including on the automatic retry. The Ollama-focused suites pass.