### PR TITLE
Doubao: read Agent Plan (AFP) usage on the AK/SK API source

### DIFF
--- a/Sources/CodexBarCore/Providers/Doubao/DoubaoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Doubao/DoubaoUsageFetcher.swift
@@ -266,6 +266,12 @@ public struct DoubaoUsageFetcher: Sendable {
     private static let apiURL = URL(string: "https://ark.cn-beijing.volces.com/api/coding/v3/chat/completions")!
     private static let codingPlanAPIURL = URL(
         string: "https://open.volcengineapi.com/?Action=GetCodingPlanUsage&Version=2024-01-01")!
+    /// Agent Plan usage lives behind a sibling Volcengine Top OpenAPI action (`GetAFPUsage`,
+    /// AFP = "Agent Flow Points"), signed with the same AK/SK the Coding Plan path uses. An
+    /// account holds a Coding Plan *or* an Agent Plan, so `GetCodingPlanUsage` returns no
+    /// active quota for an Agent Plan account and we fall back to this action.
+    private static let agentPlanAPIURL = URL(
+        string: "https://open.volcengineapi.com/?Action=GetAFPUsage&Version=2024-01-01")!
 
     /// Closure that runs `arkcli usage plan` and returns raw stdout.
     public typealias ArkcliRunner = @Sendable () async throws -> Data
@@ -354,6 +360,17 @@ public struct DoubaoUsageFetcher: Sendable {
         }
 
         let codingPlanUsage = try self.decodeCodingPlanUsage(from: response.data)
+        if codingPlanUsage.quotas.isEmpty {
+            // A 200 with no quota window means the Coding Plan is not active for this account
+            // (e.g. Status "Reclaimed" after switching to an Agent Plan). Fall back to the
+            // Agent Plan (AFP) usage before surfacing an empty Coding Plan snapshot.
+            if let agentSnapshot = try? await self.fetchAgentPlanUsage(
+                credentials: credentials, session: transport, date: date),
+                agentSnapshot.codingPlanUsage?.quotas.isEmpty == false
+            {
+                return agentSnapshot
+            }
+        }
         return DoubaoUsageSnapshot(
             remainingRequests: 0,
             limitRequests: 0,
@@ -361,6 +378,74 @@ public struct DoubaoUsageFetcher: Sendable {
             updatedAt: codingPlanUsage.updateTime ?? date,
             apiKeyValid: true,
             codingPlanUsage: codingPlanUsage)
+    }
+
+    /// Fetches Agent Plan (AFP) usage via the AK/SK-signed `GetAFPUsage` action. Mirrors the
+    /// Coding Plan request path; maps the AFP rolling windows onto the same `agent_*` quota
+    /// levels the arkcli (`.cli`) Agent Plan path already renders, so `.api` and `.cli` show
+    /// an Agent Plan account identically.
+    static func fetchAgentPlanUsage(
+        credentials: DoubaoCodingPlanCredentials,
+        session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        date: Date = Date()) async throws -> DoubaoUsageSnapshot
+    {
+        let body = Data()
+        var request = URLRequest(url: self.agentPlanAPIURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 15
+        request.httpBody = body
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        DoubaoVolcengineSigner.sign(
+            request: &request,
+            body: body,
+            credentials: credentials,
+            date: date)
+
+        let response = try await transport.response(for: request)
+        guard response.statusCode == 200 else {
+            let summary = Self.apiErrorSummary(statusCode: response.statusCode, data: response.data)
+            Self.log.error("Doubao agent plan API returned \(response.statusCode): \(summary)")
+            throw DoubaoUsageError.apiError(response.statusCode, summary)
+        }
+
+        let agentPlanUsage = try self.decodeAgentPlanUsage(from: response.data)
+        return DoubaoUsageSnapshot(
+            remainingRequests: 0,
+            limitRequests: 0,
+            resetTime: nil,
+            updatedAt: agentPlanUsage.updateTime ?? date,
+            apiKeyValid: true,
+            codingPlanUsage: agentPlanUsage)
+    }
+
+    static func decodeAgentPlanUsage(from data: Data) throws -> DoubaoCodingPlanUsage {
+        let response: AgentPlanUsageResponse
+        do {
+            response = try JSONDecoder().decode(AgentPlanUsageResponse.self, from: data)
+        } catch {
+            throw DoubaoUsageError.parseFailed(error.localizedDescription)
+        }
+        let result = response.result
+        var quotas: [DoubaoCodingPlanUsage.Quota] = []
+        func appendQuota(_ window: AgentPlanWindowPayload?, level: String) {
+            guard let window, window.quota > 0 else { return }
+            let percent = min(100, max(0, window.used / window.quota * 100))
+            quotas.append(DoubaoCodingPlanUsage.Quota(
+                level: level,
+                percent: percent,
+                resetTime: self.date(fromEpochMilliseconds: window.resetTime)))
+        }
+        // Only the 5-hour/weekly/monthly windows have a renderer slot in `toUsageSnapshot`;
+        // the daily window (`AFPDaily`) is intentionally skipped to match the arkcli path.
+        appendQuota(result.fiveHour, level: "agent_5h")
+        appendQuota(result.weekly, level: "agent_weekly")
+        appendQuota(result.monthly, level: "agent_monthly")
+        return DoubaoCodingPlanUsage(status: nil, updateTime: nil, quotas: quotas)
+    }
+
+    private static func date(fromEpochMilliseconds milliseconds: TimeInterval?) -> Date? {
+        guard let milliseconds, milliseconds > 0 else { return nil }
+        return Date(timeIntervalSince1970: milliseconds / 1000)
     }
 
     static func decodeCodingPlanUsage(from data: Data) throws -> DoubaoCodingPlanUsage {
@@ -914,6 +999,15 @@ public struct DoubaoUsageFetcher: Sendable {
             case updateTimestamp = "UpdateTimestamp"
             case quotaUsage = "QuotaUsage"
         }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.status = try container.decodeIfPresent(String.self, forKey: .status)
+            self.updateTimestamp = try container.decodeIfPresent(TimeInterval.self, forKey: .updateTimestamp)
+            // A reclaimed/inactive Coding Plan returns Status only and omits `QuotaUsage`.
+            // Decode it as no quota rather than a hard failure so the Agent Plan fallback runs.
+            self.quotaUsage = try container.decodeIfPresent([QuotaPayload].self, forKey: .quotaUsage) ?? []
+        }
     }
 
     private struct QuotaPayload: Decodable {
@@ -925,6 +1019,40 @@ public struct DoubaoUsageFetcher: Sendable {
             case level = "Level"
             case percent = "Percent"
             case resetTimestamp = "ResetTimestamp"
+        }
+    }
+
+    // MARK: - Agent Plan (GetAFPUsage) signed API response
+
+    private struct AgentPlanUsageResponse: Decodable {
+        let result: AgentPlanResultPayload
+
+        private enum CodingKeys: String, CodingKey {
+            case result = "Result"
+        }
+    }
+
+    private struct AgentPlanResultPayload: Decodable {
+        let fiveHour: AgentPlanWindowPayload?
+        let weekly: AgentPlanWindowPayload?
+        let monthly: AgentPlanWindowPayload?
+
+        private enum CodingKeys: String, CodingKey {
+            case fiveHour = "AFPFiveHour"
+            case weekly = "AFPWeekly"
+            case monthly = "AFPMonthly"
+        }
+    }
+
+    private struct AgentPlanWindowPayload: Decodable {
+        let quota: Double
+        let used: Double
+        let resetTime: TimeInterval?
+
+        private enum CodingKeys: String, CodingKey {
+            case quota = "Quota"
+            case used = "Used"
+            case resetTime = "ResetTime"
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Doubao/DoubaoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Doubao/DoubaoUsageFetcher.swift
@@ -364,10 +364,9 @@ public struct DoubaoUsageFetcher: Sendable {
             // A 200 with no quota window means the Coding Plan is not active for this account
             // (e.g. Status "Reclaimed" after switching to an Agent Plan). Fall back to the
             // Agent Plan (AFP) usage before surfacing an empty Coding Plan snapshot.
-            if let agentSnapshot = try? await self.fetchAgentPlanUsage(
-                credentials: credentials, session: transport, date: date),
-                agentSnapshot.codingPlanUsage?.quotas.isEmpty == false
-            {
+            let agentSnapshot = try await self.fetchAgentPlanUsage(
+                credentials: credentials, session: transport, date: date)
+            if agentSnapshot.codingPlanUsage?.quotas.isEmpty == false {
                 return agentSnapshot
             }
         }
@@ -401,7 +400,16 @@ public struct DoubaoUsageFetcher: Sendable {
             credentials: credentials,
             date: date)
 
-        let response = try await transport.response(for: request)
+        let response: ProviderHTTPResponse
+        do {
+            response = try await transport.response(for: request)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as URLError where error.code == .cancelled {
+            throw CancellationError()
+        } catch {
+            throw DoubaoUsageError.networkError(error.localizedDescription)
+        }
         guard response.statusCode == 200 else {
             let summary = Self.apiErrorSummary(statusCode: response.statusCode, data: response.data)
             Self.log.error("Doubao agent plan API returned \(response.statusCode): \(summary)")

--- a/Tests/CodexBarTests/DoubaoUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DoubaoUsageFetcherTests.swift
@@ -1058,3 +1058,135 @@ private actor DoubaoScriptedTransport: ProviderHTTPTransport {
         }
     }
 }
+
+struct DoubaoAgentPlanUsageTests {
+    @Test
+    func `reclaimed coding plan decodes as empty quotas rather than throwing`() throws {
+        // An account that switched from Coding Plan to Agent Plan returns Status only, with no
+        // `QuotaUsage` key. That must not be a decode failure (it previously surfaced as
+        // "Failed to parse Doubao response") so the Agent Plan fallback can run.
+        let data = Data(#"{"Result":{"Status":"Reclaimed","UpdateTimestamp":1785322689}}"#.utf8)
+        let usage = try DoubaoUsageFetcher.decodeCodingPlanUsage(from: data)
+        #expect(usage.quotas.isEmpty)
+        #expect(usage.status == "Reclaimed")
+    }
+
+    @Test
+    func `agent plan usage maps AFP windows onto agent rate windows`() throws {
+        // Real GetAFPUsage body for an Agent Plan "medium" account. ResetTime is epoch
+        // milliseconds; -1 marks a window with no active reset (zero usage).
+        let data = Data(
+            """
+            {
+              "Result": {
+                "PlanType": "medium",
+                "AFPFiveHour": {"Quota": 10000, "Used": 0, "ResetTime": -1},
+                "AFPWeekly": {"Quota": 35000, "Used": 8750, "ResetTime": 1785686400000},
+                "AFPMonthly": {"Quota": 100000, "Used": 25000, "ResetTime": 1787846399000},
+                "AFPDaily": {"Quota": 50000, "Used": 0, "ResetTime": 1785340800000}
+              }
+            }
+            """.utf8)
+        let usage = try DoubaoUsageFetcher.decodeAgentPlanUsage(from: data)
+        let snapshot = usage.toUsageSnapshot(updatedAt: Date(timeIntervalSince1970: 1_785_300_000))
+
+        // Coding Plan windows stay empty; the Agent Plan renders through the extra windows,
+        // matching the arkcli (`.cli`) path so both sources look identical.
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.secondary == nil)
+        #expect(snapshot.tertiary == nil)
+
+        let extra = snapshot.extraRateWindows ?? []
+        let fiveHour = extra.first { $0.id == "doubao-agent-session" }
+        let weekly = extra.first { $0.id == "doubao-agent-weekly" }
+        let monthly = extra.first { $0.id == "doubao-agent-monthly" }
+
+        #expect(fiveHour?.title == "5-hour")
+        #expect(fiveHour?.window.usedPercent == 0)
+        #expect(fiveHour?.window.resetsAt == nil)
+
+        #expect(weekly?.title == "Weekly")
+        #expect(weekly?.window.usedPercent == 25) // 8750 / 35000
+        #expect(weekly?.window.resetsAt == Date(timeIntervalSince1970: 1_785_686_400))
+
+        #expect(monthly?.title == "Monthly")
+        #expect(monthly?.window.usedPercent == 25) // 25000 / 100000
+        #expect(monthly?.window.resetsAt == Date(timeIntervalSince1970: 1_787_846_399))
+
+        // `AFPDaily` has no renderer slot and must not leak into the windows.
+        #expect(extra.count == 3)
+    }
+
+    @Test
+    func `coding plan fetch falls back to agent plan when coding plan is reclaimed`() async throws {
+        let transport = DoubaoScriptedTransport(results: [
+            .rawResponse(
+                statusCode: 200,
+                body: #"{"Result":{"Status":"Reclaimed","UpdateTimestamp":1785322689}}"#),
+            .rawResponse(
+                statusCode: 200,
+                body: """
+                {
+                  "Result": {
+                    "PlanType": "medium",
+                    "AFPFiveHour": {"Quota": 10000, "Used": 0, "ResetTime": -1},
+                    "AFPWeekly": {"Quota": 35000, "Used": 0, "ResetTime": 1785686400000},
+                    "AFPMonthly": {"Quota": 100000, "Used": 0, "ResetTime": 1787846399000}
+                  }
+                }
+                """),
+        ])
+        let credentials = DoubaoCodingPlanCredentials(
+            accessKeyID: "AKLTTEST",
+            secretAccessKey: "secret",
+            region: "cn-beijing")
+
+        let snapshot = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
+            credentials: credentials,
+            session: transport,
+            date: Date(timeIntervalSince1970: 1_781_654_400))
+
+        // Both the Coding Plan probe and the Agent Plan fallback were issued, and the
+        // fallback's second request targeted the GetAFPUsage action.
+        #expect(await transport.requestCount() == 2)
+        let request = await transport.lastCapturedRequest()
+        #expect(request?.url == "https://open.volcengineapi.com/?Action=GetAFPUsage&Version=2024-01-01")
+
+        let usage = snapshot.toUsageSnapshot()
+        let extra = usage.extraRateWindows ?? []
+        #expect(extra.contains { $0.id == "doubao-agent-weekly" && $0.window.usedPercent == 0 })
+        #expect(extra.contains { $0.id == "doubao-agent-monthly" })
+    }
+
+    @Test
+    func `coding plan fetch keeps active coding plan without probing agent plan`() async throws {
+        let transport = DoubaoScriptedTransport(results: [
+            .rawResponse(
+                statusCode: 200,
+                body: """
+                {
+                  "Result": {
+                    "Status": "Running",
+                    "UpdateTimestamp": 1782226444,
+                    "QuotaUsage": [
+                      {"Level": "session", "Percent": 12.5, "ResetTimestamp": 1782226478}
+                    ]
+                  }
+                }
+                """),
+        ])
+        let credentials = DoubaoCodingPlanCredentials(
+            accessKeyID: "AKLTTEST",
+            secretAccessKey: "secret",
+            region: "cn-beijing")
+
+        let snapshot = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
+            credentials: credentials,
+            session: transport,
+            date: Date(timeIntervalSince1970: 1_781_654_400))
+
+        // An active Coding Plan is returned as-is; no second (Agent Plan) request is made.
+        #expect(await transport.requestCount() == 1)
+        #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 12.5)
+    }
+}

--- a/Tests/CodexBarTests/DoubaoUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DoubaoUsageFetcherTests.swift
@@ -1189,4 +1189,84 @@ struct DoubaoAgentPlanUsageTests {
         #expect(await transport.requestCount() == 1)
         #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 12.5)
     }
+
+    @Test
+    func `agent plan fallback surfaces access denied`() async {
+        let transport = DoubaoScriptedTransport(results: [
+            .rawResponse(
+                statusCode: 200,
+                body: #"{"Result":{"Status":"Reclaimed"}}"#),
+            .rawResponse(
+                statusCode: 403,
+                body: #"{"ResponseMetadata":{"Error":{"Code":"AccessDenied","Message":"not authorized"}}}"#),
+        ])
+
+        await #expect {
+            _ = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
+                credentials: Self.credentials,
+                session: transport)
+        } throws: { error in
+            guard case let DoubaoUsageError.apiError(code, message) = error else { return false }
+            return code == 403 && message.contains("AccessDenied")
+        }
+    }
+
+    @Test
+    func `agent plan fallback surfaces malformed response`() async {
+        let transport = DoubaoScriptedTransport(results: [
+            .rawResponse(
+                statusCode: 200,
+                body: #"{"Result":{"Status":"Reclaimed"}}"#),
+            .rawResponse(statusCode: 200, body: #"{"Result":null}"#),
+        ])
+
+        await #expect {
+            _ = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
+                credentials: Self.credentials,
+                session: transport)
+        } throws: { error in
+            guard case .parseFailed = error as? DoubaoUsageError else { return false }
+            return true
+        }
+    }
+
+    @Test
+    func `agent plan fallback surfaces transport failure`() async {
+        let transport = DoubaoScriptedTransport(results: [
+            .rawResponse(
+                statusCode: 200,
+                body: #"{"Result":{"Status":"Reclaimed"}}"#),
+            .failure(URLError(.timedOut)),
+        ])
+
+        await #expect {
+            _ = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
+                credentials: Self.credentials,
+                session: transport)
+        } throws: { error in
+            guard case let DoubaoUsageError.networkError(message) = error else { return false }
+            return !message.isEmpty
+        }
+    }
+
+    @Test
+    func `agent plan fallback propagates cancellation`() async {
+        let transport = DoubaoScriptedTransport(results: [
+            .rawResponse(
+                statusCode: 200,
+                body: #"{"Result":{"Status":"Reclaimed"}}"#),
+            .cancellation,
+        ])
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
+                credentials: Self.credentials,
+                session: transport)
+        }
+    }
+
+    private static let credentials = DoubaoCodingPlanCredentials(
+        accessKeyID: "AKLTTEST",
+        secretAccessKey: "secret",
+        region: "cn-beijing")
 }


### PR DESCRIPTION
## Summary

The Doubao `.api` (AK/SK) source signs `GetCodingPlanUsage`, which only
covers a **Coding Plan**. A Volcengine Ark account holds a Coding Plan
*or* an **Agent Plan** — not both — so on an Agent Plan account the Coding
Plan is *reclaimed* and `GetCodingPlanUsage` returns `Status` only, with no
`QuotaUsage`:

```json
{"Result":{"Status":"Reclaimed","UpdateTimestamp":1785322689}}
```

The strict decoder treats a missing `QuotaUsage` as a hard failure, so the
account surfaces **“Failed to parse Doubao response”** and shows no usage
at all on the `.api` source.

This teaches the AK/SK path to read the Agent Plan:

1. A quota-less Coding Plan result decodes as **empty** instead of throwing.
2. When the Coding Plan carries no active quota, fall back to the sibling
   **`GetAFPUsage`** action (AFP = "Agent Flow Points"), signed with the
   same AK/SK, version, and region. Its rolling windows map onto the
   existing `agent_*` rate-window levels:

   ```json
   {"Result":{"PlanType":"medium",
     "AFPFiveHour":{"Quota":10000,"Used":0,"ResetTime":-1},
     "AFPWeekly":{"Quota":35000,"Used":8750,"ResetTime":1785686400000},
     "AFPMonthly":{"Quota":100000,"Used":25000,"ResetTime":1787846399000}}}
   ```

So the `.api` source now renders an Agent Plan account **identically to the
arkcli `.cli` path** — the 5-hour / Weekly / Monthly windows — without
requiring `arkcli` to be installed or an SSO login.

The fallback is deliberately narrow: it fires only on a `200` whose Coding
Plan has no active quota (e.g. `Status: "Reclaimed"`). Hard errors (403,
etc.) still surface as-is, and an active Coding Plan is returned as before,
with no extra request.

## Relationship to existing Doubao work

- **#2221** (merged) reads Coding/Agent Plan usage through `arkcli usage
  plan` on the `.cli` source. This PR brings **Agent Plan** parity to the
  `.api` (AK/SK) source, so users with AK/SK credentials no longer need to
  install `arkcli` or do an SSO login just to see Agent Plan usage.
- **#1835** is about Agent Plan **bearer** keys and the OpenAI-compatible
  `/api/plan/v3/chat/completions` probe — a distinct auth path. This PR
  does not touch that; it uses the AK/SK-signed `GetAFPUsage` usage action.

## Verification

- `swift test --filter Doubao` — 67 passed, including a new
  `DoubaoAgentPlanUsageTests` suite (4 cases): AFP window → `agent_*`
  mapping (incl. `AFPDaily` correctly *not* surfaced), the
  reclaimed-Coding-Plan → Agent-Plan fallback (asserts the second request
  targets `GetAFPUsage`), a reclaimed Coding Plan decoding as empty rather
  than throwing, and an active Coding Plan returning without probing AFP.
- `swiftlint --strict` — 0 violations; SwiftFormat — clean.
- **Live**: ran the built CLI against a real Agent Plan (**Medium**)
  account on the `.api` source. It now returns the 5-hour (0%), Weekly, and
  Monthly windows with correct resets — matching that account's `.cli`
  output — instead of the parse error.

`GetAFPUsage` was confirmed both from a live `200` response and by
cross-checking `arkcli`'s own usage operation set; it needs no extra
request parameters (empty signed body, `Version=2024-01-01`, service `ark`).
