### PR TITLE
fix(opencode): use SweetCookieKit Chromium schema-v24 cookie fix

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9ff984774bac1045e21694cf1cf092fd19719dbedc3eb429c07cee54f299512b",
+  "originHash" : "2e8a73bbec33ba73063dc95b68b75cec0a6766aa9f1d5f83925f95e09e47a55e",
   "pins" : [
     {
       "identity" : "commander",
@@ -33,7 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/SweetCookieKit",
       "state" : {
-        "revision" : "c105de35b20509dc2d58c16eb9f3e6c96593406d"
+        "revision" : "228c7927e03b85b25b41da23a44c4f5308519796",
+        "version" : "0.5.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d5ef2ec180d58ea5f869b40e5024f2e23d1ce02e999305b2e78d1b5c3783b83b",
+  "originHash" : "9ff984774bac1045e21694cf1cf092fd19719dbedc3eb429c07cee54f299512b",
   "pins" : [
     {
       "identity" : "commander",
@@ -33,8 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/SweetCookieKit",
       "state" : {
-        "revision" : "21bedea672a3e63ccad24d744051e76cdf0462dd",
-        "version" : "0.4.1"
+        "revision" : "c105de35b20509dc2d58c16eb9f3e6c96593406d"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let useLocalSweetCookieKit =
 let sweetCookieKitDependency: Package.Dependency =
     useLocalSweetCookieKit && FileManager.default.fileExists(atPath: sweetCookieKitPath)
     ? .package(path: sweetCookieKitPath)
-    : .package(url: "https://github.com/steipete/SweetCookieKit", revision: "c105de35b20509dc2d58c16eb9f3e6c96593406d")
+    : .package(url: "https://github.com/steipete/SweetCookieKit", exact: "0.5.1")
 
 let sqlite3LibDir = ProcessInfo.processInfo.environment["CODEXBAR_SQLITE3_LIB_DIR"]?
     .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let useLocalSweetCookieKit =
 let sweetCookieKitDependency: Package.Dependency =
     useLocalSweetCookieKit && FileManager.default.fileExists(atPath: sweetCookieKitPath)
     ? .package(path: sweetCookieKitPath)
-    : .package(url: "https://github.com/steipete/SweetCookieKit", from: "0.4.1")
+    : .package(url: "https://github.com/steipete/SweetCookieKit", revision: "c105de35b20509dc2d58c16eb9f3e6c96593406d")
 
 let sqlite3LibDir = ProcessInfo.processInfo.environment["CODEXBAR_SQLITE3_LIB_DIR"]?
     .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let useLocalSweetCookieKit =
 let sweetCookieKitDependency: Package.Dependency =
     useLocalSweetCookieKit && FileManager.default.fileExists(atPath: sweetCookieKitPath)
     ? .package(path: sweetCookieKitPath)
-    : .package(url: "https://github.com/steipete/SweetCookieKit", exact: "0.5.1")
+    : .package(url: "https://github.com/steipete/SweetCookieKit", from: "0.5.1")
 
 let sqlite3LibDir = ProcessInfo.processInfo.environment["CODEXBAR_SQLITE3_LIB_DIR"]?
     .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/BrowserCookieImportOrder.swift
+++ b/Sources/CodexBarCore/BrowserCookieImportOrder.swift
@@ -34,7 +34,7 @@ extension [Browser] {
 extension Browser {
     var usesKeychainForCookieDecryption: Bool {
         switch self {
-        case .safari, .firefox, .zen:
+        case .safari, .firefox, .firefoxBeta, .firefoxDeveloperEdition, .firefoxNightly, .zen:
             return false
         case .chrome, .chromeBeta, .chromeCanary,
              .arc, .arcBeta, .arcCanary,

--- a/Sources/CodexBarCore/Providers/Cursor/CursorInteractiveLoginBrowser.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorInteractiveLoginBrowser.swift
@@ -52,6 +52,9 @@ extension CursorStatusProbe {
         "net.imput.helium": .helium,
         "org.chromium.chromium": .chromium,
         "org.mozilla.firefox": .firefox,
+        "org.mozilla.firefox.beta": .firefoxBeta,
+        "org.mozilla.firefoxdeveloperedition": .firefoxDeveloperEdition,
+        "org.mozilla.nightly": .firefoxNightly,
     ]
 
     private static func normalizedBundleIdentifier(_ value: String?) -> String? {

--- a/Tests/CodexBarTests/CursorAccountSwitchBrowserScanTests.swift
+++ b/Tests/CodexBarTests/CursorAccountSwitchBrowserScanTests.swift
@@ -51,6 +51,18 @@ struct CursorAccountSwitchBrowserScanTests {
     }
 
     @Test
+    func `mapped Firefox variants are keychain-free for interactive login`() {
+        let mappedFirefoxVariants: Set<Browser> = [
+            .firefox,
+            .firefoxBeta,
+            .firefoxDeveloperEdition,
+            .firefoxNightly,
+        ]
+
+        #expect(mappedFirefoxVariants.allSatisfy { !$0.usesKeychainForCookieDecryption })
+    }
+
+    @Test
     func `interactive browser support requires a readable cookie source`() throws {
         let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let applicationURL = temp.appendingPathComponent("Firefox.app", isDirectory: true)


### PR DESCRIPTION
## Summary

OpenCode Go (and other Chrome-cookie-based providers) fail to import the session cookie on recent Chrome builds, surfacing as:

> No OpenCode session cookies found in browsers.

Root cause (verified against Chromium source by the SweetCookieKit maintainer): Chromium cookie schema v24 encrypts `SHA256(host_key) + cookie_value` with the existing fixed-IV `v10` AES-CBC format. The bundled SweetCookieKit only stripped a fixed 32-byte prefix, which both mis-handled schema-v24 hashes and truncated legitimate legacy values.

## Change

- Bump `SweetCookieKit` to the **released tag `0.5.1`** (`228c7927`), which contains the merged upstream fix [steipete/SweetCookieKit#17](https://github.com/steipete/SweetCookieKit/pull/17) ("fix: validate Chromium cookie domain hashes", commit `c105de35`). It reads the Chromium schema version, decrypts `v10` values with the fixed IV, and validates/removes version-24 domain hashes.
- Declared as `from: "0.5.1"` from the official upstream repository (the repository's normal compatible range; `Package.resolved` stays locked to the audited `0.5.1` release, no fork pin, no untagged revision).
- `0.5.1` also includes the upstream `v10` inline-IV decryption fix and Keychain interaction changes released after `0.4.1`.
- SweetCookieKit `0.5.1` adds three Firefox variant browsers (Beta, Developer Edition, Nightly); the Cursor interactive-browser mapping now covers their bundle identifiers so the exhaustive browser-mapping test stays green.

## Test

- `swift build --target CodexBarCore` — clean.
- `swift test --filter "OpenCode"` — 113 tests in 11 suites pass (re-run against the `0.5.1` tag pin).
- `make check` — 0 lint violations across 1668 files.
- Upstream proof from the maintainer: red-green on legacy + schema-v24 Unicode cases; 16 focused / 66 full tests pass on the repaired head.

Related: #2543 (OpenCode Go auto mode never applies web usage), #2541 (cookie refresh validates but session never authenticates).
