### PR TITLE
Menu: eliminate provider tab-switch flicker with synchronous hosted-row flush

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -406,6 +406,7 @@ extension StatusItemController {
         context: MenuRebuildContext)
     {
         self.performMenuMutationWithoutAnimation {
+            defer { self.flushHostedMenuRowRendering(in: menu) }
             let displacedSelection = self.lastMergedMenuContentSelection
             self.lastMergedMenuContentSelection = nil
             self.harvestRecyclableMenuCardViews(in: menu, fromIndex: 0, displacedSelection: displacedSelection)

--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -142,6 +142,20 @@ extension StatusItemController {
         return displacedItems
     }
 
+    /// Forces hosted rows to lay out and draw inside the caller's disabled-actions
+    /// transaction. `NSHostingView` commits SwiftUI updates asynchronously by
+    /// default, so a provider-tab switch could paint the previous card content for
+    /// a frame after the item mutation — visible as a brief flicker. Flushing
+    /// synchronously makes the content swap composite atomically with the menu
+    /// update. Views without a window (closed or detached menus) are skipped.
+    func flushHostedMenuRowRendering(in menu: NSMenu) {
+        for item in menu.items {
+            guard let view = item.view, view.window != nil else { continue }
+            view.layoutSubtreeIfNeeded()
+            view.displayIfNeeded()
+        }
+    }
+
     private func finishReconciledHighlightTracking(in menu: NSMenu) {
         let menuKey = ObjectIdentifier(menu)
         guard let highlightedItem = self.highlightedMenuItems[menuKey] else { return }

--- a/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
+++ b/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
@@ -21,6 +21,7 @@ extension StatusItemController {
         context: MenuUpdateContext)
     {
         self.performMenuMutationWithoutAnimation {
+            defer { self.flushHostedMenuRowRendering(in: menu) }
             let contentStartIndex = self.providerSwitcherContentStartIndex(in: menu)
             if let switcherView = menu.items.first?.view as? ProviderSwitcherView {
                 switcherView.updateSelection(context.switcherSelection)


### PR DESCRIPTION
## Summary

Switching provider tabs in the merged menu (e.g. Claude ↔ Codex) produced a brief content flicker.

Root cause: on a tab switch the menu reuses each card's hosting view and swaps its SwiftUI `rootView` (recycle pool → `prepareForReuse`), but `NSHostingView` commits SwiftUI updates asynchronously. The AppKit item mutation lands immediately while the SwiftUI content commit lands a frame later, so the previous tab's content stays visible for a frame — perceived as a flash.

Fix: `flushHostedMenuRowRendering(in:)` forces attached hosted rows to `layoutSubtreeIfNeeded()` + `displayIfNeeded()` inside the same disabled-actions `CATransaction` as the menu mutation, on all three update paths:

- cached instant swap (`updateMenuContentPreservingSwitcher` cached branch)
- in-place reconcile (scratch-menu rebuild branch)
- full rebuild (`rebuildMenuContent`, which also covers Overview transitions)

Views without a window (closed/detached menus) are skipped, so the flush only costs a synchronous layout pass during interactive updates of an open menu.

## Verification

- `make check` clean; `make test` full suite green locally.
- Menu behavior suites pass: `StatusMenuTests`, `StatusMenuHighlightTests`, `StatusMenuViewportRestoreTests`, `MenuCardViewRecyclingTests`, `StatusMenuHeightCacheTests`.
- Visual confirmation still needed on a live menu — this environment cannot drive the status-bar menu (no screen-recording permission, and the status item is not reachable via accessibility automation on this macOS build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
