### PR TITLE
Menu: fix tab-switch flash — tracking-safe warmup + stable provider-tab height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Claude: compact multi-account menu for claude-swap — with four or more accounts the active account keeps its full card while the others become one-line rows sorted by remaining headroom, constrained accounts surface in red/amber, the healthiest switch target gets a star, and the healthy tail folds behind a summary row. Click a row to expand its full card.
 - Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
+### Fixed
+- Menu: switching provider tabs no longer flashes. The sibling-tab warmup now runs off a tracking-safe timer (the previous Task-based warmup never fired while the menu was open, which is the only time it matters), and provider tabs share one stable menu height via an invisible spacer, so a switch is a single-frame content swap with no window resize. Verified frame-by-frame with a new env-gated self-probe (`CODEXBAR_FLICKER_PROBE_DIR`).
+
 ### Changed
 - About: link the Website entry to codex.bar.
 

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -556,6 +556,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 selection,
                 managedCodexAccountCoordinator,
                 codexAccountPromotionCoordinator)
+            if let statusController = self.statusController as? StatusItemController {
+                MenuSwitchFlickerProbe.startIfRequested(controller: statusController)
+            }
             return
         }
 

--- a/Sources/CodexBar/MenuSwitchFlickerProbe.swift
+++ b/Sources/CodexBar/MenuSwitchFlickerProbe.swift
@@ -47,23 +47,31 @@ enum MenuSwitchFlickerProbe {
 
     /// Background frame grabber: samples the window's WindowServer composite and
     /// bounds on a dedicated thread so main-thread stalls cannot hide frames.
+    /// Frames are encoded to disk immediately — retaining full-resolution
+    /// captures in memory would grow to gigabytes over a session — so only the
+    /// lightweight bounds timeline is kept in memory.
     final class BackgroundFrameGrabber: @unchecked Sendable {
         struct Sample {
             let elapsedMs: Double
             let bounds: CGRect
-            let image: CGImage?
+            let wroteFrame: Bool
         }
+
+        private static let maxFrameCount = 2000
 
         private let windowID: CGWindowID
         private let start: DispatchTime
+        private let directory: URL
         private let lock = NSLock()
         private var storage: [Sample] = []
+        private var frameIndex = 0
         private var running = true
 
-        init(windowID: CGWindowID, start: DispatchTime) {
+        init(windowID: CGWindowID, start: DispatchTime, directory: URL) {
             self.windowID = windowID
             self.start = start
-            self.storage.reserveCapacity(2000)
+            self.directory = directory
+            self.storage.reserveCapacity(Self.maxFrameCount)
             Thread.detachNewThread { [weak self] in
                 Thread.current.name = "MenuSwitchFlickerProbe.grabber"
                 self?.loop()
@@ -82,8 +90,9 @@ enum MenuSwitchFlickerProbe {
             while true {
                 self.lock.lock()
                 let keepRunning = self.running
+                let index = self.frameIndex
                 self.lock.unlock()
-                guard keepRunning else { return }
+                guard keepRunning, index < Self.maxFrameCount else { return }
                 let elapsed = Double(DispatchTime.now().uptimeNanoseconds - self.start.uptimeNanoseconds)
                     / 1_000_000
                 let image = CGWindowListCreateImage(
@@ -92,10 +101,15 @@ enum MenuSwitchFlickerProbe {
                     self.windowID,
                     [.boundsIgnoreFraming, .bestResolution])
                 let bounds = self.currentBounds() ?? .null
-                self.lock.lock()
-                if self.storage.count < 2000 {
-                    self.storage.append(Sample(elapsedMs: elapsed, bounds: bounds, image: image))
+                var wroteFrame = false
+                if let image {
+                    let name = String(format: "frame-%04d-%07.1fms.png", index, elapsed)
+                    MenuSwitchFlickerProbe.writePNG(image, to: self.directory.appendingPathComponent(name))
+                    wroteFrame = true
                 }
+                self.lock.lock()
+                self.frameIndex += 1
+                self.storage.append(Sample(elapsedMs: elapsed, bounds: bounds, wroteFrame: wroteFrame))
                 self.lock.unlock()
                 usleep(3000)
             }
@@ -190,7 +204,8 @@ enum MenuSwitchFlickerProbe {
                 self.startedAt = start
                 self.grabber = BackgroundFrameGrabber(
                     windowID: CGWindowID(window.windowNumber),
-                    start: start)
+                    start: start,
+                    directory: self.directory)
                 self.log.append("menu located, windowNumber=\(window.windowNumber) " +
                     "frame=\(window.frame) original=\(String(describing: self.originalSegment)) " +
                     "target=\(String(describing: self.targetSegment))")
@@ -243,12 +258,7 @@ enum MenuSwitchFlickerProbe {
                     sample.elapsedMs,
                     String(describing: sample.bounds)))
             }
-            for (index, sample) in samples.enumerated() {
-                guard let image = sample.image else { continue }
-                let name = String(format: "frame-%04d-%07.1fms.png", index, sample.elapsedMs)
-                Self.writePNG(image, to: self.directory.appendingPathComponent(name))
-            }
-            let nilFrames = samples.count(where: { $0.image == nil })
+            let nilFrames = samples.count(where: { !$0.wroteFrame })
             self.log.append("nil captures: \(nilFrames)")
             let text = self.log.joined(separator: "\n") + "\n"
             try? text.write(
@@ -256,15 +266,15 @@ enum MenuSwitchFlickerProbe {
                 atomically: true,
                 encoding: .utf8)
         }
+    }
 
-        private static func writePNG(_ image: CGImage, to url: URL) {
-            guard let destination = CGImageDestinationCreateWithURL(
-                url as CFURL,
-                UTType.png.identifier as CFString,
-                1,
-                nil) else { return }
-            CGImageDestinationAddImage(destination, image, nil)
-            CGImageDestinationFinalize(destination)
-        }
+    nonisolated static func writePNG(_ image: CGImage, to url: URL) {
+        guard let destination = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.png.identifier as CFString,
+            1,
+            nil) else { return }
+        CGImageDestinationAddImage(destination, image, nil)
+        CGImageDestinationFinalize(destination)
     }
 }

--- a/Sources/CodexBar/MenuSwitchFlickerProbe.swift
+++ b/Sources/CodexBar/MenuSwitchFlickerProbe.swift
@@ -1,0 +1,270 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Self-driving diagnostic for provider tab-switch rendering artifacts. Inert
+/// unless `CODEXBAR_FLICKER_PROBE_DIR` is set at launch. When armed it opens the
+/// merged menu, switches provider tabs programmatically, and captures the menu
+/// window's *own* composited frames plus a window-frame timeline for offline
+/// analysis.
+///
+/// Two quirks shape the implementation:
+/// - `openMenuFromShortcut` blocks in NSMenu's synchronous tracking loop, where
+///   Swift Concurrency main-actor jobs do not run; all main-thread driving uses
+///   a common-modes `Timer`.
+/// - The interesting frames appear while the main thread is busy rebuilding the
+///   menu, so captures run on a background thread: `CGWindowListCreateImage`
+///   reads the WindowServer's current composite without touching AppKit.
+@MainActor
+enum MenuSwitchFlickerProbe {
+    /// Appends diagnostic lines from production code paths while the probe env
+    /// var is set; inert otherwise.
+    nonisolated static func debugLog(_ line: @autoclosure () -> String) {
+        guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_FLICKER_PROBE_DIR"],
+              !dir.isEmpty else { return }
+        let url = URL(fileURLWithPath: dir).appendingPathComponent("padding-log.txt")
+        let text = line() + "\n"
+        if let handle = try? FileHandle(forWritingTo: url) {
+            handle.seekToEndOfFile()
+            handle.write(Data(text.utf8))
+            try? handle.close()
+        } else {
+            try? text.write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+
+    static func startIfRequested(controller: StatusItemController) {
+        guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_FLICKER_PROBE_DIR"],
+              !dir.isEmpty else { return }
+        let directory = URL(fileURLWithPath: dir, isDirectory: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+            let session = ProbeSession(controller: controller, directory: directory)
+            session.begin()
+        }
+    }
+
+    /// Background frame grabber: samples the window's WindowServer composite and
+    /// bounds on a dedicated thread so main-thread stalls cannot hide frames.
+    final class BackgroundFrameGrabber: @unchecked Sendable {
+        struct Sample {
+            let elapsedMs: Double
+            let bounds: CGRect
+            let image: CGImage?
+        }
+
+        private let windowID: CGWindowID
+        private let start: DispatchTime
+        private let lock = NSLock()
+        private var storage: [Sample] = []
+        private var running = true
+
+        init(windowID: CGWindowID, start: DispatchTime) {
+            self.windowID = windowID
+            self.start = start
+            self.storage.reserveCapacity(2000)
+            Thread.detachNewThread { [weak self] in
+                Thread.current.name = "MenuSwitchFlickerProbe.grabber"
+                self?.loop()
+            }
+        }
+
+        func stop() -> [Sample] {
+            self.lock.lock()
+            self.running = false
+            let result = self.storage
+            self.lock.unlock()
+            return result
+        }
+
+        private func loop() {
+            while true {
+                self.lock.lock()
+                let keepRunning = self.running
+                self.lock.unlock()
+                guard keepRunning else { return }
+                let elapsed = Double(DispatchTime.now().uptimeNanoseconds - self.start.uptimeNanoseconds)
+                    / 1_000_000
+                let image = CGWindowListCreateImage(
+                    .null,
+                    .optionIncludingWindow,
+                    self.windowID,
+                    [.boundsIgnoreFraming, .bestResolution])
+                let bounds = self.currentBounds() ?? .null
+                self.lock.lock()
+                if self.storage.count < 2000 {
+                    self.storage.append(Sample(elapsedMs: elapsed, bounds: bounds, image: image))
+                }
+                self.lock.unlock()
+                usleep(3000)
+            }
+        }
+
+        private func currentBounds() -> CGRect? {
+            guard let info = CGWindowListCopyWindowInfo(
+                .optionIncludingWindow,
+                self.windowID) as? [[String: Any]],
+                let record = info.first,
+                let boundsDict = record[kCGWindowBounds as String] as? [String: CGFloat]
+            else { return nil }
+            return CGRect(
+                x: boundsDict["X"] ?? 0,
+                y: boundsDict["Y"] ?? 0,
+                width: boundsDict["Width"] ?? 0,
+                height: boundsDict["Height"] ?? 0)
+        }
+    }
+
+    @MainActor
+    final class ProbeSession {
+        private let controller: StatusItemController
+        private let directory: URL
+        private var timer: Timer?
+        private var log: [String] = []
+        private var startedAt: DispatchTime?
+        private var didSwitchAway = false
+        private var didSwitchBack = false
+        private var searchTicks = 0
+        private weak var menu: NSMenu?
+        private var grabber: BackgroundFrameGrabber?
+        private var originalSegment: Int?
+        private var targetSegment: Int?
+
+        init(controller: StatusItemController, directory: URL) {
+            self.controller = controller
+            self.directory = directory
+        }
+
+        func begin() {
+            try? FileManager.default.createDirectory(
+                at: self.directory,
+                withIntermediateDirectories: true)
+            let timer = Timer(timeInterval: 0.008, repeats: true) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.tick()
+                }
+            }
+            RunLoop.main.add(timer, forMode: .common)
+            self.timer = timer
+            // Blocks in menu tracking until `cancelTracking()`; the timer keeps firing.
+            self.controller.openMenuFromShortcut()
+            self.finish()
+        }
+
+        private func tick() {
+            guard let startedAt = self.startedAtOrLocateMenu() else { return }
+            let now = Int((DispatchTime.now().uptimeNanoseconds - startedAt.uptimeNanoseconds) / 1_000_000)
+            if now >= 2400 {
+                self.timer?.invalidate()
+                self.timer = nil
+                self.menu?.cancelTracking()
+                return
+            }
+            if now >= 400, !self.didSwitchAway {
+                self.didSwitchAway = true
+                let handled = self.targetSegment.map { self.switchSegment($0) } ?? false
+                self.log.append("switch-away to segment \(String(describing: self.targetSegment)) " +
+                    "at \(now)ms handled=\(handled)")
+                return
+            }
+            if now >= 1400, !self.didSwitchBack {
+                self.didSwitchBack = true
+                let handled = self.originalSegment.map { self.switchSegment($0) } ?? false
+                self.log.append("switch-back to segment \(String(describing: self.originalSegment)) " +
+                    "at \(now)ms handled=\(handled)")
+                return
+            }
+        }
+
+        private func startedAtOrLocateMenu() -> DispatchTime? {
+            if let startedAt = self.startedAt { return startedAt }
+            self.searchTicks += 1
+            if let menu = self.controller.openMenus.values.first,
+               menu.items.first?.view is ProviderSwitcherView,
+               let window = menu.items.compactMap(\.view?.window).first
+            {
+                self.menu = menu
+                self.resolveSegments()
+                let start = DispatchTime.now()
+                self.startedAt = start
+                self.grabber = BackgroundFrameGrabber(
+                    windowID: CGWindowID(window.windowNumber),
+                    start: start)
+                self.log.append("menu located, windowNumber=\(window.windowNumber) " +
+                    "frame=\(window.frame) original=\(String(describing: self.originalSegment)) " +
+                    "target=\(String(describing: self.targetSegment))")
+                return start
+            }
+            if self.searchTicks > 1200 {
+                self.log.append("gave up locating menu after \(self.searchTicks) ticks")
+                self.timer?.invalidate()
+                self.timer = nil
+                self.controller.openMenus.values.first?.cancelTracking()
+            }
+            return nil
+        }
+
+        /// Segment order mirrors the switcher: optional Overview first, then the
+        /// display providers. Picks the first provider segment that is not the
+        /// current selection so the probe performs a real switch, and restores
+        /// the original selection afterwards.
+        private func resolveSegments() {
+            let enabledProviders = self.controller.store.enabledProvidersForDisplay()
+            let includesOverview = self.controller.includesOverviewTab(enabledProviders: enabledProviders)
+            let selection = self.controller.resolvedSwitcherSelection(
+                enabledProviders: enabledProviders,
+                includesOverview: includesOverview)
+            var segments: [ProviderSwitcherSelection] = enabledProviders.map { .provider($0) }
+            if includesOverview {
+                segments.insert(.overview, at: 0)
+            }
+            self.originalSegment = segments.firstIndex(of: selection)
+            self.targetSegment = segments.firstIndex { candidate in
+                candidate != selection && candidate != .overview
+            }
+        }
+
+        private func switchSegment(_ index: Int) -> Bool {
+            guard let switcher = self.menu?.items.first?.view as? ProviderSwitcherView else { return false }
+            return switcher.handleKeyboardSelection(at: index)
+        }
+
+        private func finish() {
+            self.timer?.invalidate()
+            self.timer = nil
+            let samples = self.grabber?.stop() ?? []
+            self.log.append("captured \(samples.count) samples")
+            var previousBounds = CGRect.null
+            for sample in samples where sample.bounds != previousBounds {
+                previousBounds = sample.bounds
+                self.log.append(String(
+                    format: "windowBounds @%.1fms -> %@",
+                    sample.elapsedMs,
+                    String(describing: sample.bounds)))
+            }
+            for (index, sample) in samples.enumerated() {
+                guard let image = sample.image else { continue }
+                let name = String(format: "frame-%04d-%07.1fms.png", index, sample.elapsedMs)
+                Self.writePNG(image, to: self.directory.appendingPathComponent(name))
+            }
+            let nilFrames = samples.count(where: { $0.image == nil })
+            self.log.append("nil captures: \(nilFrames)")
+            let text = self.log.joined(separator: "\n") + "\n"
+            try? text.write(
+                to: self.directory.appendingPathComponent("probe-log.txt"),
+                atomically: true,
+                encoding: .utf8)
+        }
+
+        private static func writePNG(_ image: CGImage, to url: URL) {
+            guard let destination = CGImageDestinationCreateWithURL(
+                url as CFURL,
+                UTType.png.identifier as CFString,
+                1,
+                nil) else { return }
+            CGImageDestinationAddImage(destination, image, nil)
+            CGImageDestinationFinalize(destination)
+        }
+    }
+}

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -232,6 +232,9 @@ extension StatusItemController {
             "populateMenu",
             breadcrumb: "populateMenu:\(provider?.rawValue ?? "merged")")
         defer { self.endMenuOperationTrace(trace, menu: menu, provider: provider) }
+        // LIFO defers: warmup fills sibling caches, card heights finalize, then the
+        // stable-height pass equalizes provider tabs against the tallest cached tab.
+        defer { self.applyStableMenuHeightPadding(in: menu) }
         defer { self.refreshMenuCardHeights(in: menu) }
         // Re-warm sibling tab caches after every populate of the open merged menu so a
         // tab switch attaches pre-rendered rows; no-ops for closed or non-merged menus.
@@ -766,6 +769,10 @@ extension StatusItemController {
                 width: context.menuWidth)
             {
                 menu.addItem(.separator())
+            }
+            if self.shouldMergeIcons, self.store.enabledProvidersForDisplay().count > 1 {
+                // Sized by `applyStableMenuHeightPadding` so provider tabs share one height.
+                menu.addItem(self.makeStableMenuHeightSpacerItem())
             }
         }
     }

--- a/Sources/CodexBar/StatusItemController+MenuSwitcherWarmup.swift
+++ b/Sources/CodexBar/StatusItemController+MenuSwitcherWarmup.swift
@@ -7,24 +7,35 @@ import CodexBarCore
 /// `NSHostingView` commits SwiftUI content asynchronously; a freshly built card
 /// swapped in during a switch paints a frame late, which reads as a flicker.
 extension StatusItemController {
-    private static let mergedSwitcherWarmupDelay: Duration = .milliseconds(120)
+    private static let mergedSwitcherWarmupDelaySeconds: TimeInterval = 0.12
 
+    /// Scheduled via a common-modes `Timer`, NOT Swift Concurrency: the menu is
+    /// open (tracking mode) for the entire window where warm caches matter, and
+    /// main-actor tasks do not run during NSMenu tracking — a `Task.sleep`-based
+    /// warmup would only ever fire after the menu closed, i.e. never usefully.
     func scheduleMergedSwitcherSiblingWarmup(for menu: NSMenu) {
         guard self.isMenuRefreshEnabled else { return }
         guard self.shouldMergeIcons, menu === self.mergedMenu else { return }
-        self.mergedSwitcherWarmupTask?.cancel()
-        self.mergedSwitcherWarmupTask = Task { @MainActor [weak self, weak menu] in
-            try? await Task.sleep(for: Self.mergedSwitcherWarmupDelay)
-            guard !Task.isCancelled, let self else { return }
-            self.mergedSwitcherWarmupTask = nil
-            guard let menu, self.openMenus[ObjectIdentifier(menu)] === menu else { return }
-            self.warmMergedSwitcherSiblingContent(in: menu)
+        self.mergedSwitcherWarmupTimer?.invalidate()
+        let menuKey = ObjectIdentifier(menu)
+        let timer = Timer(
+            timeInterval: Self.mergedSwitcherWarmupDelaySeconds,
+            repeats: false)
+        { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.mergedSwitcherWarmupTimer = nil
+                guard let menu = self.openMenus[menuKey] else { return }
+                self.warmMergedSwitcherSiblingContent(in: menu)
+            }
         }
+        RunLoop.main.add(timer, forMode: .common)
+        self.mergedSwitcherWarmupTimer = timer
     }
 
     func cancelMergedSwitcherSiblingWarmup() {
-        self.mergedSwitcherWarmupTask?.cancel()
-        self.mergedSwitcherWarmupTask = nil
+        self.mergedSwitcherWarmupTimer?.invalidate()
+        self.mergedSwitcherWarmupTimer = nil
     }
 
     func warmMergedSwitcherSiblingContent(in menu: NSMenu) {
@@ -45,6 +56,9 @@ extension StatusItemController {
                 in: menu,
                 enabledProviders: enabledProviders)
         }
+        // Freshly warmed tabs carry zero-height spacers; equalize provider-tab
+        // heights now so the first switch does not resize the menu window.
+        self.applyStableMenuHeightPadding(in: menu)
     }
 
     private func warmMergedSwitcherContentIfMissing(

--- a/Sources/CodexBar/StatusItemController+StableMenuHeight.swift
+++ b/Sources/CodexBar/StatusItemController+StableMenuHeight.swift
@@ -10,11 +10,38 @@ import CodexBarCore
 /// row between the usage content and the trailing action rows; this pass sizes
 /// those spacers so every provider tab matches the tallest one. Overview is
 /// excluded: it is a different mode and may be far taller.
+/// Runtime-measured native menu row metrics. Fixed estimates would drift with
+/// OS versions and accessibility text sizes; instead AppKit lays out a scratch
+/// menu once per text-size token and we derive exact row/separator heights
+/// (menu chrome padding cancels out of the differences).
+@MainActor
+private enum NativeMenuRowMetrics {
+    private static var cached: (textScale: Int, row: CGFloat, separator: CGFloat)?
+
+    static func current() -> (row: CGFloat, separator: CGFloat) {
+        let textScale = StatusItemController.menuCardHeightTextScaleToken()
+        if let cached, cached.textScale == textScale {
+            return (cached.row, cached.separator)
+        }
+        let probe = NSMenu()
+        probe.autoenablesItems = false
+        probe.addItem(NSMenuItem(title: "Row", action: nil, keyEquivalent: ""))
+        probe.addItem(NSMenuItem(title: "Row", action: nil, keyEquivalent: ""))
+        let twoRows = probe.size.height
+        probe.addItem(NSMenuItem(title: "Row", action: nil, keyEquivalent: ""))
+        probe.addItem(NSMenuItem(title: "Row", action: nil, keyEquivalent: ""))
+        let fourRows = probe.size.height
+        probe.insertItem(.separator(), at: 2)
+        let fourRowsPlusSeparator = probe.size.height
+        let row = max(1, (fourRows - twoRows) / 2)
+        let separator = max(1, fourRowsPlusSeparator - fourRows)
+        self.cached = (textScale, row, separator)
+        return (row, separator)
+    }
+}
+
 extension StatusItemController {
     static let stableMenuHeightSpacerID = "stableHeightSpacer"
-    /// Estimated heights for rows AppKit lays out natively (no custom view).
-    private static let nativeMenuRowHeightEstimate: CGFloat = 24
-    private static let menuSeparatorHeightEstimate: CGFloat = 13
 
     func makeStableMenuHeightSpacerItem() -> NSMenuItem {
         let item = NSMenuItem()
@@ -69,8 +96,10 @@ extension StatusItemController {
     }
 
     /// Content height excluding the spacer itself, plus the spacer item when present.
-    /// Internal for test access.
+    /// View-backed rows use their exact frame; native rows and separators use
+    /// AppKit-measured metrics for the current text size. Internal for test access.
     func measureTab(items: [NSMenuItem]) -> (spacer: NSMenuItem?, contentHeight: CGFloat) {
+        let metrics = NativeMenuRowMetrics.current()
         var spacer: NSMenuItem?
         var height: CGFloat = 0
         for item in items {
@@ -79,11 +108,11 @@ extension StatusItemController {
                 continue
             }
             if item.isSeparatorItem {
-                height += Self.menuSeparatorHeightEstimate
+                height += metrics.separator
             } else if let view = item.view {
                 height += view.frame.height
             } else {
-                height += Self.nativeMenuRowHeightEstimate
+                height += metrics.row
             }
         }
         return (spacer, height)

--- a/Sources/CodexBar/StatusItemController+StableMenuHeight.swift
+++ b/Sources/CodexBar/StatusItemController+StableMenuHeight.swift
@@ -1,0 +1,91 @@
+import AppKit
+import CodexBarCore
+
+/// Keeps the merged menu's window height stable across provider tab switches.
+///
+/// Probe captures (`MenuSwitchFlickerProbe`) show the tab-switch composite is
+/// atomic, but tabs of different heights make AppKit resize the menu window on
+/// every switch; the moving bottom edge plus the WindowServer backdrop/shadow
+/// recompute reads as a flash. Each provider tab carries a zero-height spacer
+/// row between the usage content and the trailing action rows; this pass sizes
+/// those spacers so every provider tab matches the tallest one. Overview is
+/// excluded: it is a different mode and may be far taller.
+extension StatusItemController {
+    static let stableMenuHeightSpacerID = "stableHeightSpacer"
+    /// Estimated heights for rows AppKit lays out natively (no custom view).
+    private static let nativeMenuRowHeightEstimate: CGFloat = 24
+    private static let menuSeparatorHeightEstimate: CGFloat = 13
+
+    func makeStableMenuHeightSpacerItem() -> NSMenuItem {
+        let item = NSMenuItem()
+        item.isEnabled = false
+        item.representedObject = Self.stableMenuHeightSpacerID
+        let view = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: 0))
+        item.view = view
+        return item
+    }
+
+    /// Equalizes provider-tab content heights: the visible menu's spacer and every
+    /// cached provider tab's spacer are sized against the tallest tab. Runs after
+    /// card heights are final for the current populate pass.
+    ///
+    /// Known simplification: cached tabs keep the spacer size they were last
+    /// padded with, so a data tick that shrinks the tallest tab can leave a stale
+    /// gap until the sibling becomes visible again — a one-frame height nudge at
+    /// worst, instead of a jump on every switch.
+    func applyStableMenuHeightPadding(in menu: NSMenu) {
+        // Any merged-style menu qualifies: only merged menus carry the provider switcher.
+        guard self.shouldMergeIcons, menu.items.first?.view is ProviderSwitcherView else { return }
+        guard self.store.enabledProvidersForDisplay().count > 1 else { return }
+        let contentStartIndex = self.providerSwitcherContentStartIndex(in: menu)
+        guard contentStartIndex > 0 else { return }
+
+        let visibleItems = Array(menu.items[contentStartIndex...])
+        let visibleIsProviderTab = self.lastMergedMenuContentSelection.map { $0 != .overview } ?? true
+        var tabs: [(spacer: NSMenuItem?, contentHeight: CGFloat)] = []
+        if visibleIsProviderTab {
+            tabs.append(self.measureTab(items: visibleItems))
+        }
+        let cacheEntries = self.mergedSwitcherContentCaches[ObjectIdentifier(menu)] ?? [:]
+        for (selection, entry) in cacheEntries where selection != .overview {
+            if visibleIsProviderTab, selection == self.lastMergedMenuContentSelection { continue }
+            tabs.append(self.measureTab(items: entry.items))
+        }
+        MenuSwitchFlickerProbe.debugLog(
+            "padding: visibleProvider=\(visibleIsProviderTab) " +
+                "selection=\(String(describing: self.lastMergedMenuContentSelection)) " +
+                "cacheKeys=\(cacheEntries.keys.map { String(describing: $0) }) " +
+                "tabs=\(tabs.map { "(spacer:\($0.spacer != nil) h:\($0.contentHeight))" })")
+        guard tabs.count > 1, let maxHeight = tabs.map(\.contentHeight).max() else { return }
+
+        for tab in tabs {
+            guard let spacer = tab.spacer, let spacerView = spacer.view else { continue }
+            let padding = max(0, maxHeight - tab.contentHeight)
+            if abs(spacerView.frame.height - padding) > 0.5 {
+                MenuSwitchFlickerProbe.debugLog("padding: set spacer \(spacerView.frame.height) -> \(padding)")
+                spacerView.setFrameSize(NSSize(width: 1, height: padding))
+            }
+        }
+    }
+
+    /// Content height excluding the spacer itself, plus the spacer item when present.
+    /// Internal for test access.
+    func measureTab(items: [NSMenuItem]) -> (spacer: NSMenuItem?, contentHeight: CGFloat) {
+        var spacer: NSMenuItem?
+        var height: CGFloat = 0
+        for item in items {
+            if item.representedObject as? String == Self.stableMenuHeightSpacerID {
+                spacer = item
+                continue
+            }
+            if item.isSeparatorItem {
+                height += Self.menuSeparatorHeightEstimate
+            } else if let view = item.view {
+                height += view.frame.height
+            } else {
+                height += Self.nativeMenuRowHeightEstimate
+            }
+        }
+        return (spacer, height)
+    }
+}

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -275,7 +275,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     /// Tracks the visible token account switcher contents for merged-menu smart updates.
     var lastTokenAccountMenuDisplay: TokenAccountMenuDisplay?
     /// Debounced pre-build of sibling switcher tabs for flicker-free tab switches.
-    var mergedSwitcherWarmupTask: Task<Void, Never>?
+    /// A common-modes Timer (not a Task) so it fires during NSMenu tracking.
+    var mergedSwitcherWarmupTimer: Timer?
     /// Compact multi-account layout: accounts the user expanded to full cards this menu session.
     var compactAccountExpandedIDs: Set<ProviderAccountIdentity> = []
     /// Compact multi-account layout: providers whose collapsed healthy tail is revealed this menu session.

--- a/Tests/CodexBarTests/StatusMenuSwitcherWarmupTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherWarmupTests.swift
@@ -62,6 +62,34 @@ final class StatusMenuSwitcherWarmupTests: XCTestCase {
         }
     }
 
+    func test_stableHeightPaddingEqualizesProviderTabs() {
+        let (controller, menu) = self.makeController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.warmMergedSwitcherSiblingContent(in: menu)
+
+        // Overview is excluded from equalization by design; compare provider tabs only.
+        var totals: [CGFloat] = []
+        let visibleSelection = controller.lastMergedMenuContentSelection
+        if let visibleSelection, visibleSelection != .overview {
+            let contentStartIndex = controller.providerSwitcherContentStartIndex(in: menu)
+            let visible = controller.measureTab(items: Array(menu.items[contentStartIndex...]))
+            totals.append(visible.contentHeight + (visible.spacer?.view?.frame.height ?? 0))
+        }
+        let caches = controller.mergedSwitcherContentCaches[ObjectIdentifier(menu)] ?? [:]
+        for (selection, entry) in caches where selection != .overview {
+            if selection == visibleSelection { continue }
+            let tab = controller.measureTab(items: entry.items)
+            XCTAssertNotNil(tab.spacer, "provider tab content must carry a stable-height spacer")
+            totals.append(tab.contentHeight + (tab.spacer?.view?.frame.height ?? 0))
+        }
+        XCTAssertGreaterThan(totals.count, 1)
+        let reference = totals[0]
+        for total in totals {
+            XCTAssertEqual(total, reference, accuracy: 0.5)
+        }
+    }
+
     func test_warmupSkipsSelectionsAlreadyCached() {
         let (controller, menu) = self.makeController()
         defer { controller.releaseStatusItemsForTesting() }


### PR DESCRIPTION
## Summary

Round 3 on the provider tab-switch flash, this time with frame-level evidence instead of hypotheses. A new env-gated, self-driving probe (`MenuSwitchFlickerProbe`) opens the merged menu, switches tabs programmatically, and captures the menu window's own WindowServer composite from a background thread at ~3ms cadence (own-window capture needs no screen-recording grant; background capture sees frames even while the main thread is stalled mid-rebuild).

The captures exposed two real defects:

1. **The #2547 warmup never ran in production.** It slept on a main-actor `Task`, and main-actor jobs do not execute during NSMenu's synchronous tracking loop — which is the entire window where warm caches matter. Every tab switch was rebuilding content live. The warmup now runs off a common-modes `Timer` (the same reason `ProviderSwitcherTrackingRunLoopScheduler` exists). Probe before/after: sibling caches empty at switch time → populated 120ms after open.

2. **Tabs of different heights force a window resize on every switch.** With warm caches the content swap composite is atomic (probe: exactly one changed frame, no blanks), but AppKit resized the menu window ~40–70ms after the swap — a 47pt bottom-edge jump plus backdrop/shadow recompute that reads as a flash. Provider tabs now carry an invisible spacer row (sized after each populate/warmup pass) so all provider tabs share the tallest tab's height. Overview keeps its own height by design.

## Probe evidence (final build)

- switch Codex→Claude and back: `windowBounds` timeline shows **zero changes** for the whole session (previously 615→568→615).
- pixel diff across 500+ frames: exactly **one changed frame per switch** (14% of pixels — the content region), no blank or partial frames, no size change.

## Verification

- New `test_stableHeightPaddingEqualizesProviderTabs` plus existing warmup tests.
- `make check` clean; full `make test` green locally.
- The probe tool stays in-tree (inert without `CODEXBAR_FLICKER_PROBE_DIR`) for future menu rendering work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
