### PR TITLE
Fix Command Code rolling and monthly usage windows

### DIFF
--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -689,10 +689,15 @@ extension CodexBarCLI {
                 return false
             }
         }
-        if provider == .commandcode,
-           settings?.commandcode?.cookieSource == .manual
-        {
-            return false
+        if provider == .commandcode {
+            if sourceMode == .auto,
+               environment.map({ CommandCodeAPIKeyReader.apiKey(environment: $0) != nil }) == true
+            {
+                return false
+            }
+            if settings?.commandcode?.cookieSource == .manual {
+                return false
+            }
         }
         #if os(Linux)
         if provider == .cursor,

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeAPIKeyReader.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeAPIKeyReader.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public enum CommandCodeAPIKeyReader {
+    public static let environmentKeys = ["COMMAND_CODE_API_KEY", "CODEXBAR_COMMANDCODE_API_KEY"]
+
+    public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        for key in self.environmentKeys {
+            if let value = self.cleaned(environment[key]) {
+                return value
+            }
+        }
+
+        let homeDirectory: URL = if let home = self.cleaned(environment["HOME"]) {
+            URL(
+                fileURLWithPath: NSString(string: home).expandingTildeInPath,
+                isDirectory: true)
+        } else {
+            FileManager.default.homeDirectoryForCurrentUser
+        }
+
+        guard let data = try? Data(contentsOf: self.defaultAuthFileURL(homeDirectory: homeDirectory)) else {
+            return nil
+        }
+        return self.parseAuthFile(data: data)
+    }
+
+    public static func defaultAuthFileURL(homeDirectory: URL) -> URL {
+        homeDirectory
+            .appendingPathComponent(".commandcode", isDirectory: true)
+            .appendingPathComponent("auth.json", isDirectory: false)
+    }
+
+    static func parseAuthFile(data: Data) -> String? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        for key in ["apiKey", "api_key", "token", "accessToken"] {
+            if let value = self.cleaned(root[key] as? String) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    static func cleaned(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
@@ -9,12 +9,12 @@ public enum CommandCodeProviderDescriptor {
             metadata: ProviderMetadata(
                 id: .commandcode,
                 displayName: "Command Code",
-                sessionLabel: "Monthly credits",
-                weeklyLabel: "Monthly",
-                opusLabel: nil,
-                supportsOpus: false,
+                sessionLabel: "5-hour",
+                weeklyLabel: "Weekly",
+                opusLabel: "Monthly",
+                supportsOpus: true,
                 supportsCredits: true,
-                creditsHint: "Monthly USD credits from Command Code billing.",
+                creditsHint: "Monthly USD credits and rolling usage limits from Command Code billing.",
                 toggleTitle: "Show Command Code usage",
                 cliName: "commandcode",
                 defaultEnabled: false,
@@ -37,13 +37,51 @@ public enum CommandCodeProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Command Code cost summary is not yet supported." }),
+            pace: .calendarMonthResetWindow,
             fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [CommandCodeWebFetchStrategy()] })),
+                sourceModes: [.auto, .api, .web],
+                pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "commandcode",
                 aliases: ["command-code"],
                 versionDetector: nil))
+    }
+
+    private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
+        switch context.sourceMode {
+        case .api:
+            [CommandCodeAPIKeyFetchStrategy()]
+        case .web:
+            [CommandCodeWebFetchStrategy()]
+        case .auto:
+            [CommandCodeAPIKeyFetchStrategy(), CommandCodeWebFetchStrategy()]
+        case .cli, .oauth:
+            []
+        }
+    }
+}
+
+struct CommandCodeAPIKeyFetchStrategy: ProviderFetchStrategy {
+    let id: String = "commandcode.api"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let apiKey = CommandCodeAPIKeyReader.apiKey(environment: context.env) else {
+            throw CommandCodeUsageError.missingCredentials
+        }
+        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(apiKey: apiKey)
+        return self.makeResult(usage: snapshot.toUsageSnapshot(), sourceLabel: "api key")
+    }
+
+    func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
+        guard context.sourceMode == .auto, let usageError = error as? CommandCodeUsageError else {
+            return false
+        }
+        return usageError == .missingCredentials || usageError == .invalidCredentials
     }
 }
 

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
@@ -3,15 +3,22 @@ import Foundation
 import FoundationNetworking
 #endif
 
-/// Fetches live billing data from `api.commandcode.ai` using a better-auth session
-/// cookie scraped from the user's browser.
+private enum CommandCodeAuthentication: Sendable {
+    case cookieHeader(String)
+    case apiKey(String)
+}
+
+/// Fetches live billing data from `api.commandcode.ai` using either the Command Code
+/// CLI API key or a better-auth browser session cookie.
 public enum CommandCodeUsageFetcher {
     private static let log = CodexBarLog.logger(LogCategories.commandcodeUsage)
     private static let requestTimeoutSeconds: TimeInterval = 15
     private static let subscriptionGraceSeconds: TimeInterval = 2
     private static let apiBase = URL(string: "https://api.commandcode.ai")!
-    private static let creditsPath = "/internal/billing/credits"
-    private static let subscriptionsPath = "/internal/billing/subscriptions"
+    private static let webCreditsPath = "/internal/billing/credits"
+    private static let webSubscriptionsPath = "/internal/billing/subscriptions"
+    private static let apiCreditsPath = "/alpha/billing/credits"
+    private static let apiSubscriptionsPath = "/alpha/billing/subscriptions"
     private static let webOrigin = "https://commandcode.ai"
     private static let userAgent =
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
@@ -23,7 +30,19 @@ public enum CommandCodeUsageFetcher {
         now: Date = Date()) async throws -> CommandCodeUsageSnapshot
     {
         try await self.fetchUsage(
-            cookieHeader: cookieHeader,
+            authentication: .cookieHeader(cookieHeader),
+            transport: transport,
+            now: now,
+            subscriptionGrace: .seconds(self.subscriptionGraceSeconds))
+    }
+
+    public static func fetchUsage(
+        apiKey: String,
+        session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        now: Date = Date()) async throws -> CommandCodeUsageSnapshot
+    {
+        try await self.fetchUsage(
+            authentication: .apiKey(apiKey),
             transport: transport,
             now: now,
             subscriptionGrace: .seconds(self.subscriptionGraceSeconds))
@@ -36,20 +55,20 @@ public enum CommandCodeUsageFetcher {
         subscriptionGrace: Duration) async throws -> CommandCodeUsageSnapshot
     {
         try await self.fetchUsage(
-            cookieHeader: cookieHeader,
+            authentication: .cookieHeader(cookieHeader),
             transport: transport,
             now: now,
             subscriptionGrace: subscriptionGrace)
     }
 
     private static func fetchUsage(
-        cookieHeader: String,
+        authentication: CommandCodeAuthentication,
         transport: any ProviderHTTPTransport,
         now: Date,
         subscriptionGrace: Duration) async throws -> CommandCodeUsageSnapshot
     {
         let (credits, subscription, subscriptionEnrichmentUnavailable) = try await self.fetchPayloads(
-            cookieHeader: cookieHeader,
+            authentication: authentication,
             transport: transport,
             subscriptionGrace: subscriptionGrace)
 
@@ -69,6 +88,8 @@ public enum CommandCodeUsageFetcher {
             purchasedCredits: credits.purchasedCredits,
             premiumMonthlyCredits: credits.premiumMonthlyCredits,
             opensourceMonthlyCredits: credits.opensourceMonthlyCredits,
+            fiveHourWindow: credits.fiveHourWindow,
+            weeklyWindow: credits.weeklyWindow,
             plan: plan,
             billingPeriodEnd: subscription?.currentPeriodEnd,
             subscriptionStatus: subscription?.status,
@@ -77,17 +98,17 @@ public enum CommandCodeUsageFetcher {
     }
 
     private static func fetchPayloads(
-        cookieHeader: String,
+        authentication: CommandCodeAuthentication,
         transport: any ProviderHTTPTransport,
         subscriptionGrace: Duration) async throws -> (CreditsPayload, SubscriptionPayload?, Bool)
     {
         let subscriptionTask = Task<SubscriptionPayload?, Error> {
-            try await self.fetchSubscription(cookieHeader: cookieHeader, transport: transport)
+            try await self.fetchSubscription(authentication: authentication, transport: transport)
         }
         let credits: CreditsPayload
         do {
             credits = try await withTaskCancellationHandler {
-                try await self.fetchCredits(cookieHeader: cookieHeader, transport: transport)
+                try await self.fetchCredits(authentication: authentication, transport: transport)
             } onCancel: {
                 subscriptionTask.cancel()
             }
@@ -126,6 +147,8 @@ public enum CommandCodeUsageFetcher {
         let purchasedCredits: Double
         let premiumMonthlyCredits: Double
         let opensourceMonthlyCredits: Double
+        let fiveHourWindow: RateWindow?
+        let weeklyWindow: RateWindow?
     }
 
     struct SubscriptionPayload {
@@ -135,32 +158,46 @@ public enum CommandCodeUsageFetcher {
     }
 
     private static func fetchCredits(
-        cookieHeader: String,
+        authentication: CommandCodeAuthentication,
         transport: any ProviderHTTPTransport) async throws -> CreditsPayload
     {
-        let url = self.apiBase.appendingPathComponent(self.creditsPath)
-        let data = try await self.send(url: url, cookieHeader: cookieHeader, transport: transport)
+        let path = switch authentication {
+        case .cookieHeader: self.webCreditsPath
+        case .apiKey: self.apiCreditsPath
+        }
+        let url = self.apiBase.appendingPathComponent(path)
+        let data = try await self.send(url: url, authentication: authentication, transport: transport)
         return try self.parseCredits(data: data)
     }
 
     private static func fetchSubscription(
-        cookieHeader: String,
+        authentication: CommandCodeAuthentication,
         transport: any ProviderHTTPTransport) async throws -> SubscriptionPayload?
     {
-        let url = self.apiBase.appendingPathComponent(self.subscriptionsPath)
-        let data = try await self.send(url: url, cookieHeader: cookieHeader, transport: transport)
+        let path = switch authentication {
+        case .cookieHeader: self.webSubscriptionsPath
+        case .apiKey: self.apiSubscriptionsPath
+        }
+        let url = self.apiBase.appendingPathComponent(path)
+        let data = try await self.send(url: url, authentication: authentication, transport: transport)
         return try self.parseSubscription(data: data)
     }
 
     private static func send(
         url: URL,
-        cookieHeader: String,
+        authentication: CommandCodeAuthentication,
         transport: any ProviderHTTPTransport) async throws -> Data
     {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.timeoutInterval = self.requestTimeoutSeconds
-        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        switch authentication {
+        case let .cookieHeader(cookieHeader):
+            request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        case let .apiKey(apiKey):
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+            request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        }
         request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
         request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "Accept-Language")
         request.setValue(self.userAgent, forHTTPHeaderField: "User-Agent")
@@ -199,11 +236,19 @@ public enum CommandCodeUsageFetcher {
         guard let monthly = self.double(from: credits["monthlyCredits"]) else {
             throw CommandCodeUsageError.parseFailed("Credits: missing monthlyCredits")
         }
+        let windowLimits = (root["windowLimits"] as? [String: Any])
+            ?? (credits["windowLimits"] as? [String: Any])
         return CreditsPayload(
             monthlyCredits: monthly,
             purchasedCredits: self.double(from: credits["purchasedCredits"]) ?? 0,
             premiumMonthlyCredits: self.double(from: credits["premiumMonthlyCredits"]) ?? 0,
-            opensourceMonthlyCredits: self.double(from: credits["opensourceMonthlyCredits"]) ?? 0)
+            opensourceMonthlyCredits: self.double(from: credits["opensourceMonthlyCredits"]) ?? 0,
+            fiveHourWindow: self.rateWindow(
+                from: windowLimits?["fiveHour"],
+                windowMinutes: 5 * 60),
+            weeklyWindow: self.rateWindow(
+                from: windowLimits?["weekly"],
+                windowMinutes: 7 * 24 * 60))
     }
 
     static func parseSubscription(data: Data) throws -> SubscriptionPayload? {
@@ -234,6 +279,21 @@ public enum CommandCodeUsageFetcher {
         return SubscriptionPayload(planID: planID, status: status, currentPeriodEnd: periodEnd)
     }
 
+    private static func rateWindow(from value: Any?, windowMinutes: Int) -> RateWindow? {
+        guard let limit = value as? [String: Any],
+              let cap = self.double(from: limit["cap"]),
+              cap > 0
+        else {
+            return nil
+        }
+        let used = self.double(from: limit["used"]) ?? 0
+        return RateWindow(
+            usedPercent: UsagePercent(used: used, limit: cap).displayClamped,
+            windowMinutes: windowMinutes,
+            resetsAt: self.date(from: limit["resetAt"]),
+            resetDescription: nil)
+    }
+
     // MARK: - Value coercion
 
     private static func double(from value: Any?) -> Double? {
@@ -250,6 +310,10 @@ public enum CommandCodeUsageFetcher {
     }
 
     private static func date(from value: Any?) -> Date? {
+        if let timestamp = self.double(from: value), timestamp > 0 {
+            let seconds = timestamp > 10_000_000_000 ? timestamp / 1000 : timestamp
+            return Date(timeIntervalSince1970: seconds)
+        }
         guard let s = value as? String else { return nil }
         let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageSnapshot.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Parsed view of CommandCode `/internal/billing/credits` + `/internal/billing/subscriptions`.
+/// Parsed view of Command Code billing credits, rolling limits, and subscription state.
 public struct CommandCodeUsageSnapshot: Sendable {
     /// USD remaining in the current monthly grant (`credits.monthlyCredits`).
     public let monthlyCreditsRemaining: Double
@@ -10,6 +10,10 @@ public struct CommandCodeUsageSnapshot: Sendable {
     public let premiumMonthlyCredits: Double
     /// USD remaining in the open-source monthly grant (`credits.opensourceMonthlyCredits`).
     public let opensourceMonthlyCredits: Double
+    /// Rolling five-hour usage limit reported by `credits.windowLimits`.
+    public let fiveHourWindow: RateWindow?
+    /// Rolling weekly usage limit reported by `credits.windowLimits`.
+    public let weeklyWindow: RateWindow?
     /// Subscription plan, or nil when the user is on the free tier.
     public let plan: CommandCodePlanCatalog.Plan?
     /// `currentPeriodEnd` from the active subscription.
@@ -25,6 +29,8 @@ public struct CommandCodeUsageSnapshot: Sendable {
         purchasedCredits: Double,
         premiumMonthlyCredits: Double,
         opensourceMonthlyCredits: Double,
+        fiveHourWindow: RateWindow? = nil,
+        weeklyWindow: RateWindow? = nil,
         plan: CommandCodePlanCatalog.Plan?,
         billingPeriodEnd: Date?,
         subscriptionStatus: String?,
@@ -35,6 +41,8 @@ public struct CommandCodeUsageSnapshot: Sendable {
         self.purchasedCredits = purchasedCredits
         self.premiumMonthlyCredits = premiumMonthlyCredits
         self.opensourceMonthlyCredits = opensourceMonthlyCredits
+        self.fiveHourWindow = fiveHourWindow
+        self.weeklyWindow = weeklyWindow
         self.plan = plan
         self.billingPeriodEnd = billingPeriodEnd
         self.subscriptionStatus = subscriptionStatus
@@ -54,8 +62,7 @@ public struct CommandCodeUsageSnapshot: Sendable {
     }
 
     public func toUsageSnapshot() -> UsageSnapshot {
-        let primary = self.makePrimaryWindow()
-
+        let monthly = self.makeMonthlyWindow()
         let identity = ProviderIdentitySnapshot(
             providerID: .commandcode,
             accountEmail: nil,
@@ -63,9 +70,9 @@ public struct CommandCodeUsageSnapshot: Sendable {
             loginMethod: self.makeLoginMethod())
 
         return UsageSnapshot(
-            primary: primary,
-            secondary: nil,
-            tertiary: nil,
+            primary: self.fiveHourWindow,
+            secondary: self.weeklyWindow,
+            tertiary: monthly,
             providerCost: nil,
             commandCodeSubscriptionEnrichmentUnavailable: self.subscriptionEnrichmentUnavailable,
             commandCodeHasSubscriptionPlan: self.plan != nil,
@@ -74,13 +81,12 @@ public struct CommandCodeUsageSnapshot: Sendable {
             identity: identity)
     }
 
-    private func makePrimaryWindow() -> RateWindow? {
+    private func makeMonthlyWindow() -> RateWindow? {
         guard let total = self.monthlyCreditsTotal, total > 0 else {
-            // Free / unknown plan with no allowance — surface 100% so the bar renders empty.
             if self.monthlyCreditsRemaining > 0 || self.purchasedCredits > 0 {
                 return RateWindow(
                     usedPercent: 0,
-                    windowMinutes: nil,
+                    windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
                     resetsAt: self.billingPeriodEnd,
                     resetDescription: nil)
             }
@@ -90,7 +96,7 @@ public struct CommandCodeUsageSnapshot: Sendable {
         let percent = UsagePercent(used: used, limit: total).displayClamped
         return RateWindow(
             usedPercent: percent,
-            windowMinutes: nil,
+            windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
             resetsAt: self.billingPeriodEnd,
             resetDescription: nil)
     }

--- a/Tests/CodexBarTests/CommandCodeProviderTests.swift
+++ b/Tests/CodexBarTests/CommandCodeProviderTests.swift
@@ -29,6 +29,11 @@ struct CommandCodeProviderTests {
         #expect(descriptor.metadata.cliName == "commandcode")
         #expect(descriptor.branding.iconResourceName == "ProviderIcon-commandcode")
         #expect(descriptor.branding.iconStyle == .commandcode)
+        #expect(descriptor.metadata.sessionLabel == "5-hour")
+        #expect(descriptor.metadata.weeklyLabel == "Weekly")
+        #expect(descriptor.metadata.opusLabel == "Monthly")
+        #expect(descriptor.metadata.supportsOpus)
+        #expect(descriptor.fetchPlan.sourceModes == [.auto, .api, .web])
     }
 
     @Test

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -10,7 +10,9 @@ import FoundationNetworking
 struct CommandCodeUsageFetcherTests {
     private static let creditsJSON = """
     {"credits":{"belowThreshold":false,"creditThreshold":0,"monthlyCredits":8.7784,\
-    "purchasedCredits":0,"premiumMonthlyCredits":0,"opensourceMonthlyCredits":8.7784}}
+    "purchasedCredits":0,"premiumMonthlyCredits":0,"opensourceMonthlyCredits":8.7784},\
+    "windowLimits":{"fiveHour":{"cap":3,"used":0.75,"resetAt":1780000000000},\
+    "weekly":{"cap":15,"used":1.5,"resetAt":1780100000000}}}
     """
 
     private static let subscriptionJSON = """
@@ -31,6 +33,14 @@ struct CommandCodeUsageFetcherTests {
         #expect(payload.purchasedCredits == 0)
         #expect(payload.premiumMonthlyCredits == 0)
         #expect(payload.opensourceMonthlyCredits == 8.7784)
+        let fiveHour = try #require(payload.fiveHourWindow)
+        #expect(fiveHour.usedPercent == 25)
+        #expect(fiveHour.windowMinutes == 5 * 60)
+        #expect(fiveHour.resetsAt == Date(timeIntervalSince1970: 1_780_000_000))
+        let weekly = try #require(payload.weeklyWindow)
+        #expect(weekly.usedPercent == 10)
+        #expect(weekly.windowMinutes == 7 * 24 * 60)
+        #expect(weekly.resetsAt == Date(timeIntervalSince1970: 1_780_100_000))
     }
 
     @Test
@@ -304,6 +314,43 @@ struct CommandCodeUsageFetcherTests {
     }
 
     @Test
+    func `API key fetch uses alpha billing endpoints and API headers`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            #expect(path == "/alpha/billing/credits" || path == "/alpha/billing/subscriptions")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer api-test")
+            #expect(request.value(forHTTPHeaderField: "x-api-key") == "api-test")
+            #expect(request.value(forHTTPHeaderField: "Cookie") == nil)
+            let body = path.hasSuffix("/credits") ? Self.creditsJSON : Self.subscriptionJSON
+            return try Self.response(request: request, statusCode: 200, body: body)
+        }
+
+        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+            apiKey: "api-test",
+            session: transport)
+
+        #expect(snapshot.fiveHourWindow?.usedPercent == 25)
+        #expect(snapshot.weeklyWindow?.usedPercent == 10)
+    }
+
+    @Test
+    func `API key reader prefers environment and loads CLI auth file`() throws {
+        let environment = ["COMMAND_CODE_API_KEY": " env-key ", "HOME": "/unused"]
+        #expect(CommandCodeAPIKeyReader.apiKey(environment: environment) == "env-key")
+
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let authFile = CommandCodeAPIKeyReader.defaultAuthFileURL(homeDirectory: home)
+        try FileManager.default.createDirectory(
+            at: authFile.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        try Data(#"{"apiKey":"file-key"}"#.utf8).write(to: authFile)
+
+        #expect(CommandCodeAPIKeyReader.apiKey(environment: ["HOME": home.path]) == "file-key")
+    }
+
+    @Test
     func `snapshot derives used and total from plan catalog`() throws {
         let plan = try #require(CommandCodePlanCatalog.plan(forID: "individual-go"))
         let snapshot = CommandCodeUsageSnapshot(
@@ -311,6 +358,16 @@ struct CommandCodeUsageFetcherTests {
             purchasedCredits: 0,
             premiumMonthlyCredits: 0,
             opensourceMonthlyCredits: 8.7784,
+            fiveHourWindow: RateWindow(
+                usedPercent: 25,
+                windowMinutes: 5 * 60,
+                resetsAt: Date(timeIntervalSince1970: 1_779_000_000),
+                resetDescription: nil),
+            weeklyWindow: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: Date(timeIntervalSince1970: 1_779_500_000),
+                resetDescription: nil),
             plan: plan,
             billingPeriodEnd: Date(timeIntervalSince1970: 1_780_000_000),
             subscriptionStatus: "active",
@@ -319,9 +376,12 @@ struct CommandCodeUsageFetcherTests {
         #expect(abs((snapshot.monthlyCreditsUsed ?? -1) - 1.2216) < 0.0001)
 
         let usage = snapshot.toUsageSnapshot()
-        let primary = try #require(usage.primary)
-        #expect(abs(primary.usedPercent - 12.216) < 0.001)
-        #expect(primary.resetsAt == Date(timeIntervalSince1970: 1_780_000_000))
+        #expect(usage.primary?.usedPercent == 25)
+        #expect(usage.secondary?.usedPercent == 10)
+        let monthly = try #require(usage.tertiary)
+        #expect(abs(monthly.usedPercent - 12.216) < 0.001)
+        #expect(monthly.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
+        #expect(monthly.resetsAt == Date(timeIntervalSince1970: 1_780_000_000))
         #expect(usage.identity?.loginMethod == "Go · $1.22 of $10.00")
     }
 
@@ -336,7 +396,7 @@ struct CommandCodeUsageFetcherTests {
             billingPeriodEnd: nil,
             subscriptionStatus: nil)
 
-        #expect(snapshot.toUsageSnapshot().primary == nil)
+        #expect(snapshot.toUsageSnapshot().tertiary == nil)
     }
 
     @Test

--- a/TestsLinux/CommandCodeProviderLinuxTests.swift
+++ b/TestsLinux/CommandCodeProviderLinuxTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+@testable import CodexBarCore
+
+struct CommandCodeProviderLinuxTests {
+    private static let creditsJSON = #"""
+    {
+      "credits": {
+        "monthlyCredits": 9.15,
+        "purchasedCredits": 0,
+        "premiumMonthlyCredits": 0,
+        "opensourceMonthlyCredits": 0
+      },
+      "windowLimits": {
+        "fiveHour": {"cap": 3, "used": 0.75, "resetAt": 1780000000000},
+        "weekly": {"cap": 6, "used": 1.5, "resetAt": 1780100000000}
+      }
+    }
+    """#
+
+    private static let subscriptionJSON = #"""
+    {
+      "success": true,
+      "data": {
+        "status": "active",
+        "planId": "individual-go",
+        "currentPeriodEnd": "2026-08-23T18:08:48.000Z"
+      }
+    }
+    """#
+
+    @Test
+    func `registers rolling and monthly quota lanes`() {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .commandcode)
+
+        #expect(descriptor.metadata.sessionLabel == "5-hour")
+        #expect(descriptor.metadata.weeklyLabel == "Weekly")
+        #expect(descriptor.metadata.opusLabel == "Monthly")
+        #expect(descriptor.metadata.supportsOpus)
+        #expect(descriptor.fetchPlan.sourceModes == [.auto, .api, .web])
+    }
+
+    @Test
+    func `loads API key from environment and Command Code auth file`() throws {
+        #expect(CommandCodeAPIKeyReader.apiKey(environment: [
+            "COMMAND_CODE_API_KEY": " environment-key ",
+        ]) == "environment-key")
+
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let authFile = CommandCodeAPIKeyReader.defaultAuthFileURL(homeDirectory: home)
+        try FileManager.default.createDirectory(
+            at: authFile.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        try Data(#"{"apiKey":"file-key"}"#.utf8).write(to: authFile)
+
+        #expect(CommandCodeAPIKeyReader.apiKey(environment: ["HOME": home.path]) == "file-key")
+    }
+
+    @Test
+    func `fetches API key usage from alpha billing endpoints`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            let path = try #require(request.url?.path)
+            #expect(path == "/alpha/billing/credits" || path == "/alpha/billing/subscriptions")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer api-test")
+            #expect(request.value(forHTTPHeaderField: "x-api-key") == "api-test")
+            #expect(request.value(forHTTPHeaderField: "Cookie") == nil)
+            let body = path.hasSuffix("/credits") ? Self.creditsJSON : Self.subscriptionJSON
+            return try Self.response(for: request, body: body)
+        }
+
+        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+            apiKey: "api-test",
+            session: transport,
+            now: Date(timeIntervalSince1970: 123))
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.primary?.usedPercent == 25)
+        #expect(usage.primary?.windowMinutes == 5 * 60)
+        #expect(usage.primary?.resetsAt == Date(timeIntervalSince1970: 1_780_000_000))
+        #expect(usage.secondary?.usedPercent == 25)
+        #expect(usage.secondary?.windowMinutes == 7 * 24 * 60)
+        #expect(usage.secondary?.resetsAt == Date(timeIntervalSince1970: 1_780_100_000))
+        #expect(abs((usage.tertiary?.usedPercent ?? -1) - 8.5) < 0.0001)
+        #expect(usage.tertiary?.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
+        #expect(usage.tertiary?.resetsAt == Self.date("2026-08-23T18:08:48.000Z"))
+        #expect(usage.identity?.loginMethod == "Go · $0.85 of $10.00")
+        #expect(usage.updatedAt == Date(timeIntervalSince1970: 123))
+    }
+
+    private static func date(_ raw: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: raw)
+    }
+
+    private static func response(
+        for request: URLRequest,
+        body: String,
+        statusCode: Int = 200) throws -> (Data, URLResponse)
+    {
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: statusCode,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: ["Content-Type": "application/json"])
+        else {
+            throw URLError(.badServerResponse)
+        }
+        return (Data(body.utf8), response)
+    }
+}

--- a/TestsLinux/OpenCodeGoLinuxTests.swift
+++ b/TestsLinux/OpenCodeGoLinuxTests.swift
@@ -34,6 +34,21 @@ struct OpenCodeGoLinuxTests {
     }
 
     @Test
+    func commandCodeAPIKeyAutoDoesNotRequireMacOSWebSupport() {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("command-code-no-auth-\(UUID().uuidString)", isDirectory: true)
+
+        #expect(!CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .commandcode,
+            environment: ["COMMAND_CODE_API_KEY": "api-test", "HOME": home.path]))
+        #expect(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .commandcode,
+            environment: ["HOME": home.path]))
+    }
+
+    @Test
     func localReaderLoadsOpenCodeDatabase() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("OpenCodeGoLinuxTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary
- read Command Code API-key credentials from the CLI auth file or environment
- fetch live 5-hour, weekly, and monthly billing windows through the alpha billing API
- preserve browser-cookie fallback while allowing Linux auto mode to use API-key auth
- expose reset timestamps and correct quota labels in provider output
- add cross-platform and Linux coverage for auth, headers, percentages, and reset dates

## Verification
- `make test`
- `./Scripts/lint.sh lint-linux`
- SwiftFormat lint on changed files
- live `codexbar usage --provider commandcode --format json --pretty` against a Go account