### PR TITLE
Fix Grok browser cookie refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.45.3 — Unreleased
 
 ### Fixed
+- Grok: cache validated browser sessions so background usage fetches and explicit cookie refreshes can reuse them.
 
 ## 0.45.2 — 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.45.3 — Unreleased
 
 ### Fixed
-- Grok: cache validated browser sessions so background usage fetches and explicit cookie refreshes can reuse them.
 
 ## 0.45.2 — 2026-07-19
 

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -126,6 +126,10 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
         sourceLabel: String,
         authenticatedByAuthFile: Bool)
 
+    /// Browser-cookie import must stay limited to surfaces where a person explicitly asked for it:
+    /// the menu-bar app runtime, a `userInitiated` interaction (set only by explicit refresh
+    /// commands and app UI gestures), or the environment override. Scheduled and background work
+    /// must keep the default `.background` context so it can never reach Chromium Keychain prompts.
     static func canImportBrowserCookies(runtime: ProviderRuntime, env: [String: String]) -> Bool {
         runtime == .app ||
             ProviderInteractionContext.current == .userInitiated ||
@@ -208,12 +212,12 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
         #if os(macOS)
         var cacheObservation = CookieHeaderCache.observeForConditionalMutation(provider: .grok)
         var lastCookieError: Error?
-        if let cached = CookieHeaderCache.load(provider: .grok) {
+        if let cached = cacheObservation.entry {
             do {
                 let snapshot = try await Self.fetchValidCookieHeader(
                     cached.cookieHeader,
                     credentials: browserCredentials,
-                    preserveTeamUsageUnsupported: false)
+                    preferTrailingAuthenticationFailure: true)
                 return (snapshot, cached.sourceLabel, false)
             } catch {
                 guard Self.isCookieAuthenticationFailure(error) else { throw error }
@@ -300,10 +304,14 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
         throw teamUsageUnsupportedError ?? lastError ?? GrokWebBillingError.missingCredentials
     }
 
+    /// `preferTrailingAuthenticationFailure` lets a cached-cookie caller surface a trailing
+    /// 401/403 over the team classification so stale sessions still trigger cache eviction.
+    /// Non-authentication trailing errors keep `teamUsageUnsupported` so team principals
+    /// degrade to identity-only data instead of failing outright.
     static func fetchValidCookieHeader(
         _ cookieHeader: String,
         credentials: GrokCredentials? = nil,
-        preserveTeamUsageUnsupported: Bool = true,
+        preferTrailingAuthenticationFailure: Bool = false,
         fetch: ((String, GrokCredentials?) async throws -> GrokWebBillingSnapshot)? = nil) async throws
         -> GrokWebBillingSnapshot
     {
@@ -324,8 +332,12 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
                 lastError = error
             }
         }
-        if preserveTeamUsageUnsupported, let teamUsageUnsupportedError {
-            throw teamUsageUnsupportedError
+        if let teamUsageUnsupportedError {
+            let trailingAuthenticationFailure = preferTrailingAuthenticationFailure
+                && lastError.map(Self.isCookieAuthenticationFailure) == true
+            if !trailingAuthenticationFailure {
+                throw teamUsageUnsupportedError
+            }
         }
         throw lastError ?? GrokWebBillingError.missingCredentials
     }

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -127,11 +127,16 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
         authenticatedByAuthFile: Bool)
 
     static func canImportBrowserCookies(runtime: ProviderRuntime, env: [String: String]) -> Bool {
-        runtime == .app || env["CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT"] == "1"
+        runtime == .app ||
+            ProviderInteractionContext.current == .userInitiated ||
+            env["CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT"] == "1"
     }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         #if os(macOS)
+        if CookieHeaderCache.load(provider: .grok) != nil {
+            return true
+        }
         if Self.canImportBrowserCookies(runtime: context.runtime, env: context.env),
            GrokCookieImporter.hasSession(browserDetection: context.browserDetection)
         {
@@ -201,13 +206,30 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
         let browserCredentials = try? credentialsResult.get()
 
         #if os(macOS)
+        var cacheObservation = CookieHeaderCache.observeForConditionalMutation(provider: .grok)
+        var lastCookieError: Error?
+        if let cached = CookieHeaderCache.load(provider: .grok) {
+            do {
+                let snapshot = try await Self.fetchValidCookieHeader(
+                    cached.cookieHeader,
+                    credentials: browserCredentials)
+                return (snapshot, cached.sourceLabel, false)
+            } catch {
+                guard Self.isCookieAuthenticationFailure(error) else { throw error }
+                if CookieHeaderCache.clearIfCurrent(provider: .grok, expected: cached) {
+                    cacheObservation = cacheObservation.afterOwnedClear()
+                }
+                lastCookieError = error
+            }
+        }
+
         if Self.canImportBrowserCookies(runtime: context.runtime, env: context.env) {
-            var lastCookieError: Error?
             do {
                 let sessions = try GrokCookieImporter.importSessions(browserDetection: context.browserDetection)
                 let (snapshot, sourceLabel) = try await Self.fetchFirstValidCookieSession(
                     sessions,
-                    credentials: browserCredentials)
+                    credentials: browserCredentials,
+                    cacheObservation: cacheObservation)
                 return (snapshot, sourceLabel, false)
             } catch {
                 lastCookieError = error
@@ -242,6 +264,7 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
     static func fetchFirstValidCookieSession(
         _ sessions: [GrokCookieImporter.SessionInfo],
         credentials: GrokCredentials? = nil,
+        cacheObservation: CookieHeaderCache.ConditionalMutationObservation? = nil,
         fetch: ((String, GrokCredentials?) async throws -> GrokWebBillingSnapshot)? = nil) async throws
         -> (GrokWebBillingSnapshot, String)
     {
@@ -253,16 +276,50 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
         var lastError: Error?
         var teamUsageUnsupportedError: Error?
         for session in sessions {
-            for authCredentials in Self.cookieAuthAttempts(credentials: credentials) {
-                do {
-                    let snapshot = try await fetchSnapshot(session.cookieHeader, authCredentials)
-                    return (snapshot, session.sourceLabel)
-                } catch {
-                    if case GrokWebBillingError.teamUsageUnsupported = error {
-                        teamUsageUnsupportedError = error
-                    }
-                    lastError = error
+            do {
+                let snapshot = try await Self.fetchValidCookieHeader(
+                    session.cookieHeader,
+                    credentials: credentials,
+                    fetch: fetchSnapshot)
+                if let cacheObservation {
+                    CookieHeaderCache.storeIfObservationCurrent(
+                        provider: .grok,
+                        expected: cacheObservation,
+                        cookieHeader: session.cookieHeader,
+                        sourceLabel: session.sourceLabel)
                 }
+                return (snapshot, session.sourceLabel)
+            } catch {
+                if case GrokWebBillingError.teamUsageUnsupported = error {
+                    teamUsageUnsupportedError = error
+                }
+                lastError = error
+            }
+        }
+        throw teamUsageUnsupportedError ?? lastError ?? GrokWebBillingError.missingCredentials
+    }
+
+    static func fetchValidCookieHeader(
+        _ cookieHeader: String,
+        credentials: GrokCredentials? = nil,
+        fetch: ((String, GrokCredentials?) async throws -> GrokWebBillingSnapshot)? = nil) async throws
+        -> GrokWebBillingSnapshot
+    {
+        let fetchSnapshot = fetch ?? { cookieHeader, credentials in
+            try await GrokWebBillingFetcher.fetch(
+                cookieHeader: cookieHeader,
+                credentials: credentials)
+        }
+        var lastError: Error?
+        var teamUsageUnsupportedError: Error?
+        for authCredentials in Self.cookieAuthAttempts(credentials: credentials) {
+            do {
+                return try await fetchSnapshot(cookieHeader, authCredentials)
+            } catch {
+                if case GrokWebBillingError.teamUsageUnsupported = error {
+                    teamUsageUnsupportedError = error
+                }
+                lastError = error
             }
         }
         throw teamUsageUnsupportedError ?? lastError ?? GrokWebBillingError.missingCredentials
@@ -271,6 +328,18 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
     static func cookieAuthAttempts(credentials: GrokCredentials?) -> [GrokCredentials?] {
         guard let credentials, !credentials.isExpired else { return [nil] }
         return [credentials, nil]
+    }
+
+    static func isCookieAuthenticationFailure(_ error: Error) -> Bool {
+        guard let error = error as? GrokWebBillingError else { return false }
+        switch error {
+        case let .requestFailed(status, _):
+            return status == 401 || status == 403
+        case let .rpcFailed(status, message):
+            return GrokWebBillingError.isAuthenticationFailure(status: status, message: message)
+        case .missingCredentials, .emptyResponse, .invalidResponse, .teamUsageUnsupported, .parseFailed:
+            return false
+        }
     }
     #endif
 

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -212,7 +212,8 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
             do {
                 let snapshot = try await Self.fetchValidCookieHeader(
                     cached.cookieHeader,
-                    credentials: browserCredentials)
+                    credentials: browserCredentials,
+                    preserveTeamUsageUnsupported: false)
                 return (snapshot, cached.sourceLabel, false)
             } catch {
                 guard Self.isCookieAuthenticationFailure(error) else { throw error }
@@ -302,6 +303,7 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
     static func fetchValidCookieHeader(
         _ cookieHeader: String,
         credentials: GrokCredentials? = nil,
+        preserveTeamUsageUnsupported: Bool = true,
         fetch: ((String, GrokCredentials?) async throws -> GrokWebBillingSnapshot)? = nil) async throws
         -> GrokWebBillingSnapshot
     {
@@ -322,7 +324,10 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
                 lastError = error
             }
         }
-        throw teamUsageUnsupportedError ?? lastError ?? GrokWebBillingError.missingCredentials
+        if preserveTeamUsageUnsupported, let teamUsageUnsupportedError {
+            throw teamUsageUnsupportedError
+        }
+        throw lastError ?? GrokWebBillingError.missingCredentials
     }
 
     static func cookieAuthAttempts(credentials: GrokCredentials?) -> [GrokCredentials?] {

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -138,6 +138,30 @@ struct GrokWebBillingFetcherTests {
     }
 
     @Test
+    func `cached team cookie surfaces trailing authentication failure`() async throws {
+        var attempts: [String] = []
+
+        await #expect {
+            _ = try await GrokWebFetchStrategy.fetchValidCookieHeader(
+                "sso=stale",
+                credentials: Self.credentials,
+                preserveTeamUsageUnsupported: false)
+            { _, authCredentials in
+                if authCredentials != nil {
+                    attempts.append("cookie+bearer")
+                    throw GrokWebBillingError.teamUsageUnsupported
+                }
+                attempts.append("cookie-only")
+                throw GrokWebBillingError.requestFailed(401, "expired")
+            }
+        } throws: { error in
+            GrokWebFetchStrategy.isCookieAuthenticationFailure(error)
+        }
+
+        #expect(attempts == ["cookie+bearer", "cookie-only"])
+    }
+
+    @Test
     func `web strategy tries later browser session when first cookie is stale`() async throws {
         let stale = try #require(Self.cookie(name: "sso", value: "stale"))
         let valid = try #require(Self.cookie(name: "sso", value: "valid"))

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -55,113 +55,6 @@ struct GrokWebBillingFetcherTests {
     }
 
     @Test
-    func `cli runtime imports browser cookies only when explicitly enabled`() {
-        #expect(GrokWebFetchStrategy.canImportBrowserCookies(runtime: .app, env: [:]))
-        #expect(!GrokWebFetchStrategy.canImportBrowserCookies(runtime: .cli, env: [:]))
-        #expect(GrokWebFetchStrategy.canImportBrowserCookies(
-            runtime: .cli,
-            env: ["CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT": "1"]))
-        let userInitiated = ProviderInteractionContext.$current.withValue(.userInitiated) {
-            GrokWebFetchStrategy.canImportBrowserCookies(runtime: .cli, env: [:])
-        }
-        #expect(userInitiated)
-    }
-
-    @Test
-    func `web strategy is available from a cached browser session`() async {
-        let service = "com.steipete.codexbar.tests.grok-availability.\(UUID().uuidString)"
-        await KeychainCacheStore.withServiceOverrideForTesting(service) {
-            await KeychainCacheStore.withImplicitTestStoreForTesting {
-                CookieHeaderCache.store(
-                    provider: .grok,
-                    cookieHeader: "sso=cached-session",
-                    sourceLabel: "Chrome")
-                let grokHome = FileManager.default.temporaryDirectory
-                    .appendingPathComponent(
-                        "CodexBar-GrokCachedAvailability-\(UUID().uuidString)",
-                        isDirectory: true)
-                let browserDetection = BrowserDetection(cacheTTL: 0)
-                let context = ProviderFetchContext(
-                    runtime: .cli,
-                    sourceMode: .web,
-                    includeCredits: true,
-                    webTimeout: 1,
-                    webDebugDumpHTML: false,
-                    verbose: false,
-                    env: ["GROK_HOME": grokHome.path],
-                    settings: nil,
-                    fetcher: UsageFetcher(),
-                    claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
-                    browserDetection: browserDetection)
-
-                #expect(await GrokWebFetchStrategy().isAvailable(context))
-            }
-        }
-    }
-
-    @Test
-    func `validated browser session stages a cache replacement for explicit refresh`() async throws {
-        let service = "com.steipete.codexbar.tests.grok-refresh.\(UUID().uuidString)"
-        try await KeychainCacheStore.withServiceOverrideForTesting(service) {
-            try await KeychainCacheStore.withImplicitTestStoreForTesting {
-                let gate = try #require(CookieHeaderCache.beginRefreshReadSuppression(provider: .grok))
-                defer { CookieHeaderCache.endRefreshReadSuppression(gate) }
-                let observation = CookieHeaderCache.observeForConditionalMutation(provider: .grok)
-                let cookie = try #require(Self.cookie(name: "sso", value: "fresh-session"))
-                let sessions = [GrokCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")]
-
-                let result = try await GrokWebFetchStrategy.fetchFirstValidCookieSession(
-                    sessions,
-                    cacheObservation: observation)
-                { _, _ in
-                    GrokWebBillingSnapshot(usedPercent: 7, resetsAt: nil)
-                }
-
-                #expect(result.0.usedPercent == 7)
-                #expect(CookieHeaderCache.load(provider: .grok)?.cookieHeader == "sso=fresh-session")
-                let commit = CookieHeaderCache.commitRefreshReadSuppression(gate)
-                #expect(commit == CookieRefreshCommitSummary(stagedCount: 1, committedCount: 1, failedCount: 0))
-            }
-        }
-    }
-
-    @Test
-    func `cached cookie eviction is limited to authentication failures`() {
-        #expect(GrokWebFetchStrategy.isCookieAuthenticationFailure(
-            GrokWebBillingError.requestFailed(401, "expired")))
-        #expect(GrokWebFetchStrategy.isCookieAuthenticationFailure(
-            GrokWebBillingError.rpcFailed(16, "unauthenticated")))
-        #expect(!GrokWebFetchStrategy.isCookieAuthenticationFailure(
-            GrokWebBillingError.requestFailed(503, "unavailable")))
-        #expect(!GrokWebFetchStrategy.isCookieAuthenticationFailure(
-            GrokWebBillingError.parseFailed))
-    }
-
-    @Test
-    func `cached team cookie surfaces trailing authentication failure`() async throws {
-        var attempts: [String] = []
-
-        await #expect {
-            _ = try await GrokWebFetchStrategy.fetchValidCookieHeader(
-                "sso=stale",
-                credentials: Self.credentials,
-                preserveTeamUsageUnsupported: false)
-            { _, authCredentials in
-                if authCredentials != nil {
-                    attempts.append("cookie+bearer")
-                    throw GrokWebBillingError.teamUsageUnsupported
-                }
-                attempts.append("cookie-only")
-                throw GrokWebBillingError.requestFailed(401, "expired")
-            }
-        } throws: { error in
-            GrokWebFetchStrategy.isCookieAuthenticationFailure(error)
-        }
-
-        #expect(attempts == ["cookie+bearer", "cookie-only"])
-    }
-
-    @Test
     func `web strategy tries later browser session when first cookie is stale`() async throws {
         let stale = try #require(Self.cookie(name: "sso", value: "stale"))
         let valid = try #require(Self.cookie(name: "sso", value: "valid"))
@@ -1094,6 +987,142 @@ extension GrokWebBillingFetcherTests {
             index = next
         }
         return data
+    }
+}
+
+// MARK: - Browser cookie cache
+
+extension GrokWebBillingFetcherTests {
+    @Test
+    func `cli runtime imports browser cookies only when explicitly enabled`() {
+        #expect(GrokWebFetchStrategy.canImportBrowserCookies(runtime: .app, env: [:]))
+        #expect(!GrokWebFetchStrategy.canImportBrowserCookies(runtime: .cli, env: [:]))
+        #expect(GrokWebFetchStrategy.canImportBrowserCookies(
+            runtime: .cli,
+            env: ["CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT": "1"]))
+        let userInitiated = ProviderInteractionContext.$current.withValue(.userInitiated) {
+            GrokWebFetchStrategy.canImportBrowserCookies(runtime: .cli, env: [:])
+        }
+        #expect(userInitiated)
+    }
+
+    @Test
+    func `web strategy is available from a cached browser session`() async {
+        let service = "com.steipete.codexbar.tests.grok-availability.\(UUID().uuidString)"
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+        await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            await KeychainCacheStore.withImplicitTestStoreForTesting {
+                CookieHeaderCache.store(
+                    provider: .grok,
+                    cookieHeader: "sso=cached-session",
+                    sourceLabel: "Chrome")
+                let grokHome = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(
+                        "CodexBar-GrokCachedAvailability-\(UUID().uuidString)",
+                        isDirectory: true)
+                let browserDetection = BrowserDetection(cacheTTL: 0)
+                let context = ProviderFetchContext(
+                    runtime: .cli,
+                    sourceMode: .web,
+                    includeCredits: true,
+                    webTimeout: 1,
+                    webDebugDumpHTML: false,
+                    verbose: false,
+                    env: ["GROK_HOME": grokHome.path],
+                    settings: nil,
+                    fetcher: UsageFetcher(),
+                    claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+                    browserDetection: browserDetection)
+
+                #expect(await GrokWebFetchStrategy().isAvailable(context))
+            }
+        }
+    }
+
+    @Test
+    func `validated browser session stages a cache replacement for explicit refresh`() async throws {
+        let service = "com.steipete.codexbar.tests.grok-refresh.\(UUID().uuidString)"
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+        try await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            try await KeychainCacheStore.withImplicitTestStoreForTesting {
+                let gate = try #require(CookieHeaderCache.beginRefreshReadSuppression(provider: .grok))
+                defer { CookieHeaderCache.endRefreshReadSuppression(gate) }
+                let observation = CookieHeaderCache.observeForConditionalMutation(provider: .grok)
+                let cookie = try #require(Self.cookie(name: "sso", value: "fresh-session"))
+                let sessions = [GrokCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")]
+
+                let result = try await GrokWebFetchStrategy.fetchFirstValidCookieSession(
+                    sessions,
+                    cacheObservation: observation)
+                { _, _ in
+                    GrokWebBillingSnapshot(usedPercent: 7, resetsAt: nil)
+                }
+
+                #expect(result.0.usedPercent == 7)
+                #expect(CookieHeaderCache.load(provider: .grok)?.cookieHeader == "sso=fresh-session")
+                let commit = CookieHeaderCache.commitRefreshReadSuppression(gate)
+                #expect(commit == CookieRefreshCommitSummary(stagedCount: 1, committedCount: 1, failedCount: 0))
+            }
+        }
+    }
+
+    @Test
+    func `cached cookie eviction is limited to authentication failures`() {
+        #expect(GrokWebFetchStrategy.isCookieAuthenticationFailure(
+            GrokWebBillingError.requestFailed(401, "expired")))
+        #expect(GrokWebFetchStrategy.isCookieAuthenticationFailure(
+            GrokWebBillingError.rpcFailed(16, "unauthenticated")))
+        #expect(!GrokWebFetchStrategy.isCookieAuthenticationFailure(
+            GrokWebBillingError.requestFailed(503, "unavailable")))
+        #expect(!GrokWebFetchStrategy.isCookieAuthenticationFailure(
+            GrokWebBillingError.parseFailed))
+    }
+
+    @Test
+    func `cached team cookie surfaces trailing authentication failure`() async throws {
+        var attempts: [String] = []
+
+        await #expect {
+            _ = try await GrokWebFetchStrategy.fetchValidCookieHeader(
+                "sso=stale",
+                credentials: Self.credentials,
+                preferTrailingAuthenticationFailure: true)
+            { _, authCredentials in
+                if authCredentials != nil {
+                    attempts.append("cookie+bearer")
+                    throw GrokWebBillingError.teamUsageUnsupported
+                }
+                attempts.append("cookie-only")
+                throw GrokWebBillingError.requestFailed(401, "expired")
+            }
+        } throws: { error in
+            GrokWebFetchStrategy.isCookieAuthenticationFailure(error)
+        }
+
+        #expect(attempts == ["cookie+bearer", "cookie-only"])
+    }
+
+    @Test
+    func `cached team cookie keeps team classification for non-auth trailing errors`() async {
+        await #expect {
+            _ = try await GrokWebFetchStrategy.fetchValidCookieHeader(
+                "sso=team-session",
+                credentials: Self.credentials,
+                preferTrailingAuthenticationFailure: true)
+            { _, authCredentials in
+                if authCredentials != nil {
+                    throw GrokWebBillingError.teamUsageUnsupported
+                }
+                throw GrokWebBillingError.rpcFailed(9, "No personal team")
+            }
+        } throws: { error in
+            if case GrokWebBillingError.teamUsageUnsupported = error {
+                return true
+            }
+            return false
+        }
     }
 }
 

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -55,12 +55,86 @@ struct GrokWebBillingFetcherTests {
     }
 
     @Test
-    func `cli runtime does not import browser cookies unless explicitly enabled`() {
+    func `cli runtime imports browser cookies only when explicitly enabled`() {
         #expect(GrokWebFetchStrategy.canImportBrowserCookies(runtime: .app, env: [:]))
         #expect(!GrokWebFetchStrategy.canImportBrowserCookies(runtime: .cli, env: [:]))
         #expect(GrokWebFetchStrategy.canImportBrowserCookies(
             runtime: .cli,
             env: ["CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT": "1"]))
+        let userInitiated = ProviderInteractionContext.$current.withValue(.userInitiated) {
+            GrokWebFetchStrategy.canImportBrowserCookies(runtime: .cli, env: [:])
+        }
+        #expect(userInitiated)
+    }
+
+    @Test
+    func `web strategy is available from a cached browser session`() async {
+        let service = "com.steipete.codexbar.tests.grok-availability.\(UUID().uuidString)"
+        await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            await KeychainCacheStore.withImplicitTestStoreForTesting {
+                CookieHeaderCache.store(
+                    provider: .grok,
+                    cookieHeader: "sso=cached-session",
+                    sourceLabel: "Chrome")
+                let grokHome = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(
+                        "CodexBar-GrokCachedAvailability-\(UUID().uuidString)",
+                        isDirectory: true)
+                let browserDetection = BrowserDetection(cacheTTL: 0)
+                let context = ProviderFetchContext(
+                    runtime: .cli,
+                    sourceMode: .web,
+                    includeCredits: true,
+                    webTimeout: 1,
+                    webDebugDumpHTML: false,
+                    verbose: false,
+                    env: ["GROK_HOME": grokHome.path],
+                    settings: nil,
+                    fetcher: UsageFetcher(),
+                    claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+                    browserDetection: browserDetection)
+
+                #expect(await GrokWebFetchStrategy().isAvailable(context))
+            }
+        }
+    }
+
+    @Test
+    func `validated browser session stages a cache replacement for explicit refresh`() async throws {
+        let service = "com.steipete.codexbar.tests.grok-refresh.\(UUID().uuidString)"
+        try await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            try await KeychainCacheStore.withImplicitTestStoreForTesting {
+                let gate = try #require(CookieHeaderCache.beginRefreshReadSuppression(provider: .grok))
+                defer { CookieHeaderCache.endRefreshReadSuppression(gate) }
+                let observation = CookieHeaderCache.observeForConditionalMutation(provider: .grok)
+                let cookie = try #require(Self.cookie(name: "sso", value: "fresh-session"))
+                let sessions = [GrokCookieImporter.SessionInfo(cookies: [cookie], sourceLabel: "Chrome")]
+
+                let result = try await GrokWebFetchStrategy.fetchFirstValidCookieSession(
+                    sessions,
+                    cacheObservation: observation)
+                { _, _ in
+                    GrokWebBillingSnapshot(usedPercent: 7, resetsAt: nil)
+                }
+
+                #expect(result.0.usedPercent == 7)
+                #expect(CookieHeaderCache.load(provider: .grok)?.cookieHeader == "sso=fresh-session")
+                let commit = CookieHeaderCache.commitRefreshReadSuppression(gate)
+                #expect(commit == CookieRefreshCommitSummary(stagedCount: 1, committedCount: 1, failedCount: 0))
+            }
+        }
+    }
+
+    @Test
+    func `cached cookie eviction is limited to authentication failures`() {
+        #expect(GrokWebFetchStrategy.isCookieAuthenticationFailure(
+            GrokWebBillingError.requestFailed(401, "expired")))
+        #expect(GrokWebFetchStrategy.isCookieAuthenticationFailure(
+            GrokWebBillingError.rpcFailed(16, "unauthenticated")))
+        #expect(!GrokWebFetchStrategy.isCookieAuthenticationFailure(
+            GrokWebBillingError.requestFailed(503, "unavailable")))
+        #expect(!GrokWebFetchStrategy.isCookieAuthenticationFailure(
+            GrokWebBillingError.parseFailed))
     }
 
     @Test

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -46,6 +46,11 @@ browser session when the CLI surface does not expose billing.
    - Ordinary CLI/test runtime does not import browser cookies unless
      `CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT=1` is set. An explicit
      `codexbar cookie refresh --provider grok` also opts in for that refresh.
+   - Validated sessions are stored in the Keychain-backed cookie cache and are
+     reused first by later app and CLI fetches, so background work does not
+     re-open the Chromium Keychain gate. The cached cookie is evicted only on
+     authentication failures (HTTP 401/403 or gRPC auth statuses); a cached
+     team-limited session keeps degrading to identity-only data.
    - `~/.grok/auth.json` is still used for identity and as a last best-effort
      bearer-only probe after browser sessions fail. Expired tokens are not sent.
    - Parses the returned protobuf enough to recover used percent and

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -43,8 +43,9 @@ browser session when the CLI surface does not expose billing.
      browser session, then retries that session with cookies only.
    - CodexBar imports Chrome only by default to avoid unrelated browser
      Keychain prompts.
-   - CLI/test runtime does not import browser cookies unless
-     `CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT=1` is set.
+   - Ordinary CLI/test runtime does not import browser cookies unless
+     `CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT=1` is set. An explicit
+     `codexbar cookie refresh --provider grok` also opts in for that refresh.
    - `~/.grok/auth.json` is still used for identity and as a last best-effort
      bearer-only probe after browser sessions fail. Expired tokens are not sent.
    - Parses the returned protobuf enough to recover used percent and

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -445,7 +445,8 @@ scan fails, while provider/account configuration changes replace obsolete result
 - `grok agent stdio` (ACP) JSON-RPC `x.ai/billing` method; requires `grok login` (SuperGrok OAuth/OIDC).
 - Reads cached credentials from `~/.grok/auth.json` for identity (email, team).
 - Falls back to grok.com's billing gRPC-web endpoint via Chrome session cookies when the CLI does not expose billing.
-- CLI/test runs do not import browser cookies unless `CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT=1` is set.
+- Ordinary CLI/test runs do not import browser cookies unless `CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT=1` is set;
+  `codexbar cookie refresh --provider grok` opts in for its explicit refresh.
 - Local fallback aggregates `~/.grok/sessions/**/signals.json` token counts when the RPC is unavailable.
 - Status: link only to `https://status.x.ai` (no auto-polling yet).
 - Details: `docs/grok.md`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -447,6 +447,8 @@ scan fails, while provider/account configuration changes replace obsolete result
 - Falls back to grok.com's billing gRPC-web endpoint via Chrome session cookies when the CLI does not expose billing.
 - Ordinary CLI/test runs do not import browser cookies unless `CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT=1` is set;
   `codexbar cookie refresh --provider grok` opts in for its explicit refresh.
+- Validated sessions are cached in the Keychain cookie cache and reused before any new browser import;
+  the cache is evicted only on authentication failures.
 - Local fallback aggregates `~/.grok/sessions/**/signals.json` token counts when the RPC is unavailable.
 - Status: link only to `https://status.x.ai` (no auto-polling yet).
 - Details: `docs/grok.md`.


### PR DESCRIPTION
## Summary

- Allow explicitly user-initiated Grok CLI cookie refreshes to import browser cookies while keeping ordinary CLI and background imports gated.
- Cache validated grok.com sessions and reuse them for background/app and later CLI fetches.
- Clear cached Grok cookies only on authentication failures, with conditional mutations so concurrent replacements are preserved.
- Keep the `teamUsageUnsupported` classification for cached sessions whose trailing cookie-only attempt fails with a non-authentication error, so team principals continue degrading to identity-only data instead of pinning an ineradicable failing cache entry.
- Read the cached entry from the conditional-mutation observation (single Keychain read, matching the Claude web fetcher).
- Document the explicit refresh behavior, the cache/eviction policy, and the browser-cookie import contract; add regression coverage for availability, refresh staging, eviction policy, and both team-cookie fallbacks.

## Root cause

The generic cookie refresh command marks provider work as user initiated, but the Grok strategy still rejected every CLI browser import unless CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT was set manually. After a browser session did validate, Grok also did not store it in CookieHeaderCache, so the refresh command had no staged cookie to commit and background fetches could not reuse the session behind the Chromium Keychain gate.

Two follow-up fixes hardened the cached path:

1. (Codex review finding) A stale cached team cookie could hide its trailing 401 behind the `teamUsageUnsupported` classification and never evict. The cached path now prefers a trailing **authentication** failure so stale sessions evict and re-import.
2. (Inverse case) A still-valid cached team cookie whose trailing cookie-only attempt fails with gRPC 9 "No personal team" (a non-authentication error) must not surface that raw error — it would bypass the identity-only degradation and could never be evicted. The trailing error now wins only when it is an authentication failure; otherwise `teamUsageUnsupported` is preserved.

## Security note: `userInitiated` import boundary

Producers of `ProviderInteractionContext.userInitiated` were audited for this change: in the CLI, only the explicit `cookie refresh` command sets it (`CLICookieCommand.performCookieRefreshes`); `usage` and `serve` explicitly bind `.background`. In the app, every setter is a direct UI gesture, and the app runtime was already permitted via `runtime == .app`, so the new clause only affects explicit CLI refreshes. Scheduled/background work inherits the `.background` task-local default. The contract is now documented on `canImportBrowserCookies`.

## Live behavior proof

Validated on macOS with the final branch binary (`87cffdea`) and a real signed-in Chrome profile. Cookie values, usage values, reset timestamps, and account data are redacted.

### 1. Ordinary CLI reuses the validated cached session without browser-import opt-in

```text
$ env -u CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT CodexBarCLI usage --provider grok --source web --log-level debug --format json
... debug com.steipete.codexbar.cookie-cache: provider=grok [CodexBarCore] Cookie cache hit
[{"source":"Chrome Default","usage":{"identity":{"providerID":"grok"},"primary":{"usedPercent":<redacted>,"resetsAt":"<redacted>"},...},"provider":"grok"}]
```

No browser-cookie import or Keychain-attempt log was emitted.

### 2. A stale cached session is evicted on a real authentication failure

For this check, the cached entry's `cookieHeader` was replaced with an invalid value (entry shape untouched); the Chrome source session was left signed in.

```text
$ env -u CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT CodexBarCLI usage --provider grok --source web --log-level debug --format json
... Cookie cache hit
[{"source":"web","error":{"kind":"provider","code":1,"message":"Grok auth.json not found. Run `grok login` to authenticate."},"provider":"grok"}]
```

grok.com rejected the invalid session with an authentication failure, the entry was evicted, and the run fell through to the auth-file probe (absent on this machine). The next run proves the eviction and that ordinary CLI work stays gated — it exited 1 with no browser-cookie import or Keychain-attempt log:

```text
$ env -u CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT CodexBarCLI usage --provider grok --source web --log-level debug --format json
... Cookie cache miss
[{"error":{"message":"No available fetch strategy for grok.","code":1,"kind":"provider"},"source":"web","provider":"grok"}]
```

### 3. Explicit refresh imports, validates, and commits a fresh browser session

```text
$ env -u CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT CodexBarCLI cookie refresh --provider grok --allow-keychain-prompt --format json
[{"provider":"grok","status":"refreshed","message":"Browser cookie refreshed."}]
```

### 4. The committed session is reused by the next ordinary CLI fetch

```text
$ env -u CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT CodexBarCLI usage --provider grok --source web --log-level debug --format json
... Cookie cache hit
[{"source":"Chrome Default","usage":{...,"primary":{"usedPercent":<redacted>,"resetsAt":"<redacted>"},...},"provider":"grok"}]
```

The team-cookie matrix (trailing 401 evicts; trailing gRPC 9 keeps the team classification) is covered by unit tests; no team account was available for a live team run.

## Validation

- `swift test --filter "GrokWebBillingFetcherTests|CLICookieRefreshTests"` (52 tests in 2 suites passed on `87cffde`)
- `make check` (clean: 0 violations in 1581 files)
- Full `make test` was previously blocked at group 48/61 by four unrelated singularization expectations in SessionEquivalentForecastTests (`1 windows` versus `1 window`); this PR does not touch the forecast implementation or tests.
