### PR TITLE
feat: add standalone token activity heatmap

### DIFF
--- a/Sources/CodexBar/PreferencesSpendDashboardPane.swift
+++ b/Sources/CodexBar/PreferencesSpendDashboardPane.swift
@@ -150,6 +150,12 @@ struct SpendDashboardPane: View {
             }
         }
 
+        if self.settings.costUsageEnabled, !self.controller.model.tokenActivity.isEmpty {
+            SpendDashboardPanel {
+                SpendActivityHeatmapView(points: self.controller.model.tokenActivity)
+            }
+        }
+
         if self.controller.failedSourceCount > 0 {
             Label(
                 spendDashboardRefreshFailureText(self.controller.failedSourceCount),

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1353,3 +1353,13 @@
 "Cost today unavailable" = "تكلفة اليوم: غير متوفر";
 "30-day cost unavailable" = "تكلفة 30 يوماً: غير متوفر";
 "Resets" = "إعادات الضبط";
+
+"Cumulative" = "تراكمي";
+"Token activity" = "نشاط الرموز";
+"View" = "عرض";
+"in the last year" = "في العام الماضي";
+"No activity in the last 12 months" = "لا يوجد نشاط في آخر 12 شهرًا";
+"Each column = 1 week" = "كل عمود = أسبوع واحد";
+"Running total" = "الإجمالي التراكمي";
+"Less" = "أقل";
+"More" = "أكثر";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1352,3 +1352,13 @@
 "Cost today unavailable" = "Cost d’avui: No disponible";
 "30-day cost unavailable" = "Cost de 30 dies: No disponible";
 "Resets" = "Reinicis";
+
+"Cumulative" = "Acumulat";
+"Token activity" = "Activitat de tokens";
+"View" = "Vista";
+"in the last year" = "l'últim any";
+"No activity in the last 12 months" = "Sense activitat en els últims 12 mesos";
+"Each column = 1 week" = "Cada columna = 1 setmana";
+"Running total" = "Total acumulat";
+"Less" = "Menys";
+"More" = "Més";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1350,3 +1350,13 @@
 "Cost today unavailable" = "Kosten heute: Nicht verfügbar";
 "30-day cost unavailable" = "Kosten 30 Tage: Nicht verfügbar";
 "Resets" = "Zurücksetzungen";
+
+"Cumulative" = "Kumulativ";
+"Token activity" = "Token-Aktivität";
+"View" = "Ansicht";
+"in the last year" = "im letzten Jahr";
+"No activity in the last 12 months" = "Keine Aktivität in den letzten 12 Monaten";
+"Each column = 1 week" = "Jede Spalte = 1 Woche";
+"Running total" = "Laufende Summe";
+"Less" = "Weniger";
+"More" = "Mehr";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1354,3 +1354,13 @@
 "Cost today unavailable" = "Cost today unavailable";
 "30-day cost unavailable" = "30-day cost unavailable";
 "Resets" = "Resets";
+
+"Cumulative" = "Cumulative";
+"Token activity" = "Token activity";
+"View" = "View";
+"in the last year" = "in the last year";
+"No activity in the last 12 months" = "No activity in the last 12 months";
+"Each column = 1 week" = "Each column = 1 week";
+"Running total" = "Running total";
+"Less" = "Less";
+"More" = "More";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1348,3 +1348,13 @@
 "Cost today unavailable" = "Coste de hoy: No disponible";
 "30-day cost unavailable" = "Coste de 30 días: No disponible";
 "Resets" = "Reinicios";
+
+"Cumulative" = "Acumulado";
+"Token activity" = "Actividad de tokens";
+"View" = "Vista";
+"in the last year" = "en el último año";
+"No activity in the last 12 months" = "Sin actividad en los últimos 12 meses";
+"Each column = 1 week" = "Cada columna = 1 semana";
+"Running total" = "Total acumulado";
+"Less" = "Menos";
+"More" = "Más";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1353,3 +1353,13 @@
 "Cost today unavailable" = "هزینهٔ امروز: در دسترس نیست";
 "30-day cost unavailable" = "هزینهٔ ۳۰ روز: در دسترس نیست";
 "Resets" = "بازنشانی‌ها";
+
+"Cumulative" = "تجمعی";
+"Token activity" = "فعالیت توکن";
+"View" = "نمایش";
+"in the last year" = "در سال گذشته";
+"No activity in the last 12 months" = "هیچ فعالیتی در ۱۲ ماه گذشته وجود ندارد";
+"Each column = 1 week" = "هر ستون = ۱ هفته";
+"Running total" = "مجموع تجمعی";
+"Less" = "کمتر";
+"More" = "بیشتر";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1349,3 +1349,13 @@
 "Cost today unavailable" = "Coût aujourd’hui: Indisponible";
 "30-day cost unavailable" = "Coût sur 30 j: Indisponible";
 "Resets" = "Réinitialisations";
+
+"Cumulative" = "Cumulé";
+"Token activity" = "Activité des tokens";
+"View" = "Vue";
+"in the last year" = "sur l'année écoulée";
+"No activity in the last 12 months" = "Aucune activité au cours des 12 derniers mois";
+"Each column = 1 week" = "Chaque colonne = 1 semaine";
+"Running total" = "Total cumulé";
+"Less" = "Moins";
+"More" = "Plus";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1349,3 +1349,13 @@
 "Cost today unavailable" = "Custo de hoxe: Non dispoñible";
 "30-day cost unavailable" = "Custo de 30 días: Non dispoñible";
 "Resets" = "Reinicios";
+
+"Cumulative" = "Acumulado";
+"Token activity" = "Actividade de tokens";
+"View" = "Vista";
+"in the last year" = "no último ano";
+"No activity in the last 12 months" = "Sen actividade nos últimos 12 meses";
+"Each column = 1 week" = "Cada columna = 1 semana";
+"Running total" = "Total acumulado";
+"Less" = "Menos";
+"More" = "Máis";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1353,3 +1353,13 @@
 "Cost today unavailable" = "Biaya hari ini: Tidak tersedia";
 "30-day cost unavailable" = "Biaya 30 hari: Tidak tersedia";
 "Resets" = "Reset";
+
+"Cumulative" = "Kumulatif";
+"Token activity" = "Aktivitas token";
+"View" = "Tampilan";
+"in the last year" = "dalam setahun terakhir";
+"No activity in the last 12 months" = "Tidak ada aktivitas dalam 12 bulan terakhir";
+"Each column = 1 week" = "Setiap kolom = 1 minggu";
+"Running total" = "Total berjalan";
+"Less" = "Sedikit";
+"More" = "Banyak";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1353,3 +1353,13 @@
 "Cost today unavailable" = "Costo oggi: Non disponibile";
 "30-day cost unavailable" = "Costo 30 gg: Non disponibile";
 "Resets" = "Ripristini";
+
+"Cumulative" = "Cumulativo";
+"Token activity" = "Attività token";
+"View" = "Vista";
+"in the last year" = "nell'ultimo anno";
+"No activity in the last 12 months" = "Nessuna attività negli ultimi 12 mesi";
+"Each column = 1 week" = "Ogni colonna = 1 settimana";
+"Running total" = "Totale progressivo";
+"Less" = "Meno";
+"More" = "Più";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1350,3 +1350,13 @@
 "Cost today unavailable" = "今日のコスト: 利用不可";
 "30-day cost unavailable" = "30日間のコスト: 利用不可";
 "Resets" = "リセット";
+
+"Cumulative" = "累計";
+"Token activity" = "トークンアクティビティ";
+"View" = "表示";
+"in the last year" = "過去1年";
+"No activity in the last 12 months" = "過去12か月にアクティビティなし";
+"Each column = 1 week" = "各列 = 1週間";
+"Running total" = "累計";
+"Less" = "少";
+"More" = "多";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1317,3 +1317,13 @@
 "Cost today unavailable" = "오늘 비용: 사용할 수 없음";
 "30-day cost unavailable" = "30일 비용: 사용할 수 없음";
 "Resets" = "재설정";
+
+"Cumulative" = "누적";
+"Token activity" = "토큰 활동";
+"View" = "보기";
+"in the last year" = "지난 1년";
+"No activity in the last 12 months" = "지난 12개월 동안 활동 없음";
+"Each column = 1 week" = "각 열 = 1주";
+"Running total" = "누적 합계";
+"Less" = "적음";
+"More" = "많음";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1349,3 +1349,13 @@
 "Cost today unavailable" = "Kosten vandaag: Niet beschikbaar";
 "30-day cost unavailable" = "Kosten 30 dagen: Niet beschikbaar";
 "Resets" = "Resets";
+
+"Cumulative" = "Cumulatief";
+"Token activity" = "Token-activiteit";
+"View" = "Weergave";
+"in the last year" = "in het afgelopen jaar";
+"No activity in the last 12 months" = "Geen activiteit in de afgelopen 12 maanden";
+"Each column = 1 week" = "Elke kolom = 1 week";
+"Running total" = "Lopend totaal";
+"Less" = "Minder";
+"More" = "Meer";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1353,3 +1353,13 @@
 "Cost today unavailable" = "Koszt dzisiaj: Niedostępne";
 "30-day cost unavailable" = "Koszt 30 dni: Niedostępne";
 "Resets" = "Resety";
+
+"Cumulative" = "Łącznie";
+"Token activity" = "Aktywność tokenów";
+"View" = "Widok";
+"in the last year" = "w ciągu ostatniego roku";
+"No activity in the last 12 months" = "Brak aktywności w ciągu ostatnich 12 miesięcy";
+"Each column = 1 week" = "Każda kolumna = 1 tydzień";
+"Running total" = "Suma narastająca";
+"Less" = "Mniej";
+"More" = "Więcej";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1350,3 +1350,13 @@
 "Cost today unavailable" = "Custo hoje: Indisponível";
 "30-day cost unavailable" = "Custo em 30 dias: Indisponível";
 "Resets" = "Redefinições";
+
+"Cumulative" = "Acumulado";
+"Token activity" = "Atividade de tokens";
+"View" = "Visualização";
+"in the last year" = "no último ano";
+"No activity in the last 12 months" = "Sem atividade nos últimos 12 meses";
+"Each column = 1 week" = "Cada coluna = 1 semana";
+"Running total" = "Total acumulado";
+"Less" = "Menos";
+"More" = "Mais";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1351,3 +1351,13 @@
 "Cost today unavailable" = "Расход сегодня: Недоступно";
 "30-day cost unavailable" = "Расход за 30 дней: Недоступно";
 "Resets" = "Сбросы";
+
+"Cumulative" = "Накопительно";
+"Token activity" = "Активность токенов";
+"View" = "Вид";
+"in the last year" = "за последний год";
+"No activity in the last 12 months" = "Нет активности за последние 12 месяцев";
+"Each column = 1 week" = "Каждый столбец = 1 неделя";
+"Running total" = "Накопленный итог";
+"Less" = "Меньше";
+"More" = "Больше";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1348,3 +1348,13 @@
 "Cost today unavailable" = "Kostnad idag: Inte tillgänglig";
 "30-day cost unavailable" = "Kostnad 30 dagar: Inte tillgänglig";
 "Resets" = "Återställningar";
+
+"Cumulative" = "Kumulativt";
+"Token activity" = "Token-aktivitet";
+"View" = "Vy";
+"in the last year" = "det senaste året";
+"No activity in the last 12 months" = "Ingen aktivitet de senaste 12 månaderna";
+"Each column = 1 week" = "Varje kolumn = 1 vecka";
+"Running total" = "Löpande summa";
+"Less" = "Mindre";
+"More" = "Mer";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1353,3 +1353,13 @@
 "Cost today unavailable" = "ค่าใช้จ่ายวันนี้: ไม่พร้อมใช้งาน";
 "30-day cost unavailable" = "ค่าใช้จ่าย 30 วัน: ไม่พร้อมใช้งาน";
 "Resets" = "การรีเซ็ต";
+
+"Cumulative" = "สะสม";
+"Token activity" = "กิจกรรมโทเทน";
+"View" = "มุมมอง";
+"in the last year" = "ในปีที่ผ่านมา";
+"No activity in the last 12 months" = "ไม่มีกิจกรรมในช่วง 12 เดือนที่ผ่านมา";
+"Each column = 1 week" = "แต่ละคอลัมน์ = 1 สัปดาห์";
+"Running total" = "ยอดรวมสะสม";
+"Less" = "น้อย";
+"More" = "มาก";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1351,3 +1351,13 @@
 "Cost today unavailable" = "Bugünkü maliyet: Kullanılamıyor";
 "30-day cost unavailable" = "30 günlük maliyet: Kullanılamıyor";
 "Resets" = "Sıfırlamalar";
+
+"Cumulative" = "Kümülatif";
+"Token activity" = "Token etkinliği";
+"View" = "Görünüm";
+"in the last year" = "son yılda";
+"No activity in the last 12 months" = "Son 12 ayda etkinlik yok";
+"Each column = 1 week" = "Her sütun = 1 hafta";
+"Running total" = "Birikimli toplam";
+"Less" = "Az";
+"More" = "Çok";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1349,3 +1349,13 @@
 "Cost today unavailable" = "Вартість сьогодні: Недоступний";
 "30-day cost unavailable" = "Вартість за 30 днів: Недоступний";
 "Resets" = "Скидання";
+
+"Cumulative" = "Наростаючим підсумком";
+"Token activity" = "Активність токенів";
+"View" = "Вигляд";
+"in the last year" = "за останній рік";
+"No activity in the last 12 months" = "Немає активності за останні 12 місяців";
+"Each column = 1 week" = "Кожен стовпець = 1 тиждень";
+"Running total" = "Накопичений підсумок";
+"Less" = "Менше";
+"More" = "Більше";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1350,3 +1350,13 @@
 "Cost today unavailable" = "Chi phí hôm nay: Không có sẵn";
 "30-day cost unavailable" = "Chi phí 30 ngày: Không có sẵn";
 "Resets" = "Lần đặt lại";
+
+"Cumulative" = "Tích lũy";
+"Token activity" = "Hoạt động token";
+"View" = "Chế độ xem";
+"in the last year" = "trong năm qua";
+"No activity in the last 12 months" = "Không có hoạt động trong 12 tháng qua";
+"Each column = 1 week" = "Mỗi cột = 1 tuần";
+"Running total" = "Tổng lũy kế";
+"Less" = "Ít";
+"More" = "Nhiều";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1325,3 +1325,13 @@
 "Cost today unavailable" = "今日费用: 不可用";
 "30-day cost unavailable" = "30 天费用: 不可用";
 "Resets" = "重置";
+
+"Cumulative" = "累计";
+"Token activity" = "Token 活动";
+"View" = "视图";
+"in the last year" = "近一年";
+"No activity in the last 12 months" = "近 12 个月暂无活动";
+"Each column = 1 week" = "每列 = 1 周";
+"Running total" = "累计总量";
+"Less" = "少";
+"More" = "多";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1380,3 +1380,13 @@
 "Cost today unavailable" = "今日費用: 無法使用";
 "30-day cost unavailable" = "30 天費用: 無法使用";
 "Resets" = "重設";
+
+"Cumulative" = "累計";
+"Token activity" = "Token 活動";
+"View" = "檢視";
+"in the last year" = "近一年";
+"No activity in the last 12 months" = "近 12 個月暫無活動";
+"Each column = 1 week" = "每列 = 1 週";
+"Running total" = "累計總量";
+"Less" = "少";
+"More" = "多";

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -1,0 +1,593 @@
+import CodexBarCore
+import Foundation
+import SwiftUI
+
+enum SpendActivityViewMode: String, CaseIterable, Identifiable {
+    case daily
+    case weekly
+    case cumulative
+
+    var id: Self {
+        self
+    }
+
+    var title: String {
+        switch self {
+        case .daily: L("Daily")
+        case .weekly: L("Weekly")
+        case .cumulative: L("Cumulative")
+        }
+    }
+}
+
+struct SpendActivitySeries {
+    static let weekCount = 52
+    static let dayCount = 7
+
+    let daily: [Int]
+    let start: Date
+    let today: Date
+    let calendar: Calendar
+
+    static func make(
+        from points: [SpendDashboardModel.TokenActivityPoint],
+        now: Date = Date(),
+        calendar: Calendar = .current) -> Self
+    {
+        var totals: [Date: Int] = [:]
+        for point in points {
+            let day = calendar.startOfDay(for: point.day)
+            totals[day] = Self.saturatingAdd(totals[day] ?? 0, max(point.totalTokens, 0))
+        }
+
+        let today = calendar.startOfDay(for: now)
+        let weekday = calendar.component(.weekday, from: today)
+        let thisWeekSunday = calendar.date(byAdding: .day, value: -(weekday - 1), to: today) ?? today
+        let start = calendar.date(
+            byAdding: .weekOfYear,
+            value: -(Self.weekCount - 1),
+            to: thisWeekSunday) ?? thisWeekSunday
+        let cellCount = Self.weekCount * Self.dayCount
+        var daily = [Int](repeating: 0, count: cellCount)
+        for index in 0..<cellCount {
+            guard let date = calendar.date(byAdding: .day, value: index, to: start), date <= today else {
+                continue
+            }
+            daily[index] = totals[date] ?? 0
+        }
+        return Self(daily: daily, start: start, today: today, calendar: calendar)
+    }
+
+    func date(at index: Int) -> Date? {
+        self.calendar.date(byAdding: .day, value: index, to: self.start)
+    }
+
+    func weekStartDate(at week: Int) -> Date? {
+        self.calendar.date(byAdding: .day, value: week * Self.dayCount, to: self.start)
+    }
+
+    private static func saturatingAdd(_ lhs: Int, _ rhs: Int) -> Int {
+        let result = lhs.addingReportingOverflow(rhs)
+        return result.overflow ? Int.max : result.partialValue
+    }
+}
+
+enum SpendActivityLevels {
+    static func dailyLevels(_ values: [Int]) -> [Int] {
+        let maxValue = values.max() ?? 0
+        return values.map { value in
+            guard value > 0, maxValue > 0 else { return 0 }
+            let ratio = Double(value) / Double(maxValue)
+            if ratio > 0.75 { return 4 }
+            if ratio > 0.5 { return 3 }
+            if ratio > 0.25 { return 2 }
+            return 1
+        }
+    }
+
+    static func weeklyTotals(_ daily: [Int]) -> [Int] {
+        stride(from: 0, to: daily.count, by: SpendActivitySeries.dayCount).map { start in
+            daily[start..<min(start + SpendActivitySeries.dayCount, daily.count)].reduce(0) { total, value in
+                let result = total.addingReportingOverflow(value)
+                return result.overflow ? Int.max : result.partialValue
+            }
+        }
+    }
+
+    static func cumulativeTotals(_ weekly: [Int]) -> [Int] {
+        var sum = 0
+        return weekly.map { value in
+            let result = sum.addingReportingOverflow(value)
+            sum = result.overflow ? Int.max : result.partialValue
+            return sum
+        }
+    }
+
+    static func color(forLevel level: Int) -> Color {
+        switch level {
+        case 4: self.rgb(0x216E39)
+        case 3: self.rgb(0x30A14E)
+        case 2: self.rgb(0x40C463)
+        case 1: self.rgb(0x9BE9A8)
+        default: self.rgb(0xEBEDF0)
+        }
+    }
+
+    static var uniformFill: Color {
+        self.rgb(0x40C463)
+    }
+
+    private static func rgb(_ hex: UInt32) -> Color {
+        Color(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255)
+    }
+}
+
+struct SpendActivityGridGeometry {
+    static let weekdayGutterWidth: CGFloat = 40
+    static let gridSpacing: CGFloat = 8
+    static let tooltipInset: CGFloat = 4
+    static let tooltipGap: CGFloat = 7
+    static let tooltipWidth: CGFloat = 148
+    static let tooltipHeight: CGFloat = 50
+
+    static func gridFrame(containerWidth: CGFloat, columns: Int = SpendActivitySeries.weekCount) -> CGRect {
+        let leading = self.weekdayGutterWidth + self.gridSpacing
+        let width = max(containerWidth - leading, 0)
+        let pitch = columns > 0 ? width / CGFloat(columns) : 0
+        return CGRect(x: leading, y: 0, width: width, height: pitch * CGFloat(SpendActivitySeries.dayCount))
+    }
+
+    static func weekdayCenter(row: Int, rowPitch: CGFloat) -> CGFloat {
+        (CGFloat(row) + 0.5) * rowPitch
+    }
+
+    static func tooltipCenterX(anchorX: CGFloat, tooltipWidth: CGFloat, gridWidth: CGFloat) -> CGFloat {
+        let halfWidth = tooltipWidth / 2
+        let lower = min(halfWidth + self.tooltipInset, gridWidth / 2)
+        let upper = max(gridWidth - halfWidth - self.tooltipInset, gridWidth / 2)
+        return min(max(anchorX, lower), upper)
+    }
+
+    static func tooltipOriginY(anchorY: CGFloat, tooltipHeight: CGFloat, gridHeight: CGFloat) -> CGFloat {
+        let below = anchorY + self.tooltipGap
+        if below + tooltipHeight <= gridHeight {
+            return below
+        }
+        return max(anchorY - tooltipHeight - self.tooltipGap, 0)
+    }
+}
+
+enum SpendActivityWeekday {
+    static let labeledRows = [1, 3, 5]
+
+    static func label(for row: Int, locale: Locale? = nil) -> String {
+        guard self.labeledRows.contains(row) else { return "" }
+        let formatter = DateFormatter()
+        formatter.locale = locale ?? codexBarLocalizedResourceLocale()
+        guard let symbols = formatter.shortStandaloneWeekdaySymbols, symbols.indices.contains(row) else {
+            return ""
+        }
+        return symbols[row]
+    }
+}
+
+enum SpendActivityDateFormatting {
+    static func mediumDateString(_ date: Date, locale: Locale? = nil) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale ?? codexBarLocalizedResourceLocale()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
+    }
+}
+
+struct SpendActivityHeatmapView: View {
+    let points: [SpendDashboardModel.TokenActivityPoint]
+    let now: Date
+
+    @AppStorage("spendActivityViewMode") private var mode: SpendActivityViewMode = .daily
+    @State private var series: SpendActivitySeries
+
+    init(points: [SpendDashboardModel.TokenActivityPoint], now: Date = Date()) {
+        self.points = points
+        self.now = now
+        self._series = State(initialValue: SpendActivitySeries.make(from: points, now: now))
+    }
+
+    var body: some View {
+        let hasActivity = (self.series.daily.max() ?? 0) > 0
+        let totalTokens = Self.saturatingTotal(self.series.daily)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 16) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L("Token activity"))
+                        .font(.headline)
+                    if hasActivity {
+                        Text("\(UsageFormatter.tokenCountString(totalTokens)) \(L("in the last year"))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                Picker(L("View"), selection: self.$mode) {
+                    ForEach(SpendActivityViewMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .fixedSize()
+            }
+
+            if hasActivity {
+                switch self.mode {
+                case .daily:
+                    SpendActivityDailyGrid(series: self.series)
+                    self.dailyLegend
+                case .weekly:
+                    SpendActivityWeekGrid(
+                        series: self.series,
+                        values: SpendActivityLevels.weeklyTotals(self.series.daily),
+                        cumulative: false)
+                    self.caption(L("Each column = 1 week"))
+                case .cumulative:
+                    SpendActivityWeekGrid(
+                        series: self.series,
+                        values: SpendActivityLevels.cumulativeTotals(
+                            SpendActivityLevels.weeklyTotals(self.series.daily)),
+                        cumulative: true)
+                    self.caption(L("Running total"))
+                }
+            } else {
+                Text(L("No activity in the last 12 months"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 12)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onChange(of: self.points) { _, points in
+            self.series = SpendActivitySeries.make(from: points, now: self.now)
+        }
+    }
+
+    private var dailyLegend: some View {
+        HStack(spacing: 4) {
+            Spacer()
+            Text(L("Less"))
+            ForEach(0...4, id: \.self) { level in
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(SpendActivityLevels.color(forLevel: level))
+                    .frame(width: 9, height: 9)
+            }
+            Text(L("More"))
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+
+    private func caption(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+    }
+
+    private static func saturatingTotal(_ values: [Int]) -> Int {
+        values.reduce(0) { total, value in
+            let result = total.addingReportingOverflow(value)
+            return result.overflow ? Int.max : result.partialValue
+        }
+    }
+}
+
+private struct SpendActivityDailyGrid: View {
+    let series: SpendActivitySeries
+
+    @State private var hoveredIndex: Int?
+
+    private let columns = SpendActivitySeries.weekCount
+    private let rows = SpendActivitySeries.dayCount
+
+    var body: some View {
+        let levels = SpendActivityLevels.dailyLevels(self.series.daily)
+        VStack(alignment: .leading, spacing: 3) {
+            self.monthRow
+            GeometryReader { proxy in
+                let gridFrame = SpendActivityGridGeometry.gridFrame(containerWidth: proxy.size.width)
+                let pitch = gridFrame.width / CGFloat(self.columns)
+                let cell = max(pitch - 2, 2)
+                ZStack(alignment: .topLeading) {
+                    self.weekdayLabels(rowPitch: pitch)
+                    ZStack(alignment: .topLeading) {
+                        Canvas { context, _ in
+                            let corner = min(cell * 0.22, 2.5)
+                            for index in 0..<(self.columns * self.rows) where self.isVisibleCell(index) {
+                                let col = index / self.rows
+                                let row = index % self.rows
+                                let rect = CGRect(
+                                    x: CGFloat(col) * pitch + (pitch - cell) / 2,
+                                    y: CGFloat(row) * pitch + (pitch - cell) / 2,
+                                    width: cell,
+                                    height: cell)
+                                context.fill(
+                                    RoundedRectangle(cornerRadius: corner, style: .continuous).path(in: rect),
+                                    with: .color(SpendActivityLevels.color(forLevel: levels[index])))
+                            }
+                        }
+                        self.hoverHighlight(cell: cell, pitch: pitch)
+                        self.tooltip(size: gridFrame.size, pitch: pitch)
+                    }
+                    .frame(width: gridFrame.width, height: gridFrame.height)
+                    .contentShape(Rectangle())
+                    .onContinuousHover { phase in
+                        switch phase {
+                        case let .active(location):
+                            self.hoveredIndex = self.cellIndex(at: location, pitch: pitch)
+                        case .ended:
+                            self.hoveredIndex = nil
+                        }
+                    }
+                    .offset(x: gridFrame.minX)
+                }
+            }
+            .aspectRatio(CGFloat(self.columns + 2) / CGFloat(self.rows), contentMode: .fit)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(L("Token activity"))
+        .accessibilityValue(UsageFormatter.tokenCountString(Self.saturatingTotal(self.series.daily)))
+    }
+
+    private var monthRow: some View {
+        GeometryReader { proxy in
+            let gridFrame = SpendActivityGridGeometry.gridFrame(containerWidth: proxy.size.width)
+            let pitch = gridFrame.width / CGFloat(self.columns)
+            ZStack(alignment: .topLeading) {
+                ForEach(self.monthMarkers(pitch: pitch)) { marker in
+                    Text(marker.label)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .offset(x: gridFrame.minX + marker.offset)
+                }
+            }
+        }
+        .frame(height: 14)
+    }
+
+    private func weekdayLabels(rowPitch: CGFloat) -> some View {
+        ForEach(SpendActivityWeekday.labeledRows, id: \.self) { row in
+            Text(SpendActivityWeekday.label(for: row))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .frame(width: SpendActivityGridGeometry.weekdayGutterWidth, alignment: .trailing)
+                .position(
+                    x: SpendActivityGridGeometry.weekdayGutterWidth / 2,
+                    y: SpendActivityGridGeometry.weekdayCenter(row: row, rowPitch: rowPitch))
+        }
+    }
+
+    @ViewBuilder
+    private func hoverHighlight(cell: CGFloat, pitch: CGFloat) -> some View {
+        if let index = self.hoveredIndex {
+            let col = index / self.rows
+            let row = index % self.rows
+            RoundedRectangle(cornerRadius: min(cell * 0.22, 2.5), style: .continuous)
+                .stroke(Color.primary.opacity(0.7), lineWidth: 1.5)
+                .frame(width: cell, height: cell)
+                .position(
+                    x: CGFloat(col) * pitch + pitch / 2,
+                    y: CGFloat(row) * pitch + pitch / 2)
+                .allowsHitTesting(false)
+        }
+    }
+
+    @ViewBuilder
+    private func tooltip(size: CGSize, pitch: CGFloat) -> some View {
+        if let index = self.hoveredIndex, let date = self.series.date(at: index) {
+            let col = index / self.rows
+            let row = index % self.rows
+            let anchorX = CGFloat(col) * pitch + pitch / 2
+            let anchorY = CGFloat(row) * pitch + pitch / 2
+            let width = min(SpendActivityGridGeometry.tooltipWidth, max(size.width - 8, 1))
+            let originY = SpendActivityGridGeometry.tooltipOriginY(
+                anchorY: anchorY,
+                tooltipHeight: SpendActivityGridGeometry.tooltipHeight,
+                gridHeight: size.height)
+            SpendActivityTooltip(
+                title: UsageFormatter.tokenCountString(self.series.daily[index]),
+                subtitle: SpendActivityDateFormatting.mediumDateString(date),
+                width: width)
+                .position(
+                    x: SpendActivityGridGeometry.tooltipCenterX(
+                        anchorX: anchorX,
+                        tooltipWidth: width,
+                        gridWidth: size.width),
+                    y: originY + SpendActivityGridGeometry.tooltipHeight / 2)
+                .allowsHitTesting(false)
+        }
+    }
+
+    private func cellIndex(at location: CGPoint, pitch: CGFloat) -> Int? {
+        guard pitch > 0 else { return nil }
+        let col = Int(location.x / pitch)
+        let row = Int(location.y / pitch)
+        guard col >= 0, col < self.columns, row >= 0, row < self.rows else { return nil }
+        let index = col * self.rows + row
+        return self.isVisibleCell(index) ? index : nil
+    }
+
+    private func isVisibleCell(_ index: Int) -> Bool {
+        guard let date = self.series.date(at: index) else { return false }
+        return date <= self.series.today
+    }
+
+    private struct MonthMarker: Identifiable {
+        let id: Int
+        let offset: CGFloat
+        let label: String
+    }
+
+    private func monthMarkers(pitch: CGFloat) -> [MonthMarker] {
+        let formatter = DateFormatter()
+        formatter.locale = codexBarLocalizedResourceLocale()
+        formatter.dateFormat = "MMM"
+        var markers: [MonthMarker] = []
+        var lastLabel = ""
+        for col in 0..<self.columns {
+            guard let date = self.series.date(at: col * self.rows),
+                  self.series.calendar.component(.day, from: date) <= 7
+            else { continue }
+            let label = formatter.string(from: date)
+            guard label != lastLabel else { continue }
+            markers.append(MonthMarker(id: col, offset: CGFloat(col) * pitch, label: label))
+            lastLabel = label
+        }
+        return markers
+    }
+
+    private static func saturatingTotal(_ values: [Int]) -> Int {
+        values.reduce(0) { total, value in
+            let result = total.addingReportingOverflow(value)
+            return result.overflow ? Int.max : result.partialValue
+        }
+    }
+}
+
+private struct SpendActivityWeekGrid: View {
+    let series: SpendActivitySeries
+    let values: [Int]
+    let cumulative: Bool
+
+    @State private var hoverLocation: CGPoint?
+
+    private let columns = SpendActivitySeries.weekCount
+    private let rows = SpendActivitySeries.dayCount
+
+    var body: some View {
+        let maxValue = self.values.max() ?? 0
+        GeometryReader { proxy in
+            let gridFrame = SpendActivityGridGeometry.gridFrame(containerWidth: proxy.size.width)
+            let pitch = gridFrame.width / CGFloat(self.columns)
+            let cell = max(pitch - 2, 2)
+            ZStack(alignment: .topLeading) {
+                Canvas { context, _ in
+                    let corner = min(cell * 0.22, 2.5)
+                    for col in 0..<self.columns where col < self.values.count && self.isVisible(col) {
+                        let value = self.values[col]
+                        let rawFill = maxValue > 0
+                            ? Int((Double(value) / Double(maxValue) * Double(self.rows)).rounded())
+                            : 0
+                        let filled = value > 0 ? max(rawFill, 1) : 0
+                        for row in 0..<self.rows {
+                            let rect = CGRect(
+                                x: CGFloat(col) * pitch + (pitch - cell) / 2,
+                                y: CGFloat(row) * pitch + (pitch - cell) / 2,
+                                width: cell,
+                                height: cell)
+                            context.fill(
+                                RoundedRectangle(cornerRadius: corner, style: .continuous).path(in: rect),
+                                with: .color(row >= self.rows - filled
+                                    ? SpendActivityLevels.uniformFill
+                                    : SpendActivityLevels.color(forLevel: 0)))
+                        }
+                    }
+                }
+                self.tooltip(size: gridFrame.size, pitch: pitch)
+            }
+            .frame(width: gridFrame.width, height: gridFrame.height)
+            .contentShape(Rectangle())
+            .onContinuousHover { phase in
+                switch phase {
+                case let .active(location):
+                    self.hoverLocation = self.column(at: location, pitch: pitch) == nil ? nil : location
+                case .ended:
+                    self.hoverLocation = nil
+                }
+            }
+            .offset(x: gridFrame.minX)
+        }
+        .aspectRatio(CGFloat(self.columns + 2) / CGFloat(self.rows), contentMode: .fit)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(L("Token activity"))
+        .accessibilityValue(UsageFormatter.tokenCountString(self.accessibilityTokenTotal))
+    }
+
+    @ViewBuilder
+    private func tooltip(size: CGSize, pitch: CGFloat) -> some View {
+        if let location = self.hoverLocation,
+           let col = self.column(at: location, pitch: pitch),
+           col < self.values.count,
+           let weekStart = self.series.weekStartDate(at: col)
+        {
+            let width = min(SpendActivityGridGeometry.tooltipWidth, max(size.width - 8, 1))
+            let originY = SpendActivityGridGeometry.tooltipOriginY(
+                anchorY: location.y,
+                tooltipHeight: SpendActivityGridGeometry.tooltipHeight,
+                gridHeight: size.height)
+            SpendActivityTooltip(
+                title: UsageFormatter.tokenCountString(self.values[col]),
+                subtitle: SpendActivityDateFormatting.mediumDateString(weekStart),
+                width: width)
+                .position(
+                    x: SpendActivityGridGeometry.tooltipCenterX(
+                        anchorX: CGFloat(col) * pitch + pitch / 2,
+                        tooltipWidth: width,
+                        gridWidth: size.width),
+                    y: originY + SpendActivityGridGeometry.tooltipHeight / 2)
+                .allowsHitTesting(false)
+        }
+    }
+
+    private func column(at location: CGPoint, pitch: CGFloat) -> Int? {
+        guard pitch > 0 else { return nil }
+        let col = Int(location.x / pitch)
+        guard col >= 0, col < self.columns, self.isVisible(col) else { return nil }
+        return col
+    }
+
+    private func isVisible(_ column: Int) -> Bool {
+        guard let start = self.series.weekStartDate(at: column) else { return false }
+        return start <= self.series.today
+    }
+
+    private var accessibilityTokenTotal: Int {
+        if self.cumulative { return self.values.last ?? 0 }
+        return self.values.reduce(0) { total, value in
+            let result = total.addingReportingOverflow(value)
+            return result.overflow ? Int.max : result.partialValue
+        }
+    }
+}
+
+private struct SpendActivityTooltip: View {
+    let title: String
+    let subtitle: String
+    let width: CGFloat
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(self.title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            Text(self.subtitle)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 8)
+        .frame(
+            width: self.width,
+            height: SpendActivityGridGeometry.tooltipHeight,
+            alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .strokeBorder(Color(nsColor: .separatorColor).opacity(0.3))
+        }
+    }
+}

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -484,9 +484,19 @@ private struct SpendActivityDailyGrid: View {
                 self.keyboardIndex = self.lastVisibleIndex
             }
         }
-        .accessibilityElement(children: .ignore)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(L("Token activity"))
         .accessibilityValue(self.accessibilityValue)
+        .accessibilityChildren {
+            ForEach(self.series.daily.indices.filter(self.series.isVisible), id: \.self) { index in
+                if let date = self.series.date(at: index) {
+                    Color.clear
+                        .accessibilityElement()
+                        .accessibilityLabel(SpendActivityDateFormatting.mediumDateString(date))
+                        .accessibilityValue(self.accessibilityTokenValue(at: index))
+                }
+            }
+        }
         .accessibilityAdjustableAction { direction in
             switch direction {
             case .increment:
@@ -594,7 +604,9 @@ private struct SpendActivityDailyGrid: View {
     }
 
     private func moveKeyboardSelection(_ direction: MoveCommandDirection) {
+        self.hoveredIndex = nil
         guard let current = self.keyboardIndex ?? self.lastVisibleIndex else { return }
+        self.keyboardIndex = current
         let move: SpendActivityGridMove? = switch direction {
         case .left:
             .left
@@ -614,6 +626,7 @@ private struct SpendActivityDailyGrid: View {
     }
 
     private func moveKeyboardSelectionChronologically(by offset: Int) {
+        self.hoveredIndex = nil
         guard let current = self.keyboardIndex else {
             self.keyboardIndex = self.lastVisibleIndex
             return
@@ -656,10 +669,7 @@ private struct SpendActivityDailyGrid: View {
 
     private var accessibilityValue: String {
         if let index = self.activeIndex, let date = self.series.date(at: index) {
-            let value = self.series.isCovered[index]
-                ? UsageFormatter.tokenCountString(self.series.daily[index])
-                : L("Unavailable")
-            return "\(SpendActivityDateFormatting.mediumDateString(date)): \(value)"
+            return "\(SpendActivityDateFormatting.mediumDateString(date)): \(self.accessibilityTokenValue(at: index))"
         }
         let total = UsageFormatter.tokenCountString(Self.saturatingTotal(self.series.daily))
         guard self.series.hasUnknownCoverage else { return total }
@@ -667,6 +677,12 @@ private struct SpendActivityDailyGrid: View {
             covered: self.series.coveredDayCount,
             requested: self.series.visibleDayCount)
         return "\(total) · \(coverage)"
+    }
+
+    private func accessibilityTokenValue(at index: Int) -> String {
+        self.series.isCovered[index]
+            ? UsageFormatter.tokenCountString(self.series.daily[index])
+            : L("Unavailable")
     }
 }
 

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -490,9 +490,7 @@ private struct SpendActivityDailyGrid: View {
         .accessibilityChildren {
             ForEach(self.series.daily.indices.filter(self.series.isVisible), id: \.self) { index in
                 if let date = self.series.date(at: index) {
-                    Text(self.accessibilityTokenValue(at: index))
-                        .accessibilityLabel(SpendActivityDateFormatting.mediumDateString(date))
-                        .accessibilityValue(self.accessibilityTokenValue(at: index))
+                    Text(self.accessibilityDescription(at: index, date: date))
                 }
             }
         }
@@ -668,7 +666,7 @@ private struct SpendActivityDailyGrid: View {
 
     private var accessibilityValue: String {
         if let index = self.activeIndex, let date = self.series.date(at: index) {
-            return "\(SpendActivityDateFormatting.mediumDateString(date)): \(self.accessibilityTokenValue(at: index))"
+            return self.accessibilityDescription(at: index, date: date)
         }
         let total = UsageFormatter.tokenCountString(Self.saturatingTotal(self.series.daily))
         guard self.series.hasUnknownCoverage else { return total }
@@ -676,6 +674,10 @@ private struct SpendActivityDailyGrid: View {
             covered: self.series.coveredDayCount,
             requested: self.series.visibleDayCount)
         return "\(total) · \(coverage)"
+    }
+
+    private func accessibilityDescription(at index: Int, date: Date) -> String {
+        "\(SpendActivityDateFormatting.mediumDateString(date)): \(self.accessibilityTokenValue(at: index))"
     }
 
     private func accessibilityTokenValue(at index: Int) -> String {

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -21,12 +21,14 @@ enum SpendActivityViewMode: String, CaseIterable, Identifiable {
 }
 
 struct SpendActivitySeries {
-    static let weekCount = 52
+    static let weekCount = 53
     static let dayCount = 7
+    static let rangeDayCount = 365
 
     let daily: [Int]
     let isCovered: [Bool]
     let start: Date
+    let rangeStart: Date
     let today: Date
     let calendar: Calendar
 
@@ -49,24 +51,35 @@ struct SpendActivitySeries {
         }
 
         let today = calendar.startOfDay(for: now)
-        let weekday = calendar.component(.weekday, from: today)
-        let thisWeekSunday = calendar.date(byAdding: .day, value: -(weekday - 1), to: today) ?? today
+        let rangeStart = calendar.date(
+            byAdding: .day,
+            value: -(Self.rangeDayCount - 1),
+            to: today) ?? today
+        let rangeStartWeekday = calendar.component(.weekday, from: rangeStart)
         let start = calendar.date(
-            byAdding: .weekOfYear,
-            value: -(Self.weekCount - 1),
-            to: thisWeekSunday) ?? thisWeekSunday
+            byAdding: .day,
+            value: -(rangeStartWeekday - 1),
+            to: rangeStart) ?? rangeStart
         let cellCount = Self.weekCount * Self.dayCount
         var daily = [Int](repeating: 0, count: cellCount)
         var isCovered = [Bool](repeating: false, count: cellCount)
         for index in 0..<cellCount {
-            guard let date = calendar.date(byAdding: .day, value: index, to: start), date <= today else {
+            guard let date = calendar.date(byAdding: .day, value: index, to: start),
+                  rangeStart...today ~= date
+            else {
                 continue
             }
             guard !unknownDays.contains(date), let total = totals[date] else { continue }
             daily[index] = total
             isCovered[index] = true
         }
-        return Self(daily: daily, isCovered: isCovered, start: start, today: today, calendar: calendar)
+        return Self(
+            daily: daily,
+            isCovered: isCovered,
+            start: start,
+            rangeStart: rangeStart,
+            today: today,
+            calendar: calendar)
     }
 
     func date(at index: Int) -> Date? {
@@ -101,9 +114,9 @@ struct SpendActivitySeries {
         return SpendActivityAggregateSeries(values: values, isCovered: coverage)
     }
 
-    private func isVisible(_ index: Int) -> Bool {
+    func isVisible(_ index: Int) -> Bool {
         guard let date = self.date(at: index) else { return false }
-        return date <= self.today
+        return self.rangeStart...self.today ~= date
     }
 
     static func saturatingAdd(_ lhs: Int, _ rhs: Int) -> Int {
@@ -220,6 +233,32 @@ struct SpendActivityGridGeometry {
             return below
         }
         return max(anchorY - tooltipHeight - self.tooltipGap, 0)
+    }
+}
+
+enum SpendActivityGridMove {
+    case left
+    case right
+    case up
+    case down
+}
+
+enum SpendActivityGridNavigation {
+    static func candidate(from current: Int, move: SpendActivityGridMove, rows: Int) -> Int? {
+        guard rows > 0 else { return nil }
+        let row = current % rows
+        return switch move {
+        case .left:
+            current - rows
+        case .right:
+            current + rows
+        case .up where row > 0:
+            current - 1
+        case .down where row < rows - 1:
+            current + 1
+        default:
+            nil
+        }
     }
 }
 
@@ -384,6 +423,8 @@ private struct SpendActivityDailyGrid: View {
     let series: SpendActivitySeries
 
     @State private var hoveredIndex: Int?
+    @State private var keyboardIndex: Int?
+    @FocusState private var isKeyboardFocused: Bool
 
     private let columns = SpendActivitySeries.weekCount
     private let rows = SpendActivitySeries.dayCount
@@ -435,9 +476,27 @@ private struct SpendActivityDailyGrid: View {
             }
             .aspectRatio(CGFloat(self.columns + 2) / CGFloat(self.rows), contentMode: .fit)
         }
+        .focusable()
+        .focused(self.$isKeyboardFocused)
+        .onMoveCommand(perform: self.moveKeyboardSelection)
+        .onChange(of: self.isKeyboardFocused) { _, isFocused in
+            if isFocused, self.keyboardIndex == nil {
+                self.keyboardIndex = self.lastVisibleIndex
+            }
+        }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(L("Token activity"))
         .accessibilityValue(self.accessibilityValue)
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment:
+                self.moveKeyboardSelectionChronologically(by: 1)
+            case .decrement:
+                self.moveKeyboardSelectionChronologically(by: -1)
+            @unknown default:
+                break
+            }
+        }
     }
 
     private var monthRow: some View {
@@ -471,7 +530,7 @@ private struct SpendActivityDailyGrid: View {
 
     @ViewBuilder
     private func hoverHighlight(cell: CGFloat, pitch: CGFloat) -> some View {
-        if let index = self.hoveredIndex {
+        if let index = self.activeIndex {
             let col = index / self.rows
             let row = index % self.rows
             RoundedRectangle(cornerRadius: min(cell * 0.22, 2.5), style: .continuous)
@@ -486,7 +545,7 @@ private struct SpendActivityDailyGrid: View {
 
     @ViewBuilder
     private func tooltip(size: CGSize, pitch: CGFloat) -> some View {
-        if let index = self.hoveredIndex, let date = self.series.date(at: index) {
+        if let index = self.activeIndex, let date = self.series.date(at: index) {
             let col = index / self.rows
             let row = index % self.rows
             let anchorX = CGFloat(col) * pitch + pitch / 2
@@ -522,8 +581,46 @@ private struct SpendActivityDailyGrid: View {
     }
 
     private func isVisibleCell(_ index: Int) -> Bool {
-        guard let date = self.series.date(at: index) else { return false }
-        return date <= self.series.today
+        self.series.isVisible(index)
+    }
+
+    private var activeIndex: Int? {
+        if let hoveredIndex { return hoveredIndex }
+        return self.keyboardIndex
+    }
+
+    private var lastVisibleIndex: Int? {
+        self.series.daily.indices.last(where: self.series.isVisible)
+    }
+
+    private func moveKeyboardSelection(_ direction: MoveCommandDirection) {
+        guard let current = self.keyboardIndex ?? self.lastVisibleIndex else { return }
+        let move: SpendActivityGridMove? = switch direction {
+        case .left:
+            .left
+        case .right:
+            .right
+        case .up:
+            .up
+        case .down:
+            .down
+        default:
+            nil
+        }
+        guard let move else { return }
+        let candidate = SpendActivityGridNavigation.candidate(from: current, move: move, rows: self.rows)
+        guard let candidate, self.isVisibleCell(candidate) else { return }
+        self.keyboardIndex = candidate
+    }
+
+    private func moveKeyboardSelectionChronologically(by offset: Int) {
+        guard let current = self.keyboardIndex else {
+            self.keyboardIndex = self.lastVisibleIndex
+            return
+        }
+        let candidate = current + offset
+        guard self.isVisibleCell(candidate) else { return }
+        self.keyboardIndex = candidate
     }
 
     private struct MonthMarker: Identifiable {
@@ -558,6 +655,12 @@ private struct SpendActivityDailyGrid: View {
     }
 
     private var accessibilityValue: String {
+        if let index = self.activeIndex, let date = self.series.date(at: index) {
+            let value = self.series.isCovered[index]
+                ? UsageFormatter.tokenCountString(self.series.daily[index])
+                : L("Unavailable")
+            return "\(SpendActivityDateFormatting.mediumDateString(date)): \(value)"
+        }
         let total = UsageFormatter.tokenCountString(Self.saturatingTotal(self.series.daily))
         guard self.series.hasUnknownCoverage else { return total }
         let coverage = spendDashboardCoverageText(
@@ -672,7 +775,11 @@ private struct SpendActivityWeekGrid: View {
 
     private func isVisible(_ column: Int) -> Bool {
         guard let start = self.series.weekStartDate(at: column) else { return false }
-        return start <= self.series.today
+        let end = self.series.calendar.date(
+            byAdding: .day,
+            value: SpendActivitySeries.dayCount - 1,
+            to: start) ?? start
+        return start <= self.series.today && end >= self.series.rangeStart
     }
 
     private var accessibilityTokenTotal: Int {

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -490,8 +490,7 @@ private struct SpendActivityDailyGrid: View {
         .accessibilityChildren {
             ForEach(self.series.daily.indices.filter(self.series.isVisible), id: \.self) { index in
                 if let date = self.series.date(at: index) {
-                    Color.clear
-                        .accessibilityElement()
+                    Text(self.accessibilityTokenValue(at: index))
                         .accessibilityLabel(SpendActivityDateFormatting.mediumDateString(date))
                         .accessibilityValue(self.accessibilityTokenValue(at: index))
                 }

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -25,6 +25,7 @@ struct SpendActivitySeries {
     static let dayCount = 7
 
     let daily: [Int]
+    let isCovered: [Bool]
     let start: Date
     let today: Date
     let calendar: Calendar
@@ -35,9 +36,16 @@ struct SpendActivitySeries {
         calendar: Calendar = .current) -> Self
     {
         var totals: [Date: Int] = [:]
+        var unknownDays: Set<Date> = []
         for point in points {
             let day = calendar.startOfDay(for: point.day)
-            totals[day] = Self.saturatingAdd(totals[day] ?? 0, max(point.totalTokens, 0))
+            guard let totalTokens = point.totalTokens else {
+                totals.removeValue(forKey: day)
+                unknownDays.insert(day)
+                continue
+            }
+            guard !unknownDays.contains(day) else { continue }
+            totals[day] = Self.saturatingAdd(totals[day] ?? 0, max(totalTokens, 0))
         }
 
         let today = calendar.startOfDay(for: now)
@@ -49,13 +57,16 @@ struct SpendActivitySeries {
             to: thisWeekSunday) ?? thisWeekSunday
         let cellCount = Self.weekCount * Self.dayCount
         var daily = [Int](repeating: 0, count: cellCount)
+        var isCovered = [Bool](repeating: false, count: cellCount)
         for index in 0..<cellCount {
             guard let date = calendar.date(byAdding: .day, value: index, to: start), date <= today else {
                 continue
             }
-            daily[index] = totals[date] ?? 0
+            guard !unknownDays.contains(date), let total = totals[date] else { continue }
+            daily[index] = total
+            isCovered[index] = true
         }
-        return Self(daily: daily, start: start, today: today, calendar: calendar)
+        return Self(daily: daily, isCovered: isCovered, start: start, today: today, calendar: calendar)
     }
 
     func date(at index: Int) -> Date? {
@@ -66,9 +77,57 @@ struct SpendActivitySeries {
         self.calendar.date(byAdding: .day, value: week * Self.dayCount, to: self.start)
     }
 
-    private static func saturatingAdd(_ lhs: Int, _ rhs: Int) -> Int {
+    var visibleDayCount: Int {
+        self.daily.indices.filter(self.isVisible).count
+    }
+
+    var coveredDayCount: Int {
+        self.daily.indices.count(where: { self.isVisible($0) && self.isCovered[$0] })
+    }
+
+    var hasUnknownCoverage: Bool {
+        self.coveredDayCount < self.visibleDayCount
+    }
+
+    func weeklyActivity() -> SpendActivityAggregateSeries {
+        var values: [Int] = []
+        var coverage: [Bool] = []
+        for start in stride(from: 0, to: self.daily.count, by: Self.dayCount) {
+            let indices = start..<min(start + Self.dayCount, self.daily.count)
+            let visible = indices.filter(self.isVisible)
+            values.append(visible.reduce(0) { Self.saturatingAdd($0, self.daily[$1]) })
+            coverage.append(!visible.isEmpty && visible.allSatisfy { self.isCovered[$0] })
+        }
+        return SpendActivityAggregateSeries(values: values, isCovered: coverage)
+    }
+
+    private func isVisible(_ index: Int) -> Bool {
+        guard let date = self.date(at: index) else { return false }
+        return date <= self.today
+    }
+
+    static func saturatingAdd(_ lhs: Int, _ rhs: Int) -> Int {
         let result = lhs.addingReportingOverflow(rhs)
         return result.overflow ? Int.max : result.partialValue
+    }
+}
+
+struct SpendActivityAggregateSeries: Equatable {
+    let values: [Int]
+    let isCovered: [Bool]
+
+    func cumulative() -> Self {
+        var total = 0
+        var coverageIsComplete = true
+        var cumulativeValues: [Int] = []
+        var cumulativeCoverage: [Bool] = []
+        for index in self.values.indices {
+            total = SpendActivitySeries.saturatingAdd(total, self.values[index])
+            coverageIsComplete = coverageIsComplete && self.isCovered[index]
+            cumulativeValues.append(total)
+            cumulativeCoverage.append(coverageIsComplete)
+        }
+        return Self(values: cumulativeValues, isCovered: cumulativeCoverage)
     }
 }
 
@@ -115,6 +174,10 @@ enum SpendActivityLevels {
 
     static var uniformFill: Color {
         self.rgb(0x40C463)
+    }
+
+    static var unavailableFill: Color {
+        self.rgb(0xD6DCE5)
     }
 
     private static func rgb(_ hex: UInt32) -> Color {
@@ -199,14 +262,23 @@ struct SpendActivityHeatmapView: View {
 
     var body: some View {
         let hasActivity = (self.series.daily.max() ?? 0) > 0
+        let hasUnknownCoverage = self.series.hasUnknownCoverage
         let totalTokens = Self.saturatingTotal(self.series.daily)
+        let coverageText = spendDashboardCoverageText(
+            covered: self.series.coveredDayCount,
+            requested: self.series.visibleDayCount)
+        let weekly = self.series.weeklyActivity()
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .firstTextBaseline, spacing: 16) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(L("Token activity"))
                         .font(.headline)
                     if hasActivity {
-                        Text("\(UsageFormatter.tokenCountString(totalTokens)) \(L("in the last year"))")
+                        Text(self.activitySummary(totalTokens: totalTokens, coverageText: coverageText))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else if hasUnknownCoverage {
+                        Text("\(L("Unavailable")) · \(coverageText)")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -222,7 +294,7 @@ struct SpendActivityHeatmapView: View {
                 .fixedSize()
             }
 
-            if hasActivity {
+            if hasActivity || hasUnknownCoverage {
                 switch self.mode {
                 case .daily:
                     SpendActivityDailyGrid(series: self.series)
@@ -230,16 +302,17 @@ struct SpendActivityHeatmapView: View {
                 case .weekly:
                     SpendActivityWeekGrid(
                         series: self.series,
-                        values: SpendActivityLevels.weeklyTotals(self.series.daily),
+                        activity: weekly,
                         cumulative: false)
-                    self.caption(L("Each column = 1 week"))
+                    self.caption(
+                        L("Each column = 1 week"),
+                        showsUnavailable: weekly.isCovered.contains(false))
                 case .cumulative:
                     SpendActivityWeekGrid(
                         series: self.series,
-                        values: SpendActivityLevels.cumulativeTotals(
-                            SpendActivityLevels.weeklyTotals(self.series.daily)),
+                        activity: weekly.cumulative(),
                         cumulative: true)
-                    self.caption(L("Running total"))
+                    self.caption(L("Running total"), showsUnavailable: hasUnknownCoverage)
                 }
             } else {
                 Text(L("No activity in the last 12 months"))
@@ -265,15 +338,38 @@ struct SpendActivityHeatmapView: View {
                     .frame(width: 9, height: 9)
             }
             Text(L("More"))
+            if self.series.hasUnknownCoverage {
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(SpendActivityLevels.unavailableFill)
+                    .frame(width: 9, height: 9)
+                    .padding(.leading, 6)
+                Text(L("Unavailable"))
+            }
         }
         .font(.caption2)
         .foregroundStyle(.secondary)
     }
 
-    private func caption(_ text: String) -> some View {
-        Text(text)
-            .font(.caption2)
-            .foregroundStyle(.secondary)
+    private func caption(_ text: String, showsUnavailable: Bool) -> some View {
+        HStack(spacing: 4) {
+            Text(text)
+            Spacer()
+            if showsUnavailable {
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(SpendActivityLevels.unavailableFill)
+                    .frame(width: 9, height: 9)
+                Text(L("Unavailable"))
+            }
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+
+    private func activitySummary(totalTokens: Int, coverageText: String) -> String {
+        let total = UsageFormatter.tokenCountString(totalTokens)
+        return self.series.hasUnknownCoverage
+            ? "\(total) · \(coverageText)"
+            : "\(total) \(L("in the last year"))"
     }
 
     private static func saturatingTotal(_ values: [Int]) -> Int {
@@ -313,9 +409,12 @@ private struct SpendActivityDailyGrid: View {
                                     y: CGFloat(row) * pitch + (pitch - cell) / 2,
                                     width: cell,
                                     height: cell)
+                                let fill = self.series.isCovered[index]
+                                    ? SpendActivityLevels.color(forLevel: levels[index])
+                                    : SpendActivityLevels.unavailableFill
                                 context.fill(
                                     RoundedRectangle(cornerRadius: corner, style: .continuous).path(in: rect),
-                                    with: .color(SpendActivityLevels.color(forLevel: levels[index])))
+                                    with: .color(fill))
                             }
                         }
                         self.hoverHighlight(cell: cell, pitch: pitch)
@@ -338,7 +437,7 @@ private struct SpendActivityDailyGrid: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(L("Token activity"))
-        .accessibilityValue(UsageFormatter.tokenCountString(Self.saturatingTotal(self.series.daily)))
+        .accessibilityValue(self.accessibilityValue)
     }
 
     private var monthRow: some View {
@@ -398,7 +497,9 @@ private struct SpendActivityDailyGrid: View {
                 tooltipHeight: SpendActivityGridGeometry.tooltipHeight,
                 gridHeight: size.height)
             SpendActivityTooltip(
-                title: UsageFormatter.tokenCountString(self.series.daily[index]),
+                title: self.series.isCovered[index]
+                    ? UsageFormatter.tokenCountString(self.series.daily[index])
+                    : L("Unavailable"),
                 subtitle: SpendActivityDateFormatting.mediumDateString(date),
                 width: width)
                 .position(
@@ -455,11 +556,20 @@ private struct SpendActivityDailyGrid: View {
             return result.overflow ? Int.max : result.partialValue
         }
     }
+
+    private var accessibilityValue: String {
+        let total = UsageFormatter.tokenCountString(Self.saturatingTotal(self.series.daily))
+        guard self.series.hasUnknownCoverage else { return total }
+        let coverage = spendDashboardCoverageText(
+            covered: self.series.coveredDayCount,
+            requested: self.series.visibleDayCount)
+        return "\(total) · \(coverage)"
+    }
 }
 
 private struct SpendActivityWeekGrid: View {
     let series: SpendActivitySeries
-    let values: [Int]
+    let activity: SpendActivityAggregateSeries
     let cumulative: Bool
 
     @State private var hoverLocation: CGPoint?
@@ -468,7 +578,10 @@ private struct SpendActivityWeekGrid: View {
     private let rows = SpendActivitySeries.dayCount
 
     var body: some View {
-        let maxValue = self.values.max() ?? 0
+        let maxValue = self.activity.values.enumerated()
+            .filter { self.activity.isCovered[$0.offset] }
+            .map(\.element)
+            .max() ?? 0
         GeometryReader { proxy in
             let gridFrame = SpendActivityGridGeometry.gridFrame(containerWidth: proxy.size.width)
             let pitch = gridFrame.width / CGFloat(self.columns)
@@ -476,13 +589,21 @@ private struct SpendActivityWeekGrid: View {
             ZStack(alignment: .topLeading) {
                 Canvas { context, _ in
                     let corner = min(cell * 0.22, 2.5)
-                    for col in 0..<self.columns where col < self.values.count && self.isVisible(col) {
-                        let value = self.values[col]
+                    for col in 0..<self.columns where col < self.activity.values.count && self.isVisible(col) {
+                        let value = self.activity.values[col]
+                        let isCovered = self.activity.isCovered[col]
                         let rawFill = maxValue > 0
                             ? Int((Double(value) / Double(maxValue) * Double(self.rows)).rounded())
                             : 0
                         let filled = value > 0 ? max(rawFill, 1) : 0
                         for row in 0..<self.rows {
+                            let fill: Color = if !isCovered {
+                                SpendActivityLevels.unavailableFill
+                            } else if row >= self.rows - filled {
+                                SpendActivityLevels.uniformFill
+                            } else {
+                                SpendActivityLevels.color(forLevel: 0)
+                            }
                             let rect = CGRect(
                                 x: CGFloat(col) * pitch + (pitch - cell) / 2,
                                 y: CGFloat(row) * pitch + (pitch - cell) / 2,
@@ -490,9 +611,7 @@ private struct SpendActivityWeekGrid: View {
                                 height: cell)
                             context.fill(
                                 RoundedRectangle(cornerRadius: corner, style: .continuous).path(in: rect),
-                                with: .color(row >= self.rows - filled
-                                    ? SpendActivityLevels.uniformFill
-                                    : SpendActivityLevels.color(forLevel: 0)))
+                                with: .color(fill))
                         }
                     }
                 }
@@ -513,14 +632,14 @@ private struct SpendActivityWeekGrid: View {
         .aspectRatio(CGFloat(self.columns + 2) / CGFloat(self.rows), contentMode: .fit)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(L("Token activity"))
-        .accessibilityValue(UsageFormatter.tokenCountString(self.accessibilityTokenTotal))
+        .accessibilityValue(self.accessibilityValue)
     }
 
     @ViewBuilder
     private func tooltip(size: CGSize, pitch: CGFloat) -> some View {
         if let location = self.hoverLocation,
            let col = self.column(at: location, pitch: pitch),
-           col < self.values.count,
+           col < self.activity.values.count,
            let weekStart = self.series.weekStartDate(at: col)
         {
             let width = min(SpendActivityGridGeometry.tooltipWidth, max(size.width - 8, 1))
@@ -529,7 +648,9 @@ private struct SpendActivityWeekGrid: View {
                 tooltipHeight: SpendActivityGridGeometry.tooltipHeight,
                 gridHeight: size.height)
             SpendActivityTooltip(
-                title: UsageFormatter.tokenCountString(self.values[col]),
+                title: self.activity.isCovered[col]
+                    ? UsageFormatter.tokenCountString(self.activity.values[col])
+                    : L("Unavailable"),
                 subtitle: SpendActivityDateFormatting.mediumDateString(weekStart),
                 width: width)
                 .position(
@@ -555,11 +676,23 @@ private struct SpendActivityWeekGrid: View {
     }
 
     private var accessibilityTokenTotal: Int {
-        if self.cumulative { return self.values.last ?? 0 }
-        return self.values.reduce(0) { total, value in
+        if self.cumulative { return self.activity.values.last ?? 0 }
+        return self.activity.values.reduce(0) { total, value in
             let result = total.addingReportingOverflow(value)
             return result.overflow ? Int.max : result.partialValue
         }
+    }
+
+    private var accessibilityValue: String {
+        let total = UsageFormatter.tokenCountString(self.accessibilityTokenTotal)
+        let hasUnavailable = self.activity.isCovered.enumerated().contains { index, covered in
+            self.isVisible(index) && !covered
+        }
+        guard hasUnavailable else { return total }
+        let coverage = spendDashboardCoverageText(
+            covered: self.series.coveredDayCount,
+            requested: self.series.visibleDayCount)
+        return "\(total) · \(coverage)"
     }
 }
 

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -750,9 +750,16 @@ private struct SpendActivityWeekGrid: View {
             .offset(x: gridFrame.minX)
         }
         .aspectRatio(CGFloat(self.columns + 2) / CGFloat(self.rows), contentMode: .fit)
-        .accessibilityElement(children: .ignore)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(L("Token activity"))
         .accessibilityValue(self.accessibilityValue)
+        .accessibilityChildren {
+            ForEach(self.activity.values.indices.filter(self.isVisible), id: \.self) { index in
+                if let weekStart = self.series.weekStartDate(at: index) {
+                    Text(self.accessibilityDescription(at: index, weekStart: weekStart))
+                }
+            }
+        }
     }
 
     @ViewBuilder
@@ -817,6 +824,13 @@ private struct SpendActivityWeekGrid: View {
             covered: self.series.coveredDayCount,
             requested: self.series.visibleDayCount)
         return "\(total) · \(coverage)"
+    }
+
+    private func accessibilityDescription(at index: Int, weekStart: Date) -> String {
+        let value = self.activity.isCovered[index]
+            ? UsageFormatter.tokenCountString(self.activity.values[index])
+            : L("Unavailable")
+        return "\(SpendActivityDateFormatting.mediumDateString(weekStart)): \(value)"
     }
 }
 

--- a/Sources/CodexBar/SpendDashboardController.swift
+++ b/Sources/CodexBar/SpendDashboardController.swift
@@ -121,7 +121,7 @@ enum SpendDashboardSource {
     typealias CodexSnapshotLoader = @Sendable (CodexSpendSnapshotLoadContext) async throws
         -> CostUsageTokenSnapshot
 
-    static let scanDays = 30
+    static let scanDays = 365
 
     @MainActor
     static func configuration(settings: SettingsStore, store: UsageStore) -> SpendDashboardConfiguration {

--- a/Sources/CodexBar/SpendDashboardController.swift
+++ b/Sources/CodexBar/SpendDashboardController.swift
@@ -121,7 +121,9 @@ enum SpendDashboardSource {
     typealias CodexSnapshotLoader = @Sendable (CodexSpendSnapshotLoadContext) async throws
         -> CostUsageTokenSnapshot
 
-    static let scanDays = 365
+    static let scanDays = 30
+    static let activityScanDays = SpendDashboardModel.tokenActivityDayCount
+    private static let activitySnapshotCache = SpendDashboardCodexActivitySnapshotCache()
 
     @MainActor
     static func configuration(settings: SettingsStore, store: UsageStore) -> SpendDashboardConfiguration {
@@ -250,14 +252,32 @@ enum SpendDashboardSource {
     }
 
     static func load(_ request: SpendDashboardLoadRequest) async -> SpendDashboardLoadResult {
-        await self.load(request, codexSnapshotLoader: { context in
-            try await self.loadCodexSnapshot(context)
-        })
+        await self.load(
+            request,
+            codexSnapshotLoader: { context in
+                try await self.loadCodexSnapshot(context)
+            },
+            codexActivitySnapshotLoader: { context in
+                try await self.activitySnapshotCache.load(context) { activityContext in
+                    try await self.loadCodexSnapshot(activityContext)
+                }
+            })
     }
 
     static func load(
         _ request: SpendDashboardLoadRequest,
         codexSnapshotLoader: CodexSnapshotLoader) async -> SpendDashboardLoadResult
+    {
+        await self.load(
+            request,
+            codexSnapshotLoader: codexSnapshotLoader,
+            codexActivitySnapshotLoader: codexSnapshotLoader)
+    }
+
+    static func load(
+        _ request: SpendDashboardLoadRequest,
+        codexSnapshotLoader: CodexSnapshotLoader,
+        codexActivitySnapshotLoader: CodexSnapshotLoader) async -> SpendDashboardLoadResult
     {
         var inputs = request.capturedInputs
         var failedSourceIDs = request.unavailableSourceIDs
@@ -287,12 +307,32 @@ enum SpendDashboardSource {
                     invalidatedSourceIDs.insert(sourceID)
                     continue
                 }
+                var tokenActivitySnapshot = snapshot
+                do {
+                    tokenActivitySnapshot = try await codexActivitySnapshotLoader(CodexSpendSnapshotLoadContext(
+                        account: account,
+                        cacheRoot: cacheRoot,
+                        now: request.now,
+                        force: false,
+                        historyDays: Self.activityScanDays,
+                        refreshPricingInBackground: false,
+                        includePiSessions: false))
+                    try Task.checkCancellation()
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {}
+                guard self.currentAuthFingerprint(for: account) == account.authFingerprint else {
+                    failedSourceIDs.insert(sourceID)
+                    invalidatedSourceIDs.insert(sourceID)
+                    continue
+                }
                 inputs.append(SpendDashboardModel.ProviderInput(
                     id: sourceID,
                     provider: .codex,
                     displayName: account.displayName,
                     modelProviderName: ProviderDescriptorRegistry.descriptor(for: .codex).metadata.displayName,
-                    snapshot: snapshot))
+                    snapshot: snapshot,
+                    tokenActivitySnapshot: tokenActivitySnapshot))
             } catch is CancellationError {
                 failedSourceIDs.formUnion(request.codexRequests.map { "codex:\($0.id)" })
                 return SpendDashboardLoadResult(
@@ -497,6 +537,63 @@ enum SpendDashboardSource {
     private static func currentAuthFingerprint(for request: CodexSpendScanRequest) -> String? {
         let current = CodexAuthFingerprint.fingerprint(homePath: request.homePath)
         return request.authFileWasReadable ? current : current ?? request.authFingerprint
+    }
+}
+
+actor SpendDashboardCodexActivitySnapshotCache {
+    private struct Entry {
+        let snapshot: CostUsageTokenSnapshot
+        let expiresAt: Date
+    }
+
+    private let refreshInterval: TimeInterval
+    private var entries: [String: Entry] = [:]
+    private var inFlight: [String: Task<CostUsageTokenSnapshot, Error>] = [:]
+
+    init(refreshInterval: TimeInterval = 15 * 60) {
+        self.refreshInterval = refreshInterval
+    }
+
+    func load(
+        _ context: CodexSpendSnapshotLoadContext,
+        loader: @escaping SpendDashboardSource.CodexSnapshotLoader) async throws -> CostUsageTokenSnapshot
+    {
+        let key = Self.key(for: context)
+        if let entry = self.entries[key], context.now < entry.expiresAt {
+            return entry.snapshot
+        }
+        if let task = self.inFlight[key] {
+            return try await task.value
+        }
+
+        let task = Task { try await loader(context) }
+        self.inFlight[key] = task
+        do {
+            let snapshot = try await task.value
+            self.entries[key] = Entry(
+                snapshot: snapshot,
+                expiresAt: Self.expirationDate(from: context.now, refreshInterval: self.refreshInterval))
+            self.inFlight[key] = nil
+            return snapshot
+        } catch {
+            self.inFlight[key] = nil
+            throw error
+        }
+    }
+
+    private static func key(for context: CodexSpendSnapshotLoadContext) -> String {
+        [
+            context.cacheRoot.standardizedFileURL.path,
+            context.account.cacheIdentity,
+            context.account.authFingerprint ?? "missing-auth",
+        ].joined(separator: "|")
+    }
+
+    private static func expirationDate(from now: Date, refreshInterval: TimeInterval) -> Date {
+        let intervalExpiry = now.addingTimeInterval(refreshInterval)
+        let calendar = Calendar.current
+        let nextDay = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now)) ?? intervalExpiry
+        return min(intervalExpiry, nextDay)
     }
 }
 
@@ -998,7 +1095,8 @@ final class SpendDashboardController {
             provider: input.provider,
             displayName: displayName,
             modelProviderName: input.modelProviderName,
-            snapshot: input.snapshot)
+            snapshot: input.snapshot,
+            tokenActivitySnapshot: input.tokenActivitySnapshot)
     }
 
     private static func sameSourceOwnership(

--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -61,6 +61,15 @@ struct SpendDashboardModel: Equatable, Sendable {
         }
     }
 
+    struct TokenActivityPoint: Identifiable, Equatable, Sendable {
+        let day: Date
+        let totalTokens: Int
+
+        var id: Date {
+            self.day
+        }
+    }
+
     enum ModelHistoryCompleteness: Equatable, Sendable {
         case complete
         case incomplete
@@ -84,6 +93,17 @@ struct SpendDashboardModel: Equatable, Sendable {
 
     let requestedDays: Int
     let groups: [CurrencyGroup]
+    let tokenActivity: [TokenActivityPoint]
+
+    init(
+        requestedDays: Int,
+        groups: [CurrencyGroup],
+        tokenActivity: [TokenActivityPoint] = [])
+    {
+        self.requestedDays = requestedDays
+        self.groups = groups
+        self.tokenActivity = tokenActivity
+    }
 
     static func build(
         inputs: [ProviderInput],
@@ -118,7 +138,13 @@ struct SpendDashboardModel: Equatable, Sendable {
                     calendar: calculationCalendar)
             }
             .sorted { $0.currencyCode < $1.currencyCode }
-        return Self(requestedDays: days, groups: groups)
+        return Self(
+            requestedDays: days,
+            groups: groups,
+            tokenActivity: Self.tokenActivity(
+                inputs: inputs,
+                now: now,
+                calendar: calculationCalendar))
     }
 
     private struct ClassifiedInput {
@@ -539,6 +565,31 @@ struct SpendDashboardModel: Equatable, Sendable {
                     stackEnd: cursor))
             }
             return points
+        }
+    }
+
+    private static func tokenActivity(
+        inputs: [ProviderInput],
+        now: Date,
+        calendar: Calendar) -> [TokenActivityPoint]
+    {
+        let bounds = Self.bounds(days: 365, now: now, calendar: calendar)
+        var totals: [Date: Int] = [:]
+        for input in inputs {
+            for entry in input.snapshot.daily {
+                guard let day = Self.day(
+                    entry.date,
+                    provider: input.provider,
+                    displayCalendar: calendar),
+                    bounds.contains(day),
+                    let tokens = Self.nonnegative(entry.totalTokens)
+                else { continue }
+                let addition = (totals[day] ?? 0).addingReportingOverflow(tokens)
+                totals[day] = addition.overflow ? Int.max : addition.partialValue
+            }
+        }
+        return totals.keys.sorted().map { day in
+            TokenActivityPoint(day: day, totalTokens: totals[day] ?? 0)
         }
     }
 

--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -63,7 +63,9 @@ struct SpendDashboardModel: Equatable, Sendable {
 
     struct TokenActivityPoint: Identifiable, Equatable, Sendable {
         let day: Date
-        let totalTokens: Int
+        /// `nil` means at least one included source cannot establish coverage for this day.
+        /// This must stay distinct from a proven zero so the heatmap does not fabricate inactivity.
+        let totalTokens: Int?
 
         var id: Date {
             self.day
@@ -94,6 +96,8 @@ struct SpendDashboardModel: Equatable, Sendable {
     let requestedDays: Int
     let groups: [CurrencyGroup]
     let tokenActivity: [TokenActivityPoint]
+
+    static let tokenActivityDayCount = 365
 
     init(
         requestedDays: Int,
@@ -202,6 +206,25 @@ struct SpendDashboardModel: Equatable, Sendable {
         var cost: Double?
         var invalid = false
         var overflowed = false
+    }
+
+    private struct TokenActivityInputSummary {
+        let coveredInterval: ClosedRange<Date>?
+        let totalsByDay: [Date: Int]
+        let invalidDays: Set<Date>
+        let hasCompleteHistory: Bool
+        let isGloballyInvalid: Bool
+
+        func tokens(on day: Date) -> Int? {
+            guard self.coveredInterval?.contains(day) == true,
+                  !self.isGloballyInvalid,
+                  !self.invalidDays.contains(day)
+            else { return nil }
+            if let tokens = self.totalsByDay[day] {
+                return tokens
+            }
+            return self.hasCompleteHistory ? 0 : nil
+        }
     }
 
     private static func buildCurrencyGroup(
@@ -573,24 +596,68 @@ struct SpendDashboardModel: Equatable, Sendable {
         now: Date,
         calendar: Calendar) -> [TokenActivityPoint]
     {
-        let bounds = Self.bounds(days: 365, now: now, calendar: calendar)
-        var totals: [Date: Int] = [:]
-        for input in inputs {
-            for entry in input.snapshot.daily {
-                guard let day = Self.day(
-                    entry.date,
-                    provider: input.provider,
-                    displayCalendar: calendar),
-                    bounds.contains(day),
-                    let tokens = Self.nonnegative(entry.totalTokens)
-                else { continue }
-                let addition = (totals[day] ?? 0).addingReportingOverflow(tokens)
-                totals[day] = addition.overflow ? Int.max : addition.partialValue
+        guard !inputs.isEmpty else { return [] }
+        let bounds = Self.bounds(days: Self.tokenActivityDayCount, now: now, calendar: calendar)
+        let summaries = inputs.map {
+            Self.tokenActivityInputSummary(input: $0, bounds: bounds, calendar: calendar)
+        }
+        return (0..<Self.tokenActivityDayCount).compactMap { offset in
+            guard let day = calendar.date(byAdding: .day, value: offset, to: bounds.lowerBound) else {
+                return nil
+            }
+            var total = 0
+            for summary in summaries {
+                guard let tokens = summary.tokens(on: day) else {
+                    return TokenActivityPoint(day: day, totalTokens: nil)
+                }
+                let addition = total.addingReportingOverflow(tokens)
+                total = addition.overflow ? Int.max : addition.partialValue
+            }
+            return TokenActivityPoint(day: day, totalTokens: total)
+        }
+    }
+
+    private static func tokenActivityInputSummary(
+        input: ProviderInput,
+        bounds: ClosedRange<Date>,
+        calendar: Calendar) -> TokenActivityInputSummary
+    {
+        let coveredInterval = Self.coverageInterval(
+            input: input,
+            bounds: bounds,
+            displayCalendar: calendar)
+        let sourceCoverage = Self.sourceCoverageInterval(input: input, displayCalendar: calendar)
+        var totalsByDay: [Date: Int] = [:]
+        var invalidDays: Set<Date> = []
+        var hasUnplacedTokens = false
+        for entry in input.snapshot.daily {
+            guard let day = Self.day(entry.date, provider: input.provider, displayCalendar: calendar) else {
+                hasUnplacedTokens = hasUnplacedTokens || !Self.hasProvenZeroTokens(entry)
+                continue
+            }
+            guard sourceCoverage.contains(day) else { continue }
+            guard let tokens = Self.nonnegative(entry.totalTokens) else {
+                invalidDays.insert(day)
+                continue
+            }
+            guard !invalidDays.contains(day) else { continue }
+            let addition = (totalsByDay[day] ?? 0).addingReportingOverflow(tokens)
+            if addition.overflow {
+                totalsByDay.removeValue(forKey: day)
+                invalidDays.insert(day)
+            } else {
+                totalsByDay[day] = addition.partialValue
             }
         }
-        return totals.keys.sorted().map { day in
-            TokenActivityPoint(day: day, totalTokens: totals[day] ?? 0)
-        }
+
+        let hasCompleteHistory = Self.hasCompleteTokenHistory(input, displayCalendar: calendar)
+        let aggregateIsInconsistent = input.snapshot.last30DaysTokens != nil && !hasCompleteHistory
+        return TokenActivityInputSummary(
+            coveredInterval: coveredInterval,
+            totalsByDay: totalsByDay,
+            invalidDays: invalidDays,
+            hasCompleteHistory: hasCompleteHistory,
+            isGloballyInvalid: hasUnplacedTokens || aggregateIsInconsistent)
     }
 
     private static func bounds(days: Int, now: Date, calendar: Calendar) -> ClosedRange<Date> {

--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -680,7 +680,13 @@ struct SpendDashboardModel: Equatable, Sendable {
             }
         }
 
-        let hasCompleteHistory = Self.hasCompleteTokenHistory(input, displayCalendar: calendar)
+        // A successful scan that found no sessions is confirmed zero activity: every covered day
+        // renders as zero instead of unavailable. Nonempty histories must still reconcile their
+        // aggregate against the daily entries.
+        let confirmedZeroHistory = input.snapshot.daily.isEmpty
+            && input.snapshot.last30DaysTokens == nil
+        let hasCompleteHistory = confirmedZeroHistory
+            || Self.hasCompleteTokenHistory(input, displayCalendar: calendar)
         let aggregateIsInconsistent = input.snapshot.last30DaysTokens != nil && !hasCompleteHistory
         if hasUnplacedTokens || aggregateIsInconsistent {
             invalidDays.formUnion(coveredDays)

--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -8,19 +8,22 @@ struct SpendDashboardModel: Equatable, Sendable {
         let displayName: String
         let modelProviderName: String
         let snapshot: CostUsageTokenSnapshot
+        let tokenActivitySnapshot: CostUsageTokenSnapshot
 
         init(
             id: String? = nil,
             provider: UsageProvider,
             displayName: String,
             modelProviderName: String? = nil,
-            snapshot: CostUsageTokenSnapshot)
+            snapshot: CostUsageTokenSnapshot,
+            tokenActivitySnapshot: CostUsageTokenSnapshot? = nil)
         {
             self.id = id ?? provider.rawValue
             self.provider = provider
             self.displayName = displayName
             self.modelProviderName = modelProviderName ?? displayName
             self.snapshot = snapshot
+            self.tokenActivitySnapshot = tokenActivitySnapshot ?? snapshot
         }
     }
 
@@ -206,25 +209,6 @@ struct SpendDashboardModel: Equatable, Sendable {
         var cost: Double?
         var invalid = false
         var overflowed = false
-    }
-
-    private struct TokenActivityInputSummary {
-        let coveredInterval: ClosedRange<Date>?
-        let totalsByDay: [Date: Int]
-        let invalidDays: Set<Date>
-        let hasCompleteHistory: Bool
-        let isGloballyInvalid: Bool
-
-        func tokens(on day: Date) -> Int? {
-            guard self.coveredInterval?.contains(day) == true,
-                  !self.isGloballyInvalid,
-                  !self.invalidDays.contains(day)
-            else { return nil }
-            if let tokens = self.totalsByDay[day] {
-                return tokens
-            }
-            return self.hasCompleteHistory ? 0 : nil
-        }
     }
 
     private static func buildCurrencyGroup(
@@ -620,12 +604,58 @@ struct SpendDashboardModel: Equatable, Sendable {
     private static func tokenActivityInputSummary(
         input: ProviderInput,
         bounds: ClosedRange<Date>,
-        calendar: Calendar) -> TokenActivityInputSummary
+        calendar: Calendar) -> SpendTokenActivityInputSummary
+    {
+        let annualInput = ProviderInput(
+            id: input.id,
+            provider: input.provider,
+            displayName: input.displayName,
+            modelProviderName: input.modelProviderName,
+            snapshot: input.tokenActivitySnapshot)
+        let annual = Self.tokenActivitySnapshotSummary(input: annualInput, bounds: bounds, calendar: calendar)
+        guard input.snapshot != input.tokenActivitySnapshot else { return annual }
+
+        let recentInput = ProviderInput(
+            id: input.id,
+            provider: input.provider,
+            displayName: input.displayName,
+            modelProviderName: input.modelProviderName,
+            snapshot: input.snapshot)
+        let recent = Self.tokenActivitySnapshotSummary(input: recentInput, bounds: bounds, calendar: calendar)
+        var totalsByDay = annual.totalsByDay
+        var invalidDays = annual.invalidDays
+        var zeroKnownDays = annual.zeroKnownDays
+        for day in recent.coveredDays {
+            totalsByDay.removeValue(forKey: day)
+            invalidDays.remove(day)
+            zeroKnownDays.remove(day)
+            if let tokens = recent.totalsByDay[day] {
+                totalsByDay[day] = tokens
+            }
+            if recent.invalidDays.contains(day) {
+                invalidDays.insert(day)
+            }
+            if recent.zeroKnownDays.contains(day) {
+                zeroKnownDays.insert(day)
+            }
+        }
+        return SpendTokenActivityInputSummary(
+            coveredDays: annual.coveredDays.union(recent.coveredDays),
+            totalsByDay: totalsByDay,
+            invalidDays: invalidDays,
+            zeroKnownDays: zeroKnownDays)
+    }
+
+    private static func tokenActivitySnapshotSummary(
+        input: ProviderInput,
+        bounds: ClosedRange<Date>,
+        calendar: Calendar) -> SpendTokenActivityInputSummary
     {
         let coveredInterval = Self.coverageInterval(
             input: input,
             bounds: bounds,
             displayCalendar: calendar)
+        let coveredDays = Self.days(in: coveredInterval, calendar: calendar)
         let sourceCoverage = Self.sourceCoverageInterval(input: input, displayCalendar: calendar)
         var totalsByDay: [Date: Int] = [:]
         var invalidDays: Set<Date> = []
@@ -652,12 +682,26 @@ struct SpendDashboardModel: Equatable, Sendable {
 
         let hasCompleteHistory = Self.hasCompleteTokenHistory(input, displayCalendar: calendar)
         let aggregateIsInconsistent = input.snapshot.last30DaysTokens != nil && !hasCompleteHistory
-        return TokenActivityInputSummary(
-            coveredInterval: coveredInterval,
+        if hasUnplacedTokens || aggregateIsInconsistent {
+            invalidDays.formUnion(coveredDays)
+        }
+        return SpendTokenActivityInputSummary(
+            coveredDays: coveredDays,
             totalsByDay: totalsByDay,
             invalidDays: invalidDays,
-            hasCompleteHistory: hasCompleteHistory,
-            isGloballyInvalid: hasUnplacedTokens || aggregateIsInconsistent)
+            zeroKnownDays: hasCompleteHistory ? coveredDays : [])
+    }
+
+    private static func days(in interval: ClosedRange<Date>?, calendar: Calendar) -> Set<Date> {
+        guard let interval else { return [] }
+        var result: Set<Date> = []
+        var day = interval.lowerBound
+        while day <= interval.upperBound {
+            result.insert(day)
+            guard let next = calendar.date(byAdding: .day, value: 1, to: day), next > day else { break }
+            day = next
+        }
+        return result
     }
 
     private static func bounds(days: Int, now: Date, calendar: Calendar) -> ClosedRange<Date> {
@@ -820,5 +864,20 @@ struct SpendDashboardModel: Equatable, Sendable {
             return nil
         }
         return result
+    }
+}
+
+private struct SpendTokenActivityInputSummary {
+    let coveredDays: Set<Date>
+    let totalsByDay: [Date: Int]
+    let invalidDays: Set<Date>
+    let zeroKnownDays: Set<Date>
+
+    func tokens(on day: Date) -> Int? {
+        guard self.coveredDays.contains(day), !self.invalidDays.contains(day) else { return nil }
+        if let tokens = self.totalsByDay[day] {
+            return tokens
+        }
+        return self.zeroKnownDays.contains(day) ? 0 : nil
     }
 }

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -21,7 +21,7 @@ struct SpendActivityHeatmapTests {
     }
 
     @Test
-    func `series uses a fixed Sunday first 52 week window`() throws {
+    func `series uses a Sunday aligned 53 week container for exactly 365 visible days`() throws {
         let calendar = Self.calendar
         let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 8, day: 5)))
         let previousDay = try #require(calendar.date(byAdding: .day, value: -1, to: now))
@@ -35,12 +35,35 @@ struct SpendActivityHeatmapTests {
             now: now,
             calendar: calendar)
 
-        #expect(series.daily.count == 52 * 7)
-        #expect(series.isCovered.count == 52 * 7)
+        #expect(series.daily.count == 53 * 7)
+        #expect(series.isCovered.count == 53 * 7)
         #expect(calendar.component(.weekday, from: series.start) == 1)
+        #expect(series.visibleDayCount == 365)
         #expect(series.daily.reduce(0, +) == 30)
         #expect(series.coveredDayCount == 2)
         #expect(series.date(at: series.daily.count - 1)! > series.today)
+    }
+
+    @Test(arguments: Array(2...8))
+    func `oldest annual day remains visible for every ending weekday`(augustDay: Int) throws {
+        let calendar = Self.calendar
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 8, day: augustDay)))
+        let rangeStart = try #require(calendar.date(
+            byAdding: .day,
+            value: -(SpendActivitySeries.rangeDayCount - 1),
+            to: now))
+        let points = try (0..<SpendActivitySeries.rangeDayCount).map { offset in
+            let day = try #require(calendar.date(byAdding: .day, value: offset, to: rangeStart))
+            return SpendDashboardModel.TokenActivityPoint(day: day, totalTokens: offset == 0 ? 1 : 0)
+        }
+        let series = SpendActivitySeries.make(from: points, now: now, calendar: calendar)
+        let visibleIndices = series.daily.indices.filter(series.isVisible)
+
+        #expect(series.visibleDayCount == SpendActivitySeries.rangeDayCount)
+        #expect(series.coveredDayCount == SpendActivitySeries.rangeDayCount)
+        #expect(series.daily.reduce(0, +) == 1)
+        #expect(visibleIndices.first.flatMap(series.date(at:)) == rangeStart)
+        #expect(visibleIndices.last.flatMap(series.date(at:)) == now)
     }
 
     @Test
@@ -118,6 +141,7 @@ struct SpendActivityHeatmapTests {
             daily: [Int](repeating: 1, count: covered.count),
             isCovered: covered,
             start: start,
+            rangeStart: start,
             today: today,
             calendar: Self.calendar)
 
@@ -168,6 +192,16 @@ struct SpendActivityHeatmapTests {
         #expect(SpendActivityGridGeometry.weekdayCenter(row: 3, rowPitch: pitch) == pitch * 3.5)
         #expect(SpendActivityGridGeometry.weekdayCenter(row: 5, rowPitch: pitch) == pitch * 5.5)
         #expect(frame.height == pitch * 7)
+    }
+
+    @Test
+    func `grid keyboard navigation follows rows and weeks without wrapping`() {
+        #expect(SpendActivityGridNavigation.candidate(from: 10, move: .left, rows: 7) == 3)
+        #expect(SpendActivityGridNavigation.candidate(from: 10, move: .right, rows: 7) == 17)
+        #expect(SpendActivityGridNavigation.candidate(from: 10, move: .up, rows: 7) == 9)
+        #expect(SpendActivityGridNavigation.candidate(from: 10, move: .down, rows: 7) == 11)
+        #expect(SpendActivityGridNavigation.candidate(from: 7, move: .up, rows: 7) == nil)
+        #expect(SpendActivityGridNavigation.candidate(from: 13, move: .down, rows: 7) == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -36,41 +36,127 @@ struct SpendActivityHeatmapTests {
             calendar: calendar)
 
         #expect(series.daily.count == 52 * 7)
+        #expect(series.isCovered.count == 52 * 7)
         #expect(calendar.component(.weekday, from: series.start) == 1)
         #expect(series.daily.reduce(0, +) == 30)
+        #expect(series.coveredDayCount == 2)
         #expect(series.date(at: series.daily.count - 1)! > series.today)
     }
 
     @Test
-    func `token activity spans a year without widening the spend chart`() throws {
+    func `mixed provider activity marks days outside common coverage unavailable`() throws {
         let now = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 16)))
         let oldDay = "2025-08-01"
-        let first = Self.snapshot(entries: [
-            Self.entry(day: oldDay, cost: 2, tokens: 40),
-            Self.entry(day: "2026-07-16", cost: 3, tokens: 10),
-            Self.entry(day: "2026-08-01", cost: 4, tokens: 100),
-        ])
-        let second = Self.snapshot(entries: [
-            Self.entry(day: oldDay, cost: 1, tokens: 60),
-            Self.entry(day: "2025-07-15", cost: 1, tokens: 200),
-            Self.entry(day: "invalid", cost: 1, tokens: 300),
-            Self.entry(day: "2026-07-15", cost: 1, tokens: -1),
-        ])
+        let annual = Self.snapshot(
+            entries: [
+                Self.entry(day: oldDay, cost: 2, tokens: 40),
+                Self.entry(day: "2026-07-16", cost: 3, tokens: 10),
+            ],
+            historyDays: 365,
+            last30DaysTokens: 50)
+        let recent = Self.snapshot(
+            entries: [
+                Self.entry(day: "2026-07-16", cost: 1, tokens: 60),
+            ],
+            historyDays: 30,
+            last30DaysTokens: 60)
         let model = SpendDashboardModel.build(
             inputs: [
-                .init(id: "first", provider: .claude, displayName: "Claude", snapshot: first),
-                .init(id: "second", provider: .openai, displayName: "OpenAI", snapshot: second),
+                .init(id: "annual", provider: .claude, displayName: "Claude", snapshot: annual),
+                .init(id: "recent", provider: .openai, displayName: "OpenAI", snapshot: recent),
             ],
             requestedDays: 30,
             now: now,
             calendar: Self.calendar)
 
         let oldDate = try #require(Self.calendar.date(from: DateComponents(year: 2025, month: 8, day: 1)))
-        #expect(model.tokenActivity == [
-            .init(day: oldDate, totalTokens: 100),
-            .init(day: now, totalTokens: 10),
-        ])
-        #expect(model.groups.first?.dailyPoints.map(\.day) == [now])
+        #expect(model.tokenActivity.count == SpendDashboardModel.tokenActivityDayCount)
+        #expect(model.tokenActivity.first { $0.day == oldDate }?.totalTokens == nil)
+        #expect(model.tokenActivity.first { $0.day == now }?.totalTokens == 70)
+        #expect(model.groups.first?.dailyPoints.allSatisfy { $0.day == now } == true)
+    }
+
+    @Test
+    func `covered empty history is zero while unestablished history remains unavailable`() throws {
+        let now = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 16)))
+        let covered = SpendDashboardModel.build(
+            inputs: [
+                .init(
+                    provider: .claude,
+                    displayName: "Claude",
+                    snapshot: Self.snapshot(entries: [], historyDays: 365, last30DaysTokens: 0)),
+            ],
+            requestedDays: 30,
+            now: now,
+            calendar: Self.calendar)
+        let unavailable = SpendDashboardModel.build(
+            inputs: [
+                .init(
+                    provider: .claude,
+                    displayName: "Claude",
+                    snapshot: Self.snapshot(
+                        entries: [],
+                        historyDays: 365,
+                        last30DaysTokens: nil,
+                        historyCoverageIsEstablished: false)),
+            ],
+            requestedDays: 30,
+            now: now,
+            calendar: Self.calendar)
+
+        #expect(covered.tokenActivity.allSatisfy { $0.totalTokens == 0 })
+        #expect(unavailable.tokenActivity.allSatisfy { $0.totalTokens == nil })
+    }
+
+    @Test
+    func `weekly and cumulative activity preserve unavailable coverage`() throws {
+        let start = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 5)))
+        let today = try #require(Self.calendar.date(byAdding: .day, value: 13, to: start))
+        var covered = [Bool](repeating: true, count: SpendActivitySeries.weekCount * 7)
+        covered[2] = false
+        let series = SpendActivitySeries(
+            daily: [Int](repeating: 1, count: covered.count),
+            isCovered: covered,
+            start: start,
+            today: today,
+            calendar: Self.calendar)
+
+        let weekly = series.weeklyActivity()
+        #expect(weekly.values.prefix(2) == [7, 7])
+        #expect(weekly.isCovered.prefix(2) == [false, true])
+        #expect(weekly.cumulative().isCovered.prefix(2) == [false, false])
+    }
+
+    @Test
+    func `annual aggregation output stays fixed with many full year providers`() throws {
+        let now = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 16)))
+        let formatter = DateFormatter()
+        formatter.calendar = Self.calendar
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let entries = try (0..<SpendDashboardModel.tokenActivityDayCount).map { offset in
+            let day = try #require(Self.calendar.date(byAdding: .day, value: -offset, to: now))
+            return Self.entry(day: formatter.string(from: day), cost: 0, tokens: 1)
+        }
+        let snapshot = Self.snapshot(
+            entries: entries,
+            historyDays: SpendDashboardModel.tokenActivityDayCount,
+            last30DaysTokens: SpendDashboardModel.tokenActivityDayCount)
+        let inputs = (0..<32).map { index in
+            SpendDashboardModel.ProviderInput(
+                id: "provider-\(index)",
+                provider: .claude,
+                displayName: "Provider \(index)",
+                snapshot: snapshot)
+        }
+        let model = SpendDashboardModel.build(
+            inputs: inputs,
+            requestedDays: 30,
+            now: now,
+            calendar: Self.calendar)
+
+        #expect(model.tokenActivity.count == SpendDashboardModel.tokenActivityDayCount)
+        #expect(model.tokenActivity.allSatisfy { $0.totalTokens == inputs.count })
     }
 
     @Test
@@ -130,14 +216,20 @@ struct SpendActivityHeatmapTests {
         return calendar
     }
 
-    private static func snapshot(entries: [CostUsageDailyReport.Entry]) -> CostUsageTokenSnapshot {
+    private static func snapshot(
+        entries: [CostUsageDailyReport.Entry],
+        historyDays: Int = 365,
+        last30DaysTokens: Int?,
+        historyCoverageIsEstablished: Bool = true) -> CostUsageTokenSnapshot
+    {
         CostUsageTokenSnapshot(
             sessionTokens: nil,
             sessionCostUSD: nil,
-            last30DaysTokens: nil,
+            last30DaysTokens: last30DaysTokens,
             last30DaysCostUSD: nil,
             currencyCode: "USD",
-            historyDays: 365,
+            historyDays: historyDays,
+            historyCoverageIsEstablished: historyCoverageIsEstablished,
             daily: entries,
             updatedAt: Date(timeIntervalSince1970: 1_784_179_200))
     }

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -1,0 +1,155 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct SpendActivityHeatmapTests {
+    @Test
+    func `daily levels keep exact boundaries and tolerate Int max`() {
+        #expect(SpendActivityLevels.dailyLevels([0, 1, 25, 26, 50, 51, 75, 76, 100]) == [
+            0, 1, 1, 2, 2, 3, 3, 4, 4,
+        ])
+        #expect(SpendActivityLevels.dailyLevels([Int.max, Int.max / 2]) == [4, 2])
+    }
+
+    @Test
+    func `weekly and cumulative totals saturate instead of overflowing`() {
+        let daily = [Int.max, 1, 0, 0, 0, 0, 0, 2]
+        let weekly = SpendActivityLevels.weeklyTotals(daily)
+        #expect(weekly == [Int.max, 2])
+        #expect(SpendActivityLevels.cumulativeTotals(weekly) == [Int.max, Int.max])
+    }
+
+    @Test
+    func `series uses a fixed Sunday first 52 week window`() throws {
+        let calendar = Self.calendar
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 8, day: 5)))
+        let previousDay = try #require(calendar.date(byAdding: .day, value: -1, to: now))
+        let futureDay = try #require(calendar.date(byAdding: .day, value: 1, to: now))
+        let series = SpendActivitySeries.make(
+            from: [
+                .init(day: previousDay, totalTokens: 10),
+                .init(day: now, totalTokens: 20),
+                .init(day: futureDay, totalTokens: 30),
+            ],
+            now: now,
+            calendar: calendar)
+
+        #expect(series.daily.count == 52 * 7)
+        #expect(calendar.component(.weekday, from: series.start) == 1)
+        #expect(series.daily.reduce(0, +) == 30)
+        #expect(series.date(at: series.daily.count - 1)! > series.today)
+    }
+
+    @Test
+    func `token activity spans a year without widening the spend chart`() throws {
+        let now = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 16)))
+        let oldDay = "2025-08-01"
+        let first = Self.snapshot(entries: [
+            Self.entry(day: oldDay, cost: 2, tokens: 40),
+            Self.entry(day: "2026-07-16", cost: 3, tokens: 10),
+            Self.entry(day: "2026-08-01", cost: 4, tokens: 100),
+        ])
+        let second = Self.snapshot(entries: [
+            Self.entry(day: oldDay, cost: 1, tokens: 60),
+            Self.entry(day: "2025-07-15", cost: 1, tokens: 200),
+            Self.entry(day: "invalid", cost: 1, tokens: 300),
+            Self.entry(day: "2026-07-15", cost: 1, tokens: -1),
+        ])
+        let model = SpendDashboardModel.build(
+            inputs: [
+                .init(id: "first", provider: .claude, displayName: "Claude", snapshot: first),
+                .init(id: "second", provider: .openai, displayName: "OpenAI", snapshot: second),
+            ],
+            requestedDays: 30,
+            now: now,
+            calendar: Self.calendar)
+
+        let oldDate = try #require(Self.calendar.date(from: DateComponents(year: 2025, month: 8, day: 1)))
+        #expect(model.tokenActivity == [
+            .init(day: oldDate, totalTokens: 100),
+            .init(day: now, totalTokens: 10),
+        ])
+        #expect(model.groups.first?.dailyPoints.map(\.day) == [now])
+    }
+
+    @Test
+    func `weekday labels and cells share the same row pitch`() {
+        let frame = SpendActivityGridGeometry.gridFrame(containerWidth: 1088)
+        let pitch = frame.width / CGFloat(SpendActivitySeries.weekCount)
+
+        #expect(SpendActivityGridGeometry.weekdayCenter(row: 1, rowPitch: pitch) == pitch * 1.5)
+        #expect(SpendActivityGridGeometry.weekdayCenter(row: 3, rowPitch: pitch) == pitch * 3.5)
+        #expect(SpendActivityGridGeometry.weekdayCenter(row: 5, rowPitch: pitch) == pitch * 5.5)
+        #expect(frame.height == pitch * 7)
+    }
+
+    @Test
+    func `tooltip stays beside the hovered cell and clamps only at the edge`() {
+        let gridWidth: CGFloat = 1000
+        let width = SpendActivityGridGeometry.tooltipWidth
+        let centered = SpendActivityGridGeometry.tooltipCenterX(
+            anchorX: 500,
+            tooltipWidth: width,
+            gridWidth: gridWidth)
+        let trailing = SpendActivityGridGeometry.tooltipCenterX(
+            anchorX: 995,
+            tooltipWidth: width,
+            gridWidth: gridWidth)
+
+        #expect(centered == 500)
+        #expect(trailing > 900)
+        #expect(trailing <= gridWidth - width / 2)
+        #expect(SpendActivityGridGeometry.tooltipOriginY(
+            anchorY: 10,
+            tooltipHeight: 50,
+            gridHeight: 130) > 10)
+        #expect(SpendActivityGridGeometry.tooltipOriginY(
+            anchorY: 120,
+            tooltipHeight: 50,
+            gridHeight: 130) < 70)
+    }
+
+    @Test
+    func `weekday and date formatting follow the selected resource locale`() throws {
+        let date = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 8, day: 1)))
+        let english = Locale(identifier: "en_US")
+        let chinese = Locale(identifier: "zh_Hans")
+
+        #expect(SpendActivityWeekday.label(for: 1, locale: english) == "Mon")
+        #expect(SpendActivityWeekday.label(for: 3, locale: english) == "Wed")
+        #expect(SpendActivityWeekday.label(for: 5, locale: english) == "Fri")
+        #expect(SpendActivityDateFormatting.mediumDateString(date, locale: english).contains("Aug"))
+        #expect(!SpendActivityDateFormatting.mediumDateString(date, locale: english).contains("年"))
+        #expect(SpendActivityDateFormatting.mediumDateString(date, locale: chinese).contains("年"))
+    }
+
+    private static var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private static func snapshot(entries: [CostUsageDailyReport.Entry]) -> CostUsageTokenSnapshot {
+        CostUsageTokenSnapshot(
+            sessionTokens: nil,
+            sessionCostUSD: nil,
+            last30DaysTokens: nil,
+            last30DaysCostUSD: nil,
+            currencyCode: "USD",
+            historyDays: 365,
+            daily: entries,
+            updatedAt: Date(timeIntervalSince1970: 1_784_179_200))
+    }
+
+    private static func entry(day: String, cost: Double?, tokens: Int?) -> CostUsageDailyReport.Entry {
+        CostUsageDailyReport.Entry(
+            date: day,
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: tokens,
+            costUSD: cost,
+            modelsUsed: nil,
+            modelBreakdowns: [])
+    }
+}

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -167,6 +167,30 @@ struct SpendActivityHeatmapTests {
     }
 
     @Test
+    func `established empty history with nil aggregate is confirmed zero activity`() throws {
+        let now = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 16)))
+        // Codex's tokenSnapshot returns an empty daily array with last30DaysTokens nil for a
+        // successful scan of an account with no sessions in the window.
+        let model = SpendDashboardModel.build(
+            inputs: [
+                .init(
+                    provider: .codex,
+                    displayName: "Codex",
+                    snapshot: Self.snapshot(
+                        entries: [],
+                        historyDays: 365,
+                        last30DaysTokens: nil,
+                        historyCoverageIsEstablished: true)),
+            ],
+            requestedDays: 30,
+            now: now,
+            calendar: Self.calendar)
+
+        #expect(!model.tokenActivity.isEmpty)
+        #expect(model.tokenActivity.allSatisfy { $0.totalTokens == 0 })
+    }
+
+    @Test
     func `weekly and cumulative activity preserve unavailable coverage`() throws {
         let start = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 5)))
         let today = try #require(Self.calendar.date(byAdding: .day, value: 13, to: start))

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -100,6 +100,41 @@ struct SpendActivityHeatmapTests {
     }
 
     @Test
+    func `annual activity snapshot does not widen spend aggregation`() throws {
+        let now = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 16)))
+        let oldDay = "2025-08-01"
+        let spend = Self.snapshot(
+            entries: [Self.entry(day: "2026-07-16", cost: 2, tokens: 10)],
+            historyDays: 30,
+            last30DaysTokens: 10)
+        let activity = Self.snapshot(
+            entries: [
+                Self.entry(day: oldDay, cost: nil, tokens: 40),
+                Self.entry(day: "2026-07-16", cost: nil, tokens: 5),
+            ],
+            historyDays: 365,
+            last30DaysTokens: 45)
+        let model = SpendDashboardModel.build(
+            inputs: [
+                .init(
+                    provider: .codex,
+                    displayName: "Codex",
+                    snapshot: spend,
+                    tokenActivitySnapshot: activity),
+            ],
+            requestedDays: 30,
+            now: now,
+            calendar: Self.calendar)
+
+        let oldDate = try #require(Self.calendar.date(from: DateComponents(year: 2025, month: 8, day: 1)))
+        #expect(model.groups.first?.totalTokens == 10)
+        #expect(model.groups.first?.totalCost == 2)
+        #expect(model.groups.first?.dailyPoints.count == 1)
+        #expect(model.tokenActivity.first { $0.day == oldDate }?.totalTokens == 40)
+        #expect(model.tokenActivity.first { $0.day == now }?.totalTokens == 10)
+    }
+
+    @Test
     func `covered empty history is zero while unestablished history remains unavailable`() throws {
         let now = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 16)))
         let covered = SpendDashboardModel.build(

--- a/Tests/CodexBarTests/SpendDashboardControllerTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardControllerTests.swift
@@ -48,7 +48,7 @@ struct SpendDashboardControllerTests {
         #expect(contexts.first?.cacheRoot.lastPathComponent == "inactive-cache")
         #expect(contexts.first?.now == now)
         #expect(contexts.first?.force == false)
-        #expect(contexts.first?.historyDays == 30)
+        #expect(contexts.first?.historyDays == 365)
         #expect(contexts.first?.refreshPricingInBackground == false)
         #expect(contexts.first?.includePiSessions == false)
     }

--- a/Tests/CodexBarTests/SpendDashboardControllerTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardControllerTests.swift
@@ -7,53 +7,6 @@ import Testing
 @Suite(.serialized)
 struct SpendDashboardControllerTests {
     @Test
-    func `empty codex history loads as successful inactive source`() async {
-        let now = Date(timeIntervalSince1970: 1_784_179_200)
-        let recorder = SpendDashboardCodexLoadRecorder()
-        let account = CodexSpendScanRequest(
-            id: "inactive",
-            displayName: "Codex",
-            source: .profileHome(path: "/synthetic/codex-home"),
-            homePath: "/synthetic/codex-home",
-            authFingerprint: nil,
-            authFileWasReadable: false,
-            cacheIdentity: "inactive-cache")
-        let request = SpendDashboardLoadRequest(
-            configuration: Self.configuration(account: "inactive|inactive-cache"),
-            capturedInputs: [],
-            unavailableSourceIDs: [],
-            codexRequests: [account],
-            now: now,
-            force: false)
-
-        let result = await SpendDashboardSource.load(request, codexSnapshotLoader: { context in
-            await recorder.record(context)
-            return CostUsageTokenSnapshot(
-                sessionTokens: nil,
-                sessionCostUSD: nil,
-                last30DaysTokens: 0,
-                last30DaysCostUSD: 0,
-                historyDays: context.historyDays,
-                daily: [],
-                updatedAt: context.now)
-        })
-        let contexts = await recorder.contexts
-
-        #expect(result.inputs.count == 1)
-        #expect(result.inputs.first?.id == "codex:inactive")
-        #expect(result.inputs.first?.snapshot.daily.isEmpty == true)
-        #expect(result.failedSourceIDs.isEmpty)
-        #expect(contexts.count == 1)
-        #expect(contexts.first?.account == account)
-        #expect(contexts.first?.cacheRoot.lastPathComponent == "inactive-cache")
-        #expect(contexts.first?.now == now)
-        #expect(contexts.first?.force == false)
-        #expect(contexts.first?.historyDays == 365)
-        #expect(contexts.first?.refreshPricingInBackground == false)
-        #expect(contexts.first?.includePiSessions == false)
-    }
-
-    @Test
     func `Codex auth rotation invalidates stale spend while retaining unrelated providers`() async throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent(
@@ -99,6 +52,8 @@ struct SpendDashboardControllerTests {
             })
 
         controller.update(configuration: configuration)
+        await Self.waitForCodexPendingCount(1, gate: gate)
+        await gate.resume(at: 0, snapshot: Self.input(cost: 6).snapshot)
         await Self.waitForCodexPendingCount(1, gate: gate)
         await gate.resume(at: 0, snapshot: Self.input(cost: 6).snapshot)
         await Self.waitUntil { !controller.isRefreshing }
@@ -1206,14 +1161,6 @@ private actor SpendDashboardCapturedInputStore {
 
     func replace(with inputs: [SpendDashboardModel.ProviderInput]) {
         self.inputs = inputs
-    }
-}
-
-private actor SpendDashboardCodexLoadRecorder {
-    private(set) var contexts: [CodexSpendSnapshotLoadContext] = []
-
-    func record(_ context: CodexSpendSnapshotLoadContext) {
-        self.contexts.append(context)
     }
 }
 

--- a/Tests/CodexBarTests/SpendDashboardForceStateMachineTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardForceStateMachineTests.swift
@@ -407,6 +407,8 @@ struct SpendDashboardForceStateMachineTests {
         await Self.waitForCodexGate(codexGate)
         controller.update(configuration: confirmedEmpty)
         await codexGate.resume(codexInput.snapshot)
+        await Self.waitForCodexGate(codexGate)
+        await codexGate.resume(codexInput.snapshot)
         await Self.waitUntil { !controller.isRefreshing }
 
         let settledGeneration = controller.generation
@@ -475,6 +477,8 @@ struct SpendDashboardForceStateMachineTests {
         controller.refresh()
         await Self.waitForCodexGate(codexGate)
         controller.update(configuration: unavailable)
+        await codexGate.resume(codexInput.snapshot)
+        await Self.waitForCodexGate(codexGate)
         await codexGate.resume(codexInput.snapshot)
         await Self.waitForBuildGate(captureGate)
         controller.update(configuration: latest)

--- a/Tests/CodexBarTests/SpendDashboardModelTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardModelTests.swift
@@ -753,7 +753,7 @@ struct SpendDashboardModelTests {
         #expect(!request.authFileWasReadable)
         #expect(request.displayName == "Codex · #2")
         #expect(request.cacheIdentity.count == 64)
-        #expect(SpendDashboardSource.scanDays == 30)
+        #expect(SpendDashboardSource.scanDays == 365)
         #expect(SpendDashboardSource.codexRequest(
             account: account,
             homePath: "relative/path",

--- a/Tests/CodexBarTests/SpendDashboardModelTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardModelTests.swift
@@ -753,7 +753,6 @@ struct SpendDashboardModelTests {
         #expect(!request.authFileWasReadable)
         #expect(request.displayName == "Codex · #2")
         #expect(request.cacheIdentity.count == 64)
-        #expect(SpendDashboardSource.scanDays == 365)
         #expect(SpendDashboardSource.codexRequest(
             account: account,
             homePath: "relative/path",

--- a/Tests/CodexBarTests/SpendDashboardScanBudgetTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardScanBudgetTests.swift
@@ -1,0 +1,172 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct SpendDashboardScanBudgetTests {
+    @Test
+    func `empty codex history loads separate spend and activity snapshots`() async {
+        let now = Date(timeIntervalSince1970: 1_784_179_200)
+        let recorder = SpendDashboardScanContextRecorder()
+        let account = Self.account(id: "inactive", cacheIdentity: "inactive-cache")
+        let request = Self.request(account: account, now: now, force: false)
+
+        let result = await SpendDashboardSource.load(request, codexSnapshotLoader: { context in
+            await recorder.record(context)
+            return Self.snapshot(context: context, tokens: 0, cost: 0)
+        })
+        let contexts = await recorder.contexts
+
+        #expect(result.inputs.count == 1)
+        #expect(result.inputs.first?.id == "codex:inactive")
+        #expect(result.inputs.first?.snapshot.daily.isEmpty == true)
+        #expect(result.failedSourceIDs.isEmpty)
+        #expect(contexts.count == 2)
+        #expect(contexts.first?.account == account)
+        #expect(contexts.first?.cacheRoot.lastPathComponent == "inactive-cache")
+        #expect(contexts.first?.now == now)
+        #expect(contexts.first?.force == false)
+        #expect(contexts.first?.historyDays == 30)
+        #expect(contexts.first?.refreshPricingInBackground == false)
+        #expect(contexts.first?.includePiSessions == false)
+        #expect(contexts.last?.historyDays == 365)
+        #expect(contexts.last?.force == false)
+        #expect(result.inputs.first?.snapshot.historyDays == 30)
+        #expect(result.inputs.first?.tokenActivitySnapshot.historyDays == 365)
+    }
+
+    @Test
+    func `forced dashboard refresh preserves the normal scan budget`() async {
+        let now = Date(timeIntervalSince1970: 1_784_179_200)
+        let recorder = SpendDashboardScanContextRecorder()
+        let account = Self.account(id: "account", cacheIdentity: "scan-budget")
+
+        _ = await SpendDashboardSource.load(
+            Self.request(account: account, now: now, force: true),
+            codexSnapshotLoader: { context in
+                await recorder.record(context)
+                return Self.snapshot(context: context, tokens: 0, cost: 0)
+            })
+        let contexts = await recorder.contexts
+
+        #expect(SpendDashboardSource.scanDays == 30)
+        #expect(SpendDashboardSource.activityScanDays == 365)
+        #expect(contexts.map(\.historyDays) == [30, 365])
+        #expect(contexts.map(\.force) == [true, false])
+    }
+
+    @Test
+    func `annual activity scan failure retains the normal spend snapshot`() async {
+        let now = Date(timeIntervalSince1970: 1_784_179_200)
+        let account = Self.account(id: "account", cacheIdentity: "activity-failure")
+        let result = await SpendDashboardSource.load(
+            Self.request(account: account, now: now, force: false),
+            codexSnapshotLoader: { context in
+                if context.historyDays == SpendDashboardSource.activityScanDays {
+                    throw CocoaError(.fileReadUnknown)
+                }
+                return Self.snapshot(context: context, tokens: 10, cost: 1)
+            })
+
+        #expect(result.failedSourceIDs.isEmpty)
+        #expect(result.inputs.count == 1)
+        #expect(result.inputs.first?.snapshot.historyDays == 30)
+        #expect(result.inputs.first?.tokenActivitySnapshot.historyDays == 30)
+    }
+
+    @Test
+    func `annual activity cache limits rescans and expires on schedule`() async throws {
+        let now = Date(timeIntervalSince1970: 1_784_179_200)
+        let account = Self.account(id: "account", cacheIdentity: "activity-cache")
+        let cache = SpendDashboardCodexActivitySnapshotCache(refreshInterval: 15 * 60)
+        let recorder = SpendDashboardScanContextRecorder()
+        let context = Self.context(account: account, now: now)
+
+        _ = try await cache.load(context) { loadContext in
+            await recorder.record(loadContext)
+            return Self.snapshot(context: loadContext, tokens: 10, cost: 1)
+        }
+        _ = try await cache.load(context) { loadContext in
+            await recorder.record(loadContext)
+            return Self.snapshot(context: loadContext, tokens: 20, cost: 2)
+        }
+        let cachedContexts = await recorder.contexts
+        #expect(cachedContexts.count == 1)
+
+        let expiredContext = Self.context(account: account, now: now.addingTimeInterval(15 * 60))
+        let expired = try await cache.load(expiredContext) { loadContext in
+            await recorder.record(loadContext)
+            return Self.snapshot(context: loadContext, tokens: 30, cost: 3)
+        }
+        #expect(expired.last30DaysTokens == 30)
+        let refreshedContexts = await recorder.contexts
+        #expect(refreshedContexts.count == 2)
+    }
+
+    private static func account(id: String, cacheIdentity: String) -> CodexSpendScanRequest {
+        CodexSpendScanRequest(
+            id: id,
+            displayName: "Codex",
+            source: .profileHome(path: "/synthetic/codex-home"),
+            homePath: "/synthetic/codex-home",
+            authFingerprint: nil,
+            authFileWasReadable: false,
+            cacheIdentity: cacheIdentity)
+    }
+
+    private static func request(
+        account: CodexSpendScanRequest,
+        now: Date,
+        force: Bool) -> SpendDashboardLoadRequest
+    {
+        SpendDashboardLoadRequest(
+            configuration: SpendDashboardConfiguration(
+                costUsageEnabled: true,
+                providerIDs: [UsageProvider.codex.rawValue],
+                codexAccountIdentities: ["\(account.id)|\(account.cacheIdentity)"]),
+            capturedInputs: [],
+            unavailableSourceIDs: [],
+            codexRequests: [account],
+            now: now,
+            force: force)
+    }
+
+    private static func context(
+        account: CodexSpendScanRequest,
+        now: Date) -> CodexSpendSnapshotLoadContext
+    {
+        CodexSpendSnapshotLoadContext(
+            account: account,
+            cacheRoot: URL(fileURLWithPath: "/synthetic/cache", isDirectory: true),
+            now: now,
+            force: false,
+            historyDays: SpendDashboardSource.activityScanDays,
+            refreshPricingInBackground: false,
+            includePiSessions: false)
+    }
+
+    private nonisolated static func snapshot(
+        context: CodexSpendSnapshotLoadContext,
+        tokens: Int,
+        cost: Double) -> CostUsageTokenSnapshot
+    {
+        CostUsageTokenSnapshot(
+            sessionTokens: tokens,
+            sessionCostUSD: cost,
+            last30DaysTokens: tokens,
+            last30DaysCostUSD: cost,
+            historyDays: context.historyDays,
+            daily: [],
+            updatedAt: context.now)
+    }
+}
+
+private actor SpendDashboardScanContextRecorder {
+    private(set) var contexts: [CodexSpendSnapshotLoadContext] = []
+
+    func record(_ context: CodexSpendSnapshotLoadContext) {
+        self.contexts.append(context)
+    }
+}

--- a/Tests/CodexBarTests/SpendDashboardSourceConcurrencyTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardSourceConcurrencyTests.swift
@@ -50,6 +50,8 @@ struct SpendDashboardSourceConcurrencyTests {
             to: CodexAuthFingerprint.authFileURL(homePath: failed.homePath),
             options: .atomic)
         await gate.resume(snapshot: laterSnapshot)
+        await Self.waitForCodexGate(gate)
+        await gate.resume(snapshot: laterSnapshot)
 
         let result = await loadTask.value
         #expect(result.inputs.map(\.id) == ["codex:later"])


### PR DESCRIPTION
## Overview

Adds a standalone 365-day token activity heatmap to **Usage & Spend**. The view makes long-term token usage patterns inspectable without changing the existing 7/30-day spend chart range.

The UI and data path are intentionally kept in this independent, `main`-based PR so the heatmap can be reviewed separately from the larger Usage & Spend work in #2322.

## What the UI does

- **Daily:** renders exactly 365 visible days inside a Sunday-aligned 53-column calendar container; leading/trailing alignment cells are blank.
- **Weekly:** aggregates each intersecting calendar-week column and makes the grouping explicit with “Each column = 1 week”.
- **Cumulative:** shows the running total across the same exact date range.
- **Edge-aware hover:** keeps the detail card beside the selected cell and clamps it only when it would leave the chart.
- **Shared grid geometry:** weekday labels and activity cells use the same row pitch, keeping `Mon`, `Wed`, and `Fri` visually aligned.
- **Selected-language formatting:** weekday symbols, dates, labels, and mode descriptions follow the CodexBar app language instead of the host system locale.
- **Honest partial coverage:** unavailable provider history is rendered separately from confirmed zero activity, with coverage shown in the summary and tooltips.
- **Accessible inspection:** the daily grid is keyboard-focusable, supports arrow-key movement, exposes chronological VoiceOver adjustable navigation, and publishes one semantic child per visible day; Weekly and Cumulative publish one child per visible week column.

## Native macOS proof

Captured from the locally signed release build at commit `2af1b1cbf009b901c4b1b906c9745c4cad1675c7`, with the CodexBar app language set to English. The screenshots contain only aggregated token activity; no account identifiers or credentials are shown. The later range, coverage, and accessibility follow-ups do not change the demonstrated alignment, hover placement, modes, or locale behavior.

### Daily — aligned default state

The month headers, weekday labels, cells, and legend share one layout. Empty history remains visually quiet while recent activity stays easy to scan.

<img width="1182" height="424" alt="Daily token activity heatmap with aligned weekday labels" src="https://github.com/user-attachments/assets/43da2738-d00f-4d5d-bbdd-214287a0cab3" />

### Daily — right-edge hover behavior

The tooltip stays adjacent to the hovered late-July cell, moves inward only enough to remain inside the chart, and formats the date in English.

<img width="1178" height="406" alt="Daily heatmap tooltip clamped beside a right-edge cell" src="https://github.com/user-attachments/assets/47a183b8-418a-4b89-b885-b5f43e83262f" />

### Weekly — calendar-week aggregation

Each column represents one calendar week; the tooltip reports the selected week’s aggregate and anchor date.

<img width="1184" height="392" alt="Weekly token activity heatmap with one column per week" src="https://github.com/user-attachments/assets/9e052b97-39d0-4ab6-a954-98269a7bc895" />

### Cumulative — running total

The cumulative mode uses the same grid and date range while exposing progression toward the full-period token total.

<img width="1178" height="380" alt="Cumulative token activity heatmap showing the running total" src="https://github.com/user-attachments/assets/15fb8879-73b8-4f66-a9b5-1b1f304baab3" />

### Current-head accessibility proof

Built, signed, and launched commit `2f820c94c0688327e39362fc80789f1aac8017ea`, then queried the running AppKit accessibility tree through macOS System Events. This is system-level output from the shipped view, not a source-code assertion or an isolated SwiftUI host:

```console
$ # Read the first and last children of the daily Token activity AXGroup.
$ osascript ... 'return {count of UI elements, role of UI element 1, value of UI element 1, role of UI element 365, value of UI element 365}'
365, AXStaticText, Aug 2, 2025: Unavailable, AXStaticText, Aug 1, 2026: 283M

$ # Read the actions published by that same AXGroup.
$ osascript ... 'return name of every action'
AXIncrement, AXDecrement

$ # Switch to Weekly and read its first/last column children.
53, AXStaticText, Jul 27, 2025: Unavailable, AXStaticText, Jul 26, 2026: 1.1B

$ # Switch to Cumulative and read its first/last column children.
53, AXStaticText, Jul 27, 2025: Unavailable, AXStaticText, Jul 26, 2026: Unavailable
```

This verifies that all 365 visible days and all 53 visible week columns are individually traversable, each node publishes its English date plus token/availability value, and the daily grid exposes chronological VoiceOver adjustment actions on the current PR head. Cumulative stays unavailable when earlier source coverage is unknown instead of presenting a fabricated running total.

## Data behavior

- adds a dedicated `tokenActivity` series to `SpendDashboardModel`
- aggregates validated, nonnegative token totals independently of spend/currency availability
- requests a bounded 365-day direct Codex history for the annual view while keeping the existing spend chart at 7/30 days
- intersects coverage across included provider snapshots, so mixed 365-day and 30-day sources do not fabricate older zero-usage cells
- represents unestablished or malformed coverage as unavailable and propagates it through weekly and cumulative modes
- distinguishes unavailable cells from confirmed zero activity in fill color, tooltip, legend/caption, summary, and accessibility text
- uses overflow-safe daily, weekly, and cumulative arithmetic and always caps output at 365 points
- renders and aggregates every one of those 365 points regardless of the ending weekday

## Localization

The heatmap includes localized strings across all app catalogs for the title, view modes, empty state, legend, weekly grouping, and cumulative description. The coverage follow-up reuses the existing localized `Coverage` and `Unavailable` keys. Locale regression coverage verifies that an English app selection produces English weekday/date output even when the system locale differs.

## Scope / relationship

- extracted from #2322 as an independent PR based directly on `main`
- does **not** depend on #2527
- contains seven focused commits: standalone heatmap, mixed-provider coverage hardening, annual-range/navigation repair, per-day accessibility/navigation, native semantic-role repair, current-head date/value publication, and Weekly/Cumulative column accessibility

## Validation

- `make check`
  - app locale checker: 22 catalogs against 1,316 English keys
  - SwiftFormat: 0 files require formatting
  - SwiftLint: 0 violations across 1,668 files
- `swift test --filter 'SpendActivityHeatmapTests|SpendDashboardModelTests|SpendDashboardControllerTests'`
  - 64 tests in 5 suites passed on `2f820c94`
- annual boundary regression covers all seven possible ending weekdays
  - exactly 365 visible and covered days in each case
  - oldest-day-only activity remains part of the total and empty-state decision
- bounded annual regression: 32 providers × 365 daily entries
  - output remains exactly 365 points
  - completed in 0.185 seconds on the final local run
- `make start`
  - current-head Release build, signing, bundle validation, launch, and native macOS AX QA completed

## Review follow-up

- [x] Attach inspectable native macOS proof for Daily, Weekly, Cumulative, right-edge tooltip placement, weekday alignment, and English date formatting.
- [x] Preserve mixed-provider coverage: non-Codex snapshots with less than 365 days no longer turn older absent data into confirmed zero activity.
- [x] Add mixed-provider, unavailable-propagation, confirmed-zero, malformed-history, and bounded 365-day regressions.
- [x] Render all 365 advertised days with regressions for every ending weekday.
- [x] Add keyboard/VoiceOver navigation plus one localized accessibility child for every visible day.
- [x] Publish one localized accessibility child for every visible Weekly/Cumulative column.
- [x] Ensure keyboard or VoiceOver input overrides stale pointer hover in the shared highlight, tooltip, and accessibility value.

The contributor-action findings are addressed through `2f820c94`. The PR remains Ready for current-head CI and maintainer feature-direction review under `VISION.md`.


## Split PRs

Part of the #2322 umbrella split, stacked on #2527:

1. **#2527** — data layer (base)
2. **This PR (#2548)** — token activity heatmap
3. **#2569** — Models view (rebases on #2527 + #2548)
