### PR TITLE
Fix duplicate weekly row from garbled Claude all-models capture

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -784,7 +784,14 @@ extension ClaudeStatusProbe {
             return normalizedLine.contains(normalizedLabel)
         }
         guard let actualModel = self.weeklyModelName(from: line) else { return false }
-        return self.normalizedForLabelSearch(actualModel) == self.normalizedForLabelSearch(expectedModel)
+        let expectedNormalized = self.normalizedForLabelSearch(expectedModel)
+        let actualNormalized = self.normalizedForLabelSearch(actualModel)
+        // When looking up the all-models weekly bucket, tolerate garbled TUI captures ("all modls")
+        // so the Weekly percent/reset are still recovered even if the clean copy never survived.
+        if self.isAllModelsWeeklyModel(expectedNormalized) {
+            return self.isAllModelsWeeklyModel(actualNormalized)
+        }
+        return actualNormalized == expectedNormalized
     }
 
     private static func crossesLabelBoundary(
@@ -798,7 +805,12 @@ extension ClaudeStatusProbe {
             return !normalizedLine.contains(normalizedLabel)
         }
         guard let actualModel = self.weeklyModelName(from: line) else { return true }
-        return self.normalizedForLabelSearch(actualModel) != self.normalizedForLabelSearch(expectedModel)
+        let expectedNormalized = self.normalizedForLabelSearch(expectedModel)
+        let actualNormalized = self.normalizedForLabelSearch(actualModel)
+        if self.isAllModelsWeeklyModel(expectedNormalized) {
+            return !self.isAllModelsWeeklyModel(actualNormalized)
+        }
+        return actualNormalized != expectedNormalized
     }
 
     private static func weeklyModelName(from line: String) -> String? {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -341,6 +341,17 @@ extension ClaudeStatusProbe {
     }
 
     private static func extractPercent(labelSubstring: String, context: LabelSearchContext) -> Int? {
+        // Prefer an exact label match; only fall back to a fuzzy (garbled-capture) match when no exact
+        // copy yields a value, so a clean row always wins over a corrupted duplicate regardless of order.
+        self.extractPercent(labelSubstring: labelSubstring, context: context, allowFuzzy: false)
+            ?? self.extractPercent(labelSubstring: labelSubstring, context: context, allowFuzzy: true)
+    }
+
+    private static func extractPercent(
+        labelSubstring: String,
+        context: LabelSearchContext,
+        allowFuzzy: Bool) -> Int?
+    {
         let lines = context.lines
         let label = self.normalizedForLabelSearch(labelSubstring)
         for (idx, line) in lines.enumerated() {
@@ -349,7 +360,8 @@ extension ClaudeStatusProbe {
                 line: line,
                 normalizedLine: normalizedLine,
                 labelSubstring: labelSubstring,
-                normalizedLabel: label)
+                normalizedLabel: label,
+                allowFuzzy: allowFuzzy)
             else { continue }
 
             // Claude's usage panel can take a moment to render percentages (especially on enterprise accounts),
@@ -359,7 +371,8 @@ extension ClaudeStatusProbe {
                 if self.crossesLabelBoundary(
                     line: candidate,
                     labelSubstring: labelSubstring,
-                    normalizedLabel: label)
+                    normalizedLabel: label,
+                    allowFuzzy: allowFuzzy)
                 {
                     break
                 }
@@ -746,6 +759,16 @@ extension ClaudeStatusProbe {
     }
 
     private static func extractReset(labelSubstring: String, context: LabelSearchContext) -> String? {
+        // Exact match wins over a garbled duplicate, mirroring extractPercent's candidate selection.
+        self.extractReset(labelSubstring: labelSubstring, context: context, allowFuzzy: false)
+            ?? self.extractReset(labelSubstring: labelSubstring, context: context, allowFuzzy: true)
+    }
+
+    private static func extractReset(
+        labelSubstring: String,
+        context: LabelSearchContext,
+        allowFuzzy: Bool) -> String?
+    {
         let lines = context.lines
         let label = self.normalizedForLabelSearch(labelSubstring)
         for (idx, line) in lines.enumerated() {
@@ -754,7 +777,8 @@ extension ClaudeStatusProbe {
                 line: line,
                 normalizedLine: normalizedLine,
                 labelSubstring: labelSubstring,
-                normalizedLabel: label)
+                normalizedLabel: label,
+                allowFuzzy: allowFuzzy)
             else { continue }
 
             let window = lines.dropFirst(idx).prefix(14)
@@ -762,7 +786,8 @@ extension ClaudeStatusProbe {
                 if self.crossesLabelBoundary(
                     line: candidate,
                     labelSubstring: labelSubstring,
-                    normalizedLabel: label)
+                    normalizedLabel: label,
+                    allowFuzzy: allowFuzzy)
                 {
                     break
                 }
@@ -778,7 +803,8 @@ extension ClaudeStatusProbe {
         line: String,
         normalizedLine: String,
         labelSubstring: String,
-        normalizedLabel: String) -> Bool
+        normalizedLabel: String,
+        allowFuzzy: Bool = false) -> Bool
     {
         guard let expectedModel = self.weeklyModelName(from: labelSubstring) else {
             return normalizedLine.contains(normalizedLabel)
@@ -787,8 +813,9 @@ extension ClaudeStatusProbe {
         let expectedNormalized = self.normalizedForLabelSearch(expectedModel)
         let actualNormalized = self.normalizedForLabelSearch(actualModel)
         // When looking up the all-models weekly bucket, tolerate garbled TUI captures ("all modls")
-        // so the Weekly percent/reset are still recovered even if the clean copy never survived.
-        if self.isAllModelsWeeklyModel(expectedNormalized) {
+        // so the Weekly percent/reset are still recovered even if the clean copy never survived. The
+        // fuzzy match is opt-in so callers can prefer an exact copy before accepting a corrupted one.
+        if allowFuzzy, self.isAllModelsWeeklyModel(expectedNormalized) {
             return self.isAllModelsWeeklyModel(actualNormalized)
         }
         return actualNormalized == expectedNormalized
@@ -797,7 +824,8 @@ extension ClaudeStatusProbe {
     private static func crossesLabelBoundary(
         line: String,
         labelSubstring: String,
-        normalizedLabel: String) -> Bool
+        normalizedLabel: String,
+        allowFuzzy: Bool = false) -> Bool
     {
         let normalizedLine = self.normalizedForLabelSearch(line)
         guard normalizedLine.hasPrefix("current") else { return false }
@@ -807,7 +835,7 @@ extension ClaudeStatusProbe {
         guard let actualModel = self.weeklyModelName(from: line) else { return true }
         let expectedNormalized = self.normalizedForLabelSearch(expectedModel)
         let actualNormalized = self.normalizedForLabelSearch(actualModel)
-        if self.isAllModelsWeeklyModel(expectedNormalized) {
+        if allowFuzzy, self.isAllModelsWeeklyModel(expectedNormalized) {
             return !self.isAllModelsWeeklyModel(actualNormalized)
         }
         return actualNormalized != expectedNormalized

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -234,7 +234,7 @@ extension ClaudeStatusProbe {
         // Only apply the fallback when the corresponding label exists in the rendered panel; enterprise accounts
         // may omit the weekly panel entirely, and we should treat that as "unavailable" rather than guessing.
         let weeklyModels = Set(labelContext.lines.compactMap(self.weeklyModelName).map(self.normalizedForLabelSearch))
-        let hasAllModelsWeeklyLabel = weeklyModels.contains("allmodels")
+        let hasAllModelsWeeklyLabel = weeklyModels.contains(where: self.isAllModelsWeeklyModel)
         let opusModels = Set(opusLabels.compactMap(self.weeklyModelName).map(self.normalizedForLabelSearch))
         let hasOpusLabel = !weeklyModels.isDisjoint(with: opusModels)
 
@@ -413,7 +413,7 @@ extension ClaudeStatusProbe {
         for (index, line) in context.lines.enumerated() {
             guard let modelName = self.weeklyModelName(from: line) else { continue }
             let normalizedModel = self.normalizedForLabelSearch(modelName)
-            guard normalizedModel != "allmodels", !normalizedModel.isEmpty else { continue }
+            guard !normalizedModel.isEmpty, !self.isAllModelsWeeklyModel(normalizedModel) else { continue }
 
             let window = context.lines.dropFirst(index).prefix(14)
             var percentLeft: Int?
@@ -812,6 +812,42 @@ extension ClaudeStatusProbe {
               let modelRange = Range(match.range(at: 1), in: line)
         else { return nil }
         return String(line[modelRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Recognizes the "all models" weekly bucket even when the TUI capture dropped or duplicated a
+    /// character (e.g. "all modls"). Claude renders `/usage` as a redrawing TUI, so the same
+    /// "Current week (all models)" line can be captured mid-repaint; without tolerant matching that
+    /// garbled copy escapes the all-models filter and is surfaced as a bogus second weekly row
+    /// ("all modls only") beside the real Weekly limit. Genuine model-scoped names (Opus, Sonnet,
+    /// Fable, …) are far outside this edit-distance window.
+    private static func isAllModelsWeeklyModel(_ normalizedModel: String) -> Bool {
+        normalizedModel == "allmodels" || self.editDistance(normalizedModel, "allmodels") <= 2
+    }
+
+    /// Levenshtein distance. Inputs here are short normalized model tokens, so the naive
+    /// single-row implementation is more than fast enough.
+    private static func editDistance(_ lhs: String, _ rhs: String) -> Int {
+        let a = Array(lhs.unicodeScalars)
+        let b = Array(rhs.unicodeScalars)
+        if a.isEmpty {
+            return b.count
+        }
+        if b.isEmpty {
+            return a.count
+        }
+        var row = Array(0...b.count)
+        for i in 1...a.count {
+            var previousDiagonal = row[0]
+            row[0] = i
+            for j in 1...b.count {
+                let deletion = row[j] + 1
+                let insertion = row[j - 1] + 1
+                let substitution = previousDiagonal + (a[i - 1] == b[j - 1] ? 0 : 1)
+                previousDiagonal = row[j]
+                row[j] = Swift.min(deletion, insertion, substitution)
+            }
+        }
+        return row[b.count]
     }
 
     private static func extractReset(labelSubstrings: [String], context: LabelSearchContext) -> String? {

--- a/Tests/CodexBarTests/ClaudeAllModelsWeeklyDuplicateTests.swift
+++ b/Tests/CodexBarTests/ClaudeAllModelsWeeklyDuplicateTests.swift
@@ -3,9 +3,11 @@ import Foundation
 import Testing
 
 /// The Claude CLI renders /usage as a redrawing TUI, so a half-painted capture frame can drop a
-/// character from "Current week (all models)" (-> "all modls"). These cover both shapes: the
-/// garbled copy must not become a bogus second weekly row, and if it is the only surviving
-/// all-models line the Weekly limit must still be recovered from it.
+/// character from "Current week (all models)" (-> "all modls"). These cover the shapes that matters:
+/// the garbled copy must not become a bogus second weekly row, an exact copy must always win the
+/// Weekly value regardless of order, the Weekly limit must still be recovered when only the garbled
+/// copy survived, genuine model-scoped rows must be preserved, and the edit-distance boundary is
+/// pinned so heavier corruption stays a (visible) scoped row rather than being silently absorbed.
 struct ClaudeAllModelsWeeklyDuplicateTests {
     @Test
     func `garbled all-models copy does not duplicate the weekly row`() throws {
@@ -31,9 +33,34 @@ struct ClaudeAllModelsWeeklyDuplicateTests {
 
         let snap = try ClaudeStatusProbe.parse(text: sample)
         #expect(snap.weeklyPercentLeft == 34)
-        // Only the genuine model-scoped window (Fable) survives; the garbled all-models copy is dropped.
         let titles = snap.extraRateWindows.map(\.title)
         #expect(titles == ["Fable only"], "unexpected scoped weekly rows: \(titles)")
+    }
+
+    @Test
+    func `exact all-models row wins over an earlier garbled duplicate`() throws {
+        // Garbled 67% copy appears BEFORE the clean 66% copy; the Weekly value and reset must still
+        // come from the exact row (34% left, 2pm), not the corrupted one that happens to be first.
+        let sample = """
+        Settings:  Status   Config   Usage  (tab to cycle)
+
+         Current session
+         ▌                                                  0% used
+         Resets 1:10pm (Asia/Seoul)
+
+         Current week (all modls)
+         █████████████████████████████████▌                67% used
+         Resets Jul 24 at 1:59pm (Asia/Seoul)
+
+         Current week (all models)
+         █████████████████████████████████▌                66% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+        """
+
+        let snap = try ClaudeStatusProbe.parse(text: sample)
+        #expect(snap.weeklyPercentLeft == 34)
+        #expect(snap.secondaryResetDescription == "Resets Jul 24 at 2pm (Asia/Seoul)")
+        #expect(snap.extraRateWindows.isEmpty, "garbled copy leaked as a scoped row")
     }
 
     @Test
@@ -64,23 +91,63 @@ struct ClaudeAllModelsWeeklyDuplicateTests {
     }
 
     @Test
-    func `genuine scoped model is not swallowed by the tolerant match`() throws {
+    func `single-character insertion is treated as all-models`() throws {
+        // A dropped-then-doubled render ("all modelss", edit distance 1) is still the aggregate row.
         let sample = """
          Current session
          ▌                                                  0% used
          Resets 1:10pm (Asia/Seoul)
 
-         Current week (all models)
-         █▌                                                 66% used
+         Current week (all modelss)
+         █████████████████████████████████▌                66% used
          Resets Jul 24 at 2pm (Asia/Seoul)
 
-         Current week (Sonnet only)
-         █▌                                                 10% used
+         Current week (Fable)
+         ████████████████████████████████████              71% used
          Resets Jul 24 at 2pm (Asia/Seoul)
         """
 
         let snap = try ClaudeStatusProbe.parse(text: sample)
         #expect(snap.weeklyPercentLeft == 34)
-        #expect(snap.opusPercentLeft == 90)
+        #expect(snap.extraRateWindows.map(\.title) == ["Fable only"])
+    }
+
+    @Test
+    func `genuine scoped model is preserved and leaves the weekly limit unset`() throws {
+        // No all-models row at all: the Weekly limit must be nil and the scoped Haiku row kept.
+        // (Sonnet/Opus are folded into opusPercentLeft, so Haiku is used to exercise the extra-row path.)
+        let sample = """
+         Current session
+         ▌                                                  0% used
+         Resets 1:10pm (Asia/Seoul)
+
+         Current week (Haiku)
+         █▌                                                 10% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+        """
+
+        let snap = try ClaudeStatusProbe.parse(text: sample)
+        #expect(snap.weeklyPercentLeft == nil)
+        #expect(snap.extraRateWindows.map(\.title) == ["Haiku only"])
+    }
+
+    @Test
+    func `heavier corruption stays a visible scoped row`() throws {
+        // "almdls" is edit distance 3 from "allmodels" — beyond the tolerance. We intentionally do
+        // NOT absorb it into Weekly (that would risk swallowing a real future scoped model); instead
+        // it stays visible as its own row so nothing is silently dropped.
+        let sample = """
+         Current session
+         ▌                                                  0% used
+         Resets 1:10pm (Asia/Seoul)
+
+         Current week (almdls)
+         █████████████████████████████████▌                66% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+        """
+
+        let snap = try ClaudeStatusProbe.parse(text: sample)
+        #expect(snap.weeklyPercentLeft == nil)
+        #expect(snap.extraRateWindows.map(\.title) == ["almdls only"])
     }
 }

--- a/Tests/CodexBarTests/ClaudeAllModelsWeeklyDuplicateTests.swift
+++ b/Tests/CodexBarTests/ClaudeAllModelsWeeklyDuplicateTests.swift
@@ -1,0 +1,86 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+/// The Claude CLI renders /usage as a redrawing TUI, so a half-painted capture frame can drop a
+/// character from "Current week (all models)" (-> "all modls"). These cover both shapes: the
+/// garbled copy must not become a bogus second weekly row, and if it is the only surviving
+/// all-models line the Weekly limit must still be recovered from it.
+struct ClaudeAllModelsWeeklyDuplicateTests {
+    @Test
+    func `garbled all-models copy does not duplicate the weekly row`() throws {
+        let sample = """
+        Settings:  Status   Config   Usage  (tab to cycle)
+
+         Current session
+         ▌                                                  0% used
+         Resets 1:10pm (Asia/Seoul)
+
+         Current week (all models)
+         █████████████████████████████████▌                66% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+
+         Current week (all modls)
+         █████████████████████████████████▌                67% used
+         Resets Jul 24 at 1:59pm (Asia/Seoul)
+
+         Current week (Fable)
+         ████████████████████████████████████              71% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+        """
+
+        let snap = try ClaudeStatusProbe.parse(text: sample)
+        #expect(snap.weeklyPercentLeft == 34)
+        // Only the genuine model-scoped window (Fable) survives; the garbled all-models copy is dropped.
+        let titles = snap.extraRateWindows.map(\.title)
+        #expect(titles == ["Fable only"], "unexpected scoped weekly rows: \(titles)")
+    }
+
+    @Test
+    func `garbled all-models line still populates the weekly limit`() throws {
+        // Only the corrupted all-models label survived this capture; the Weekly quota must be
+        // recovered from it rather than dropped, and it must not appear as a scoped row.
+        let sample = """
+        Settings:  Status   Config   Usage  (tab to cycle)
+
+         Current session
+         ▌                                                  0% used
+         Resets 1:10pm (Asia/Seoul)
+
+         Current week (all modls)
+         █████████████████████████████████▌                66% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+
+         Current week (Fable)
+         ████████████████████████████████████              71% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+        """
+
+        let snap = try ClaudeStatusProbe.parse(text: sample)
+        #expect(snap.weeklyPercentLeft == 34)
+        #expect(snap.secondaryResetDescription == "Resets Jul 24 at 2pm (Asia/Seoul)")
+        let titles = snap.extraRateWindows.map(\.title)
+        #expect(titles == ["Fable only"], "unexpected scoped weekly rows: \(titles)")
+    }
+
+    @Test
+    func `genuine scoped model is not swallowed by the tolerant match`() throws {
+        let sample = """
+         Current session
+         ▌                                                  0% used
+         Resets 1:10pm (Asia/Seoul)
+
+         Current week (all models)
+         █▌                                                 66% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+
+         Current week (Sonnet only)
+         █▌                                                 10% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+        """
+
+        let snap = try ClaudeStatusProbe.parse(text: sample)
+        #expect(snap.weeklyPercentLeft == 34)
+        #expect(snap.opusPercentLeft == 90)
+    }
+}

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -290,6 +290,39 @@ struct StatusProbeTests {
     }
 
     @Test
+    func `parse claude status ignores garbled all-models weekly duplicate`() throws {
+        // The Claude CLI renders /usage as a redrawing TUI. A half-painted frame can drop a
+        // character from "Current week (all models)" (-> "all modls"), and that garbled copy
+        // must not escape the all-models filter and appear as a second weekly row
+        // ("all modls only") beside the real Weekly limit.
+        let sample = """
+        Settings:  Status   Config   Usage  (tab to cycle)
+
+         Current session
+         ▌                                                  0% used
+         Resets 1:10pm (Asia/Seoul)
+
+         Current week (all models)
+         █████████████████████████████████▌                66% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+
+         Current week (all modls)
+         █████████████████████████████████▌                67% used
+         Resets Jul 24 at 1:59pm (Asia/Seoul)
+
+         Current week (Fable)
+         ████████████████████████████████████              71% used
+         Resets Jul 24 at 2pm (Asia/Seoul)
+        """
+
+        let snap = try ClaudeStatusProbe.parse(text: sample)
+        #expect(snap.weeklyPercentLeft == 34)
+        // Only the genuine model-scoped window (Fable) survives; the garbled all-models copy is dropped.
+        let titles = snap.extraRateWindows.map(\.title)
+        #expect(titles == ["Fable only"], "unexpected scoped weekly rows: \(titles)")
+    }
+
+    @Test
     func `parse claude status ignores status bar context percent`() throws {
         let sample = """
         Claude Code v2.1.29

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -290,39 +290,6 @@ struct StatusProbeTests {
     }
 
     @Test
-    func `parse claude status ignores garbled all-models weekly duplicate`() throws {
-        // The Claude CLI renders /usage as a redrawing TUI. A half-painted frame can drop a
-        // character from "Current week (all models)" (-> "all modls"), and that garbled copy
-        // must not escape the all-models filter and appear as a second weekly row
-        // ("all modls only") beside the real Weekly limit.
-        let sample = """
-        Settings:  Status   Config   Usage  (tab to cycle)
-
-         Current session
-         ▌                                                  0% used
-         Resets 1:10pm (Asia/Seoul)
-
-         Current week (all models)
-         █████████████████████████████████▌                66% used
-         Resets Jul 24 at 2pm (Asia/Seoul)
-
-         Current week (all modls)
-         █████████████████████████████████▌                67% used
-         Resets Jul 24 at 1:59pm (Asia/Seoul)
-
-         Current week (Fable)
-         ████████████████████████████████████              71% used
-         Resets Jul 24 at 2pm (Asia/Seoul)
-        """
-
-        let snap = try ClaudeStatusProbe.parse(text: sample)
-        #expect(snap.weeklyPercentLeft == 34)
-        // Only the genuine model-scoped window (Fable) survives; the garbled all-models copy is dropped.
-        let titles = snap.extraRateWindows.map(\.title)
-        #expect(titles == ["Fable only"], "unexpected scoped weekly rows: \(titles)")
-    }
-
-    @Test
     func `parse claude status ignores status bar context percent`() throws {
         let sample = """
         Claude Code v2.1.29


### PR DESCRIPTION
## Summary

On a CLI-auth Claude account the menu can show the weekly (all models) limit **twice**: once as the real **Weekly** row and again as a bogus model-scoped row titled **"all modls only"** (note the dropped character), sitting right next to it with a slightly different percentage/reset.

## Root cause

`claude /usage` is a redrawing TUI, and CodexBar scrapes it through a PTY. A half-painted capture frame can drop a character from `Current week (all models)`, so the same window is captured twice in one scrape — once clean (`all models`) and once garbled (`all modls`).

`extractScopedWeeklyUsages` filtered the all-models bucket out of the model-scoped windows with an **exact** string compare:

```swift
guard normalizedModel != "allmodels", !normalizedModel.isEmpty else { continue }
```

The clean copy is dropped (and used for the Weekly row), but the garbled copy normalizes to `allmodls != allmodels`, slips through, and is surfaced as an extra `NamedRateWindow` → the duplicate `"all modls only"` row. This is the same class of duplicate the 0.44.0 fix ("suppress duplicate all-model scoped quota rows that could appear as 'All models only' beside Weekly") targeted, but the exact-string guard is defeated by a single-character capture corruption.

## Fix

Match the all-models bucket with a small edit-distance tolerance (Levenshtein ≤ 2) instead of exact equality, so minor TUI capture corruption no longer escapes the filter. Genuine model-scoped names (Opus, Sonnet, Fable, …) are far outside that window, so they are unaffected.

## Test plan

Added `parse claude status ignores garbled all-models weekly duplicate` to `StatusProbeTests` (feeds a clean + garbled all-models frame plus a Fable window; asserts Weekly is captured and the only scoped row left is `Fable only`).

Because `@testable import CodexBar` links the full app target (whose SwiftUI `#Preview` macro needs full Xcode) I couldn't run the whole `swift test` suite locally on a Command-Line-Tools-only box, so I also verified the change end-to-end by linking the real compiled `CodexBarCore` and calling the public `ClaudeStatusProbe.parse` directly:

**Before the fix** (garbled input):
```
weeklyPercentLeft: Optional(34)
extraRateWindows (2):
  - title=all modls only  used=67.0  reset=Resets Jul 24 at 1:59pm (Asia/Seoul)
  - title=Fable only      used=71.0  reset=Resets Jul 24 at 2pm (Asia/Seoul)
RESULT: BUG — duplicate all-models row(s): ["all modls only"]
```

**After the fix:**
```
Case 1: garbled all-models duplicate
        weeklyPercentLeft=Optional(34)  extraRateWindows=["Fable only"]
  PASS  weekly (all models) still captured
  PASS  no duplicate all-models row; only Fable survives
Case 2: clean panel (regression guard)
        weeklyPercentLeft=Optional(34)  extraRateWindows=["Fable only"]
  PASS  weekly parsed
  PASS  clean panel unchanged: only Fable
Case 3: real scoped model preserved
        opusPercentLeft=Optional(90)  extraRateWindows=[]
  PASS  weekly parsed
  PASS  Sonnet-only scoped limit still recognized

ALL CHECKS PASSED
```

Logs are from synthetic fixtures — no account identity/PII. `swiftformat` was run on the changed files; `swiftlint` couldn't load `sourcekitdInProc` on this CLT-only box (CI covers lint).
