### PR TITLE
Fix Claude enterprise usage in widgets (#2411 by @ChenZiHong-Gavin)

### DIFF
--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -147,6 +147,19 @@ extension UsageStore {
                     window: window)
             }
         }
+        if provider == .claude,
+           let spendLimit = MenuBarMetricWindowResolver.claudeSpendLimitWindow(snapshot: snapshot)
+        {
+            let period = snapshot.providerCost?.period?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let title = period.flatMap { $0.isEmpty ? nil : $0 } ?? "Extra usage"
+            return [
+                WidgetSnapshot.WidgetUsageRowSnapshot(
+                    id: "extraUsage",
+                    title: title,
+                    percentLeft: spendLimit.remainingPercent,
+                    window: spendLimit),
+            ]
+        }
         if provider == .antigravity,
            let rows = Self.antigravityQuotaSummaryWidgetRows(snapshot: snapshot),
            !rows.isEmpty

--- a/Tests/CodexBarTests/SpendDashboardClockRolloverTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardClockRolloverTests.swift
@@ -7,6 +7,10 @@ import Testing
 struct SpendDashboardClockRolloverTests {
     @Test
     func `reporting window advances and rescans source inputs`() async throws {
+        let suiteName = "SpendDashboardClockRolloverTests-reporting-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let loadedAt = try #require(ISO8601DateFormatter().date(from: "2026-07-16T12:00:00Z"))
         let afterRollover = try #require(ISO8601DateFormatter().date(from: "2026-07-22T12:00:00Z"))
         let loadCount = LockIsolated(0)
@@ -56,6 +60,10 @@ struct SpendDashboardClockRolloverTests {
 
     @Test
     func `rollover replaces an in flight load instead of dropping the rescan`() async throws {
+        let suiteName = "SpendDashboardClockRolloverTests-in-flight-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let loadedAt = try #require(ISO8601DateFormatter().date(from: "2026-07-16T12:00:00Z"))
         let afterRollover = try #require(ISO8601DateFormatter().date(from: "2026-07-22T12:00:00Z"))
         let clock = LockIsolated(loadedAt)

--- a/Tests/CodexBarTests/SpendDashboardClockRolloverTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardClockRolloverTests.swift
@@ -7,10 +7,6 @@ import Testing
 struct SpendDashboardClockRolloverTests {
     @Test
     func `reporting window advances and rescans source inputs`() async throws {
-        let suiteName = "SpendDashboardClockRolloverTests-reporting-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.removePersistentDomain(forName: suiteName)
-        defer { defaults.removePersistentDomain(forName: suiteName) }
         let loadedAt = try #require(ISO8601DateFormatter().date(from: "2026-07-16T12:00:00Z"))
         let afterRollover = try #require(ISO8601DateFormatter().date(from: "2026-07-22T12:00:00Z"))
         let loadCount = LockIsolated(0)
@@ -60,10 +56,6 @@ struct SpendDashboardClockRolloverTests {
 
     @Test
     func `rollover replaces an in flight load instead of dropping the rescan`() async throws {
-        let suiteName = "SpendDashboardClockRolloverTests-in-flight-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.removePersistentDomain(forName: suiteName)
-        defer { defaults.removePersistentDomain(forName: suiteName) }
         let loadedAt = try #require(ISO8601DateFormatter().date(from: "2026-07-16T12:00:00Z"))
         let afterRollover = try #require(ISO8601DateFormatter().date(from: "2026-07-22T12:00:00Z"))
         let clock = LockIsolated(loadedAt)

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -369,6 +369,63 @@ struct UsageStoreWidgetSnapshotTests {
         #expect(entry.tokenUsage?.last30DaysTokens == 42000)
     }
 
+    @Test
+    func `widget snapshot uses Claude enterprise spend limit instead of placeholder quota`() async throws {
+        let suite = "UsageStoreWidgetSnapshotTests-claude-enterprise-spend-limit"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let updatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 0,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil,
+                    isSyntheticPlaceholder: true),
+                secondary: nil,
+                providerCost: ProviderCostSnapshot(
+                    used: 25545.63,
+                    limit: 30000,
+                    currencyCode: "USD",
+                    period: "Monthly cap",
+                    updatedAt: updatedAt),
+                updatedAt: updatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .claude,
+                    accountEmail: nil,
+                    accountOrganization: nil,
+                    loginMethod: nil)),
+            provider: .claude)
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        store.persistWidgetSnapshot(reason: "claude-enterprise-spend-limit-test")
+        await store.widgetSnapshotPersistTask?.value
+
+        let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .claude })
+        let row = try #require(entry.usageRows?.first)
+        #expect(entry.usageRows?.count == 1)
+        #expect(row.id == "extraUsage")
+        #expect(row.title == "Monthly cap")
+        #expect(abs((row.percentLeft ?? 0) - 14.8479) < 0.0001)
+        #expect(row.window?.isSyntheticPlaceholder == false)
+    }
+
     @Test(arguments: [true, false])
     func `widget snapshot respects extra usage visibility for Devin`(_ showsExtraUsage: Bool) async throws {
         let suite = "UsageStoreWidgetSnapshotTests-devin-extra-usage-\(showsExtraUsage)"


### PR DESCRIPTION
## Summary

- Recreate @ChenZiHong-Gavin's fix from #2411 on current `main` because the original fork does not allow maintainer edits.
- Persist spend-cap-only Claude enterprise widget data as one `extraUsage` row through `MenuBarMetricWindowResolver.claudeSpendLimitWindow`.
- Preserve genuine Claude session and weekly quota rows.

## Verification

- `swift test --filter UsageStoreWidgetSnapshotTests` (12 tests passed; rerun with the locally built Sparkle framework on SwiftPM's framework search path)
- `swift test --filter MenuBarMetricWindowResolverTests` (32 tests passed)
- Autoreview: clean, no accepted/actionable findings

Original contribution: #2411 by @ChenZiHong-Gavin.
