### PR TITLE
fix: keep cookie caches in memory when Keychain is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Fixed
 - Ollama: reuse validated browser sessions across refreshes, and skip inaccessible Safari cookies during automatic
   fallback while preserving explicit Safari permission guidance.
+- Cursor: keep cookie/session caches in process when “Disable Keychain access” is on, so refreshes no longer fail
+  with “Cursor session changed during refresh”.
+- Cursor/Keychain: clear the in-process cookie cache whenever Keychain access is toggled so disabled-mode sessions
+  cannot resurface later.
 
 ## 0.45.2 — 2026-07-19
 

--- a/Sources/CodexBarCore/KeychainAccessGate.swift
+++ b/Sources/CodexBarCore/KeychainAccessGate.swift
@@ -18,9 +18,15 @@ public enum KeychainAccessGate {
             self.stateLock.withLock { self.isDisabledLocked() }
         }
         set {
-            self.stateLock.withLock {
+            let shouldClearDisabledAccessMemory = self.stateLock.withLock { () -> Bool in
+                let wasExplicitlyDisabled = self.isExplicitlyDisabledLocked()
                 self.overrideValue = newValue
+                let nowExplicitlyDisabled = self.isExplicitlyDisabledLocked()
                 self.updateBrowserCookieMirrorLocked()
+                return wasExplicitlyDisabled != nowExplicitlyDisabled
+            }
+            if shouldClearDisabledAccessMemory {
+                KeychainCacheStore.clearDisabledAccessMemoryStore()
             }
         }
     }
@@ -31,6 +37,23 @@ public enum KeychainAccessGate {
         #if DEBUG
         if Self.forcesDisabledUnderTests { return true }
         #endif
+        if self.processForceDisabledReason != nil { return true }
+        if let overrideValue { return overrideValue }
+        if UserDefaults.standard.bool(forKey: Self.flagKey) { return true }
+        if let shared = AppGroupSupport.sharedDefaults(), shared.bool(forKey: Self.flagKey) { return true }
+        return false
+    }
+
+    /// True when Keychain access was turned off by the user, environment, or an explicit test override.
+    /// Unlike `isDisabled`, this ignores the default test-process Keychain block so production-only
+    /// recovery paths (in-process cookie cache while Keychain is disabled) stay scoped correctly.
+    public static var isExplicitlyDisabled: Bool {
+        self.stateLock.withLock { self.isExplicitlyDisabledLocked() }
+    }
+
+    private static func isExplicitlyDisabledLocked() -> Bool {
+        if let taskOverrideValue { return taskOverrideValue }
+        if self.isDisabledByEnvironment() { return true }
         if self.processForceDisabledReason != nil { return true }
         if let overrideValue { return overrideValue }
         if UserDefaults.standard.bool(forKey: Self.flagKey) { return true }
@@ -51,9 +74,15 @@ public enum KeychainAccessGate {
     }
 
     public static func forceDisabledForProcess(reason: String) {
-        self.stateLock.withLock {
+        let shouldClearDisabledAccessMemory = self.stateLock.withLock { () -> Bool in
+            let wasExplicitlyDisabled = self.isExplicitlyDisabledLocked()
             self.processForceDisabledReason = reason
+            let nowExplicitlyDisabled = self.isExplicitlyDisabledLocked()
             self.updateBrowserCookieMirrorLocked()
+            return wasExplicitlyDisabled != nowExplicitlyDisabled
+        }
+        if shouldClearDisabledAccessMemory {
+            KeychainCacheStore.clearDisabledAccessMemoryStore()
         }
     }
 

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -95,8 +95,13 @@ public enum KeychainCacheStore {
             return self.loadResultForKeychainReadFailure(status: status, key: key)
         }
         #endif
-        if let testResult = loadFromTestStore(key: key, as: type) {
+        if let testResult = loadFromTestStore(key: key, as: type),
+           !self.prefersDisabledAccessMemoryStoreOverTestStore
+        {
             return testResult
+        }
+        if self.shouldUseDisabledAccessMemoryStore {
+            return self.loadFromDisabledAccessMemory(key: key, as: type)
         }
         guard self.canUseRealKeychain else { return .missing }
         #if os(macOS)
@@ -146,8 +151,13 @@ public enum KeychainCacheStore {
             return false
         }
         #endif
-        if let stored = self.storeInTestStore(key: key, entry: entry) {
+        if !self.prefersDisabledAccessMemoryStoreOverTestStore,
+           let stored = self.storeInTestStore(key: key, entry: entry)
+        {
             return stored
+        }
+        if self.shouldUseDisabledAccessMemoryStore {
+            return self.storeInDisabledAccessMemory(key: key, entry: entry)
         }
         guard self.canUseRealKeychain else { return false }
         #if os(macOS)
@@ -207,8 +217,13 @@ public enum KeychainCacheStore {
             return self.clearResultForKeychainDeleteStatus(status, key: key)
         }
         #endif
-        if let removed = self.clearTestStore(key: key) {
+        if !self.prefersDisabledAccessMemoryStoreOverTestStore,
+           let removed = self.clearTestStore(key: key)
+        {
             return removed ? .removed : .missing
+        }
+        if self.shouldUseDisabledAccessMemoryStore {
+            return self.clearDisabledAccessMemory(key: key) ? .removed : .missing
         }
         guard self.canUseRealKeychain else { return .failed }
         #if os(macOS)
@@ -239,8 +254,13 @@ public enum KeychainCacheStore {
             return self.keysResultForKeychainStatus(status, category: category, result: nil)
         }
         #endif
-        if let keys = self.keysFromTestStore(category: category) {
+        if !self.prefersDisabledAccessMemoryStoreOverTestStore,
+           let keys = self.keysFromTestStore(category: category)
+        {
             return .found(keys)
+        }
+        if self.shouldUseDisabledAccessMemoryStore {
+            return .found(self.keysFromDisabledAccessMemory(category: category))
         }
         guard self.canUseRealKeychain else { return .failed }
         #if os(macOS)
@@ -410,6 +430,69 @@ public enum KeychainCacheStore {
 
     private static var canUseRealKeychain: Bool {
         !KeychainAccessGate.isDisabled
+    }
+
+    /// When the user disables Keychain access, keep an in-process cache so cookie/session
+    /// reconciliation can still succeed without treating every refresh as a session change.
+    /// Unit tests keep using the isolated test stores instead, unless a test explicitly opts in.
+    private static var shouldUseDisabledAccessMemoryStore: Bool {
+        #if DEBUG
+        if self.disabledAccessMemoryStoreEnabledForTesting == true {
+            return true
+        }
+        if KeychainTestSafety.isRunningUnderTests(
+            processName: ProcessInfo.processInfo.processName,
+            environment: ProcessInfo.processInfo.environment)
+        {
+            return false
+        }
+        #endif
+        return KeychainAccessGate.isExplicitlyDisabled
+    }
+
+    #if DEBUG
+    @TaskLocal private static var disabledAccessMemoryStoreEnabledForTesting: Bool?
+
+    static func withDisabledAccessMemoryStoreForTesting<T>(
+        _ enabled: Bool,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$disabledAccessMemoryStoreEnabledForTesting.withValue(enabled) {
+            try operation()
+        }
+    }
+
+    static func withDisabledAccessMemoryStoreForTesting<T>(
+        _ enabled: Bool,
+        isolation _: isolated (any Actor)? = #isolation,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$disabledAccessMemoryStoreEnabledForTesting.withValue(enabled) {
+            try await operation()
+        }
+    }
+
+    static func resetDisabledAccessMemoryStoreForTesting() {
+        self.clearDisabledAccessMemoryStore()
+    }
+    #endif
+
+    /// Drops the in-process fallback used while Keychain access is explicitly disabled.
+    static func clearDisabledAccessMemoryStore() {
+        self.disabledAccessMemoryLock.lock()
+        self.disabledAccessMemoryStore.removeAll()
+        self.disabledAccessMemoryLock.unlock()
+    }
+
+    private static let disabledAccessMemoryLock = NSLock()
+    private nonisolated(unsafe) static var disabledAccessMemoryStore: [TestStoreKey: Data] = [:]
+
+    private static var prefersDisabledAccessMemoryStoreOverTestStore: Bool {
+        #if DEBUG
+        self.disabledAccessMemoryStoreEnabledForTesting == true
+        #else
+        false
+        #endif
     }
 
     #if DEBUG
@@ -660,6 +743,50 @@ public enum KeychainCacheStore {
             : self.testStore ?? (self.shouldUseImplicitTestStore ? self.implicitTestStore : nil)
         else { return nil }
         return store.keys
+            .filter { $0.service == self.serviceName }
+            .compactMap { self.key(fromAccount: $0.account, category: category) }
+            .sorted { $0.identifier < $1.identifier }
+    }
+
+    private static func loadFromDisabledAccessMemory<Entry: Codable>(
+        key: Key,
+        as type: Entry.Type) -> LoadResult<Entry>
+    {
+        self.disabledAccessMemoryLock.lock()
+        defer { self.disabledAccessMemoryLock.unlock() }
+        let memoryKey = TestStoreKey(service: self.serviceName, account: key.account)
+        guard let data = self.disabledAccessMemoryStore[memoryKey] else { return .missing }
+        let decoder = Self.makeDecoder()
+        guard let decoded = try? decoder.decode(Entry.self, from: data) else {
+            return .invalid
+        }
+        return .found(decoded)
+    }
+
+    private static func storeInDisabledAccessMemory(key: Key, entry: some Codable) -> Bool {
+        let encoder = Self.makeEncoder()
+        guard let data = try? encoder.encode(entry) else { return false }
+        self.disabledAccessMemoryLock.lock()
+        defer { self.disabledAccessMemoryLock.unlock() }
+        let memoryKey = TestStoreKey(service: self.serviceName, account: key.account)
+        self.disabledAccessMemoryStore[memoryKey] = data
+        self.log.debug("Keychain cache stored in memory (Keychain access disabled)", metadata: [
+            "account": key.account,
+        ])
+        return true
+    }
+
+    private static func clearDisabledAccessMemory(key: Key) -> Bool {
+        self.disabledAccessMemoryLock.lock()
+        defer { self.disabledAccessMemoryLock.unlock() }
+        let memoryKey = TestStoreKey(service: self.serviceName, account: key.account)
+        return self.disabledAccessMemoryStore.removeValue(forKey: memoryKey) != nil
+    }
+
+    private static func keysFromDisabledAccessMemory(category: String) -> [Key] {
+        self.disabledAccessMemoryLock.lock()
+        defer { self.disabledAccessMemoryLock.unlock() }
+        return self.disabledAccessMemoryStore.keys
             .filter { $0.service == self.serviceName }
             .compactMap { self.key(fromAccount: $0.account, category: category) }
             .sorted { $0.identifier < $1.identifier }

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -100,7 +100,7 @@ public enum KeychainCacheStore {
         {
             return testResult
         }
-        if self.shouldUseDisabledAccessMemoryStore {
+        if self.shouldUseDisabledAccessMemoryStore(for: key.category) {
             return self.loadFromDisabledAccessMemory(key: key, as: type)
         }
         guard self.canUseRealKeychain else { return .missing }
@@ -156,7 +156,7 @@ public enum KeychainCacheStore {
         {
             return stored
         }
-        if self.shouldUseDisabledAccessMemoryStore {
+        if self.shouldUseDisabledAccessMemoryStore(for: key.category) {
             return self.storeInDisabledAccessMemory(key: key, entry: entry)
         }
         guard self.canUseRealKeychain else { return false }
@@ -222,8 +222,12 @@ public enum KeychainCacheStore {
         {
             return removed ? .removed : .missing
         }
-        if self.shouldUseDisabledAccessMemoryStore {
-            return self.clearDisabledAccessMemory(key: key) ? .removed : .missing
+        if self.shouldUseDisabledAccessMemoryStore(for: key.category) {
+            // The matching persistent Keychain row is deliberately inaccessible in this mode. Remove the
+            // process-local copy, but report the operation as incomplete so callers never claim the durable
+            // credential was deleted only for it to reappear after Keychain access is re-enabled.
+            _ = self.clearDisabledAccessMemory(key: key)
+            return .failed
         }
         guard self.canUseRealKeychain else { return .failed }
         #if os(macOS)
@@ -259,8 +263,11 @@ public enum KeychainCacheStore {
         {
             return .found(keys)
         }
-        if self.shouldUseDisabledAccessMemoryStore {
-            return .found(self.keysFromDisabledAccessMemory(category: category))
+        if self.shouldUseDisabledAccessMemoryStore(for: category) {
+            let keys = self.keysFromDisabledAccessMemory(category: category)
+            // An empty process-local store cannot prove there are no persistent entries hidden behind the
+            // disabled Keychain gate. Surface that uncertainty instead of reporting "no cached cookies".
+            return keys.isEmpty ? .failed : .found(keys)
         }
         guard self.canUseRealKeychain else { return .failed }
         #if os(macOS)
@@ -435,7 +442,8 @@ public enum KeychainCacheStore {
     /// When the user disables Keychain access, keep an in-process cache so cookie/session
     /// reconciliation can still succeed without treating every refresh as a session change.
     /// Unit tests keep using the isolated test stores instead, unless a test explicitly opts in.
-    private static var shouldUseDisabledAccessMemoryStore: Bool {
+    private static func shouldUseDisabledAccessMemoryStore(for category: String) -> Bool {
+        guard category == "cookie" else { return false }
         #if DEBUG
         if self.disabledAccessMemoryStoreEnabledForTesting == true {
             return true

--- a/Tests/CodexBarTests/CookieHeaderCacheConditionalMutationTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheConditionalMutationTests.swift
@@ -246,6 +246,66 @@ struct CookieHeaderCacheConditionalMutationTests {
         }
     }
 
+    @Test
+    func `cookie cache persists while Keychain access is disabled`() {
+        KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+        defer {
+            KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+            KeychainAccessGate.resetOverrideForTesting()
+        }
+
+        KeychainAccessGate.withTaskOverrideForTesting(true) {
+            KeychainCacheStore.withDisabledAccessMemoryStoreForTesting(true) {
+                KeychainCacheStore.withServiceOverrideForTesting("cookie-disabled-\(UUID().uuidString)") {
+                    let observation = CookieHeaderCache.observeForConditionalMutation(provider: .cursor)
+                    #expect(CookieHeaderCache.storeIfObservationCurrent(
+                        provider: .cursor,
+                        expected: observation,
+                        cookieHeader: "WorkosCursorSessionToken=disabled-keychain",
+                        sourceLabel: "Safari"))
+                    #expect(CookieHeaderCache.load(provider: .cursor)?.cookieHeader ==
+                        "WorkosCursorSessionToken=disabled-keychain")
+                }
+            }
+        }
+    }
+
+    @Test
+    func `interactive mutation gate still blocks stores while Keychain access is disabled`() {
+        KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+        defer {
+            KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+            KeychainAccessGate.resetOverrideForTesting()
+        }
+
+        KeychainAccessGate.withTaskOverrideForTesting(true) {
+            KeychainCacheStore.withDisabledAccessMemoryStoreForTesting(true) {
+                KeychainCacheStore.withServiceOverrideForTesting("cookie-disabled-gate-\(UUID().uuidString)") {
+                    let scope = CookieHeaderCache.Scope.providerVariant(UUID().uuidString)
+                    CookieHeaderCache.store(
+                        provider: .cursor,
+                        scope: scope,
+                        cookieHeader: "fixtureSession=original",
+                        sourceLabel: "Original")
+                    let observation = CookieHeaderCache.observeForConditionalMutation(
+                        provider: .cursor,
+                        scope: scope)
+                    let gate = CookieHeaderCache.beginConditionalMutationGate(provider: .cursor, scope: scope)
+
+                    #expect(!CookieHeaderCache.storeIfObservationCurrent(
+                        provider: .cursor,
+                        scope: scope,
+                        expected: observation,
+                        cookieHeader: "fixtureSession=background-during-login",
+                        sourceLabel: "Background"))
+                    #expect(CookieHeaderCache.load(provider: .cursor, scope: scope)?.cookieHeader ==
+                        "fixtureSession=original")
+                    CookieHeaderCache.endConditionalMutationGate(gate)
+                }
+            }
+        }
+    }
+
     private func withIsolatedCookieCache<T>(_ operation: () -> T) -> T {
         KeychainCacheStore.withServiceOverrideForTesting("cookie-conditional-\(UUID().uuidString)") {
             let legacyBase = FileManager.default.temporaryDirectory

--- a/Tests/CodexBarTests/KeychainCacheStoreTests.swift
+++ b/Tests/CodexBarTests/KeychainCacheStoreTests.swift
@@ -218,6 +218,70 @@ struct KeychainCacheStoreTests {
     }
 
     @Test
+    func `disabled keychain access keeps an in process memory cache`() {
+        KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+        defer {
+            KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+            KeychainAccessGate.resetOverrideForTesting()
+        }
+
+        let service = "disabled-memory-\(UUID().uuidString)"
+        let key = KeychainCacheStore.Key(category: "cookie", identifier: "cursor")
+        let entry = TestEntry(value: "WorkosCursorSessionToken=memory", storedAt: Date(timeIntervalSince1970: 3))
+
+        KeychainAccessGate.withTaskOverrideForTesting(true) {
+            KeychainCacheStore.withDisabledAccessMemoryStoreForTesting(true) {
+                KeychainCacheStore.withServiceOverrideForTesting(service) {
+                    #expect(KeychainCacheStore.storeResult(key: key, entry: entry))
+                    switch KeychainCacheStore.load(key: key, as: TestEntry.self) {
+                    case let .found(loaded):
+                        #expect(loaded == entry)
+                    case .missing, .temporarilyUnavailable, .invalid:
+                        #expect(Bool(false), "Expected in-process memory cache entry")
+                    }
+                    #expect(KeychainCacheStore.keys(category: "cookie").contains(key))
+                    #expect(KeychainCacheStore.clearResult(key: key) == .removed)
+                    switch KeychainCacheStore.load(key: key, as: TestEntry.self) {
+                    case .missing:
+                        break
+                    case .found, .temporarilyUnavailable, .invalid:
+                        #expect(Bool(false), "Expected memory cache entry to be cleared")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    func `toggling Keychain access clears the disabled access memory cache`() {
+        KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+        defer {
+            KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+            KeychainAccessGate.resetOverrideForTesting()
+        }
+
+        let service = "disabled-memory-toggle-\(UUID().uuidString)"
+        let key = KeychainCacheStore.Key(category: "cookie", identifier: "cursor")
+        let entry = TestEntry(value: "WorkosCursorSessionToken=stale", storedAt: Date(timeIntervalSince1970: 4))
+
+        KeychainAccessGate.isDisabled = true
+        KeychainCacheStore.withDisabledAccessMemoryStoreForTesting(true) {
+            KeychainCacheStore.withServiceOverrideForTesting(service) {
+                #expect(KeychainCacheStore.storeResult(key: key, entry: entry))
+                #expect(self.loadedEntry(for: key) == entry)
+            }
+        }
+
+        KeychainAccessGate.isDisabled = false
+
+        KeychainCacheStore.withDisabledAccessMemoryStoreForTesting(true) {
+            KeychainCacheStore.withServiceOverrideForTesting(service) {
+                #expect(self.loadedEntry(for: key) == nil)
+            }
+        }
+    }
+
+    @Test
     func `cache ACL trusts bundled app and CLI helper`() {
         let root = URL(fileURLWithPath: "/Applications/CodexBar.app")
         let executable = root.appendingPathComponent("Contents/MacOS/CodexBar")

--- a/Tests/CodexBarTests/KeychainCacheStoreTests.swift
+++ b/Tests/CodexBarTests/KeychainCacheStoreTests.swift
@@ -240,13 +240,53 @@ struct KeychainCacheStoreTests {
                         #expect(Bool(false), "Expected in-process memory cache entry")
                     }
                     #expect(KeychainCacheStore.keys(category: "cookie").contains(key))
-                    #expect(KeychainCacheStore.clearResult(key: key) == .removed)
+                    #expect(KeychainCacheStore.clearResult(key: key) == .failed)
                     switch KeychainCacheStore.load(key: key, as: TestEntry.self) {
                     case .missing:
                         break
                     case .found, .temporarilyUnavailable, .invalid:
                         #expect(Bool(false), "Expected memory cache entry to be cleared")
                     }
+                }
+            }
+        }
+    }
+
+    @Test
+    func `disabled keychain access does not retain OAuth entries in memory`() {
+        KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+        defer {
+            KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+            KeychainAccessGate.resetOverrideForTesting()
+        }
+
+        let service = "disabled-memory-oauth-\(UUID().uuidString)"
+        let key = KeychainCacheStore.Key.oauth(provider: .claude)
+        let entry = TestEntry(value: "synthetic-oauth-credential", storedAt: Date(timeIntervalSince1970: 4))
+
+        KeychainAccessGate.withTaskOverrideForTesting(true) {
+            KeychainCacheStore.withDisabledAccessMemoryStoreForTesting(true) {
+                KeychainCacheStore.withServiceOverrideForTesting(service) {
+                    #expect(!KeychainCacheStore.storeResult(key: key, entry: entry))
+                    #expect(self.loadedEntry(for: key) == nil)
+                    #expect(KeychainCacheStore.keysResult(category: "oauth") == .failed)
+                }
+            }
+        }
+    }
+
+    @Test
+    func `disabled keychain access reports empty cookie enumeration as incomplete`() {
+        KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+        defer {
+            KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+            KeychainAccessGate.resetOverrideForTesting()
+        }
+
+        KeychainAccessGate.withTaskOverrideForTesting(true) {
+            KeychainCacheStore.withDisabledAccessMemoryStoreForTesting(true) {
+                KeychainCacheStore.withServiceOverrideForTesting("disabled-empty-\(UUID().uuidString)") {
+                    #expect(KeychainCacheStore.keysResult(category: "cookie") == .failed)
                 }
             }
         }

--- a/docs/KEYCHAIN_FIX.md
+++ b/docs/KEYCHAIN_FIX.md
@@ -95,9 +95,11 @@ This is OS/keychain ACL behavior, not a `ThisDeviceOnly` migration issue.
 `Advanced -> Disable Keychain access` sets `debugDisableKeychainAccess` and flips `KeychainAccessGate.isDisabled`.
 
 Effects:
-- Blocks keychain reads/writes in legacy stores.
-- Disables keychain-backed cookie auto-import paths.
-- Forces cookie source resolution to manual/off where applicable.
+- Blocks keychain reads/writes in legacy stores and Claude CLI keychain bootstrap.
+- Disables Chromium cookie auto-import paths that require Safe Storage keychain decryption (Safari/Firefox remain eligible).
+- Keeps an in-process memory fallback for `KeychainCacheStore` / cookie session caches so Cursor (and other cookie providers) can still reconcile sessions without Keychain persistence.
+- Clears that in-process fallback whenever Keychain access is toggled, so disabled-mode cookies cannot resurface after re-enabling Keychain.
+- Continues to block Claude Auto **background** CLI launches, because the Claude CLI child process can still invoke `/usr/bin/security` and prompt outside CodexBar’s gate. Manual Refresh may still launch CLI (user-initiated).
 
 ## Verification
 

--- a/docs/KEYCHAIN_FIX.md
+++ b/docs/KEYCHAIN_FIX.md
@@ -97,8 +97,11 @@ This is OS/keychain ACL behavior, not a `ThisDeviceOnly` migration issue.
 Effects:
 - Blocks keychain reads/writes in legacy stores and Claude CLI keychain bootstrap.
 - Disables Chromium cookie auto-import paths that require Safe Storage keychain decryption (Safari/Firefox remain eligible).
-- Keeps an in-process memory fallback for `KeychainCacheStore` / cookie session caches so Cursor (and other cookie providers) can still reconcile sessions without Keychain persistence.
+- Keeps an in-process memory fallback only for cookie-session entries in `KeychainCacheStore`, so Cursor (and other
+  cookie providers) can still reconcile sessions without retaining OAuth credentials or other cache categories.
 - Clears that in-process fallback whenever Keychain access is toggled, so disabled-mode cookies cannot resurface after re-enabling Keychain.
+- Reports cookie deletion as incomplete while Keychain access is disabled: the process-local copy is removed, but
+  CodexBar cannot truthfully claim that an inaccessible persistent Keychain row was deleted.
 - Continues to block Claude Auto **background** CLI launches, because the Claude CLI child process can still invoke `/usr/bin/security` and prompt outside CodexBar’s gate. Manual Refresh may still launch CLI (user-initiated).
 
 ## Verification


### PR DESCRIPTION
## Summary
- Keep cookie/session caches in process when **Disable Keychain access** is on, so Cursor refresh can reconcile the active session without Keychain persistence.
- Restrict the fallback to the `cookie` category; OAuth and other credential categories remain unavailable.
- Clear process-local cookies whenever Keychain access is toggled.
- When clearing while Keychain is disabled, remove the process-local copy but report the durable operation as incomplete; an inaccessible persistent Keychain row is never falsely reported as deleted.
- Rebase the focused change on current `main` and drop the unrelated CI-only/dashboard commits.

Fixes #2408

## Test plan
- [x] `swift test --filter 'KeychainCacheStoreTests|CookieHeaderCacheConditionalMutationTests'` — 26 tests
- [x] `make check`
- [x] `TZ=UTC make test` — 724 selections, 61/61 groups passed, no retries
- [x] Packaged live provider matrix with **Disable Keychain access** enabled; every enabled provider refreshed and the reported Cursor session-change error did not recur
- [ ] Live: toggle Keychain access and confirm disabled-mode process memory is cleared
- [ ] CI green

## Safety
Claude Auto background CLI remains blocked while Keychain is disabled; CodexBar cannot constrain Keychain access or prompts from that external process.