### PR TITLE
Improve CLI error message when setting API key for codex provider (#2501)

### DIFF
--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -119,6 +119,14 @@ extension CodexBarCLI {
         Self.exit(code: .success, output: output, kind: .config)
     }
 
+    static func unsupportedAPIKeyErrorMessage(for provider: UsageProvider, rawProvider: String) -> String {
+        if provider == .codex {
+            return "\(rawProvider) does not support config API keys. For OpenAI Platform API keys, use '--provider openai'."
+        } else {
+            return "\(rawProvider) does not support config API keys."
+        }
+    }
+
     static func runConfigSetAPIKey(_ values: ParsedValues) {
         let output = CLIOutputPreferences.from(values: values)
 
@@ -134,7 +142,7 @@ extension CodexBarCLI {
         guard ProviderConfigEnvironment.supportsAPIKeyOverride(for: provider) else {
             Self.exit(
                 code: .failure,
-                message: "\(rawProvider) does not support config API keys.",
+                message: Self.unsupportedAPIKeyErrorMessage(for: provider, rawProvider: rawProvider),
                 output: output,
                 kind: .args)
         }

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -121,9 +121,9 @@ extension CodexBarCLI {
 
     static func unsupportedAPIKeyErrorMessage(for provider: UsageProvider, rawProvider: String) -> String {
         if provider == .codex {
-            return "\(rawProvider) does not support config API keys. For OpenAI Platform API keys, use '--provider openai'."
+            "\(rawProvider) does not support config API keys. For OpenAI Platform API keys, use '--provider openai'."
         } else {
-            return "\(rawProvider) does not support config API keys."
+            "\(rawProvider) does not support config API keys."
         }
     }
 

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -22,6 +22,16 @@ struct CLIConfigCommandTests {
     }
 
     @Test
+    func `config set api key for codex provider hints openai provider`() {
+        #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .codex) == false)
+        let codexMsg = CodexBarCLI.unsupportedAPIKeyErrorMessage(for: .codex, rawProvider: "codex")
+        #expect(codexMsg == "codex does not support config API keys. For OpenAI Platform API keys, use '--provider openai'.")
+
+        let claudeMsg = CodexBarCLI.unsupportedAPIKeyErrorMessage(for: .claude, rawProvider: "claude")
+        #expect(claudeMsg == "claude does not support config API keys.")
+    }
+
+    @Test
     func `config set api key parses zai team account options`() throws {
         let parser = CommandParser(signature: CodexBarCLI._configSetAPIKeySignatureForTesting())
         let parsed = try parser.parse(arguments: [

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -25,7 +25,8 @@ struct CLIConfigCommandTests {
     func `config set api key for codex provider hints openai provider`() {
         #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .codex) == false)
         let codexMsg = CodexBarCLI.unsupportedAPIKeyErrorMessage(for: .codex, rawProvider: "codex")
-        #expect(codexMsg == "codex does not support config API keys. For OpenAI Platform API keys, use '--provider openai'.")
+        #expect(codexMsg ==
+            "codex does not support config API keys. For OpenAI Platform API keys, use '--provider openai'.")
 
         let claudeMsg = CodexBarCLI.unsupportedAPIKeyErrorMessage(for: .claude, rawProvider: "claude")
         #expect(claudeMsg == "claude does not support config API keys.")


### PR DESCRIPTION
### Summary
When a user attempts to set an API key for the `codex` provider via the CLI (`codexbar config set-api-key --provider codex`), the CLI previously reported `codex does not support config API keys.`. 

Since `codex` uses Codex CLI local sessions while OpenAI Platform API keys require `--provider openai`, this PR enhances the error message to guide users explicitly:
> `codex does not support config API keys. For OpenAI Platform API keys, use '--provider openai'.`

### Terminal Proof (CLI Stderr Output)
```
$ codexbar config set-api-key --provider codex
codex does not support config API keys. For OpenAI Platform API keys, use '--provider openai'.
```

### Changes Made
- **Sources/CodexBarCLI/CLIConfigCommand.swift**: Expose `unsupportedAPIKeyErrorMessage(for:rawProvider:)` and add explicit guidance for `--provider codex` when attempting `set-api-key`.
- **Tests/CodexBarTests/CLIConfigCommandTests.swift**: Add automated unit test `config set api key for codex provider hints openai provider` testing production helper paths for codex and generic providers.

### Verification
- Ran `swift test --filter CLIConfigCommandTests` (17/17 passed).
- Ran `make check` (0 format/lint violations).

Fixes #2501