### PR TITLE
fix: allow MiniMax usage on Linux with a configured API key

### DIFF
--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -784,10 +784,12 @@ extension CodexBarCLI {
             guard sourceMode == .auto || sourceMode == .cli else { return false }
             return environment.map { FactorySettingsReader.apiKey(environment: $0) != nil } == true
         case .minimax:
-            // The MiniMax API fetch is plain HTTPS + Bearer auth; only its web/cookie path
-            // needs macOS, so a configured API key works off macOS too.
-            guard sourceMode == .auto else { return false }
-            return environment.map { MiniMaxAPISettingsReader.apiToken(environment: $0) != nil } == true
+            // The MiniMax API fetch is plain HTTPS + Bearer auth, so a configured key works off
+            // macOS. Standard `sk-api-` keys are the exception: Auto resolves them to the Coding
+            // Plan web strategy, which still needs the macOS-only web path.
+            guard sourceMode == .auto, let environment else { return false }
+            guard MiniMaxAPISettingsReader.apiToken(environment: environment) != nil else { return false }
+            return MiniMaxAPISettingsReader.apiKeyKind(environment: environment) != .standard
         case .mimo:
             guard sourceMode == .auto, let environment else { return false }
             return MiMoLocalUsageFallback.cacheExists(environment: environment)

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -254,7 +254,9 @@ extension CodexBarCLI {
     }
 
     private static func accountSelections(from accounts: [ProviderTokenAccount]) -> [ProviderTokenAccount?] {
-        if accounts.isEmpty { return [nil] }
+        if accounts.isEmpty {
+            return [nil]
+        }
         return accounts.map { Optional($0) }
     }
 
@@ -674,103 +676,11 @@ extension CodexBarCLI {
         environment: [String: String]? = nil,
         settings: ProviderSettingsSnapshot? = nil) -> Bool
     {
-        guard provider != .grok, provider != .amp else {
-            return false
-        }
-        if provider == .codex, sourceMode == .auto {
-            return false
-        }
-        if provider == .claude, sourceMode == .auto {
-            // Claude's cross-platform planner skips its unavailable web step and falls back to the CLI.
-            return false
-        }
-        if provider == .opencodego {
-            if sourceMode == .auto || settings?.opencodego?.cookieSource == .manual {
-                return false
-            }
-        }
-        if provider == .commandcode,
-           settings?.commandcode?.cookieSource == .manual
-        {
-            return false
-        }
-        if provider == .alibabatokenplan,
-           settings?.alibabaTokenPlan?.cookieSource == .manual
-        {
-            // The Alibaba/Qwen Token Plan fetch is plain URLSession + cookies; only browser
-            // cookie auto-import needs macOS, so a manual cookie header works off macOS too.
-            return false
-        }
-        #if os(Linux)
-        if provider == .cursor,
-           settings?.cursor?.cookieSource != .off
-        {
-            // Linux uses Cursor app auth and manual cookies; browser import remains macOS-only.
-            return false
-        }
-        #endif
-        if provider == .sakana,
-           sourceMode == .auto || sourceMode == .web,
-           environment.map({ SakanaSettingsReader.cookieHeader(environment: $0) != nil }) == true
-        {
-            return false
-        }
-        if provider == .qwencloud,
-           sourceMode == .auto || sourceMode == .web,
-           settings?.qwenCloud?.cookieSource != .off
-        {
-            let hasEnvironmentCookie = environment.map {
-                QwenCloudSettingsReader.cookieHeader(environment: $0) != nil
-            } == true
-            let hasManualCookie = settings?.qwenCloud?.cookieSource == .manual &&
-                CookieHeaderNormalizer.normalize(settings?.qwenCloud?.manualCookieHeader) != nil
-            if hasEnvironmentCookie || hasManualCookie {
-                return false
-            }
-        }
-        if provider == .qoder,
-           settings?.qoder?.cookieSource == .manual
-        {
-            return false
-        }
-        if provider == .ollama,
-           sourceMode == .auto
-        {
-            let hasEnvironmentToken = environment.map {
-                ProviderTokenResolver.ollamaToken(environment: $0) != nil
-            } == true
-            if settings?.ollama?.cookieSource == .off || hasEnvironmentToken {
-                return false
-            }
-        }
-        if provider == .kimi,
-           sourceMode == .auto,
-           environment.map({ environment in
-               ProviderTokenResolver.kimiAPIToken(environment: environment) != nil ||
-                   KimiSettingsReader.hasKimiCodeCredential(environment: environment)
-           }) == true
-        {
-            return false
-        }
-        if provider == .factory,
-           sourceMode == .auto || sourceMode == .cli,
-           environment.map({ FactorySettingsReader.apiKey(environment: $0) != nil }) == true
-        {
-            // Linux Auto/legacy-cli can use FACTORY_API_KEY without browser cookies.
-            return false
-        }
-        if provider == .minimax,
-           sourceMode == .auto,
-           environment.map({ MiniMaxAPISettingsReader.apiToken(environment: $0) != nil }) == true
-        {
-            // The MiniMax API fetch is plain HTTPS + Bearer auth; only its web/cookie path
-            // needs macOS, so a configured API key works off macOS too.
-            return false
-        }
-        if provider == .mimo,
-           sourceMode == .auto,
-           let environment,
-           MiMoLocalUsageFallback.cacheExists(environment: environment)
+        if self.webSupportExempt(
+            sourceMode,
+            provider: provider,
+            environment: environment,
+            settings: settings)
         {
             return false
         }
@@ -781,6 +691,108 @@ extension CodexBarCLI {
             ProviderDescriptorRegistry.descriptor(for: provider).fetchPlan.sourceModes.contains(.web)
         case .cli, .oauth, .api:
             false
+        }
+    }
+
+    /// Providers that can satisfy a source mode without the macOS-only web/browser path.
+    private static func webSupportExempt(
+        _ sourceMode: ProviderSourceMode,
+        provider: UsageProvider,
+        environment: [String: String]?,
+        settings: ProviderSettingsSnapshot?) -> Bool
+    {
+        if provider == .grok || provider == .amp {
+            return true
+        }
+        if sourceMode == .auto, provider == .codex || provider == .claude {
+            // Claude's cross-platform planner skips its unavailable web step and falls back to the CLI.
+            return true
+        }
+        if self.cookieSourceExempt(sourceMode, provider: provider, settings: settings) {
+            return true
+        }
+        return self.credentialExempt(
+            sourceMode,
+            provider: provider,
+            environment: environment,
+            settings: settings)
+    }
+
+    /// Exemptions granted by a manual cookie header instead of browser auto-import.
+    private static func cookieSourceExempt(
+        _ sourceMode: ProviderSourceMode,
+        provider: UsageProvider,
+        settings: ProviderSettingsSnapshot?) -> Bool
+    {
+        switch provider {
+        case .opencodego:
+            return sourceMode == .auto || settings?.opencodego?.cookieSource == .manual
+        case .commandcode:
+            return settings?.commandcode?.cookieSource == .manual
+        case .alibabatokenplan:
+            // The Alibaba/Qwen Token Plan fetch is plain URLSession + cookies; only browser
+            // cookie auto-import needs macOS, so a manual cookie header works off macOS too.
+            return settings?.alibabaTokenPlan?.cookieSource == .manual
+        case .qoder:
+            return settings?.qoder?.cookieSource == .manual
+        case .cursor:
+            #if os(Linux)
+            // Linux uses Cursor app auth and manual cookies; browser import remains macOS-only.
+            return settings?.cursor?.cookieSource != .off
+            #else
+            return false
+            #endif
+        default:
+            return false
+        }
+    }
+
+    /// Exemptions granted by an already-configured credential (token, API key, or local cache).
+    private static func credentialExempt(
+        _ sourceMode: ProviderSourceMode,
+        provider: UsageProvider,
+        environment: [String: String]?,
+        settings: ProviderSettingsSnapshot?) -> Bool
+    {
+        switch provider {
+        case .sakana:
+            guard sourceMode == .auto || sourceMode == .web else { return false }
+            return environment.map { SakanaSettingsReader.cookieHeader(environment: $0) != nil } == true
+        case .qwencloud:
+            guard sourceMode == .auto || sourceMode == .web,
+                  settings?.qwenCloud?.cookieSource != .off else { return false }
+            let hasEnvironmentCookie = environment.map {
+                QwenCloudSettingsReader.cookieHeader(environment: $0) != nil
+            } == true
+            let hasManualCookie = settings?.qwenCloud?.cookieSource == .manual &&
+                CookieHeaderNormalizer.normalize(settings?.qwenCloud?.manualCookieHeader) != nil
+            return hasEnvironmentCookie || hasManualCookie
+        case .ollama:
+            guard sourceMode == .auto else { return false }
+            let hasEnvironmentToken = environment.map {
+                ProviderTokenResolver.ollamaToken(environment: $0) != nil
+            } == true
+            return settings?.ollama?.cookieSource == .off || hasEnvironmentToken
+        case .kimi:
+            guard sourceMode == .auto else { return false }
+            return environment.map { environment in
+                ProviderTokenResolver.kimiAPIToken(environment: environment) != nil ||
+                    KimiSettingsReader.hasKimiCodeCredential(environment: environment)
+            } == true
+        case .factory:
+            // Linux Auto/legacy-cli can use FACTORY_API_KEY without browser cookies.
+            guard sourceMode == .auto || sourceMode == .cli else { return false }
+            return environment.map { FactorySettingsReader.apiKey(environment: $0) != nil } == true
+        case .minimax:
+            // The MiniMax API fetch is plain HTTPS + Bearer auth; only its web/cookie path
+            // needs macOS, so a configured API key works off macOS too.
+            guard sourceMode == .auto else { return false }
+            return environment.map { MiniMaxAPISettingsReader.apiToken(environment: $0) != nil } == true
+        case .mimo:
+            guard sourceMode == .auto, let environment else { return false }
+            return MiMoLocalUsageFallback.cacheExists(environment: environment)
+        default:
+            return false
         }
     }
 }

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -759,6 +759,14 @@ extension CodexBarCLI {
             // Linux Auto/legacy-cli can use FACTORY_API_KEY without browser cookies.
             return false
         }
+        if provider == .minimax,
+           sourceMode == .auto,
+           environment.map({ MiniMaxAPISettingsReader.apiToken(environment: $0) != nil }) == true
+        {
+            // The MiniMax API fetch is plain HTTPS + Bearer auth; only its web/cookie path
+            // needs macOS, so a configured API key works off macOS too.
+            return false
+        }
         if provider == .mimo,
            sourceMode == .auto,
            let environment,

--- a/TestsLinux/MiniMaxLinuxTests.swift
+++ b/TestsLinux/MiniMaxLinuxTests.swift
@@ -6,23 +6,23 @@ import Testing
 
 struct MiniMaxLinuxTests {
     @Test
-    func `configured API key does not require macOS web support`() {
-        // The MiniMax API fetch is plain HTTPS + Bearer auth, so a configured API key must
-        // be usable off macOS (matches the Factory/Kimi credential exemptions).
-        #expect(!CodexBarCLI.sourceModeRequiresWebSupport(
-            .auto,
-            provider: .minimax,
-            environment: [MiniMaxAPISettingsReader.apiTokenKey: "sk-api-test"]))
-    }
-
-    @Test
-    func `coding plan API key also skips the web-support gate`() {
-        // `config set-api-key --provider minimax` resolves through the same reader, which
-        // accepts the coding-plan key as well.
+    func `coding plan API key does not require macOS web support`() {
+        // A coding-plan key resolves to the plain HTTPS + Bearer API strategy, so it must be
+        // usable off macOS (matches the Factory/Kimi credential exemptions).
         #expect(!CodexBarCLI.sourceModeRequiresWebSupport(
             .auto,
             provider: .minimax,
             environment: [MiniMaxAPISettingsReader.codingPlanAPITokenKey: "sk-cp-test"]))
+    }
+
+    @Test
+    func `standard API key still requires web support because Auto resolves to the coding plan page`() {
+        // `MiniMaxAPIFetchStrategy` refuses standard `sk-api-` keys, so Auto falls back to the
+        // Coding Plan web strategy. Exempting it here would only produce `noAvailableStrategy`.
+        #expect(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .minimax,
+            environment: [MiniMaxAPISettingsReader.apiTokenKey: "sk-api-test"]))
     }
 
     @Test
@@ -42,7 +42,33 @@ struct MiniMaxLinuxTests {
         #expect(CodexBarCLI.sourceModeRequiresWebSupport(
             .web,
             provider: .minimax,
-            environment: [MiniMaxAPISettingsReader.apiTokenKey: "sk-api-test"]))
+            environment: [MiniMaxAPISettingsReader.codingPlanAPITokenKey: "sk-cp-test"]))
+    }
+
+    @Test
+    func `exempted coding plan key actually resolves a linux capable strategy`() async {
+        // Gate agreement is not enough: the Auto plan must contain a strategy that can run
+        // without the macOS web path, otherwise the exemption ends in `noAvailableStrategy`.
+        let env = [MiniMaxAPISettingsReader.codingPlanAPITokenKey: "sk-cp-test"]
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        let context = ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: .auto,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: env,
+            settings: ProviderSettingsSnapshot.make(),
+            fetcher: UsageFetcher(environment: env),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+        let strategies = await ProviderDescriptorRegistry
+            .descriptor(for: .minimax)
+            .fetchPlan
+            .pipeline
+            .resolveStrategies(context)
+        #expect(strategies.contains { $0.id == "minimax.api" })
     }
 }
 #endif

--- a/TestsLinux/MiniMaxLinuxTests.swift
+++ b/TestsLinux/MiniMaxLinuxTests.swift
@@ -1,0 +1,48 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCLI
+@testable import CodexBarCore
+
+struct MiniMaxLinuxTests {
+    @Test
+    func `configured API key does not require macOS web support`() {
+        // The MiniMax API fetch is plain HTTPS + Bearer auth, so a configured API key must
+        // be usable off macOS (matches the Factory/Kimi credential exemptions).
+        #expect(!CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .minimax,
+            environment: [MiniMaxAPISettingsReader.apiTokenKey: "sk-api-test"]))
+    }
+
+    @Test
+    func `coding plan API key also skips the web-support gate`() {
+        // `config set-api-key --provider minimax` resolves through the same reader, which
+        // accepts the coding-plan key as well.
+        #expect(!CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .minimax,
+            environment: [MiniMaxAPISettingsReader.codingPlanAPITokenKey: "sk-cp-test"]))
+    }
+
+    @Test
+    func `auto without an API key still requires web support off macOS`() {
+        // Without a credential the only remaining Auto path is the web/cookie one, which
+        // genuinely needs macOS — the gate must still fire.
+        #expect(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .minimax,
+            environment: [:]))
+    }
+
+    @Test
+    func `explicit web source still requires web support even with an API key`() {
+        // The exemption is scoped to Auto; asking for the web source explicitly must not
+        // be silently redirected to the API path.
+        #expect(CodexBarCLI.sourceModeRequiresWebSupport(
+            .web,
+            provider: .minimax,
+            environment: [MiniMaxAPISettingsReader.apiTokenKey: "sk-api-test"]))
+    }
+}
+#endif


### PR DESCRIPTION
Closes #2474.

## Problem

On Linux, `minimax` fails even with an API key configured:

```
$ codexbar config enable --provider minimax
$ printf '%s' "$MINIMAX_API_KEY" | codexbar config set-api-key --provider minimax --stdin
$ codexbar --provider minimax --format json
"message" : "Error: selected source requires web support and is only supported on macOS."
```

`MiniMaxProviderDescriptor` advertises `sourceModes: [.auto, .web, .api]`, so under Auto the CLI's
`sourceModeRequiresWebSupport` gate returns `true` purely because `.web` is in the list — the API
strategy never gets a chance to run. But `minimax.api` is `kind: .apiToken`, a plain HTTPS request
with `Authorization: Bearer …`: no WebKit, no cookie import, no JS.

## Fix

Exempt Auto from the gate when a MiniMax API key actually resolves, mirroring the existing
credential exemptions in the same function (`.factory` reads `FactorySettingsReader.apiKey`,
`.kimi` reads `ProviderTokenResolver.kimiAPIToken`):

```swift
if provider == .minimax,
   sourceMode == .auto,
   environment.map({ MiniMaxAPISettingsReader.apiToken(environment: $0) != nil }) == true
{
    // The MiniMax API fetch is plain HTTPS + Bearer auth; only its web/cookie path
    // needs macOS, so a configured API key works off macOS too.
    return false
}
```

`MiniMaxAPISettingsReader.apiToken` covers both `MINIMAX_API_KEY` and `MINIMAX_CODING_API_KEY`, and
`ProviderConfigEnvironment.directAPIKeyEnvironmentKey` maps `.minimax` to that same key — so keys
stored via `config set-api-key` are seen here too, not just environment variables.

Scope is deliberately narrow: explicit `--source web` and the no-credential case still require web
support, so nothing that genuinely needs macOS is bypassed.

## Scope note

The issue also reports `--source api` failing. I could not reproduce that from source: the gate's
final switch already returns `false` for `case .cli, .oauth, .api`, so the explicit-API path should
not hit it. This PR therefore fixes only the Auto path, which is reproducible and covered below.

## Validation

Built and tested on Linux in `swift:6.3.3`; macOS CI validates the rest.

**Green — with the fix (4/4):**

```
$ swift test --filter MiniMaxLinuxTests
◇ Suite MiniMaxLinuxTests started.
✔ Test "configured API key does not require macOS web support" passed after 0.001 seconds.
✔ Test "coding plan API key also skips the web-support gate" passed after 0.001 seconds.
✔ Test "explicit web source still requires web support even with an API key" passed after 0.001 seconds.
✔ Test "auto without an API key still requires web support off macOS" passed after 0.001 seconds.
✔ Test run with 4 tests in 1 suite passed after 0.003 seconds.
```

**Red — same tests with the fix reverted (simulating current `main`):**

```
$ swift test --filter MiniMaxLinuxTests
✘ Test "configured API key does not require macOS web support" recorded an issue at MiniMaxLinuxTests.swift:12:9:
  Expectation failed: !(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .minimax,
  environment: (… → ["MINIMAX_API_KEY": "sk-api-test"])) → true)
✘ Test "coding plan API key also skips the web-support gate" recorded an issue at MiniMaxLinuxTests.swift:22:9:
  Expectation failed: !(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .minimax,
  environment: (… → ["MINIMAX_CODING_API_KEY": "sk-cp-test"])) → true)
✔ Test "explicit web source still requires web support even with an API key" passed after 0.001 seconds.
✔ Test "auto without an API key still requires web support off macOS" passed after 0.003 seconds.
✘ Test run with 4 tests in 1 suite failed after 0.007 seconds with 2 issues.
```

Note the two negative controls pass in **both** states — they confirm the gate still fires for
explicit `.web` and for the no-credential case, so the exemption is scoped rather than a blanket
bypass.

**Lint:**

```
$ swiftlint --strict
Done linting! Found 0 violations, 0 serious in 1582 files.
```

**Not tested:** a live MiniMax account round-trip — I don't have MiniMax credentials. The issue
reporter already verified the endpoint answers on Linux via `curl`, and this change only affects
the CLI platform gate, not the request itself.

Competing open PR scan: none — no other open PR references #2474 or touches
`sourceModeRequiresWebSupport`.
