### PR TITLE
Fix Claude sign-in menu state

### DIFF
--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -552,12 +552,14 @@ struct MenuDescriptor {
         let targetProvider = provider ?? store.enabledProviders().first
         let metadata = targetProvider.map { store.metadata(for: $0) }
         let fallbackAccount = targetProvider.map { store.accountInfo(for: $0) } ?? account
+        let hasAccount = self.hasAccount(for: targetProvider, store: store, account: fallbackAccount)
         let loginContext = targetProvider.map {
             ProviderMenuLoginContext(
                 provider: $0,
                 store: store,
                 settings: store.settings,
-                account: fallbackAccount)
+                account: fallbackAccount,
+                hasAccount: hasAccount)
         }
 
         // Show "Add Account" if no account, "Switch Account" if logged in
@@ -571,7 +573,6 @@ struct MenuDescriptor {
                 entries.append(.action(override.label, override.action))
             } else {
                 let loginAction = self.switchAccountTarget(for: provider, store: store)
-                let hasAccount = self.hasAccount(for: provider, store: store, account: fallbackAccount)
                 let accountLabel = hasAccount ? L("Switch Account...") : L("Add Account...")
                 entries.append(.action(accountLabel, loginAction))
             }

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -648,8 +648,15 @@ struct MenuDescriptor {
 
     private static func hasAccount(for provider: UsageProvider?, store: UsageStore, account: AccountInfo) -> Bool {
         let target = provider ?? store.enabledProviders().first ?? .codex
-        if let email = store.snapshot(for: target)?.accountEmail(for: target),
+        let snapshot = store.snapshot(for: target)
+        if let email = snapshot?.accountEmail(for: target),
            !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return true
+        }
+        if target == .claude,
+           snapshot?.identity(for: .claude) != nil,
+           snapshot?.hasRateLimitWindows == true
         {
             return true
         }

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -321,6 +321,7 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         if self.shouldOpenTerminalForOAuthError(store: context.store) {
             return ("Open Terminal", .openTerminal(command: "claude"))
         }
+        guard !context.hasAccount else { return nil }
         return (L("Sign in with Claude Code..."), .switchAccount(.claude))
     }
 

--- a/Sources/CodexBar/Providers/Shared/ProviderMenuContext.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderMenuContext.swift
@@ -25,4 +25,5 @@ struct ProviderMenuLoginContext {
     let store: UsageStore
     let settings: SettingsStore
     let account: AccountInfo
+    let hasAccount: Bool
 }

--- a/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
@@ -29,6 +29,7 @@ struct ClaudeWebRecoveryMenuTests {
         source: ClaudeUsageDataSource,
         cookieSource: ProviderCookieSource = .auto,
         selectedSessionKey: Bool = false,
+        authenticatedAccountEmail: String? = nil,
         attempts: [ProviderFetchAttempt] = []) -> [(String, MenuDescriptor.MenuAction)]
     {
         let settings = self.makeSettings()
@@ -42,6 +43,19 @@ struct ClaudeWebRecoveryMenuTests {
             fetcher: fetcher,
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings)
+        if let authenticatedAccountEmail {
+            store._setSnapshotForTesting(
+                UsageSnapshot(
+                    primary: nil,
+                    secondary: nil,
+                    updatedAt: Date(),
+                    identity: ProviderIdentitySnapshot(
+                        providerID: .claude,
+                        accountEmail: authenticatedAccountEmail,
+                        accountOrganization: nil,
+                        loginMethod: "Claude Pro")),
+                provider: .claude)
+        }
         store.errors[.claude] = error
         store.lastFetchAttempts[.claude] = attempts
 
@@ -69,6 +83,18 @@ struct ClaudeWebRecoveryMenuTests {
             $0.0 == "使用 Claude Code 登入…" && $0.1 == .switchAccount(.claude)
         })
         #expect(!actions.contains { $0.0 == "Add Account..." })
+    }
+
+    @Test
+    func `authenticated Claude account shows switch action instead of sign in`() {
+        let actions = self.actions(
+            source: .auto,
+            authenticatedAccountEmail: "claude@example.com")
+
+        #expect(actions.contains {
+            $0.0 == "Switch Account..." && $0.1 == .switchAccount(.claude)
+        })
+        #expect(!actions.contains { $0.0 == "Sign in with Claude Code..." })
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
@@ -30,6 +30,7 @@ struct ClaudeWebRecoveryMenuTests {
         cookieSource: ProviderCookieSource = .auto,
         selectedSessionKey: Bool = false,
         authenticatedAccountEmail: String? = nil,
+        authenticatedOAuthWithoutEmail: Bool = false,
         attempts: [ProviderFetchAttempt] = []) -> [(String, MenuDescriptor.MenuAction)]
     {
         let settings = self.makeSettings()
@@ -43,10 +44,16 @@ struct ClaudeWebRecoveryMenuTests {
             fetcher: fetcher,
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings)
-        if let authenticatedAccountEmail {
+        if authenticatedAccountEmail != nil || authenticatedOAuthWithoutEmail {
             store._setSnapshotForTesting(
                 UsageSnapshot(
-                    primary: nil,
+                    primary: authenticatedOAuthWithoutEmail
+                        ? RateWindow(
+                            usedPercent: 25,
+                            windowMinutes: 5 * 60,
+                            resetsAt: nil,
+                            resetDescription: nil)
+                        : nil,
                     secondary: nil,
                     updatedAt: Date(),
                     identity: ProviderIdentitySnapshot(
@@ -90,6 +97,18 @@ struct ClaudeWebRecoveryMenuTests {
         let actions = self.actions(
             source: .auto,
             authenticatedAccountEmail: "claude@example.com")
+
+        #expect(actions.contains {
+            $0.0 == "Switch Account..." && $0.1 == .switchAccount(.claude)
+        })
+        #expect(!actions.contains { $0.0 == "Sign in with Claude Code..." })
+    }
+
+    @Test
+    func `email-less Claude OAuth snapshot shows switch action instead of sign in`() {
+        let actions = self.actions(
+            source: .oauth,
+            authenticatedOAuthWithoutEmail: true)
 
         #expect(actions.contains {
             $0.0 == "Switch Account..." && $0.1 == .switchAccount(.claude)


### PR DESCRIPTION
## Summary

- show Switch Account... for authenticated Claude accounts
- recognize successful email-less Claude OAuth snapshots as authenticated
- keep Sign in with Claude Code... for signed-out accounts
- preserve Claude-specific web re-login and terminal recovery actions
- cover both account states through the shared MenuDescriptor seam

## Root cause

The Claude provider-specific login action always returned Sign in with Claude Code..., bypassing the shared account-state logic. The first fix relied on account email, but successful Claude OAuth snapshots intentionally omit email even though they include provider-scoped identity and live quota windows.

The account detector now treats only a Claude-scoped identity with real rate-limit data as authenticated, so an empty or cross-provider snapshot cannot suppress the sign-in action.

This is a focused follow-up to #1811. It does not change Claude authentication or multi-account behavior.

## Validation

- swift test --filter ClaudeWebRecoveryMenuTests
- make check
- make test attempted; it repeats the pre-existing failures in ClaudeOAuthCredentialsStoreTemporaryKeychainCacheTests that also reproduce on upstream before this change
