### PR TITLE
Simplify Overview menu separators

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -605,6 +605,7 @@ struct UsageMenuCardHeaderSectionView: View {
 private struct UsageMenuCardUsageContentView: View {
     let model: UsageMenuCardView.Model
     let showBottomDivider: Bool
+    var showsSectionDividers = true
     @Environment(\.menuItemHighlighted) private var isHighlighted
 
     /// Doubao ships Coding Plan and Agent Plan subscriptions, each with personal
@@ -644,7 +645,7 @@ private struct UsageMenuCardUsageContentView: View {
                     self.groupHeader("Coding Plan")
                     self.metricRows(split.coding)
                 }
-                if !split.coding.isEmpty {
+                if !split.coding.isEmpty, self.showsSectionDividers {
                     Divider()
                 }
                 self.groupHeader("Agent Plan")
@@ -653,7 +654,7 @@ private struct UsageMenuCardUsageContentView: View {
                 self.metricRows(self.model.metrics)
             }
             if let resetCredits = self.model.codexResetCredits {
-                if !self.model.metrics.isEmpty {
+                if !self.model.metrics.isEmpty, self.showsSectionDividers {
                     Divider()
                 }
                 CodexResetCreditsContent(presentation: resetCredits)
@@ -681,11 +682,15 @@ struct UsageMenuCardUsageSectionView: View {
     let showBottomDivider: Bool
     let bottomPadding: CGFloat
     let width: CGFloat
+    var showsSectionDividers = true
     @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
 
     var body: some View {
         let liveModel = self.liveModel
-        UsageMenuCardUsageContentView(model: liveModel, showBottomDivider: self.showBottomDivider)
+        UsageMenuCardUsageContentView(
+            model: liveModel,
+            showBottomDivider: self.showBottomDivider,
+            showsSectionDividers: self.showsSectionDividers)
             .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
             .padding(.top, UsageMenuCardLayout.usageSectionTopPadding)
             .padding(.bottom, self.bottomPadding)

--- a/Sources/CodexBar/StatusItemController+MenuTypes.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTypes.swift
@@ -22,6 +22,8 @@ extension ProviderSwitcherSelection {
 }
 
 struct OverviewMenuCardRowView: View {
+    static let showsSectionDividers = false
+
     let model: UsageMenuCardView.Model
     let storageText: String?
     let width: CGFloat
@@ -31,14 +33,15 @@ struct OverviewMenuCardRowView: View {
         VStack(alignment: .leading, spacing: 0) {
             UsageMenuCardHeaderSectionView(
                 model: self.model,
-                showDivider: self.hasUsageBlock,
+                showDivider: Self.showsSectionDividers && self.hasUsageBlock,
                 width: self.width)
             if self.hasUsageBlock {
                 UsageMenuCardUsageSectionView(
                     model: self.model,
                     showBottomDivider: false,
                     bottomPadding: 6,
-                    width: self.width)
+                    width: self.width,
+                    showsSectionDividers: Self.showsSectionDividers)
             }
             if let storageText {
                 HStack(alignment: .firstTextBaseline, spacing: 4) {

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -1572,8 +1572,8 @@ extension StatusMenuTests {
         controller.menuWillOpen(menu)
         let ids = self.representedIDs(in: menu)
         let overviewRows = ids.filter { $0.hasPrefix("overviewRow-") }
-        #expect(overviewRows.count == enabledProviders.count && ids.contains("menuCard") == false)
-        #expect(enabledProviders.allSatisfy { overviewRows.contains("overviewRow-\($0.rawValue)") })
+        #expect(Set(overviewRows) == Set(enabledProviders.map { "overviewRow-\($0.rawValue)" }))
+        #expect(menu.items.count(where: \.isSeparatorItem) == overviewRows.count + 1)
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageMenuCardLayoutTests.swift
+++ b/Tests/CodexBarTests/UsageMenuCardLayoutTests.swift
@@ -9,6 +9,11 @@ struct UsageMenuCardLayoutTests {
     private static let heightTolerance: CGFloat = 1
 
     @Test
+    func `overview groups provider content without section dividers`() {
+        #expect(OverviewMenuCardRowView.showsSectionDividers == false)
+    }
+
+    @Test
     func `header only menu card keeps comfortable padding`() {
         let model = Self.model()
         let width: CGFloat = 296


### PR DESCRIPTION
Closes #2405

## Summary

- remove section dividers inside each provider row in the Overview tab
- retain native separators between provider groups and around the Overview content
- preserve the existing sectioned layout in individual provider tabs
- cover the Overview divider policy and the `N + 1` provider-boundary separator contract

## Why

Overview reused divider-bearing provider card components while also placing native menu separators between provider rows. With multiple providers, those two separator layers made the menu visually cluttered and obscured provider boundaries.

## User impact

Each provider now reads as one continuous group in Overview, while individual provider tabs keep their existing internal organization.

## Validation

- `swift test --filter UsageMenuCardLayoutTests`
- `swift test --filter 'CodexBarTests.StatusMenuTests/`overview tab renders overview rows for six active providers`()'`
- `make check`
- manually verified the freshly built menu bar app with multiple providers