### PR TITLE
Use descriptor pace rules in CLI

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -736,27 +736,7 @@ extension UsageMenuCardView.Model {
 
     private static func resetWindowForPace(provider: UsageProvider, window: RateWindow) -> RateWindow {
         // Provider snapshots use 30 days as a monthly sentinel; use the reset date for the real calendar-cycle length.
-        let pace = ProviderDescriptorRegistry.descriptor(for: provider).pace
-        guard pace.usesInferredMonthlyDuration(window: window),
-              let resetsAt = window.resetsAt,
-              let minutes = self.inferredMonthlyWindowMinutes(endingAt: resetsAt)
-        else { return window }
-        return RateWindow(
-            usedPercent: window.usedPercent,
-            windowMinutes: minutes,
-            resetsAt: window.resetsAt,
-            resetDescription: window.resetDescription,
-            nextRegenPercent: window.nextRegenPercent,
-            isSyntheticPlaceholder: window.isSyntheticPlaceholder)
-    }
-
-    private static func inferredMonthlyWindowMinutes(endingAt resetsAt: Date) -> Int? {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? calendar.timeZone
-        guard let startsAt = calendar.date(byAdding: .month, value: -1, to: resetsAt) else { return nil }
-        let minutes = resetsAt.timeIntervalSince(startsAt) / 60
-        guard minutes.isFinite, minutes > 0 else { return nil }
-        return Int(minutes.rounded())
+        ProviderDescriptorRegistry.descriptor(for: provider).pace.resolvedResetWindowForPace(window)
     }
 
     static func antigravityMetrics(input: Input, snapshot: UsageSnapshot) -> [Metric] {

--- a/Sources/CodexBarCLI/CLIPayloads.swift
+++ b/Sources/CodexBarCLI/CLIPayloads.swift
@@ -98,6 +98,7 @@ struct ProviderPayload: Encodable {
 struct ProviderPacePayload: Encodable {
     let primary: PacePayload?
     let secondary: PacePayload?
+    let tertiary: PacePayload?
 }
 
 struct PacePayload: Encodable {

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -34,7 +34,13 @@ enum CLIRenderer {
             context: context,
             now: now,
             lines: &lines)
-        self.appendTertiaryLines(snapshot: snapshot, labels: labels, context: context, now: now, lines: &lines)
+        self.appendTertiaryLines(
+            provider: provider,
+            snapshot: snapshot,
+            labels: labels,
+            context: context,
+            now: now,
+            lines: &lines)
         self.appendMiMoBalanceLine(snapshot: snapshot, useColor: context.useColor, lines: &lines)
         self.appendClawRouterUsageLines(snapshot: snapshot, useColor: context.useColor, lines: &lines)
         self.appendSub2APIUsageLines(snapshot: snapshot, useColor: context.useColor, lines: &lines)
@@ -103,7 +109,13 @@ enum CLIRenderer {
             context: context,
             now: now,
             lines: &lines)
-        self.appendTertiaryLines(snapshot: snapshot, labels: labels, context: context, now: now, lines: &lines)
+        self.appendTertiaryLines(
+            provider: provider,
+            snapshot: snapshot,
+            labels: labels,
+            context: context,
+            now: now,
+            lines: &lines)
         self.appendMiMoBalanceLine(snapshot: snapshot, useColor: context.useColor, lines: &lines)
         self.appendClawRouterUsageLines(snapshot: snapshot, useColor: context.useColor, lines: &lines)
         self.appendSub2APIUsageLines(snapshot: snapshot, useColor: context.useColor, lines: &lines)
@@ -577,8 +589,16 @@ enum CLIRenderer {
                 weeklyWorkDays: weeklyWorkDays,
                 now: now)
         }
-        guard primary != nil || secondary != nil else { return nil }
-        return ProviderPacePayload(primary: primary, secondary: secondary)
+        let tertiary = snapshot.tertiary.flatMap {
+            self.pacePayload(
+                provider: provider,
+                window: $0,
+                kind: self.paceKind(provider: provider, fallback: .weekly),
+                weeklyWorkDays: weeklyWorkDays,
+                now: now)
+        }
+        guard primary != nil || secondary != nil || tertiary != nil else { return nil }
+        return ProviderPacePayload(primary: primary, secondary: secondary, tertiary: tertiary)
     }
 
     static func rateLine(title: String, window: RateWindow, useColor: Bool) -> String {
@@ -784,16 +804,28 @@ enum CLIRenderer {
         }
     }
 
+    // swiftlint:disable:next function_parameter_count
     private static func appendTertiaryLines(
+        provider: UsageProvider,
         snapshot: UsageSnapshot,
         labels: RateWindowLabels,
         context: RenderContext,
         now: Date,
         lines: inout [String])
     {
-        guard labels.showsTertiary, let opus = snapshot.tertiary else { return }
-        lines.append(self.rateLine(title: labels.tertiary, window: opus, useColor: context.useColor))
-        if let reset = self.resetLine(for: opus, style: context.resetStyle, now: now) {
+        guard labels.showsTertiary, let tertiary = snapshot.tertiary else { return }
+        lines.append(self.rateLine(title: labels.tertiary, window: tertiary, useColor: context.useColor))
+        if let pace = self.paceLine(
+            provider: provider,
+            window: tertiary,
+            kind: self.paceKind(provider: provider, fallback: .weekly),
+            weeklyWorkDays: context.weeklyWorkDays,
+            useColor: context.useColor,
+            now: now)
+        {
+            lines.append(pace)
+        }
+        if let reset = self.resetLine(for: tertiary, style: context.resetStyle, now: now) {
             lines.append(self.subtleLine(reset, useColor: context.useColor))
         }
     }
@@ -1121,8 +1153,9 @@ enum CLIRenderer {
 
     /// .session mirrors the GUI's session pace (5h window, real session windows only); .weekly reads
     /// weeklyProgressWorkDays from the GUI's UserDefaults (same key) and passes it to UsagePace.weekly,
-    /// so the baseline matches the menu bar when the setting is configured. Codex historical refinement
-    /// is not applied (fixed allowlist only), so it can still differ from the menu for Codex accounts.
+    /// so the baseline matches the menu bar when the setting is configured. Descriptor-backed reset windows
+    /// also use .weekly wording. Codex historical refinement is not applied, so it can still differ from the
+    /// menu for Codex accounts.
     private enum PaceKind {
         case session
         case weekly
@@ -1134,7 +1167,7 @@ enum CLIRenderer {
             }
         }
 
-        func supports(provider: UsageProvider) -> Bool {
+        func supportsStandardPace(provider: UsageProvider) -> Bool {
             switch self {
             case .session:
                 provider == .codex || provider == .claude || provider == .ollama || provider == .kimi
@@ -1143,6 +1176,11 @@ enum CLIRenderer {
                     provider == .kimi
             }
         }
+    }
+
+    private struct PaceComputation {
+        let pace: UsagePace
+        let kind: PaceKind
     }
 
     private static func paceKind(provider: UsageProvider, fallback: PaceKind) -> PaceKind {
@@ -1161,36 +1199,45 @@ enum CLIRenderer {
         window: RateWindow,
         kind: PaceKind,
         weeklyWorkDays: Int? = nil,
-        now: Date) -> UsagePace?
+        now: Date) -> PaceComputation?
     {
-        guard kind.supports(provider: provider) else { return nil }
+        let capability = ProviderDescriptorRegistry.descriptor(for: provider).pace
+        let paceWindow: RateWindow
+        let resolvedKind: PaceKind
+        if capability.supportsResetWindowPace(window: window, now: now) {
+            paceWindow = capability.resolvedResetWindowForPace(window)
+            resolvedKind = .weekly
+        } else {
+            guard kind.supportsStandardPace(provider: provider) else { return nil }
+            paceWindow = window
+            resolvedKind = kind
+        }
         if provider == .kimi {
-            let supportsWindow = switch kind {
+            let supportsWindow = switch resolvedKind {
             case .session:
-                window.windowMinutes == KimiProviderDescriptor.sessionWindowMinutes
+                paceWindow.windowMinutes == KimiProviderDescriptor.sessionWindowMinutes
             case .weekly:
-                ProviderDescriptorRegistry.descriptor(for: provider).pace
-                    .supportsResetWindowPace(window: window, now: now)
+                capability.supportsResetWindowPace(window: paceWindow, now: now)
             }
             guard supportsWindow else { return nil }
         }
         // Only pace a real session window here; Claude w/o 5-hour data falls a 7-day window into primary.
-        if case .session = kind, let minutes = window.windowMinutes, minutes > 300 {
+        if case .session = resolvedKind, let minutes = paceWindow.windowMinutes, minutes > 300 {
             return nil
         }
-        if provider == .ollama, window.windowMinutes == nil {
+        if provider == .ollama, paceWindow.windowMinutes == nil {
             return nil
         }
-        guard window.remainingPercent > 0 else { return nil }
+        guard paceWindow.remainingPercent > 0 else { return nil }
         // workDays applies only to the weekly (10 080-min) window; UsagePace.weekly ignores it for other durations.
-        let workDays = kind == .weekly ? weeklyWorkDays : nil
+        let workDays = resolvedKind == .weekly ? weeklyWorkDays : nil
         guard let pace = UsagePace.weekly(
-            window: window,
+            window: paceWindow,
             now: now,
-            defaultWindowMinutes: kind.defaultWindowMinutes,
+            defaultWindowMinutes: resolvedKind.defaultWindowMinutes,
             workDays: workDays) else { return nil }
         guard pace.expectedUsedPercent >= Self.paceMinimumExpectedPercent else { return nil }
-        return pace
+        return PaceComputation(pace: pace, kind: resolvedKind)
     }
 
     private static func paceSummary(
@@ -1217,14 +1264,19 @@ enum CLIRenderer {
         useColor: Bool,
         now: Date) -> String?
     {
-        guard let pace = self.computePace(
+        guard let computation = self.computePace(
             provider: provider,
             window: window,
             kind: kind,
             weeklyWorkDays: weeklyWorkDays,
             now: now) else { return nil }
         let label = self.label("Pace", useColor: useColor)
-        return "\(label): \(self.paceSummary(provider: provider, for: pace, kind: kind, now: now))"
+        let summary = self.paceSummary(
+            provider: provider,
+            for: computation.pace,
+            kind: computation.kind,
+            now: now)
+        return "\(label): \(summary)"
     }
 
     private static func pacePayload(
@@ -1234,20 +1286,24 @@ enum CLIRenderer {
         weeklyWorkDays: Int? = nil,
         now: Date) -> PacePayload?
     {
-        guard let pace = self.computePace(
+        guard let computation = self.computePace(
             provider: provider,
             window: window,
             kind: kind,
             weeklyWorkDays: weeklyWorkDays,
             now: now) else { return nil }
         return PacePayload(
-            stage: Self.stageString(pace.stage),
-            deltaPercent: pace.deltaPercent.rounded(),
-            expectedUsedPercent: pace.expectedUsedPercent.rounded(),
-            willLastToReset: pace.willLastToReset,
-            etaSeconds: pace.etaSeconds.map { $0.rounded() },
-            runOutProbability: pace.runOutProbability,
-            summary: self.paceSummary(provider: provider, for: pace, kind: kind, now: now))
+            stage: Self.stageString(computation.pace.stage),
+            deltaPercent: computation.pace.deltaPercent.rounded(),
+            expectedUsedPercent: computation.pace.expectedUsedPercent.rounded(),
+            willLastToReset: computation.pace.willLastToReset,
+            etaSeconds: computation.pace.etaSeconds.map { $0.rounded() },
+            runOutProbability: computation.pace.runOutProbability,
+            summary: self.paceSummary(
+                provider: provider,
+                for: computation.pace,
+                kind: computation.kind,
+                now: now))
     }
 
     private static func stageString(_ stage: UsagePace.Stage) -> String {

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -75,6 +75,29 @@ public struct ProviderPaceCapability: Sendable {
     public func usesInferredMonthlyDuration(window: RateWindow) -> Bool {
         self.inferredMonthlyDuration.matches(window: window)
     }
+
+    public func resolvedResetWindowForPace(_ window: RateWindow) -> RateWindow {
+        guard self.usesInferredMonthlyDuration(window: window),
+              let resetsAt = window.resetsAt,
+              let minutes = Self.inferredMonthlyWindowMinutes(endingAt: resetsAt)
+        else { return window }
+        return RateWindow(
+            usedPercent: window.usedPercent,
+            windowMinutes: minutes,
+            resetsAt: window.resetsAt,
+            resetDescription: window.resetDescription,
+            nextRegenPercent: window.nextRegenPercent,
+            isSyntheticPlaceholder: window.isSyntheticPlaceholder)
+    }
+
+    private static func inferredMonthlyWindowMinutes(endingAt resetsAt: Date) -> Int? {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? calendar.timeZone
+        guard let startsAt = calendar.date(byAdding: .month, value: -1, to: resetsAt) else { return nil }
+        let minutes = resetsAt.timeIntervalSince(startsAt) / 60
+        guard minutes.isFinite, minutes > 0 else { return nil }
+        return Int(minutes.rounded())
+    }
 }
 
 public struct ProviderDescriptor: Sendable {

--- a/Tests/CodexBarTests/CLISnapshotTests.swift
+++ b/Tests/CodexBarTests/CLISnapshotTests.swift
@@ -676,6 +676,111 @@ struct CLISnapshotTests {
     }
 
     @Test
+    func `descriptor reset window capability enables CLI pace`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = UsageSnapshot(
+            primary: .init(
+                usedPercent: 30,
+                windowMinutes: nil,
+                resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60),
+                resetDescription: "weekly"),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: now)
+
+        let pace = try #require(CLIRenderer.providerPacePayload(provider: .grok, snapshot: snapshot, now: now))
+        let primary = try #require(pace.primary)
+        #expect(primary.expectedUsedPercent == 43)
+        #expect(primary.summary == "13% in reserve | Expected 43% used | Lasts until reset")
+    }
+
+    @Test
+    func `descriptor monthly CLI pace uses the calendar cycle`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let resetsAt = try #require(calendar.date(from: DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 3,
+            day: 1)))
+        let now = try #require(calendar.date(from: DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 2,
+            day: 15)))
+        let snapshot = UsageSnapshot(
+            primary: .init(
+                usedPercent: 40,
+                windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
+                resetsAt: resetsAt,
+                resetDescription: "monthly"),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: now)
+
+        let pace = try #require(CLIRenderer.providerPacePayload(provider: .amp, snapshot: snapshot, now: now))
+        #expect(pace.primary?.expectedUsedPercent == 50)
+    }
+
+    @Test
+    func `descriptor monthly CLI pace includes tertiary text and JSON`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let resetsAt = try #require(calendar.date(from: DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 3,
+            day: 1)))
+        let now = try #require(calendar.date(from: DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 2,
+            day: 15)))
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: .init(
+                usedPercent: 40,
+                windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
+                resetsAt: resetsAt,
+                resetDescription: "monthly"),
+            updatedAt: now)
+
+        for provider: UsageProvider in [.alibaba, .opencodego] {
+            let pace = try #require(CLIRenderer.providerPacePayload(
+                provider: provider,
+                snapshot: snapshot,
+                now: now))
+            #expect(pace.primary == nil)
+            #expect(pace.secondary == nil)
+            #expect(pace.tertiary?.expectedUsedPercent == 50)
+
+            let output = CLIRenderer.renderText(
+                provider: provider,
+                snapshot: snapshot,
+                credits: nil,
+                context: RenderContext(
+                    header: provider.rawValue,
+                    status: nil,
+                    useColor: false,
+                    resetStyle: .countdown),
+                now: now)
+            #expect(output.contains("Monthly: 60% left"))
+            #expect(output.contains("Pace: 10% in reserve | Expected 50% used | Lasts until reset"))
+
+            let data = try JSONEncoder().encode(pace)
+            let encoded = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(encoded["primary"] == nil)
+            #expect(encoded["secondary"] == nil)
+            #expect(encoded["tertiary"] != nil)
+        }
+    }
+
+    @Test
     func `renders Ollama weekly pace line when weekly window has reset`() {
         let now = Date()
         let snap = UsageSnapshot(

--- a/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
+++ b/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
@@ -66,6 +66,27 @@ struct ProviderPaceCapabilityTests {
         #expect(capability.usesInferredMonthlyDuration(window: subscription))
     }
 
+    @Test
+    func `calendar month pace resolves the real cycle duration`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let resetsAt = try #require(calendar.date(from: DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 3,
+            day: 1)))
+        let window = Self.window(
+            minutes: Self.monthlyWindowSentinelMinutes,
+            resetsAt: resetsAt)
+
+        let resolved = ProviderPaceCapability.calendarMonthResetWindow.resolvedResetWindowForPace(window)
+
+        #expect(resolved.windowMinutes == 28 * 24 * 60)
+        #expect(resolved.resetsAt == resetsAt)
+        #expect(resolved.usedPercent == window.usedPercent)
+    }
+
     private static func window(minutes: Int?, resetsAt: Date?) -> RateWindow {
         RateWindow(
             usedPercent: 50,


### PR DESCRIPTION
Addresses the CLI follow-up discussed in #2431.

## Summary

- use provider descriptor reset-window pace rules when producing CLI text and JSON
- share calendar-month duration resolution between menu and CLI rendering
- include eligible tertiary windows in CLI text and the additive `pace.tertiary` JSON field
- add Grok weekly, Amp calendar-month, and Alibaba/OpenCode Go tertiary regression coverage

## Root cause

`CLIRenderer.PaceKind.supports` still used provider allowlists from before the descriptor capability move in #2364. Descriptor-supported windows such as Grok weekly and Amp monthly were therefore omitted from CLI pace output even though the menu could pace them. The same computation also stopped at primary and secondary slots, so monthly quotas stored in `snapshot.tertiary` remained absent from CLI text and JSON.

## Verification

- final head: `8146e13f`, rebased onto `3c34bcbd`
- `git range-diff e92a6fa4..f2ada4a0 3c34bcbd..8146e13f` — patch is semantically unchanged by the rebase
- regression proof on the original base: the initial Grok and Amp CLI tests failed because both provider pace payloads were `nil`
- `swift test --filter 'CLISnapshotTests|ProviderPaceCapabilityTests|ZoomMateCreditsHistoryFetcherTests'` — 71 tests passed, including Alibaba and OpenCode Go tertiary text/JSON coverage
- `make check` — passed; SwiftFormat 0/1671 files, SwiftLint 0 violations in 1670 files
- `git diff --check origin/main...HEAD` — passed
- `make test` — group 4 and its isolated retry timed out after 180 seconds in unchanged `AdaptiveRefreshHeuristicsTests`; the exact filtered suite on untouched `3c34bcbd` also stalled for more than 180 seconds at `adaptive cadence schedules a reset-boundary refresh through the refresh pipeline`

## Compatibility

Risk is low. Existing primary/secondary Codex, Claude, Ollama, OpenCode, and Kimi pace behavior is preserved. Tertiary pace is additive and only appears when the existing standard rules or the provider descriptor can compute it. The JSON change is additive: `pace.tertiary` is omitted when no tertiary pace applies.

Review focus: descriptor-to-CLI window/kind resolution, tertiary text/JSON parity, and the shared calendar-month duration calculation.
