### PR TITLE
Show Claude prepaid balance

### DIFF
--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -107,6 +107,7 @@ extension UsageMenuCardView.Model.ProviderCostSection {
             MenuCardHeightFingerprint.field("title", self.title),
             MenuCardHeightFingerprint.field("spend", self.spendLine),
             MenuCardHeightFingerprint.field("percentLine", self.percentLine),
+            MenuCardHeightFingerprint.field("balance", self.balanceLine),
             MenuCardHeightFingerprint.field("personalSpend", self.personalSpendLine),
             self.percentUsed == nil ? "percent=0" : "percent=1",
         ])

--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -107,7 +107,6 @@ extension UsageMenuCardView.Model.ProviderCostSection {
             MenuCardHeightFingerprint.field("title", self.title),
             MenuCardHeightFingerprint.field("spend", self.spendLine),
             MenuCardHeightFingerprint.field("percentLine", self.percentLine),
-            MenuCardHeightFingerprint.field("balance", self.balanceLine),
             MenuCardHeightFingerprint.field("personalSpend", self.personalSpendLine),
             self.percentUsed == nil ? "percent=0" : "percent=1",
         ])

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -1,5 +1,66 @@
 import CodexBarCore
 import Foundation
+import SwiftUI
+
+struct ProviderCostContent: View {
+    let section: UsageMenuCardView.Model.ProviderCostSection
+    let progressColor: Color
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        if self.section.presentation == .inlineValue {
+            HStack(alignment: .firstTextBaseline) {
+                Text(self.section.title)
+                    .font(.body)
+                    .fontWeight(.medium)
+                Spacer()
+                Text(self.section.spendLine)
+                    .font(.footnote)
+                    .monospacedDigit()
+                    .lineLimit(1)
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(self.section.title)
+                        .font(.body)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    if let balanceLine = self.section.balanceLine {
+                        Spacer(minLength: 8)
+                        Text(balanceLine)
+                            .font(.footnote)
+                            .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                            .monospacedDigit()
+                            .lineLimit(1)
+                            .layoutPriority(1)
+                    }
+                }
+                if let percentUsed = self.section.percentUsed {
+                    UsageProgressBar(
+                        percent: percentUsed,
+                        tint: self.progressColor,
+                        accessibilityLabel: L("Extra usage spent"))
+                }
+                HStack(alignment: .firstTextBaseline) {
+                    Text(self.section.spendLine).font(.footnote).lineLimit(1)
+                    Spacer()
+                    if let percentLine = self.section.percentLine {
+                        Text(percentLine)
+                            .font(.footnote)
+                            .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                            .lineLimit(1)
+                    }
+                }
+                if let personalSpendLine = self.section.personalSpendLine {
+                    Text(personalSpendLine)
+                        .font(.footnote).foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted)).lineLimit(1)
+                }
+            }
+        }
+    }
+}
 
 extension UsageMenuCardView.Model.ProviderCostSection {
     enum Presentation: Equatable {
@@ -12,6 +73,7 @@ extension UsageMenuCardView.Model.ProviderCostSection {
         percentUsed: Double?,
         spendLine: String,
         percentLine: String?,
+        balanceLine: String? = nil,
         presentation: Presentation = .detail,
         showsInProviderDetails: Bool = true)
     {
@@ -20,6 +82,7 @@ extension UsageMenuCardView.Model.ProviderCostSection {
             percentUsed: percentUsed,
             spendLine: spendLine,
             percentLine: percentLine,
+            balanceLine: balanceLine,
             personalSpendLine: nil,
             presentation: presentation,
             showsInProviderDetails: showsInProviderDetails)
@@ -366,14 +429,31 @@ extension UsageMenuCardView.Model {
                     percentLine: nil)
             }
 
-            guard let balance = cost.balance else { return nil }
-            let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
+            if cost.limit <= 0 {
+                guard let balance = cost.balance else { return nil }
+                let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
+                return ProviderCostSection(
+                    title: L("Credits"),
+                    percentUsed: nil,
+                    spendLine: value,
+                    percentLine: nil,
+                    presentation: .inlineValue,
+                    showsInProviderDetails: false)
+            }
+
+            let used = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
+            let limit = UsageFormatter.currencyString(cost.limit, currencyCode: cost.currencyCode)
+            let percentUsed = Self.clamped((cost.used / cost.limit) * 100)
+            let periodLabel = Self.localizedPeriodLabel(cost.period ?? "This month")
+            let balanceLine = cost.balance.map {
+                "\(L("Balance")): \(UsageFormatter.currencyString($0, currencyCode: cost.currencyCode))"
+            }
             return ProviderCostSection(
-                title: L("Credits"),
-                percentUsed: nil,
-                spendLine: value,
-                percentLine: nil,
-                presentation: .inlineValue,
+                title: L("Extra usage"),
+                percentUsed: percentUsed,
+                spendLine: "\(periodLabel): \(used) / \(limit)",
+                percentLine: String(format: L("%.0f%% used"), min(100, max(0, percentUsed))),
+                balanceLine: balanceLine,
                 showsInProviderDetails: false)
         }
 
@@ -438,6 +518,7 @@ extension UsageMenuCardView.Model {
             percentUsed: percentUsed,
             spendLine: "\(periodLabel): \(used) / \(limit)",
             percentLine: String(format: L("%.0f%% used"), min(100, max(0, percentUsed))),
+            balanceLine: nil,
             personalSpendLine: personalSpendLine)
     }
 

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -345,6 +345,15 @@ extension UsageMenuCardView.Model {
                 percentLine: nil)
         }
 
+        if provider == .claude, let balance = cost.balance, cost.limit <= 0 {
+            let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
+            return ProviderCostSection(
+                title: L("Extra usage"),
+                percentUsed: nil,
+                spendLine: "\(L("Balance")): \(value)",
+                percentLine: nil)
+        }
+
         if provider == .openai || provider == .claude || provider == .litellm || provider == .aiand,
            cost.limit <= 0
         {
@@ -406,6 +415,9 @@ extension UsageMenuCardView.Model {
             percentUsed: percentUsed,
             spendLine: "\(periodLabel): \(used) / \(limit)",
             percentLine: String(format: L("%.0f%% used"), min(100, max(0, percentUsed))),
+            balanceLine: cost.balance.map {
+                "\(L("Balance")): \(UsageFormatter.currencyString($0, currencyCode: cost.currencyCode))"
+            },
             personalSpendLine: personalSpendLine)
     }
 

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -2,18 +2,27 @@ import CodexBarCore
 import Foundation
 
 extension UsageMenuCardView.Model.ProviderCostSection {
+    enum Presentation: Equatable {
+        case detail
+        case inlineValue
+    }
+
     init(
         title: String,
         percentUsed: Double?,
         spendLine: String,
-        percentLine: String?)
+        percentLine: String?,
+        presentation: Presentation = .detail,
+        showsInProviderDetails: Bool = true)
     {
         self.init(
             title: title,
             percentUsed: percentUsed,
             spendLine: spendLine,
             percentLine: percentLine,
-            personalSpendLine: nil)
+            personalSpendLine: nil,
+            presentation: presentation,
+            showsInProviderDetails: showsInProviderDetails)
     }
 }
 
@@ -301,7 +310,8 @@ extension UsageMenuCardView.Model {
 
     static func providerCostSection(
         provider: UsageProvider,
-        cost: ProviderCostSnapshot?) -> ProviderCostSection?
+        cost: ProviderCostSnapshot?,
+        isClaudeAdminAPI: Bool = false) -> ProviderCostSection?
     {
         if provider == .manus {
             return nil
@@ -345,16 +355,29 @@ extension UsageMenuCardView.Model {
                 percentLine: nil)
         }
 
-        if provider == .claude, let balance = cost.balance, cost.limit <= 0 {
+        if provider == .claude {
+            if isClaudeAdminAPI {
+                let spend = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
+                let periodLabel = Self.localizedPeriodLabel(cost.period ?? "Last 30 days")
+                return ProviderCostSection(
+                    title: L("API spend"),
+                    percentUsed: nil,
+                    spendLine: "\(periodLabel): \(spend)",
+                    percentLine: nil)
+            }
+
+            guard let balance = cost.balance else { return nil }
             let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
             return ProviderCostSection(
-                title: L("Extra usage"),
+                title: L("Credits"),
                 percentUsed: nil,
-                spendLine: "\(L("Balance")): \(value)",
-                percentLine: nil)
+                spendLine: value,
+                percentLine: nil,
+                presentation: .inlineValue,
+                showsInProviderDetails: false)
         }
 
-        if provider == .openai || provider == .claude || provider == .litellm || provider == .aiand,
+        if provider == .openai || provider == .litellm || provider == .aiand,
            cost.limit <= 0
         {
             let spend = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
@@ -415,9 +438,6 @@ extension UsageMenuCardView.Model {
             percentUsed: percentUsed,
             spendLine: "\(periodLabel): \(used) / \(limit)",
             percentLine: String(format: L("%.0f%% used"), min(100, max(0, percentUsed))),
-            balanceLine: cost.balance.map {
-                "\(L("Balance")): \(UsageFormatter.currencyString($0, currencyCode: cost.currencyCode))"
-            },
             personalSpendLine: personalSpendLine)
     }
 

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -121,8 +121,9 @@ struct UsageMenuCardView: View {
             let percentUsed: Double?
             let spendLine: String
             let percentLine: String?
-            var balanceLine: String?
             var personalSpendLine: String?
+            var presentation: Presentation = .detail
+            var showsInProviderDetails = true
         }
 
         let provider: UsageProvider
@@ -469,33 +470,42 @@ private struct ProviderCostContent: View {
     @Environment(\.menuItemHighlighted) private var isHighlighted
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(self.section.title)
-                .font(.body)
-                .fontWeight(.medium)
-            if let percentUsed = self.section.percentUsed {
-                UsageProgressBar(
-                    percent: percentUsed,
-                    tint: self.progressColor,
-                    accessibilityLabel: L("Extra usage spent"))
-            }
+        if self.section.presentation == .inlineValue {
             HStack(alignment: .firstTextBaseline) {
-                Text(self.section.spendLine).font(.footnote).lineLimit(1)
+                Text(self.section.title)
+                    .font(.body)
+                    .fontWeight(.medium)
                 Spacer()
-                if let percentLine = self.section.percentLine {
-                    Text(percentLine)
-                        .font(.footnote)
-                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                        .lineLimit(1)
+                Text(self.section.spendLine)
+                    .font(.footnote)
+                    .monospacedDigit()
+                    .lineLimit(1)
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(self.section.title)
+                    .font(.body)
+                    .fontWeight(.medium)
+                if let percentUsed = self.section.percentUsed {
+                    UsageProgressBar(
+                        percent: percentUsed,
+                        tint: self.progressColor,
+                        accessibilityLabel: L("Extra usage spent"))
                 }
-            }
-            if let personalSpendLine = self.section.personalSpendLine {
-                Text(personalSpendLine)
-                    .font(.footnote).foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted)).lineLimit(1)
-            }
-            if let balanceLine = self.section.balanceLine {
-                Text(balanceLine)
-                    .font(.footnote).foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted)).lineLimit(1)
+                HStack(alignment: .firstTextBaseline) {
+                    Text(self.section.spendLine).font(.footnote).lineLimit(1)
+                    Spacer()
+                    if let percentLine = self.section.percentLine {
+                        Text(percentLine)
+                            .font(.footnote)
+                            .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                            .lineLimit(1)
+                    }
+                }
+                if let personalSpendLine = self.section.personalSpendLine {
+                    Text(personalSpendLine)
+                        .font(.footnote).foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted)).lineLimit(1)
+                }
             }
         }
     }
@@ -927,7 +937,7 @@ extension UsageMenuCardView.Model {
         let creditsScaleText = Self.creditsScaleText(credits: input.credits)
         let codexCreditLimitDetail = Self.codexCreditLimitDetail(credits: input.credits, now: input.now)
         let isClaudeAdminAPI = input.provider == .claude &&
-            input.snapshot?.identity?.loginMethod == "Admin API"
+            input.snapshot?.claudeAdminAPIUsage != nil
         let isRequiredOpenCodeZenBalance = Self.isRequiredOpenCodeZenBalance(input.snapshot)
         let hidesOptionalProviderCost = ((input.provider == .claude && !isClaudeAdminAPI) ||
             input.provider == .factory ||
@@ -943,7 +953,10 @@ extension UsageMenuCardView.Model {
         {
             nil
         } else {
-            Self.providerCostSection(provider: input.provider, cost: input.snapshot?.providerCost)
+            Self.providerCostSection(
+                provider: input.provider,
+                cost: input.snapshot?.providerCost,
+                isClaudeAdminAPI: isClaudeAdminAPI)
         }
         let tokenUsageSnapshot = Self.tokenUsageSnapshot(input: input)
         let tokenUsage = Self.tokenUsageSection(

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -121,6 +121,7 @@ struct UsageMenuCardView: View {
             let percentUsed: Double?
             let spendLine: String
             let percentLine: String?
+            var balanceLine: String?
             var personalSpendLine: String?
         }
 
@@ -490,6 +491,10 @@ private struct ProviderCostContent: View {
             }
             if let personalSpendLine = self.section.personalSpendLine {
                 Text(personalSpendLine)
+                    .font(.footnote).foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted)).lineLimit(1)
+            }
+            if let balanceLine = self.section.balanceLine {
+                Text(balanceLine)
                     .font(.footnote).foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted)).lineLimit(1)
             }
         }

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -121,6 +121,7 @@ struct UsageMenuCardView: View {
             let percentUsed: Double?
             let spendLine: String
             let percentLine: String?
+            var balanceLine: String?
             var personalSpendLine: String?
             var presentation: Presentation = .detail
             var showsInProviderDetails = true
@@ -459,53 +460,6 @@ private struct TokenUsageSectionContent: View {
                     .overlay {
                         ClickToCopyOverlay(copyText: self.tokenUsage.errorCopyText ?? error)
                     }
-            }
-        }
-    }
-}
-
-private struct ProviderCostContent: View {
-    let section: UsageMenuCardView.Model.ProviderCostSection
-    let progressColor: Color
-    @Environment(\.menuItemHighlighted) private var isHighlighted
-
-    var body: some View {
-        if self.section.presentation == .inlineValue {
-            HStack(alignment: .firstTextBaseline) {
-                Text(self.section.title)
-                    .font(.body)
-                    .fontWeight(.medium)
-                Spacer()
-                Text(self.section.spendLine)
-                    .font(.footnote)
-                    .monospacedDigit()
-                    .lineLimit(1)
-            }
-        } else {
-            VStack(alignment: .leading, spacing: 6) {
-                Text(self.section.title)
-                    .font(.body)
-                    .fontWeight(.medium)
-                if let percentUsed = self.section.percentUsed {
-                    UsageProgressBar(
-                        percent: percentUsed,
-                        tint: self.progressColor,
-                        accessibilityLabel: L("Extra usage spent"))
-                }
-                HStack(alignment: .firstTextBaseline) {
-                    Text(self.section.spendLine).font(.footnote).lineLimit(1)
-                    Spacer()
-                    if let percentLine = self.section.percentLine {
-                        Text(percentLine)
-                            .font(.footnote)
-                            .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                            .lineLimit(1)
-                    }
-                }
-                if let personalSpendLine = self.section.personalSpendLine {
-                    Text(personalSpendLine)
-                        .font(.footnote).foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted)).lineLimit(1)
-                }
             }
         }
     }

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -382,7 +382,7 @@ struct ProviderMetricsInlineView: View {
         let hasMetrics = !self.model.metrics.isEmpty
         let hasUsageNotes = !self.model.usageNotes.isEmpty
         let infoRows = Self.infoRows(for: self.model, openAIWebDiagnostic: self.openAIWebDiagnostic)
-        let hasProviderCost = self.model.providerCost != nil
+        let hasProviderCost = self.model.providerCost?.showsInProviderDetails == true
         let hasTokenUsage = self.model.tokenUsage != nil
         let hasResetCredits = self.model.codexResetCredits != nil
 
@@ -418,7 +418,7 @@ struct ProviderMetricsInlineView: View {
                 ProviderCodexResetCreditsInlineRow(presentation: resetCredits)
             }
 
-            if let providerCost = self.model.providerCost {
+            if let providerCost = self.model.providerCost, providerCost.showsInProviderDetails {
                 ProviderMetricInlineCostRow(
                     section: providerCost,
                     progressColor: self.model.progressColor)

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -281,17 +281,11 @@ struct ClaudeProviderImplementation: ProviderImplementation {
 
         if let cost = context.snapshot?.providerCost,
            context.settings.showOptionalCreditsAndExtraUsage,
-           cost.currencyCode != "Quota"
+           cost.currencyCode != "Quota",
+           let balance = cost.balance
         {
-            if let balance = cost.balance {
-                let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
-                entries.append(.text(L("Extra usage balance: %@", value), .primary))
-            }
-            let used = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
-            let limit = UsageFormatter.currencyString(cost.limit, currencyCode: cost.currencyCode)
-            if cost.limit > 0 {
-                entries.append(.text(String(format: L("extra_usage_format"), used, limit), .primary))
-            }
+            let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
+            entries.append(.text("\(L("Credits")): \(value)", .primary))
         }
     }
 

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -283,9 +283,15 @@ struct ClaudeProviderImplementation: ProviderImplementation {
            context.settings.showOptionalCreditsAndExtraUsage,
            cost.currencyCode != "Quota"
         {
+            if let balance = cost.balance {
+                let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
+                entries.append(.text(L("Extra usage balance: %@", value), .primary))
+            }
             let used = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
             let limit = UsageFormatter.currencyString(cost.limit, currencyCode: cost.currencyCode)
-            entries.append(.text(String(format: L("extra_usage_format"), used, limit), .primary))
+            if cost.limit > 0 {
+                entries.append(.text(String(format: L("extra_usage_format"), used, limit), .primary))
+            }
         }
     }
 

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -281,11 +281,18 @@ struct ClaudeProviderImplementation: ProviderImplementation {
 
         if let cost = context.snapshot?.providerCost,
            context.settings.showOptionalCreditsAndExtraUsage,
-           cost.currencyCode != "Quota",
-           let balance = cost.balance
+           cost.currencyCode != "Quota"
         {
-            let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
-            entries.append(.text("\(L("Credits")): \(value)", .primary))
+            if cost.limit > 0 {
+                let used = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
+                let limit = UsageFormatter.currencyString(cost.limit, currencyCode: cost.currencyCode)
+                entries.append(.text(String(format: L("extra_usage_format"), used, limit), .primary))
+            }
+            if let balance = cost.balance {
+                let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
+                let label = cost.limit > 0 ? L("Balance") : L("Credits")
+                entries.append(.text("\(label): \(value)", .primary))
+            }
         }
     }
 

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -46,6 +46,11 @@ enum CLIRenderer {
             snapshot: snapshot,
             useColor: context.useColor,
             lines: &lines)
+        self.appendClaudeExtraUsageBalanceLine(
+            provider: provider,
+            snapshot: snapshot,
+            useColor: context.useColor,
+            lines: &lines)
         self.appendLimitsUnavailableLine(
             provider: provider,
             snapshot: snapshot,
@@ -105,6 +110,11 @@ enum CLIRenderer {
         self.appendDeepgramLines(snapshot: snapshot, useColor: context.useColor, lines: &lines)
         self.appendAmpBalanceLines(snapshot: snapshot, useColor: context.useColor, lines: &lines)
         self.appendDevinOverageBalanceLine(
+            provider: provider,
+            snapshot: snapshot,
+            useColor: context.useColor,
+            lines: &lines)
+        self.appendClaudeExtraUsageBalanceLine(
             provider: provider,
             snapshot: snapshot,
             useColor: context.useColor,
@@ -491,6 +501,11 @@ enum CLIRenderer {
             snapshot: snapshot,
             useColor: context.useColor,
             lines: &lines)
+        self.appendClaudeExtraUsageBalanceLine(
+            provider: provider,
+            snapshot: snapshot,
+            useColor: context.useColor,
+            lines: &lines)
         self.appendLimitsUnavailableLine(
             provider: provider,
             snapshot: snapshot,
@@ -587,7 +602,8 @@ enum CLIRenderer {
         guard
             provider != .clawrouter,
             let cost = snapshot.providerCost,
-            !(provider == .devin && cost.period == "Extra usage balance")
+            !(provider == .devin && cost.period == "Extra usage balance"),
+            !(provider == .claude && cost.used == 0 && cost.limit == 0 && cost.balance != nil)
         else { return }
         // Fallback to cost/quota display if no primary rate window.
         let label = cost.currencyCode == "Quota" ? "Quota" : "Cost"
@@ -636,6 +652,20 @@ enum CLIRenderer {
         else { return }
         let balance = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
         lines.append(self.labelValueLine("Extra usage", value: balance, useColor: useColor))
+    }
+
+    private static func appendClaudeExtraUsageBalanceLine(
+        provider: UsageProvider,
+        snapshot: UsageSnapshot,
+        useColor: Bool,
+        lines: inout [String])
+    {
+        guard provider == .claude,
+              let cost = snapshot.providerCost,
+              let balance = cost.balance
+        else { return }
+        let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
+        lines.append(self.labelValueLine("Extra usage balance", value: value, useColor: useColor))
     }
 
     private static func appendClawRouterUsageLines(

--- a/Sources/CodexBarCore/ProviderCostSnapshot.swift
+++ b/Sources/CodexBarCore/ProviderCostSnapshot.swift
@@ -14,6 +14,8 @@ public struct ProviderCostSnapshot: Equatable, Codable, Sendable {
     /// This account's own contribution when `used`/`limit` describe a shared/pooled budget
     /// (e.g. Cursor team on-demand pool). nil when the budget is already personal.
     public let personalUsed: Double?
+    /// Remaining prepaid balance, when the provider exposes it separately from spend and budget.
+    public let balance: Double?
     public let updatedAt: Date
 
     public init(
@@ -24,6 +26,7 @@ public struct ProviderCostSnapshot: Equatable, Codable, Sendable {
         resetsAt: Date? = nil,
         nextRegenAmount: Double? = nil,
         personalUsed: Double? = nil,
+        balance: Double? = nil,
         updatedAt: Date)
     {
         self.used = used
@@ -33,6 +36,20 @@ public struct ProviderCostSnapshot: Equatable, Codable, Sendable {
         self.resetsAt = resetsAt
         self.nextRegenAmount = nextRegenAmount
         self.personalUsed = personalUsed
+        self.balance = balance
         self.updatedAt = updatedAt
+    }
+
+    func replacing(balance: Double?) -> Self {
+        Self(
+            used: self.used,
+            limit: self.limit,
+            currencyCode: self.currencyCode,
+            period: self.period,
+            resetsAt: self.resetsAt,
+            nextRegenAmount: self.nextRegenAmount,
+            personalUsed: self.personalUsed,
+            balance: balance,
+            updatedAt: self.updatedAt)
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
@@ -44,6 +44,7 @@ public enum ClaudeOAuthFetchError: LocalizedError, Sendable {
 enum ClaudeOAuthUsageFetcher {
     private static let baseURL = "https://api.anthropic.com"
     private static let usagePath = "/api/oauth/usage"
+    private static let profilePath = "/api/oauth/profile"
     private static let betaHeader = "oauth-2025-04-20"
     private static let fallbackClaudeCodeVersion = "2.1.0"
 
@@ -104,6 +105,37 @@ enum ClaudeOAuthUsageFetcher {
         }
     }
 
+    static func fetchProfile(
+        accessToken: String,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> OAuthProfileResponse
+    {
+        guard let url = URL(string: self.baseURL + self.profilePath) else {
+            throw ClaudeOAuthFetchError.invalidResponse
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            let response = try await transport.response(for: request)
+            guard response.statusCode == 200 else {
+                let body = String(data: response.data, encoding: .utf8)
+                throw ClaudeOAuthFetchError.serverError(response.statusCode, body)
+            }
+            return try JSONDecoder().decode(OAuthProfileResponse.self, from: response.data)
+        } catch let error as ClaudeOAuthFetchError {
+            throw error
+        } catch is DecodingError {
+            throw ClaudeOAuthFetchError.invalidResponse
+        } catch {
+            throw ClaudeOAuthFetchError.networkError(error)
+        }
+    }
+
     static func decodeUsageResponse(_ data: Data) throws -> OAuthUsageResponse {
         let decoder = JSONDecoder()
         return try decoder.decode(OAuthUsageResponse.self, from: data)
@@ -156,6 +188,59 @@ enum ClaudeOAuthUsageFetcher {
         let token = raw.split(whereSeparator: \.isWhitespace).first.map(String.init) ?? raw
         let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+struct OAuthProfileResponse: Decodable, Sendable {
+    let emailAddress: String?
+    let organizationUuid: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        let account = try Self.decodeNestedContainer(in: container, key: "account")
+        let organization = try Self.decodeNestedContainer(in: container, key: "organization")
+        self.emailAddress =
+            account.flatMap { Self.decodeString(in: $0, keys: ["emailAddress", "email_address", "email"]) }
+                ?? Self.decodeString(in: container, keys: ["emailAddress", "email_address", "email"])
+        self.organizationUuid =
+            organization.flatMap { Self.decodeString(in: $0, keys: ["uuid"]) }
+                ?? Self.decodeString(in: container, keys: ["organizationUuid", "organization_uuid"])
+    }
+
+    init(emailAddress: String?, organizationUuid: String?) {
+        self.emailAddress = emailAddress
+        self.organizationUuid = organizationUuid
+    }
+
+    private static func decodeString(
+        in container: KeyedDecodingContainer<DynamicCodingKey>,
+        keys: [String]) -> String?
+    {
+        for keyName in keys {
+            guard let key = DynamicCodingKey(stringValue: keyName),
+                  let value = try? container.decodeIfPresent(String.self, forKey: key)
+            else {
+                continue
+            }
+            let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !normalized.isEmpty {
+                return normalized
+            }
+        }
+        return nil
+    }
+
+    private static func decodeNestedContainer(
+        in container: KeyedDecodingContainer<DynamicCodingKey>,
+        key keyName: String) throws -> KeyedDecodingContainer<DynamicCodingKey>?
+    {
+        guard let key = DynamicCodingKey(stringValue: keyName),
+              container.contains(key),
+              !((try? container.decodeNil(forKey: key)) ?? true)
+        else {
+            return nil
+        }
+        return try container.nestedContainer(keyedBy: DynamicCodingKey.self, forKey: key)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -57,7 +57,7 @@ public enum ClaudeProviderDescriptor {
 
         let planningInput = Self.makePlanningInput(context: context)
         let plan = ClaudeSourcePlanner.resolve(input: planningInput)
-        let manualCookieHeader = Self.manualCookieHeader(from: context)
+        let webEnrichmentAccess = Self.webEnrichmentAccess(context: context)
 
         return plan.orderedSteps.map { step in
             let strategy: any ProviderFetchStrategy = switch step.dataSource {
@@ -70,8 +70,12 @@ public enum ClaudeProviderDescriptor {
             case .cli:
                 ClaudeCLIFetchStrategy(
                     useWebExtras: context.runtime == .app
-                        && planningInput.webExtrasEnabled,
-                    manualCookieHeader: manualCookieHeader,
+                        && planningInput.webExtrasEnabled
+                        && webEnrichmentAccess.isAvailable,
+                    includePrepaidBalance: context.runtime == .app
+                        && context.includeOptionalUsage
+                        && webEnrichmentAccess.isAvailable,
+                    manualCookieHeader: webEnrichmentAccess.manualCookieHeader,
                     browserDetection: context.browserDetection,
                     hasWebFallback: planningInput.hasWebSession)
             case .auto:
@@ -131,6 +135,25 @@ public enum ClaudeProviderDescriptor {
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
         guard context.settings?.claude?.cookieSource == .manual else { return nil }
         return CookieHeaderNormalizer.normalize(context.settings?.claude?.manualCookieHeader)
+    }
+
+    fileprivate struct WebEnrichmentAccess {
+        let isAvailable: Bool
+        let manualCookieHeader: String?
+    }
+
+    fileprivate static func webEnrichmentAccess(context: ProviderFetchContext) -> WebEnrichmentAccess {
+        switch context.settings?.claude?.cookieSource {
+        case .off?:
+            return WebEnrichmentAccess(isAvailable: false, manualCookieHeader: nil)
+        case .manual?:
+            let header = self.manualCookieHeader(from: context)
+            return WebEnrichmentAccess(
+                isAvailable: ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: header),
+                manualCookieHeader: header)
+        case .auto?, nil:
+            return WebEnrichmentAccess(isAvailable: true, manualCookieHeader: nil)
+        }
     }
 
     private static func noDataMessage() -> String {
@@ -376,6 +399,13 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let webEnrichmentAccess = ClaudeProviderDescriptor.webEnrichmentAccess(context: context)
+        let useWebExtras = context.runtime == .app &&
+            (context.settings?.claude?.webExtrasEnabled ?? false) &&
+            webEnrichmentAccess.isAvailable
+        let includePrepaidBalance = context.runtime == .app &&
+            context.includeOptionalUsage &&
+            webEnrichmentAccess.isAvailable
         let fetcher = ClaudeUsageFetcher(
             browserDetection: context.browserDetection,
             environment: context.env,
@@ -383,7 +413,11 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
             dataSource: .oauth,
             oauthKeychainPromptCooldownEnabled: context.sourceMode == .auto,
             allowBackgroundDelegatedRefresh: false,
-            useWebExtras: false)
+            useWebExtras: useWebExtras,
+            manualCookieHeader: webEnrichmentAccess.manualCookieHeader,
+            webOrganizationID: context.settings?.claude?.organizationID,
+            webExtrasTimeout: context.webTimeout,
+            includePrepaidBalance: includePrepaidBalance)
         let usage = try await fetcher.loadLatestUsage(model: "sonnet")
         return ProviderFetchResult(
             usage: Self.snapshot(from: usage),
@@ -584,7 +618,8 @@ struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
                 dataSource: .web,
                 useWebExtras: false,
                 manualCookieHeader: Self.manualCookieHeader(from: context),
-                webOrganizationID: context.settings?.claude?.organizationID)
+                webOrganizationID: context.settings?.claude?.organizationID,
+                includePrepaidBalance: context.includeOptionalUsage)
             return try await fetcher.loadLatestUsage(model: "sonnet")
         }
         let race = BoundedTaskJoin(sourceTask: sourceTask)
@@ -637,6 +672,7 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
     let id: String = "claude.cli"
     let kind: ProviderFetchKind = .cli
     let useWebExtras: Bool
+    let includePrepaidBalance: Bool
     let manualCookieHeader: String?
     let browserDetection: BrowserDetection
     let hasWebFallback: Bool
@@ -673,6 +709,8 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
             useWebExtras: self.useWebExtras,
             manualCookieHeader: self.manualCookieHeader,
             webOrganizationID: context.settings?.claude?.organizationID,
+            webExtrasTimeout: context.webTimeout,
+            includePrepaidBalance: self.includePrepaidBalance && context.includeOptionalUsage,
             keepCLISessionsAlive: keepAlive)
         let usage = try await fetcher.loadLatestUsage(model: "sonnet")
         return self.makeResult(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -152,7 +152,10 @@ public enum ClaudeProviderDescriptor {
                 isAvailable: ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: header),
                 manualCookieHeader: header)
         case .auto?, nil:
-            return WebEnrichmentAccess(isAvailable: true, manualCookieHeader: nil)
+            let header = CookieHeaderCache.load(provider: .claude)?.cookieHeader
+            return WebEnrichmentAccess(
+                isAvailable: ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: header),
+                manualCookieHeader: header)
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -113,6 +113,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         let useWebExtras: Bool
         let manualCookieHeader: String?
         let webOrganizationID: String?
+        let webExtrasTimeout: TimeInterval
+        let includePrepaidBalance: Bool
         let keepCLISessionsAlive: Bool
         let browserDetection: BrowserDetection
     }
@@ -161,6 +163,14 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
 
     private var webOrganizationID: String? {
         self.configuration.webOrganizationID
+    }
+
+    private var webExtrasTimeout: TimeInterval {
+        self.configuration.webExtrasTimeout
+    }
+
+    private var includePrepaidBalance: Bool {
+        self.configuration.includePrepaidBalance
     }
 
     private var keepCLISessionsAlive: Bool {
@@ -248,6 +258,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
     @TaskLocal static var fetchOAuthUsageOverride: (@Sendable (
         String,
         Bool) async throws -> OAuthUsageResponse)?
+    @TaskLocal static var fetchOAuthProfileOverride: (@Sendable (String) async throws -> OAuthProfileResponse)?
     @TaskLocal static var delegatedRefreshAttemptOverride: (@Sendable (
         Date,
         TimeInterval,
@@ -270,6 +281,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         useWebExtras: Bool = false,
         manualCookieHeader: String? = nil,
         webOrganizationID: String? = nil,
+        webExtrasTimeout: TimeInterval = 15,
+        includePrepaidBalance: Bool = false,
         keepCLISessionsAlive: Bool = false)
     {
         self.configuration = Configuration(
@@ -281,6 +294,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             useWebExtras: useWebExtras,
             manualCookieHeader: manualCookieHeader,
             webOrganizationID: webOrganizationID,
+            webExtrasTimeout: webExtrasTimeout,
+            includePrepaidBalance: includePrepaidBalance,
             keepCLISessionsAlive: keepCLISessionsAlive,
             browserDetection: browserDetection)
     }
@@ -322,7 +337,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     detectClaudeVersion: self.fetcher.allowsOAuthClaudeVersionDetection)
                 let keychainMatch = ClaudeOAuthCredentialsStore
                     .claudeKeychainCredentialMatchWithoutPrompt(for: credentialRecord)
-                return try ClaudeUsageFetcher.mapOAuthUsage(
+                let snapshot = try ClaudeUsageFetcher.mapOAuthUsage(
                     usage,
                     credentials: credentials,
                     oauthKeychainPersistentRefHash: keychainMatch.persistentRefHash,
@@ -330,6 +345,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     oauthKeychainCredentialMismatch: keychainMatch.isMismatch,
                     oauthKeychainCredentialAbsent: keychainMatch.isAbsent,
                     oauthKeychainCredentialUnavailable: keychainMatch.isUnavailable)
+                return try await self.fetcher.applyWebExtrasIfNeeded(
+                    to: snapshot,
+                    oauthAccessToken: credentials.accessToken)
             } catch let error as CancellationError {
                 throw error
             } catch let error as ClaudeUsageError {
@@ -458,7 +476,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     detectClaudeVersion: self.fetcher.allowsOAuthClaudeVersionDetection)
                 let keychainMatch = ClaudeOAuthCredentialsStore
                     .claudeKeychainCredentialMatchWithoutPrompt(for: refreshedRecord)
-                return try ClaudeUsageFetcher.mapOAuthUsage(
+                let snapshot = try ClaudeUsageFetcher.mapOAuthUsage(
                     usage,
                     credentials: refreshedCredentials,
                     oauthKeychainPersistentRefHash: keychainMatch.persistentRefHash,
@@ -466,6 +484,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     oauthKeychainCredentialMismatch: keychainMatch.isMismatch,
                     oauthKeychainCredentialAbsent: keychainMatch.isAbsent,
                     oauthKeychainCredentialUnavailable: keychainMatch.isUnavailable)
+                return try await self.fetcher.applyWebExtrasIfNeeded(
+                    to: snapshot,
+                    oauthAccessToken: refreshedCredentials.accessToken)
             } catch {
                 ClaudeUsageFetcher.log.debug(
                     "Claude OAuth post-delegation retry failed",
@@ -503,10 +524,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             case .api:
                 throw ClaudeUsageError.parseFailed("Claude Admin API usage is handled by the provider descriptor.")
             case .oauth:
-                var snapshot = try await self.fetcher.loadViaOAuth(
+                return try await self.fetcher.loadViaOAuth(
                     allowDelegatedRetry: self.fetcher.allowsDelegatedOAuthRefresh)
-                snapshot = await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
-                return snapshot
             case .web:
                 return try await self.fetcher.loadViaWebAPI()
             case .cli:
@@ -579,10 +598,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             case .api:
                 throw ClaudeUsageError.parseFailed("Planner emitted invalid api execution step.")
             case .oauth:
-                var snapshot = try await self.fetcher.loadViaOAuth(
+                return try await self.fetcher.loadViaOAuth(
                     allowDelegatedRetry: self.fetcher.allowsDelegatedOAuthRefresh)
-                snapshot = await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
-                return snapshot
             case .web:
                 return try await self.fetcher.loadViaWebAPI()
             case .cli:
@@ -650,7 +667,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                 }
             }
             ClaudeCLIRateLimitGate.recordSuccess()
-            snapshot = await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
+            snapshot = try await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
             return snapshot
         }
 
@@ -883,6 +900,15 @@ extension ClaudeUsageFetcher {
         return try await ClaudeOAuthUsageFetcher.fetchUsage(
             accessToken: accessToken,
             detectClaudeVersion: detectClaudeVersion)
+    }
+
+    private static func fetchOAuthProfile(accessToken: String) async throws -> OAuthProfileResponse {
+        #if DEBUG
+        if let override = fetchOAuthProfileOverride {
+            return try await override(accessToken)
+        }
+        #endif
+        return try await ClaudeOAuthUsageFetcher.fetchProfile(accessToken: accessToken)
     }
 
     private static func attemptDelegatedRefresh(
@@ -1202,14 +1228,16 @@ extension ClaudeUsageFetcher {
             if let header = self.manualCookieHeader {
                 try await ClaudeWebAPIFetcher.fetchUsage(
                     cookieHeader: header,
-                    targetOrganizationID: self.webOrganizationID)
+                    targetOrganizationID: self.webOrganizationID,
+                    includePrepaidBalance: self.includePrepaidBalance)
                 { msg in
                     Self.log.debug(msg)
                 }
             } else {
                 try await ClaudeWebAPIFetcher.fetchUsage(
                     browserDetection: self.browserDetection,
-                    targetOrganizationID: self.webOrganizationID)
+                    targetOrganizationID: self.webOrganizationID,
+                    includePrepaidBalance: self.includePrepaidBalance)
                 { msg in
                     Self.log.debug(msg)
                 }
@@ -1342,30 +1370,75 @@ extension ClaudeUsageFetcher {
             rawText: snap.rawText)
     }
 
-    private func applyWebExtrasIfNeeded(to snapshot: ClaudeUsageSnapshot) async -> ClaudeUsageSnapshot {
-        guard self.useWebExtras, self.dataSource != .web else { return snapshot }
-        do {
+    private struct WebExtrasCandidate: Sendable {
+        let webData: ClaudeWebAPIFetcher.WebUsageData
+        let oauthProfile: OAuthProfileResponse?
+    }
+
+    private func applyWebExtrasIfNeeded(
+        to snapshot: ClaudeUsageSnapshot,
+        oauthAccessToken: String? = nil) async throws -> ClaudeUsageSnapshot
+    {
+        guard self.useWebExtras || self.includePrepaidBalance, self.dataSource != .web else { return snapshot }
+        guard self.webExtrasTimeout.isFinite,
+              self.webExtrasTimeout >= 0,
+              self.webExtrasTimeout <= TimeInterval(Int64.max)
+        else {
+            return snapshot
+        }
+
+        let sourceTask = Task<WebExtrasCandidate, Error> {
+            let oauthProfile: OAuthProfileResponse? = if let oauthAccessToken {
+                try await Self.fetchOAuthProfile(accessToken: oauthAccessToken)
+            } else {
+                nil
+            }
             let webData: ClaudeWebAPIFetcher.WebUsageData =
                 if let header = self.manualCookieHeader {
                     try await ClaudeWebAPIFetcher.fetchUsage(
                         cookieHeader: header,
-                        targetOrganizationID: self.webOrganizationID)
+                        targetOrganizationID: self.webOrganizationID,
+                        includeUsageDetails: self.useWebExtras,
+                        includePrepaidBalance: self.includePrepaidBalance)
                     { msg in
                         Self.log.debug(msg)
                     }
                 } else {
                     try await ClaudeWebAPIFetcher.fetchUsage(
                         browserDetection: self.browserDetection,
-                        targetOrganizationID: self.webOrganizationID)
+                        targetOrganizationID: self.webOrganizationID,
+                        includeUsageDetails: self.useWebExtras,
+                        includePrepaidBalance: self.includePrepaidBalance)
                     { msg in
                         Self.log.debug(msg)
                     }
                 }
+            return WebExtrasCandidate(webData: webData, oauthProfile: oauthProfile)
+        }
+
+        let race = BoundedTaskJoin(sourceTask: sourceTask)
+        switch await race.value(joinGrace: .seconds(self.webExtrasTimeout)) {
+        case let .value(candidate):
+            try Task.checkCancellation()
+            let webData = candidate.webData
+            guard Self.webExtrasAccountMatches(
+                snapshot: snapshot,
+                webData: webData,
+                oauthProfile: candidate.oauthProfile)
+            else {
+                Self.log.debug("Claude web extras account did not match primary usage account")
+                return snapshot
+            }
             // Only merge usage/cost extras; keep identity fields from the primary data source.
-            let mergedExtraRateWindows = Self.mergeExtraRateWindows(
-                primary: snapshot.extraRateWindows,
-                web: webData.extraRateWindows)
-            let mergedProviderCost = snapshot.providerCost ?? webData.extraUsageCost
+            let mergedExtraRateWindows = self.useWebExtras
+                ? Self.mergeExtraRateWindows(
+                    primary: snapshot.extraRateWindows,
+                    web: webData.extraRateWindows)
+                : snapshot.extraRateWindows
+            let mergedProviderCost = Self.mergeProviderCost(
+                primary: snapshot.providerCost,
+                web: webData.extraUsageCost,
+                includeUsageDetails: self.useWebExtras)
             if mergedProviderCost != snapshot.providerCost || mergedExtraRateWindows != snapshot.extraRateWindows {
                 return ClaudeUsageSnapshot(
                     primary: snapshot.primary,
@@ -1385,10 +1458,78 @@ extension ClaudeUsageFetcher {
                     oauthKeychainCredentialAbsent: snapshot.oauthKeychainCredentialAbsent,
                     oauthKeychainCredentialUnavailable: snapshot.oauthKeychainCredentialUnavailable)
             }
-        } catch {
+        case let .failure(error):
+            if error is CancellationError ||
+                (error as? URLError)?.code == .cancelled ||
+                Task.isCancelled
+            {
+                throw CancellationError()
+            }
             Self.log.debug("Claude web extras fetch failed: \(error.localizedDescription)")
+        case .timedOut:
+            try Task.checkCancellation()
+            Self.log.debug("Claude web extras fetch timed out")
         }
         return snapshot
+    }
+
+    static func webExtrasAccountMatches(
+        snapshot: ClaudeUsageSnapshot,
+        webData: ClaudeWebAPIFetcher.WebUsageData,
+        oauthProfile: OAuthProfileResponse?) -> Bool
+    {
+        let primaryEmail = Self.normalizedAccountField(oauthProfile?.emailAddress ?? snapshot.accountEmail)
+        let webEmail = Self.normalizedAccountField(webData.accountEmail)
+        if let primaryEmail, let webEmail, primaryEmail != webEmail {
+            return false
+        }
+
+        let primaryOrganization = Self.normalizedAccountField(
+            oauthProfile?.organizationUuid ?? snapshot.accountOrganization)
+        let webOrganization = Self.normalizedAccountField(
+            oauthProfile == nil ? webData.accountOrganization : webData.accountOrganizationID)
+        if let primaryOrganization, let webOrganization, primaryOrganization != webOrganization {
+            return false
+        }
+
+        let emailMatches = primaryEmail != nil && primaryEmail == webEmail
+        let organizationMatches = primaryOrganization != nil && primaryOrganization == webOrganization
+        return emailMatches || organizationMatches
+    }
+
+    private static func normalizedAccountField(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func mergeProviderCost(
+        primary: ProviderCostSnapshot?,
+        web: ProviderCostSnapshot?,
+        includeUsageDetails: Bool = true) -> ProviderCostSnapshot?
+    {
+        if !includeUsageDetails {
+            guard let web, let balance = web.balance else { return primary }
+            guard let primary else {
+                return ProviderCostSnapshot(
+                    used: 0,
+                    limit: 0,
+                    currencyCode: web.currencyCode,
+                    period: web.period,
+                    balance: balance,
+                    updatedAt: web.updatedAt)
+            }
+            guard primary.currencyCode.caseInsensitiveCompare(web.currencyCode) == .orderedSame else {
+                return primary
+            }
+            return primary.replacing(balance: balance)
+        }
+        guard let primary else { return web }
+        guard let web,
+              let balance = web.balance,
+              primary.currencyCode.caseInsensitiveCompare(web.currencyCode) == .orderedSame
+        else { return primary }
+        return primary.replacing(balance: balance)
     }
 
     private static func mergeExtraRateWindows(
@@ -1495,6 +1636,13 @@ extension ClaudeUsageFetcher {
 
 #if DEBUG
 extension ClaudeUsageFetcher {
+    public static func _mergeProviderCostForTesting(
+        primary: ProviderCostSnapshot?,
+        web: ProviderCostSnapshot?) -> ProviderCostSnapshot?
+    {
+        self.mergeProviderCost(primary: primary, web: web)
+    }
+
     public static func _mergeExtraRateWindowsForTesting(
         primary: [NamedRateWindow],
         web: [NamedRateWindow]) -> [NamedRateWindow]

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -19,6 +19,21 @@ enum ClaudeWebHTTPTransport {
     }
 }
 
+enum ClaudeWebPrepaidCreditsRequest {
+    private static let requestTimeout: Duration = .seconds(2)
+    #if DEBUG
+    @TaskLocal static var timeoutOverrideForTesting: Duration?
+    #endif
+
+    static var timeout: Duration {
+        #if DEBUG
+        self.timeoutOverrideForTesting ?? self.requestTimeout
+        #else
+        self.requestTimeout
+        #endif
+    }
+}
+
 enum ClaudeWebSessionKeyImport {
     #if DEBUG
     @TaskLocal static var overrideForTesting: ClaudeWebAPIFetcher.SessionKeyInfo?
@@ -107,6 +122,7 @@ private enum ClaudeWebBrowserFetchSerialization {
 /// API endpoints used:
 /// - `GET https://claude.ai/api/organizations` → get org UUID
 /// - `GET https://claude.ai/api/organizations/{org_id}/usage` → usage percentages + reset times
+/// - `GET https://claude.ai/api/organizations/{org_id}/prepaid/credits` → remaining Extra usage balance
 public enum ClaudeWebAPIFetcher {
     private static let baseURL = "https://claude.ai/api"
     private static let maxProbeBytes = 200_000
@@ -183,10 +199,11 @@ public enum ClaudeWebAPIFetcher {
         public let weeklyResetsAt: Date?
         public let opusPercentUsed: Double?
         public let extraRateWindows: [NamedRateWindow]
-        public let extraUsageCost: ProviderCostSnapshot?
-        public let accountOrganization: String?
-        public let accountEmail: String?
-        public let loginMethod: String?
+        public fileprivate(set) var extraUsageCost: ProviderCostSnapshot?
+        public fileprivate(set) var accountOrganization: String?
+        public fileprivate(set) var accountOrganizationID: String?
+        public fileprivate(set) var accountEmail: String?
+        public fileprivate(set) var loginMethod: String?
         /// Whether the API reported a `five_hour` session object. When `false` (the API sent
         /// `five_hour: null`, as enterprise/credit accounts with no live session do), `sessionPercentUsed`
         /// is the synthesized `0` placeholder rather than a real reading. Distinguishing this from a real
@@ -203,6 +220,7 @@ public enum ClaudeWebAPIFetcher {
             extraRateWindows: [NamedRateWindow],
             extraUsageCost: ProviderCostSnapshot?,
             accountOrganization: String?,
+            accountOrganizationID: String? = nil,
             accountEmail: String?,
             loginMethod: String?,
             hasLiveSessionWindow: Bool = true)
@@ -215,6 +233,7 @@ public enum ClaudeWebAPIFetcher {
             self.extraRateWindows = extraRateWindows
             self.extraUsageCost = extraUsageCost
             self.accountOrganization = accountOrganization
+            self.accountOrganizationID = accountOrganizationID
             self.accountEmail = accountEmail
             self.loginMethod = loginMethod
             self.hasLiveSessionWindow = hasLiveSessionWindow
@@ -232,6 +251,20 @@ public enum ClaudeWebAPIFetcher {
         public let bodyPreview: String?
     }
 
+    private struct CachePersistence {
+        let sourceLabel: String
+        let expectedObservation: CookieHeaderCache.ConditionalMutationObservation
+        let persistInitialSessionKey: Bool
+    }
+
+    private struct FetchOptions {
+        let targetOrganizationID: String?
+        let includeUsageDetails: Bool
+        let includePrepaidBalance: Bool
+    }
+}
+
+extension ClaudeWebAPIFetcher {
     // MARK: - Public API
 
     #if os(macOS)
@@ -241,12 +274,17 @@ public enum ClaudeWebAPIFetcher {
     public static func fetchUsage(
         browserDetection: BrowserDetection,
         targetOrganizationID: String? = nil,
+        includeUsageDetails: Bool = true,
+        includePrepaidBalance: Bool = true,
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
         try await ClaudeWebBrowserFetchSerialization.run {
             try await self.fetchUsageSerialized(
                 browserDetection: browserDetection,
-                targetOrganizationID: targetOrganizationID,
+                options: FetchOptions(
+                    targetOrganizationID: targetOrganizationID,
+                    includeUsageDetails: includeUsageDetails,
+                    includePrepaidBalance: includePrepaidBalance),
                 logger: logger)
         }
     }
@@ -254,6 +292,8 @@ public enum ClaudeWebAPIFetcher {
     public static func fetchUsage(
         cookieHeader: String,
         targetOrganizationID: String? = nil,
+        includeUsageDetails: Bool = true,
+        includePrepaidBalance: Bool = true,
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
         let log: (String) -> Void = { msg in logger?("[claude-web] \(msg)") }
@@ -261,44 +301,52 @@ public enum ClaudeWebAPIFetcher {
         log("Using manual session key (\(sessionInfo.cookieCount) cookies)")
         return try await self.fetchUsage(
             using: sessionInfo,
-            targetOrganizationID: targetOrganizationID,
-            logger: log)
+            options: FetchOptions(
+                targetOrganizationID: targetOrganizationID,
+                includeUsageDetails: includeUsageDetails,
+                includePrepaidBalance: includePrepaidBalance),
+            logger: log,
+            cachePersistence: nil)
     }
 
     public static func fetchUsage(
         using sessionKeyInfo: SessionKeyInfo,
         targetOrganizationID: String? = nil,
+        includeUsageDetails: Bool = true,
+        includePrepaidBalance: Bool = true,
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
         try await self.fetchUsage(
             using: sessionKeyInfo,
-            targetOrganizationID: targetOrganizationID,
+            options: FetchOptions(
+                targetOrganizationID: targetOrganizationID,
+                includeUsageDetails: includeUsageDetails,
+                includePrepaidBalance: includePrepaidBalance),
             logger: logger,
-            cacheSourceLabel: nil,
-            expectedCacheObservation: .authoritative(nil))
+            cachePersistence: nil)
     }
 
     private static func fetchUsageAndRenewCache(
         cachedEntry: CookieHeaderCache.Entry,
-        targetOrganizationID: String?,
+        options: FetchOptions,
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
         let sessionInfo = try self.sessionKeyInfo(cookieHeader: cachedEntry.cookieHeader)
         return try await self.fetchUsage(
             using: sessionInfo,
-            targetOrganizationID: targetOrganizationID,
+            options: options,
             logger: logger,
-            cacheSourceLabel: cachedEntry.sourceLabel,
-            expectedCacheObservation: .authoritative(cachedEntry))
+            cachePersistence: CachePersistence(
+                sourceLabel: cachedEntry.sourceLabel,
+                expectedObservation: .authoritative(cachedEntry),
+                persistInitialSessionKey: false))
     }
 
     private static func fetchUsage(
         using sessionKeyInfo: SessionKeyInfo,
-        targetOrganizationID: String?,
+        options: FetchOptions,
         logger: ((String) -> Void)?,
-        cacheSourceLabel: String?,
-        expectedCacheObservation: CookieHeaderCache.ConditionalMutationObservation,
-        persistInitialSessionKey: Bool = false) async throws -> WebUsageData
+        cachePersistence: CachePersistence?) async throws -> WebUsageData
     {
         let log: (String) -> Void = { msg in logger?(msg) }
         let sessionKey = sessionKeyInfo.key
@@ -307,7 +355,7 @@ public enum ClaudeWebAPIFetcher {
         // Fetch organization info
         let organization = try await fetchOrganizationInfo(
             sessionKey: sessionKey,
-            targetOrganizationID: targetOrganizationID,
+            targetOrganizationID: options.targetOrganizationID,
             logger: log,
             renewalTracker: renewalTracker)
         log("Organization resolved")
@@ -317,68 +365,54 @@ public enum ClaudeWebAPIFetcher {
             sessionKey: renewalTracker.sessionKey,
             logger: log,
             renewalTracker: renewalTracker)
-        if usage.extraUsageCost == nil,
-           let extra = await ClaudeWebExtraUsageCost.fetch(
+        usage.accountOrganizationID = organization.id
+        if !options.includeUsageDetails {
+            usage.extraUsageCost = nil
+        }
+        if options.includeUsageDetails,
+           usage.extraUsageCost == nil,
+           let extra = try await ClaudeWebExtraUsageCost.fetch(
                baseURL: Self.baseURL,
                orgId: organization.id,
                sessionKey: renewalTracker.sessionKey,
                logger: log,
                renewalTracker: renewalTracker)
         {
-            usage = WebUsageData(
-                sessionPercentUsed: usage.sessionPercentUsed,
-                sessionResetsAt: usage.sessionResetsAt,
-                weeklyPercentUsed: usage.weeklyPercentUsed,
-                weeklyResetsAt: usage.weeklyResetsAt,
-                opusPercentUsed: usage.opusPercentUsed,
-                extraRateWindows: usage.extraRateWindows,
-                extraUsageCost: extra,
-                accountOrganization: usage.accountOrganization,
-                accountEmail: usage.accountEmail,
-                loginMethod: usage.loginMethod,
-                hasLiveSessionWindow: usage.hasLiveSessionWindow)
+            usage.extraUsageCost = extra
         }
-        if let account = await fetchAccountInfo(
+        if options.includePrepaidBalance,
+           let balance = try await ClaudeWebExtraUsageCost.fetchPrepaidBalance(
+               baseURL: Self.baseURL,
+               orgId: organization.id,
+               sessionKey: renewalTracker.sessionKey,
+               logger: log,
+               renewalTracker: renewalTracker)
+        {
+            usage.extraUsageCost = ClaudeWebExtraUsageCost.applyingPrepaidBalance(
+                balance,
+                to: usage.extraUsageCost)
+        }
+        if let account = try await fetchAccountInfo(
             sessionKey: renewalTracker.sessionKey,
             orgId: organization.id,
             logger: log,
             renewalTracker: renewalTracker)
         {
-            usage = WebUsageData(
-                sessionPercentUsed: usage.sessionPercentUsed,
-                sessionResetsAt: usage.sessionResetsAt,
-                weeklyPercentUsed: usage.weeklyPercentUsed,
-                weeklyResetsAt: usage.weeklyResetsAt,
-                opusPercentUsed: usage.opusPercentUsed,
-                extraRateWindows: usage.extraRateWindows,
-                extraUsageCost: usage.extraUsageCost,
-                accountOrganization: usage.accountOrganization,
-                accountEmail: account.email,
-                loginMethod: account.loginMethod,
-                hasLiveSessionWindow: usage.hasLiveSessionWindow)
+            usage.accountEmail = account.email
+            usage.loginMethod = account.loginMethod
         }
         if usage.accountOrganization == nil, let name = organization.name {
-            usage = WebUsageData(
-                sessionPercentUsed: usage.sessionPercentUsed,
-                sessionResetsAt: usage.sessionResetsAt,
-                weeklyPercentUsed: usage.weeklyPercentUsed,
-                weeklyResetsAt: usage.weeklyResetsAt,
-                opusPercentUsed: usage.opusPercentUsed,
-                extraRateWindows: usage.extraRateWindows,
-                extraUsageCost: usage.extraUsageCost,
-                accountOrganization: name,
-                accountEmail: usage.accountEmail,
-                loginMethod: usage.loginMethod,
-                hasLiveSessionWindow: usage.hasLiveSessionWindow)
+            usage.accountOrganization = name
         }
-        if let cacheSourceLabel {
+        if let cachePersistence {
             self.persistSessionKeyIfNeeded(
-                source: (sessionKey, cacheSourceLabel),
+                source: (sessionKey, cachePersistence.sourceLabel),
                 renewedCookieHeader: renewalTracker.renewedCookieHeader,
-                expectedCacheObservation: expectedCacheObservation,
-                persistInitialSessionKey: persistInitialSessionKey,
+                expectedCacheObservation: cachePersistence.expectedObservation,
+                persistInitialSessionKey: cachePersistence.persistInitialSessionKey,
                 logger: log)
         }
+        try Task.checkCancellation()
         return usage
     }
 
@@ -697,6 +731,11 @@ public enum ClaudeWebAPIFetcher {
         ClaudeWebExtraUsageCost.parseOverageSpendLimit(data)
     }
 
+    public static func _parsePrepaidCreditsForTesting(_ data: Data) -> ProviderCostSnapshot? {
+        guard let balance = ClaudeWebExtraUsageCost.parsePrepaidBalance(data) else { return nil }
+        return ClaudeWebExtraUsageCost.applyingPrepaidBalance(balance, to: nil)
+    }
+
     public static func _parseAccountInfoForTesting(_ data: Data, orgId: String?) -> WebAccountInfo? {
         self.parseAccountInfo(data, orgId: orgId)
     }
@@ -791,7 +830,7 @@ public enum ClaudeWebAPIFetcher {
         sessionKey: String,
         orgId: String?,
         logger: ((String) -> Void)? = nil,
-        renewalTracker: ClaudeWebSessionKeyRenewalTracker? = nil) async -> WebAccountInfo?
+        renewalTracker: ClaudeWebSessionKeyRenewalTracker? = nil) async throws -> WebAccountInfo?
     {
         let url = URL(string: "\(baseURL)/account")!
         var request = URLRequest(url: url)
@@ -801,13 +840,18 @@ public enum ClaudeWebAPIFetcher {
         request.timeoutInterval = 15
 
         do {
-            let (data, response) = try await ClaudeWebHTTPTransport.current.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else { return nil }
-            renewalTracker?.observe(response: httpResponse)
-            logger?("Account API status: \(httpResponse.statusCode)")
-            guard httpResponse.statusCode == 200 else { return nil }
-            return Self.parseAccountInfo(data, orgId: orgId)
+            let response = try await ClaudeWebHTTPTransport.current.response(for: request)
+            renewalTracker?.observe(response: response.response)
+            logger?("Account API status: \(response.statusCode)")
+            guard response.statusCode == 200 else { return nil }
+            return Self.parseAccountInfo(response.data, orgId: orgId)
         } catch {
+            if error is CancellationError ||
+                (error as? URLError)?.code == .cancelled ||
+                Task.isCancelled
+            {
+                throw CancellationError()
+            }
             return nil
         }
     }
@@ -965,10 +1009,14 @@ public enum ClaudeWebAPIFetcher {
     public static func fetchUsage(
         browserDetection: BrowserDetection,
         targetOrganizationID: String? = nil,
+        includeUsageDetails: Bool = true,
+        includePrepaidBalance: Bool = true,
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
         _ = browserDetection
         _ = targetOrganizationID
+        _ = includeUsageDetails
+        _ = includePrepaidBalance
         _ = logger
         throw FetchError.notSupportedOnThisPlatform
     }
@@ -976,10 +1024,14 @@ public enum ClaudeWebAPIFetcher {
     public static func fetchUsage(
         cookieHeader: String,
         targetOrganizationID: String? = nil,
+        includeUsageDetails: Bool = true,
+        includePrepaidBalance: Bool = true,
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
         _ = cookieHeader
         _ = targetOrganizationID
+        _ = includeUsageDetails
+        _ = includePrepaidBalance
         _ = logger
         throw FetchError.notSupportedOnThisPlatform
     }
@@ -987,9 +1039,13 @@ public enum ClaudeWebAPIFetcher {
     public static func fetchUsage(
         using sessionKeyInfo: SessionKeyInfo,
         targetOrganizationID: String? = nil,
+        includeUsageDetails: Bool = true,
+        includePrepaidBalance: Bool = true,
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
         _ = targetOrganizationID
+        _ = includeUsageDetails
+        _ = includePrepaidBalance
         throw FetchError.notSupportedOnThisPlatform
     }
 
@@ -1126,6 +1182,16 @@ private final class ClaudeWebSessionKeyRenewalTracker: @unchecked Sendable {
 private enum ClaudeWebExtraUsageCost {
     // MARK: - Extra usage cost (Claude "Extra")
 
+    struct PrepaidBalance: Equatable, Sendable {
+        let amount: Double
+        let currencyCode: String
+    }
+
+    private struct PrepaidCreditsResponse: Decodable {
+        let amount: Double
+        let currency: String
+    }
+
     static func parse(from value: Any?) -> ProviderCostSnapshot? {
         guard let extraUsage = value as? [String: Any] else { return nil }
         guard let used = Self.doubleValue(extraUsage["used_credits"]),
@@ -1159,25 +1225,18 @@ private enum ClaudeWebExtraUsageCost {
         orgId: String,
         sessionKey: String,
         logger: ((String) -> Void)? = nil,
-        renewalTracker: ClaudeWebSessionKeyRenewalTracker? = nil) async -> ProviderCostSnapshot?
+        renewalTracker: ClaudeWebSessionKeyRenewalTracker? = nil) async throws -> ProviderCostSnapshot?
     {
-        let url = URL(string: "\(baseURL)/organizations/\(orgId)/overage_spend_limit")!
-        var request = URLRequest(url: url)
-        request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.httpMethod = "GET"
-        request.timeoutInterval = 15
-
-        do {
-            let (data, response) = try await ClaudeWebHTTPTransport.current.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else { return nil }
-            renewalTracker?.observe(response: httpResponse)
-            logger?("Overage API status: \(httpResponse.statusCode)")
-            guard httpResponse.statusCode == 200 else { return nil }
-            return Self.parseOverageSpendLimit(data)
-        } catch {
-            return nil
-        }
+        let data = try await Self.fetchBestEffortJSON(
+            request: BestEffortRequest(
+                url: URL(string: "\(baseURL)/organizations/\(orgId)/overage_spend_limit"),
+                requestTimeout: 15,
+                joinGrace: .seconds(15),
+                logLabel: "Overage"),
+            sessionKey: sessionKey,
+            logger: logger,
+            renewalTracker: renewalTracker)
+        return data.flatMap(Self.parseOverageSpendLimit)
     }
 
     static func parseOverageSpendLimit(_ data: Data) -> ProviderCostSnapshot? {
@@ -1192,6 +1251,101 @@ private enum ClaudeWebExtraUsageCost {
             usedCredits: used,
             monthlyCreditLimit: limit,
             currencyCode: currency)
+    }
+
+    /// Best-effort fetch of Claude's remaining prepaid Extra usage balance.
+    static func fetchPrepaidBalance(
+        baseURL: String,
+        orgId: String,
+        sessionKey: String,
+        logger: ((String) -> Void)? = nil,
+        renewalTracker: ClaudeWebSessionKeyRenewalTracker? = nil) async throws -> PrepaidBalance?
+    {
+        let data = try await Self.fetchBestEffortJSON(
+            request: BestEffortRequest(
+                url: URL(string: "\(baseURL)/organizations/\(orgId)/prepaid/credits"),
+                requestTimeout: 15,
+                joinGrace: ClaudeWebPrepaidCreditsRequest.timeout,
+                logLabel: "Prepaid credits"),
+            sessionKey: sessionKey,
+            logger: logger,
+            renewalTracker: renewalTracker)
+        return data.flatMap(Self.parsePrepaidBalance)
+    }
+
+    private static func fetchBestEffortJSON(
+        request spec: BestEffortRequest,
+        sessionKey: String,
+        logger: ((String) -> Void)?,
+        renewalTracker: ClaudeWebSessionKeyRenewalTracker?) async throws -> Data?
+    {
+        guard let url = spec.url else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpMethod = "GET"
+        request.timeoutInterval = spec.requestTimeout
+
+        let transport = ClaudeWebHTTPTransport.current
+        let sourceTask = Task<ProviderHTTPResponse, Error> {
+            try await transport.response(for: request)
+        }
+        let race = BoundedTaskJoin(sourceTask: sourceTask)
+        switch await race.value(joinGrace: spec.joinGrace) {
+        case let .value(payload):
+            try Task.checkCancellation()
+            renewalTracker?.observe(response: payload.response)
+            logger?("\(spec.logLabel) API status: \(payload.statusCode)")
+            guard payload.statusCode == 200 else { return nil }
+            return payload.data
+        case let .failure(error):
+            if error is CancellationError ||
+                (error as? URLError)?.code == .cancelled ||
+                Task.isCancelled
+            {
+                throw CancellationError()
+            }
+            return nil
+        case .timedOut:
+            try Task.checkCancellation()
+            return nil
+        }
+    }
+
+    static func parsePrepaidBalance(_ data: Data) -> PrepaidBalance? {
+        guard let response = try? JSONDecoder().decode(PrepaidCreditsResponse.self, from: data),
+              response.amount.isFinite,
+              response.amount >= 0
+        else { return nil }
+        let currency = response.currency.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        guard !currency.isEmpty else { return nil }
+        return PrepaidBalance(amount: response.amount / 100.0, currencyCode: currency)
+    }
+
+    static func applyingPrepaidBalance(
+        _ balance: PrepaidBalance,
+        to cost: ProviderCostSnapshot?) -> ProviderCostSnapshot
+    {
+        if let cost {
+            guard cost.currencyCode.caseInsensitiveCompare(balance.currencyCode) == .orderedSame else {
+                return cost
+            }
+            return cost.replacing(balance: balance.amount)
+        }
+        return ProviderCostSnapshot(
+            used: 0,
+            limit: 0,
+            currencyCode: balance.currencyCode,
+            period: "Extra usage",
+            balance: balance.amount,
+            updatedAt: Date())
+    }
+
+    private struct BestEffortRequest {
+        let url: URL?
+        let requestTimeout: TimeInterval
+        let joinGrace: Duration
+        let logLabel: String
     }
 
     static func makeExtraUsageCost(
@@ -1227,9 +1381,9 @@ private enum ClaudeWebExtraUsageCost {
 
 #if os(macOS)
 extension ClaudeWebAPIFetcher {
-    fileprivate static func fetchUsageSerialized(
+    private static func fetchUsageSerialized(
         browserDetection: BrowserDetection,
-        targetOrganizationID: String?,
+        options: FetchOptions,
         logger: ((String) -> Void)?) async throws -> WebUsageData
     {
         let log: (String) -> Void = { msg in logger?("[claude-web] \(msg)") }
@@ -1242,7 +1396,7 @@ extension ClaudeWebAPIFetcher {
             do {
                 return try await self.fetchUsageAndRenewCache(
                     cachedEntry: cached,
-                    targetOrganizationID: targetOrganizationID,
+                    options: options,
                     logger: log)
             } catch let error as FetchError {
                 switch error {
@@ -1262,11 +1416,12 @@ extension ClaudeWebAPIFetcher {
 
         return try await self.fetchUsage(
             using: sessionInfo,
-            targetOrganizationID: targetOrganizationID,
+            options: options,
             logger: log,
-            cacheSourceLabel: sessionInfo.sourceLabel,
-            expectedCacheObservation: cacheObservation,
-            persistInitialSessionKey: true)
+            cachePersistence: CachePersistence(
+                sourceLabel: sessionInfo.sourceLabel,
+                expectedObservation: cacheObservation,
+                persistInitialSessionKey: true))
     }
 }
 #endif

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -366,9 +366,6 @@ extension ClaudeWebAPIFetcher {
             logger: log,
             renewalTracker: renewalTracker)
         usage.accountOrganizationID = organization.id
-        if !options.includeUsageDetails {
-            usage.extraUsageCost = nil
-        }
         if options.includeUsageDetails,
            usage.extraUsageCost == nil,
            let extra = try await ClaudeWebExtraUsageCost.fetch(

--- a/Tests/CodexBarTests/CLIOutputTests.swift
+++ b/Tests/CodexBarTests/CLIOutputTests.swift
@@ -174,4 +174,61 @@ struct CLIOutputTests {
         #expect(text.contains("Plan: \(summary)"))
         #expect(!text.contains("Stale 34D"))
     }
+
+    @Test
+    func `text renderer includes Claude extra usage balance`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 5,
+                limit: 20,
+                currencyCode: "USD",
+                period: "Monthly cap",
+                balance: 100,
+                updatedAt: now),
+            updatedAt: now)
+
+        let text = CLIRenderer.renderText(
+            provider: .claude,
+            snapshot: snapshot,
+            credits: nil,
+            context: RenderContext(
+                header: "Claude (web)",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown))
+
+        #expect(text.contains("Extra usage balance: $100.00"))
+    }
+
+    @Test
+    func `text renderer does not show zero cost for Claude balance only snapshot`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 0,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Extra usage",
+                balance: 100,
+                updatedAt: now),
+            updatedAt: now)
+
+        let text = CLIRenderer.renderText(
+            provider: .claude,
+            snapshot: snapshot,
+            credits: nil,
+            context: RenderContext(
+                header: "Claude (web)",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown))
+
+        #expect(text.contains("Extra usage balance: $100.00"))
+        #expect(!text.contains("Cost: 0.0 / 0.0"))
+    }
 }

--- a/Tests/CodexBarTests/CLIWebFallbackTests.swift
+++ b/Tests/CodexBarTests/CLIWebFallbackTests.swift
@@ -167,11 +167,13 @@ struct CLIWebFallbackTests {
     func `claude CLI fallback is enabled only for app auto`() {
         let webAvailableStrategy = ClaudeCLIFetchStrategy(
             useWebExtras: false,
+            includePrepaidBalance: false,
             manualCookieHeader: nil,
             browserDetection: BrowserDetection(cacheTTL: 0),
             hasWebFallback: true)
         let webUnavailableStrategy = ClaudeCLIFetchStrategy(
             useWebExtras: false,
+            includePrepaidBalance: false,
             manualCookieHeader: nil,
             browserDetection: BrowserDetection(cacheTTL: 0),
             hasWebFallback: false)

--- a/Tests/CodexBarTests/ClaudeEducationAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeEducationAvailabilityTests.swift
@@ -9,6 +9,7 @@ struct ClaudeEducationAvailabilityTests {
         let browserDetection = BrowserDetection(cacheTTL: 0)
         let strategy = ClaudeCLIFetchStrategy(
             useWebExtras: false,
+            includePrepaidBalance: false,
             manualCookieHeader: "sessionKey=test-session",
             browserDetection: browserDetection,
             hasWebFallback: true)

--- a/Tests/CodexBarTests/ClaudeMenuCardCostTests.swift
+++ b/Tests/CodexBarTests/ClaudeMenuCardCostTests.swift
@@ -1,0 +1,137 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct ClaudeMenuCardCostTests {
+    @Test
+    func `claude credits card only shows balance`() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.claude])
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 5,
+                limit: 20,
+                currencyCode: "USD",
+                period: "Monthly cap",
+                balance: 100,
+                updatedAt: now),
+            updatedAt: now,
+            identity: nil)
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .claude,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.providerCost?.title == "Credits")
+        #expect(model.providerCost?.spendLine == "$100.00")
+        #expect(model.providerCost?.percentUsed == nil)
+        #expect(model.providerCost?.percentLine == nil)
+        #expect(model.providerCost?.presentation == .inlineValue)
+        #expect(model.providerCost?.showsInProviderDetails == false)
+    }
+
+    @Test
+    func `claude admin api spend remains visible without prepaid balance`() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.claude])
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 12.34,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Last 30 days",
+                updatedAt: now),
+            claudeAdminAPIUsage: ClaudeAdminAPIUsageSnapshot(daily: [], updatedAt: now),
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "admin@example.com",
+                accountOrganization: nil,
+                loginMethod: "Admin API"))
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .claude,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: false,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.providerCost?.title == "API spend")
+        #expect(model.providerCost?.spendLine == "Last 30 days: $12.34")
+        #expect(model.providerCost?.presentation == .detail)
+        #expect(model.providerCost?.showsInProviderDetails == true)
+    }
+
+    @Test
+    func `claude extra usage spend stays hidden when prepaid balance is unavailable`() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.claude])
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 0.42,
+                limit: 100,
+                currencyCode: "USD",
+                period: "Monthly cap",
+                updatedAt: now),
+            updatedAt: now)
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .claude,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.providerCost == nil)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeMenuCardCostTests.swift
+++ b/Tests/CodexBarTests/ClaudeMenuCardCostTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 struct ClaudeMenuCardCostTests {
     @Test
-    func `claude credits card only shows balance`() throws {
+    func `claude extra usage card shows balance above monthly cap`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.claude])
         let snapshot = UsageSnapshot(
@@ -42,8 +42,54 @@ struct ClaudeMenuCardCostTests {
             hidePersonalInfo: false,
             now: now))
 
+        #expect(model.providerCost?.title == "Extra usage")
+        #expect(model.providerCost?.balanceLine == "Balance: $100.00")
+        #expect(model.providerCost?.spendLine == "Monthly cap: $5.00 / $20.00")
+        #expect(model.providerCost?.percentUsed == 25)
+        #expect(model.providerCost?.percentLine == "25% used")
+        #expect(model.providerCost?.presentation == .detail)
+        #expect(model.providerCost?.showsInProviderDetails == false)
+    }
+
+    @Test
+    func `claude balance only card stays compact`() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.claude])
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 0,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Usage credits",
+                balance: 100,
+                updatedAt: now),
+            updatedAt: now)
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .claude,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
         #expect(model.providerCost?.title == "Credits")
         #expect(model.providerCost?.spendLine == "$100.00")
+        #expect(model.providerCost?.balanceLine == nil)
         #expect(model.providerCost?.percentUsed == nil)
         #expect(model.providerCost?.percentLine == nil)
         #expect(model.providerCost?.presentation == .inlineValue)
@@ -98,15 +144,15 @@ struct ClaudeMenuCardCostTests {
     }
 
     @Test
-    func `claude extra usage spend stays hidden when prepaid balance is unavailable`() throws {
+    func `claude monthly cap stays visible when prepaid balance is unavailable`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.claude])
         let snapshot = UsageSnapshot(
             primary: nil,
             secondary: nil,
             providerCost: ProviderCostSnapshot(
-                used: 0.42,
-                limit: 100,
+                used: 0.49,
+                limit: 50,
                 currencyCode: "USD",
                 period: "Monthly cap",
                 updatedAt: now),
@@ -132,6 +178,13 @@ struct ClaudeMenuCardCostTests {
             hidePersonalInfo: false,
             now: now))
 
-        #expect(model.providerCost == nil)
+        #expect(model.providerCost?.title == "Extra usage")
+        #expect(model.providerCost?.balanceLine == nil)
+        #expect(model.providerCost?.spendLine == "Monthly cap: $0.49 / $50.00")
+        let percentUsed = try #require(model.providerCost?.percentUsed)
+        #expect(abs(percentUsed - 0.98) < 0.0001)
+        #expect(model.providerCost?.percentLine == "1% used")
+        #expect(model.providerCost?.presentation == .detail)
+        #expect(model.providerCost?.showsInProviderDetails == false)
     }
 }

--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -159,7 +159,8 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                 sourceLabel: "Browser",
                 cookieCount: 1)
             let transport = ProviderHTTPTransportHandler { request in
-                Issue.record("Unexpected Claude browser-cookie discovery request: \(request.url?.absoluteString ?? "nil")")
+                let url = request.url?.absoluteString ?? "nil"
+                Issue.record("Unexpected Claude browser-cookie discovery request: \(url)")
                 throw URLError(.badServerResponse)
             }
             let loadCredentials: @Sendable (
@@ -802,7 +803,8 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
     private func withIsolatedCookieCache<T>(_ operation: () async throws -> T) async rethrows -> T {
         let legacyBase = FileManager.default.temporaryDirectory
             .appendingPathComponent("claude-oauth-enrichment-\(UUID().uuidString)", isDirectory: true)
-        return try await KeychainCacheStore.withServiceOverrideForTesting("claude-oauth-enrichment-\(UUID().uuidString)") {
+        let service = "claude-oauth-enrichment-\(UUID().uuidString)"
+        return try await KeychainCacheStore.withServiceOverrideForTesting(service) {
             try await CookieHeaderCache.withLegacyBaseURLOverrideForTesting(legacyBase) {
                 KeychainCacheStore.setTestStoreForTesting(true)
                 defer { KeychainCacheStore.setTestStoreForTesting(false) }

--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -21,17 +21,21 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
 
     private func makeContext(
         sourceMode: ProviderSourceMode,
-        env: [String: String] = [:]) -> ProviderFetchContext
+        env: [String: String] = [:],
+        settings: ProviderSettingsSnapshot? = nil,
+        includeOptionalUsage: Bool = true,
+        webTimeout: TimeInterval = 1) -> ProviderFetchContext
     {
         ProviderFetchContext(
             runtime: .app,
             sourceMode: sourceMode,
             includeCredits: false,
-            webTimeout: 1,
+            includeOptionalUsage: includeOptionalUsage,
+            webTimeout: webTimeout,
             webDebugDumpHTML: false,
             verbose: false,
             env: env,
-            settings: nil,
+            settings: settings,
             fetcher: UsageFetcher(environment: env),
             claudeFetcher: StubClaudeFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0))
@@ -47,6 +51,287 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
                 rateLimitTier: nil),
             owner: owner,
             source: .cacheKeychain)
+    }
+
+    @Test
+    func `O auth strategy enriches usage with web balance when optional usage is enabled`() async throws {
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .auto,
+            webExtrasEnabled: false,
+            cookieSource: .manual,
+            manualCookieHeader: "sessionKey=sk-ant-session-token"))
+        let context = self.makeContext(sourceMode: .auto, settings: settings)
+        let credentials = ClaudeOAuthCredentials(
+            accessToken: "oauth-token",
+            refreshToken: nil,
+            expiresAt: Date(timeIntervalSinceNow: 3600),
+            scopes: ["user:profile"],
+            rateLimitTier: "claude_pro")
+        let usageResponse = try ClaudeOAuthUsageFetcher._decodeUsageResponseForTesting(Data("""
+        {
+          "five_hour": { "utilization": 7 },
+          "extra_usage": {
+            "is_enabled": true,
+            "monthly_limit": 2000,
+            "used_credits": 500,
+            "currency": "USD"
+          }
+        }
+        """.utf8))
+        let transport = ProviderHTTPTransportHandler { request in
+            let url = try #require(request.url)
+            let body: String
+            let statusCode: Int
+            switch url.path {
+            case "/api/organizations":
+                body = #"[{"uuid":"org-123","name":"Test Org","capabilities":["chat"]}]"#
+                statusCode = 200
+            case "/api/organizations/org-123/usage":
+                body = #"{"five_hour":{"utilization":44}}"#
+                statusCode = 200
+            case "/api/organizations/org-123/prepaid/credits":
+                body = #"{"amount":10000,"currency":"USD"}"#
+                statusCode = 200
+            case "/api/account":
+                body = """
+                {
+                  "email_address": "user@example.com",
+                  "memberships": [{"organization": {"uuid": "org-123"}}]
+                }
+                """
+                statusCode = 200
+            default:
+                body = "{}"
+                statusCode = 404
+            }
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]))
+            return (Data(body.utf8), response)
+        }
+        let loadCredentials: @Sendable (
+            [String: String],
+            Bool,
+            Bool) async throws -> ClaudeOAuthCredentials = { _, _, _ in credentials }
+        let fetchUsage: @Sendable (String, Bool) async throws -> OAuthUsageResponse = { _, _ in usageResponse }
+        let fetchProfile: @Sendable (String) async throws -> OAuthProfileResponse = { _ in
+            OAuthProfileResponse(emailAddress: "user@example.com", organizationUuid: "org-123")
+        }
+
+        let result = try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+            try await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(loadCredentials) {
+                try await ClaudeUsageFetcher.$fetchOAuthUsageOverride.withValue(fetchUsage) {
+                    try await ClaudeUsageFetcher.$fetchOAuthProfileOverride.withValue(fetchProfile) {
+                        try await ClaudeOAuthFetchStrategy().fetch(context)
+                    }
+                }
+            }
+        }
+
+        #expect(result.usage.primary?.usedPercent == 7)
+        #expect(result.usage.providerCost?.used == 5)
+        #expect(result.usage.providerCost?.limit == 20)
+        #expect(result.usage.providerCost?.balance == 100)
+    }
+
+    @Test
+    func `blank manual cookie does not fall back to browser enrichment`() async throws {
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .oauth,
+            webExtrasEnabled: true,
+            cookieSource: .manual,
+            manualCookieHeader: "   "))
+        let context = self.makeContext(sourceMode: .oauth, settings: settings)
+        let credentials = ClaudeOAuthCredentials(
+            accessToken: "oauth-token",
+            refreshToken: nil,
+            expiresAt: Date(timeIntervalSinceNow: 3600),
+            scopes: ["user:profile"],
+            rateLimitTier: "claude_pro")
+        let usageResponse = try ClaudeOAuthUsageFetcher._decodeUsageResponseForTesting(Data("""
+        {
+          "five_hour": { "utilization": 7 }
+        }
+        """.utf8))
+        let transport = ProviderHTTPTransportHandler { request in
+            Issue.record("Unexpected Claude web request: \(request.url?.absoluteString ?? "nil")")
+            throw URLError(.badServerResponse)
+        }
+        let loadCredentials: @Sendable (
+            [String: String],
+            Bool,
+            Bool) async throws -> ClaudeOAuthCredentials = { _, _, _ in credentials }
+        let fetchUsage: @Sendable (String, Bool) async throws -> OAuthUsageResponse = { _, _ in usageResponse }
+
+        let result = try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+            try await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(loadCredentials) {
+                try await ClaudeUsageFetcher.$fetchOAuthUsageOverride.withValue(fetchUsage) {
+                    try await ClaudeOAuthFetchStrategy().fetch(context)
+                }
+            }
+        }
+
+        #expect(result.usage.primary?.usedPercent == 7)
+        #expect(result.usage.providerCost == nil)
+    }
+
+    @Test
+    func `O auth web enrichment timeout preserves completed usage`() async throws {
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .oauth,
+            webExtrasEnabled: false,
+            cookieSource: .manual,
+            manualCookieHeader: "sessionKey=sk-ant-session-token"))
+        let context = self.makeContext(
+            sourceMode: .oauth,
+            settings: settings,
+            webTimeout: 0.02)
+        let credentials = ClaudeOAuthCredentials(
+            accessToken: "oauth-token",
+            refreshToken: nil,
+            expiresAt: Date(timeIntervalSinceNow: 3600),
+            scopes: ["user:profile"],
+            rateLimitTier: "claude_pro")
+        let usageResponse = try ClaudeOAuthUsageFetcher._decodeUsageResponseForTesting(Data("""
+        {"five_hour":{"utilization":7}}
+        """.utf8))
+        let transport = ProviderHTTPTransportHandler { request in
+            let url = try #require(request.url)
+            if url.path == "/api/organizations" {
+                try await Task.sleep(for: .seconds(10))
+                throw CancellationError()
+            }
+            throw URLError(.badServerResponse)
+        }
+        let loadCredentials: @Sendable (
+            [String: String],
+            Bool,
+            Bool) async throws -> ClaudeOAuthCredentials = { _, _, _ in credentials }
+        let fetchUsage: @Sendable (String, Bool) async throws -> OAuthUsageResponse = { _, _ in usageResponse }
+        let fetchProfile: @Sendable (String) async throws -> OAuthProfileResponse = { _ in
+            OAuthProfileResponse(emailAddress: "user@example.com", organizationUuid: "org-123")
+        }
+
+        let result = try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+            try await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(loadCredentials) {
+                try await ClaudeUsageFetcher.$fetchOAuthUsageOverride.withValue(fetchUsage) {
+                    try await ClaudeUsageFetcher.$fetchOAuthProfileOverride.withValue(fetchProfile) {
+                        try await ClaudeOAuthFetchStrategy().fetch(context)
+                    }
+                }
+            }
+        }
+
+        #expect(result.usage.primary?.usedPercent == 7)
+        #expect(result.usage.providerCost?.balance == nil)
+    }
+
+    @Test
+    func `auto CLI fallback enriches usage with matching web balance`() async throws {
+        let cliPath = try Self.makeExecutableClaudeStub()
+        defer { try? FileManager.default.removeItem(atPath: cliPath) }
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .auto,
+            webExtrasEnabled: false,
+            cookieSource: .manual,
+            manualCookieHeader: "sessionKey=sk-ant-session-token"))
+        let context = self.makeContext(
+            sourceMode: .auto,
+            env: ["CLAUDE_CLI_PATH": cliPath],
+            settings: settings)
+        let unavailableOAuthRecord = ClaudeOAuthCredentialRecord(
+            credentials: ClaudeOAuthCredentials(
+                accessToken: "oauth-token-without-profile-scope",
+                refreshToken: nil,
+                expiresAt: Date(timeIntervalSinceNow: 3600),
+                scopes: ["user:inference"],
+                rateLimitTier: nil),
+            owner: .claudeCLI,
+            source: .environment)
+        let transport = ProviderHTTPTransportHandler { request in
+            let url = try #require(request.url)
+            let body: String
+            let statusCode: Int
+            switch url.path {
+            case "/api/organizations":
+                body = #"[{"uuid":"org-123","name":"Test Org","capabilities":["chat"]}]"#
+                statusCode = 200
+            case "/api/organizations/org-123/usage":
+                body = #"{"five_hour":{"utilization":44}}"#
+                statusCode = 200
+            case "/api/organizations/org-123/prepaid/credits":
+                body = #"{"amount":10000,"currency":"USD"}"#
+                statusCode = 200
+            case "/api/account":
+                body = """
+                {
+                  "email_address": "user@example.com",
+                  "memberships": [{"organization": {"uuid": "org-123"}}]
+                }
+                """
+                statusCode = 200
+            default:
+                body = "{}"
+                statusCode = 404
+            }
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]))
+            return (Data(body.utf8), response)
+        }
+        let cliFetch: @Sendable (String, TimeInterval, Bool) async throws -> ClaudeStatusSnapshot = { _, _, _ in
+            ClaudeStatusSnapshot(
+                sessionPercentLeft: 93,
+                weeklyPercentLeft: nil,
+                opusPercentLeft: nil,
+                accountEmail: "user@example.com",
+                accountOrganization: "Test Org",
+                loginMethod: "Pro",
+                primaryResetDescription: nil,
+                secondaryResetDescription: nil,
+                opusResetDescription: nil,
+                rawText: "stub")
+        }
+
+        func fetchResult(context: ProviderFetchContext) async throws -> ProviderFetchResult {
+            let outcome = await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+                await ClaudeOAuthFetchStrategy.$nonInteractiveCredentialRecordOverride.withValue(
+                    unavailableOAuthRecord)
+                {
+                    await ClaudeOAuthFetchStrategy.$claudeCLIAvailableOverride.withValue(true) {
+                        await ClaudeOAuthKeychainAccessGate.withShouldAllowPromptOverrideForTesting(false) {
+                            await ClaudeStatusProbe.$fetchOverride.withValue(cliFetch) {
+                                await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                                    await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                                        context: context,
+                                        provider: .claude)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return try outcome.result.get()
+        }
+
+        let result = try await fetchResult(context: context)
+
+        #expect(result.strategyID == "claude.cli")
+        #expect(result.usage.primary?.usedPercent == 7)
+        #expect(result.usage.providerCost?.balance == 100)
+
+        let hiddenResult = try await fetchResult(context: self.makeContext(
+            sourceMode: .auto,
+            env: ["CLAUDE_CLI_PATH": cliPath],
+            settings: settings,
+            includeOptionalUsage: false))
+        #expect(hiddenResult.strategyID == "claude.cli")
+        #expect(hiddenResult.usage.primary?.usedPercent == 7)
+        #expect(hiddenResult.usage.providerCost == nil)
     }
 
     @Test
@@ -452,6 +737,14 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
 
     private var ordinaryOAuthKeychainPayload: Data {
         Data(#"{"claudeAiOauth":{"accessToken":"fixture"}}"#.utf8)
+    }
+
+    private static func makeExecutableClaudeStub() throws -> String {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-extra-credit-\(UUID().uuidString)")
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
     }
 
     private func expiredCLIAvailability(

--- a/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthFetchStrategyAvailabilityTests.swift
@@ -137,6 +137,58 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
     }
 
     @Test
+    func `auto without cached web session publishes O auth usage without browser discovery`() async throws {
+        try await self.withIsolatedCookieCache {
+            let settings = ProviderSettingsSnapshot.make(claude: .init(
+                usageDataSource: .auto,
+                webExtrasEnabled: false,
+                cookieSource: .auto,
+                manualCookieHeader: nil))
+            let context = self.makeContext(sourceMode: .auto, settings: settings)
+            let credentials = ClaudeOAuthCredentials(
+                accessToken: "oauth-token",
+                refreshToken: nil,
+                expiresAt: Date(timeIntervalSinceNow: 3600),
+                scopes: ["user:profile"],
+                rateLimitTier: "claude_pro")
+            let usageResponse = try ClaudeOAuthUsageFetcher._decodeUsageResponseForTesting(Data("""
+            {"five_hour":{"utilization":7}}
+            """.utf8))
+            let importedSession = ClaudeWebAPIFetcher.SessionKeyInfo(
+                key: "sk-ant-browser-session",
+                sourceLabel: "Browser",
+                cookieCount: 1)
+            let transport = ProviderHTTPTransportHandler { request in
+                Issue.record("Unexpected Claude browser-cookie discovery request: \(request.url?.absoluteString ?? "nil")")
+                throw URLError(.badServerResponse)
+            }
+            let loadCredentials: @Sendable (
+                [String: String],
+                Bool,
+                Bool) async throws -> ClaudeOAuthCredentials = { _, _, _ in credentials }
+            let fetchUsage: @Sendable (String, Bool) async throws -> OAuthUsageResponse = { _, _ in usageResponse }
+            let fetchProfile: @Sendable (String) async throws -> OAuthProfileResponse = { _ in
+                OAuthProfileResponse(emailAddress: "user@example.com", organizationUuid: "org-123")
+            }
+
+            let result = try await ClaudeWebSessionKeyImport.$overrideForTesting.withValue(importedSession) {
+                try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+                    try await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(loadCredentials) {
+                        try await ClaudeUsageFetcher.$fetchOAuthUsageOverride.withValue(fetchUsage) {
+                            try await ClaudeUsageFetcher.$fetchOAuthProfileOverride.withValue(fetchProfile) {
+                                try await ClaudeOAuthFetchStrategy().fetch(context)
+                            }
+                        }
+                    }
+                }
+            }
+
+            #expect(result.usage.primary?.usedPercent == 7)
+            #expect(result.usage.providerCost == nil)
+        }
+    }
+
+    @Test
     func `blank manual cookie does not fall back to browser enrichment`() async throws {
         let settings = ProviderSettingsSnapshot.make(claude: .init(
             usageDataSource: .oauth,
@@ -745,6 +797,20 @@ struct ClaudeOAuthFetchStrategyAvailabilityTests {
         try Data("#!/bin/sh\nexit 0\n".utf8).write(to: url)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
         return url.path
+    }
+
+    private func withIsolatedCookieCache<T>(_ operation: () async throws -> T) async rethrows -> T {
+        let legacyBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-oauth-enrichment-\(UUID().uuidString)", isDirectory: true)
+        return try await KeychainCacheStore.withServiceOverrideForTesting("claude-oauth-enrichment-\(UUID().uuidString)") {
+            try await CookieHeaderCache.withLegacyBaseURLOverrideForTesting(legacyBase) {
+                KeychainCacheStore.setTestStoreForTesting(true)
+                defer { KeychainCacheStore.setTestStoreForTesting(false) }
+                CookieHeaderCache.resetDisplayCacheForTesting()
+                defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+                return try await operation()
+            }
+        }
     }
 
     private func expiredCLIAvailability(

--- a/Tests/CodexBarTests/ClaudeOAuthTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthTests.swift
@@ -115,6 +115,42 @@ struct ClaudeOAuthTests {
     }
 
     @Test
+    func `O auth profile request decodes nested account identity`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]))
+            let body = """
+            {
+              "account": {
+                "uuid": "account-123",
+                "email": "user@example.com"
+              },
+              "organization": {
+                "uuid": "org-123"
+              }
+            }
+            """
+            return (Data(body.utf8), response)
+        }
+
+        let profile = try await ClaudeOAuthUsageFetcher.fetchProfile(
+            accessToken: "oauth-token",
+            transport: transport)
+
+        #expect(profile.emailAddress == "user@example.com")
+        #expect(profile.organizationUuid == "org-123")
+        let request = try #require(await transport.requests().first)
+        #expect(request.url?.absoluteString == "https://api.anthropic.com/api/oauth/profile")
+        #expect(request.httpMethod == "GET")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer oauth-token")
+        #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+    }
+
+    @Test
     func `maps O auth subscription type when rate limit tier is generic`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/ClaudeProviderImplementationTests.swift
+++ b/Tests/CodexBarTests/ClaudeProviderImplementationTests.swift
@@ -35,13 +35,50 @@ struct ClaudeProviderImplementationTests {
             context: Self.context(snapshot: snapshot, showOptionalUsage: true),
             entries: &visibleEntries)
 
-        guard case let .text(title, style) = try #require(visibleEntries.first) else {
+        guard case let .text(extraUsageTitle, extraUsageStyle) = try #require(visibleEntries.first),
+              case let .text(balanceTitle, balanceStyle) = try #require(visibleEntries.last)
+        else {
+            Issue.record("Expected Claude extra usage and prepaid balance menu text")
+            return
+        }
+        #expect(extraUsageTitle == "Extra usage: $5.00 / $20.00")
+        #expect(extraUsageStyle == .primary)
+        #expect(balanceTitle == "Balance: $100.00")
+        #expect(balanceStyle == .primary)
+        #expect(visibleEntries.count == 2)
+    }
+
+    @Test
+    func `prepaid balance without monthly cap stays a compact credits entry`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: nil),
+            providerCost: ProviderCostSnapshot(
+                used: 0,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Usage credits",
+                balance: 100,
+                updatedAt: now),
+            updatedAt: now)
+
+        var entries: [ProviderMenuEntry] = []
+        try ClaudeProviderImplementation().appendUsageMenuEntries(
+            context: Self.context(snapshot: snapshot, showOptionalUsage: true),
+            entries: &entries)
+
+        guard case let .text(title, style) = try #require(entries.first) else {
             Issue.record("Expected Claude prepaid balance menu text")
             return
         }
         #expect(title == "Credits: $100.00")
         #expect(style == .primary)
-        #expect(visibleEntries.count == 1)
+        #expect(entries.count == 1)
     }
 
     private static func context(

--- a/Tests/CodexBarTests/ClaudeProviderImplementationTests.swift
+++ b/Tests/CodexBarTests/ClaudeProviderImplementationTests.swift
@@ -1,0 +1,86 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct ClaudeProviderImplementationTests {
+    @Test
+    func `prepaid balance respects optional usage setting`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: nil),
+            providerCost: ProviderCostSnapshot(
+                used: 0,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Extra usage",
+                balance: 100,
+                updatedAt: now),
+            updatedAt: now)
+
+        var hiddenEntries: [ProviderMenuEntry] = []
+        try ClaudeProviderImplementation().appendUsageMenuEntries(
+            context: Self.context(snapshot: snapshot, showOptionalUsage: false),
+            entries: &hiddenEntries)
+        #expect(hiddenEntries.isEmpty)
+
+        var visibleEntries: [ProviderMenuEntry] = []
+        try ClaudeProviderImplementation().appendUsageMenuEntries(
+            context: Self.context(snapshot: snapshot, showOptionalUsage: true),
+            entries: &visibleEntries)
+
+        guard case let .text(title, style) = try #require(visibleEntries.first) else {
+            Issue.record("Expected Claude prepaid balance menu text")
+            return
+        }
+        #expect(title == "Extra usage balance: $100.00")
+        #expect(style == .primary)
+        #expect(visibleEntries.count == 1)
+    }
+
+    private static func context(
+        snapshot: UsageSnapshot,
+        showOptionalUsage: Bool) throws -> ProviderMenuUsageContext
+    {
+        let suite = "ClaudeProviderImplementationTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.showOptionalCreditsAndExtraUsage = showOptionalUsage
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
+
+        return ProviderMenuUsageContext(
+            provider: .claude,
+            store: store,
+            settings: settings,
+            metadata: ClaudeProviderDescriptor.descriptor.metadata,
+            snapshot: snapshot)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeProviderImplementationTests.swift
+++ b/Tests/CodexBarTests/ClaudeProviderImplementationTests.swift
@@ -16,10 +16,10 @@ struct ClaudeProviderImplementationTests {
                 resetsAt: nil,
                 resetDescription: nil),
             providerCost: ProviderCostSnapshot(
-                used: 0,
-                limit: 0,
+                used: 5,
+                limit: 20,
                 currencyCode: "USD",
-                period: "Extra usage",
+                period: "Monthly cap",
                 balance: 100,
                 updatedAt: now),
             updatedAt: now)
@@ -39,7 +39,7 @@ struct ClaudeProviderImplementationTests {
             Issue.record("Expected Claude prepaid balance menu text")
             return
         }
-        #expect(title == "Extra usage balance: $100.00")
+        #expect(title == "Credits: $100.00")
         #expect(style == .primary)
         #expect(visibleEntries.count == 1)
     }

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -119,6 +119,49 @@ struct ClaudeWebCookieRenewalTests {
     }
 
     @Test
+    func `balance enrichment preserves extra usage cost from usage response`() async throws {
+        let paths = RequestHeaderLog()
+        try await self.withClaudeWebStub { request in
+            let url = try #require(request.url)
+            paths.append(url.path)
+            switch url.path {
+            case "/api/organizations/org-123/usage":
+                return Self.jsonResponse(
+                    url: url,
+                    body: """
+                    {
+                      "five_hour": { "utilization": 11 },
+                      "extra_usage": {
+                        "is_enabled": true,
+                        "monthly_limit": 10000,
+                        "used_credits": 42,
+                        "currency": "USD"
+                      }
+                    }
+                    """,
+                    setCookie: nil)
+            case "/api/organizations/org-123/prepaid/credits":
+                return Self.jsonResponse(
+                    url: url,
+                    body: #"{"amount":9958,"currency":"USD"}"#,
+                    setCookie: nil)
+            default:
+                return try Self.response(for: request, setCookie: nil)
+            }
+        } operation: {
+            let usage = try await ClaudeWebAPIFetcher.fetchUsage(
+                cookieHeader: "sessionKey=sk-ant-manual-token",
+                includeUsageDetails: false,
+                includePrepaidBalance: true)
+
+            #expect(usage.extraUsageCost?.used == 0.42)
+            #expect(usage.extraUsageCost?.limit == 100)
+            #expect(usage.extraUsageCost?.balance == 99.58)
+            #expect(!paths.values.contains("/api/organizations/org-123/overage_spend_limit"))
+        }
+    }
+
+    @Test
     func `web fetch skips prepaid credits when optional usage is disabled`() async throws {
         let paths = RequestHeaderLog()
         try await self.withClaudeWebStub { request in

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -5,6 +5,136 @@ import Testing
 @Suite(.serialized)
 struct ClaudeWebCookieRenewalTests {
     @Test
+    func `stalled prepaid credits request does not fail completed usage`() async throws {
+        let probe = ClaudePrepaidRequestProbe()
+        let transport = ProviderHTTPTransportHandler { request in
+            let url = try #require(request.url)
+            if url.path == "/api/organizations/org-123/prepaid/credits" {
+                try await probe.stallUntilCancelled()
+            }
+            let (response, data) = try Self.response(for: request, setCookie: nil)
+            return (data, response)
+        }
+        let usage = try await ClaudeWebPrepaidCreditsRequest.$timeoutOverrideForTesting.withValue(
+            .milliseconds(20))
+        {
+            try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+                try await ClaudeWebAPIFetcher.fetchUsage(
+                    cookieHeader: "sessionKey=sk-ant-manual-token")
+            }
+        }
+
+        #expect(usage.sessionPercentUsed == 11)
+        #expect(usage.extraUsageCost?.balance == nil)
+        #expect(await probe.waitForCancellation())
+    }
+
+    @Test
+    func `caller cancellation during prepaid credits request is propagated`() async {
+        let probe = ClaudePrepaidRequestProbe()
+        let transport = ProviderHTTPTransportHandler { request in
+            let url = try #require(request.url)
+            if url.path == "/api/organizations/org-123/prepaid/credits" {
+                try await probe.stallUntilCancelled()
+            }
+            let (response, data) = try Self.response(for: request, setCookie: nil)
+            return (data, response)
+        }
+        let fetchTask = Task {
+            try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+                try await ClaudeWebAPIFetcher.fetchUsage(
+                    cookieHeader: "sessionKey=sk-ant-manual-token")
+            }
+        }
+
+        await probe.waitUntilStarted()
+        fetchTask.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await fetchTask.value
+        }
+        #expect(await probe.waitForCancellation())
+    }
+
+    @Test
+    func `web fetch merges prepaid credits into Claude extra usage cost`() async throws {
+        try await self.withClaudeWebStub { request in
+            let url = try #require(request.url)
+            if url.path == "/api/organizations/org-123/prepaid/credits" {
+                return Self.jsonResponse(
+                    url: url,
+                    body: #"{"amount":10000,"currency":"USD"}"#,
+                    setCookie: nil)
+            }
+            if url.path == "/api/organizations/org-123/usage" {
+                return Self.jsonResponse(
+                    url: url,
+                    body: """
+                    {
+                      "five_hour": { "utilization": 11 },
+                      "extra_usage": {
+                        "is_enabled": true,
+                        "monthly_limit": 2000,
+                        "used_credits": 500,
+                        "currency": "USD"
+                      }
+                    }
+                    """,
+                    setCookie: nil)
+            }
+            return try Self.response(for: request, setCookie: nil)
+        } operation: {
+            let usage = try await ClaudeWebAPIFetcher.fetchUsage(
+                cookieHeader: "sessionKey=sk-ant-manual-token")
+
+            #expect(usage.extraUsageCost?.balance == 100)
+            #expect(usage.extraUsageCost?.currencyCode == "USD")
+        }
+    }
+
+    @Test
+    func `balance only fetch skips legacy overage request`() async throws {
+        let paths = RequestHeaderLog()
+        try await self.withClaudeWebStub { request in
+            let url = try #require(request.url)
+            paths.append(url.path)
+            if url.path == "/api/organizations/org-123/prepaid/credits" {
+                return Self.jsonResponse(
+                    url: url,
+                    body: #"{"amount":10000,"currency":"USD"}"#,
+                    setCookie: nil)
+            }
+            return try Self.response(for: request, setCookie: nil)
+        } operation: {
+            let usage = try await ClaudeWebAPIFetcher.fetchUsage(
+                cookieHeader: "sessionKey=sk-ant-manual-token",
+                includeUsageDetails: false,
+                includePrepaidBalance: true)
+
+            #expect(usage.extraUsageCost?.balance == 100)
+            #expect(usage.extraUsageCost?.used == 0)
+            #expect(usage.extraUsageCost?.limit == 0)
+            #expect(!paths.values.contains("/api/organizations/org-123/overage_spend_limit"))
+        }
+    }
+
+    @Test
+    func `web fetch skips prepaid credits when optional usage is disabled`() async throws {
+        let paths = RequestHeaderLog()
+        try await self.withClaudeWebStub { request in
+            paths.append(request.url?.path)
+            return try Self.response(for: request, setCookie: nil)
+        } operation: {
+            let usage = try await ClaudeWebAPIFetcher.fetchUsage(
+                cookieHeader: "sessionKey=sk-ant-manual-token",
+                includePrepaidBalance: false)
+
+            #expect(usage.sessionPercentUsed == 11)
+            #expect(!paths.values.contains("/api/organizations/org-123/prepaid/credits"))
+        }
+    }
+
+    @Test
     func `cached web session key renews from set cookie after successful fetch`() async throws {
         try await self.withIsolatedCookieCache {
             CookieHeaderCache.store(
@@ -226,7 +356,7 @@ struct ClaudeWebCookieRenewalTests {
     }
 
     @Test
-    func `usage response renewal propagates to later requests and cache`() async throws {
+    func `usage and prepaid response renewals propagate to later requests and cache`() async throws {
         try await self.withIsolatedCookieCache {
             CookieHeaderCache.store(
                 provider: .claude,
@@ -235,6 +365,7 @@ struct ClaudeWebCookieRenewalTests {
             defer { CookieHeaderCache.clear(provider: .claude) }
             let usageCookies = RequestHeaderLog()
             let overageCookies = RequestHeaderLog()
+            let prepaidCookies = RequestHeaderLog()
             let accountCookies = RequestHeaderLog()
 
             try await self.withClaudeWebStub { request in
@@ -244,22 +375,39 @@ struct ClaudeWebCookieRenewalTests {
                     usageCookies.append(request.value(forHTTPHeaderField: "Cookie"))
                 case "/api/organizations/org-123/overage_spend_limit":
                     overageCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                case "/api/organizations/org-123/prepaid/credits":
+                    prepaidCookies.append(request.value(forHTTPHeaderField: "Cookie"))
                 case "/api/account":
                     accountCookies.append(request.value(forHTTPHeaderField: "Cookie"))
                 default:
                     break
                 }
+                let setCookie: String? = switch path {
+                case "/api/organizations/org-123/usage":
+                    Self.renewedSessionCookie
+                case "/api/organizations/org-123/prepaid/credits":
+                    "sessionKey=sk-ant-prepaid-token; Path=/; HttpOnly"
+                default:
+                    nil
+                }
+                if path == "/api/organizations/org-123/prepaid/credits" {
+                    return try Self.jsonResponse(
+                        url: #require(request.url),
+                        body: #"{"amount":10000,"currency":"USD"}"#,
+                        setCookie: setCookie)
+                }
                 return try Self.response(
                     for: request,
-                    setCookie: path == "/api/organizations/org-123/usage" ? Self.renewedSessionCookie : nil)
+                    setCookie: setCookie)
             } operation: {
                 _ = try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
 
                 #expect(usageCookies.values == ["sessionKey=sk-ant-old-token"])
                 #expect(overageCookies.values == ["sessionKey=sk-ant-renewed-token"])
-                #expect(accountCookies.values == ["sessionKey=sk-ant-renewed-token"])
+                #expect(prepaidCookies.values == ["sessionKey=sk-ant-renewed-token"])
+                #expect(accountCookies.values == ["sessionKey=sk-ant-prepaid-token"])
                 let cached = try #require(CookieHeaderCache.load(provider: .claude))
-                #expect(cached.cookieHeader == "sessionKey=sk-ant-renewed-token")
+                #expect(cached.cookieHeader == "sessionKey=sk-ant-prepaid-token")
             }
         }
     }
@@ -426,6 +574,43 @@ struct ClaudeWebCookieRenewalTests {
             httpVersion: "HTTP/1.1",
             headerFields: headerFields)!
         return (response, Data(body.utf8))
+    }
+}
+
+private actor ClaudePrepaidRequestProbe {
+    private var started = false
+    private var cancelled = false
+    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func stallUntilCancelled() async throws {
+        self.started = true
+        for waiter in self.startedWaiters {
+            waiter.resume()
+        }
+        self.startedWaiters.removeAll()
+
+        do {
+            try await Task.sleep(for: .seconds(10))
+        } catch {
+            self.cancelled = true
+            throw error
+        }
+        throw CancellationError()
+    }
+
+    func waitUntilStarted() async {
+        if self.started { return }
+        await withCheckedContinuation { continuation in
+            self.startedWaiters.append(continuation)
+        }
+    }
+
+    func waitForCancellation() async -> Bool {
+        for _ in 0..<100 {
+            if self.cancelled { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return self.cancelled
     }
 }
 

--- a/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebFetchDeadlineTests.swift
@@ -4,6 +4,47 @@ import Testing
 
 struct ClaudeWebFetchDeadlineTests {
     @Test
+    func `prepaid timeout preserves usage before outer web deadline`() async throws {
+        let context = Self.makeContext(sourceMode: .web, webTimeout: 0.5)
+        let transport = ProviderHTTPTransportHandler { request in
+            let url = try #require(request.url)
+            let body: String
+            let statusCode: Int
+            switch url.path {
+            case "/api/organizations":
+                body = #"[{"uuid":"org-123","name":"Test Org","capabilities":["chat"]}]"#
+                statusCode = 200
+            case "/api/organizations/org-123/usage":
+                body = #"{"five_hour":{"utilization":11}}"#
+                statusCode = 200
+            case "/api/organizations/org-123/prepaid/credits":
+                try await Task.sleep(for: .seconds(10))
+                throw CancellationError()
+            default:
+                body = "{}"
+                statusCode = 404
+            }
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]))
+            return (Data(body.utf8), response)
+        }
+        let strategy = ClaudeWebFetchStrategy(browserDetection: context.browserDetection)
+        let result = try await ClaudeWebPrepaidCreditsRequest.$timeoutOverrideForTesting.withValue(
+            .milliseconds(20))
+        {
+            try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+                try await strategy.fetch(context)
+            }
+        }
+
+        #expect(result.usage.primary?.usedPercent == 11)
+        #expect(result.usage.providerCost?.balance == nil)
+    }
+
+    @Test
     func `CLI auto descriptor defers browser probe and falls back after web deadline`() async throws {
         let planningProbe = ClaudeWebPlanningAvailabilityProbe()
         let webProbe = ClaudeWebDeadlineProbe()

--- a/Tests/CodexBarTests/ClaudeWebUsageExtraWindowTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebUsageExtraWindowTests.swift
@@ -17,6 +17,125 @@ struct ClaudeWebUsageExtraWindowTests {
     }
 
     @Test
+    func `parses Claude prepaid credits in minor units`() throws {
+        let data = Data(#"{"amount":10000,"currency":"usd"}"#.utf8)
+        let cost = try #require(ClaudeWebAPIFetcher._parsePrepaidCreditsForTesting(data))
+
+        #expect(cost.balance == 100)
+        #expect(cost.currencyCode == "USD")
+        #expect(cost.used == 0)
+        #expect(cost.limit == 0)
+    }
+
+    @Test
+    func `rejects invalid Claude prepaid credit balances`() {
+        let negative = Data(#"{"amount":-1,"currency":"USD"}"#.utf8)
+        let missingCurrency = Data(#"{"amount":10000}"#.utf8)
+        let booleanAmount = Data(#"{"amount":true,"currency":"USD"}"#.utf8)
+
+        #expect(ClaudeWebAPIFetcher._parsePrepaidCreditsForTesting(negative) == nil)
+        #expect(ClaudeWebAPIFetcher._parsePrepaidCreditsForTesting(missingCurrency) == nil)
+        #expect(ClaudeWebAPIFetcher._parsePrepaidCreditsForTesting(booleanAmount) == nil)
+    }
+
+    @Test
+    func `merges Claude prepaid balance into primary O auth cost`() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let primary = ProviderCostSnapshot(
+            used: 5,
+            limit: 20,
+            currencyCode: "USD",
+            period: "Monthly cap",
+            updatedAt: now)
+        let web = ProviderCostSnapshot(
+            used: 0,
+            limit: 0,
+            currencyCode: "usd",
+            period: "Extra usage",
+            balance: 100,
+            updatedAt: now.addingTimeInterval(1))
+
+        let merged = try #require(ClaudeUsageFetcher._mergeProviderCostForTesting(
+            primary: primary,
+            web: web))
+
+        #expect(merged.used == 5)
+        #expect(merged.limit == 20)
+        #expect(merged.period == "Monthly cap")
+        #expect(merged.balance == 100)
+        #expect(merged.updatedAt == now)
+    }
+
+    @Test
+    func `does not merge Claude prepaid balance with a different currency`() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let primary = ProviderCostSnapshot(
+            used: 5,
+            limit: 20,
+            currencyCode: "USD",
+            period: "Monthly cap",
+            updatedAt: now)
+        let web = ProviderCostSnapshot(
+            used: 0,
+            limit: 0,
+            currencyCode: "EUR",
+            period: "Extra usage",
+            balance: 100,
+            updatedAt: now)
+
+        let merged = try #require(ClaudeUsageFetcher._mergeProviderCostForTesting(
+            primary: primary,
+            web: web))
+
+        #expect(merged == primary)
+    }
+
+    @Test
+    func `web extras require the same Claude account and organization`() {
+        let snapshot = ClaudeUsageSnapshot(
+            primary: RateWindow(usedPercent: 7, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            opus: nil,
+            providerCost: nil,
+            updatedAt: Date(),
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: "Pro",
+            rawText: nil)
+        let webData = ClaudeWebAPIFetcher.WebUsageData(
+            sessionPercentUsed: 7,
+            sessionResetsAt: nil,
+            weeklyPercentUsed: nil,
+            weeklyResetsAt: nil,
+            opusPercentUsed: nil,
+            extraRateWindows: [],
+            extraUsageCost: nil,
+            accountOrganization: "Test Org",
+            accountOrganizationID: "org-123",
+            accountEmail: "user@example.com",
+            loginMethod: "Pro")
+
+        #expect(ClaudeUsageFetcher.webExtrasAccountMatches(
+            snapshot: snapshot,
+            webData: webData,
+            oauthProfile: OAuthProfileResponse(
+                emailAddress: "user@example.com",
+                organizationUuid: "org-123")))
+        #expect(!ClaudeUsageFetcher.webExtrasAccountMatches(
+            snapshot: snapshot,
+            webData: webData,
+            oauthProfile: OAuthProfileResponse(
+                emailAddress: "other@example.com",
+                organizationUuid: "org-123")))
+        #expect(!ClaudeUsageFetcher.webExtrasAccountMatches(
+            snapshot: snapshot,
+            webData: webData,
+            oauthProfile: OAuthProfileResponse(
+                emailAddress: "user@example.com",
+                organizationUuid: "org-other")))
+    }
+
+    @Test
     func `ignores merged claude web API omelette usage window`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -776,6 +776,7 @@ struct ClaudeMenuCardCostTests {
                 limit: 20,
                 currencyCode: "USD",
                 period: "Monthly cap",
+                balance: 100,
                 updatedAt: now),
             updatedAt: now,
             identity: nil)
@@ -801,6 +802,7 @@ struct ClaudeMenuCardCostTests {
             now: now))
 
         #expect(model.providerCost?.spendLine == "Monthly cap: $5.00 / $20.00")
+        #expect(model.providerCost?.balanceLine == "Balance: $100.00")
     }
 }
 

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -762,50 +762,6 @@ struct MiniMaxMenuCardModelTests {
     }
 }
 
-struct ClaudeMenuCardCostTests {
-    @Test
-    func `claude extra usage labels monthly denominator as cap`() throws {
-        let now = Date()
-        let metadata = try #require(ProviderDefaults.metadata[.claude])
-        let snapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            tertiary: nil,
-            providerCost: ProviderCostSnapshot(
-                used: 5,
-                limit: 20,
-                currencyCode: "USD",
-                period: "Monthly cap",
-                balance: 100,
-                updatedAt: now),
-            updatedAt: now,
-            identity: nil)
-
-        let model = UsageMenuCardView.Model.make(.init(
-            provider: .claude,
-            metadata: metadata,
-            snapshot: snapshot,
-            credits: nil,
-            creditsError: nil,
-            dashboard: nil,
-            dashboardError: nil,
-            tokenSnapshot: nil,
-            tokenError: nil,
-            account: AccountInfo(email: nil, plan: nil),
-            isRefreshing: false,
-            lastError: nil,
-            usageBarsShowUsed: false,
-            resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
-            showOptionalCreditsAndExtraUsage: true,
-            hidePersonalInfo: false,
-            now: now))
-
-        #expect(model.providerCost?.spendLine == "Monthly cap: $5.00 / $20.00")
-        #expect(model.providerCost?.balanceLine == "Balance: $100.00")
-    }
-}
-
 struct MenuCardModelTests {
     @Test
     func `builds metrics using remaining percent`() throws {

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -67,8 +67,10 @@ Admin API key setup:
   - Claude CLI Keychain bootstrap/repair fallback: `Claude Code-credentials`.
 - On Claude Code 2.1.x, `Claude Code-credentials` may contain only MCP server OAuth state (`mcpOAuth`) with no `claudeAiOauth`. CodexBar treats that as an OAuth configuration error, does not run background delegated `claude /status` refresh, and surfaces re-auth guidance. Use Web or CLI usage source, or restore a valid Claude OAuth keychain entry. See #1844.
 - Requires `user:profile` scope (CLI tokens with only `user:inference` cannot call usage).
-- Endpoint:
+- Endpoints:
   - `GET https://api.anthropic.com/api/oauth/usage`
+  - `GET https://api.anthropic.com/api/oauth/profile` → account identity used to verify that optional Web enrichment
+    belongs to the same Claude account.
 - Headers:
   - `Authorization: Bearer <access_token>`
   - `anthropic-beta: oauth-2025-04-20`
@@ -108,11 +110,13 @@ Admin API key setup:
   - `GET https://claude.ai/api/organizations` → org UUID.
   - `GET https://claude.ai/api/organizations/{orgId}/usage` → session/weekly/opus.
   - `GET https://claude.ai/api/organizations/{orgId}/overage_spend_limit` → Extra usage spend/limit.
+  - `GET https://claude.ai/api/organizations/{orgId}/prepaid/credits` → remaining Usage credits balance.
   - `GET https://claude.ai/api/account` → email + plan hints.
 - Outputs:
   - Session + weekly + model-specific percent used.
   - Daily Routines extra window when returned by the usage API.
   - Extra usage spend/limit (if enabled).
+  - Remaining Usage credits balance (if enabled).
   - Account email + inferred plan.
 
 ## claude-swap accounts (opt-in)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -121,7 +121,8 @@ See `docs/configuration.md` for the schema.
     - Codex web: OpenAI web dashboard (usage limits, credits remaining, code review remaining, usage breakdown).
         - `--web-timeout <seconds>` (default: 60)
         - `--web-debug-dump-html` (writes HTML snapshots to `/tmp` when data is missing)
-    - Claude web: claude.ai API (session + weekly usage, plus account metadata when available).
+    - Claude web: claude.ai API (session + weekly usage, account metadata, and prepaid Usage credits balance when
+      available).
     - Command Code web: commandcode.ai browser session cookies on macOS, or a configured manual cookie on Linux, for monthly credit usage.
     - OpenCode Go auto: local SQLite usage on macOS and Linux, with optional manual-cookie web enrichment.
     - Kilo auto: app.kilo.ai API first, then CLI auth fallback (`~/.local/share/kilo/auth.json`) on missing/unauthorized API credentials.

--- a/docs/refactor/claude-current-baseline.md
+++ b/docs/refactor/claude-current-baseline.md
@@ -119,9 +119,12 @@ Current routing rules:
 
 ## Siloing and web-enrichment baseline
 
-Claude Web enrichment is cost-only when the primary source is OAuth or CLI:
+Claude Web enrichment is usage-extra-only when the primary source is OAuth or CLI:
 
-- Web extras may populate `providerCost` when it is missing.
+- Web extras may add optional rate windows and may populate `providerCost` when it is missing.
+- A matching prepaid balance may enrich an existing `providerCost` without replacing its spend/limit values.
+- OAuth enrichment calls `GET /api/oauth/profile`; Web data is merged only when the email or organization UUID
+  matches the primary Claude account.
 - Web extras must not replace `accountEmail`, `accountOrganization`, or `loginMethod` from the primary source.
 - Snapshot identity remains provider-scoped to Claude.
 


### PR DESCRIPTION
## Summary

- fetch Claude's remaining prepaid Usage credits balance from the web API
- preserve Claude's existing Extra usage spent/cap display and show the prepaid balance right-aligned on the same header row
- retain the compact Credits presentation when no monthly cap is configured, along with legacy-menu and CLI output
- enrich OAuth and Auto/CLI results only when the Claude web account matches
- keep balance-only enrichment bounded, cancellable, and independent of legacy web-extras fetching

## Why

CodexBar could show Claude Extra usage spent/cap values but not the remaining prepaid balance. Claude exposes that balance separately in minor currency units, so this adds the missing field without treating it as another quota denominator.

Related: #975.

## Validation

- `swift test --filter 'ClaudeWebCookieRenewalTests|ClaudeOAuthFetchStrategyAvailabilityTests|ClaudeOAuthTests|ClaudeWebFetchDeadlineTests|ClaudeWebUsageExtraWindowTests|ClaudeProviderImplementationTests|CLIOutputTests|ClaudeMenuCardCostTests|MenuCardHeightFingerprintTests|PreferencesPaneSmokeTests'` — 136 tests passed across 11 suites
- `swift test --filter 'ClaudeMenuCardCostTests|ClaudeProviderImplementationTests'` — 6 tests passed across 2 suites
- `make check`
- `make test` — stopped in three Keychain credential-store suites not modified by this PR; the focused feature tests pass separately

## Screenshot
<img width="308" height="73" alt="Screenshot 2026-07-25 at 10 56 11 AM" src="https://github.com/user-attachments/assets/9cd24b2a-6655-411b-a113-e52688f8aed9" />
