### PR TITLE
Stabilize token provenance fixture clock

### DIFF
--- a/Tests/CodexBarTests/SpendDashboardTokenProvenanceTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardTokenProvenanceTests.swift
@@ -124,9 +124,7 @@ struct SpendDashboardTokenProvenanceTests {
         store.activateCachedTokenAccountSnapshot(provider: .mistral, accountID: account.id)
         #expect(store.tokenSnapshotPublicationRevision(for: .mistral) == baselineRevision)
         store._test_providerRefreshOverride = { _ in }
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = Self.dashboardController(settings: settings, store: store)
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.model.groups.first?.totalCost == 3)
@@ -148,9 +146,7 @@ struct SpendDashboardTokenProvenanceTests {
             return loadCount == 1 ? Self.tokenSnapshot(cost: 4) : Self.emptyTokenSnapshot()
         }
         await store.refreshTokenUsageNow(for: .bedrock, force: true)
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = Self.dashboardController(settings: settings, store: store)
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.model.groups.first?.totalCost == 4)
@@ -177,9 +173,7 @@ struct SpendDashboardTokenProvenanceTests {
         }
         await store.refreshTokenUsageNow(for: .bedrock, force: true)
         let publicationRevision = store.tokenSnapshotPublicationRevision(for: .bedrock)
-        let controller = SpendDashboardController(requestBuilder: { mode in
-            await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: mode)
-        })
+        let controller = Self.dashboardController(settings: settings, store: store)
 
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }
@@ -306,6 +300,23 @@ struct SpendDashboardTokenProvenanceTests {
             startupBehavior: .testing,
             environmentBase: [:])
         return (settings, store)
+    }
+
+    private static let fixtureNow = Date(timeIntervalSince1970: 1_784_179_200)
+
+    private static func dashboardController(
+        settings: SettingsStore,
+        store: UsageStore) -> SpendDashboardController
+    {
+        SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(
+                    settings: settings,
+                    store: store,
+                    mode: mode,
+                    now: Self.fixtureNow)
+            })
     }
 
     private static func tokenSnapshot(cost: Double) -> CostUsageTokenSnapshot {


### PR DESCRIPTION
## Summary

Stabilize the spend dashboard token-provenance tests by injecting the same fixed clock used by their July 16 fixture snapshots.

## Root cause

Three controller constructions called `SpendDashboardSource.makeRequest` with the real current date. Once the calendar moved beyond the fixtures' selected dashboard window, valid fixture spend was filtered out and the cost assertions received `nil`.

The same three failures appear in recent macOS test-shard runs for #2402 and #2436.

## Change

- add one fixture-clock controller helper
- route the three affected controller constructions through it
- preserve the production request clock and all dashboard behavior

This complements #2390, which fixes the same failure mode in `SpendDashboardControllerTests`.

## Verification

- before the change, the affected 25-test selection failed with three issues
- after the change, the same selection passed: 25 tests across 4 suites
- `make check` — clean, including SwiftFormat and SwiftLint (0 violations in 1581 files)
- `make test` — stopped in unrelated `AdaptiveRefreshTimerTests`: two 30-second `CancellationError()` failures reproduced on the automatic retry and in an isolated run

## Risk and review focus

Test-only change; no production or public API impact. Please focus on whether the fixed fixture clock should remain scoped to these three dashboard controller constructions.
