### PR TITLE
Menu bar: add a pipe separator token to the layout editor

### DIFF
--- a/Sources/CodexBar/MenuBarLayout.swift
+++ b/Sources/CodexBar/MenuBarLayout.swift
@@ -19,6 +19,7 @@ enum MenuBarLayoutToken: Codable, Hashable, Sendable {
     case costToday
     case cost30d
     case separatorDot
+    case separatorPipe
     case space
 }
 

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -261,7 +261,7 @@ struct MenuBarLayoutEditor: View {
             MenuBarLayoutPaletteGroup(
                 id: "structure",
                 title: L("menu_bar_layout_group_structure"),
-                tokens: [.separatorDot, .space],
+                tokens: [.separatorDot, .separatorPipe, .space],
                 includesLineBreak: true),
         ]
     }
@@ -785,6 +785,7 @@ extension MenuBarLayoutToken {
         case .costToday: L("menu_bar_layout_token_cost_today")
         case .cost30d: L("menu_bar_layout_token_cost_30d")
         case .separatorDot: "·"
+        case .separatorPipe: "|"
         case .space: L("menu_bar_layout_token_space")
         }
     }
@@ -792,6 +793,7 @@ extension MenuBarLayoutToken {
     var editorAccessibilityLabel: String {
         switch self {
         case .separatorDot: L("menu_bar_layout_token_separator_accessibility")
+        case .separatorPipe: L("menu_bar_layout_token_separator_pipe_accessibility")
         default: self.editorLabel
         }
     }
@@ -809,6 +811,7 @@ extension MenuBarLayoutToken {
         case .costToday: "dollarsign.circle"
         case .cost30d: "calendar.badge.clock"
         case .separatorDot: "smallcircle.filled.circle"
+        case .separatorPipe: "rectangle.split.2x1"
         case .space: "space"
         }
     }

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -292,6 +292,8 @@ final class MenuBarLayoutRenderer {
                 attributes: style.attributes)
         case .separatorDot:
             return self.textToken("·", accessibilityText: nil, attributes: style.attributes)
+        case .separatorPipe:
+            return self.textToken("|", accessibilityText: nil, attributes: style.attributes)
         case .space:
             return self.textToken(" ", accessibilityText: nil, attributes: style.attributes)
         }

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1337,6 +1337,7 @@
 "menu_bar_layout_token_space" = "مسافة";
 "menu_bar_layout_token_line_break" = "فاصل سطر";
 "menu_bar_layout_token_separator_accessibility" = "نقطة فاصلة";
+"menu_bar_layout_token_separator_pipe_accessibility" = "خط فاصل";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "الأيقونة: غير متوفر";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1336,6 +1336,7 @@
 "menu_bar_layout_token_space" = "Espai";
 "menu_bar_layout_token_line_break" = "Salt de línia";
 "menu_bar_layout_token_separator_accessibility" = "Punt separador";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Barra separadora";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Icona: No disponible";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1334,6 +1334,7 @@
 "menu_bar_layout_token_space" = "Leerraum";
 "menu_bar_layout_token_line_break" = "Zeilenumbruch";
 "menu_bar_layout_token_separator_accessibility" = "Trennpunkt";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Trennstrich";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Symbol: Nicht verfügbar";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1338,6 +1338,7 @@
 "menu_bar_layout_token_space" = "Space";
 "menu_bar_layout_token_line_break" = "Line break";
 "menu_bar_layout_token_separator_accessibility" = "Separator dot";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Separator bar";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Icon unavailable";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1332,6 +1332,7 @@
 "menu_bar_layout_token_space" = "Espacio";
 "menu_bar_layout_token_line_break" = "Salto de línea";
 "menu_bar_layout_token_separator_accessibility" = "Punto separador";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Barra separadora";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Icono: No disponible";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1337,6 +1337,7 @@
 "menu_bar_layout_token_space" = "فاصله";
 "menu_bar_layout_token_line_break" = "شکست خط";
 "menu_bar_layout_token_separator_accessibility" = "نقطهٔ جداکننده";
+"menu_bar_layout_token_separator_pipe_accessibility" = "خط جداکننده";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "آیکون: در دسترس نیست";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1333,6 +1333,7 @@
 "menu_bar_layout_token_space" = "Espace";
 "menu_bar_layout_token_line_break" = "Saut de ligne";
 "menu_bar_layout_token_separator_accessibility" = "Point séparateur";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Barre séparatrice";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Icône: Indisponible";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1333,6 +1333,7 @@
 "menu_bar_layout_token_space" = "Espazo";
 "menu_bar_layout_token_line_break" = "Salto de liña";
 "menu_bar_layout_token_separator_accessibility" = "Punto separador";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Barra separadora";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Icona: Non dispoñible";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1337,6 +1337,7 @@
 "menu_bar_layout_token_space" = "Spasi";
 "menu_bar_layout_token_line_break" = "Pemisah baris";
 "menu_bar_layout_token_separator_accessibility" = "Titik pemisah";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Garis pemisah";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Ikon: Tidak tersedia";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1337,6 +1337,7 @@
 "menu_bar_layout_token_space" = "Spazio";
 "menu_bar_layout_token_line_break" = "Interruzione di riga";
 "menu_bar_layout_token_separator_accessibility" = "Punto separatore";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Barra separatrice";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Icona: Non disponibile";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1334,6 +1334,7 @@
 "menu_bar_layout_token_space" = "空白";
 "menu_bar_layout_token_line_break" = "改行";
 "menu_bar_layout_token_separator_accessibility" = "区切り点";
+"menu_bar_layout_token_separator_pipe_accessibility" = "区切り線";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "アイコン: 利用不可";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1301,6 +1301,7 @@
 "menu_bar_layout_token_space" = "공백";
 "menu_bar_layout_token_line_break" = "줄 바꿈";
 "menu_bar_layout_token_separator_accessibility" = "구분점";
+"menu_bar_layout_token_separator_pipe_accessibility" = "구분선";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "아이콘: 사용할 수 없음";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1333,6 +1333,7 @@
 "menu_bar_layout_token_space" = "Spatie";
 "menu_bar_layout_token_line_break" = "Regeleinde";
 "menu_bar_layout_token_separator_accessibility" = "Scheidingspunt";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Scheidingsstreep";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Pictogram: Niet beschikbaar";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1337,6 +1337,7 @@
 "menu_bar_layout_token_space" = "Odstęp";
 "menu_bar_layout_token_line_break" = "Podział wiersza";
 "menu_bar_layout_token_separator_accessibility" = "Kropka oddzielająca";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Kreska oddzielająca";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Ikona: Niedostępne";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1334,6 +1334,7 @@
 "menu_bar_layout_token_space" = "Espaço";
 "menu_bar_layout_token_line_break" = "Quebra de linha";
 "menu_bar_layout_token_separator_accessibility" = "Ponto separador";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Barra separadora";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Ícone: Indisponível";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1335,6 +1335,7 @@
 "menu_bar_layout_token_space" = "Пробел";
 "menu_bar_layout_token_line_break" = "Разрыв строки";
 "menu_bar_layout_token_separator_accessibility" = "Точка-разделитель";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Черта-разделитель";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Значок: Недоступно";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1332,6 +1332,7 @@
 "menu_bar_layout_token_space" = "Blanksteg";
 "menu_bar_layout_token_line_break" = "Radbrytning";
 "menu_bar_layout_token_separator_accessibility" = "Avgränsarpunkt";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Avgränsarstreck";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Ikon: Inte tillgänglig";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1337,6 +1337,7 @@
 "menu_bar_layout_token_space" = "ช่องว่าง";
 "menu_bar_layout_token_line_break" = "ขึ้นบรรทัดใหม่";
 "menu_bar_layout_token_separator_accessibility" = "จุดคั่น";
+"menu_bar_layout_token_separator_pipe_accessibility" = "เส้นคั่น";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "ไอคอน: ไม่พร้อมใช้งาน";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1335,6 +1335,7 @@
 "menu_bar_layout_token_space" = "Boşluk";
 "menu_bar_layout_token_line_break" = "Satır sonu";
 "menu_bar_layout_token_separator_accessibility" = "Ayırıcı nokta";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Ayırıcı çubuk";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Simge: Kullanılamıyor";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1333,6 +1333,7 @@
 "menu_bar_layout_token_space" = "Пробіл";
 "menu_bar_layout_token_line_break" = "Розрив рядка";
 "menu_bar_layout_token_separator_accessibility" = "Крапка-роздільник";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Риска-роздільник";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Значок: Недоступний";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1334,6 +1334,7 @@
 "menu_bar_layout_token_space" = "Khoảng trắng";
 "menu_bar_layout_token_line_break" = "Ngắt dòng";
 "menu_bar_layout_token_separator_accessibility" = "Dấu chấm phân cách";
+"menu_bar_layout_token_separator_pipe_accessibility" = "Thanh phân cách";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "Biểu tượng: Không có sẵn";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1309,6 +1309,7 @@
 "menu_bar_layout_token_space" = "空格";
 "menu_bar_layout_token_line_break" = "换行";
 "menu_bar_layout_token_separator_accessibility" = "分隔点";
+"menu_bar_layout_token_separator_pipe_accessibility" = "分隔线";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "图标: 不可用";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1364,6 +1364,7 @@
 "menu_bar_layout_token_space" = "空格";
 "menu_bar_layout_token_line_break" = "換行";
 "menu_bar_layout_token_separator_accessibility" = "分隔點";
+"menu_bar_layout_token_separator_pipe_accessibility" = "分隔線";
 
 /* Menu bar layout accessibility */
 "Icon unavailable" = "圖示: 無法使用";

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -26,6 +26,7 @@ struct MenuBarLayoutRendererTests {
             (.costToday, "$1.25"),
             (.cost30d, "$20.00"),
             (.separatorDot, "·"),
+            (.separatorPipe, "|"),
             (.space, " "),
         ]
 


### PR DESCRIPTION
Adds `|` as a second separator token in the menu bar layout editor, alongside the existing `·`.

## Why

The Structure palette offers a middot and a space. A vertical bar reads better in some strips — `5h 25% | W 60%` — and today that has to be faked with spaces. This makes it a first-class token.

## Changes

- New `MenuBarLayoutToken.separatorPipe`, rendered as `|` by `MenuBarLayoutRenderer` with the same attributes as the dot separator.
- Structure palette now offers `·`, `|`, space, in that order. The pipe uses `rectangle.split.2x1` (SF Symbols has no plain vertical-bar glyph — happy to swap it) and has its own VoiceOver label.
- `menu_bar_layout_token_separator_pipe_accessibility` added to all 23 catalogs.
- Renderer test token table covers the pipe.

Purely additive: the enum gains a case, so stored `separatorDot` layouts decode exactly as before. No preset or migration changed.

## Verification

`swift build` and `node Scripts/check-app-locales.mjs` clean against this branch on current `main`.

The non-English strings for the new accessibility key are machine-generated — worth a skim if the wording matters to you.
