### PR TITLE
Show Grok pace for late-cycle credit windows

### DIFF
--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -42,6 +42,8 @@ public enum GrokProviderDescriptor {
                       label == "Weekly" || label == "Monthly",
                       let resetsAt = window.resetsAt
                 else { return false }
+                // SuperGrok included usage is a weekly pool; monthly only appears when a measured
+                // billing-period length is present (legacy CLI / older payloads).
                 let defaultMinutes = label == "Weekly" ? 7 * 24 * 60 : 30 * 24 * 60
                 let windowMinutes = window.windowMinutes ?? defaultMinutes
                 let timeUntilReset = resetsAt.timeIntervalSince(now)
@@ -71,28 +73,39 @@ public enum GrokProviderDescriptor {
     }
 
     /// Returns a contextual label for Grok's primary usage bar ("Weekly" or "Monthly").
-    /// Prefer the billing period duration when available; fall back to reset distance for
-    /// web billing payloads that expose only a reset timestamp.
+    /// Prefer a measured billing-period duration when available. For reset-only web payloads,
+    /// treat remaining time within a week-sized horizon as Weekly — SuperGrok's included usage
+    /// pool resets weekly, so late-cycle windows must not fall back to "Credits".
     public static func primaryLabel(window: RateWindow?, now: Date = .now) -> String? {
         if let minutes = window?.windowMinutes {
-            return self.primaryLabel(duration: TimeInterval(minutes) * 60)
+            return self.primaryLabel(duration: TimeInterval(minutes) * 60, fromMeasuredDuration: true)
         }
         return self.primaryLabel(resetsAt: window?.resetsAt, now: now)
     }
 
     public static func primaryLabel(resetsAt: Date?, now: Date = .now) -> String? {
         guard let resetsAt else { return nil }
-        return self.primaryLabel(duration: resetsAt.timeIntervalSince(now))
+        return self.primaryLabel(
+            duration: resetsAt.timeIntervalSince(now),
+            fromMeasuredDuration: false)
     }
 
-    private static func primaryLabel(duration seconds: TimeInterval) -> String? {
+    private static func primaryLabel(duration seconds: TimeInterval, fromMeasuredDuration: Bool) -> String? {
         guard seconds > 3600 else { return nil }
         let days = Int((seconds / 86400).rounded(.toNearestOrAwayFromZero))
-        if (4...12).contains(days) {
-            return "Weekly"
+        if fromMeasuredDuration {
+            if (4...12).contains(days) {
+                return "Weekly"
+            }
+            if (20...45).contains(days) {
+                return "Monthly"
+            }
+            return nil
         }
-        if (20...45).contains(days) {
-            return "Monthly"
+        // Reset-distance only: SuperGrok usage is weekly, so any remaining time that still fits a
+        // week-sized horizon is Weekly (including late-cycle 1–3 day remainders).
+        if (1...12).contains(days) {
+            return "Weekly"
         }
         return nil
     }

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -92,8 +92,8 @@ public enum GrokProviderDescriptor {
 
     private static func primaryLabel(duration seconds: TimeInterval, fromMeasuredDuration: Bool) -> String? {
         guard seconds > 3600 else { return nil }
-        let days = Int((seconds / 86400).rounded(.toNearestOrAwayFromZero))
         if fromMeasuredDuration {
+            let days = Int((seconds / 86400).rounded(.toNearestOrAwayFromZero))
             if (4...12).contains(days) {
                 return "Weekly"
             }
@@ -102,9 +102,11 @@ public enum GrokProviderDescriptor {
             }
             return nil
         }
-        // Reset-distance only: SuperGrok usage is weekly, so any remaining time that still fits a
-        // week-sized horizon is Weekly (including late-cycle 1–3 day remainders).
-        if (1...12).contains(days) {
+        // Reset-distance only: SuperGrok usage is weekly. Compare the remaining interval directly
+        // against a week-sized horizon so late-cycle partial-day remainders (1–12h) stay Weekly
+        // instead of rounding to 0 days and falling back to Credits.
+        let weekSizedHorizonSeconds: TimeInterval = 12 * 86400
+        if seconds <= weekSizedHorizonSeconds {
             return "Weekly"
         }
         return nil

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -38,10 +38,12 @@ public enum GrokProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Grok cost summary is not supported yet." }),
             pace: ProviderPaceCapability(resetWindowPace: .custom { window, now in
-                guard Self.primaryLabel(window: window, now: now) == "Weekly",
+                guard let label = Self.primaryLabel(window: window, now: now),
+                      label == "Weekly" || label == "Monthly",
                       let resetsAt = window.resetsAt
                 else { return false }
-                let windowMinutes = window.windowMinutes ?? 7 * 24 * 60
+                let defaultMinutes = label == "Weekly" ? 7 * 24 * 60 : 30 * 24 * 60
+                let windowMinutes = window.windowMinutes ?? defaultMinutes
                 let timeUntilReset = resetsAt.timeIntervalSince(now)
                 return windowMinutes > 0
                     && timeUntilReset > 0

--- a/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
@@ -44,7 +44,7 @@ public struct GrokUsageSnapshot: Sendable {
         {
             primary = RateWindow(
                 usedPercent: percent,
-                windowMinutes: nil,
+                windowMinutes: webBilling.windowMinutes,
                 resetsAt: webBilling.resetsAt,
                 resetDescription: nil)
         }

--- a/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
@@ -283,7 +283,7 @@ public enum GrokWebBillingFetcher {
                 field.path == [1, 4, 1] || field.path == [1, 8, 2, 1]
             }
             .map(\.date)
-            .filter { $0 < resetsAt }
+            .filter { $0 <= now && $0 < resetsAt }
         if let preferred = preferredStarts.max() {
             return preferred
         }

--- a/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
@@ -6,10 +6,14 @@ import FoundationNetworking
 public struct GrokWebBillingSnapshot: Sendable, Equatable {
     public let usedPercent: Double?
     public let resetsAt: Date?
+    /// Billing-period length in minutes when the protobuf exposes both period start and end.
+    /// Late-cycle web windows need this so Weekly/Monthly labeling and pace can still resolve.
+    public let windowMinutes: Int?
 
-    public init(usedPercent: Double?, resetsAt: Date?) {
+    public init(usedPercent: Double?, resetsAt: Date?, windowMinutes: Int? = nil) {
         self.usedPercent = usedPercent
         self.resetsAt = resetsAt
+        self.windowMinutes = windowMinutes
     }
 }
 
@@ -233,18 +237,20 @@ public enum GrokWebBillingFetcher {
             }
             .map { Double($0.value) }
 
-        let resetFields = scan.varintFields.compactMap { field -> (path: [UInt64], date: Date)? in
+        let timestampFields = scan.varintFields.compactMap { field -> (path: [UInt64], date: Date)? in
             let raw = field.value
             guard raw >= 1_700_000_000, raw <= 2_100_000_000 else { return nil }
             return (field.path, Date(timeIntervalSince1970: TimeInterval(raw)))
         }
-        let futureResetFields = resetFields.filter { $0.date > now }
+        let futureResetFields = timestampFields.filter { $0.date > now }
         let reset = futureResetFields
             .filter { $0.path == [1, 5, 1] }
             .map(\.date)
             .min() ?? futureResetFields
             .map(\.date)
             .min()
+        let periodStart = Self.billingPeriodStart(from: timestampFields, resetsAt: reset, now: now)
+        let windowMinutes = Self.billingWindowMinutes(from: periodStart, to: reset)
 
         let hasUsagePeriod = scan.varintFields.contains { field in
             field.path.starts(with: [1, 6]) ||
@@ -257,7 +263,43 @@ public enum GrokWebBillingFetcher {
         guard let percent = parsedPercent ?? (noUsageYet ? 0 : nil) else {
             throw GrokWebBillingError.parseFailed
         }
-        return GrokWebBillingSnapshot(usedPercent: percent, resetsAt: reset)
+        return GrokWebBillingSnapshot(
+            usedPercent: percent,
+            resetsAt: reset,
+            windowMinutes: windowMinutes)
+    }
+
+    /// Prefers the protobuf period-start siblings (`[1,4,1]` / `[1,8,2,1]`), then any past timestamp
+    /// that precedes the chosen reset.
+    static func billingPeriodStart(
+        from timestampFields: [(path: [UInt64], date: Date)],
+        resetsAt: Date?,
+        now: Date) -> Date?
+    {
+        guard let resetsAt else { return nil }
+
+        let preferredStarts = timestampFields
+            .filter { field in
+                field.path == [1, 4, 1] || field.path == [1, 8, 2, 1]
+            }
+            .map(\.date)
+            .filter { $0 < resetsAt }
+        if let preferred = preferredStarts.max() {
+            return preferred
+        }
+
+        return timestampFields
+            .map(\.date)
+            .filter { $0 <= now && $0 < resetsAt }
+            .max()
+    }
+
+    static func billingWindowMinutes(from start: Date?, to end: Date?) -> Int? {
+        guard let start, let end else { return nil }
+        let minutes = end.timeIntervalSince(start) / 60
+        // Accept common Grok credit cycles (~daily through ~monthly); reject noise.
+        guard minutes.isFinite, minutes >= 24 * 60, minutes <= 45 * 24 * 60 else { return nil }
+        return Int(minutes.rounded())
     }
 
     static func looksLikeProtobufPayload(_ data: Data) -> Bool {

--- a/Tests/CodexBarTests/GrokMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/GrokMenuCardModelTests.swift
@@ -118,14 +118,33 @@ struct GrokMenuCardModelTests {
     }
 
     @Test
-    func `unclassified quota does not show weekly projection`() throws {
+    func `late cycle reset-only web quota defaults to weekly projection`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let model = try Self.model(
+            now: now,
+            window: RateWindow(
+                usedPercent: 37,
+                windowMinutes: nil,
+                resetsAt: now.addingTimeInterval((2 * 24 + 9) * 3600),
+                resetDescription: nil))
+
+        let metric = try #require(model.metrics.first { $0.id == "primary" })
+        #expect(metric.title == "Weekly")
+        #expect(metric.detailLeftText == "29% in reserve")
+        #expect(metric.detailRightText == "Lasts until reset")
+        #expect(metric.pacePercent != nil)
+        #expect(metric.paceOnTop == true)
+    }
+
+    @Test
+    func `far reset without measured duration does not invent weekly projection`() throws {
         let now = Date(timeIntervalSince1970: 0)
         let model = try Self.model(
             now: now,
             window: RateWindow(
                 usedPercent: 50,
                 windowMinutes: nil,
-                resetsAt: now.addingTimeInterval(2 * 24 * 3600),
+                resetsAt: now.addingTimeInterval(20 * 24 * 3600),
                 resetDescription: nil))
 
         let metric = try #require(model.metrics.first { $0.id == "primary" })

--- a/Tests/CodexBarTests/GrokMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/GrokMenuCardModelTests.swift
@@ -92,9 +92,10 @@ struct GrokMenuCardModelTests {
 
         let metric = try #require(model.metrics.first { $0.id == "primary" })
         #expect(metric.title == "Weekly")
-        #expect(metric.detailLeftText != nil)
-        #expect(metric.detailRightText != nil)
+        #expect(metric.detailLeftText == "29% in reserve")
+        #expect(metric.detailRightText == "Lasts until reset")
         #expect(metric.pacePercent != nil)
+        #expect(metric.paceOnTop == true)
     }
 
     @Test
@@ -110,9 +111,10 @@ struct GrokMenuCardModelTests {
 
         let metric = try #require(model.metrics.first { $0.id == "primary" })
         #expect(metric.title == "Monthly")
-        #expect(metric.detailLeftText != nil)
-        #expect(metric.detailRightText != nil)
+        #expect(metric.detailLeftText == "55% in reserve")
+        #expect(metric.detailRightText == "Lasts until reset")
         #expect(metric.pacePercent != nil)
+        #expect(metric.paceOnTop == true)
     }
 
     @Test

--- a/Tests/CodexBarTests/GrokMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/GrokMenuCardModelTests.swift
@@ -61,7 +61,7 @@ struct GrokMenuCardModelTests {
     }
 
     @Test
-    func `monthly quota does not show weekly projection`() throws {
+    func `monthly quota shows projection and pace marker`() throws {
         let now = Date(timeIntervalSince1970: 0)
         let model = try Self.model(
             now: now,
@@ -73,9 +73,46 @@ struct GrokMenuCardModelTests {
 
         let metric = try #require(model.metrics.first { $0.id == "primary" })
         #expect(metric.title == "Monthly")
-        #expect(metric.detailLeftText == nil)
-        #expect(metric.detailRightText == nil)
-        #expect(metric.pacePercent == nil)
+        #expect(metric.detailLeftText == "17% in deficit")
+        #expect(metric.detailRightText == "Runs out in 10d")
+        #expect(metric.pacePercent != nil)
+        #expect(metric.paceOnTop == false)
+    }
+
+    @Test
+    func `late cycle web weekly quota keeps label and projection`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let model = try Self.model(
+            now: now,
+            window: RateWindow(
+                usedPercent: 37,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval((2 * 24 + 9) * 3600),
+                resetDescription: nil))
+
+        let metric = try #require(model.metrics.first { $0.id == "primary" })
+        #expect(metric.title == "Weekly")
+        #expect(metric.detailLeftText != nil)
+        #expect(metric.detailRightText != nil)
+        #expect(metric.pacePercent != nil)
+    }
+
+    @Test
+    func `late cycle web monthly quota keeps label and projection`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let model = try Self.model(
+            now: now,
+            window: RateWindow(
+                usedPercent: 37,
+                windowMinutes: 30 * 24 * 60,
+                resetsAt: now.addingTimeInterval((2 * 24 + 9) * 3600),
+                resetDescription: nil))
+
+        let metric = try #require(model.metrics.first { $0.id == "primary" })
+        #expect(metric.title == "Monthly")
+        #expect(metric.detailLeftText != nil)
+        #expect(metric.detailRightText != nil)
+        #expect(metric.pacePercent != nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -636,8 +636,8 @@ struct GrokWebBillingFetcherTests {
     @Test
     func `rejects future preferred period start when deriving window length`() throws {
         let nowEpoch = UInt64(1_800_000_000)
-        let futureStart = nowEpoch + 86_400
-        let billingEnd = nowEpoch + 8 * 86_400
+        let futureStart = nowEpoch + 86400
+        let billingEnd = nowEpoch + 8 * 86400
         var payload = Data()
         payload.append(0x0A) // field 1, length-delimited billing message
         var inner = Data()

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -36,8 +36,9 @@ struct GrokWebBillingFetcherTests {
     }
 
     @Test
-    func `primaryLabel derives Weekly or Monthly from resetsAt`() {
+    func `primaryLabel prefers Weekly for reset-only SuperGrok usage windows`() {
         let now = Date()
+        let in2Days = now.addingTimeInterval(2 * 86400)
         let in6Days = now.addingTimeInterval(6 * 86400)
         let in30Days = now.addingTimeInterval(30 * 86400)
         let in90Days = now.addingTimeInterval(90 * 86400)
@@ -46,11 +47,18 @@ struct GrokWebBillingFetcherTests {
             windowMinutes: 7 * 24 * 60,
             resetsAt: now.addingTimeInterval(86400),
             resetDescription: nil)
+        let measuredMonthlyWindow = RateWindow(
+            usedPercent: 25,
+            windowMinutes: 30 * 24 * 60,
+            resetsAt: now.addingTimeInterval(86400),
+            resetDescription: nil)
 
+        #expect(GrokProviderDescriptor.primaryLabel(resetsAt: in2Days, now: now) == "Weekly")
         #expect(GrokProviderDescriptor.primaryLabel(resetsAt: in6Days, now: now) == "Weekly")
-        #expect(GrokProviderDescriptor.primaryLabel(resetsAt: in30Days, now: now) == "Monthly")
+        #expect(GrokProviderDescriptor.primaryLabel(resetsAt: in30Days, now: now) == nil)
         #expect(GrokProviderDescriptor.primaryLabel(resetsAt: in90Days, now: now) == nil)
         #expect(GrokProviderDescriptor.primaryLabel(window: lateWeeklyWindow, now: now) == "Weekly")
+        #expect(GrokProviderDescriptor.primaryLabel(window: measuredMonthlyWindow, now: now) == "Monthly")
         #expect(GrokProviderDescriptor.primaryLabel(resetsAt: nil) == nil)
     }
 

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -123,7 +123,7 @@ struct GrokWebBillingFetcherTests {
 
         let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
             data,
-            now: Date(timeIntervalSince1970: 1_780_000_000))
+            now: Date(timeIntervalSince1970: 1_781_000_000))
 
         #expect(snapshot.usedPercent == 1.222000002861023)
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: 1_782_864_000))
@@ -565,7 +565,7 @@ struct GrokWebBillingFetcherTests {
 
         let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
             data,
-            now: Date(timeIntervalSince1970: 1_768_000_000))
+            now: Date(timeIntervalSince1970: 1_778_500_000))
 
         #expect(snapshot.usedPercent == 0)
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: 1_780_272_000))
@@ -631,6 +631,36 @@ struct GrokWebBillingFetcherTests {
 
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: TimeInterval(billingEnd)))
         #expect(snapshot.windowMinutes == Int((TimeInterval(billingEnd) - TimeInterval(recentStart)) / 60))
+    }
+
+    @Test
+    func `rejects future preferred period start when deriving window length`() throws {
+        let nowEpoch = UInt64(1_800_000_000)
+        let futureStart = nowEpoch + 86_400
+        let billingEnd = nowEpoch + 8 * 86_400
+        var payload = Data()
+        payload.append(0x0A) // field 1, length-delimited billing message
+        var inner = Data()
+        inner.append(0x0D) // field 1, fixed32 usage percent
+        var percentBits = Float(40).bitPattern.littleEndian
+        withUnsafeBytes(of: &percentBits) { inner.append(contentsOf: $0) }
+        inner.append(0x22) // field 4, nested period start
+        inner.append(0x06)
+        inner.append(0x08) // nested field 1 varint
+        inner.append(contentsOf: Self.varint(futureStart))
+        inner.append(0x2A) // field 5, nested period end
+        inner.append(0x06)
+        inner.append(0x08)
+        inner.append(contentsOf: Self.varint(billingEnd))
+        payload.append(UInt8(inner.count))
+        payload.append(inner)
+
+        let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
+            Self.grpcFrame(payload),
+            now: Date(timeIntervalSince1970: TimeInterval(nowEpoch)))
+
+        #expect(snapshot.resetsAt == Date(timeIntervalSince1970: TimeInterval(billingEnd)))
+        #expect(snapshot.windowMinutes == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -53,8 +53,11 @@ struct GrokWebBillingFetcherTests {
             resetsAt: now.addingTimeInterval(86400),
             resetDescription: nil)
 
+        let in6Hours = now.addingTimeInterval(6 * 3600)
+
         #expect(GrokProviderDescriptor.primaryLabel(resetsAt: in2Days, now: now) == "Weekly")
         #expect(GrokProviderDescriptor.primaryLabel(resetsAt: in6Days, now: now) == "Weekly")
+        #expect(GrokProviderDescriptor.primaryLabel(resetsAt: in6Hours, now: now) == "Weekly")
         #expect(GrokProviderDescriptor.primaryLabel(resetsAt: in30Days, now: now) == nil)
         #expect(GrokProviderDescriptor.primaryLabel(resetsAt: in90Days, now: now) == nil)
         #expect(GrokProviderDescriptor.primaryLabel(window: lateWeeklyWindow, now: now) == "Weekly")

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -111,6 +111,7 @@ struct GrokWebBillingFetcherTests {
 
         #expect(snapshot.usedPercent == 42.5)
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: TimeInterval(reset)))
+        #expect(snapshot.windowMinutes == nil)
     }
 
     @Test
@@ -126,6 +127,7 @@ struct GrokWebBillingFetcherTests {
 
         #expect(snapshot.usedPercent == 1.222000002861023)
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: 1_782_864_000))
+        #expect(snapshot.windowMinutes == 30 * 24 * 60)
     }
 
     @Test
@@ -567,6 +569,7 @@ struct GrokWebBillingFetcherTests {
 
         #expect(snapshot.usedPercent == 0)
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: 1_780_272_000))
+        #expect(snapshot.windowMinutes == 31 * 24 * 60)
     }
 
     @Test
@@ -589,6 +592,7 @@ struct GrokWebBillingFetcherTests {
 
         #expect(snapshot.usedPercent == 0)
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: 1_782_864_000))
+        #expect(snapshot.windowMinutes == 30 * 24 * 60)
     }
 
     @Test
@@ -626,6 +630,7 @@ struct GrokWebBillingFetcherTests {
             now: Date(timeIntervalSince1970: TimeInterval(recentStart + 1800)))
 
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: TimeInterval(billingEnd)))
+        #expect(snapshot.windowMinutes == Int((TimeInterval(billingEnd) - TimeInterval(recentStart)) / 60))
     }
 
     @Test
@@ -914,7 +919,8 @@ extension GrokWebBillingFetcherTests {
             billing: nil,
             webBilling: GrokWebBillingSnapshot(
                 usedPercent: 67.25,
-                resetsAt: Date(timeIntervalSince1970: 1_800_000_003)),
+                resetsAt: Date(timeIntervalSince1970: 1_800_000_003),
+                windowMinutes: 7 * 24 * 60),
             credentials: Self.credentials,
             localSummary: nil,
             cliVersion: nil,
@@ -923,7 +929,7 @@ extension GrokWebBillingFetcherTests {
         let usage = snapshot.toUsageSnapshot()
 
         #expect(usage.primary?.usedPercent == 67.25)
-        #expect(usage.primary?.windowMinutes == nil)
+        #expect(usage.primary?.windowMinutes == 7 * 24 * 60)
         #expect(usage.primary?.resetsAt == Date(timeIntervalSince1970: 1_800_000_003))
         #expect(usage.accountEmail(for: .grok) == "grok@example.com")
         #expect(usage.loginMethod(for: .grok) == "SuperGrok")

--- a/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
+++ b/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
@@ -69,10 +69,12 @@ struct ProviderPaceCapabilityTests {
         case .cursor:
             return window.windowMinutes != nil
         case .grok:
-            guard GrokProviderDescriptor.primaryLabel(window: window, now: now) == "Weekly",
+            guard let label = GrokProviderDescriptor.primaryLabel(window: window, now: now),
+                  label == "Weekly" || label == "Monthly",
                   let resetsAt = window.resetsAt
             else { return false }
-            let windowMinutes = window.windowMinutes ?? self.weeklyWindowMinutes
+            let defaultMinutes = label == "Weekly" ? self.weeklyWindowMinutes : self.monthlyWindowSentinelMinutes
+            let windowMinutes = window.windowMinutes ?? defaultMinutes
             let timeUntilReset = resetsAt.timeIntervalSince(now)
             return windowMinutes > 0
                 && timeUntilReset > 0

--- a/TestsLinux/GrokWebBillingPaceLinuxTests.swift
+++ b/TestsLinux/GrokWebBillingPaceLinuxTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct GrokWebBillingPaceLinuxTests {
+    @Test
+    func `web billing parses period length from start and end timestamps`() throws {
+        let hex =
+            "0a3f0d7f6a9c3f12001a002206088097f3d0062a060880b191d2063a07080215a9389b3f3a07080115d6ea183c" +
+            "421208011206088097f3d0061a060880b191d206"
+        let data = try #require(Self.data(hexString: hex))
+
+        let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
+            data,
+            now: Date(timeIntervalSince1970: 1_780_000_000))
+
+        #expect(snapshot.resetsAt == Date(timeIntervalSince1970: 1_782_864_000))
+        #expect(snapshot.windowMinutes == 30 * 24 * 60)
+    }
+
+    @Test
+    func `late cycle monthly window supports reset pace when duration is known`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 37,
+            windowMinutes: 30 * 24 * 60,
+            resetsAt: now.addingTimeInterval((2 * 24 + 9) * 3600),
+            resetDescription: nil)
+        let capability = GrokProviderDescriptor.descriptor.pace
+
+        #expect(GrokProviderDescriptor.primaryLabel(window: window, now: now) == "Monthly")
+        #expect(capability.supportsResetWindowPace(window: window, now: now))
+    }
+
+    @Test
+    func `late cycle weekly window supports reset pace when duration is known`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 37,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: now.addingTimeInterval((2 * 24 + 9) * 3600),
+            resetDescription: nil)
+        let capability = GrokProviderDescriptor.descriptor.pace
+
+        #expect(GrokProviderDescriptor.primaryLabel(window: window, now: now) == "Weekly")
+        #expect(capability.supportsResetWindowPace(window: window, now: now))
+    }
+
+    @Test
+    func `unclassified short reset without duration still skips pace`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 37,
+            windowMinutes: nil,
+            resetsAt: now.addingTimeInterval((2 * 24 + 9) * 3600),
+            resetDescription: nil)
+        let capability = GrokProviderDescriptor.descriptor.pace
+
+        #expect(GrokProviderDescriptor.primaryLabel(window: window, now: now) == nil)
+        #expect(!capability.supportsResetWindowPace(window: window, now: now))
+    }
+
+    private static func data(hexString: String) -> Data? {
+        var data = Data()
+        var index = hexString.startIndex
+        while index < hexString.endIndex {
+            let next = hexString.index(index, offsetBy: 2, limitedBy: hexString.endIndex) ?? hexString.endIndex
+            guard next > index,
+                  let byte = UInt8(hexString[index..<next], radix: 16)
+            else { return nil }
+            data.append(byte)
+            index = next
+        }
+        return data
+    }
+}

--- a/TestsLinux/GrokWebBillingPaceLinuxTests.swift
+++ b/TestsLinux/GrokWebBillingPaceLinuxTests.swift
@@ -64,12 +64,26 @@ struct GrokWebBillingPaceLinuxTests {
     }
 
     @Test
-    func `unclassified short reset without duration still skips pace`() {
+    func `late cycle reset-only window defaults to weekly pace`() {
         let now = Date(timeIntervalSince1970: 0)
         let window = RateWindow(
             usedPercent: 37,
             windowMinutes: nil,
             resetsAt: now.addingTimeInterval((2 * 24 + 9) * 3600),
+            resetDescription: nil)
+        let capability = GrokProviderDescriptor.descriptor.pace
+
+        #expect(GrokProviderDescriptor.primaryLabel(window: window, now: now) == "Weekly")
+        #expect(capability.supportsResetWindowPace(window: window, now: now))
+    }
+
+    @Test
+    func `far reset without measured duration still skips pace`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 37,
+            windowMinutes: nil,
+            resetsAt: now.addingTimeInterval(20 * 24 * 3600),
             resetDescription: nil)
         let capability = GrokProviderDescriptor.descriptor.pace
 

--- a/TestsLinux/GrokWebBillingPaceLinuxTests.swift
+++ b/TestsLinux/GrokWebBillingPaceLinuxTests.swift
@@ -91,6 +91,20 @@ struct GrokWebBillingPaceLinuxTests {
         #expect(!capability.supportsResetWindowPace(window: window, now: now))
     }
 
+    @Test
+    func `final half-day reset-only window keeps weekly pace`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 88,
+            windowMinutes: nil,
+            resetsAt: now.addingTimeInterval(6 * 3600),
+            resetDescription: nil)
+        let capability = GrokProviderDescriptor.descriptor.pace
+
+        #expect(GrokProviderDescriptor.primaryLabel(window: window, now: now) == "Weekly")
+        #expect(capability.supportsResetWindowPace(window: window, now: now))
+    }
+
     private static func data(hexString: String) -> Data? {
         var data = Data()
         var index = hexString.startIndex

--- a/TestsLinux/GrokWebBillingPaceLinuxTests.swift
+++ b/TestsLinux/GrokWebBillingPaceLinuxTests.swift
@@ -21,8 +21,8 @@ struct GrokWebBillingPaceLinuxTests {
     @Test
     func `rejects future preferred period start when deriving window length`() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let futureStart = now.addingTimeInterval(86_400)
-        let resetsAt = now.addingTimeInterval(8 * 86_400)
+        let futureStart = now.addingTimeInterval(86400)
+        let resetsAt = now.addingTimeInterval(8 * 86400)
         let start = GrokWebBillingFetcher.billingPeriodStart(
             from: [
                 (path: [1, 4, 1], date: futureStart),

--- a/TestsLinux/GrokWebBillingPaceLinuxTests.swift
+++ b/TestsLinux/GrokWebBillingPaceLinuxTests.swift
@@ -12,10 +12,27 @@ struct GrokWebBillingPaceLinuxTests {
 
         let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
             data,
-            now: Date(timeIntervalSince1970: 1_780_000_000))
+            now: Date(timeIntervalSince1970: 1_781_000_000))
 
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: 1_782_864_000))
         #expect(snapshot.windowMinutes == 30 * 24 * 60)
+    }
+
+    @Test
+    func `rejects future preferred period start when deriving window length`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let futureStart = now.addingTimeInterval(86_400)
+        let resetsAt = now.addingTimeInterval(8 * 86_400)
+        let start = GrokWebBillingFetcher.billingPeriodStart(
+            from: [
+                (path: [1, 4, 1], date: futureStart),
+                (path: [1, 5, 1], date: resetsAt),
+            ],
+            resetsAt: resetsAt,
+            now: now)
+
+        #expect(start == nil)
+        #expect(GrokWebBillingFetcher.billingWindowMinutes(from: start, to: resetsAt) == nil)
     }
 
     @Test

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -112,10 +112,12 @@ browser session when the CLI surface does not expose billing.
     `resetsAt` = `billingCycle.billingPeriodEnd`.
   - grok.com fallback: `usedPercent` and `resetsAt` parsed from the gRPC-web
     billing protobuf.
-  - The UI label for the live usage bar is dynamic: "Weekly" or "Monthly"
-    when `resetsAt` matches a common cycle, falling back to the registered
-    "Credits" label otherwise. Settings and history views continue to use
-    "Credits" as the stable metric name.
+  - The UI label for the live usage bar is dynamic: SuperGrok included usage is a
+    weekly pool, so reset-only web payloads with a week-sized remaining horizon
+    show "Weekly" (including late-cycle remainders). "Monthly" is reserved for
+    measured ~month-long billing-period durations from CLI/older payloads.
+    Settings and history views continue to use "Credits" as the stable metric
+    name.
 - **Identity**:
   - `accountEmail` from credential `email`.
   - `accountOrganization` from credential `team_id`.


### PR DESCRIPTION
## Summary

- Grok web billing derives `windowMinutes` from protobuf period start/end when available, so late-cycle windows keep a usable duration for pace.
- SuperGrok included usage is treated as a **weekly** pool (per [xAI FAQ](https://docs.x.ai/grok/faq)): reset-only windows with a week-sized remaining horizon label as Weekly — including late-cycle remainders like `Resets in 2d 9h` — so reserve / lasts-until-reset stats can render.
- Monthly labeling/pace is kept only when a measured ~month billing-period duration is present (legacy CLI / older payloads).
- Preferred period starts must already have begun (`<= now`) so next-cycle timestamps cannot invent a window length.

## Why

SuperGrok already had remaining % and reset time, but late-cycle web payloads without `windowMinutes` were treated as unclassified Credits and skipped pace. No open upstream issue covered this gap (related: #2165 / #2170).

## Validation

- `swift test --filter GrokWebBillingPaceLinuxTests` — 6 tests passed
- Focused menu/parser tests updated for weekly-default late-cycle behavior (`GrokMenuCardModelTests`, `GrokWebBillingFetcherTests`, `ProviderPaceCapabilityTests`)

## After-fix proof (Linux cloud agent — 2026-07-29)
**Head:** `245eb8c8` — Keep Grok weekly pace through final half-day

### Transcript
```text
Host: Linux 6.12.94+ x86_64
Swift: Swift version 6.3.3 (swift-6.3.3-RELEASE)
Command: swift test --filter GrokWebBillingPaceLinuxTests
✔ Test "late cycle reset-only window defaults to weekly pace" passed
✔ Test "final half-day reset-only window keeps weekly pace" passed
✔ Test "far reset without measured duration still skips pace" passed
✔ Test "late cycle monthly window supports reset pace when duration is known" passed
✔ Test "late cycle weekly window supports reset pace when duration is known" passed
✔ Test "rejects future preferred period start when deriving window length" passed
✔ Test "web billing parses period length from start and end timestamps" passed
✔ Test run with 7 tests in 1 suite passed
```

Final half-day classification (reset-only)
Remaining | Before | After
-- | -- | --
6 hours | Credits | Weekly
11 hours | Credits | Weekly
2 days | Weekly | Weekly
20 days | Credits | Credits
