### PR TITLE
Handle claude-swap relogin status

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountList.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountList.swift
@@ -75,6 +75,7 @@ public struct ClaudeSwapUsageWindow: Equatable, Sendable {
 public enum ClaudeSwapUsageStatus: Equatable, Sendable {
     case ok
     case tokenExpired
+    case reloginRequired
     case apiKey
     case keychainUnavailable
     case noCredentials
@@ -85,6 +86,7 @@ public enum ClaudeSwapUsageStatus: Equatable, Sendable {
         switch rawValue {
         case "ok": self = .ok
         case "token_expired": self = .tokenExpired
+        case "relogin_required": self = .reloginRequired
         case "api_key": self = .apiKey
         case "keychain_unavailable": self = .keychainUnavailable
         case "no_credentials": self = .noCredentials

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
@@ -101,7 +101,7 @@ public enum ClaudeSwapAccountProjection {
         case .tokenExpired:
             "Token expired. Switch to this account in claude-swap to refresh it."
         case .reloginRequired:
-            "Re-login required. Switch to this account in claude-swap to refresh it."
+            "Re-login required. Re-authenticate this account in claude-swap."
         case .apiKey:
             "API-key account; subscription usage is unavailable."
         case .keychainUnavailable:

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
@@ -100,6 +100,8 @@ public enum ClaudeSwapAccountProjection {
                 : nil
         case .tokenExpired:
             "Token expired. Switch to this account in claude-swap to refresh it."
+        case .reloginRequired:
+            "Re-login required. Switch to this account in claude-swap to refresh it."
         case .apiKey:
             "API-key account; subscription usage is unavailable."
         case .keychainUnavailable:
@@ -117,7 +119,7 @@ public enum ClaudeSwapAccountProjection {
         switch row.usageStatus {
         case .ok, .apiKey, .unavailable:
             true
-        case .tokenExpired, .keychainUnavailable, .noCredentials, .unknown:
+        case .tokenExpired, .reloginRequired, .keychainUnavailable, .noCredentials, .unknown:
             false
         }
     }

--- a/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
+++ b/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
@@ -241,6 +241,7 @@ struct CLICardsClaudeSwapTests {
         let statuses: [ClaudeSwapUsageStatus] = [
             .apiKey,
             .tokenExpired,
+            .reloginRequired,
             .keychainUnavailable,
             .noCredentials,
             .unavailable,
@@ -265,6 +266,7 @@ struct CLICardsClaudeSwapTests {
         #expect(output.cards.map(\.accountProblem) == [
             "API-key account; subscription usage is unavailable.",
             "Token expired. Switch to this account in claude-swap to refresh it.",
+            "Re-login required. Switch to this account in claude-swap to refresh it.",
             "claude-swap could not read the active account's Keychain entry.",
             "No stored credentials for this account slot.",
             "Usage fetch failed.",

--- a/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
+++ b/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
@@ -266,7 +266,7 @@ struct CLICardsClaudeSwapTests {
         #expect(output.cards.map(\.accountProblem) == [
             "API-key account; subscription usage is unavailable.",
             "Token expired. Switch to this account in claude-swap to refresh it.",
-            "Re-login required. Switch to this account in claude-swap to refresh it.",
+            "Re-login required. Re-authenticate this account in claude-swap.",
             "claude-swap could not read the active account's Keychain entry.",
             "No stored credentials for this account slot.",
             "Usage fetch failed.",

--- a/Tests/CodexBarTests/ClaudeSwapAccountProjectionTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapAccountProjectionTests.swift
@@ -76,6 +76,7 @@ struct ClaudeSwapAccountProjectionTests {
     func `maps sentinel statuses to per account errors without usage`() throws {
         let rows: [(ClaudeSwapUsageStatus, String)] = [
             (.tokenExpired, "Token expired"),
+            (.reloginRequired, "Re-login required"),
             (.apiKey, "API-key account"),
             (.keychainUnavailable, "Keychain"),
             (.noCredentials, "No stored credentials"),

--- a/Tests/CodexBarTests/ClaudeSwapListParserTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapListParserTests.swift
@@ -163,7 +163,7 @@ struct ClaudeSwapListParserTests {
 
         let list = try self.parse(json)
         let account = try #require(ClaudeSwapAccountProjection.accountSnapshots(from: list).first)
-        #expect(account.error == "Re-login required. Switch to this account in claude-swap to refresh it.")
+        #expect(account.error == "Re-login required. Re-authenticate this account in claude-swap.")
         #expect(account.canActivate == false)
     }
 

--- a/Tests/CodexBarTests/ClaudeSwapListParserTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapListParserTests.swift
@@ -144,6 +144,30 @@ struct ClaudeSwapListParserTests {
     }
 
     @Test
+    func `projects relogin required status to recovery guidance`() throws {
+        let json = """
+        {
+          "schemaVersion": 1,
+          "activeAccountNumber": null,
+          "accounts": [
+            {
+              "number": 1,
+              "email": "expired@example.com",
+              "active": false,
+              "usageStatus": "relogin_required",
+              "usage": null
+            }
+          ]
+        }
+        """
+
+        let list = try self.parse(json)
+        let account = try #require(ClaudeSwapAccountProjection.accountSnapshots(from: list).first)
+        #expect(account.error == "Re-login required. Switch to this account in claude-swap to refresh it.")
+        #expect(account.canActivate == false)
+    }
+
+    @Test
     func `surfaces schema v1 error envelope`() throws {
         let json = """
         {"schemaVersion": 1, "error": {"type": "SwitchError", "message": "boom"}}


### PR DESCRIPTION
Fixes #2444.

## Problem

cswap 0.23.0 can report `"usageStatus": "relogin_required"` for an inactive account. CodexBar currently treats that value as unknown, so the account card shows the raw status instead of recovery guidance.

## Change

- Map `relogin_required` to a dedicated Claude swap usage status.
- Show re-login guidance and keep the affected account non-activatable until its credentials are refreshed in claude-swap.
- Cover the reported schema-v1 payload in parser, projection, and CLI card tests.

This does not change credential reading or account switching behavior.

## Verification

- `swift test --filter ClaudeSwapListParserTests`: the new regression failed before the implementation, then all 13 tests passed.
- `swift test --no-parallel --filter ClaudeSwap`: 69 tests passed.
- `make check`: passed (SwiftFormat: 0/1582 files; SwiftLint: 0 violations in 1581 files).
- `git diff --check`: passed.
- `make test`: stopped after its automatic retry because two unchanged `AdaptiveRefreshTimerTests` timed out with `CancellationError()` at 30 seconds:
  - `menu open advances a long idle timer during refresh without postponing an earlier tick`
  - `coding activity advances a long idle timer without postponing an earlier tick`

Both timer failures reproduce when that untouched suite runs alone.

Compatibility risk is low: this only changes handling for the newly recognized status string. Unknown future values still use the existing fallback.

Review focus: whether the recovery text and non-activatable state match the expected cswap behavior.
