### PR TITLE
Harden background refresh under constrained power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - About: link the Website entry to codex.bar.
+- Automatic refreshes now use a 30-minute safety cadence during Low Power Mode or serious/critical thermal pressure, defer status and token-cost background lanes, and skip automatic OpenAI Web refreshes; ambiguous legacy OpenAI Web configurations now default off.
 
 ## 0.46.0 — 2026-07-29
 

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -33,6 +33,10 @@ check_package_info_plist() {
   "${ROOT_DIR}/Scripts/test_package_info_plist.sh"
 }
 
+check_package_runtime_integrity() {
+  "${ROOT_DIR}/Scripts/test_package_runtime_integrity.sh"
+}
+
 check_release_dsym_paths() {
   "${ROOT_DIR}/Scripts/test_release_dsym_paths.sh"
 }
@@ -89,6 +93,7 @@ run_portable_checks() {
   check_package_strip
   check_package_signing
   check_package_info_plist
+  check_package_runtime_integrity
   check_release_dsym_paths
   check_sparkle_signing_paths
   check_swift_test_sharding

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -23,10 +23,54 @@ verify_no_quarantine_attribute() {
   fi
 }
 
+verify_no_dart_flutter_artifacts() {
+  local bundle="$1"
+  local artifact
+  local lower
+  local resolved
+  local bundleRoot
+
+  bundleRoot="$(python3 - "$bundle" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+)"
+
+  while IFS= read -r -d '' artifact; do
+    lower="$(printf '%s' "$artifact" | tr '[:upper:]' '[:lower:]')"
+    case "$lower" in
+      */dart*|*/flutter*)
+        echo "ERROR: Packaged app contains a Dart/Flutter artifact: ${artifact}" >&2
+        return 1
+        ;;
+    esac
+
+    if [[ -L "$artifact" ]]; then
+      resolved="$(python3 - "$artifact" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+)"
+      case "$resolved" in
+        "$bundleRoot"/*) ;;
+        *)
+          echo "ERROR: Packaged app contains an external linked artifact: ${artifact}" >&2
+          return 1
+          ;;
+      esac
+    fi
+  done < <(find "$bundle/Contents" -print0)
+}
+
 verify_packaged_app_integrity() {
   local bundle="$1"
   local sparkle="$bundle/Contents/Frameworks/Sparkle.framework"
 
+  verify_no_dart_flutter_artifacts "$bundle" || return 1
   verify_no_quarantine_attribute "$bundle" || return 1
   codesign --verify --deep --strict --verbose=2 "$sparkle" || return 1
   codesign --verify --deep --strict --verbose=2 "$bundle" || return 1

--- a/Scripts/test_package_runtime_integrity.sh
+++ b/Scripts/test_package_runtime_integrity.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+PACKAGE_SCRIPT="$ROOT/Scripts/package_app.sh"
+FUNCTIONS_FILE=$(mktemp "${TMPDIR:-/tmp}/codexbar-package-runtime-functions.XXXXXX")
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexbar-package-runtime.XXXXXX")
+trap 'rm -f "$FUNCTIONS_FILE"; rm -rf "$TEMP_DIR"' EXIT
+
+python3 - "$PACKAGE_SCRIPT" "$FUNCTIONS_FILE" <<'PY'
+import sys
+from pathlib import Path
+
+script = Path(sys.argv[1]).read_text()
+start = script.index('verify_no_dart_flutter_artifacts() {')
+end = script.index('\n}\n', start) + 3
+Path(sys.argv[2]).write_text(script[start:end])
+PY
+
+source "$FUNCTIONS_FILE"
+
+APP="$TEMP_DIR/CodexBar.app"
+mkdir -p "$APP/Contents/Frameworks/Sparkle.framework/Versions"
+touch "$APP/Contents/Frameworks/Sparkle.framework/Versions/1"
+ln -s 1 "$APP/Contents/Frameworks/Sparkle.framework/Versions/Current"
+verify_no_dart_flutter_artifacts "$APP"
+
+mkdir -p "$APP/Contents/Frameworks/Flutter.framework"
+if verify_no_dart_flutter_artifacts "$APP" 2>/dev/null; then
+  echo "Contaminated Flutter bundle unexpectedly passed integrity verification" >&2
+  exit 1
+fi
+
+rm -rf "$APP/Contents/Frameworks/Flutter.framework"
+mkdir -p "$APP/Contents/Frameworks/dartvm.framework"
+if verify_no_dart_flutter_artifacts "$APP" 2>/dev/null; then
+  echo "Contaminated Dart bundle unexpectedly passed integrity verification" >&2
+  exit 1
+fi
+
+rm -rf "$APP/Contents/Frameworks/dartvm.framework"
+mkdir -p "$APP/Contents/Frameworks/Runtime"
+ln -s /tmp/libflutter_engine.dylib "$APP/Contents/Frameworks/Runtime/libengine.dylib"
+if verify_no_dart_flutter_artifacts "$APP" 2>/dev/null; then
+  echo "External linked runtime unexpectedly passed integrity verification" >&2
+  exit 1
+fi
+
+echo "Package runtime integrity tests passed."

--- a/Scripts/test_package_signing.sh
+++ b/Scripts/test_package_signing.sh
@@ -16,6 +16,7 @@ functions = []
 for name in (
     'resolve_package_signing_mode',
     'verify_no_quarantine_attribute',
+    'verify_no_dart_flutter_artifacts',
     'verify_packaged_app_integrity',
 ):
     start = script.index(f'{name}() {{')

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -364,9 +364,7 @@ final class SettingsStore {
         let resolvedOpenAIWebAccessEnabled = if hasStoredOpenAIWebAccessPreference {
             self.defaultsState.openAIWebAccessEnabled
         } else {
-            Self.inferredInitialOpenAIWebAccessEnabled(
-                config: config,
-                hadExistingConfig: hadExistingConfig)
+            Self.inferredInitialOpenAIWebAccessEnabled(config: config)
         }
         if Self.isRunningTests {
             self.openAIWebAccessEnabled = resolvedOpenAIWebAccessEnabled
@@ -398,8 +396,7 @@ extension SettingsStore {
     }
 
     private static func inferredInitialOpenAIWebAccessEnabled(
-        config: CodexBarConfig,
-        hadExistingConfig: Bool) -> Bool
+        config: CodexBarConfig) -> Bool
     {
         guard let codex = config.providerConfig(for: .codex) else { return false }
         if let cookieSource = codex.cookieSource {
@@ -408,7 +405,7 @@ extension SettingsStore {
         if codex.sanitizedCookieHeader != nil {
             return true
         }
-        return hadExistingConfig
+        return false
     }
 
     // swiftlint:disable:next function_body_length

--- a/Sources/CodexBar/UsageStore+AdaptiveRefresh.swift
+++ b/Sources/CodexBar/UsageStore+AdaptiveRefresh.swift
@@ -1,9 +1,54 @@
+import CodexBarCore
 import Foundation
+
+struct RefreshPowerState: Sendable, Equatable {
+    let lowPowerModeEnabled: Bool
+    let thermalState: ProcessInfo.ThermalState
+
+    static let nominal = Self(lowPowerModeEnabled: false, thermalState: .nominal)
+
+    static var current: Self {
+        Self(
+            lowPowerModeEnabled: ProcessInfo.processInfo.isLowPowerModeEnabled,
+            thermalState: ProcessInfo.processInfo.thermalState)
+    }
+
+    var isConstrained: Bool {
+        self.lowPowerModeEnabled || self.thermalState == .serious || self.thermalState == .critical
+    }
+
+    var thermalStateLabel: String {
+        switch self.thermalState {
+        case .nominal: "nominal"
+        case .fair: "fair"
+        case .serious: "serious"
+        case .critical: "critical"
+        @unknown default: "unknown"
+        }
+    }
+}
 
 /// Wiring around `AdaptiveRefreshPolicy` for `UsageStore.startTimer()`: gathering live signals,
 /// logging the resulting decision, and applying the DEBUG-only sleep-duration override used by
 /// tests. Split out of UsageStore.swift to keep that file's class body under the lint line limit.
 extension UsageStore {
+    nonisolated static let constrainedRefreshInterval: Duration = .seconds(30 * 60)
+
+    nonisolated static func constrainedFixedRefreshInterval(
+        _ interval: Duration,
+        powerState: RefreshPowerState) -> Duration
+    {
+        powerState.isConstrained ? max(interval, self.constrainedRefreshInterval) : interval
+    }
+
+    nonisolated static func shouldDeferConstrainedBackgroundWork(
+        interaction: ProviderInteraction,
+        enrichmentMode: RefreshEnrichmentMode,
+        powerState: RefreshPowerState) -> Bool
+    {
+        interaction == .background && enrichmentMode == .automatic && powerState.isConstrained
+    }
+
     func effectiveTimerSleepDuration(_ computed: Duration) -> Duration {
         #if DEBUG
         self.refreshTimerSleepOverrideForTesting ?? computed
@@ -81,11 +126,25 @@ extension UsageStore {
         sleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
             try await Task.sleep(for: duration)
         },
+        powerState: @escaping @Sendable () -> RefreshPowerState = { .current },
+        decision: @escaping @Sendable (RefreshPowerState, Duration) async -> Void = { _, _ in },
         refresh: @escaping @Sendable () async -> Void) async
     {
         precondition(interval > .zero)
-        var scheduledAt = await now() + interval
+        var scheduledInterval = Self.constrainedFixedRefreshInterval(interval, powerState: powerState())
+        var scheduledAt = await now() + scheduledInterval
         while !Task.isCancelled {
+            let currentPowerState = powerState()
+            let effectiveInterval = Self.constrainedFixedRefreshInterval(
+                interval,
+                powerState: currentPowerState)
+            if effectiveInterval != scheduledInterval {
+                let current = await now()
+                scheduledAt = current + effectiveInterval
+                scheduledInterval = effectiveInterval
+            }
+            await decision(currentPowerState, scheduledInterval)
+
             let current = await now()
             let computedSleep = current >= scheduledAt ? .zero : scheduledAt - current
             do {
@@ -94,19 +153,50 @@ extension UsageStore {
                 return
             }
             guard !Task.isCancelled else { return }
+
+            let tickInterval = Self.constrainedFixedRefreshInterval(interval, powerState: powerState())
+            if sleepOverride == nil, tickInterval != scheduledInterval {
+                scheduledAt = await now() + tickInterval
+                scheduledInterval = tickInterval
+                await decision(powerState(), scheduledInterval)
+                continue
+            }
+
             await refresh()
+            let nextPowerState = powerState()
+            let nextInterval = Self.constrainedFixedRefreshInterval(
+                interval,
+                powerState: nextPowerState)
+            let completedAt = await now()
             scheduledAt = await self.nextFixedTimerScheduledAt(
                 previousScheduledAt: scheduledAt,
-                completedAt: now(),
-                interval: interval)
+                completedAt: completedAt,
+                interval: nextInterval)
+            scheduledInterval = nextInterval
         }
     }
 
-    func logAdaptiveRefreshDecision(_ decision: AdaptiveRefreshPolicy.Decision) {
-        // Reason and delay only; never provider/account/email/path/credential/response data.
+    func logAdaptiveRefreshDecision(
+        _ decision: AdaptiveRefreshPolicy.Decision,
+        powerState: RefreshPowerState)
+    {
+        // Never provider/account/email/path/credential/response data.
         // No "adaptive refresh: " prefix — the adaptiveRefresh log category already identifies the source.
         self.adaptiveRefreshLogger.debug(
-            "reason=\(decision.reason.rawValue) delay=\(decision.delay.components.seconds)s")
+            "reason=\(decision.reason.rawValue) delay=\(decision.delay.components.seconds)s " +
+                "lowPower=\(powerState.lowPowerModeEnabled ? 1 : 0) thermal=\(powerState.thermalStateLabel)")
+    }
+
+    func logConstrainedRefreshDecision(
+        lane: String,
+        powerState: RefreshPowerState,
+        cadence: Duration = Self.constrainedRefreshInterval,
+        decision: String = "defer")
+    {
+        guard powerState.isConstrained else { return }
+        self.adaptiveRefreshLogger.debug(
+            "decision=\(decision) lane=\(lane) lowPower=\(powerState.lowPowerModeEnabled ? 1 : 0) " +
+                "thermal=\(powerState.thermalStateLabel) cadence=\(cadence.components.seconds)s")
     }
 
     /// Computes this tick's adaptive sleep duration (and logs the decision) while briefly holding a
@@ -115,16 +205,17 @@ extension UsageStore {
     static func nextAdaptiveTimerSleepDuration(for store: UsageStore?) async -> Duration? {
         guard let store else { return nil }
         let now = Date()
+        let powerState = RefreshPowerState.current
         let decision = Self.adaptiveRefreshDecision(
             now: now,
             lastMenuOpenAt: store.lastMenuOpenAt,
             lastCodingActivityAt: store.settings.adaptiveActivityScanningEnabled
                 ? store.lastCodingActivityAt
                 : nil,
-            lowPowerModeEnabled: ProcessInfo.processInfo.isLowPowerModeEnabled,
-            thermalState: ProcessInfo.processInfo.thermalState)
+            lowPowerModeEnabled: powerState.lowPowerModeEnabled,
+            thermalState: powerState.thermalState)
         store.adaptiveRefreshScheduledAt = now.addingTimeInterval(TimeInterval(decision.delay.components.seconds))
-        store.logAdaptiveRefreshDecision(decision)
+        store.logAdaptiveRefreshDecision(decision, powerState: powerState)
         return store.effectiveTimerSleepDuration(decision.delay)
     }
 

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -16,6 +16,24 @@ struct OpenAIWebRefreshPolicyContext {
     let batterySaverEnabled: Bool
     let force: Bool
     let refreshPhase: ProviderRefreshPhase
+    let powerState: RefreshPowerState
+    let interaction: ProviderInteraction
+
+    init(
+        accessEnabled: Bool,
+        batterySaverEnabled: Bool,
+        force: Bool,
+        refreshPhase: ProviderRefreshPhase,
+        powerState: RefreshPowerState = .nominal,
+        interaction: ProviderInteraction = .background)
+    {
+        self.accessEnabled = accessEnabled
+        self.batterySaverEnabled = batterySaverEnabled
+        self.force = force
+        self.refreshPhase = refreshPhase
+        self.powerState = powerState
+        self.interaction = interaction
+    }
 }
 
 // MARK: - OpenAI web lifecycle
@@ -75,6 +93,15 @@ extension UsageStore {
               self.settings.openAIWebAccessEnabled,
               self.settings.codexCookieSource.isEnabled
         else { return }
+        let powerState = RefreshPowerState.current
+        if Self.shouldDeferConstrainedBackgroundWork(
+            interaction: ProviderInteractionContext.current,
+            enrichmentMode: .automatic,
+            powerState: powerState)
+        {
+            self.logConstrainedRefreshDecision(lane: "openai-web", powerState: powerState)
+            return
+        }
         let now = Date()
         let refreshInterval = self.openAIWebRefreshIntervalSeconds()
         let dashboard = self.openAIDashboard ?? self.lastOpenAIDashboardSnapshot
@@ -407,6 +434,16 @@ extension UsageStore {
         allowCodexUsageBackfill: Bool = true) async
     {
         self.syncOpenAIWebState()
+        let powerState = RefreshPowerState.current
+        if !force,
+           Self.shouldDeferConstrainedBackgroundWork(
+               interaction: ProviderInteractionContext.current,
+               enrichmentMode: .automatic,
+               powerState: powerState)
+        {
+            self.logConstrainedRefreshDecision(lane: "openai-web", powerState: powerState)
+            return
+        }
         guard self.isEnabled(.codex),
               self.settings.openAIWebAccessEnabled,
               self.settings.codexCookieSource.isEnabled
@@ -1436,6 +1473,9 @@ extension UsageStore {
     nonisolated static func shouldRunOpenAIWebRefresh(_ context: OpenAIWebRefreshPolicyContext) -> Bool {
         guard context.accessEnabled else { return false }
         guard context.force || context.refreshPhase != .startup else { return false }
+        guard context.force || !context.powerState.isConstrained || context.interaction == .userInitiated else {
+            return false
+        }
         return context.force || !context.batterySaverEnabled
     }
 

--- a/Sources/CodexBar/UsageStore+RefreshEnrichment.swift
+++ b/Sources/CodexBar/UsageStore+RefreshEnrichment.swift
@@ -298,7 +298,9 @@ extension UsageStore {
                 self.settings.codexCookieSource.isEnabled,
             batterySaverEnabled: self.settings.openAIWebBatterySaverEnabled,
             force: force,
-            refreshPhase: refreshPhase)
+            refreshPhase: refreshPhase,
+            powerState: .current,
+            interaction: ProviderInteractionContext.current)
         let shouldRefreshOpenAIWeb = Self.shouldRunOpenAIWebRefresh(refreshPolicy)
         self.openAIWebLogger.debug(
             "OpenAI web refresh gate",
@@ -307,9 +309,21 @@ extension UsageStore {
                 "accessEnabled": refreshPolicy.accessEnabled ? "1" : "0",
                 "batterySaverEnabled": refreshPolicy.batterySaverEnabled ? "1" : "0",
                 "force": refreshPolicy.force ? "1" : "0",
+                "lowPowerMode": refreshPolicy.powerState.lowPowerModeEnabled ? "1" : "0",
+                "thermalState": refreshPolicy.powerState.thermalStateLabel,
                 "interaction": ProviderInteractionContext.current == .userInitiated ? "user" : "background",
                 "phase": refreshPhase == .startup ? "startup" : "regular",
             ])
+        if !shouldRefreshOpenAIWeb, !force,
+           Self.shouldDeferConstrainedBackgroundWork(
+               interaction: refreshPolicy.interaction,
+               enrichmentMode: .automatic,
+               powerState: refreshPolicy.powerState)
+        {
+            self.logConstrainedRefreshDecision(
+                lane: "openai-web",
+                powerState: refreshPolicy.powerState)
+        }
         guard shouldRefreshOpenAIWeb, !Task.isCancelled else { return }
 
         let codexDashboardGuard = self.freshCodexOpenAIWebRefreshGuard()

--- a/Sources/CodexBar/UsageStore+TokenRefreshSequence.swift
+++ b/Sources/CodexBar/UsageStore+TokenRefreshSequence.swift
@@ -24,7 +24,18 @@ extension UsageStore {
     }
 
     func scheduleTokenRefresh() {
-        guard self.tokenRefreshSequenceTask == nil, !self.hasForcedRefreshEnrichmentInFlight else { return }
+        guard self.hasEligibleTokenCostWork,
+              self.tokenRefreshSequenceTask == nil,
+              !self.hasForcedRefreshEnrichmentInFlight
+        else { return }
+        if Self.shouldDeferConstrainedBackgroundWork(
+            interaction: ProviderInteractionContext.current,
+            enrichmentMode: .automatic,
+            powerState: .current)
+        {
+            self.logConstrainedRefreshDecision(lane: "token-cost", powerState: .current)
+            return
+        }
         if self.startPendingTokenRefreshRetryIfPossible() {
             return
         }
@@ -127,6 +138,14 @@ extension UsageStore {
               self.tokenRefreshSequenceTask == nil,
               self.settings.costUsageEnabled || self.settings.codexLocalSessionCostLedgerEnabled
         else {
+            return false
+        }
+        if Self.shouldDeferConstrainedBackgroundWork(
+            interaction: ProviderInteractionContext.current,
+            enrichmentMode: .automatic,
+            powerState: .current)
+        {
+            self.logConstrainedRefreshDecision(lane: "token-cost", powerState: .current)
             return false
         }
         let providers = self.enabledProvidersForBackgroundWork().filter(self.tokenRefreshRetryProviders.contains)

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -379,7 +379,15 @@ final class UsageStore {
     static let minimumTokenFetchTTL: TimeInterval = 5 * 60
 
     var tokenFetchTTL: TimeInterval? {
-        Self.tokenFetchTTL(for: self.settings.refreshFrequency)
+        guard self.hasEligibleTokenCostWork else { return nil }
+        return Self.tokenFetchTTL(for: self.settings.refreshFrequency)
+    }
+
+    var hasEligibleTokenCostWork: Bool {
+        self.enabledProvidersForBackgroundWork().contains { provider in
+            self.settings.isCostUsageEffectivelyEnabled(for: provider) &&
+                !Self.tokenCostRequiresProviderSnapshot(provider)
+        }
     }
 
     static func tokenFetchTTL(for frequency: RefreshFrequency) -> TimeInterval? {
@@ -673,6 +681,11 @@ final class UsageStore {
         let refreshProviders = self.enabledProvidersForBackgroundWork()
         let availableRefreshProviders = Set(self.enabledProviders())
         let refreshStartedAt = Date()
+        let refreshPowerState = RefreshPowerState.current
+        let constrainedBackgroundPass = Self.shouldDeferConstrainedBackgroundWork(
+            interaction: ProviderInteractionContext.current,
+            enrichmentMode: enrichmentMode,
+            powerState: refreshPowerState)
 
         let completedRefresh = await ProviderRefreshContext.$current.withValue(refreshPhase) {
             self.isRefreshing = true
@@ -688,6 +701,15 @@ final class UsageStore {
                 availableProviders: availableRefreshProviders)
             self.scheduleStorageFootprintRefresh(for: displayEnabledProviders)
 
+            if constrainedBackgroundPass,
+               self.statusChecksEnabled,
+               refreshProviders.contains(where: { availableRefreshProviders.contains($0) })
+            {
+                self.logConstrainedRefreshDecision(
+                    lane: "provider-status",
+                    powerState: refreshPowerState)
+            }
+
             await withTaskGroup(of: Void.self) { group in
                 for provider in refreshProviders {
                     group.addTask {
@@ -696,7 +718,7 @@ final class UsageStore {
                             coalesceIfRefreshing: coalesceProviderRefreshesOverride ??
                                 (ProviderInteractionContext.current == .background))
                     }
-                    if availableRefreshProviders.contains(provider) {
+                    if availableRefreshProviders.contains(provider), !constrainedBackgroundPass {
                         group.addTask { await self.refreshProviderStatus(provider) }
                     }
                 }
@@ -836,6 +858,14 @@ final class UsageStore {
             await Self.runFixedRefreshTimer(
                 interval: .seconds(wait),
                 sleepOverride: fixedTimerSleepOverride,
+                powerState: { .current },
+                decision: { [weak self] powerState, cadence in
+                    await self?.logConstrainedRefreshDecision(
+                        lane: "provider-poll",
+                        powerState: powerState,
+                        cadence: cadence,
+                        decision: "constrained")
+                },
                 refresh: { [weak self] in
                     await self?.refresh(enrichmentMode: .automatic)
                 })
@@ -1382,6 +1412,16 @@ extension UsageStore {
 
         guard self.isEnabled(provider) else {
             self.resetTokenUsageState(for: provider)
+            return
+        }
+
+        if !force,
+           Self.shouldDeferConstrainedBackgroundWork(
+               interaction: ProviderInteractionContext.current,
+               enrichmentMode: .automatic,
+               powerState: .current)
+        {
+            self.logConstrainedRefreshDecision(lane: "token-cost", powerState: .current)
             return
         }
 

--- a/Tests/CodexBarTests/AdaptiveRefreshTimerTests.swift
+++ b/Tests/CodexBarTests/AdaptiveRefreshTimerTests.swift
@@ -24,6 +24,54 @@ struct AdaptiveRefreshTimerTests {
     }
 
     @Test
+    func `fixed cadence clamps to thirty minutes only while constrained`() {
+        let oneMinute = Duration.seconds(60)
+
+        #expect(UsageStore.constrainedFixedRefreshInterval(oneMinute, powerState: .nominal) == oneMinute)
+        #expect(UsageStore.constrainedFixedRefreshInterval(
+            oneMinute,
+            powerState: RefreshPowerState(lowPowerModeEnabled: true, thermalState: .nominal)) ==
+            .seconds(30 * 60))
+        #expect(UsageStore.constrainedFixedRefreshInterval(
+            oneMinute,
+            powerState: RefreshPowerState(lowPowerModeEnabled: false, thermalState: .serious)) ==
+            .seconds(30 * 60))
+        #expect(UsageStore.constrainedFixedRefreshInterval(
+            oneMinute,
+            powerState: RefreshPowerState(lowPowerModeEnabled: false, thermalState: .critical)) ==
+            .seconds(30 * 60))
+        #expect(UsageStore.constrainedFixedRefreshInterval(
+            oneMinute,
+            powerState: RefreshPowerState(lowPowerModeEnabled: false, thermalState: .fair)) == oneMinute)
+        #expect(UsageStore.constrainedFixedRefreshInterval(
+            .seconds(30 * 60),
+            powerState: RefreshPowerState(lowPowerModeEnabled: true, thermalState: .critical)) ==
+            .seconds(30 * 60))
+    }
+
+    @Test
+    func `background lanes defer only for automatic constrained work`() {
+        let constrained = RefreshPowerState(lowPowerModeEnabled: true, thermalState: .nominal)
+
+        #expect(UsageStore.shouldDeferConstrainedBackgroundWork(
+            interaction: .background,
+            enrichmentMode: .automatic,
+            powerState: constrained))
+        #expect(!UsageStore.shouldDeferConstrainedBackgroundWork(
+            interaction: .userInitiated,
+            enrichmentMode: .automatic,
+            powerState: constrained))
+        #expect(!UsageStore.shouldDeferConstrainedBackgroundWork(
+            interaction: .background,
+            enrichmentMode: .forcedForeground,
+            powerState: constrained))
+        #expect(!UsageStore.shouldDeferConstrainedBackgroundWork(
+            interaction: .background,
+            enrichmentMode: .automatic,
+            powerState: .nominal))
+    }
+
+    @Test
     func `menu-open signal changes the next adaptive decision`() {
         let now = Date(timeIntervalSinceReferenceDate: 900_000_000)
 

--- a/Tests/CodexBarTests/OpenAIWebRefreshGateTests.swift
+++ b/Tests/CodexBarTests/OpenAIWebRefreshGateTests.swift
@@ -26,12 +26,50 @@ struct OpenAIWebRefreshGateTests {
     }
 
     @Test
+    func `Low Power Mode skips constrained background OpenAI web refreshes`() {
+        let shouldRun = UsageStore.shouldRunOpenAIWebRefresh(.init(
+            accessEnabled: true,
+            batterySaverEnabled: false,
+            force: false,
+            refreshPhase: .regular,
+            powerState: RefreshPowerState(lowPowerModeEnabled: true, thermalState: .nominal)))
+
+        #expect(shouldRun == false)
+    }
+
+    @Test
+    func `Serious thermal pressure skips constrained background OpenAI web refreshes`() {
+        let shouldRun = UsageStore.shouldRunOpenAIWebRefresh(.init(
+            accessEnabled: true,
+            batterySaverEnabled: false,
+            force: false,
+            refreshPhase: .regular,
+            powerState: RefreshPowerState(lowPowerModeEnabled: false, thermalState: .serious)))
+
+        #expect(shouldRun == false)
+    }
+
+    @Test
+    func `User initiated constrained OpenAI web refreshes remain allowed`() {
+        let shouldRun = UsageStore.shouldRunOpenAIWebRefresh(.init(
+            accessEnabled: true,
+            batterySaverEnabled: false,
+            force: false,
+            refreshPhase: .regular,
+            powerState: RefreshPowerState(lowPowerModeEnabled: true, thermalState: .critical),
+            interaction: .userInitiated))
+
+        #expect(shouldRun == true)
+    }
+
+    @Test
     func `Manual refresh still forces OpenAI web refreshes with battery saver enabled`() {
         let shouldRun = UsageStore.shouldRunOpenAIWebRefresh(.init(
             accessEnabled: true,
             batterySaverEnabled: true,
             force: true,
-            refreshPhase: .regular))
+            refreshPhase: .regular,
+            powerState: RefreshPowerState(lowPowerModeEnabled: true, thermalState: .critical)))
 
         #expect(shouldRun == true)
     }

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -1257,7 +1257,7 @@ struct SettingsStoreTests {
     }
 
     @Test
-    func `infers open AI web access enabled for legacy codex config with implicit auto cookies`() throws {
+    func `ambiguous legacy codex config defaults open AI web access to disabled`() throws {
         let suite = "SettingsStoreTests-openai-web-legacy-implicit-auto"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -1274,11 +1274,33 @@ struct SettingsStoreTests {
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
 
-        #expect(store.openAIWebAccessEnabled == true)
-        #expect(defaults.bool(forKey: "openAIWebAccessEnabled") == true)
+        #expect(store.openAIWebAccessEnabled == false)
+        #expect(defaults.bool(forKey: "openAIWebAccessEnabled") == false)
         #expect(store.openAIWebBatterySaverEnabled == false)
         #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == false)
         #expect(store.codexCookieSource == .auto)
+    }
+
+    @Test
+    func `stored codex cookie header remains an explicit Open AI web signal`() throws {
+        let suite = "SettingsStoreTests-openai-web-cookie-header"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defaults.removeObject(forKey: "openAIWebAccessEnabled")
+        defaults.set(false, forKey: "debugDisableKeychainAccess")
+        let configStore = testConfigStore(suiteName: suite)
+        try configStore.save(CodexBarConfig(providers: [
+            ProviderConfig(id: .codex, cookieHeader: "session=fixture"),
+        ]))
+
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(store.openAIWebAccessEnabled == true)
+        #expect(defaults.bool(forKey: "openAIWebAccessEnabled") == true)
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStoreDisabledProviderCleanupTests.swift
+++ b/Tests/CodexBarTests/UsageStoreDisabledProviderCleanupTests.swift
@@ -6,6 +6,21 @@ import Testing
 @MainActor
 struct UsageStoreDisabledProviderCleanupTests {
     @Test
+    func `token timer stops when no eligible cost work is enabled`() throws {
+        let settings = Self.makeSettingsStore(suite: "UsageStoreDisabledProviderCleanupTests-token-timer")
+        try Self.setOnlyProvider(.amp, enabled: false, settings: settings)
+        settings.costUsageEnabled = true
+        settings.refreshFrequency = .fiveMinutes
+        let store = Self.makeUsageStore(settings: settings)
+        store.startTokenTimer()
+        defer { store.tokenTimerTask?.cancel() }
+
+        #expect(store.hasEligibleTokenCostWork == false)
+        #expect(store.tokenFetchTTL == nil)
+        #expect(store.tokenTimerTask == nil)
+    }
+
+    @Test
     func `disabled cleanup rejects stale provider publication after re-enable`() async throws {
         let settings = Self.makeSettingsStore(suite: "UsageStoreDisabledProviderCleanupTests-provider-race")
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/UsageStoreTokenRefreshCadenceTests.swift
+++ b/Tests/CodexBarTests/UsageStoreTokenRefreshCadenceTests.swift
@@ -27,4 +27,18 @@ struct UsageStoreTokenRefreshCadenceTests {
     func `manual refresh disables the automatic token cadence`() {
         #expect(UsageStore.tokenFetchTTL(for: .manual) == nil)
     }
+
+    @Test
+    func `constrained automatic token work defers while forced work bypasses`() {
+        let constrained = RefreshPowerState(lowPowerModeEnabled: true, thermalState: .nominal)
+
+        #expect(UsageStore.shouldDeferConstrainedBackgroundWork(
+            interaction: .background,
+            enrichmentMode: .automatic,
+            powerState: constrained))
+        #expect(!UsageStore.shouldDeferConstrainedBackgroundWork(
+            interaction: .userInitiated,
+            enrichmentMode: .forcedForeground,
+            powerState: constrained))
+    }
 }


### PR DESCRIPTION
## Summary

- Treat Low Power Mode and serious or critical thermal pressure as constrained background state.
- Clamp fixed automatic provider polling to a 30-minute safety cadence while constrained, defer enrichment lanes, and preserve explicit manual refreshes.
- Make ambiguous legacy OpenAI Web inference fail safe and add bundle runtime-integrity fixtures rejecting Dart or Flutter artifacts.
- Add privacy-safe adaptiveRefresh decisions and an unreleased changelog entry.

## Verification

Verified in the isolated worktree:

- Package fixture scripts, including runtime-integrity clean and contaminated bundle cases.
- Pinned SwiftFormat lint.
- `swift build --disable-sandbox --target CodexBarCore`.
- Swift frontend parsing of all changed Swift files.
- Explicit diff-scope audit: no Mole paths or installed-app paths.

Environment-blocked:

- `make check`: SwiftLint could not load `sourcekitdInProc.framework`.
- `make test` and focused Swift tests: CommandLineTools lacks the `Testing` module during discovery.
- `swift build -c release`: existing `KeyboardShortcuts` dependency preview macro plugin is unavailable.

Live-provider, browser-cookie, Keychain, and `test-live` lanes were intentionally not run. Unit tests do not establish measured battery improvement.

## Scope

Based on freshly fetched `origin/main` at `8ef8607`. No Mole, `/Applications/CodexBar.app`, live accounts, Keychain data, deployment, or merge actions were touched.