### PR TITLE
Show model-scoped weekly rows before Daily Routines

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -1160,7 +1160,9 @@ extension ClaudeUsageFetcher {
                     resetsAt: resetDate,
                     resetDescription: resetDescription))
         }
-        return routineWindows + Self.oauthScopedWeeklyLimitWindows(from: usage)
+        // Keep the same row order as the Web path: model-scoped weekly limits first,
+        // Daily Routines last.
+        return Self.oauthScopedWeeklyLimitWindows(from: usage) + routineWindows
     }
 
     private static func oauthScopedWeeklyLimitWindows(from usage: OAuthUsageResponse) -> [NamedRateWindow] {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebExtraRateWindowParser.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebExtraRateWindowParser.swift
@@ -21,6 +21,11 @@ enum ClaudeWebExtraRateWindowParser {
         var sourceKeys: [String: String] = [:]
         windows.reserveCapacity(Self.definitions.count)
 
+        // Model-scoped weekly limits come first: they track the model budget users spend
+        // day to day, while Daily Routines stays at 0% for accounts that never use
+        // Routines/Cowork and would otherwise push the meaningful row down the card.
+        windows.append(contentsOf: Self.scopedWeeklyLimitWindows(from: json))
+
         for definition in Self.definitions {
             if let foundWindow = Self.firstUsageWindow(in: json, keys: definition.keys) {
                 let rawWindow = foundWindow.window
@@ -46,7 +51,6 @@ enum ClaudeWebExtraRateWindowParser {
                 sourceKeys[definition.id] = key
             }
         }
-        windows.append(contentsOf: Self.scopedWeeklyLimitWindows(from: json))
         return (windows, sourceKeys)
     }
 

--- a/Tests/CodexBarTests/ClaudeOAuthTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthTests.swift
@@ -181,6 +181,27 @@ struct ClaudeOAuthTests {
     }
 
     @Test
+    func `orders O auth scoped weekly windows before daily routines`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 12.5, "resets_at": "2025-12-25T12:00:00.000Z" },
+          "seven_day": { "utilization": 30, "resets_at": "2025-12-31T00:00:00.000Z" },
+          "seven_day_routines": { "utilization": 18, "resets_at": "2026-01-01T00:00:00.000Z" },
+          "limits": [
+            {
+              "kind": "weekly_scoped", "group": "weekly", "percent": 29,
+              "resets_at": "2025-12-31T00:00:00.000Z",
+              "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+              "is_active": false
+            }
+          ]
+        }
+        """
+        let snap = try ClaudeUsageFetcher._mapOAuthUsageForTesting(Data(json.utf8))
+        #expect(snap.extraRateWindows.map(\.title) == ["Fable only", "Daily Routines"])
+    }
+
+    @Test
     func `ignores weekly scoped limit without a model display name`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/ClaudeWebUsageExtraWindowTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebUsageExtraWindowTests.swift
@@ -102,4 +102,32 @@ struct ClaudeWebUsageExtraWindowTests {
         let parsed = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(data)
         #expect(parsed.extraRateWindows.map(\.title) == ["Fable only", "Daily Routines"])
     }
+
+    @Test
+    func `keeps multiple scoped weekly windows in payload order before routines`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 9, "resets_at": "2026-07-03T00:30:00.440902+00:00" },
+          "seven_day": { "utilization": 20, "resets_at": "2026-07-08T09:00:00.440924+00:00" },
+          "seven_day_cowork": { "utilization": 11, "resets_at": "2026-07-08T09:00:00.440924+00:00" },
+          "limits": [
+            {
+              "kind": "weekly_scoped", "group": "weekly", "percent": 12,
+              "resets_at": "2026-07-08T09:00:00.441154+00:00",
+              "scope": { "model": { "id": null, "display_name": "Opus" }, "surface": null },
+              "is_active": false
+            },
+            {
+              "kind": "weekly_scoped", "group": "weekly", "percent": 29,
+              "resets_at": "2026-07-08T09:00:00.441154+00:00",
+              "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+              "is_active": false
+            }
+          ]
+        }
+        """
+        let data = Data(json.utf8)
+        let parsed = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(data)
+        #expect(parsed.extraRateWindows.map(\.title) == ["Opus only", "Fable only", "Daily Routines"])
+    }
 }

--- a/Tests/CodexBarTests/ClaudeWebUsageExtraWindowTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebUsageExtraWindowTests.swift
@@ -80,4 +80,26 @@ struct ClaudeWebUsageExtraWindowTests {
         #expect(fable?.window.usedPercent == 5)
         #expect(fable?.window.resetsAt != nil)
     }
+
+    @Test
+    func `orders scoped weekly windows before daily routines`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 9, "resets_at": "2026-07-03T00:30:00.440902+00:00" },
+          "seven_day": { "utilization": 20, "resets_at": "2026-07-08T09:00:00.440924+00:00" },
+          "seven_day_cowork": { "utilization": 11, "resets_at": "2026-07-08T09:00:00.440924+00:00" },
+          "limits": [
+            {
+              "kind": "weekly_scoped", "group": "weekly", "percent": 29,
+              "resets_at": "2026-07-08T09:00:00.441154+00:00",
+              "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+              "is_active": false
+            }
+          ]
+        }
+        """
+        let data = Data(json.utf8)
+        let parsed = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(data)
+        #expect(parsed.extraRateWindows.map(\.title) == ["Fable only", "Daily Routines"])
+    }
 }


### PR DESCRIPTION
## Summary

Implements the fixed-reorder option recommended in the review of #2460: on the Claude card, model-scoped weekly rows (e.g. `Fable only`) now render **before** the `Daily Routines` row. No new settings are introduced.

Rationale: accounts that never use Routines/Cowork see `Daily Routines` sit permanently at 0% while the model-scoped weekly row — the one tracking the budget they actually spend day to day — gets pushed to the bottom of the card.

## Changes

Two ordering-only edits, plus regression coverage for both:

- `ClaudeWebExtraRateWindowParser.swift` — append `scopedWeeklyLimitWindows(from:)` before the `definitions` loop that produces `Daily Routines`.
- `ClaudeUsageFetcher.swift` — OAuth path returns `oauthScopedWeeklyLimitWindows(from:) + routineWindows` instead of the reverse, so both sources agree on row order.
- `ClaudeWebUsageExtraWindowTests.swift` — new `orders scoped weekly windows before daily routines`: feeds a payload containing both `seven_day_cowork` and a `weekly_scoped` limit, asserts `extraRateWindows.map(\.title) == ["Fable only", "Daily Routines"]`.
- `ClaudeWebUsageExtraWindowTests.swift` — new `keeps multiple scoped weekly windows in payload order before routines`: two `weekly_scoped` limits plus routines, asserts `["Opus only", "Fable only", "Daily Routines"]`, pinning that scoped rows keep their payload order relative to each other.
- `ClaudeOAuthTests.swift` — new `orders O auth scoped weekly windows before daily routines`: same assertion through `_mapOAuthUsageForTesting`.

The CLI/status-probe path is untouched: its order comes from the order the windows appear in the `claude` CLI output.

## Real behavior proof

Built `CodexBarCLI` from this branch and compared its JSON output against the shipped 0.45.2 helper on the same account, same minute. Output redacted to `id` + `title` (percentages, reset timestamps and account identifiers stripped):

```
$ CodexBarCLI usage --provider claude --json | extract_rows.py   # shipped 0.45.2
  [0] id='claude-routines'                        title='Daily Routines'
  [1] id='claude-weekly-scoped-fable'             title='Fable only'

$ .build/debug/CodexBarCLI usage --provider claude --json | extract_rows.py   # this branch
  [0] id='claude-weekly-scoped-fable'             title='Fable only'
  [1] id='claude-routines'                        title='Daily Routines'
```

`extract_rows.py` just walks the JSON for `extraRateWindows` and prints `id`/`title` per row.

Disclosure per AGENTS.md: this was a live provider probe against a real Claude Max account, run at the explicit request of the account owner (who also filed #2460) on their own machine. No screenshot is attached — the menu card on that account shows spend figures that should not go into a public PR; the redacted CLI output above is the equivalent evidence for row order.

## Why this direction matches existing expectations

`ClaudeCLIScopedWeeklyUsageTests` already constructs `web: [webFable, routines]` and asserts `merged.map(\.id) == ["claude-weekly-scoped-fable", "claude-routines"]` — scoped weekly first. The parsers were producing the opposite order; this change makes them agree with that expectation.

## Test impact review

Every order-sensitive assertion I could find:

- `MenuCardModelTests.swift:987` — `#expect(model.metrics.map(\.title) == ["Session", "Weekly", "Sonnet", "Daily Routines"])`. Unaffected: `Sonnet` comes from the `tertiary` slot, and that fixture's `extraRateWindows` contains only `Daily Routines`.
- `ClaudeCLIScopedWeeklyUsageTests.swift:285` — `#expect(merged.last?.title == "Daily Routines")`. Still holds once scoped rows come first.
- `ClaudeWebUsageExtraWindowTests.swift`, `ClaudeOAuthTests.swift` (existing cases) — use `first(where: { $0.id == ... })`, order-independent.
- Remaining `extraRateWindows.first?` assertions in `ClaudeCLIScopedWeeklyUsageTests` use fixtures whose only window is a scoped weekly one (`map(\.title) == ["Fable only"]`), so they are unaffected.

## Known gaps in this PR's coverage

Disclosing these rather than leaving them to be found in review:

1. **No UI-level assertion.** The new tests pin the data layer (`extraRateWindows` order out of each parser). Nothing pins "the third row rendered on the Claude card is the scoped weekly one" — `MenuCardModelTests` covers the card model but its Claude fixture carries only `Daily Routines` in `extraRateWindows`. I verified the rendered result out of band by reading the app's widget snapshot after a refresh, which is not automated. Happy to add a card-model case with both row kinds if you want that pinned too.
2. **CLI source is not brought in line.** On the account I could test, `claude`'s own `/usage` output does not print a Daily Routines line at all (the CLI source yielded only `Fable only`), so no ordering conflict is observable there. But the status-probe path still takes whatever order `claude` prints, so if some account prints both, the CLI source could disagree with the Web/OAuth order this PR establishes. If you want all three sources strongly consistent, I can sort in `ClaudeStatusProbe` too — I left it out to keep the diff to the two sites the issue is about.

## Commands run

```
swift build --target CodexBarCore     # exit 0
swift build --product CodexBarCLI     # exit 0
```

## Not run, and why

- `make test` / `swift test` — this machine has only the Command Line Tools, so the test targets fail to build with `no such module 'Testing'`. **The two new tests have therefore not been executed locally**; they are written against the same fixture shapes as the neighbouring cases in each file, but please let CI be the first real run.
- `swiftformat` / `swiftlint` — not installed here, and AGENTS.md says not to add tooling without confirmation. Longest added line is 89 chars and indentation matches the surrounding code.

Happy to push fixups if CI or the linters flag anything.

Refs #2460. Related: #2353 (hide Daily Routines) remains a separate product decision; this PR deliberately does not add a visibility/order preference.
