### PR TITLE
fix(cookies): let background refresh reuse an already-authorized Safe Storage ACL (#2451)

### DIFF
--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -87,10 +87,7 @@ public enum BrowserCookieAccessGate {
         guard browser.usesKeychainForCookieDecryption else { return true }
         guard !KeychainAccessGate.isDisabled else { return false }
         guard ProviderInteractionContext.current == .userInitiated else {
-            self.log.info(
-                "Skipping background Chromium cookie import to avoid a Keychain prompt",
-                metadata: ["browser": browser.displayName])
-            return false
+            return self.shouldAttemptInBackground(browser, now: now)
         }
         if self.deniedBrowsersForTesting?.contains(browser) == true {
             return self.isExplicitRetryAllowed(for: browser)
@@ -277,6 +274,69 @@ public enum BrowserCookieAccessGate {
                 return false
             case .interactionRequired:
                 return true
+            case .notFound, .failure:
+                continue
+            }
+        }
+        return false
+    }
+
+    /// Background (non-user-initiated) refreshes must never surface a Keychain prompt. Rather than
+    /// skipping unconditionally, reuse the strictly no-UI Safe Storage preflight: when the ACL already
+    /// grants access (an explicit `.allowed`), a scheduled refresh can read cookies without any prompt,
+    /// so background usage stays in sync instead of only updating when the menu is opened. Anything else
+    /// — interaction required, not found, or a query failure — keeps the no-surprise boundary and skips.
+    /// An active per-browser or Chromium-family denial cooldown is still honored.
+    private static func shouldAttemptInBackground(_ browser: Browser, now: Date) -> Bool {
+        if self.deniedBrowsersForTesting?.contains(browser) == true {
+            return false
+        }
+        if self.hasActiveDenialCooldown(for: browser, now: now) {
+            self.log.debug(
+                "Skipping background Chromium cookie import; denial cooldown active",
+                metadata: ["browser": browser.displayName])
+            return false
+        }
+        guard self.chromiumKeychainAccessIsAllowed(for: browser) else {
+            self.log.info(
+                "Skipping background Chromium cookie import to avoid a Keychain prompt",
+                metadata: ["browser": browser.displayName])
+            return false
+        }
+        self.log.debug(
+            "Background Chromium cookie import allowed by no-UI Keychain preflight",
+            metadata: ["browser": browser.displayName])
+        return true
+    }
+
+    /// Read-only check for an active per-browser or Chromium-family denial cooldown. Mirrors the
+    /// suppression window enforced on the user-initiated path without mutating persisted state, so a
+    /// scheduled refresh stays side-effect free.
+    private static func hasActiveDenialCooldown(for browser: Browser, now: Date) -> Bool {
+        self.lock.withLock { state in
+            self.loadIfNeeded(&state)
+            if let blockedUntil = state.deniedUntilByBrowser[browser.rawValue], blockedUntil > now {
+                return true
+            }
+            if let familyBlockedUntil = state.chromiumFamilyDeniedUntil, familyBlockedUntil > now {
+                return true
+            }
+            return false
+        }
+    }
+
+    /// Returns true only when the no-UI Safe Storage preflight explicitly reports `.allowed` for one of
+    /// the browser's labels before any label requires interaction. Symmetric with
+    /// `chromiumKeychainRequiresInteraction`; `.notFound`/`.failure` are skipped and never treated as a
+    /// grant, so only an already-authorized ACL enables a background read.
+    private static func chromiumKeychainAccessIsAllowed(for browser: Browser) -> Bool {
+        let labels = browser.safeStorageLabels.isEmpty ? self.safeStorageLabels : browser.safeStorageLabels
+        for label in labels {
+            switch KeychainAccessPreflight.checkGenericPassword(service: label.service, account: label.account) {
+            case .allowed:
+                return true
+            case .interactionRequired:
+                return false
             case .notFound, .failure:
                 continue
             }

--- a/Tests/CodexBarTests/BrowserCookieAccessGateTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieAccessGateTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if os(macOS)
+import SweetCookieKit
+
+/// Covers the background (non-user-initiated) branch of `BrowserCookieAccessGate.shouldAttempt`.
+/// Before the preflight was consulted, any scheduled refresh returned early, so an already-authorized
+/// Safe Storage entry could only refresh when the menu was opened. These tests drive the gate through
+/// the strictly no-UI preflight override, never touching the real Keychain.
+///
+/// Serialized because the gate persists denial cooldowns in process-global state that
+/// `resetForTesting()` clears — parallel cases would clobber each other's setup.
+@Suite(.serialized)
+struct BrowserCookieAccessGateTests {
+    /// Evaluate `shouldAttempt` with the Keychain enabled, a stubbed no-UI preflight outcome, and an
+    /// explicit interaction context — the exact three seams the production gate reads.
+    private func evaluate(
+        _ browser: Browser,
+        preflight: KeychainAccessPreflight.Outcome,
+        interaction: ProviderInteraction,
+        now: Date = Date()) -> Bool
+    {
+        var result = false
+        KeychainAccessGate.withTaskOverrideForTesting(false) {
+            ProviderInteractionContext.$current.withValue(interaction) {
+                KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in preflight } operation: {
+                    result = BrowserCookieAccessGate.shouldAttempt(browser, now: now)
+                }
+            }
+        }
+        return result
+    }
+
+    @Test
+    func `background refresh proceeds when the no-UI preflight already grants access`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        #expect(self.evaluate(.chrome, preflight: .allowed, interaction: .background))
+    }
+
+    @Test
+    func `background refresh is skipped when the preflight requires interaction`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        // An interaction-required ACL would surface a Keychain prompt, so a scheduled refresh must not
+        // attempt the read — preserving the no-surprise boundary.
+        #expect(self.evaluate(.chrome, preflight: .interactionRequired, interaction: .background) == false)
+    }
+
+    @Test
+    func `background refresh is skipped when the preflight cannot confirm access`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        // Only an explicit `.allowed` enables a background read. A missing item (or a query failure)
+        // is never optimistically treated as a grant the way the user-initiated path allows.
+        #expect(self.evaluate(.chrome, preflight: .notFound, interaction: .background) == false)
+        #expect(self.evaluate(.chrome, preflight: .failure(-25293), interaction: .background) == false)
+    }
+
+    @Test
+    func `an active denial cooldown suppresses background refresh even when the ACL is allowed`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        let start = Date(timeIntervalSince1970: 2000)
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: start)
+
+        // Within the six-hour cooldown the background gate stays suppressed regardless of a now-allowed
+        // preflight, matching the suppression the user-initiated path honors.
+        #expect(self.evaluate(
+            .chrome,
+            preflight: .allowed,
+            interaction: .background,
+            now: start.addingTimeInterval(60)) == false)
+
+        // Once the six-hour cooldown lapses, an allowed preflight lets the background refresh proceed
+        // again.
+        let sixHours: TimeInterval = 6 * 60 * 60
+        #expect(self.evaluate(
+            .chrome,
+            preflight: .allowed,
+            interaction: .background,
+            now: start.addingTimeInterval(sixHours + 60)))
+    }
+
+    @Test
+    func `user initiated refresh is unchanged and still proceeds on an allowed preflight`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        #expect(self.evaluate(.chrome, preflight: .allowed, interaction: .userInitiated))
+    }
+
+    @Test
+    func `browsers that do not use the Keychain are unaffected by the background gate`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        // Safari does not decrypt cookies via the Keychain, so the gate short-circuits to true before
+        // any preflight or interaction check — in the background just as in a user-initiated refresh.
+        #expect(self.evaluate(.safari, preflight: .interactionRequired, interaction: .background))
+    }
+}
+#endif

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -270,7 +270,7 @@ struct BrowserDetectionTests {
     }
 
     @Test
-    func `background cookie import skips chromium before keychain preflight`() {
+    func `background chromium refresh proceeds when the no-UI preflight already grants access`() {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 
@@ -282,17 +282,21 @@ struct BrowserDetectionTests {
                 return .allowed
             } operation: {
                 ProviderInteractionContext.$current.withValue(.background) {
-                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == false)
+                    // An already-authorized Safe Storage ACL lets a scheduled refresh read cookies
+                    // without any prompt, so the gate now consults the strictly no-UI preflight instead
+                    // of skipping outright.
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == true)
                     #expect(BrowserCookieAccessGate.shouldAttempt(.safari) == true)
                 }
             }
         }
 
-        #expect(preflightCount == 0)
+        // Only the Keychain-backed browser reaches the preflight; Safari short-circuits before it.
+        #expect(preflightCount == 1)
     }
 
     @Test
-    func `background cookie import skips chromium without probing keychain interaction`() {
+    func `background chromium refresh skips when the no-UI preflight requires interaction`() {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 
@@ -304,13 +308,16 @@ struct BrowserDetectionTests {
                 return .interactionRequired
             } operation: {
                 ProviderInteractionContext.$current.withValue(.background) {
+                    // The no-UI preflight never prompts; when it reports interaction is required the
+                    // background refresh still skips, preserving the no-surprise-prompt boundary.
                     #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == false)
                     #expect(BrowserCookieAccessGate.shouldAttempt(.safari) == true)
                 }
             }
         }
 
-        #expect(preflightCount == 0)
+        // The gate must probe the no-UI preflight to learn that interaction is required.
+        #expect(preflightCount == 1)
     }
 
     @Test


### PR DESCRIPTION
Fixes #2451.

## Problem

`BrowserCookieAccessGate.shouldAttempt` returns `false` for **every** non-user-initiated Chromium request before it ever reaches the existing no-UI Keychain preflight:

```swift
guard ProviderInteractionContext.current == .userInitiated else {
    // ...logs and returns false, before chromiumKeychainRequiresInteraction() ever runs
    return false
}
```

So even when a browser's Safe Storage entry is **already authorized** (the ACL grants access without any prompt), a scheduled/background refresh can't use it — cookie-backed usage only updates when the menu is opened. The gate short-circuits *before* the preflight that would have told it the read is safe.

## Fix

Move the background-context decision until **after** the same strictly no-UI Safe Storage preflight the user-initiated path already relies on (`KeychainAccessPreflight.checkGenericPassword`, which uses `kSecUseAuthenticationUIFail` + a non-interactive `LAContext`, so it can never surface a prompt):

- **`.allowed`** → the ACL already grants access with no prompt → background read proceeds.
- **`.interactionRequired`** → would prompt → skip (no-surprise boundary preserved).
- **`.notFound` / `.failure`** → not an explicit grant → skip. (Stricter than the user-initiated path, which is optimistic here — a background refresh should never take a chance.)
- An active **per-browser or Chromium-family denial cooldown** is still honored, and is checked **before** the preflight so a suppressed family never probes (this keeps the existing family-suppression test's preflight-count invariant intact).

The user-initiated path is byte-for-byte unchanged. Because the fix reuses the *same* no-UI preflight the interactive path already trusts, it introduces no new Keychain-prompt surface — it just stops discarding the already-authorized case in the background.

## Tests

- Two `BrowserDetectionTests` cases were characterization tests that pinned the old *"skip before preflight"* behavior (one was literally named `background cookie import skips chromium before keychain preflight` and asserted `preflightCount == 0`). Updated to the fixed behavior and renamed.
- New `BrowserCookieAccessGateTests` covers the background matrix: allowed → proceed, interaction/not-found/failure → skip, an active cooldown suppresses even an allowed ACL (and lapses after 6h), user-initiated unchanged, and non-Keychain browsers (Safari) bypass the gate.

Acceptance criteria:

- `swift test --filter BrowserCookieAccessGateTests` ✅ (6/6)
- All `shouldAttempt`-touching suites green under the by-suite (`--no-parallel`) runner (288 tests / 15 suites).
- `./Scripts/lint.sh lint` clean (swiftformat + swiftlint --strict).

I also reverse-verified the guard: reverting only the source change makes the new "background proceeds on `.allowed`" test fail, confirming it pins the fix rather than tautologically passing.

Per `AGENTS.md`, verification stays on the existing no-UI preflight override and never reads the real login Keychain.

## Out of scope

The issue also floats surfacing the selected source/fallback in the UI when a provider shows local data instead of account usage. That's a separate rendering concern; this PR is scoped to the gate defect + tests. Happy to follow up if you'd like it in the same issue.

---

## Real-behavior proof (macOS, real Chrome Safe Storage)

Ran the fixed gate against the **real** `Chrome Safe Storage` login-keychain item on macOS, in a genuine `.background` interaction context, via the strictly no-UI preflight (`kSecUseAuthenticationUIFail`, attributes-only — cannot show a prompt):

```
preflight   service="Chrome Safe Storage" account="Chrome"  ->  allowed
background       shouldAttempt(.chrome)  =  true     # ← the fix; pre-fix this was false
userInitiated    shouldAttempt(.chrome)  =  true     # unchanged
```

- **Already-authorized ACL → background proceeds**, prompt-free: on real Keychain state reporting `.allowed`, the background gate now returns `true`; pre-fix it returned `false` for every non-user-initiated request regardless of the ACL.
- **No secret touched**: attributes-only preflight, never `kSecReturnData`; reuses the existing no-UI seam per `AGENTS.md`.
- Reverse-verified: reverting only the source change makes the "background proceeds on `.allowed`" test fail. Full write-up in the PR comment thread.
