### PR TITLE
fix: support amp subscription usage

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -286,12 +286,19 @@ extension UsageMenuCardView.Model {
             DoubaoProviderDescriptor.primaryLabel(window: snapshot.primary) ?? input.metadata.sessionLabel
         } else if input.provider == .sub2api {
             Sub2APIProviderDescriptor.primaryLabel(details: snapshot.sub2APIUsage) ?? input.metadata.sessionLabel
+        } else if input.provider == .amp {
+            AmpProviderDescriptor.primaryLabel(details: snapshot.ampUsage) ?? input.metadata.sessionLabel
         } else {
             input.metadata.sessionLabel
         }
+        let secondaryLabel = if input.provider == .amp {
+            AmpProviderDescriptor.secondaryLabel(details: snapshot.ampUsage) ?? input.metadata.weeklyLabel
+        } else {
+            input.metadata.weeklyLabel
+        }
         return (
             L(primaryLabel),
-            L(input.metadata.weeklyLabel),
+            L(secondaryLabel),
             input.metadata.opusLabel.map(L) ?? L("Sonnet"),
             input.metadata.supportsOpus)
     }

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1035,6 +1035,12 @@ extension UsageMenuCardView.Model {
             }
             return self.planDisplay(pass, for: provider)
         }
+        if provider == .amp,
+           let plan = snapshot?.ampUsage?.subscriptionPlan,
+           !plan.isEmpty
+        {
+            return self.planDisplay(plan, for: provider)
+        }
         if let plan = snapshot?.loginMethod(for: provider), !plan.isEmpty {
             return self.planDisplay(plan, for: provider)
         }

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -675,12 +675,19 @@ struct MenuDescriptor {
             DoubaoProviderDescriptor.primaryLabel(window: snapshot.primary) ?? metadata.sessionLabel
         } else if provider == .sub2api {
             Sub2APIProviderDescriptor.primaryLabel(details: snapshot.sub2APIUsage) ?? metadata.sessionLabel
+        } else if provider == .amp {
+            AmpProviderDescriptor.primaryLabel(details: snapshot.ampUsage) ?? metadata.sessionLabel
         } else {
             metadata.sessionLabel
         }
+        let secondaryLabel = if provider == .amp {
+            AmpProviderDescriptor.secondaryLabel(details: snapshot.ampUsage) ?? metadata.weeklyLabel
+        } else {
+            metadata.weeklyLabel
+        }
         return (
             L(primaryLabel),
-            L(metadata.weeklyLabel),
+            L(secondaryLabel),
             metadata.opusLabel.map(L) ?? L("Sonnet"),
             metadata.supportsOpus)
     }

--- a/Sources/CodexBar/UsageStore+QuotaWarnings.swift
+++ b/Sources/CodexBar/UsageStore+QuotaWarnings.swift
@@ -77,19 +77,27 @@ extension UsageStore {
             primaryWindow = provider == .mimo || provider == .qoder ? nil : snapshot.primary
             secondaryWindow = provider == .mimo || provider == .qoder ? nil : snapshot.secondary
         }
+        let primaryWindowDisplayLabel = provider == .amp
+            ? AmpProviderDescriptor.primaryLabel(details: snapshot.ampUsage)
+            : nil
+        let secondaryWindowDisplayLabel = provider == .amp
+            ? AmpProviderDescriptor.secondaryLabel(details: snapshot.ampUsage)
+            : nil
         if notificationsEnabled {
             self.handleQuotaWarningTransition(
                 provider: provider,
                 window: .session,
                 rateWindow: primaryWindow,
                 source: source,
-                accountContext: accountContext)
+                accountContext: accountContext,
+                windowDisplayLabel: primaryWindowDisplayLabel)
             self.handleQuotaWarningTransition(
                 provider: provider,
                 window: .weekly,
                 rateWindow: secondaryWindow,
                 source: source,
-                accountContext: accountContext)
+                accountContext: accountContext,
+                windowDisplayLabel: secondaryWindowDisplayLabel)
             self.handleClaudeExtraWindowQuotaWarnings(
                 provider: provider,
                 snapshot: snapshot,
@@ -102,7 +110,7 @@ extension UsageStore {
                 lane: QuotaLowHookLane(
                     window: .session,
                     windowID: nil,
-                    label: QuotaWarningWindow.session.displayName),
+                    label: primaryWindowDisplayLabel ?? QuotaWarningWindow.session.displayName),
                 rateWindow: primaryWindow,
                 accountDiscriminator: accountContext.discriminator,
                 accountDisplayName: accountContext.displayName)
@@ -111,7 +119,7 @@ extension UsageStore {
                 lane: QuotaLowHookLane(
                     window: .weekly,
                     windowID: nil,
-                    label: QuotaWarningWindow.weekly.displayName),
+                    label: secondaryWindowDisplayLabel ?? QuotaWarningWindow.weekly.displayName),
                 rateWindow: secondaryWindow,
                 accountDiscriminator: accountContext.discriminator,
                 accountDisplayName: accountContext.displayName)

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -177,8 +177,18 @@ extension UsageStore {
             {
                 return dyn
             }
+            if provider == .amp,
+               let dyn = AmpProviderDescriptor.primaryLabel(details: snapshot.ampUsage)
+            {
+                return dyn
+            }
             return metadata?.sessionLabel ?? "Session"
         }()
+        let secondaryTitle = if provider == .amp {
+            AmpProviderDescriptor.secondaryLabel(details: snapshot.ampUsage) ?? metadata?.weeklyLabel ?? "Weekly"
+        } else {
+            metadata?.weeklyLabel ?? "Weekly"
+        }
 
         var rows: [WidgetSnapshot.WidgetUsageRowSnapshot] = [
             WidgetSnapshot.WidgetUsageRowSnapshot(
@@ -187,7 +197,7 @@ extension UsageStore {
                 percentLeft: snapshot.primary?.remainingPercent),
             WidgetSnapshot.WidgetUsageRowSnapshot(
                 id: "secondary",
-                title: metadata?.weeklyLabel ?? "Weekly",
+                title: secondaryTitle,
                 percentLeft: snapshot.secondary?.remainingPercent),
         ]
         if metadata?.supportsOpus == true {

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -811,12 +811,19 @@ enum CLIRenderer {
             GrokProviderDescriptor.primaryLabel(window: snapshot.primary) ?? metadata.sessionLabel
         } else if provider == .sub2api {
             Sub2APIProviderDescriptor.primaryLabel(details: snapshot.sub2APIUsage) ?? metadata.sessionLabel
+        } else if provider == .amp {
+            AmpProviderDescriptor.primaryLabel(details: snapshot.ampUsage) ?? metadata.sessionLabel
         } else {
             metadata.sessionLabel
         }
+        let secondaryLabel = if provider == .amp {
+            AmpProviderDescriptor.secondaryLabel(details: snapshot.ampUsage) ?? metadata.weeklyLabel
+        } else {
+            metadata.weeklyLabel
+        }
         return RateWindowLabels(
             primary: primaryLabel,
-            secondary: metadata.weeklyLabel,
+            secondary: secondaryLabel,
             tertiary: metadata.opusLabel ?? "Sonnet",
             showsTertiary: metadata.supportsOpus)
     }

--- a/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
+++ b/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
@@ -164,12 +164,15 @@ enum DashboardSnapshotBuilder {
         guard let usage else { return [] }
         let labels = self.rateWindowLabels(provider: provider, metadata: metadata, usage: usage)
         var windows: [DashboardWindowPayload] = []
+        let isAmpSubscription = provider == .amp && usage.ampUsage?.subscriptionPlan != nil
 
         if let primary = usage.primary {
-            windows.append(self.makeWindow(kind: "session", label: labels.primary, window: primary))
+            let kind = isAmpSubscription ? "other" : "session"
+            windows.append(self.makeWindow(kind: kind, label: labels.primary, window: primary))
         }
         if let secondary = usage.secondary {
-            windows.append(self.makeWindow(kind: "weekly", label: labels.secondary, window: secondary))
+            let kind = isAmpSubscription ? "orb" : "weekly"
+            windows.append(self.makeWindow(kind: kind, label: labels.secondary, window: secondary))
         }
         if let tertiary = usage.tertiary {
             windows.append(self.makeWindow(kind: "tertiary", label: labels.tertiary, window: tertiary))
@@ -196,9 +199,19 @@ enum DashboardSnapshotBuilder {
             return RateWindowLabels(primary: "5-hour", secondary: "Weekly", tertiary: "Monthly")
         }
 
+        let primaryLabel = if provider == .amp {
+            AmpProviderDescriptor.primaryLabel(details: usage.ampUsage) ?? metadata?.sessionLabel ?? "Session"
+        } else {
+            metadata?.sessionLabel ?? "Session"
+        }
+        let secondaryLabel = if provider == .amp {
+            AmpProviderDescriptor.secondaryLabel(details: usage.ampUsage) ?? metadata?.weeklyLabel ?? "Weekly"
+        } else {
+            metadata?.weeklyLabel ?? "Weekly"
+        }
         return RateWindowLabels(
-            primary: metadata?.sessionLabel ?? "Session",
-            secondary: metadata?.weeklyLabel ?? "Weekly",
+            primary: primaryLabel,
+            secondary: secondaryLabel,
             tertiary: metadata?.opusLabel ?? "Tertiary")
     }
 

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -35,12 +35,21 @@ public enum AmpProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Amp cost summary is not supported." }),
+            pace: .calendarMonthResetWindow,
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web, .cli],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "amp",
                 versionDetector: nil))
+    }
+
+    public static func primaryLabel(details: AmpUsageDetails?) -> String? {
+        details?.subscriptionPlan == nil ? nil : "Other usage"
+    }
+
+    public static func secondaryLabel(details: AmpUsageDetails?) -> String? {
+        details?.subscriptionPlan == nil ? nil : "Orb usage"
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
@@ -31,6 +31,10 @@ enum AmpUsageParser {
             #"\s+remaining(?:\s*\(replenishes\s*\+\$?"# + amountPattern + #"\s*/\s*hour\))?"#
         let freePercentPattern = #"(?im)^\s*Amp Free:\s*"# + amountPattern +
             #"\s*%\s+remaining(?:\s+today)?(?:\s*\(resets\s+daily\))?"#
+        let subscriptionPattern = #"(?im)^\s*Subscription\s+(.+?):\s*"# + amountPattern +
+            #"\s*%\s+other\s+usage\s+and\s+"# + amountPattern +
+            #"\s*%\s+orb\s+usage\s+remaining\s*-\s*resets\s+upon\s+renewal\s+in\s+"# +
+            #"([0-9][0-9,]*)\s+days?\s*$"#
         let creditsPattern = #"(?im)^\s*Individual credits:\s*\$?"# + amountPattern + #"\s+remaining"#
         let individualCredits = self.captures(in: text, pattern: creditsPattern)?.first
             .flatMap(self.number(from:))
@@ -73,7 +77,25 @@ enum AmpUsageParser {
                 resetDescription: "resets daily")
         }()
         let resolvedFreeUsage = freeUsage ?? freePercentUsage
-        guard resolvedFreeUsage != nil || individualCredits != nil || !workspaceBalances.isEmpty else {
+        let subscriptionUsage: AmpSubscriptionUsage? = {
+            guard let subscription = self.captures(in: text, pattern: subscriptionPattern),
+                  subscription.count == 4,
+                  let plan = self.nonEmpty(subscription[0]),
+                  let otherRemaining = self.number(from: subscription[1]),
+                  let orbRemaining = self.number(from: subscription[2]),
+                  let renewalDays = Int(subscription[3].replacingOccurrences(of: ",", with: ""))
+            else { return nil }
+            let resetDescription = renewalDays == 1 ? "renews in 1 day" : "renews in \(renewalDays) days"
+            return AmpSubscriptionUsage(
+                plan: plan,
+                otherUsedPercent: 100 - min(100, max(0, otherRemaining)),
+                orbUsedPercent: 100 - min(100, max(0, orbRemaining)),
+                resetsAt: now.addingTimeInterval(TimeInterval(renewalDays) * 24 * 60 * 60),
+                resetDescription: resetDescription)
+        }()
+        guard resolvedFreeUsage != nil || subscriptionUsage != nil || individualCredits != nil ||
+            !workspaceBalances.isEmpty
+        else {
             throw AmpUsageError.parseFailed("Missing Amp usage data.")
         }
 
@@ -87,7 +109,8 @@ enum AmpUsageParser {
             accountEmail: self.nonEmpty(identity?[0]),
             accountOrganization: self.nonEmpty(identity?[1]),
             updatedAt: now,
-            freeResetDescription: resolvedFreeUsage?.resetDescription)
+            freeResetDescription: resolvedFreeUsage?.resetDescription,
+            subscription: subscriptionUsage)
     }
 
     private struct FreeTierUsage {

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
@@ -34,7 +34,7 @@ enum AmpUsageParser {
         let subscriptionPattern = #"(?im)^\s*Subscription\s+(.+?):\s*"# + amountPattern +
             #"\s*%\s+other\s+usage\s+and\s+"# + amountPattern +
             #"\s*%\s+orb\s+usage\s+remaining\s*-\s*resets\s+upon\s+renewal\s+in\s+"# +
-            #"([0-9][0-9,]*)\s+days?\s*$"#
+            #"([0-9][0-9,]*)\s+days?(?:\s+-\s+https?://\S+)?\s*$"#
         let creditsPattern = #"(?im)^\s*Individual credits:\s*\$?"# + amountPattern + #"\s+remaining"#
         let individualCredits = self.captures(in: text, pattern: creditsPattern)?.first
             .flatMap(self.number(from:))

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageSnapshot.swift
@@ -13,10 +13,38 @@ public struct AmpWorkspaceBalance: Codable, Equatable, Sendable {
 public struct AmpUsageDetails: Codable, Equatable, Sendable {
     public let individualCredits: Double?
     public let workspaceBalances: [AmpWorkspaceBalance]
+    public let subscriptionPlan: String?
 
-    public init(individualCredits: Double?, workspaceBalances: [AmpWorkspaceBalance]) {
+    public init(
+        individualCredits: Double?,
+        workspaceBalances: [AmpWorkspaceBalance],
+        subscriptionPlan: String? = nil)
+    {
         self.individualCredits = individualCredits
         self.workspaceBalances = workspaceBalances
+        self.subscriptionPlan = subscriptionPlan
+    }
+}
+
+public struct AmpSubscriptionUsage: Equatable, Sendable {
+    public let plan: String
+    public let otherUsedPercent: Double
+    public let orbUsedPercent: Double
+    public let resetsAt: Date
+    public let resetDescription: String
+
+    public init(
+        plan: String,
+        otherUsedPercent: Double,
+        orbUsedPercent: Double,
+        resetsAt: Date,
+        resetDescription: String)
+    {
+        self.plan = plan
+        self.otherUsedPercent = otherUsedPercent
+        self.orbUsedPercent = orbUsedPercent
+        self.resetsAt = resetsAt
+        self.resetDescription = resetDescription
     }
 }
 
@@ -31,6 +59,7 @@ public struct AmpUsageSnapshot: Sendable {
     public let accountOrganization: String?
     public let updatedAt: Date
     public let freeResetDescription: String?
+    public let subscription: AmpSubscriptionUsage?
 
     public init(
         freeQuota: Double?,
@@ -42,7 +71,8 @@ public struct AmpUsageSnapshot: Sendable {
         accountEmail: String? = nil,
         accountOrganization: String? = nil,
         updatedAt: Date,
-        freeResetDescription: String? = nil)
+        freeResetDescription: String? = nil,
+        subscription: AmpSubscriptionUsage? = nil)
     {
         self.freeQuota = freeQuota
         self.freeUsed = freeUsed
@@ -54,12 +84,13 @@ public struct AmpUsageSnapshot: Sendable {
         self.accountOrganization = accountOrganization
         self.updatedAt = updatedAt
         self.freeResetDescription = freeResetDescription
+        self.subscription = subscription
     }
 }
 
 extension AmpUsageSnapshot {
     public func toUsageSnapshot(now: Date = Date()) -> UsageSnapshot {
-        let primary: RateWindow? = if let freeQuota, let freeUsed {
+        let freeWindow: RateWindow? = if let freeQuota, let freeUsed {
             {
                 let quota = max(0, freeQuota)
                 let used = max(0, freeUsed)
@@ -83,23 +114,42 @@ extension AmpUsageSnapshot {
             nil
         }
 
+        let subscriptionPrimary = self.subscription.map { usage in
+            RateWindow(
+                usedPercent: usage.otherUsedPercent,
+                windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
+                resetsAt: usage.resetsAt,
+                resetDescription: usage.resetDescription)
+        }
+        let subscriptionSecondary = self.subscription.map { usage in
+            RateWindow(
+                usedPercent: usage.orbUsedPercent,
+                windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
+                resetsAt: usage.resetsAt,
+                resetDescription: usage.resetDescription)
+        }
+        let primary = subscriptionPrimary ?? freeWindow
+
         let identity = ProviderIdentitySnapshot(
             providerID: .amp,
             accountEmail: self.accountEmail,
             accountOrganization: self.accountOrganization,
-            loginMethod: primary == nil ? "Amp" : "Amp Free")
+            loginMethod: self.subscription?.plan ?? (primary == nil ? "Amp" : "Amp Free"))
 
-        let ampUsage: AmpUsageDetails? = if self.individualCredits != nil || !self.workspaceBalances.isEmpty {
+        let ampUsage: AmpUsageDetails? = if self.individualCredits != nil || !self.workspaceBalances.isEmpty ||
+            self.subscription != nil
+        {
             AmpUsageDetails(
                 individualCredits: self.individualCredits,
-                workspaceBalances: self.workspaceBalances)
+                workspaceBalances: self.workspaceBalances,
+                subscriptionPlan: self.subscription?.plan)
         } else {
             nil
         }
 
         return UsageSnapshot(
             primary: primary,
-            secondary: nil,
+            secondary: subscriptionSecondary,
             tertiary: nil,
             ampUsage: ampUsage,
             providerCost: nil,

--- a/Tests/CodexBarTests/AmpUsageParserTests.swift
+++ b/Tests/CodexBarTests/AmpUsageParserTests.swift
@@ -175,8 +175,11 @@ struct AmpUsageParserTests {
         #expect(snapshot.freeUsed == nil)
         #expect(snapshot.individualCredits == 25.64)
         #expect(usage.primary == nil)
+        #expect(usage.secondary == nil)
         #expect(usage.ampUsage == AmpUsageDetails(individualCredits: 25.64, workspaceBalances: []))
         #expect(usage.identity?.loginMethod == "Amp")
+        #expect(AmpProviderDescriptor.primaryLabel(details: usage.ampUsage) == nil)
+        #expect(AmpProviderDescriptor.secondaryLabel(details: usage.ampUsage) == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/AmpUsageParserTests.swift
+++ b/Tests/CodexBarTests/AmpUsageParserTests.swift
@@ -113,6 +113,20 @@ struct AmpUsageParserTests {
     }
 
     @Test
+    func `parses amp subscription usage with settings link`() throws {
+        let output = """
+        Subscription Megawatt: 97% other usage and 100% orb usage remaining - resets upon renewal in 29 days \
+        - https://ampcode.com/settings#subscription
+        """
+
+        let snapshot = try AmpUsageParser.parse(displayText: output)
+
+        #expect(snapshot.subscription?.plan == "Megawatt")
+        #expect(snapshot.subscription?.otherUsedPercent == 3)
+        #expect(snapshot.subscription?.orbUsedPercent == 0)
+    }
+
+    @Test
     func `legacy amp free usage keeps replenishment reset when percentage text also exists`() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let output = """

--- a/Tests/CodexBarTests/AmpUsageParserTests.swift
+++ b/Tests/CodexBarTests/AmpUsageParserTests.swift
@@ -86,6 +86,33 @@ struct AmpUsageParserTests {
     }
 
     @Test
+    func `parses amp subscription usage`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let output = """
+        Signed in as user@example.com (username)
+        Subscription Megawatt: 97% other usage and 100% orb usage remaining - resets upon renewal in 29 days
+        """
+
+        let snapshot = try AmpUsageParser.parse(displayText: output, now: now)
+        let usage = snapshot.toUsageSnapshot(now: now)
+
+        #expect(snapshot.subscription == AmpSubscriptionUsage(
+            plan: "Megawatt",
+            otherUsedPercent: 3,
+            orbUsedPercent: 0,
+            resetsAt: now.addingTimeInterval(29 * 24 * 60 * 60),
+            resetDescription: "renews in 29 days"))
+        #expect(usage.primary?.usedPercent == 3)
+        #expect(usage.secondary?.usedPercent == 0)
+        #expect(usage.primary?.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
+        #expect(usage.secondary?.resetsAt == now.addingTimeInterval(29 * 24 * 60 * 60))
+        #expect(usage.identity?.loginMethod == "Megawatt")
+        #expect(usage.ampUsage?.subscriptionPlan == "Megawatt")
+        #expect(AmpProviderDescriptor.primaryLabel(details: usage.ampUsage) == "Other usage")
+        #expect(AmpProviderDescriptor.secondaryLabel(details: usage.ampUsage) == "Orb usage")
+    }
+
+    @Test
     func `legacy amp free usage keeps replenishment reset when percentage text also exists`() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let output = """

--- a/Tests/CodexBarTests/CLIOutputTests.swift
+++ b/Tests/CodexBarTests/CLIOutputTests.swift
@@ -97,6 +97,40 @@ struct CLIOutputTests {
     }
 
     @Test
+    func `text renderer labels amp subscription pools`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = AmpUsageSnapshot(
+            freeQuota: nil,
+            freeUsed: nil,
+            hourlyReplenishment: nil,
+            windowHours: nil,
+            updatedAt: now,
+            subscription: AmpSubscriptionUsage(
+                plan: "Megawatt",
+                otherUsedPercent: 3,
+                orbUsedPercent: 0,
+                resetsAt: now.addingTimeInterval(29 * 24 * 60 * 60),
+                resetDescription: "renews in 29 days"))
+            .toUsageSnapshot(now: now)
+
+        let text = CLIRenderer.renderText(
+            provider: .amp,
+            snapshot: snapshot,
+            credits: nil,
+            context: RenderContext(
+                header: "Amp (cli)",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown),
+            now: now)
+
+        #expect(text.contains("Other usage:"))
+        #expect(text.contains("Orb usage:"))
+        #expect(!text.contains("Amp Free:"))
+        #expect(!text.contains("Balance:"))
+    }
+
+    @Test
     func `text renderer shows mimo balance without quota or reset text`() {
         let snapshot = MiMoUsageSnapshot(
             balance: 25.51,

--- a/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
+++ b/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
@@ -166,6 +166,50 @@ struct DashboardSnapshotBuilderTests {
     }
 
     @Test
+    func `dashboard labels amp subscription pools as provider specific windows`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let usage = AmpUsageSnapshot(
+            freeQuota: nil,
+            freeUsed: nil,
+            hourlyReplenishment: nil,
+            windowHours: nil,
+            updatedAt: now,
+            subscription: AmpSubscriptionUsage(
+                plan: "Megawatt",
+                otherUsedPercent: 3,
+                orbUsedPercent: 0,
+                resetsAt: now.addingTimeInterval(29 * 24 * 60 * 60),
+                resetDescription: "renews in 29 days"))
+            .toUsageSnapshot(now: now)
+        let payload = ProviderPayload(
+            provider: .amp,
+            account: nil,
+            version: nil,
+            source: "cli",
+            status: nil,
+            usage: usage,
+            credits: nil,
+            antigravityPlanInfo: nil,
+            openaiDashboard: nil,
+            error: nil)
+
+        let snapshot = DashboardSnapshotBuilder.makeSnapshot(
+            usagePayloads: [payload],
+            costPayloads: [],
+            config: CodexBarConfig(providers: [ProviderConfig(id: .amp, enabled: true)]),
+            identityMode: .redacted,
+            generatedAt: now,
+            refreshInterval: 60,
+            codexBarVersion: nil)
+        let object = try self.jsonObject(snapshot)
+        let provider = try #require((object["providers"] as? [[String: Any]])?.first)
+        let windows = try #require(provider["windows"] as? [[String: Any]])
+
+        #expect(windows.map { $0["kind"] as? String } == ["other", "orb"])
+        #expect(windows.map { $0["label"] as? String } == ["Other usage", "Orb usage"])
+    }
+
+    @Test
     func `dashboard identity mode redacted hides local part but keeps domain`() throws {
         let snapshot = DashboardSnapshotBuilder.makeSnapshot(
             usagePayloads: [self.identityPayload(email: "user@example.com")],

--- a/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
+++ b/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
@@ -49,6 +49,23 @@ struct ProviderPaceCapabilityTests {
         }
     }
 
+    @Test
+    func `amp monthly pace is limited to subscription windows`() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let capability = AmpProviderDescriptor.descriptor.pace
+        let freeTier = Self.window(
+            minutes: 24 * 60,
+            resetsAt: now.addingTimeInterval(12 * 60 * 60))
+        let subscription = Self.window(
+            minutes: Self.monthlyWindowSentinelMinutes,
+            resetsAt: now.addingTimeInterval(20 * 24 * 60 * 60))
+
+        #expect(!capability.supportsResetWindowPace(window: freeTier, now: now))
+        #expect(!capability.usesInferredMonthlyDuration(window: freeTier))
+        #expect(capability.supportsResetWindowPace(window: subscription, now: now))
+        #expect(capability.usesInferredMonthlyDuration(window: subscription))
+    }
+
     private static func window(minutes: Int?, resetsAt: Date?) -> RateWindow {
         RateWindow(
             usedPercent: 50,

--- a/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
+++ b/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
@@ -79,7 +79,7 @@ struct ProviderPaceCapabilityTests {
                 && timeUntilReset <= TimeInterval(windowMinutes) * 60
         case .kimi:
             return window.windowMinutes == self.weeklyWindowMinutes
-        case .alibaba, .alibabatokenplan, .doubao, .opencodego:
+        case .alibaba, .alibabatokenplan, .amp, .doubao, .opencodego:
             return window.windowMinutes == self.monthlyWindowSentinelMinutes
         default:
             return false
@@ -93,7 +93,7 @@ struct ProviderPaceCapabilityTests {
         switch provider {
         case .copilot:
             window.windowMinutes == nil
-        case .alibaba, .alibabatokenplan, .doubao, .opencodego:
+        case .alibaba, .alibabatokenplan, .amp, .doubao, .opencodego:
             window.windowMinutes == self.monthlyWindowSentinelMinutes
         default:
             false

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -228,6 +228,37 @@ struct UsageStoreCoverageTests {
     }
 
     @Test
+    func `amp subscription pools use their own labels`() {
+        let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-amp-subscription")
+        let store = Self.makeUsageStore(settings: settings)
+        let now = Date()
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 3,
+                    windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
+                    resetsAt: now.addingTimeInterval(29 * 24 * 60 * 60),
+                    resetDescription: "renews in 29 days"),
+                secondary: RateWindow(
+                    usedPercent: 0,
+                    windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
+                    resetsAt: now.addingTimeInterval(29 * 24 * 60 * 60),
+                    resetDescription: "renews in 29 days"),
+                ampUsage: AmpUsageDetails(
+                    individualCredits: nil,
+                    workspaceBalances: [],
+                    subscriptionPlan: "Megawatt"),
+                updatedAt: now),
+            provider: .amp)
+
+        let model = ProvidersPane(settings: settings, store: store)._test_menuCardModel(for: .amp)
+
+        #expect(model.metrics.map(\.title) == ["Other usage", "Orb usage"])
+        #expect(model.planText == "Megawatt")
+    }
+
+    @Test
     func `account info caches codex auth parsing until config revision changes`() throws {
         let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-account-info-cache")
         let home = FileManager.default.temporaryDirectory.appendingPathComponent(

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -219,6 +219,8 @@ struct UsageStoreCoverageTests {
             provider: .amp)
         let model = ProvidersPane(settings: settings, store: store)._test_menuCardModel(for: .amp)
 
+        #expect(model.metrics.map(\.title) == ["Amp Free"])
+        #expect(model.metrics.allSatisfy { $0.pacePercent == nil })
         #expect(model.creditsText == "Individual credits: $25.64\nWorkspace billing@example.test: $10.22")
         #expect(model.creditsRemaining == nil)
 

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -665,6 +665,39 @@ struct UsageStoreSessionQuotaTransitionTests {
     }
 
     @Test
+    func `amp subscription quota warnings use pool labels`() {
+        let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-amp")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50]
+        settings.setQuotaWarningWindowEnabled(.session, enabled: true)
+        settings.setQuotaWarningWindowEnabled(.weekly, enabled: true)
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        func snapshot(used: Double) -> UsageSnapshot {
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: used, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(usedPercent: used, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                ampUsage: AmpUsageDetails(
+                    individualCredits: nil,
+                    workspaceBalances: [],
+                    subscriptionPlan: "Megawatt"),
+                updatedAt: Date())
+        }
+        store.handleQuotaWarningTransitions(provider: .amp, snapshot: snapshot(used: 40))
+        store.handleQuotaWarningTransitions(provider: .amp, snapshot: snapshot(used: 55))
+
+        #expect(notifier.quotaWarningPosts.map(\.event.windowDisplayLabel) == ["Other usage", "Orb usage"])
+    }
+
+    @Test
     func `antigravity quota warnings use named session and weekly durations`() {
         let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-antigravity")
         settings.refreshFrequency = .manual


### PR DESCRIPTION
## summary

- parse the subscription output used by Megawatt and other Amp plans
- expose the other and orb pools as separate monthly usage windows with renewal metadata
- preserve the plan name and use accurate labels in the menu, CLI, widget, and dashboard
- keep the existing Amp Free and credit-balance paths unchanged

## verification

- `swift test --filter AmpUsageParserTests` (18 passed)
- `swift test --filter ProviderPaceCapabilityTests` (2 passed)
- `swift test --filter UsageStoreCoverageTests` (33 passed)
- `swift test --filter CLIOutputTests` (10 passed)
- `swift test --filter DashboardSnapshotBuilderTests` (10 passed)
- `make check`
- full `make test` reaches unrelated existing `SpendDashboardTokenProvenanceTests` failures

The compatibility coverage explicitly verifies that Amp Free keeps its `Amp Free` label and receives no monthly pace, credit-only output keeps no rate windows or subscription labels, and only subscription sentinel windows opt into monthly pace.

## live subscription proof

Confirmed by the original reporter on a real Megawatt subscription account in a [redacted branch-built CLI transcript](https://github.com/steipete/CodexBar/pull/2438#issuecomment-5071595503). The run successfully parsed both monthly usage pools, showed their renewal timing, and preserved the Megawatt plan. The reporter tested on macOS 26.5.1 with Swift 6.3.3 and the current Amp CLI.

Fixes #2435
