### PR TITLE
Fix OpenCode dashboard links

### DIFF
--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
@@ -21,7 +21,7 @@ public enum OpenCodeProviderDescriptor {
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
                 browserCookieOrder: ProviderBrowserCookieDefaults.opencodeCookieImportOrder,
-                dashboardURL: "https://opencode.ai",
+                dashboardURL: "https://opencode.ai/auth",
                 statusPageURL: nil),
             branding: ProviderBranding(
                 iconStyle: .opencode,

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -21,7 +21,7 @@ public enum OpenCodeGoProviderDescriptor {
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
                 browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
-                dashboardURL: "https://opencode.ai",
+                dashboardURL: "https://opencode.ai/auth",
                 statusPageURL: nil),
             branding: ProviderBranding(
                 iconStyle: .opencodego,

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -26,6 +26,7 @@ public enum OpenCodeGoUsageError: LocalizedError {
 public struct OpenCodeGoUsageFetcher: Sendable {
     private static let log = CodexBarLog.logger(LogCategories.opencodeGoUsage)
     private static let baseURL = URL(string: "https://opencode.ai")!
+    private static let authURL = URL(string: "https://opencode.ai/auth")!
     private static let serverURL = URL(string: "https://opencode.ai/_server")!
     private static let workspacesServerID = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f"
     private static let billingServerID = "c83b78a614689c38ebee981f9b39a8b377716db85c1fd7dbab604adc02d3313d"
@@ -263,7 +264,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         guard let workspaceID = self.normalizeWorkspaceID(raw),
               let url = URL(string: "\(self.baseURL.absoluteString)/workspace/\(workspaceID)/go")
         else {
-            return self.baseURL
+            return self.authURL
         }
         return url
     }

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -53,7 +53,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
                 .absoluteString == "https://opencode.ai/workspace/wrk_def456/go")
         #expect(
             OpenCodeGoUsageFetcher.dashboardURL(workspaceID: nil)
-                .absoluteString == "https://opencode.ai")
+                .absoluteString == "https://opencode.ai/auth")
     }
 
     private struct UsageWindow {

--- a/Tests/CodexBarTests/OpenCodeProviderDescriptorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeProviderDescriptorTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import CodexBarCore
+
+struct OpenCodeProviderDescriptorTests {
+    @Test
+    func `dashboard links use the official auth entry point`() {
+        #expect(OpenCodeProviderDescriptor.descriptor.metadata.dashboardURL == "https://opencode.ai/auth")
+        #expect(OpenCodeGoProviderDescriptor.descriptor.metadata.dashboardURL == "https://opencode.ai/auth")
+    }
+}


### PR DESCRIPTION
## Summary

- send the OpenCode and OpenCode Go dashboard actions to the official `https://opencode.ai/auth` entry point instead of the public homepage
- use the auth entry point as OpenCode Go's fallback when no workspace is configured
- preserve the existing workspace-specific `/workspace/<id>/go` deep link
- add descriptor and URL-helper regression coverage

## Why

The provider descriptors and the OpenCode Go fallback used the bare `https://opencode.ai` URL, which opens the product homepage rather than the account flow. OpenCode's official provider documentation directs both Zen and Go users to `https://opencode.ai/auth`.

When CodexBar already knows an OpenCode Go workspace, it still opens that workspace's Go dashboard directly. This change only fixes the generic fallback.

## Behavior proof

- Before: both provider descriptors and the unscoped OpenCode Go helper resolved to `https://opencode.ai`.
- After: both descriptors and the unscoped helper resolve to `https://opencode.ai/auth`.
- A clean logged-out browser navigation to `/auth` reached OpenCode's authorization service.
- The existing configured-workspace case remains `https://opencode.ai/workspace/wrk_abc123/go`.

Inspectable after-fix production-code trace (official `swift:6.3.3-noble` image, digest
`sha256:66520bcba471018a34fd54ba09be97ba4abebd950a96ff5cb8c2bf50a2d33259`):

```text
LIVE_PROOF opencode.generic=https://opencode.ai/auth
LIVE_PROOF opencodego.unscoped=https://opencode.ai/auth
LIVE_PROOF opencodego.scoped=https://opencode.ai/workspace/wrk_REDACTED/go
✔ Test run with 1 test in 1 suite passed after 0.002 seconds.
```

This trace calls `OpenCodeProviderDescriptor.descriptor.metadata.dashboardURL` and
`OpenCodeGoUsageFetcher.dashboardURL(workspaceID:)` directly. The scoped workspace ID
is deliberately fictitious; no cookies, credentials, or account data were read or printed.
The temporary trace-only harness was deleted after the run and is not part of this PR.

Official reference: [OpenCode provider documentation](https://opencode.ai/docs/providers#opencode-go).

## Existing issue / PR search

No matching issue or PR was found. The closest prior work was #667, which fixed the configured workspace deep link and was landed separately on `main`; this patch preserves that behavior and fixes the remaining no-workspace fallback.

## Validation

- `make format`
- `git diff --check`
- `make check` portable checks and SwiftFormat passed; local SwiftLint could not load SourceKit because this machine has Apple Swift 5.10, while current CodexBar requires Swift 6.2+
- focused `swift test` was likewise blocked locally by the Swift 5.10 toolchain
- exact-head full CI [run 30529938152](https://github.com/steipete/CodexBar/actions/runs/30529938152) passed: lint, Linux x64, Linux ARM64, musl, both macOS shards, and the aggregate gate
