### PR TITLE
Menu: extend compact multi-account layout to token accounts and Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Claude: compact multi-account menu for claude-swap — with four or more accounts the active account keeps its full card while the others become one-line rows sorted by remaining headroom, constrained accounts surface in red/amber, the healthiest switch target gets a star, and the healthy tail folds behind a summary row. Click a row to expand its full card.
+- Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
 ### Changed
 - About: link the Website entry to codex.bar.

--- a/Sources/CodexBar/StatusItemController+ClaudeSwapMenu.swift
+++ b/Sources/CodexBar/StatusItemController+ClaudeSwapMenu.swift
@@ -8,88 +8,25 @@ extension StatusItemController {
         context: MenuCardContext)
     {
         let accounts = self.store.claudeSwapAccountSnapshots
-        let plan = AccountMenuLayoutPlanner.plan(
-            accounts: accounts,
-            expandedAccountIDs: self.claudeSwapExpandedAccountIDs,
-            healthyTailExpanded: self.claudeSwapHealthyTailExpanded)
+        let plan = self.compactAccountPlan(for: .claude, accounts: accounts)
         guard plan.usesCompactLayout else {
             self.addStackedClaudeSwapMenuCards(accounts: accounts, to: menu, captureMenu: captureMenu, context: context)
             return
         }
-
-        let accountsByID = Dictionary(uniqueKeysWithValues: accounts.map { ($0.id, $0) })
-        let progressColor = UsageMenuCardView.Model.progressColor(for: .claude)
-        var previousRowWasCard = false
-        for (index, row) in plan.rows.enumerated() {
-            switch row {
-            case let .card(accountID):
-                guard let account = accountsByID[accountID],
-                      let model = self.claudeSwapCardModel(for: account) else { continue }
-                if index > 0 {
-                    menu.addItem(.separator())
-                }
-                let collapseClick: (() -> Void)? = account.isActive ? nil : { [weak self, weak captureMenu] in
-                    self?.toggleClaudeSwapAccountExpansion(accountID, menu: captureMenu)
-                }
-                menu.addItem(self.makeMenuCardItem(
-                    UsageMenuCardView(
-                        model: model,
-                        width: context.menuWidth,
-                        planAction: self.claudeSwapAccountSwitchAction(account, menu: captureMenu)),
-                    id: "claudeSwapCard-\(accountID.opaqueID)",
-                    width: context.menuWidth,
-                    heightCacheScope: "claude-swap-card-\(accountID.opaqueID)",
-                    heightCacheFingerprint: model.heightFingerprint(section: "card"),
-                    containsInteractiveControls: true,
-                    onClick: collapseClick))
-                previousRowWasCard = true
-            case let .compact(compactRow):
-                if previousRowWasCard {
-                    menu.addItem(.separator())
-                }
-                let rowModel = MenuCardCompactAccountRowView.Model(
-                    label: PersonalInfoRedactor.redactEmail(
-                        compactRow.label,
-                        isEnabled: self.settings.hidePersonalInfo),
-                    headroomPercent: compactRow.headroomPercent,
-                    severity: compactRow.severity,
-                    constraintDetail: compactRow.constraintDetail,
-                    hasError: compactRow.hasError,
-                    showsBestBadge: compactRow.isBestCandidate)
-                let accountID = compactRow.accountID
-                menu.addItem(self.makeMenuCardItem(
-                    MenuCardCompactAccountRowView(
-                        model: rowModel,
-                        progressColor: progressColor,
-                        width: context.menuWidth),
-                    id: "claudeSwapCompact-\(accountID.opaqueID)",
-                    width: context.menuWidth,
-                    heightCacheScope: "claude-swap-compact-\(accountID.opaqueID)",
-                    heightCacheFingerprint: rowModel.heightFingerprint,
-                    onClick: { [weak self, weak captureMenu] in
-                        self?.toggleClaudeSwapAccountExpansion(accountID, menu: captureMenu)
-                    }))
-                previousRowWasCard = false
-            case let .collapsedHealthy(count):
-                let view = MenuCardCollapsedAccountsRowView(count: count, width: context.menuWidth)
-                menu.addItem(self.makeMenuCardItem(
-                    view,
-                    id: "claudeSwapCollapsed",
-                    width: context.menuWidth,
-                    heightCacheScope: "claude-swap-collapsed",
-                    heightCacheFingerprint: "collapsed-\(count)",
-                    onClick: { [weak self, weak captureMenu] in
-                        self?.expandClaudeSwapHealthyTail(menu: captureMenu)
-                    }))
-                previousRowWasCard = false
-            }
-        }
-        if !plan.rows.isEmpty {
-            menu.addItem(.separator())
-        }
-        if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
-            menu.addItem(.separator())
-        }
+        self.addCompactAccountMenuRows(
+            CompactAccountMenuRendering(
+                plan: plan,
+                accounts: accounts,
+                idPrefix: "claudeSwap",
+                cardModel: { [weak self] account in
+                    self?.claudeSwapCardModel(for: account)
+                },
+                planAction: { [weak self] account in
+                    self?.claudeSwapAccountSwitchAction(account, menu: captureMenu)
+                }),
+            to: menu,
+            captureMenu: captureMenu,
+            context: context)
     }
 
     private func addStackedClaudeSwapMenuCards(
@@ -128,29 +65,6 @@ extension StatusItemController {
                 email: account.displayLabel,
                 plan: nil),
             planOverride: self.claudeSwapAccountActionLabel(account))
-    }
-
-    private func toggleClaudeSwapAccountExpansion(_ accountID: ProviderAccountIdentity, menu: NSMenu?) {
-        self.advanceMenuInteraction(for: menu)
-        if self.claudeSwapExpandedAccountIDs.contains(accountID) {
-            self.claudeSwapExpandedAccountIDs.remove(accountID)
-        } else {
-            self.claudeSwapExpandedAccountIDs.insert(accountID)
-        }
-        self.invalidateMenus(refreshOpenMenus: true)
-    }
-
-    private func expandClaudeSwapHealthyTail(menu: NSMenu?) {
-        self.advanceMenuInteraction(for: menu)
-        self.claudeSwapHealthyTailExpanded = true
-        self.invalidateMenus(refreshOpenMenus: true)
-    }
-
-    /// Compact-layout expansion is per-open transient UI state; reset when the last menu closes.
-    func resetClaudeSwapMenuExpansionStateIfIdle() {
-        guard self.openMenus.isEmpty else { return }
-        self.claudeSwapExpandedAccountIDs.removeAll()
-        self.claudeSwapHealthyTailExpanded = false
     }
 
     private func claudeSwapAccountActionLabel(_ account: ProviderAccountUsageSnapshot) -> String? {

--- a/Sources/CodexBar/StatusItemController+CompactAccountMenu.swift
+++ b/Sources/CodexBar/StatusItemController+CompactAccountMenu.swift
@@ -1,0 +1,298 @@
+import AppKit
+import CodexBarCore
+
+/// Shared renderer for the compact multi-account menu layout: full cards for the
+/// active and explicitly expanded accounts, one-line rows for the rest, and a
+/// summary row standing in for the collapsed healthy tail. Used by every
+/// multi-account presentation (claude-swap, token accounts, Codex accounts).
+extension StatusItemController {
+    func compactAccountPlan(
+        for provider: UsageProvider,
+        accounts: [ProviderAccountUsageSnapshot]) -> AccountMenuLayoutPlanner.Plan
+    {
+        AccountMenuLayoutPlanner.plan(
+            accounts: accounts,
+            expandedAccountIDs: self.compactAccountExpandedIDs,
+            healthyTailExpanded: self.compactAccountExpandedHealthyTailProviders.contains(provider))
+    }
+
+    struct CompactAccountMenuRendering {
+        let plan: AccountMenuLayoutPlanner.Plan
+        let accounts: [ProviderAccountUsageSnapshot]
+        let idPrefix: String
+        let cardModel: (ProviderAccountUsageSnapshot) -> UsageMenuCardView.Model?
+        var planAction: ((ProviderAccountUsageSnapshot) -> (() -> Void)?)?
+    }
+
+    /// Renders the token-account list with the compact plan when it applies.
+    /// Returns false when the caller should fall back to the stacked cards.
+    func addCompactTokenAccountMenuIfPlanned(
+        display: TokenAccountMenuDisplay,
+        to menu: NSMenu,
+        captureMenu: NSMenu,
+        context: MenuCardContext) -> Bool
+    {
+        let provider = context.currentProvider
+        let projected = Self.projectedTokenAccounts(
+            provider: provider,
+            snapshots: display.snapshots,
+            selectedAccountID: self.settings.effectiveSelectedTokenAccount(for: provider)?.id)
+        let plan = self.compactAccountPlan(for: provider, accounts: projected)
+        guard plan.usesCompactLayout else { return false }
+        let snapshotsByID = Dictionary(
+            uniqueKeysWithValues: display.snapshots.map { ($0.account.id.uuidString, $0) })
+        self.addCompactAccountMenuRows(
+            CompactAccountMenuRendering(
+                plan: plan,
+                accounts: projected,
+                idPrefix: "tokenAccount",
+                cardModel: { [weak self] projectedAccount in
+                    guard let self,
+                          let accountSnapshot = snapshotsByID[projectedAccount.id.opaqueID] else { return nil }
+                    return self.tokenAccountMenuCardModel(for: provider, accountSnapshot: accountSnapshot)
+                },
+                planAction: nil),
+            to: menu,
+            captureMenu: captureMenu,
+            context: context)
+        return true
+    }
+
+    /// Renders the Codex account list with the compact plan when it applies.
+    /// Workspace-grouped lists keep their sectioned stacked layout; the flat
+    /// compact plan would lose the grouping headers.
+    func addCompactCodexAccountMenuIfPlanned(
+        display: CodexAccountMenuDisplay,
+        to menu: NSMenu,
+        captureMenu: NSMenu,
+        context: MenuCardContext) -> Bool
+    {
+        guard !display.showsWorkspaceGroups else { return false }
+        let projected = Self.projectedCodexAccounts(display: display)
+        let plan = self.compactAccountPlan(for: .codex, accounts: projected)
+        guard plan.usesCompactLayout else { return false }
+        let snapshotsByAccountID = Dictionary(
+            uniqueKeysWithValues: display.snapshots.map { ($0.account.id, $0) })
+        let accountsByID = Dictionary(
+            uniqueKeysWithValues: display.accounts.map { ($0.id, $0) })
+        self.addCompactAccountMenuRows(
+            CompactAccountMenuRendering(
+                plan: plan,
+                accounts: projected,
+                idPrefix: "codexAccount",
+                cardModel: { [weak self] projectedAccount in
+                    guard let self,
+                          let account = accountsByID[projectedAccount.id.opaqueID] else { return nil }
+                    let accountSnapshot = snapshotsByAccountID[account.id]
+                    let health = CodexAccountHealth.status(for: account, error: accountSnapshot?.error)
+                    return self.menuCardModel(
+                        for: .codex,
+                        snapshotOverride: accountSnapshot?.snapshot,
+                        errorOverride: health.label,
+                        forceOverrideCard: accountSnapshot == nil,
+                        accountOverride: self.accountInfo(for: account),
+                        historySelectionOverride: self.store.codexPlanUtilizationHistorySelection(
+                            forVisibleAccount: account))
+                },
+                planAction: nil),
+            to: menu,
+            captureMenu: captureMenu,
+            context: context)
+        return true
+    }
+
+    func addCompactAccountMenuRows(
+        _ rendering: CompactAccountMenuRendering,
+        to menu: NSMenu,
+        captureMenu: NSMenu,
+        context: MenuCardContext)
+    {
+        let plan = rendering.plan
+        let idPrefix = rendering.idPrefix
+        let cardModel = rendering.cardModel
+        let planAction = rendering.planAction
+        let provider = context.currentProvider
+        let accountsByID = Dictionary(uniqueKeysWithValues: rendering.accounts.map { ($0.id, $0) })
+        let progressColor = UsageMenuCardView.Model.progressColor(for: provider)
+        var previousRowWasCard = false
+        for (index, row) in plan.rows.enumerated() {
+            switch row {
+            case let .card(accountID):
+                guard let account = accountsByID[accountID],
+                      let model = cardModel(account) else { continue }
+                if index > 0 {
+                    menu.addItem(.separator())
+                }
+                let collapseClick: (() -> Void)? = account.isActive ? nil : { [weak self, weak captureMenu] in
+                    self?.toggleCompactAccountExpansion(accountID, menu: captureMenu)
+                }
+                menu.addItem(self.makeMenuCardItem(
+                    UsageMenuCardView(
+                        model: model,
+                        width: context.menuWidth,
+                        planAction: planAction?(account)),
+                    id: "\(idPrefix)Card-\(accountID.opaqueID)",
+                    width: context.menuWidth,
+                    heightCacheScope: "\(idPrefix)-card-\(accountID.opaqueID)",
+                    heightCacheFingerprint: model.heightFingerprint(section: "card"),
+                    containsInteractiveControls: true,
+                    onClick: collapseClick))
+                previousRowWasCard = true
+            case let .compact(compactRow):
+                if previousRowWasCard {
+                    menu.addItem(.separator())
+                }
+                let rowModel = MenuCardCompactAccountRowView.Model(
+                    label: PersonalInfoRedactor.redactEmail(
+                        compactRow.label,
+                        isEnabled: self.settings.hidePersonalInfo),
+                    headroomPercent: compactRow.headroomPercent,
+                    severity: compactRow.severity,
+                    constraintDetail: compactRow.constraintDetail,
+                    hasError: compactRow.hasError,
+                    showsBestBadge: compactRow.isBestCandidate)
+                let accountID = compactRow.accountID
+                menu.addItem(self.makeMenuCardItem(
+                    MenuCardCompactAccountRowView(
+                        model: rowModel,
+                        progressColor: progressColor,
+                        width: context.menuWidth),
+                    id: "\(idPrefix)Compact-\(accountID.opaqueID)",
+                    width: context.menuWidth,
+                    heightCacheScope: "\(idPrefix)-compact-\(accountID.opaqueID)",
+                    heightCacheFingerprint: rowModel.heightFingerprint,
+                    onClick: { [weak self, weak captureMenu] in
+                        self?.toggleCompactAccountExpansion(accountID, menu: captureMenu)
+                    }))
+                previousRowWasCard = false
+            case let .collapsedHealthy(count):
+                let view = MenuCardCollapsedAccountsRowView(count: count, width: context.menuWidth)
+                menu.addItem(self.makeMenuCardItem(
+                    view,
+                    id: "\(idPrefix)Collapsed",
+                    width: context.menuWidth,
+                    heightCacheScope: "\(idPrefix)-collapsed",
+                    heightCacheFingerprint: "collapsed-\(count)",
+                    onClick: { [weak self, weak captureMenu] in
+                        self?.expandCompactAccountHealthyTail(for: provider, menu: captureMenu)
+                    }))
+                previousRowWasCard = false
+            }
+        }
+        if !plan.rows.isEmpty {
+            menu.addItem(.separator())
+        }
+        if self.addStorageMenuCardSection(to: menu, provider: provider, width: context.menuWidth) {
+            menu.addItem(.separator())
+        }
+    }
+
+    /// Classic stacked layout: one full card per account. Shared fallback for
+    /// every multi-account list below the compact-layout threshold.
+    func addStackedMenuCards(
+        _ cards: [UsageMenuCardView.Model],
+        to menu: NSMenu,
+        context: MenuCardContext,
+        planAction: ((Int) -> (() -> Void)?)? = nil)
+    {
+        if cards.isEmpty, let model = self.menuCardModel(for: context.selectedProvider) {
+            let renderedModel = self.menuCardRefreshMonitor.model(for: model.provider, fallback: model)
+            menu.addItem(self.makeMenuCardItem(
+                UsageMenuCardView(model: model, layoutModel: renderedModel, width: context.menuWidth),
+                id: "menuCard",
+                width: context.menuWidth,
+                heightCacheScope: context.currentProvider.rawValue,
+                heightCacheFingerprint: renderedModel.heightFingerprint(section: "card"),
+                containsInteractiveControls: true))
+            menu.addItem(.separator())
+        } else {
+            for (index, model) in cards.enumerated() {
+                menu.addItem(self.makeMenuCardItem(
+                    UsageMenuCardView(
+                        model: model,
+                        width: context.menuWidth,
+                        planAction: planAction?(index)),
+                    id: "menuCard-\(index)",
+                    width: context.menuWidth,
+                    heightCacheScope: "\(context.currentProvider.rawValue)-\(index)",
+                    heightCacheFingerprint: model.heightFingerprint(section: "card"),
+                    containsInteractiveControls: true))
+                if index < cards.count - 1 {
+                    menu.addItem(.separator())
+                }
+            }
+            if !cards.isEmpty {
+                menu.addItem(.separator())
+            }
+        }
+        if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
+            menu.addItem(.separator())
+        }
+    }
+
+    // MARK: - Projections
+
+    static func projectedTokenAccounts(
+        provider: UsageProvider,
+        snapshots: [TokenAccountUsageSnapshot],
+        selectedAccountID: UUID?) -> [ProviderAccountUsageSnapshot]
+    {
+        snapshots.map { accountSnapshot in
+            let isActive = accountSnapshot.account.id == selectedAccountID
+            return ProviderAccountUsageSnapshot(
+                id: ProviderAccountIdentity(
+                    source: "token-account",
+                    opaqueID: accountSnapshot.account.id.uuidString),
+                provider: provider,
+                displayLabel: accountSnapshot.account.displayName,
+                isActive: isActive,
+                canActivate: !isActive,
+                snapshot: accountSnapshot.snapshot,
+                error: accountSnapshot.error,
+                sourceLabel: accountSnapshot.sourceLabel)
+        }
+    }
+
+    static func projectedCodexAccounts(display: CodexAccountMenuDisplay) -> [ProviderAccountUsageSnapshot] {
+        let snapshotsByAccountID = Dictionary(uniqueKeysWithValues: display.snapshots.map { ($0.account.id, $0) })
+        return display.accounts.map { account in
+            let accountSnapshot = snapshotsByAccountID[account.id]
+            let health = CodexAccountHealth.status(for: account, error: accountSnapshot?.error)
+            let isActive = account.id == display.activeVisibleAccountID || account.isActive
+            return ProviderAccountUsageSnapshot(
+                id: ProviderAccountIdentity(source: "codex-account", opaqueID: account.id),
+                provider: .codex,
+                displayLabel: account.menuDisplayName,
+                isActive: isActive,
+                canActivate: !isActive,
+                snapshot: accountSnapshot?.snapshot,
+                error: health.label,
+                sourceLabel: accountSnapshot?.sourceLabel)
+        }
+    }
+
+    // MARK: - Expansion state
+
+    private func toggleCompactAccountExpansion(_ accountID: ProviderAccountIdentity, menu: NSMenu?) {
+        self.advanceMenuInteraction(for: menu)
+        if self.compactAccountExpandedIDs.contains(accountID) {
+            self.compactAccountExpandedIDs.remove(accountID)
+        } else {
+            self.compactAccountExpandedIDs.insert(accountID)
+        }
+        self.invalidateMenus(refreshOpenMenus: true)
+    }
+
+    private func expandCompactAccountHealthyTail(for provider: UsageProvider, menu: NSMenu?) {
+        self.advanceMenuInteraction(for: menu)
+        self.compactAccountExpandedHealthyTailProviders.insert(provider)
+        self.invalidateMenus(refreshOpenMenus: true)
+    }
+
+    /// Compact-layout expansion is per-open transient UI state; reset when the last menu closes.
+    func resetCompactAccountMenuExpansionStateIfIdle() {
+        guard self.openMenus.isEmpty else { return }
+        self.compactAccountExpandedIDs.removeAll()
+        self.compactAccountExpandedHealthyTailProviders.removeAll()
+    }
+}

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -159,7 +159,7 @@ extension StatusItemController {
         if wasHostedSubviewMenu {
             self.refreshOpenMenusAfterHostedSubviewClose()
         }
-        self.resetClaudeSwapMenuExpansionStateIfIdle()
+        self.resetCompactAccountMenuExpansionStateIfIdle()
     }
 
     func forgetClosedMenu(_ menu: NSMenu) {
@@ -611,7 +611,14 @@ extension StatusItemController {
 
     private func addMenuCards(to menu: NSMenu, context: MenuCardContext, captureMenu: NSMenu? = nil) -> Bool {
         if let codexAccountDisplay = context.codexAccountDisplay, codexAccountDisplay.showAll {
-            self.addStackedCodexMenuCards(codexAccountDisplay, to: menu, context: context)
+            if !self.addCompactCodexAccountMenuIfPlanned(
+                display: codexAccountDisplay,
+                to: menu,
+                captureMenu: captureMenu ?? menu,
+                context: context)
+            {
+                self.addStackedCodexMenuCards(codexAccountDisplay, to: menu, context: context)
+            }
             return false
         }
 
@@ -627,6 +634,14 @@ extension StatusItemController {
         }
 
         if let tokenAccountDisplay = context.tokenAccountDisplay, tokenAccountDisplay.showAll {
+            if self.addCompactTokenAccountMenuIfPlanned(
+                display: tokenAccountDisplay,
+                to: menu,
+                captureMenu: captureMenu ?? menu,
+                context: context)
+            {
+                return false
+            }
             let accountSnapshots = tokenAccountDisplay.snapshots
             let cards = accountSnapshots.isEmpty
                 ? []
@@ -685,47 +700,6 @@ extension StatusItemController {
         }
         menu.addItem(.separator())
         return false
-    }
-
-    func addStackedMenuCards(
-        _ cards: [UsageMenuCardView.Model],
-        to menu: NSMenu,
-        context: MenuCardContext,
-        planAction: ((Int) -> (() -> Void)?)? = nil)
-    {
-        if cards.isEmpty, let model = self.menuCardModel(for: context.selectedProvider) {
-            let renderedModel = self.menuCardRefreshMonitor.model(for: model.provider, fallback: model)
-            menu.addItem(self.makeMenuCardItem(
-                UsageMenuCardView(model: model, layoutModel: renderedModel, width: context.menuWidth),
-                id: "menuCard",
-                width: context.menuWidth,
-                heightCacheScope: context.currentProvider.rawValue,
-                heightCacheFingerprint: renderedModel.heightFingerprint(section: "card"),
-                containsInteractiveControls: true))
-            menu.addItem(.separator())
-        } else {
-            for (index, model) in cards.enumerated() {
-                menu.addItem(self.makeMenuCardItem(
-                    UsageMenuCardView(
-                        model: model,
-                        width: context.menuWidth,
-                        planAction: planAction?(index)),
-                    id: "menuCard-\(index)",
-                    width: context.menuWidth,
-                    heightCacheScope: "\(context.currentProvider.rawValue)-\(index)",
-                    heightCacheFingerprint: model.heightFingerprint(section: "card"),
-                    containsInteractiveControls: true))
-                if index < cards.count - 1 {
-                    menu.addItem(.separator())
-                }
-            }
-            if !cards.isEmpty {
-                menu.addItem(.separator())
-            }
-        }
-        if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
-            menu.addItem(.separator())
-        }
     }
 
     private func addOpenAIWebItemsIfNeeded(

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -274,10 +274,10 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var lastCodexAccountMenuDisplay: CodexAccountMenuDisplay?
     /// Tracks the visible token account switcher contents for merged-menu smart updates.
     var lastTokenAccountMenuDisplay: TokenAccountMenuDisplay?
-    /// Claude-swap compact layout: accounts the user expanded to full cards this menu session.
-    var claudeSwapExpandedAccountIDs: Set<ProviderAccountIdentity> = []
-    /// Claude-swap compact layout: whether the collapsed healthy tail is revealed this menu session.
-    var claudeSwapHealthyTailExpanded = false
+    /// Compact multi-account layout: accounts the user expanded to full cards this menu session.
+    var compactAccountExpandedIDs: Set<ProviderAccountIdentity> = []
+    /// Compact multi-account layout: providers whose collapsed healthy tail is revealed this menu session.
+    var compactAccountExpandedHealthyTailProviders: Set<UsageProvider> = []
     /// Keeps detached merged-menu tab content reusable while the same menu remains open.
     var mergedSwitcherContentCaches: [ObjectIdentifier: [ProviderSwitcherSelection: CachedMergedSwitcherMenuContent]]
         = [:]

--- a/Sources/CodexBarCore/AccountMenuLayoutPlanner.swift
+++ b/Sources/CodexBarCore/AccountMenuLayoutPlanner.swift
@@ -159,12 +159,16 @@ public enum AccountMenuLayoutPlanner {
         for account: ProviderAccountUsageSnapshot) -> [(label: String, remainingPercent: Double)]
     {
         guard let snapshot = account.snapshot else { return [] }
+        let metadata = ProviderDefaults.metadata[account.provider]
         var windows: [(label: String, remainingPercent: Double)] = []
         if let primary = snapshot.primary, !primary.isSyntheticPlaceholder {
-            windows.append(("Session", primary.remainingPercent))
+            windows.append((metadata?.sessionLabel ?? "Session", primary.remainingPercent))
         }
         if let secondary = snapshot.secondary {
-            windows.append(("Weekly", secondary.remainingPercent))
+            windows.append((metadata?.weeklyLabel ?? "Weekly", secondary.remainingPercent))
+        }
+        if let tertiary = snapshot.tertiary {
+            windows.append((metadata?.opusLabel ?? "Monthly", tertiary.remainingPercent))
         }
         for extra in snapshot.extraRateWindows ?? [] where extra.usageKnown {
             windows.append((self.shortLabel(forWindowTitle: extra.title), extra.window.remainingPercent))

--- a/Tests/CodexBarTests/StatusMenuClaudeSwapCompactTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClaudeSwapCompactTests.swift
@@ -111,7 +111,7 @@ final class StatusMenuClaudeSwapCompactTests: XCTestCase {
         let accounts = self.sixAccounts()
         let (controller, _) = self.makeController(accounts: accounts)
         defer { controller.releaseStatusItemsForTesting() }
-        controller.claudeSwapExpandedAccountIDs = [accounts[4].id]
+        controller.compactAccountExpandedIDs = [accounts[4].id]
 
         let menu = controller.makeMenu(for: .claude)
         controller.menuWillOpen(menu)
@@ -128,7 +128,7 @@ final class StatusMenuClaudeSwapCompactTests: XCTestCase {
     func test_expandedHealthyTailShowsAllCompactRows() {
         let (controller, _) = self.makeController(accounts: self.sixAccounts())
         defer { controller.releaseStatusItemsForTesting() }
-        controller.claudeSwapHealthyTailExpanded = true
+        controller.compactAccountExpandedHealthyTailProviders = [.claude]
 
         let menu = controller.makeMenu(for: .claude)
         controller.menuWillOpen(menu)
@@ -161,14 +161,14 @@ final class StatusMenuClaudeSwapCompactTests: XCTestCase {
         let accounts = self.sixAccounts()
         let (controller, _) = self.makeController(accounts: accounts)
         defer { controller.releaseStatusItemsForTesting() }
-        controller.claudeSwapExpandedAccountIDs = [accounts[4].id]
-        controller.claudeSwapHealthyTailExpanded = true
+        controller.compactAccountExpandedIDs = [accounts[4].id]
+        controller.compactAccountExpandedHealthyTailProviders = [.claude]
 
         let menu = controller.makeMenu(for: .claude)
         controller.menuWillOpen(menu)
         controller.menuDidClose(menu)
 
-        XCTAssertTrue(controller.claudeSwapExpandedAccountIDs.isEmpty)
-        XCTAssertFalse(controller.claudeSwapHealthyTailExpanded)
+        XCTAssertTrue(controller.compactAccountExpandedIDs.isEmpty)
+        XCTAssertTrue(controller.compactAccountExpandedHealthyTailProviders.isEmpty)
     }
 }

--- a/Tests/CodexBarTests/StatusMenuCompactAccountLayoutTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCompactAccountLayoutTests.swift
@@ -1,0 +1,162 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import XCTest
+@testable import CodexBar
+
+/// Coverage for the compact multi-account layout on the token-account and Codex
+/// paths (the claude-swap path is covered by StatusMenuClaudeSwapCompactTests).
+@MainActor
+final class StatusMenuCompactAccountLayoutTests: XCTestCase {
+    private func disableMenuCardsForTesting() {
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+    }
+
+    private func makeSettings() -> SettingsStore {
+        let settings = testSettingsStore(
+            suiteName: "StatusMenuCompactAccountLayoutTests",
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.providerDetectionCompleted = true
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.multiAccountMenuLayout = .stacked
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .copilot)
+        }
+        return settings
+    }
+
+    private func snapshot(usedPercent: Double) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: usedPercent,
+                windowMinutes: 300,
+                resetsAt: Date().addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: nil)
+    }
+
+    func test_tokenAccountsUseCompactLayoutAtFourOrMoreAccounts() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        for label in ["One", "Two", "Three", "Four", "Five"] {
+            settings.addTokenAccount(provider: .copilot, label: label, token: "gh_\(label)")
+        }
+        settings.setActiveTokenAccountIndex(0, for: .copilot)
+        let accounts = settings.tokenAccounts(for: .copilot)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let usedPercents: [Double] = [10, 95, 20, 30, 40]
+        store.accountSnapshots[.copilot] = accounts.enumerated().map { index, account in
+            TokenAccountUsageSnapshot(
+                account: account,
+                snapshot: self.snapshot(usedPercent: usedPercents[index]),
+                error: nil,
+                sourceLabel: "test",
+                cacheKey: store.tokenAccountSnapshotCacheKey(provider: .copilot, account: account))
+        }
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: testStatusBar())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu(for: .copilot)
+        controller.menuWillOpen(menu)
+
+        // Active card + critical row + best-candidate row + two healthy rows folded.
+        let ids = menu.items.compactMap { $0.representedObject as? String }
+            .filter { $0.hasPrefix("tokenAccount") || $0.hasPrefix("menuCard") }
+        XCTAssertEqual(ids, [
+            "tokenAccountCard-\(accounts[0].id.uuidString)",
+            "tokenAccountCompact-\(accounts[1].id.uuidString)",
+            "tokenAccountCompact-\(accounts[2].id.uuidString)",
+            "tokenAccountCollapsed",
+        ])
+    }
+
+    func test_tokenAccountsBelowThresholdKeepStackedCards() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        for label in ["One", "Two", "Three"] {
+            settings.addTokenAccount(provider: .copilot, label: label, token: "gh_\(label)")
+        }
+        let accounts = settings.tokenAccounts(for: .copilot)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store.accountSnapshots[.copilot] = accounts.map { account in
+            TokenAccountUsageSnapshot(
+                account: account,
+                snapshot: self.snapshot(usedPercent: 10),
+                error: nil,
+                sourceLabel: "test",
+                cacheKey: store.tokenAccountSnapshotCacheKey(provider: .copilot, account: account))
+        }
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: testStatusBar())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu(for: .copilot)
+        controller.menuWillOpen(menu)
+
+        let ids = menu.items.compactMap { $0.representedObject as? String }
+            .filter { $0.hasPrefix("tokenAccount") || $0.hasPrefix("menuCard") }
+        XCTAssertEqual(ids, ["menuCard-0", "menuCard-1", "menuCard-2"])
+    }
+
+    func test_codexAccountProjectionMapsActiveHealthAndIdentity() {
+        let accounts = (1...4).map { index in
+            CodexVisibleAccount(
+                id: "account-\(index)",
+                email: "codex\(index)@example.com",
+                // account-4: stored account without live auth → "Missing auth" health.
+                storedAccountID: index == 4 ? UUID() : nil,
+                selectionSource: .liveSystem,
+                isActive: index == 2,
+                isLive: index != 4,
+                canReauthenticate: false,
+                canRemove: false)
+        }
+        let snapshots = accounts.prefix(3).map { account in
+            CodexAccountUsageSnapshot(
+                account: account,
+                snapshot: self.snapshot(usedPercent: 50),
+                error: nil,
+                sourceLabel: "test")
+        }
+        let display = CodexAccountMenuDisplay(
+            accounts: accounts,
+            snapshots: Array(snapshots),
+            activeVisibleAccountID: "account-2",
+            layout: .stacked)
+
+        let projected = StatusItemController.projectedCodexAccounts(display: display)
+
+        XCTAssertEqual(projected.map(\ProviderAccountUsageSnapshot.id.opaqueID), [
+            "account-1", "account-2", "account-3", "account-4",
+        ])
+        XCTAssertEqual(projected.map(\ProviderAccountUsageSnapshot.isActive), [false, true, false, false])
+        XCTAssertEqual(projected[0].id.source, "codex-account")
+        XCTAssertEqual(projected[0].displayLabel, "codex1@example.com")
+        // account-4 has no snapshot: unavailable health surfaces as an error row.
+        XCTAssertNil(projected[3].snapshot)
+        XCTAssertNotNil(projected[3].error)
+        XCTAssertNil(projected[0].error)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuTokenAccountSwitcherTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTokenAccountSwitcherTests.swift
@@ -310,9 +310,17 @@ final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
         controller.menuWillOpen(menu)
 
         XCTAssertNil(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
+        // Stale snapshots stay ignored and the 6-account cap still applies before the
+        // compact plan: capped accounts 0-4 plus the selected account 7. With 8 accounts
+        // the compact layout pins the active card, keeps the best candidate row visible,
+        // and folds the remaining healthy accounts.
         XCTAssertEqual(
-            self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") },
-            ["menuCard-0", "menuCard-1", "menuCard-2", "menuCard-3", "menuCard-4", "menuCard-5"])
+            self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") || $0.hasPrefix("tokenAccount") },
+            [
+                "tokenAccountCard-\(accounts[7].id.uuidString)",
+                "tokenAccountCompact-\(accounts[0].id.uuidString)",
+                "tokenAccountCollapsed",
+            ])
     }
 
     func test_multiAccountStackedLayoutRejectsSnapshotsAfterCredentialOrBaseURLChanges() throws {

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -139,7 +139,9 @@ The accepted multi-account design in
   card, inactive accounts become one-line rows sorted by remaining headroom (most constrained first, red/amber below
   50%/10% left, a star on the healthiest activatable account), and healthy rows fold behind a "N more accounts ready"
   summary row. Clicking a compact row expands that account's full card for the current menu session; the summary row
-  reveals the hidden rows. `codexbar cards` keeps the full per-account output. To use this
+  reveals the hidden rows. `codexbar cards` keeps the full per-account output. The same compact layout applies to
+  every stacked multi-account list (token accounts on any provider, and flat Codex account lists; workspace-grouped
+  Codex lists keep their sectioned stacked layout). To use this
   presentation with one account, enable “Show account card when only one account is available” or set
   `claudeSwapShowSingleAccount: true` on the Claude provider in the resolved config file (normally
   `~/.config/codexbar/config.json`; legacy installs may use `~/.codexbar/config.json`). The option defaults off,


### PR DESCRIPTION
## Summary

Follow-up to #2542: the compact multi-account layout (active card pinned, inactive accounts as headroom-sorted one-line rows, healthy tail folded behind a summary row) now applies to **every** stacked multi-account list, not just claude-swap:

- **Token accounts** on any provider (Claude manual cookies/OAuth tokens, Copilot, sub2api, …) — engages at 4+ accounts in the stacked layout; the segmented switcher layout is untouched.
- **Codex accounts** — flat lists get the compact layout; workspace-grouped lists keep their sectioned stacked layout so grouping headers survive.
- claude-swap behavior is unchanged (same row ids, same tests).

## Implementation

- The plan renderer moves out of the claude-swap file into a shared `StatusItemController+CompactAccountMenu` extension, taking a `CompactAccountMenuRendering` config. `addStackedMenuCards` (the shared below-threshold fallback) moves there too, keeping `StatusItemController+Menu.swift` under the file-length lint cap.
- Token/Codex lists project into the existing provider-neutral `ProviderAccountUsageSnapshot` (`token-account:<uuid>` / `codex-account:<id>` identities); Codex rows carry `CodexAccountHealth` labels so unhealthy accounts sort with the constrained rows instead of hiding in the healthy tail.
- `AccountMenuLayoutPlanner` now labels constraint summaries with provider metadata (session/weekly labels, tertiary window included in headroom).
- Expansion state is keyed per account identity plus per provider for the healthy-tail reveal, still resetting when the last menu closes.

Existing behavior notes: the 6-account token cap still applies before planning; `test_multiAccountStackedLayoutIgnoresStaleSnapshotsAndKeepsMenuCapped` was updated for the new compact expectation at 8 accounts.

## Commands run

- `make check` (SwiftFormat + SwiftLint clean)
- `make test` (full sharded suite)
- Focused: `swift test --filter "StatusMenuCompactAccountLayoutTests|StatusMenuClaudeSwapCompactTests|StatusMenuTokenAccountSwitcherTests|StatusMenuCodexSwitcherTests|AccountMenuLayoutPlannerTests"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
