### PR TITLE
Fix Linux posix_spawn compatibility

### DIFF
--- a/Sources/CodexBarCore/Host/Process/PosixSpawnFileActionsCloseFrom.swift
+++ b/Sources/CodexBarCore/Host/Process/PosixSpawnFileActionsCloseFrom.swift
@@ -44,7 +44,7 @@ enum PosixSpawnFileActionsCloseFrom {
         startingAt minimumFileDescriptor: Int32) throws
     {
         #if canImport(Glibc)
-        try self.check(posix_spawn_file_actions_addclosefrom_np(&fileActions, minimumFileDescriptor))
+        try self.check(PosixSpawnFileActionsCompatibility.addCloseFrom(&fileActions, startingAt: minimumFileDescriptor))
         #else
         for descriptor in try self.descriptorsToClose(startingAt: minimumFileDescriptor) {
             try self.check(posix_spawn_file_actions_addclose(&fileActions, descriptor))

--- a/Sources/CodexBarCore/Host/Process/PosixSpawnFileActionsCompatibility.swift
+++ b/Sources/CodexBarCore/Host/Process/PosixSpawnFileActionsCompatibility.swift
@@ -6,6 +6,12 @@ import Glibc
 import Musl
 #endif
 
+#if canImport(Darwin)
+typealias PosixSpawnFileActionsHandle = posix_spawn_file_actions_t?
+#else
+typealias PosixSpawnFileActionsHandle = posix_spawn_file_actions_t
+#endif
+
 #if canImport(Glibc)
 @_silgen_name("posix_spawn_file_actions_addchdir_np")
 private func glibc_posix_spawn_file_actions_addchdir_np(
@@ -20,7 +26,7 @@ private func glibc_posix_spawn_file_actions_addclosefrom_np(
 
 enum PosixSpawnFileActionsCompatibility {
     static func addChangeDirectory(
-        _ fileActions: inout posix_spawn_file_actions_t,
+        _ fileActions: inout PosixSpawnFileActionsHandle,
         path: UnsafePointer<CChar>) -> Int32
     {
         #if canImport(Glibc)
@@ -32,7 +38,7 @@ enum PosixSpawnFileActionsCompatibility {
 
     #if canImport(Glibc)
     static func addCloseFrom(
-        _ fileActions: inout posix_spawn_file_actions_t,
+        _ fileActions: inout PosixSpawnFileActionsHandle,
         startingAt minimumFileDescriptor: Int32) -> Int32
     {
         glibc_posix_spawn_file_actions_addclosefrom_np(&fileActions, minimumFileDescriptor)

--- a/Sources/CodexBarCore/Host/Process/PosixSpawnFileActionsCompatibility.swift
+++ b/Sources/CodexBarCore/Host/Process/PosixSpawnFileActionsCompatibility.swift
@@ -1,0 +1,41 @@
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+#if canImport(Glibc)
+@_silgen_name("posix_spawn_file_actions_addchdir_np")
+private func glibc_posix_spawn_file_actions_addchdir_np(
+    _ actions: UnsafeMutablePointer<posix_spawn_file_actions_t>,
+    _ path: UnsafePointer<CChar>) -> Int32
+
+@_silgen_name("posix_spawn_file_actions_addclosefrom_np")
+private func glibc_posix_spawn_file_actions_addclosefrom_np(
+    _ actions: UnsafeMutablePointer<posix_spawn_file_actions_t>,
+    _ fileDescriptor: Int32) -> Int32
+#endif
+
+enum PosixSpawnFileActionsCompatibility {
+    static func addChangeDirectory(
+        _ fileActions: inout posix_spawn_file_actions_t,
+        path: UnsafePointer<CChar>) -> Int32
+    {
+        #if canImport(Glibc)
+        glibc_posix_spawn_file_actions_addchdir_np(&fileActions, path)
+        #else
+        posix_spawn_file_actions_addchdir_np(&fileActions, path)
+        #endif
+    }
+
+    #if canImport(Glibc)
+    static func addCloseFrom(
+        _ fileActions: inout posix_spawn_file_actions_t,
+        startingAt minimumFileDescriptor: Int32) -> Int32
+    {
+        glibc_posix_spawn_file_actions_addclosefrom_np(&fileActions, minimumFileDescriptor)
+    }
+    #endif
+}

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -469,7 +469,7 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         }
         if let workingDirectory {
             fileActionResults.append(workingDirectory.path.withCString { path in
-                posix_spawn_file_actions_addchdir_np(&fileActions, path)
+                PosixSpawnFileActionsCompatibility.addChangeDirectory(&fileActions, path: path)
             })
         }
         #if canImport(Glibc) || canImport(Musl)

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -884,7 +884,7 @@ struct AntigravityPTYProcessLauncher: AntigravityCLIProcessLaunching {
 
         let homeDirectory = NSHomeDirectory()
         _ = homeDirectory.withCString { path in
-            posix_spawn_file_actions_addchdir_np(&fileActions, path)
+            PosixSpawnFileActionsCompatibility.addChangeDirectory(&fileActions, path: path)
         }
         #if canImport(Glibc) || canImport(Musl)
         do {


### PR DESCRIPTION
## Summary
- Adds a small Linux compatibility shim for `posix_spawn_file_actions_addchdir_np` and `posix_spawn_file_actions_addclosefrom_np`.
- Routes the PTY/process launchers through that shim so the Linux Swift target builds when Swift's Glibc module does not declare those GNU extensions.
- Leaves the existing Darwin and Musl code paths unchanged.

## Why
On Ubuntu 22.04 with Swift 6.2, `swift test list` failed during compilation because the symbols exist in glibc but are not exposed by Swift's Glibc module:

```text
cannot find 'posix_spawn_file_actions_addchdir_np' in scope
cannot find 'posix_spawn_file_actions_addclosefrom_np' in scope
```

The new declarations are limited to the Glibc build and keep the existing runtime behavior.

## Testing
- [x] `PATH=/opt/swift-6.2/usr/bin:$PATH swift test list`
- [x] `PATH=/opt/swift-6.2/usr/bin:$PATH swift build`
- [x] `PATH=/opt/swift-6.2/usr/bin:$PATH ./Scripts/test.sh`
- [x] `git diff --check`
- [x] `PATH=/opt/swift-6.2/usr/bin:$PATH .build/lint-tools/bin/swiftformat Sources/CodexBarCore/Host/Process/PosixSpawnFileActionsCompatibility.swift Sources/CodexBarCore/Host/Process/PosixSpawnFileActionsCloseFrom.swift Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift --lint`

Note: I also ran `make check`; its portable checks passed, but the full command stopped in repository-wide SwiftFormat lint with pre-existing `enumNamespaces` timeouts in unrelated provider files before SwiftLint ran.
