### PR TITLE
fix: keep Claude switcher bar on account weekly quota

### DIFF
--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -468,65 +468,6 @@ public struct UsageSnapshot: Codable, Sendable {
         return fallbackWindows + [primary]
     }
 
-    public func switcherWeeklyWindow(for provider: UsageProvider, showUsed: Bool) -> RateWindow? {
-        // This surface is labelled "Weekly progress", so prefer a real 7-day lane when one is
-        // available. Some providers publish model-specific weekly lanes in extraRateWindows.
-        if let weekly = self.mostConstrainedSwitcherWeeklyWindow(for: provider) {
-            return weekly
-        }
-
-        // Keep the existing provider-specific fallback for providers without a weekly allowance.
-        switch provider {
-        case .factory:
-            // Factory prefers secondary window
-            return self.secondary ?? self.primary
-        case .perplexity:
-            return self.automaticPerplexityWindow()
-        case .cursor:
-            // Cursor: fall back to on-demand budget when the included plan is exhausted (only in
-            // "show remaining" mode). The secondary/tertiary lanes are Total/Auto/API breakdowns,
-            // not extra capacity, so they should not replace the remaining paid quota indicator.
-            if !showUsed,
-               let primary = self.primary,
-               primary.remainingPercent <= 0,
-               let providerCost = self.providerCost,
-               providerCost.limit > 0
-            {
-                let usedPercent = max(0, min(100, (providerCost.used / providerCost.limit) * 100))
-                return RateWindow(
-                    usedPercent: usedPercent,
-                    windowMinutes: nil,
-                    resetsAt: providerCost.resetsAt,
-                    resetDescription: nil)
-            }
-            return self.primary ?? self.secondary
-        default:
-            return self.primary ?? self.secondary
-        }
-    }
-
-    private func mostConstrainedSwitcherWeeklyWindow(for provider: UsageProvider) -> RateWindow? {
-        // Claude's Sonnet/Opus tertiary and model-scoped extras (Fable, Daily Routines) belong on
-        // the detail card. The overview switcher should track account Weekly so an exhausted
-        // carve-out does not empty the bar while Weekly still has quota left.
-        let standardWindows: [RateWindow] = switch provider {
-        case .claude:
-            [self.primary, self.secondary].compactMap(\.self)
-        default:
-            [self.primary, self.secondary, self.tertiary].compactMap(\.self)
-        }
-        let namedWindows = (self.extraRateWindows ?? [])
-            .filter(\.usageKnown)
-            .filter { named in
-                guard provider == .claude else { return true }
-                return !named.id.hasPrefix("claude-weekly-scoped-") && named.id != "claude-routines"
-            }
-            .map(\.window)
-        return (standardWindows + namedWindows)
-            .filter { $0.windowMinutes == 7 * 24 * 60 }
-            .max { $0.usedPercent < $1.usedPercent }
-    }
-
     public func accountEmail(for provider: UsageProvider) -> String? {
         self.identity(for: provider)?.accountEmail
     }

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -506,28 +506,25 @@ public struct UsageSnapshot: Codable, Sendable {
     }
 
     private func mostConstrainedSwitcherWeeklyWindow(for provider: UsageProvider) -> RateWindow? {
-        let standardWindows = [self.primary, self.secondary, self.tertiary].compactMap(\.self)
-        let namedWindows = self.extraRateWindows?
-            .filter(\.usageKnown)
-            .map(\.window) ?? []
-        let weeklies = (standardWindows + namedWindows)
-            .filter { $0.windowMinutes == 7 * 24 * 60 }
-
-        // Claude model carve-outs (Fable, Sonnet, Routines) should still drive the overview bar
-        // while they have remaining quota. Once a carve-out is exhausted, fall back to the
-        // tightest weekly lane that still has remaining (usually account Weekly) so the bar
-        // does not go empty while other Claude quota is left.
-        if provider == .claude {
-            let usable = weeklies.filter { $0.remainingPercent > 0 }
-            if let mostConstrainedUsable = usable.max(by: { $0.usedPercent < $1.usedPercent }) {
-                return mostConstrainedUsable
-            }
-            if let accountWeekly = self.secondary, accountWeekly.windowMinutes == 7 * 24 * 60 {
-                return accountWeekly
-            }
+        // Claude's Sonnet/Opus tertiary and model-scoped extras (Fable, Daily Routines) belong on
+        // the detail card. The overview switcher should track account Weekly so an exhausted
+        // carve-out does not empty the bar while Weekly still has quota left.
+        let standardWindows: [RateWindow] = switch provider {
+        case .claude:
+            [self.primary, self.secondary].compactMap(\.self)
+        default:
+            [self.primary, self.secondary, self.tertiary].compactMap(\.self)
         }
-
-        return weeklies.max { $0.usedPercent < $1.usedPercent }
+        let namedWindows = (self.extraRateWindows ?? [])
+            .filter(\.usageKnown)
+            .filter { named in
+                guard provider == .claude else { return true }
+                return !named.id.hasPrefix("claude-weekly-scoped-") && named.id != "claude-routines"
+            }
+            .map(\.window)
+        return (standardWindows + namedWindows)
+            .filter { $0.windowMinutes == 7 * 24 * 60 }
+            .max { $0.usedPercent < $1.usedPercent }
     }
 
     public func accountEmail(for provider: UsageProvider) -> String? {

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -506,25 +506,28 @@ public struct UsageSnapshot: Codable, Sendable {
     }
 
     private func mostConstrainedSwitcherWeeklyWindow(for provider: UsageProvider) -> RateWindow? {
-        // Claude's Sonnet/Opus tertiary and model-scoped extras (Fable, Daily Routines) are
-        // detail-card carve-outs. Including them empties the overview switcher whenever one
-        // model lane is exhausted while account Weekly still has quota left.
-        let standardWindows: [RateWindow] = switch provider {
-        case .claude:
-            [self.primary, self.secondary].compactMap(\.self)
-        default:
-            [self.primary, self.secondary, self.tertiary].compactMap(\.self)
-        }
-        let namedWindows = (self.extraRateWindows ?? [])
+        let standardWindows = [self.primary, self.secondary, self.tertiary].compactMap(\.self)
+        let namedWindows = self.extraRateWindows?
             .filter(\.usageKnown)
-            .filter { named in
-                guard provider == .claude else { return true }
-                return !named.id.hasPrefix("claude-weekly-scoped-") && named.id != "claude-routines"
-            }
-            .map(\.window)
-        return (standardWindows + namedWindows)
+            .map(\.window) ?? []
+        let weeklies = (standardWindows + namedWindows)
             .filter { $0.windowMinutes == 7 * 24 * 60 }
-            .max { $0.usedPercent < $1.usedPercent }
+
+        // Claude model carve-outs (Fable, Sonnet, Routines) should still drive the overview bar
+        // while they have remaining quota. Once a carve-out is exhausted, fall back to the
+        // tightest weekly lane that still has remaining (usually account Weekly) so the bar
+        // does not go empty while other Claude quota is left.
+        if provider == .claude {
+            let usable = weeklies.filter { $0.remainingPercent > 0 }
+            if let mostConstrainedUsable = usable.max(by: { $0.usedPercent < $1.usedPercent }) {
+                return mostConstrainedUsable
+            }
+            if let accountWeekly = self.secondary, accountWeekly.windowMinutes == 7 * 24 * 60 {
+                return accountWeekly
+            }
+        }
+
+        return weeklies.max { $0.usedPercent < $1.usedPercent }
     }
 
     public func accountEmail(for provider: UsageProvider) -> String? {

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -471,7 +471,7 @@ public struct UsageSnapshot: Codable, Sendable {
     public func switcherWeeklyWindow(for provider: UsageProvider, showUsed: Bool) -> RateWindow? {
         // This surface is labelled "Weekly progress", so prefer a real 7-day lane when one is
         // available. Some providers publish model-specific weekly lanes in extraRateWindows.
-        if let weekly = self.mostConstrainedSwitcherWeeklyWindow() {
+        if let weekly = self.mostConstrainedSwitcherWeeklyWindow(for: provider) {
             return weekly
         }
 
@@ -505,11 +505,23 @@ public struct UsageSnapshot: Codable, Sendable {
         }
     }
 
-    private func mostConstrainedSwitcherWeeklyWindow() -> RateWindow? {
-        let standardWindows = [self.primary, self.secondary, self.tertiary].compactMap(\.self)
-        let namedWindows = self.extraRateWindows?
+    private func mostConstrainedSwitcherWeeklyWindow(for provider: UsageProvider) -> RateWindow? {
+        // Claude's Sonnet/Opus tertiary and model-scoped extras (Fable, Daily Routines) are
+        // detail-card carve-outs. Including them empties the overview switcher whenever one
+        // model lane is exhausted while account Weekly still has quota left.
+        let standardWindows: [RateWindow] = switch provider {
+        case .claude:
+            [self.primary, self.secondary].compactMap(\.self)
+        default:
+            [self.primary, self.secondary, self.tertiary].compactMap(\.self)
+        }
+        let namedWindows = (self.extraRateWindows ?? [])
             .filter(\.usageKnown)
-            .map(\.window) ?? []
+            .filter { named in
+                guard provider == .claude else { return true }
+                return !named.id.hasPrefix("claude-weekly-scoped-") && named.id != "claude-routines"
+            }
+            .map(\.window)
         return (standardWindows + namedWindows)
             .filter { $0.windowMinutes == 7 * 24 * 60 }
             .max { $0.usedPercent < $1.usedPercent }

--- a/Sources/CodexBarCore/UsageSnapshot+SwitcherWeeklyWindow.swift
+++ b/Sources/CodexBarCore/UsageSnapshot+SwitcherWeeklyWindow.swift
@@ -1,0 +1,60 @@
+extension UsageSnapshot {
+    public func switcherWeeklyWindow(for provider: UsageProvider, showUsed: Bool) -> RateWindow? {
+        // This surface is labelled "Weekly progress", so prefer a real 7-day lane when one is
+        // available. Some providers publish model-specific weekly lanes in extraRateWindows.
+        if let weekly = self.mostConstrainedSwitcherWeeklyWindow(for: provider) {
+            return weekly
+        }
+
+        // Keep the existing provider-specific fallback for providers without a weekly allowance.
+        switch provider {
+        case .factory:
+            // Factory prefers secondary window
+            return self.secondary ?? self.primary
+        case .perplexity:
+            return self.automaticPerplexityWindow()
+        case .cursor:
+            // Cursor: fall back to on-demand budget when the included plan is exhausted (only in
+            // "show remaining" mode). The secondary/tertiary lanes are Total/Auto/API breakdowns,
+            // not extra capacity, so they should not replace the remaining paid quota indicator.
+            if !showUsed,
+               let primary = self.primary,
+               primary.remainingPercent <= 0,
+               let providerCost = self.providerCost,
+               providerCost.limit > 0
+            {
+                let usedPercent = max(0, min(100, (providerCost.used / providerCost.limit) * 100))
+                return RateWindow(
+                    usedPercent: usedPercent,
+                    windowMinutes: nil,
+                    resetsAt: providerCost.resetsAt,
+                    resetDescription: nil)
+            }
+            return self.primary ?? self.secondary
+        default:
+            return self.primary ?? self.secondary
+        }
+    }
+
+    private func mostConstrainedSwitcherWeeklyWindow(for provider: UsageProvider) -> RateWindow? {
+        // Claude's Sonnet/Opus tertiary and model-scoped extras (Fable, Daily Routines) belong on
+        // the detail card. The overview switcher should track account Weekly so an exhausted
+        // carve-out does not empty the bar while Weekly still has quota left.
+        let standardWindows: [RateWindow] = switch provider {
+        case .claude:
+            [self.primary, self.secondary].compactMap(\.self)
+        default:
+            [self.primary, self.secondary, self.tertiary].compactMap(\.self)
+        }
+        let namedWindows = (self.extraRateWindows ?? [])
+            .filter(\.usageKnown)
+            .filter { named in
+                guard provider == .claude else { return true }
+                return !named.id.hasPrefix("claude-weekly-scoped-") && named.id != "claude-routines"
+            }
+            .map(\.window)
+        return (standardWindows + namedWindows)
+            .filter { $0.windowMinutes == 7 * 24 * 60 }
+            .max { $0.usedPercent < $1.usedPercent }
+    }
+}

--- a/Tests/CodexBarTests/SpendDashboardClockRolloverTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardClockRolloverTests.swift
@@ -14,7 +14,12 @@ struct SpendDashboardClockRolloverTests {
         let configuration = Self.configuration
         let initialInput = Self.input(day: "2026-07-15", cost: 4, updatedAt: loadedAt)
         let rolloverInput = Self.input(day: "2026-07-22", cost: 6, updatedAt: afterRollover)
+        // Keep selectDays persistence out of UserDefaults.standard so later suites that
+        // construct SpendDashboardController with the default store still get the 30-day window.
+        let defaults = try Self.isolatedDefaults(suiteName: "SpendDashboardClockRolloverTests-window")
+        defer { defaults.removePersistentDomain(forName: "SpendDashboardClockRolloverTests-window") }
         let controller = SpendDashboardController(
+            userDefaults: defaults,
             requestBuilder: { mode in
                 SpendDashboardLoadRequest(
                     configuration: configuration,
@@ -58,7 +63,10 @@ struct SpendDashboardClockRolloverTests {
         let staleInput = Self.input(day: "2026-07-15", cost: 4, updatedAt: loadedAt)
         let freshInput = Self.input(day: "2026-07-22", cost: 6, updatedAt: afterRollover)
         let gate = SpendDashboardRolloverGate()
+        let defaults = try Self.isolatedDefaults(suiteName: "SpendDashboardClockRolloverTests-inflight")
+        defer { defaults.removePersistentDomain(forName: "SpendDashboardClockRolloverTests-inflight") }
         let controller = SpendDashboardController(
+            userDefaults: defaults,
             requestBuilder: { mode in
                 SpendDashboardLoadRequest(
                     configuration: configuration,
@@ -72,7 +80,6 @@ struct SpendDashboardClockRolloverTests {
                 await gate.load(request)
             },
             nowProvider: { clock.value })
-
         controller.update(configuration: configuration)
         await Self.waitForPendingCount(1, gate: gate)
 
@@ -93,6 +100,12 @@ struct SpendDashboardClockRolloverTests {
         costUsageEnabled: true,
         providerIDs: [UsageProvider.codex.rawValue],
         codexAccountIdentities: ["rollover"])
+
+    private static func isolatedDefaults(suiteName: String) throws -> UserDefaults {
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
 
     private static func input(day: String, cost: Double, updatedAt: Date) -> SpendDashboardModel.ProviderInput {
         let entry = CostUsageDailyReport.Entry(

--- a/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
@@ -150,7 +150,7 @@ struct StatusItemControllerMenuTests {
     }
 
     @Test
-    func `claude switcher still surfaces remaining scoped weekly carve outs`() {
+    func `claude switcher keeps account weekly even when scoped carve out remains`() {
         let session = RateWindow(
             usedPercent: 20,
             windowMinutes: 5 * 60,
@@ -180,7 +180,7 @@ struct StatusItemControllerMenuTests {
             snapshot: snapshot,
             showUsed: false)
 
-        #expect(percent == 15)
+        #expect(percent == 60)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
@@ -102,6 +102,54 @@ struct StatusItemControllerMenuTests {
     }
 
     @Test
+    func `claude switcher ignores exhausted scoped weekly carve outs`() {
+        let session = RateWindow(
+            usedPercent: 77,
+            windowMinutes: 5 * 60,
+            resetsAt: nil,
+            resetDescription: nil)
+        let weekly = RateWindow(
+            usedPercent: 61,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: nil,
+            resetDescription: nil)
+        let sonnet = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: nil,
+            resetDescription: nil)
+        let snapshot = self.makeSnapshot(
+            primary: session,
+            secondary: weekly,
+            tertiary: sonnet,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "claude-weekly-scoped-fable",
+                    title: "Fable only",
+                    window: RateWindow(
+                        usedPercent: 100,
+                        windowMinutes: 7 * 24 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+                NamedRateWindow(
+                    id: "claude-routines",
+                    title: "Daily Routines",
+                    window: RateWindow(
+                        usedPercent: 100,
+                        windowMinutes: 7 * 24 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+            ])
+
+        let percent = StatusItemController.switcherWeeklyMetricPercent(
+            for: .claude,
+            snapshot: snapshot,
+            showUsed: false)
+
+        #expect(percent == 39)
+    }
+
+    @Test
     func `switcher preserves provider quota when no weekly allowance exists`() {
         let monthly = RateWindow(
             usedPercent: 28,

--- a/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
@@ -150,6 +150,40 @@ struct StatusItemControllerMenuTests {
     }
 
     @Test
+    func `claude switcher still surfaces remaining scoped weekly carve outs`() {
+        let session = RateWindow(
+            usedPercent: 20,
+            windowMinutes: 5 * 60,
+            resetsAt: nil,
+            resetDescription: nil)
+        let weekly = RateWindow(
+            usedPercent: 40,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: nil,
+            resetDescription: nil)
+        let snapshot = self.makeSnapshot(
+            primary: session,
+            secondary: weekly,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "claude-weekly-scoped-fable",
+                    title: "Fable only",
+                    window: RateWindow(
+                        usedPercent: 85,
+                        windowMinutes: 7 * 24 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+            ])
+
+        let percent = StatusItemController.switcherWeeklyMetricPercent(
+            for: .claude,
+            snapshot: snapshot,
+            showUsed: false)
+
+        #expect(percent == 15)
+    }
+
+    @Test
     func `switcher preserves provider quota when no weekly allowance exists`() {
         let monthly = RateWindow(
             usedPercent: 28,


### PR DESCRIPTION
## Summary
- Claude overview/switcher progress always tracks **account Weekly** (not Fable/Sonnet/Routines carve-outs).
- Exhausted Fable no longer empties the overview bar while Weekly still has remaining.
- Fable and other scoped lanes stay on the Claude **detail** card via `extraRateWindows`.

Closes #2423

## Test plan
- [x] `swift test --filter StatusItemControllerMenuTests`
- [x] Exhausted Fable + Weekly remaining → switcher shows Weekly %
- [x] Remaining Fable tighter than Weekly → switcher still shows Weekly % (not Fable)
- [ ] Rebuild/package: Overview Claude under-tab matches Weekly; Claude card still lists Fable only
- [ ] Antigravity named weeklies unchanged