### PR TITLE
Support LongCat Firefox cookie imports

### DIFF
--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -291,10 +291,11 @@ public enum ProviderBrowserCookieDefaults {
         #endif
     }
 
-    /// LongCat Auto imports only from Chrome by default to avoid prompting unrelated browser keychains.
+    /// LongCat Auto keeps Chrome first for existing users, then checks Firefox without adding
+    /// an unrelated browser Keychain prompt.
     public static var longcatCookieImportOrder: BrowserCookieImportOrder? {
         #if os(macOS)
-        [.chrome]
+        [.chrome, .firefox]
         #else
         nil
         #endif

--- a/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
@@ -102,9 +102,13 @@ struct BrowserCookieOrderStatusStringTests {
     }
 
     @Test
-    func `longcat cookie imports default to chrome only`() {
-        #expect(ProviderDefaults.metadata[.longcat]?.browserCookieOrder == [.chrome])
-        #expect(ProviderBrowserCookieDefaults.longcatCookieImportOrder == [.chrome])
+    func `longcat cookie import order supports chrome and firefox`() {
+        let order = ProviderDefaults.metadata[.longcat]?.browserCookieOrder ?? Browser.defaultImportOrder
+        #expect(order == ProviderBrowserCookieDefaults.longcatCookieImportOrder)
+        #expect(order == [.chrome, .firefox])
+        #expect(order.first == .chrome)
+        #expect(order.contains(.firefox))
+        #expect(!order.contains(.safari))
     }
     #endif
 }

--- a/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
@@ -103,12 +103,14 @@ struct BrowserCookieOrderStatusStringTests {
 
     @Test
     func `longcat cookie import order supports chrome and firefox`() {
-        let order = ProviderDefaults.metadata[.longcat]?.browserCookieOrder ?? Browser.defaultImportOrder
-        #expect(order == ProviderBrowserCookieDefaults.longcatCookieImportOrder)
-        #expect(order == [.chrome, .firefox])
-        #expect(order.first == .chrome)
-        #expect(order.contains(.firefox))
-        #expect(!order.contains(.safari))
+        let metadataOrder = ProviderDefaults.metadata[.longcat]?.browserCookieOrder
+        let defaultOrder = ProviderBrowserCookieDefaults.longcatCookieImportOrder
+
+        #expect(metadataOrder == [.chrome, .firefox])
+        #expect(defaultOrder == [.chrome, .firefox])
+        #expect(defaultOrder?.first == .chrome)
+        #expect(defaultOrder?.contains(.firefox) == true)
+        #expect(defaultOrder?.contains(.safari) == false)
     }
     #endif
 }


### PR DESCRIPTION
## Summary

- add Firefox as a Chrome-first fallback for LongCat automatic cookie imports
- preserve the existing Chrome precedence without adding Safari or unrelated Chromium browser probes
- update the dedicated browser-order regression test to lock the provider metadata and Firefox fallback

## Root cause

LongCat's automatic cookie import order was hard-coded to `[.chrome]`. Although the shared cookie importer already supports Firefox and other providers use it successfully, Firefox was never included in LongCat's candidate list, so a valid `longcat.chat` Firefox session could not be discovered.

## Real behavior proof

Ran a credential-safe local proof on a machine signed in to LongCat only in Firefox. The proof used the exact SweetCookieKit `0.4.1` revision pinned by this checkout and the same Firefox cookie query and LongCat endpoints used by the production importer.

```text
[proof] configured LongCat order: Chrome -> Firefox
[proof] Chrome LongCat cookie rows: 0
[proof] Firefox candidate profiles with LongCat cookies: 1
[proof] Firefox profile #1: authenticated LongCat session discovered
[proof] user-current: HTTP 200, envelope 0
[proof] tokenUsage: HTTP 200, envelope 0, totalToken present
[proof] cookie values and account fields: redacted by harness
```

The Chrome check was count-only and did not decrypt or print cookie data. The Firefox proof imported the live cookie store, sent authenticated GET requests only to `longcat.chat`, and printed only status/schema evidence. No cookie names, values, account identity, quota values, or response bodies were retained.

Firefox uses the shared Gecko SQLite/WAL reader and does not use Chromium Safe Storage, so this fallback does not introduce a browser Keychain prompt. It does expand LongCat's file-based browser probing from Chrome to Firefox when Automatic import runs; Chrome remains first.

## Verification

- real Firefox-only LongCat discovery proof above — authenticated `user-current` and `tokenUsage` requests succeeded
- `make check` — all portable repository checks and SwiftFormat passed; the initial SwiftLint invocation could not load SourceKit from the active Command Line Tools path
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer .build/lint-tools/bin/swiftlint --strict` — 0 violations across 1,581 files
- `swift test --filter BrowserCookieOrderStatusStringTests` — could not start because this checkout requires Swift tools 6.2 while the installed Xcode/Swift toolchain is 5.10
- `make test` — same local Swift 6.2 toolchain prerequisite prevented test discovery; upstream CI remains the compilation and test gate

## Changelog

LongCat: detect Firefox web sessions during Automatic cookie import.

No screenshots needed; this changes provider cookie-source selection only.

Fixes #2463
