### PR TITLE
Preserve hooks in config persistence

### DIFF
--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -8,6 +8,7 @@ public struct CodexBarConfig: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case version
         case providers
+        case hooks
     }
 
     private enum ProviderCodingKeys: String, CodingKey {
@@ -46,6 +47,7 @@ public struct CodexBarConfig: Codable, Sendable {
             try providers.append(ProviderConfig(from: providerDecoder))
         }
         self.providers = providers
+        self.hooks = try container.decodeIfPresent(HooksConfig.self, forKey: .hooks)
     }
 
     public static func makeDefault(

--- a/Tests/CodexBarTests/CodexBarConfigHooksTests.swift
+++ b/Tests/CodexBarTests/CodexBarConfigHooksTests.swift
@@ -1,0 +1,28 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CodexBarConfigHooksTests {
+    @Test
+    func `hooks survive config round trip`() throws {
+        let hooks = HooksConfig(
+            enabled: true,
+            events: [
+                HookRule(
+                    id: "quota-low",
+                    event: .quotaLow,
+                    provider: "codex",
+                    threshold: 0.9,
+                    executable: "/usr/bin/true",
+                    timeoutSeconds: 30),
+            ])
+        let config = CodexBarConfig(
+            providers: [ProviderConfig(id: .codex, enabled: true)],
+            hooks: hooks)
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(CodexBarConfig.self, from: data)
+
+        #expect(decoded.hooks == hooks)
+    }
+}


### PR DESCRIPTION
Fixes #2432.

## Summary

- include top-level `hooks` in the custom `CodexBarConfig` coding keys
- restore persisted hook settings during config decoding
- add regression coverage for a full config round trip

## Root cause

`CodexBarConfig`'s custom `CodingKeys` listed only `version` and `providers`. That excluded `hooks` from both synthesized encoding and the custom decoder, so config load/save cycles silently discarded hook settings.

## Verification

- `swift test --filter CodexBarConfigHooksTests` — the regression failed before the fix with `decoded.hooks == nil`, then passed
- `swift test --skip-build --no-parallel --filter '(CodexBarConfigHooksTests|CodexBarConfigUnknownProviderTests|CodexActiveSourceConfigTests|CLIHooksTests|ConfigValidationTests)'` — 48 tests passed
- `make check` — passed (SwiftFormat: 0/1583 files; SwiftLint: 0 violations in 1582 files)
- `git diff --check` — passed
- `make test` — stopped after its automatic retry on two unchanged `AdaptiveRefreshTimerTests` that each threw `CancellationError()` after 30 seconds:
  - `menu open advances a long idle timer during refresh without postponing an earlier tick`
  - `coding activity advances a long idle timer without postponing an earlier tick`

Both timer failures are pre-existing on base `cc8da27c` and outside this two-file config/test diff.

Compatibility risk: low. Existing configs without `hooks` continue to decode that field as `nil`; this does not change hook execution, validation, or provider behavior.

Review focus: please sanity-check the custom top-level `Codable` boundary and round-trip coverage.
