### PR TITLE
Menu: pre-build sibling switcher tabs so provider switches attach pre-rendered rows

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -159,6 +159,9 @@ extension StatusItemController {
         if wasHostedSubviewMenu {
             self.refreshOpenMenusAfterHostedSubviewClose()
         }
+        if self.openMenus.isEmpty {
+            self.cancelMergedSwitcherSiblingWarmup()
+        }
         self.resetCompactAccountMenuExpansionStateIfIdle()
     }
 
@@ -230,6 +233,9 @@ extension StatusItemController {
             breadcrumb: "populateMenu:\(provider?.rawValue ?? "merged")")
         defer { self.endMenuOperationTrace(trace, menu: menu, provider: provider) }
         defer { self.refreshMenuCardHeights(in: menu) }
+        // Re-warm sibling tab caches after every populate of the open merged menu so a
+        // tab switch attaches pre-rendered rows; no-ops for closed or non-merged menus.
+        defer { self.scheduleMergedSwitcherSiblingWarmup(for: menu) }
 
         let enabledProviders = self.store.enabledProvidersForDisplay()
         let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
@@ -468,7 +474,7 @@ extension StatusItemController {
         }
     }
 
-    private func openAIWebContext(
+    func openAIWebContext(
         currentProvider: UsageProvider,
         showAllAccounts: Bool) -> OpenAIWebContext
     {
@@ -1075,13 +1081,13 @@ extension StatusItemController {
         return enabled.first(where: { self.store.isProviderAvailable($0) }) ?? enabled.first
     }
 
-    private func includesOverviewTab(enabledProviders: [UsageProvider]) -> Bool {
+    func includesOverviewTab(enabledProviders: [UsageProvider]) -> Bool {
         !self.settings.resolvedMergedOverviewProviders(
             activeProviders: enabledProviders,
             maxVisibleProviders: Self.maxOverviewProviders).isEmpty
     }
 
-    private func resolvedSwitcherSelection(
+    func resolvedSwitcherSelection(
         enabledProviders: [UsageProvider],
         includesOverview: Bool) -> ProviderSwitcherSelection
     {

--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -149,11 +149,18 @@ extension StatusItemController {
     /// synchronously makes the content swap composite atomically with the menu
     /// update. Views without a window (closed or detached menus) are skipped.
     func flushHostedMenuRowRendering(in menu: NSMenu) {
+        // Freshly inserted item views may not be parented into the menu window yet
+        // when this runs, so lay out every hosted row unconditionally and then flush
+        // pending drawing once at the window level.
+        var menuWindow: NSWindow?
         for item in menu.items {
-            guard let view = item.view, view.window != nil else { continue }
+            guard let view = item.view else { continue }
             view.layoutSubtreeIfNeeded()
-            view.displayIfNeeded()
+            if menuWindow == nil {
+                menuWindow = view.window
+            }
         }
+        menuWindow?.displayIfNeeded()
     }
 
     private func finishReconciledHighlightTracking(in menu: NSMenu) {

--- a/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
+++ b/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
@@ -103,7 +103,7 @@ extension StatusItemController {
     /// Adds everything below the provider switcher (account switchers, card content, and
     /// actionable sections) to `target`, which may be a detached scratch menu; interaction
     /// closures always capture `captureMenu`, the live menu the rows will serve.
-    private func addSwitcherScopedMenuContent(
+    func addSwitcherScopedMenuContent(
         into target: NSMenu,
         captureMenu: NSMenu,
         context: MenuUpdateContext)

--- a/Sources/CodexBar/StatusItemController+MenuSwitcherWarmup.swift
+++ b/Sources/CodexBar/StatusItemController+MenuSwitcherWarmup.swift
@@ -1,0 +1,119 @@
+import AppKit
+import CodexBarCore
+
+/// Pre-builds the merged switcher's sibling tab content shortly after the menu
+/// opens (and after each open-menu rebuild), so switching tabs attaches fully
+/// laid-out cached rows instead of rendering fresh hosting views mid-click.
+/// `NSHostingView` commits SwiftUI content asynchronously; a freshly built card
+/// swapped in during a switch paints a frame late, which reads as a flicker.
+extension StatusItemController {
+    private static let mergedSwitcherWarmupDelay: Duration = .milliseconds(120)
+
+    func scheduleMergedSwitcherSiblingWarmup(for menu: NSMenu) {
+        guard self.isMenuRefreshEnabled else { return }
+        guard self.shouldMergeIcons, menu === self.mergedMenu else { return }
+        self.mergedSwitcherWarmupTask?.cancel()
+        self.mergedSwitcherWarmupTask = Task { @MainActor [weak self, weak menu] in
+            try? await Task.sleep(for: Self.mergedSwitcherWarmupDelay)
+            guard !Task.isCancelled, let self else { return }
+            self.mergedSwitcherWarmupTask = nil
+            guard let menu, self.openMenus[ObjectIdentifier(menu)] === menu else { return }
+            self.warmMergedSwitcherSiblingContent(in: menu)
+        }
+    }
+
+    func cancelMergedSwitcherSiblingWarmup() {
+        self.mergedSwitcherWarmupTask?.cancel()
+        self.mergedSwitcherWarmupTask = nil
+    }
+
+    func warmMergedSwitcherSiblingContent(in menu: NSMenu) {
+        guard menu.items.first?.view is ProviderSwitcherView else { return }
+        let enabledProviders = self.store.enabledProvidersForDisplay()
+        guard enabledProviders.count > 1 else { return }
+        let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
+        let currentSelection = self.resolvedSwitcherSelection(
+            enabledProviders: enabledProviders,
+            includesOverview: includesOverview)
+        var selections: [ProviderSwitcherSelection] = enabledProviders.map { .provider($0) }
+        if includesOverview {
+            selections.insert(.overview, at: 0)
+        }
+        for selection in selections where selection != currentSelection {
+            self.warmMergedSwitcherContentIfMissing(
+                for: selection,
+                in: menu,
+                enabledProviders: enabledProviders)
+        }
+    }
+
+    private func warmMergedSwitcherContentIfMissing(
+        for selection: ProviderSwitcherSelection,
+        in menu: NSMenu,
+        enabledProviders: [UsageProvider])
+    {
+        let isOverviewSelected = selection == .overview
+        let selectedProvider = isOverviewSelected
+            ? self.resolvedMenuProvider(enabledProviders: enabledProviders)
+            : selection.provider
+        let currentProvider = selectedProvider ?? enabledProviders.first ?? .codex
+        let codexAccountDisplay = isOverviewSelected ? nil : self.codexAccountMenuDisplay(for: currentProvider)
+        let tokenAccountDisplay = isOverviewSelected ? nil : self.tokenAccountMenuDisplay(for: currentProvider)
+        let showAllAccounts = (tokenAccountDisplay?.showAll ?? false) || (codexAccountDisplay?.showAll ?? false)
+        let descriptor = self.makeMenuDescriptor(
+            provider: selectedProvider,
+            includeContextualActions: !isOverviewSelected)
+        let menuWidth = self.menuCardWidth(
+            for: enabledProviders,
+            selectedProvider: selectedProvider,
+            descriptor: descriptor)
+        guard self.reusableMergedSwitcherContent(
+            for: selection,
+            in: menu,
+            menuWidth: menuWidth,
+            codexAccountDisplay: codexAccountDisplay,
+            tokenAccountDisplay: tokenAccountDisplay) == nil
+        else { return }
+
+        // Building sibling content updates the "last rendered display" trackers used by
+        // smart-update compatibility checks; restore them so the live tab's state wins.
+        let savedCodexDisplay = self.lastCodexAccountMenuDisplay
+        let savedTokenDisplay = self.lastTokenAccountMenuDisplay
+        let scratch = NSMenu()
+        scratch.autoenablesItems = false
+        self.addSwitcherScopedMenuContent(
+            into: scratch,
+            captureMenu: menu,
+            context: MenuUpdateContext(
+                provider: selectedProvider,
+                currentProvider: currentProvider,
+                switcherSelection: selection,
+                menuWidth: menuWidth,
+                codexAccountDisplay: codexAccountDisplay,
+                tokenAccountDisplay: tokenAccountDisplay,
+                openAIContext: self.openAIWebContext(
+                    currentProvider: currentProvider,
+                    showAllAccounts: showAllAccounts),
+                descriptor: descriptor))
+        self.lastCodexAccountMenuDisplay = savedCodexDisplay
+        self.lastTokenAccountMenuDisplay = savedTokenDisplay
+
+        let items = scratch.items
+        scratch.removeAllItems()
+        guard !items.isEmpty else { return }
+        // Force SwiftUI layout now so the first attach draws in the same transaction
+        // as the menu mutation instead of one frame later.
+        for item in items {
+            item.view?.layoutSubtreeIfNeeded()
+        }
+        self.cacheMergedSwitcherContent(
+            items,
+            in: menu,
+            selection: selection,
+            context: MergedSwitcherContentCacheContext(
+                menuWidth: menuWidth,
+                codexAccountDisplay: codexAccountDisplay,
+                tokenAccountDisplay: tokenAccountDisplay,
+                contentVersion: self.menuSession.contentVersion))
+    }
+}

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -274,6 +274,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var lastCodexAccountMenuDisplay: CodexAccountMenuDisplay?
     /// Tracks the visible token account switcher contents for merged-menu smart updates.
     var lastTokenAccountMenuDisplay: TokenAccountMenuDisplay?
+    /// Debounced pre-build of sibling switcher tabs for flicker-free tab switches.
+    var mergedSwitcherWarmupTask: Task<Void, Never>?
     /// Compact multi-account layout: accounts the user expanded to full cards this menu session.
     var compactAccountExpandedIDs: Set<ProviderAccountIdentity> = []
     /// Compact multi-account layout: providers whose collapsed healthy tail is revealed this menu session.

--- a/Tests/CodexBarTests/StatusMenuSwitcherWarmupTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherWarmupTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import XCTest
+@testable import CodexBar
+
+/// The merged menu pre-builds sibling switcher tabs after opening so a tab
+/// switch attaches cached, pre-laid-out rows (flicker fix follow-up).
+@MainActor
+final class StatusMenuSwitcherWarmupTests: XCTestCase {
+    private func makeController() -> (controller: StatusItemController, menu: NSMenu) {
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        let settings = testSettingsStore(
+            suiteName: "StatusMenuSwitcherWarmupTests",
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.providerDetectionCompleted = true
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            settings.setProviderEnabled(
+                provider: provider,
+                metadata: metadata,
+                enabled: provider == .claude || provider == .codex)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: testStatusBar())
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        return (controller, menu)
+    }
+
+    func test_warmupCachesSiblingSelections() {
+        let (controller, menu) = self.makeController()
+        defer { controller.releaseStatusItemsForTesting() }
+        guard menu.items.first?.view is ProviderSwitcherView else {
+            return XCTFail("expected merged menu with provider switcher")
+        }
+
+        controller.warmMergedSwitcherSiblingContent(in: menu)
+
+        let caches = controller.mergedSwitcherContentCaches[ObjectIdentifier(menu)] ?? [:]
+        let enabledProviders = controller.store.enabledProvidersForDisplay()
+        let cachedSelections = Set(caches.keys)
+        let siblingProviders = enabledProviders.filter { cachedSelections.contains(.provider($0)) }
+        // Every non-visible provider tab gets a cache entry; the visible tab is
+        // cached separately by the populate path.
+        XCTAssertGreaterThanOrEqual(siblingProviders.count, enabledProviders.count - 1)
+        for (_, entry) in caches {
+            XCTAssertFalse(entry.items.isEmpty)
+        }
+    }
+
+    func test_warmupSkipsSelectionsAlreadyCached() {
+        let (controller, menu) = self.makeController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.warmMergedSwitcherSiblingContent(in: menu)
+        let firstItems = controller.mergedSwitcherContentCaches[ObjectIdentifier(menu)]?
+            .mapValues { $0.items }
+
+        controller.warmMergedSwitcherSiblingContent(in: menu)
+        let secondItems = controller.mergedSwitcherContentCaches[ObjectIdentifier(menu)]?
+            .mapValues { $0.items }
+
+        // Re-warming with unchanged inputs must reuse the cached items, not rebuild them.
+        XCTAssertEqual(firstItems?.count, secondItems?.count)
+        for (selection, items) in firstItems ?? [:] {
+            XCTAssertTrue(secondItems?[selection]?.elementsEqual(items, by: ===) == true)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Round 2 on the provider tab-switch flicker (#2546 was insufficient — the flicker persisted in live testing).

Why #2546 didn't fully work: the synchronous flush ran while freshly built hosting views were not yet parented into the menu window (the per-view flush skipped them), and `NSHostingView` still commits SwiftUI content asynchronously — so the first switch to a tab not yet visited in that menu session painted its cards a frame late.

This PR attacks the root cause: **never build tab content during the switch.**

- After each populate of the open merged menu, a debounced (120ms) warmup pre-builds every sibling tab's rows — account switchers, cards, actionable sections — into the existing merged-switcher content cache, forcing SwiftUI layout while detached.
- A tab switch then goes through the instant cached-swap path (`replaceMenuContentKeepingRowsVisible`) attaching fully pre-laid-out items.
- Because the warmup re-runs after every populate (including data ticks), caches stay fresh while the menu is open; it cancels when the last menu closes.
- `flushHostedMenuRowRendering` now lays out every hosted row unconditionally and flushes pending drawing once at the window level, covering rows that were inserted in the same transaction.

The warmup restores the smart-update display trackers after building, so live-tab state is untouched; sibling builds capture the live menu for their interaction closures (same contract as the scratch-reconcile path).

## Verification

- New `StatusMenuSwitcherWarmupTests`: warmup fills cache entries for all sibling selections; re-warming with unchanged inputs reuses the same cached items (no rebuild).
- `make check` clean, full `make test` green locally, plus the menu behavior suites (highlight, viewport restore, recycling, height cache, token/codex switchers, compact layouts).
- Needs live visual confirmation (this environment cannot drive the status-bar menu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
