### PR TITLE
fix: retain normalized ZoomMate parent cookies

### DIFF
--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -345,6 +345,28 @@ extension BrowserCookieClient {
             throw error
         }
     }
+
+    public func codexBarRecords(
+        matching query: BrowserCookieQuery,
+        in store: BrowserCookieStore,
+        logger: ((String) -> Void)? = nil) throws -> [BrowserCookieRecord]
+    {
+        guard BrowserCookieAccessGate.cookieStoreAccessDecision(
+            homeDirectories: self.configuration.homeDirectories) == .allowed
+        else {
+            throw BrowserCookieStoreAccessSuppressedError()
+        }
+        guard BrowserCookieAccessGate.shouldAttempt(store.browser) else { return [] }
+        guard BrowserCookieAccessGate.claimExplicitRetryCookieReadIfNeeded(for: store.browser) else { return [] }
+        do {
+            let records = try self.records(matching: query, in: store, logger: logger)
+            BrowserCookieAccessGate.recordAllowed(for: store.browser)
+            return records
+        } catch {
+            BrowserCookieAccessGate.recordIfNeeded(error)
+            throw error
+        }
+    }
 }
 #else
 public enum BrowserCookieAccessGate {

--- a/Sources/CodexBarCore/Providers/ZoomMate/ZoomMateChromiumCookieScopeReader.swift
+++ b/Sources/CodexBarCore/Providers/ZoomMate/ZoomMateChromiumCookieScopeReader.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+#if os(macOS)
+import SQLite3
+import SweetCookieKit
+
+private let zoomMateSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+enum ZoomMateChromiumCookieScopeReader {
+    enum CookieScope: Hashable, Sendable {
+        case domain
+        case hostOnly
+    }
+
+    struct ScopedCookie: Sendable {
+        let record: BrowserCookieRecord
+        let scope: CookieScope
+    }
+
+    struct CookieMetadata: Sendable {
+        let hostKey: String
+        let topFrameSiteKey: String
+        let name: String
+        let path: String
+    }
+
+    struct Source: Sendable {
+        let label: String
+        let cookies: [ScopedCookie]
+    }
+
+    enum ReadError: LocalizedError {
+        case missingDatabase(label: String)
+        case sqliteFailed(label: String, details: String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .missingDatabase(label):
+                "\(label) has no Chromium cookie database."
+            case let .sqliteFailed(label, details):
+                "\(label) cookie scope read failed: \(details)"
+            }
+        }
+    }
+
+    private struct CookieKey: Hashable {
+        let domain: String
+        let name: String
+        let path: String
+    }
+
+    private struct ScopeResolution {
+        var scopes: Set<CookieScope> = []
+        var hasPartitionedRecord = false
+    }
+
+    private static let rawDomains = [
+        ".zoom.us",
+        "zoom.us",
+        ".ai.zoom.us",
+        "ai.zoom.us",
+        ".zoommate.zoom.us",
+        "zoommate.zoom.us",
+    ]
+
+    static func read(
+        matching query: BrowserCookieQuery,
+        in browser: Browser,
+        cookieClient: BrowserCookieClient,
+        logger: ((String) -> Void)? = nil) throws -> [Source]
+    {
+        let stores = try cookieClient.codexBarStores(for: browser)
+            .filter { $0.databaseURL != nil }
+        var sources: [Source] = []
+
+        for store in stores {
+            try self.withSnapshot(of: store) { snapshotStore in
+                let records = try cookieClient.codexBarRecords(
+                    matching: query,
+                    in: snapshotStore,
+                    logger: logger)
+                guard !records.isEmpty else { return }
+
+                let metadata = try self.readMetadata(from: snapshotStore)
+                let cookies = self.resolve(records: records, metadata: metadata, logger: logger)
+                guard !cookies.isEmpty else { return }
+                sources.append(Source(label: store.label, cookies: cookies))
+            }
+        }
+
+        return sources
+    }
+
+    static func resolve(
+        records: [BrowserCookieRecord],
+        metadata: [CookieMetadata],
+        logger: ((String) -> Void)? = nil) -> [ScopedCookie]
+    {
+        var resolutionByKey: [CookieKey: ScopeResolution] = [:]
+        for item in metadata {
+            let rawHost = item.hostKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let domain = self.normalizedDomain(rawHost)
+            guard !domain.isEmpty else { continue }
+
+            let key = CookieKey(domain: domain, name: item.name, path: item.path)
+            var resolution = resolutionByKey[key] ?? ScopeResolution()
+            resolution.scopes.insert(rawHost.hasPrefix(".") ? .domain : .hostOnly)
+            if !item.topFrameSiteKey.isEmpty {
+                resolution.hasPartitionedRecord = true
+            }
+            resolutionByKey[key] = resolution
+        }
+
+        var missing = 0
+        var ambiguous = 0
+        var partitioned = 0
+        let resolved = records.compactMap { record -> ScopedCookie? in
+            let key = CookieKey(
+                domain: self.normalizedDomain(record.domain),
+                name: record.name,
+                path: record.path)
+            guard let resolution = resolutionByKey[key] else {
+                missing += 1
+                return nil
+            }
+            guard !resolution.hasPartitionedRecord else {
+                partitioned += 1
+                return nil
+            }
+            guard resolution.scopes.count == 1, let scope = resolution.scopes.first else {
+                ambiguous += 1
+                return nil
+            }
+            return ScopedCookie(record: record, scope: scope)
+        }
+
+        if missing > 0 || ambiguous > 0 || partitioned > 0 {
+            logger?(
+                "Dropped unresolved Chrome cookies " +
+                    "(missing: \(missing), ambiguous scope: \(ambiguous), partitioned: \(partitioned))")
+        }
+        return resolved
+    }
+
+    private static func withSnapshot<T>(
+        of store: BrowserCookieStore,
+        operation: (BrowserCookieStore) throws -> T) throws -> T
+    {
+        guard let sourceDB = store.databaseURL else {
+            throw ReadError.missingDatabase(label: store.label)
+        }
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-zoommate-cookies-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let copiedDB = directory.appendingPathComponent("Cookies")
+        try FileManager.default.copyItem(at: sourceDB, to: copiedDB)
+        for suffix in ["-wal", "-shm"] {
+            let source = URL(fileURLWithPath: sourceDB.path + suffix)
+            guard FileManager.default.fileExists(atPath: source.path) else { continue }
+            try? FileManager.default.copyItem(
+                at: source,
+                to: URL(fileURLWithPath: copiedDB.path + suffix))
+        }
+
+        let snapshotStore = BrowserCookieStore(
+            browser: store.browser,
+            profile: store.profile,
+            kind: store.kind,
+            label: store.label,
+            databaseURL: copiedDB)
+        return try operation(snapshotStore)
+    }
+
+    private static func readMetadata(from store: BrowserCookieStore) throws -> [CookieMetadata] {
+        guard let databaseURL = store.databaseURL else {
+            throw ReadError.missingDatabase(label: store.label)
+        }
+
+        var database: OpaquePointer?
+        guard sqlite3_open_v2(databaseURL.path, &database, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            throw ReadError.sqliteFailed(label: store.label, details: self.sqliteMessage(database))
+        }
+        defer { sqlite3_close(database) }
+
+        let placeholders = Array(repeating: "?", count: self.rawDomains.count).joined(separator: ", ")
+        let sql = """
+        SELECT host_key, top_frame_site_key, name, path
+        FROM cookies
+        WHERE lower(host_key) IN (\(placeholders))
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw ReadError.sqliteFailed(label: store.label, details: self.sqliteMessage(database))
+        }
+        defer { sqlite3_finalize(statement) }
+
+        for (index, domain) in self.rawDomains.enumerated() {
+            sqlite3_bind_text(statement, Int32(index + 1), domain, -1, zoomMateSQLiteTransient)
+        }
+
+        var metadata: [CookieMetadata] = []
+        var stepResult = sqlite3_step(statement)
+        while stepResult == SQLITE_ROW {
+            guard let hostKey = self.text(statement, column: 0),
+                  let topFrameSiteKey = self.text(statement, column: 1),
+                  let name = self.text(statement, column: 2),
+                  let path = self.text(statement, column: 3)
+            else {
+                stepResult = sqlite3_step(statement)
+                continue
+            }
+            metadata.append(CookieMetadata(
+                hostKey: hostKey,
+                topFrameSiteKey: topFrameSiteKey,
+                name: name,
+                path: path))
+            stepResult = sqlite3_step(statement)
+        }
+        guard stepResult == SQLITE_DONE else {
+            throw ReadError.sqliteFailed(label: store.label, details: self.sqliteMessage(database))
+        }
+        return metadata
+    }
+
+    private static func normalizedDomain(_ raw: String) -> String {
+        let lowered = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return lowered.hasPrefix(".") ? String(lowered.dropFirst()) : lowered
+    }
+
+    private static func text(_ statement: OpaquePointer?, column: Int32) -> String? {
+        guard sqlite3_column_type(statement, column) != SQLITE_NULL,
+              let value = sqlite3_column_text(statement, column)
+        else {
+            return nil
+        }
+        return String(cString: value)
+    }
+
+    private static func sqliteMessage(_ database: OpaquePointer?) -> String {
+        guard let database else { return "Unknown SQLite error." }
+        return String(cString: sqlite3_errmsg(database))
+    }
+}
+#endif

--- a/Sources/CodexBarCore/Providers/ZoomMate/ZoomMateCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/ZoomMate/ZoomMateCookieImporter.swift
@@ -52,15 +52,9 @@ private let zoomMateCookieImportOrder: BrowserCookieImportOrder =
 /// ZoomMate's own cookie-to-token bootstrap endpoint). Modeled on `T3ChatCookieImporter`.
 public enum ZoomMateCookieImporter {
     private static let cookieClient = BrowserCookieClient()
-    /// SweetCookieKit normalizes Chromium's `.zoom.us` domain cookies to `zoom.us` before
-    /// constructing `HTTPCookie`. Treat that known parent SSO domain as shared; all leaf domains
-    /// remain exact-host only below.
-    private static let sharedParentCookieDomain = "zoom.us"
-    /// Includes the parent "zoom.us" domain — ZoomMate's SSO session cookies (`_zm_*`,
-    /// `cf_clearance`, etc.) are scoped to the shared parent domain, not the leaf subdomains, and
-    /// domain matching here is substring-based (`.contains`), so this one pattern also matches the
-    /// leaf domains below; both are kept for clarity. The over-broad `.contains("zoom.us")` read is
-    /// then narrowed at send time by `isSendable(toSessionHosts:)`.
+    /// Includes the parent "zoom.us" domain because ZoomMate's SSO session uses both parent-domain
+    /// and leaf-host cookies. The reader recovers Chromium's host-only metadata before these
+    /// candidates are narrowed to the two fixed request hosts.
     private static let cookieDomains = ["zoommate.zoom.us", "ai.zoom.us", "zoom.us"]
 
     public struct SessionInfo: Sendable {
@@ -91,13 +85,13 @@ public enum ZoomMateCookieImporter {
         for browserSource in installed {
             do {
                 let query = BrowserCookieQuery(domains: self.cookieDomains)
-                let sources = try self.cookieClient.codexBarRecords(
+                let sources = try ZoomMateChromiumCookieScopeReader.read(
                     matching: query,
                     in: browserSource,
+                    cookieClient: self.cookieClient,
                     logger: log)
-                for source in sources where !source.records.isEmpty {
-                    let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
-                    let cookieHeaders = Self.cookieHeaders(from: cookies)
+                for source in sources where !source.cookies.isEmpty {
+                    let cookieHeaders = Self.cookieHeaders(from: source.cookies)
                     guard !cookieHeaders.isEmpty else { continue }
                     log("\(source.label): found host-scoped cookie headers")
                     sessions.append(SessionInfo(cookieHeaders: cookieHeaders, sourceLabel: source.label))
@@ -112,31 +106,42 @@ public enum ZoomMateCookieImporter {
         return sessions
     }
 
-    /// Whether a browser would attach a cookie scoped to `cookieDomain` to a request to `host`, per
-    /// Leaf-host cookies stay exact-host only. SweetCookieKit has already normalized the leading
-    /// dot from Chromium's parent `.zoom.us` SSO cookies, so that one known shared domain must be
-    /// handled before the exact-host check; otherwise every browser-imported parent cookie is
-    /// discarded and no ZoomMate session can be created.
-    static func isSendable(cookieDomain: String, toHost host: String) -> Bool {
+    /// Whether a browser would attach a cookie to `host`, using Chromium's recovered host-only flag
+    /// and RFC 6265 domain matching. Only root-path cookies are retained because the cached header
+    /// is reused across ZoomMate's login, status, and history routes.
+    static func isSendable(
+        cookieDomain: String,
+        hostOnly: Bool,
+        path: String,
+        toHost host: String) -> Bool
+    {
         let normalizedDomain = cookieDomain.lowercased()
         let normalizedHost = host.lowercased()
-        guard ZoomMateCookieHeaders.allowedHosts.contains(normalizedHost), !normalizedDomain.isEmpty else {
+        guard ZoomMateCookieHeaders.allowedHosts.contains(normalizedHost),
+              !normalizedDomain.isEmpty,
+              path == "/"
+        else {
             return false
         }
-        if normalizedDomain == Self.sharedParentCookieDomain {
-            return normalizedHost.hasSuffix("." + normalizedDomain)
+        if hostOnly {
+            return normalizedHost == normalizedDomain
         }
-        guard normalizedDomain.hasPrefix(".") else { return normalizedHost == normalizedDomain }
-        let bareDomain = String(normalizedDomain.dropFirst())
-        guard !bareDomain.isEmpty else { return false }
-        return normalizedHost == bareDomain || normalizedHost.hasSuffix("." + bareDomain)
+        return normalizedHost == normalizedDomain || normalizedHost.hasSuffix("." + normalizedDomain)
     }
 
-    static func cookieHeaders(from cookies: [HTTPCookie]) -> ZoomMateCookieHeaders {
+    static func cookieHeaders(
+        from cookies: [ZoomMateChromiumCookieScopeReader.ScopedCookie]) -> ZoomMateCookieHeaders
+    {
         let pairs: [(String, String)] = ZoomMateCookieHeaders.allowedHosts.compactMap { host in
-            let sendable = cookies.filter { Self.isSendable(cookieDomain: $0.domain, toHost: host) }
+            let sendable = cookies.filter {
+                Self.isSendable(
+                    cookieDomain: $0.record.domain,
+                    hostOnly: $0.scope == .hostOnly,
+                    path: $0.record.path,
+                    toHost: host)
+            }
             guard !sendable.isEmpty else { return nil }
-            let header = sendable.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+            let header = sendable.map { "\($0.record.name)=\($0.record.value)" }.joined(separator: "; ")
             return (host, header)
         }
         return ZoomMateCookieHeaders(headersByHost: Dictionary(uniqueKeysWithValues: pairs))

--- a/Sources/CodexBarCore/Providers/ZoomMate/ZoomMateCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/ZoomMate/ZoomMateCookieImporter.swift
@@ -52,6 +52,10 @@ private let zoomMateCookieImportOrder: BrowserCookieImportOrder =
 /// ZoomMate's own cookie-to-token bootstrap endpoint). Modeled on `T3ChatCookieImporter`.
 public enum ZoomMateCookieImporter {
     private static let cookieClient = BrowserCookieClient()
+    /// SweetCookieKit normalizes Chromium's `.zoom.us` domain cookies to `zoom.us` before
+    /// constructing `HTTPCookie`. Treat that known parent SSO domain as shared; all leaf domains
+    /// remain exact-host only below.
+    private static let sharedParentCookieDomain = "zoom.us"
     /// Includes the parent "zoom.us" domain — ZoomMate's SSO session cookies (`_zm_*`,
     /// `cf_clearance`, etc.) are scoped to the shared parent domain, not the leaf subdomains, and
     /// domain matching here is substring-based (`.contains`), so this one pattern also matches the
@@ -109,15 +113,18 @@ public enum ZoomMateCookieImporter {
     }
 
     /// Whether a browser would attach a cookie scoped to `cookieDomain` to a request to `host`, per
-    /// RFC 6265 domain-matching: a host-only cookie matches its exact host; a
-    /// domain cookie (stored with a leading dot) matches that host and all of its subdomains. This
-    /// keeps parent `.zoom.us` SSO cookies while preventing an `ai.zoom.us` host-only cookie from
-    /// reaching `zoommate.zoom.us` (and vice versa).
+    /// Leaf-host cookies stay exact-host only. SweetCookieKit has already normalized the leading
+    /// dot from Chromium's parent `.zoom.us` SSO cookies, so that one known shared domain must be
+    /// handled before the exact-host check; otherwise every browser-imported parent cookie is
+    /// discarded and no ZoomMate session can be created.
     static func isSendable(cookieDomain: String, toHost host: String) -> Bool {
         let normalizedDomain = cookieDomain.lowercased()
         let normalizedHost = host.lowercased()
         guard ZoomMateCookieHeaders.allowedHosts.contains(normalizedHost), !normalizedDomain.isEmpty else {
             return false
+        }
+        if normalizedDomain == Self.sharedParentCookieDomain {
+            return normalizedHost.hasSuffix("." + normalizedDomain)
         }
         guard normalizedDomain.hasPrefix(".") else { return normalizedHost == normalizedDomain }
         let bareDomain = String(normalizedDomain.dropFirst())

--- a/Tests/CodexBarTests/ZoomMateCookieScopeTests.swift
+++ b/Tests/CodexBarTests/ZoomMateCookieScopeTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if os(macOS)
+import SweetCookieKit
+
+struct ZoomMateCookieScopeTests {
+    @Test
+    func `automatic import recovers chromium scope before partitioning cookies`() {
+        let records = [
+            Self.cookieRecord(domain: "zoom.us", name: "parent"),
+            Self.cookieRecord(domain: "zoom.us", name: "root-host-only"),
+            Self.cookieRecord(domain: "ai.zoom.us", name: "ai-only"),
+            Self.cookieRecord(domain: "zoommate.zoom.us", name: "mate-only"),
+        ]
+        let metadata = [
+            Self.cookieMetadata(hostKey: ".zoom.us", name: "parent"),
+            Self.cookieMetadata(hostKey: "zoom.us", name: "root-host-only"),
+            Self.cookieMetadata(hostKey: "ai.zoom.us", name: "ai-only"),
+            Self.cookieMetadata(hostKey: "zoommate.zoom.us", name: "mate-only"),
+        ]
+
+        let cookies = ZoomMateChromiumCookieScopeReader.resolve(records: records, metadata: metadata)
+        let headers = ZoomMateCookieImporter.cookieHeaders(from: cookies)
+
+        #expect(headers.header(forHost: "ai.zoom.us") == "parent=fake; ai-only=fake")
+        #expect(headers.header(forHost: "zoommate.zoom.us") == "parent=fake; mate-only=fake")
+    }
+
+    @Test
+    func `cookie scope filter follows RFC 6265 host-only and domain matching`() {
+        #expect(Self.isSendable(domain: "ai.zoom.us", hostOnly: true, to: "ai.zoom.us"))
+        #expect(!Self.isSendable(domain: "ai.zoom.us", hostOnly: true, to: "zoommate.zoom.us"))
+        #expect(Self.isSendable(domain: "zoom.us", hostOnly: false, to: "ai.zoom.us"))
+        #expect(Self.isSendable(domain: "zoom.us", hostOnly: false, to: "zoommate.zoom.us"))
+        #expect(!Self.isSendable(domain: "zoom.us", hostOnly: true, to: "ai.zoom.us"))
+        #expect(!Self.isSendable(domain: "zoom.us", hostOnly: true, to: "zoommate.zoom.us"))
+        #expect(!Self.isSendable(domain: "marketing.zoom.us", hostOnly: false, to: "ai.zoom.us"))
+        #expect(!Self.isSendable(domain: "zoom.us.attacker.com", hostOnly: false, to: "ai.zoom.us"))
+        #expect(!Self.isSendable(domain: "", hostOnly: false, to: "ai.zoom.us"))
+        #expect(!Self.isSendable(domain: "zoom.us", hostOnly: false, path: "/login", to: "ai.zoom.us"))
+    }
+
+    @Test
+    func `scope recovery drops ambiguous missing and partitioned records`() {
+        let records = [
+            Self.cookieRecord(domain: "zoom.us", name: "ambiguous"),
+            Self.cookieRecord(domain: "zoom.us", name: "missing"),
+            Self.cookieRecord(domain: "zoom.us", name: "partitioned"),
+            Self.cookieRecord(domain: "zoom.us", name: "parent"),
+        ]
+        let metadata = [
+            Self.cookieMetadata(hostKey: ".zoom.us", name: "ambiguous"),
+            Self.cookieMetadata(hostKey: "zoom.us", name: "ambiguous"),
+            Self.cookieMetadata(
+                hostKey: ".zoom.us",
+                topFrameSiteKey: "https://example.com",
+                name: "partitioned"),
+            Self.cookieMetadata(hostKey: ".zoom.us", name: "parent"),
+        ]
+        var messages: [String] = []
+
+        let cookies = ZoomMateChromiumCookieScopeReader.resolve(
+            records: records,
+            metadata: metadata,
+            logger: { messages.append($0) })
+
+        #expect(cookies.map(\.record.name) == ["parent"])
+        #expect(cookies.first?.scope == .domain)
+        #expect(messages.contains { $0.contains("missing: 1") })
+        #expect(messages.contains { $0.contains("ambiguous scope: 1") })
+        #expect(messages.contains { $0.contains("partitioned: 1") })
+    }
+
+    private static func cookieRecord(
+        domain: String,
+        name: String,
+        value: String = "fake",
+        path: String = "/") -> BrowserCookieRecord
+    {
+        BrowserCookieRecord(
+            domain: domain,
+            name: name,
+            path: path,
+            value: value,
+            expires: Date(timeIntervalSince1970: 1_900_000_000),
+            isSecure: true,
+            isHTTPOnly: true)
+    }
+
+    private static func cookieMetadata(
+        hostKey: String,
+        topFrameSiteKey: String = "",
+        name: String,
+        path: String = "/") -> ZoomMateChromiumCookieScopeReader.CookieMetadata
+    {
+        ZoomMateChromiumCookieScopeReader.CookieMetadata(
+            hostKey: hostKey,
+            topFrameSiteKey: topFrameSiteKey,
+            name: name,
+            path: path)
+    }
+
+    private static func isSendable(
+        domain: String,
+        hostOnly: Bool,
+        path: String = "/",
+        to host: String) -> Bool
+    {
+        ZoomMateCookieImporter.isSendable(
+            cookieDomain: domain,
+            hostOnly: hostOnly,
+            path: path,
+            toHost: host)
+    }
+}
+#endif

--- a/Tests/CodexBarTests/ZoomMateUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/ZoomMateUsageFetcherTests.swift
@@ -821,7 +821,7 @@ struct ZoomMateUsageFetcherTests {
 
     #if os(macOS)
     @Test
-    func `automatic import partitions parent and host-only cookies per destination`() throws {
+    func `automatic import keeps normalized parent cookies while partitioning leaf cookies`() throws {
         func cookie(domain: String, name: String) throws -> HTTPCookie {
             try #require(HTTPCookie(properties: [
                 .domain: domain,
@@ -833,8 +833,9 @@ struct ZoomMateUsageFetcherTests {
         }
 
         let headers = try ZoomMateCookieImporter.cookieHeaders(from: [
-            cookie(domain: ".zoom.us", name: "parent"),
-            cookie(domain: "zoom.us", name: "parent-host-only"),
+            // SweetCookieKit constructs HTTPCookie with the normalized `zoom.us` form even when
+            // Chromium stored the parent SSO cookie as `.zoom.us`.
+            cookie(domain: "zoom.us", name: "parent"),
             cookie(domain: "ai.zoom.us", name: "ai-only"),
             cookie(domain: "zoommate.zoom.us", name: "mate-only"),
             cookie(domain: "marketing.zoom.us", name: "marketing-only"),
@@ -850,7 +851,8 @@ struct ZoomMateUsageFetcherTests {
         #expect(!ZoomMateCookieImporter.isSendable(cookieDomain: "ai.zoom.us", toHost: "zoommate.zoom.us"))
         #expect(ZoomMateCookieImporter.isSendable(cookieDomain: ".zoom.us", toHost: "ai.zoom.us"))
         #expect(ZoomMateCookieImporter.isSendable(cookieDomain: ".zoom.us", toHost: "zoommate.zoom.us"))
-        #expect(!ZoomMateCookieImporter.isSendable(cookieDomain: "zoom.us", toHost: "ai.zoom.us"))
+        #expect(ZoomMateCookieImporter.isSendable(cookieDomain: "zoom.us", toHost: "ai.zoom.us"))
+        #expect(ZoomMateCookieImporter.isSendable(cookieDomain: "zoom.us", toHost: "zoommate.zoom.us"))
         #expect(!ZoomMateCookieImporter.isSendable(cookieDomain: "marketing.zoom.us", toHost: "ai.zoom.us"))
         #expect(!ZoomMateCookieImporter.isSendable(cookieDomain: "zoom.us.attacker.com", toHost: "ai.zoom.us"))
         #expect(!ZoomMateCookieImporter.isSendable(cookieDomain: "", toHost: "ai.zoom.us"))

--- a/Tests/CodexBarTests/ZoomMateUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/ZoomMateUsageFetcherTests.swift
@@ -819,46 +819,6 @@ struct ZoomMateUsageFetcherTests {
         #expect(await stub.requests().count == 2)
     }
 
-    #if os(macOS)
-    @Test
-    func `automatic import keeps normalized parent cookies while partitioning leaf cookies`() throws {
-        func cookie(domain: String, name: String) throws -> HTTPCookie {
-            try #require(HTTPCookie(properties: [
-                .domain: domain,
-                .path: "/",
-                .name: name,
-                .value: "fake",
-                .secure: "TRUE",
-            ]))
-        }
-
-        let headers = try ZoomMateCookieImporter.cookieHeaders(from: [
-            // SweetCookieKit constructs HTTPCookie with the normalized `zoom.us` form even when
-            // Chromium stored the parent SSO cookie as `.zoom.us`.
-            cookie(domain: "zoom.us", name: "parent"),
-            cookie(domain: "ai.zoom.us", name: "ai-only"),
-            cookie(domain: "zoommate.zoom.us", name: "mate-only"),
-            cookie(domain: "marketing.zoom.us", name: "marketing-only"),
-        ])
-
-        #expect(headers.header(forHost: "ai.zoom.us") == "parent=fake; ai-only=fake")
-        #expect(headers.header(forHost: "zoommate.zoom.us") == "parent=fake; mate-only=fake")
-    }
-
-    @Test
-    func `cookie scope filter follows RFC 6265 host-only and domain matching`() {
-        #expect(ZoomMateCookieImporter.isSendable(cookieDomain: "ai.zoom.us", toHost: "ai.zoom.us"))
-        #expect(!ZoomMateCookieImporter.isSendable(cookieDomain: "ai.zoom.us", toHost: "zoommate.zoom.us"))
-        #expect(ZoomMateCookieImporter.isSendable(cookieDomain: ".zoom.us", toHost: "ai.zoom.us"))
-        #expect(ZoomMateCookieImporter.isSendable(cookieDomain: ".zoom.us", toHost: "zoommate.zoom.us"))
-        #expect(ZoomMateCookieImporter.isSendable(cookieDomain: "zoom.us", toHost: "ai.zoom.us"))
-        #expect(ZoomMateCookieImporter.isSendable(cookieDomain: "zoom.us", toHost: "zoommate.zoom.us"))
-        #expect(!ZoomMateCookieImporter.isSendable(cookieDomain: "marketing.zoom.us", toHost: "ai.zoom.us"))
-        #expect(!ZoomMateCookieImporter.isSendable(cookieDomain: "zoom.us.attacker.com", toHost: "ai.zoom.us"))
-        #expect(!ZoomMateCookieImporter.isSendable(cookieDomain: "", toHost: "ai.zoom.us"))
-    }
-    #endif
-
     private static func makeContext(settings: ProviderSettingsSnapshot) -> ProviderFetchContext {
         ProviderFetchContext(
             runtime: .app,


### PR DESCRIPTION
## Summary

Fixes a live ZoomMate regression introduced by the host-partitioned cookie routing added during review of #2344.

SweetCookieKit normalizes Chromium parent-domain `.zoom.us` cookies to `zoom.us` before creating `HTTPCookie` values. The current partitioning logic interprets that bare value as host-only, dropping the shared Zoom SSO cookies for both approved API hosts and preventing any browser session from being imported.

This patch:

- treats the known shared `zoom.us` parent domain as valid for both `ai.zoom.us` and `zoommate.zoom.us`;
- keeps leaf-host cookies exact-host only;
- adds regression coverage for the normalized parent-domain form.

## Live reproduction

Using the same signed-in Chrome session:

| Build | Result |
|---|---|
| Pre-merge ZoomMate snapshot (`979fd6c`) | Successfully fetched credits |
| Current build | `No ZoomMate session is cached and no session cookies were imported from Chrome` |

## Validation

- `swift build -c debug --target CodexBarCore` passes.
- The focused test command is currently blocked by an unrelated existing compile error in `ClaudeCLIBackgroundAvailabilityTests` (missing `includePrepaidBalance` argument).