### PR TITLE
Hide Daily Routines bar when the routines payload is null

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
@@ -208,18 +208,14 @@ struct OAuthUsageResponse: Decodable {
         in container: KeyedDecodingContainer<DynamicCodingKey>,
         keys: [String]) -> (window: OAuthUsageWindow?, sourceKey: String?)
     {
-        var firstNullKey: String?
         for keyName in keys {
             guard let key = DynamicCodingKey(stringValue: keyName) else { continue }
             guard container.contains(key) else { continue }
             if let value = try? container.decodeIfPresent(OAuthUsageWindow.self, forKey: key) {
                 return (value, keyName)
             }
-            if firstNullKey == nil {
-                firstNullKey = keyName
-            }
         }
-        return (nil, firstNullKey)
+        return (nil, nil)
     }
 
     private static func decodeValue<T: Decodable>(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -1127,29 +1127,15 @@ extension ClaudeUsageFetcher {
     }
 
     private static func oauthExtraRateWindows(from usage: OAuthUsageResponse) -> [NamedRateWindow] {
-        let definitions: [(id: String, title: String, window: OAuthUsageWindow?, sourceKey: String?)] = [
-            (
-                id: "claude-routines",
-                title: "Daily Routines",
-                window: usage.sevenDayRoutines,
-                sourceKey: usage.sevenDayRoutinesSourceKey),
+        let definitions: [(id: String, title: String, window: OAuthUsageWindow?)] = [
+            (id: "claude-routines", title: "Daily Routines", window: usage.sevenDayRoutines),
         ]
         if let routinesKey = usage.sevenDayRoutinesSourceKey {
             Self.log.debug("Claude OAuth extra usage key matched: routines=\(routinesKey)")
         }
         let routineWindows: [NamedRateWindow] = definitions.compactMap { definition in
-            let utilization: Double
-            let resetDate: Date?
-            if let window = definition.window, let parsedUtilization = window.utilization {
-                utilization = parsedUtilization
-                resetDate = ClaudeOAuthUsageFetcher.parseISO8601Date(window.resetsAt)
-            } else if definition.sourceKey != nil {
-                // Keep product bars visible when the API returns a known key with null payload.
-                utilization = 0
-                resetDate = nil
-            } else {
-                return nil
-            }
+            guard let window = definition.window, let utilization = window.utilization else { return nil }
+            let resetDate = ClaudeOAuthUsageFetcher.parseISO8601Date(window.resetsAt)
             let resetDescription = resetDate.map(Self.formatResetDate)
             return NamedRateWindow(
                 id: definition.id,

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebExtraRateWindowParser.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebExtraRateWindowParser.swift
@@ -22,29 +22,16 @@ enum ClaudeWebExtraRateWindowParser {
         windows.reserveCapacity(Self.definitions.count)
 
         for definition in Self.definitions {
-            if let foundWindow = Self.firstUsageWindow(in: json, keys: definition.keys) {
-                let rawWindow = foundWindow.window
-                guard let utilization = Self.percentValue(from: rawWindow["utilization"]) else { continue }
-                let resetsAt = (rawWindow["resets_at"] as? String).flatMap(Self.parseISO8601Date)
-                windows.append(Self.namedWindow(
-                    id: definition.id,
-                    title: definition.title,
-                    usedPercent: utilization,
-                    resetsAt: resetsAt))
-                sourceKeys[definition.id] = foundWindow.sourceKey
-                continue
-            }
-
-            // Some accounts expose the key with null payloads (for example `seven_day_cowork: null`).
-            // Preserve the bar in that case with a 0% window so the product section remains visible.
-            if let key = Self.firstUsageKey(in: json, keys: definition.keys) {
-                windows.append(Self.namedWindow(
-                    id: definition.id,
-                    title: definition.title,
-                    usedPercent: 0,
-                    resetsAt: nil))
-                sourceKeys[definition.id] = key
-            }
+            guard let foundWindow = Self.firstUsageWindow(in: json, keys: definition.keys) else { continue }
+            let rawWindow = foundWindow.window
+            guard let utilization = Self.percentValue(from: rawWindow["utilization"]) else { continue }
+            let resetsAt = (rawWindow["resets_at"] as? String).flatMap(Self.parseISO8601Date)
+            windows.append(Self.namedWindow(
+                id: definition.id,
+                title: definition.title,
+                usedPercent: utilization,
+                resetsAt: resetsAt))
+            sourceKeys[definition.id] = foundWindow.sourceKey
         }
         windows.append(contentsOf: Self.scopedWeeklyLimitWindows(from: json))
         return (windows, sourceKeys)
@@ -90,13 +77,6 @@ enum ClaudeWebExtraRateWindowParser {
             if let window = json[key] as? [String: Any] {
                 return (window, key)
             }
-        }
-        return nil
-    }
-
-    private static func firstUsageKey(in json: [String: Any], keys: [String]) -> String? {
-        for key in keys where json.keys.contains(key) {
-            return key
         }
         return nil
     }

--- a/Tests/CodexBarTests/ClaudeOAuthTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthTests.swift
@@ -214,7 +214,7 @@ struct ClaudeOAuthTests {
     }
 
     @Test
-    func `maps O auth null cowork as zero routines window`() throws {
+    func `omits routines window when O auth cowork is null`() throws {
         let json = """
         {
           "five_hour": { "utilization": 12.5, "resets_at": "2025-12-25T12:00:00.000Z" },
@@ -223,7 +223,7 @@ struct ClaudeOAuthTests {
         }
         """
         let snap = try ClaudeUsageFetcher._mapOAuthUsageForTesting(Data(json.utf8))
-        #expect(snap.extraRateWindows.first(where: { $0.id == "claude-routines" })?.window.usedPercent == 0)
+        #expect(snap.extraRateWindows.contains { $0.id == "claude-routines" } == false)
         #expect(snap.extraRateWindows.contains { $0.id == "claude-design" } == false)
     }
 

--- a/Tests/CodexBarTests/ClaudeWebUsageExtraWindowTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebUsageExtraWindowTests.swift
@@ -33,7 +33,7 @@ struct ClaudeWebUsageExtraWindowTests {
     }
 
     @Test
-    func `parses claude web API cowork null as zero routines window`() throws {
+    func `omits routines window when claude web API cowork is null`() throws {
         let json = """
         {
           "five_hour": { "utilization": 9, "resets_at": "2025-12-23T16:00:00.000Z" },
@@ -43,7 +43,7 @@ struct ClaudeWebUsageExtraWindowTests {
         """
         let data = Data(json.utf8)
         let parsed = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(data)
-        #expect(parsed.extraRateWindows.first(where: { $0.id == "claude-routines" })?.window.usedPercent == 0)
+        #expect(parsed.extraRateWindows.contains { $0.id == "claude-routines" } == false)
         #expect(parsed.extraRateWindows.contains { $0.id == "claude-design" } == false)
     }
 


### PR DESCRIPTION
## Summary

- treat a routines key that is present but `null` as absent instead of synthesizing a 0% placeholder window
- update the two regression tests to assert the window is omitted

## Why

Accounts without routines data receive `null` for these aliases, so the placeholder rendered a permanent phantom "Daily Routines 0% used" row matching no quota. claude.ai renders from `limits`, which carries no routines lane, and shows no bar. Nothing is lost: the removed row was hardcoded to 0%. Accounts with a real routines window are unchanged.

Refs #2353, though this adds no toggle.

## Validation

- `make check` — 0 violations across 1,581 files
- `swift test --filter 'ClaudeOAuthTests|ClaudeWebUsageExtraWindowTests|ClaudeExtraWindowQuotaWarningTests|MenuCardModelTests'` — 127 tests passed
- `make test` — 60 of 61 groups passed; `SpendDashboardTokenProvenanceTests` failures are pre-existing
- local debug build on a live account whose payload returns `seven_day_cowork: null`: the card fetches successfully and renders Session, Weekly and Fable only, with no Daily Routines row

<img width="626" height="642" alt="Claude usage card with no Daily Routines row" src="https://github.com/user-attachments/assets/e16612c8-b5b2-44df-9a56-f8eb9cbb46a3" />

<img width="1190" height="844" alt="Claude usage card with no Daily Routines row (menu)" src="https://github.com/user-attachments/assets/a91bf6bd-1359-4b47-a71b-012bebfce028" />



The inverse case (a real routines payload still rendering) is covered by the regression tests rather than a capture: this account returns `null`, so there is no local way to produce one.
