### PR TITLE
Fix Kimi quota pace metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.45.3 — Unreleased
 
 ### Fixed
+- Kimi: add pace data and menu forecast support for weekly and 5-hour quotas (#2431).
 
 ## 0.45.2 — 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.45.3 — Unreleased
 
 ### Fixed
-- Kimi: add pace data and menu forecast support for weekly and 5-hour quotas (#2431).
 
 ## 0.45.2 — 2026-07-19
 

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1408,7 +1408,11 @@ extension UsageMenuCardView.Model {
                     primaryPaceOnTop = paceDetail.paceOnTop
                 }
             }
-        } else if let paceDetail = Self.resetWindowPaceDetail(window: primary, input: input) {
+        } else if let paceDetail = Self.resetWindowPaceDetail(
+            window: primary,
+            input: input,
+            pace: input.provider == .kimi ? input.weeklyPace : nil)
+        {
             primaryDetailLeft = paceDetail.leftLabel
             primaryDetailRight = paceDetail.rightLabel
             primaryPacePercent = paceDetail.pacePercent
@@ -1468,12 +1472,21 @@ extension UsageMenuCardView.Model {
         title: String? = nil,
         zaiTimeDetail: String?) -> Metric
     {
-        var paceDetail = Self.weeklyPaceDetail(
-            provider: input.provider,
-            window: weekly,
-            now: input.now,
-            pace: input.weeklyPace,
-            showUsed: input.usageBarsShowUsed)
+        // Kimi's secondary slot is its 5-hour rate limit rather than a weekly window.
+        var paceDetail = if input.provider == .kimi {
+            Self.sessionPaceDetail(
+                provider: input.provider,
+                window: weekly,
+                now: input.now,
+                showUsed: input.usageBarsShowUsed)
+        } else {
+            Self.weeklyPaceDetail(
+                provider: input.provider,
+                window: weekly,
+                now: input.now,
+                pace: input.weeklyPace,
+                showUsed: input.usageBarsShowUsed)
+        }
         var weeklyResetText = Self.resetText(for: weekly, style: input.resetTimeDisplayStyle, now: input.now)
         var weeklyDetailText: String? = input.provider == .zai ? zaiTimeDetail : nil
         if input.provider == .warp,

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -539,8 +539,8 @@ struct ProvidersPane: View {
             tokenError = nil
         }
 
-        // Abacus uses primary for monthly credits (no secondary window)
-        let paceWindow = provider == .abacus ? snapshot?.primary : snapshot?.secondary
+        // Abacus and Kimi carry their long-cadence window in primary rather than secondary.
+        let paceWindow = provider == .abacus || provider == .kimi ? snapshot?.primary : snapshot?.secondary
         let weeklyPace = if let codexProjection,
                             let weekly = codexProjection.rateWindow(for: .weekly)
         {

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -88,8 +88,8 @@ extension StatusItemController {
 
         let sourceLabel = surface == .liveCard ? self.store.sourceLabel(for: target) : nil
         let kiloAutoMode = target == .kilo && self.settings.kiloUsageDataSource == .auto
-        // Abacus uses primary for monthly credits (no secondary window)
-        let paceWindow = target == .abacus ? snapshot?.primary : snapshot?.secondary
+        // Abacus and Kimi carry their long-cadence window in primary rather than secondary.
+        let paceWindow = target == .abacus || target == .kimi ? snapshot?.primary : snapshot?.secondary
         let sessionEquivalentHistorySelection = self.sessionEquivalentHistorySelection(
             provider: target,
             snapshot: snapshot,

--- a/Sources/CodexBar/UsagePaceText.swift
+++ b/Sources/CodexBar/UsagePaceText.swift
@@ -152,12 +152,16 @@ enum UsagePaceText {
     }
 
     static func sessionPace(provider: UsageProvider, window: RateWindow, now: Date) -> UsagePace? {
-        guard provider == .codex || provider == .claude || provider == .ollama || provider == .antigravity
+        guard provider == .codex || provider == .claude || provider == .ollama || provider == .antigravity ||
+            provider == .kimi
         else { return nil }
         if provider == .ollama, window.windowMinutes == nil {
             return nil
         }
         if provider == .antigravity, let windowMinutes = window.windowMinutes, windowMinutes != 300 {
+            return nil
+        }
+        if provider == .kimi, window.windowMinutes != KimiProviderDescriptor.sessionWindowMinutes {
             return nil
         }
         guard window.remainingPercent > 0 else { return nil }

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -544,10 +544,20 @@ enum CLIRenderer {
         now: Date = Date()) -> ProviderPacePayload?
     {
         let primary = snapshot.primary.flatMap {
-            self.pacePayload(provider: provider, window: $0, kind: .session, now: now)
+            self.pacePayload(
+                provider: provider,
+                window: $0,
+                kind: self.paceKind(provider: provider, fallback: .session),
+                weeklyWorkDays: weeklyWorkDays,
+                now: now)
         }
         let secondary = snapshot.secondary.flatMap {
-            self.pacePayload(provider: provider, window: $0, kind: .weekly, weeklyWorkDays: weeklyWorkDays, now: now)
+            self.pacePayload(
+                provider: provider,
+                window: $0,
+                kind: self.paceKind(provider: provider, fallback: .weekly),
+                weeklyWorkDays: weeklyWorkDays,
+                now: now)
         }
         guard primary != nil || secondary != nil else { return nil }
         return ProviderPacePayload(primary: primary, secondary: secondary)
@@ -577,7 +587,7 @@ enum CLIRenderer {
                 provider: provider,
                 title: labels.primary,
                 window: primary,
-                paceKind: .session,
+                paceKind: self.paceKind(provider: provider, fallback: .session),
                 context: context,
                 now: now,
                 lines: &lines)
@@ -609,7 +619,7 @@ enum CLIRenderer {
             provider: provider,
             title: labels.secondary,
             window: weekly,
-            paceKind: .weekly,
+            paceKind: self.paceKind(provider: provider, fallback: .weekly),
             context: context,
             now: now,
             lines: &lines)
@@ -1067,10 +1077,22 @@ enum CLIRenderer {
         func supports(provider: UsageProvider) -> Bool {
             switch self {
             case .session:
-                provider == .codex || provider == .claude || provider == .ollama
+                provider == .codex || provider == .claude || provider == .ollama || provider == .kimi
             case .weekly:
-                provider == .codex || provider == .claude || provider == .opencode || provider == .ollama
+                provider == .codex || provider == .claude || provider == .opencode || provider == .ollama ||
+                    provider == .kimi
             }
+        }
+    }
+
+    private static func paceKind(provider: UsageProvider, fallback: PaceKind) -> PaceKind {
+        guard provider == .kimi else { return fallback }
+        // Kimi stores weekly in primary and its rate limit in secondary, opposite the legacy CLI slot convention.
+        switch fallback {
+        case .session:
+            return .weekly
+        case .weekly:
+            return .session
         }
     }
 
@@ -1082,6 +1104,16 @@ enum CLIRenderer {
         now: Date) -> UsagePace?
     {
         guard kind.supports(provider: provider) else { return nil }
+        if provider == .kimi {
+            let supportsWindow = switch kind {
+            case .session:
+                window.windowMinutes == KimiProviderDescriptor.sessionWindowMinutes
+            case .weekly:
+                ProviderDescriptorRegistry.descriptor(for: provider).pace
+                    .supportsResetWindowPace(window: window, now: now)
+            }
+            guard supportsWindow else { return nil }
+        }
         // Only pace a real session window here; Claude w/o 5-hour data falls a 7-day window into primary.
         if case .session = kind, let minutes = window.windowMinutes, minutes > 300 {
             return nil

--- a/Sources/CodexBarCore/Providers/Kimi/KimiModels.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiModels.swift
@@ -107,12 +107,29 @@ public struct KimiUsageDetail: Codable, Sendable {
     }
 }
 
-struct KimiRateLimit: Codable {
+struct KimiRateLimit: Codable, Sendable {
     let window: KimiWindow
     let detail: KimiUsageDetail
 }
 
-struct KimiWindow: Codable {
+struct KimiWindow: Codable, Sendable {
     let duration: Int
     let timeUnit: String
+
+    var durationMinutes: Int? {
+        guard self.duration > 0 else { return nil }
+        let multiplier: Int
+        switch self.timeUnit {
+        case "TIME_UNIT_MINUTE":
+            multiplier = 1
+        case "TIME_UNIT_HOUR":
+            multiplier = 60
+        case "TIME_UNIT_DAY":
+            multiplier = 24 * 60
+        default:
+            return nil
+        }
+        let result = self.duration.multipliedReportingOverflow(by: multiplier)
+        return result.overflow ? nil : result.partialValue
+    }
 }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public enum KimiProviderDescriptor {
+    public static let sessionWindowMinutes = 5 * 60
+    public static let weeklyWindowMinutes = 7 * 24 * 60
     public static let descriptor: ProviderDescriptor = Self.makeDescriptor()
 
     static func makeDescriptor() -> ProviderDescriptor {
@@ -35,6 +37,8 @@ public enum KimiProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Kimi cost summary is not supported." }),
+            pace: ProviderPaceCapability(
+                resetWindowPace: .windowDuration(minutes: self.weeklyWindowMinutes)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
@@ -134,9 +134,11 @@ public struct KimiUsageFetcher: Sendable {
             subscriptionStats = nil
         }
 
+        let rateLimit = codingUsage.limits?.first
         return KimiUsageSnapshot(
             weekly: codingUsage.detail,
-            rateLimit: codingUsage.limits?.first?.detail,
+            rateLimit: rateLimit?.detail,
+            rateLimitWindow: rateLimit?.window,
             subscriptionBalance: subscriptionStats?.subscriptionBalance,
             subscriptionCodeWeeklyLimit: subscriptionStats?.ratelimitCode7d,
             updatedAt: now)
@@ -179,9 +181,12 @@ public struct KimiUsageFetcher: Sendable {
 
     private static func parseCodeAPIUsage(from data: Data, now: Date) throws -> KimiUsageSnapshot {
         let response = try JSONDecoder().decode(KimiCodeAPIUsageResponse.self, from: data)
+        let rateLimit = response.limits?.first
         return KimiUsageSnapshot(
             weekly: response.usage,
-            rateLimit: response.limits?.first?.detail,
+            rateLimit: rateLimit?.detail,
+            rateLimitWindow: rateLimit?.window,
+            subscriptionBalance: nil,
             updatedAt: now)
     }
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
@@ -4,6 +4,7 @@ public struct KimiUsageSnapshot: Sendable {
     public let weekly: KimiUsageDetail
     public let rateLimit: KimiUsageDetail?
     public let updatedAt: Date
+    let rateLimitWindow: KimiWindow?
     let subscriptionBalance: KimiSubscriptionBalance?
     let subscriptionCodeWeeklyLimit: KimiSubscriptionRateLimit?
 
@@ -11,6 +12,7 @@ public struct KimiUsageSnapshot: Sendable {
         self.weekly = weekly
         self.rateLimit = rateLimit
         self.updatedAt = updatedAt
+        self.rateLimitWindow = nil
         self.subscriptionBalance = nil
         self.subscriptionCodeWeeklyLimit = nil
     }
@@ -18,12 +20,14 @@ public struct KimiUsageSnapshot: Sendable {
     init(
         weekly: KimiUsageDetail,
         rateLimit: KimiUsageDetail?,
+        rateLimitWindow: KimiWindow? = nil,
         subscriptionBalance: KimiSubscriptionBalance?,
         subscriptionCodeWeeklyLimit: KimiSubscriptionRateLimit? = nil,
         updatedAt: Date)
     {
         self.weekly = weekly
         self.rateLimit = rateLimit
+        self.rateLimitWindow = rateLimitWindow
         self.subscriptionBalance = subscriptionBalance
         self.subscriptionCodeWeeklyLimit = subscriptionCodeWeeklyLimit
         self.updatedAt = updatedAt
@@ -50,44 +54,68 @@ public struct KimiUsageSnapshot: Sendable {
     private static func clampedPercent(_ value: Double) -> Double {
         min(100, max(0, value))
     }
+
+    private static func usageCounts(_ detail: KimiUsageDetail) -> (used: Int, limit: Int, isReliable: Bool)? {
+        guard let limit = Int(detail.limit), limit > 0 else { return nil }
+
+        // Used is authoritative and may exceed the limit during overage; remaining must describe a valid balance.
+        if let rawUsed = detail.used,
+           let used = Int(rawUsed),
+           used >= 0
+        {
+            return (used, limit, true)
+        }
+
+        if let rawRemaining = detail.remaining,
+           let remaining = Int(rawRemaining),
+           (0...limit).contains(remaining)
+        {
+            return (limit - remaining, limit, true)
+        }
+
+        // Preserve the legacy 0% gauge for a valid limit, but withhold duration so invalid counters cannot create pace.
+        return (0, limit, false)
+    }
+
+    private static func rateLimitDescription(used: Int, limit: Int, windowMinutes: Int?) -> String {
+        guard let windowMinutes else { return "Rate: \(used)/\(limit)" }
+        if windowMinutes.isMultiple(of: 60) {
+            let hours = windowMinutes / 60
+            return "Rate: \(used)/\(limit) per \(hours) \(hours == 1 ? "hour" : "hours")"
+        }
+        return "Rate: \(used)/\(limit) per \(windowMinutes) \(windowMinutes == 1 ? "minute" : "minutes")"
+    }
 }
 
 extension KimiUsageSnapshot {
     public func toUsageSnapshot() -> UsageSnapshot {
         // Parse weekly quota
-        let weeklyLimit = Int(weekly.limit) ?? 0
-        let weeklyRemaining = Int(weekly.remaining ?? "")
-        let weeklyUsed = Int(weekly.used ?? "") ?? {
-            guard let remaining = weeklyRemaining else { return 0 }
-            return max(0, weeklyLimit - remaining)
-        }()
-
-        let weeklyPercent = weeklyLimit > 0 ? Self.clampedPercent(Double(weeklyUsed) / Double(weeklyLimit) * 100) : 0
-
-        let weeklyWindow = RateWindow(
-            usedPercent: weeklyPercent,
-            windowMinutes: nil, // Weekly doesn't have a fixed window like rate limit
-            resetsAt: Self.parseDate(self.weekly.resetTime),
-            resetDescription: "\(weeklyUsed)/\(weeklyLimit) requests")
+        // Both Kimi usage endpoints expose FEATURE_CODING usage.detail as the weekly quota.
+        let weeklyWindow = Self.usageCounts(self.weekly).map { counts in
+            RateWindow(
+                usedPercent: Self.clampedPercent(Double(counts.used) / Double(counts.limit) * 100),
+                windowMinutes: counts.isReliable ? KimiProviderDescriptor.weeklyWindowMinutes : nil,
+                resetsAt: Self.parseDate(self.weekly.resetTime),
+                resetDescription: "\(counts.used)/\(counts.limit) requests")
+        }
 
         // Parse rate limit if available
-        var rateLimitWindow: RateWindow?
-        if let rateLimit = self.rateLimit {
-            let rateLimitValue = Int(rateLimit.limit) ?? 0
-            if rateLimitValue > 0 {
-                let rateRemaining = Int(rateLimit.remaining ?? "")
-                let rateUsed = Int(rateLimit.used ?? "") ?? {
-                    guard let remaining = rateRemaining else { return 0 }
-                    return max(0, rateLimitValue - remaining)
-                }()
-                let ratePercent = Self.clampedPercent(Double(rateUsed) / Double(rateLimitValue) * 100)
-
-                rateLimitWindow = RateWindow(
-                    usedPercent: ratePercent,
-                    windowMinutes: 300, // 300 minutes = 5 hours
-                    resetsAt: Self.parseDate(rateLimit.resetTime),
-                    resetDescription: "Rate: \(rateUsed)/\(rateLimitValue) per 5 hours")
+        let rateLimitWindow = self.rateLimit.flatMap { rateLimit -> RateWindow? in
+            guard let counts = Self.usageCounts(rateLimit) else { return nil }
+            let apiWindowMinutes: Int? = if let apiWindow = self.rateLimitWindow {
+                apiWindow.durationMinutes
+            } else {
+                KimiProviderDescriptor.sessionWindowMinutes
             }
+            let windowMinutes = counts.isReliable ? apiWindowMinutes : nil
+            return RateWindow(
+                usedPercent: Self.clampedPercent(Double(counts.used) / Double(counts.limit) * 100),
+                windowMinutes: windowMinutes,
+                resetsAt: Self.parseDate(rateLimit.resetTime),
+                resetDescription: Self.rateLimitDescription(
+                    used: counts.used,
+                    limit: counts.limit,
+                    windowMinutes: windowMinutes))
         }
 
         let monthlyWindow = self.subscriptionBalance.flatMap { balance -> NamedRateWindow? in
@@ -98,7 +126,7 @@ extension KimiUsageSnapshot {
             guard let ratio = balance.amountUsedRatio, ratio.isFinite else { return nil }
             let window = RateWindow(
                 usedPercent: Self.clampedPercent(ratio * 100),
-                windowMinutes: nil,
+                windowMinutes: nil, // Calendar-month duration varies; do not fabricate a fixed 30-day window.
                 resetsAt: Self.parseDate(balance.expireTime),
                 resetDescription: nil)
             return NamedRateWindow(id: "kimi-monthly", title: "Monthly", window: window)
@@ -109,7 +137,7 @@ extension KimiUsageSnapshot {
             guard let ratio = limit.ratio, ratio.isFinite else { return nil }
             let window = RateWindow(
                 usedPercent: Self.clampedPercent(ratio * 100),
-                windowMinutes: 7 * 24 * 60,
+                windowMinutes: KimiProviderDescriptor.weeklyWindowMinutes,
                 resetsAt: Self.parseDate(limit.resetTime),
                 resetDescription: nil)
             return NamedRateWindow(id: "kimi-code-7d", title: "Code 7-day", window: window)

--- a/Tests/CodexBarTests/CLISnapshotTests.swift
+++ b/Tests/CodexBarTests/CLISnapshotTests.swift
@@ -567,6 +567,93 @@ struct CLISnapshotTests {
     }
 
     @Test
+    func `Kimi routes inverted quota windows to CLI pace and JSON metadata`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = UsageSnapshot(
+            primary: .init(
+                usedPercent: 30,
+                windowMinutes: KimiProviderDescriptor.weeklyWindowMinutes,
+                resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60),
+                resetDescription: "weekly"),
+            secondary: .init(
+                usedPercent: 10,
+                windowMinutes: KimiProviderDescriptor.sessionWindowMinutes,
+                resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                resetDescription: "rate limit"),
+            tertiary: nil,
+            updatedAt: now)
+
+        let pace = try #require(CLIRenderer.providerPacePayload(provider: .kimi, snapshot: snapshot, now: now))
+        #expect(pace.primary?.expectedUsedPercent == 43)
+        #expect(pace.primary?.summary == "13% in reserve | Expected 43% used | Lasts until reset")
+        #expect(pace.secondary?.expectedUsedPercent == 20)
+        #expect(pace.secondary?.summary == "10% in reserve | Expected 20% used | Lasts until reset")
+
+        let output = CLIRenderer.renderText(
+            provider: .kimi,
+            snapshot: snapshot,
+            credits: nil,
+            context: RenderContext(
+                header: "Kimi",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown),
+            now: now)
+        #expect(output.split(separator: "\n").count(where: { $0.contains("Pace:") }) == 2)
+
+        let payload = ProviderPayload(
+            provider: .kimi,
+            account: nil,
+            version: nil,
+            source: "Kimi Code API key",
+            status: nil,
+            usage: snapshot,
+            credits: nil,
+            antigravityPlanInfo: nil,
+            openaiDashboard: nil,
+            error: nil,
+            pace: pace)
+        let data = try JSONEncoder().encode(payload)
+        let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let usage = try #require(root["usage"] as? [String: Any])
+        let primary = try #require(usage["primary"] as? [String: Any])
+        let secondary = try #require(usage["secondary"] as? [String: Any])
+        #expect(primary["windowMinutes"] as? Int == KimiProviderDescriptor.weeklyWindowMinutes)
+        #expect(secondary["windowMinutes"] as? Int == KimiProviderDescriptor.sessionWindowMinutes)
+        let encodedPace = try #require(root["pace"] as? [String: Any])
+        #expect(encodedPace["primary"] != nil)
+        #expect(encodedPace["secondary"] != nil)
+    }
+
+    @Test
+    func `Kimi CLI pace rejects missing and unsupported window durations`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        for duration: Int? in [nil, 24 * 60, 30 * 24 * 60] {
+            let window = RateWindow(
+                usedPercent: 25,
+                windowMinutes: duration,
+                resetsAt: now.addingTimeInterval(60 * 60),
+                resetDescription: nil)
+            let snapshots = [
+                UsageSnapshot(
+                    primary: window,
+                    secondary: nil,
+                    tertiary: nil,
+                    updatedAt: now),
+                UsageSnapshot(
+                    primary: nil,
+                    secondary: window,
+                    tertiary: nil,
+                    updatedAt: now),
+            ]
+
+            for snapshot in snapshots {
+                #expect(CLIRenderer.providerPacePayload(provider: .kimi, snapshot: snapshot, now: now) == nil)
+            }
+        }
+    }
+
+    @Test
     func `renders Ollama weekly pace line when weekly window has reset`() {
         let now = Date()
         let snap = UsageSnapshot(

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -647,6 +647,60 @@ struct KimiUsageResponseParsingTests {
         #expect(snapshot.rateLimit?.used == nil)
         #expect(snapshot.rateLimit?.remaining == "99")
         #expect(snapshot.rateLimit?.resetTime == "2026-01-06T13:33:02Z")
+        #expect(snapshot.toUsageSnapshot().primary?.windowMinutes == KimiProviderDescriptor.weeklyWindowMinutes)
+        #expect(snapshot.toUsageSnapshot().secondary?.windowMinutes == 300)
+        #expect(snapshot.toUsageSnapshot().secondary?.resetDescription == "Rate: 1/100 per 5 hours")
+    }
+
+    @Test
+    func `derives rate window duration from API units`() throws {
+        let json = """
+        {
+          "usage": {"limit": 1000, "used": 40, "remaining": 960},
+          "limits": [
+            {
+              "window": {"duration": 2, "timeUnit": "TIME_UNIT_HOUR"},
+              "detail": {"limit": 100, "used": 25, "remaining": 75}
+            }
+          ]
+        }
+        """
+
+        let usage = try KimiUsageFetcher._parseCodeAPIUsageForTesting(Data(json.utf8)).toUsageSnapshot()
+
+        #expect(usage.secondary?.windowMinutes == 120)
+        #expect(usage.secondary?.resetDescription == "Rate: 25/100 per 2 hours")
+    }
+
+    @Test
+    func `converts supported window units and rejects invalid durations`() {
+        #expect(KimiWindow(duration: 300, timeUnit: "TIME_UNIT_MINUTE").durationMinutes == 300)
+        #expect(KimiWindow(duration: 5, timeUnit: "TIME_UNIT_HOUR").durationMinutes == 300)
+        #expect(KimiWindow(duration: 7, timeUnit: "TIME_UNIT_DAY").durationMinutes == 10080)
+        #expect(KimiWindow(duration: 0, timeUnit: "TIME_UNIT_HOUR").durationMinutes == nil)
+        #expect(KimiWindow(duration: -1, timeUnit: "TIME_UNIT_DAY").durationMinutes == nil)
+        #expect(KimiWindow(duration: Int.max, timeUnit: "TIME_UNIT_HOUR").durationMinutes == nil)
+        #expect(KimiWindow(duration: 5, timeUnit: "TIME_UNIT_UNKNOWN").durationMinutes == nil)
+    }
+
+    @Test
+    func `unknown rate window unit does not fabricate a duration`() throws {
+        let json = """
+        {
+          "usage": {"limit": 1000, "used": 40, "remaining": 960},
+          "limits": [
+            {
+              "window": {"duration": 5, "timeUnit": "TIME_UNIT_UNKNOWN"},
+              "detail": {"limit": 100, "used": 25, "remaining": 75}
+            }
+          ]
+        }
+        """
+
+        let usage = try KimiUsageFetcher._parseCodeAPIUsageForTesting(Data(json.utf8)).toUsageSnapshot()
+
+        #expect(usage.secondary?.windowMinutes == nil)
+        #expect(usage.secondary?.resetDescription == "Rate: 25/100")
     }
 
     @Test
@@ -746,6 +800,7 @@ struct KimiUsageResponseParsingTests {
         let usage = snapshot.toUsageSnapshot()
 
         #expect(usage.primary?.usedPercent == 25)
+        #expect(usage.primary?.windowMinutes == KimiProviderDescriptor.weeklyWindowMinutes)
         #expect(usage.secondary?.usedPercent == 25)
         #expect(usage.extraRateWindows == nil)
         #expect(elapsed < .milliseconds(250), "Subscription enrichment outlived its total budget: \(elapsed)")
@@ -905,7 +960,7 @@ struct KimiUsageResponseParsingTests {
 
 struct KimiUsageSnapshotConversionTests {
     @Test
-    func `converts to usage snapshot with both windows`() {
+    func `converts to usage snapshot with both windows`() throws {
         let now = Date()
         let weeklyDetail = KimiUsageDetail(
             limit: "2048",
@@ -925,17 +980,19 @@ struct KimiUsageSnapshotConversionTests {
 
         let usageSnapshot = snapshot.toUsageSnapshot()
 
-        #expect(usageSnapshot.primary != nil)
+        let primary = try #require(usageSnapshot.primary)
         let weeklyExpected = 375.0 / 2048.0 * 100.0
-        #expect(abs((usageSnapshot.primary?.usedPercent ?? 0.0) - weeklyExpected) < 0.01)
-        #expect(usageSnapshot.primary?.resetDescription == "375/2048 requests")
-        #expect(usageSnapshot.primary?.windowMinutes == nil)
+        #expect(abs(primary.usedPercent - weeklyExpected) < 0.01)
+        #expect(primary.resetDescription == "375/2048 requests")
+        #expect(primary.windowMinutes == KimiProviderDescriptor.weeklyWindowMinutes)
+        #expect(KimiProviderDescriptor.descriptor.pace.supportsResetWindowPace(window: primary, now: now))
 
-        #expect(usageSnapshot.secondary != nil)
+        let secondary = try #require(usageSnapshot.secondary)
         let rateExpected = 200.0 / 200.0 * 100.0
-        #expect(abs((usageSnapshot.secondary?.usedPercent ?? 0.0) - rateExpected) < 0.01)
-        #expect(usageSnapshot.secondary?.windowMinutes == 300) // 5 hours
-        #expect(usageSnapshot.secondary?.resetDescription == "Rate: 200/200 per 5 hours")
+        #expect(abs(secondary.usedPercent - rateExpected) < 0.01)
+        #expect(secondary.windowMinutes == KimiProviderDescriptor.sessionWindowMinutes)
+        #expect(secondary.resetDescription == "Rate: 200/200 per 5 hours")
+        #expect(!KimiProviderDescriptor.descriptor.pace.supportsResetWindowPace(window: secondary, now: now))
 
         #expect(usageSnapshot.tertiary == nil)
         #expect(usageSnapshot.updatedAt == now)
@@ -966,6 +1023,7 @@ struct KimiUsageSnapshotConversionTests {
         #expect(monthly.id == "kimi-monthly")
         #expect(monthly.title == "Monthly")
         #expect(monthly.window.usedPercent == 100)
+        #expect(monthly.window.windowMinutes == nil)
         #expect(monthly.window.resetsAt == Self.date("2026-07-23T00:00:00Z"))
     }
 
@@ -1101,6 +1159,84 @@ struct KimiUsageSnapshotConversionTests {
 
         #expect(usageSnapshot.primary?.resetDescription == "375/2048 requests")
         #expect(usageSnapshot.secondary == nil)
+    }
+
+    @Test
+    func `malformed limits do not fabricate pace metadata`() {
+        let now = Date()
+        let weekly = KimiUsageDetail(limit: "100", used: "25", remaining: "75", resetTime: nil)
+        let invalid = KimiUsageDetail(limit: "invalid", used: "5", remaining: "15", resetTime: nil)
+        let zero = KimiUsageDetail(limit: "0", used: "0", remaining: "0", resetTime: nil)
+
+        #expect(KimiUsageSnapshot(weekly: invalid, rateLimit: nil, updatedAt: now).toUsageSnapshot().primary == nil)
+        #expect(KimiUsageSnapshot(weekly: zero, rateLimit: nil, updatedAt: now).toUsageSnapshot().primary == nil)
+        #expect(KimiUsageSnapshot(weekly: weekly, rateLimit: invalid, updatedAt: now)
+            .toUsageSnapshot().secondary == nil)
+    }
+
+    @Test
+    func `derives invalid or missing used counts from valid remaining counts`() throws {
+        let now = Date()
+        let snapshot = KimiUsageSnapshot(
+            weekly: KimiUsageDetail(limit: "100", used: "invalid", remaining: "75", resetTime: nil),
+            rateLimit: KimiUsageDetail(limit: "20", used: nil, remaining: "15", resetTime: nil),
+            updatedAt: now)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(try #require(usage.primary).usedPercent == 25)
+        #expect(try #require(usage.secondary).usedPercent == 25)
+    }
+
+    @Test
+    func `over quota used count wins over contradictory remaining`() throws {
+        let now = Date()
+        let snapshot = KimiUsageSnapshot(
+            weekly: KimiUsageDetail(limit: "100", used: "125", remaining: "25", resetTime: nil),
+            rateLimit: nil,
+            updatedAt: now)
+
+        let primary = try #require(snapshot.toUsageSnapshot().primary)
+        #expect(primary.usedPercent == 100)
+        #expect(primary.resetDescription == "125/100 requests")
+        #expect(primary.windowMinutes == KimiProviderDescriptor.weeklyWindowMinutes)
+    }
+
+    @Test
+    func `negative used count falls back to valid remaining`() throws {
+        let now = Date()
+        let snapshot = KimiUsageSnapshot(
+            weekly: KimiUsageDetail(limit: "100", used: "-1", remaining: "75", resetTime: nil),
+            rateLimit: nil,
+            updatedAt: now)
+
+        #expect(try #require(snapshot.toUsageSnapshot().primary).usedPercent == 25)
+    }
+
+    @Test
+    func `invalid remaining does not synthesize a quota`() {
+        let now = Date()
+        for remaining in ["-1", "101", "invalid"] {
+            let snapshot = KimiUsageSnapshot(
+                weekly: KimiUsageDetail(limit: "100", used: nil, remaining: remaining, resetTime: nil),
+                rateLimit: nil,
+                updatedAt: now)
+
+            #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 0)
+            #expect(snapshot.toUsageSnapshot().primary?.windowMinutes == nil)
+        }
+    }
+
+    @Test
+    func `missing counters preserve gauge without pace metadata`() throws {
+        let snapshot = KimiUsageSnapshot(
+            weekly: KimiUsageDetail(limit: "100", used: nil, remaining: nil, resetTime: nil),
+            rateLimit: nil,
+            updatedAt: Date())
+
+        let primary = try #require(snapshot.toUsageSnapshot().primary)
+        #expect(primary.usedPercent == 0)
+        #expect(primary.windowMinutes == nil)
+        #expect(primary.resetDescription == "0/100 requests")
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -102,18 +102,18 @@ struct OverviewMenuCardVisibilityTests {
 
 struct ProviderInlineDashboardModelTests {
     @Test
-    func `kimi model orders rate limit before weekly quota`() throws {
+    func `kimi model orders rate limit before weekly quota and shows pace`() throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let metadata = try #require(ProviderDefaults.metadata[.kimi])
         let snapshot = UsageSnapshot(
             primary: RateWindow(
                 usedPercent: 18.3,
-                windowMinutes: nil,
+                windowMinutes: KimiProviderDescriptor.weeklyWindowMinutes,
                 resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60),
                 resetDescription: "375/2048 requests"),
             secondary: RateWindow(
                 usedPercent: 9.5,
-                windowMinutes: 300,
+                windowMinutes: KimiProviderDescriptor.sessionWindowMinutes,
                 resetsAt: now.addingTimeInterval(4 * 60 * 60),
                 resetDescription: "Rate: 19/200 per 5 hours"),
             updatedAt: now)
@@ -140,6 +140,9 @@ struct ProviderInlineDashboardModelTests {
 
         #expect(model.metrics.map(\.id) == ["secondary", "primary"])
         #expect(model.metrics.map(\.title) == ["Rate Limit", "Weekly"])
+        #expect(model.metrics.map(\.detailLeftText) == ["11% in reserve", "25% in reserve"])
+        #expect(model.metrics.map(\.detailRightText) == ["Lasts until reset", "Lasts until reset"])
+        #expect(model.metrics.allSatisfy { $0.pacePercent != nil })
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
+++ b/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
@@ -7,7 +7,7 @@ struct ProviderPaceCapabilityTests {
     private static let monthlyWindowSentinelMinutes = 30 * 24 * 60
 
     @Test
-    func `descriptor pace capabilities preserve the legacy provider mapping`() {
+    func `descriptor pace capabilities match the supported provider mapping`() {
         let now = Date(timeIntervalSince1970: 1_750_000_000)
         let fixtures: [RateWindow] = [
             Self.window(minutes: nil, resetsAt: nil),
@@ -30,12 +30,12 @@ struct ProviderPaceCapabilityTests {
             let capability = ProviderDescriptorRegistry.descriptor(for: provider).pace
             for window in fixtures {
                 let actualResetWindowPace = capability.supportsResetWindowPace(window: window, now: now)
-                let legacyResetWindowPace = Self.legacySupportsResetWindowPace(
+                let expectedResetWindowPace = Self.expectedSupportsResetWindowPace(
                     provider: provider,
                     window: window,
                     now: now)
                 #expect(
-                    actualResetWindowPace == legacyResetWindowPace,
+                    actualResetWindowPace == expectedResetWindowPace,
                     "Reset-window pace changed for \(provider.rawValue), window=\(String(describing: window)).")
 
                 let actualMonthlyInference = capability.usesInferredMonthlyDuration(window: window)
@@ -57,8 +57,8 @@ struct ProviderPaceCapabilityTests {
             resetDescription: nil)
     }
 
-    /// Snapshot of the switches removed from UsageMenuCardView.Model.
-    private static func legacySupportsResetWindowPace(
+    /// Expected provider-specific reset-window behavior, including newly declared capabilities.
+    private static func expectedSupportsResetWindowPace(
         provider: UsageProvider,
         window: RateWindow,
         now: Date) -> Bool
@@ -77,6 +77,8 @@ struct ProviderPaceCapabilityTests {
             return windowMinutes > 0
                 && timeUntilReset > 0
                 && timeUntilReset <= TimeInterval(windowMinutes) * 60
+        case .kimi:
+            return window.windowMinutes == self.weeklyWindowMinutes
         case .alibaba, .alibabatokenplan, .doubao, .opencodego:
             return window.windowMinutes == self.monthlyWindowSentinelMinutes
         default:

--- a/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
+++ b/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
@@ -164,7 +164,7 @@ struct SessionEquivalentForecastTests {
         let now = Date(timeIntervalSince1970: 1_900_000_000)
         let session = RateWindow(
             usedPercent: 20,
-            windowMinutes: 300,
+            windowMinutes: KimiProviderDescriptor.sessionWindowMinutes,
             resetsAt: now.addingTimeInterval(3600),
             resetDescription: nil)
         let burn = SessionEquivalentBurnEstimate(medianWeeklyPercentPerWindow: 10, sampleCount: 3)
@@ -703,6 +703,56 @@ extension SessionEquivalentForecastTests {
 
         let windows = try #require(store.sessionEquivalentWindows(provider: .zai, snapshot: snapshot))
         #expect(windows.weeklyWindowID == "zai-named-weekly")
+    }
+
+    @MainActor
+    @Test
+    func `Kimi resolves its inverted primary and secondary windows by duration`() throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let now = Date(timeIntervalSince1970: 1_900_000_000)
+        let weekly = RateWindow(
+            usedPercent: 40,
+            windowMinutes: KimiProviderDescriptor.weeklyWindowMinutes,
+            resetsAt: now.addingTimeInterval(3 * 24 * 60 * 60),
+            resetDescription: nil)
+        let session = RateWindow(
+            usedPercent: 20,
+            windowMinutes: KimiProviderDescriptor.sessionWindowMinutes,
+            resetsAt: now.addingTimeInterval(4 * 60 * 60),
+            resetDescription: nil)
+        let snapshot = UsageSnapshot(
+            primary: weekly,
+            secondary: session,
+            tertiary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "kimi-code-7d",
+                    title: "Code 7-day",
+                    window: RateWindow(
+                        usedPercent: 15,
+                        windowMinutes: KimiProviderDescriptor.weeklyWindowMinutes,
+                        resetsAt: now.addingTimeInterval(2 * 24 * 60 * 60),
+                        resetDescription: nil)),
+            ],
+            updatedAt: now)
+
+        let windows = try #require(store.sessionEquivalentWindows(provider: .kimi, snapshot: snapshot))
+        #expect(windows.session.windowMinutes == KimiProviderDescriptor.sessionWindowMinutes)
+        #expect(windows.weekly.windowMinutes == KimiProviderDescriptor.weeklyWindowMinutes)
+        #expect(windows.weekly.usedPercent == 40)
+
+        let forecast = try #require(SessionEquivalentForecast.make(
+            sessionWindow: windows.session,
+            weeklyWindow: windows.weekly,
+            burnEstimate: SessionEquivalentBurnEstimate(
+                medianWeeklyPercentPerWindow: 10,
+                sampleCount: 3),
+            now: now,
+            workDays: nil))
+        #expect(forecast.estimatedWindowsToExhaustWeekly == 6)
+        #expect(forecast.windowsUntilReset == 14)
+        let detail = UsagePaceText.sessionEquivalentDetail(forecast: forecast)
+        #expect(detail.verdictText == "Weekly can run out ≈8 windows early")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- populate Kimi's weekly quota with a 7-day duration and propagate the API-reported rate-limit duration
- route Kimi's inverted weekly/session slots through menu and CLI pace rendering
- enable the existing session-equivalent menu forecast for Kimi while failing closed on unknown cadence metadata

## Scope

This is the evidence-backed Kimi slice of #2431. Z.ai, Grok, and Antigravity remain out of scope because their missing durations require provider-specific contract or fixture decisions. The separate #2274 forecast structure is not added to `serve` JSON here; this change only emits the existing pace payload.

The 7-day duration follows Kimi's `FEATURE_CODING` weekly lane and the existing `ratelimitCode7d` contract. Kimi's rate-limit duration is converted from the API's minute/hour/day window metadata; unknown units retain the gauge without pace metadata.

## Behavior proof

- weekly Kimi quota: `windowMinutes = 10080`, weekly pace enabled
- current rate-limit quota: API-derived `windowMinutes = 300`, session pace enabled
- menu model: both rows expose pace, and the existing session-equivalent forecast resolves Kimi's inverted slots by duration
- invalid or missing counters preserve a 0% gauge for a valid limit but omit `windowMinutes`, so malformed data cannot fabricate pace
- non-positive or unparseable limits remain unavailable instead of producing pace
- monthly subscription balance remains duration-less because calendar-month length is variable

## Validation

Exact head: `281a123a5601ca2e995ad385acf7303c2ee293cc`

- `SwiftFormat`: 0 / 1,582 files require formatting
- `SwiftLint --strict`: 0 violations across 1,581 files
- `swiftc -frontend -parse`: all changed Swift files passed
- `git diff --check origin/main...HEAD`: passed
- `make check`: all repository checks through SwiftFormat passed; the wrapper then hit the documented Command Line Tools `sourcekitdInProc` loading failure. Running the same SwiftLint binary with its required library path passed with 0 violations.
- focused `swift test` and `make test`: could not start because this machine has a Swift 6.3.3 compiler with a Swift 6.3.2 SDK. CI is authoritative for compilation and tests.

No live provider, Keychain, or app-bundle validation was run, per repository policy.

## CI

- Linux x64 build, test suite, and CLI smoke test: passed
- Linux ARM64 build, test suite, and CLI smoke test: passed
- Linux musl static build: passed
- lint, change detection, and GitGuardian: passed
- macOS tests: intentionally deferred while this PR is draft
- aggregate `lint-build-test`: expected draft-state failure because it requires the deferred macOS jobs; no underlying runnable job failed

## AI assistance

AI assistance was used for implementation, test drafting, and private pre-push review. The final diff and validation results were manually inspected.

Refs #2431
