### PR TITLE
Menu bar: add pace tokens to the layout editor

### DIFF
--- a/Sources/CodexBar/MenuBarLayout.swift
+++ b/Sources/CodexBar/MenuBarLayout.swift
@@ -12,6 +12,7 @@ enum MenuBarLayoutToken: Codable, Hashable, Sendable {
     case providerName
     case accountLabel
     case percent(window: PercentWindow)
+    case pace(window: PercentWindow)
     case usageBar
     case resetCountdown
     case resetAbsolute

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -246,6 +246,9 @@ struct MenuBarLayoutEditor: View {
                     .percent(window: .weekly),
                     .percent(window: .automatic),
                     .usageBar,
+                    .pace(window: .session),
+                    .pace(window: .weekly),
+                    .pace(window: .automatic),
                 ],
                 includesLineBreak: false),
             MenuBarLayoutPaletteGroup(
@@ -674,9 +677,13 @@ private struct MenuBarLayoutPreview: View {
                 now: now)
         }
         let paceWindow = weekly ?? automatic
-        let runsOut = paceWindow
+        let weeklyPaceDetail = paceWindow
             .flatMap { self.store.weeklyPace(provider: provider, window: $0, now: now) }
-            .flatMap { UsagePaceText.weeklyDetail(provider: provider, pace: $0, now: now).rightLabel }
+            .map { UsagePaceText.weeklyDetail(provider: provider, pace: $0, now: now) }
+        let runsOut = weeklyPaceDetail?.rightLabel
+        let sessionPace = session
+            .flatMap { UsagePaceText.sessionDetail(provider: provider, window: $0, now: now) }?
+            .leftLabel
         let cost = self.store.tokenSnapshotForCurrentProviderConfig(for: provider)?.snapshot
         let costToday = MenuBarLayoutCostResolver.todayCostUSD(snapshot: cost, now: now)
         return MenuBarLayoutRenderData(
@@ -686,6 +693,8 @@ private struct MenuBarLayoutPreview: View {
             session: MenuBarLayoutRenderWindow(session),
             weekly: MenuBarLayoutRenderWindow(weekly),
             automatic: MenuBarLayoutRenderWindow(automatic),
+            sessionPace: sessionPace,
+            weeklyPace: weeklyPaceDetail?.leftLabel,
             runsOut: runsOut,
             costToday: costToday.map {
                 UsageFormatter.currencyString($0, currencyCode: cost?.currencyCode ?? "USD")
@@ -714,6 +723,8 @@ private struct MenuBarLayoutPreview: View {
             session: MenuBarLayoutRenderWindow(session),
             weekly: MenuBarLayoutRenderWindow(weekly),
             automatic: MenuBarLayoutRenderWindow(session),
+            sessionPace: L("%d%% in reserve", 12),
+            weeklyPace: L("%d%% in deficit", 8),
             runsOut: L("menu_bar_layout_sample_runs_out"),
             costToday: "$1.25",
             cost30d: "$20.00")
@@ -779,6 +790,9 @@ extension MenuBarLayoutToken {
         case .percent(window: .weekly): L("menu_bar_layout_token_weekly")
         case .percent(window: .automatic): L("menu_bar_layout_token_auto")
         case .usageBar: L("menu_bar_layout_token_bar")
+        case .pace(window: .session): L("menu_bar_layout_token_session_pace")
+        case .pace(window: .weekly): L("menu_bar_layout_token_weekly_pace")
+        case .pace(window: .automatic): L("menu_bar_layout_token_auto_pace")
         case .resetCountdown: L("menu_bar_layout_token_resets_in")
         case .resetAbsolute: L("menu_bar_layout_token_reset_at")
         case .runsOut: L("menu_bar_layout_token_runs_out")
@@ -802,6 +816,7 @@ extension MenuBarLayoutToken {
         case .providerName: "textformat"
         case .accountLabel: "person.crop.circle"
         case .percent: "percent"
+        case .pace: "speedometer"
         case .usageBar: "chart.bar.fill"
         case .resetCountdown: "timer"
         case .resetAbsolute: "clock"

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -252,34 +252,7 @@ final class MenuBarLayoutRenderer {
                 : L("%@ %@", accessibilityPrefix, value)
             return self.textToken(display, accessibilityText: accessibility, attributes: style.attributes)
         case let .pace(window):
-            // Pace reuses the percent token's window vocabulary so a strip carrying both reads consistently.
-            // Only the pace headline ("On pace", "23% in reserve") is shown; the run-out estimate that shares
-            // the same pace calculation stays in the dedicated `.runsOut` token.
-            let paceValue = Self.pace(window, data: data)
-            let prefix: String
-            let accessibilityPrefix: String
-            switch window {
-            case .session:
-                prefix = Self.sessionPrefix(data.session)
-                accessibilityPrefix = L("Session pace")
-            case .weekly:
-                prefix = "W"
-                accessibilityPrefix = L("Weekly pace")
-            case .automatic:
-                prefix = ""
-                accessibilityPrefix = L("Pace")
-            }
-            guard let paceValue else {
-                return self.textToken(
-                    self.missingValue,
-                    accessibilityText: L("%@ unavailable", accessibilityPrefix),
-                    attributes: style.attributes)
-            }
-            let display = prefix.isEmpty ? paceValue : "\(prefix) \(paceValue)"
-            return self.textToken(
-                display,
-                accessibilityText: L("%@ %@", accessibilityPrefix, paceValue),
-                attributes: style.attributes)
+            return self.paceToken(window, data: data, style: style)
         case .usageBar:
             guard let window = data.automatic else {
                 return self.textToken(
@@ -390,6 +363,40 @@ final class MenuBarLayoutRenderer {
         case .weekly: data.weekly
         case .automatic: data.automatic
         }
+    }
+
+    /// Pace reuses the percent token's window vocabulary so a strip carrying both reads consistently.
+    /// Only the pace headline ("On pace", "23% in reserve") is shown; the run-out estimate that shares the
+    /// same pace calculation stays in the dedicated `.runsOut` token.
+    private static func paceToken(
+        _ window: PercentWindow,
+        data: MenuBarLayoutRenderData,
+        style: TokenStyle)
+        -> (value: NSAttributedString, accessibilityText: String?)
+    {
+        let prefix: String
+        let accessibilityPrefix: String
+        switch window {
+        case .session:
+            prefix = Self.sessionPrefix(data.session)
+            accessibilityPrefix = L("Session pace")
+        case .weekly:
+            prefix = "W"
+            accessibilityPrefix = L("Weekly pace")
+        case .automatic:
+            prefix = ""
+            accessibilityPrefix = L("Pace")
+        }
+        guard let paceValue = Self.pace(window, data: data) else {
+            return self.textToken(
+                self.missingValue,
+                accessibilityText: L("%@ unavailable", accessibilityPrefix),
+                attributes: style.attributes)
+        }
+        return self.textToken(
+            prefix.isEmpty ? paceValue : "\(prefix) \(paceValue)",
+            accessibilityText: L("%@ %@", accessibilityPrefix, paceValue),
+            attributes: style.attributes)
     }
 
     private static func pace(

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -28,6 +28,8 @@ struct MenuBarLayoutRenderData: Hashable {
     let session: MenuBarLayoutRenderWindow?
     let weekly: MenuBarLayoutRenderWindow?
     let automatic: MenuBarLayoutRenderWindow?
+    let sessionPace: String?
+    let weeklyPace: String?
     let runsOut: String?
     let costToday: String?
     let cost30d: String?
@@ -249,6 +251,35 @@ final class MenuBarLayoutRenderer {
                 ? L("%@ unavailable", accessibilityPrefix)
                 : L("%@ %@", accessibilityPrefix, value)
             return self.textToken(display, accessibilityText: accessibility, attributes: style.attributes)
+        case let .pace(window):
+            // Pace reuses the percent token's window vocabulary so a strip carrying both reads consistently.
+            // Only the pace headline ("On pace", "23% in reserve") is shown; the run-out estimate that shares
+            // the same pace calculation stays in the dedicated `.runsOut` token.
+            let paceValue = Self.pace(window, data: data)
+            let prefix: String
+            let accessibilityPrefix: String
+            switch window {
+            case .session:
+                prefix = Self.sessionPrefix(data.session)
+                accessibilityPrefix = L("Session pace")
+            case .weekly:
+                prefix = "W"
+                accessibilityPrefix = L("Weekly pace")
+            case .automatic:
+                prefix = ""
+                accessibilityPrefix = L("Pace")
+            }
+            guard let paceValue else {
+                return self.textToken(
+                    self.missingValue,
+                    accessibilityText: L("%@ unavailable", accessibilityPrefix),
+                    attributes: style.attributes)
+            }
+            let display = prefix.isEmpty ? paceValue : "\(prefix) \(paceValue)"
+            return self.textToken(
+                display,
+                accessibilityText: L("%@ %@", accessibilityPrefix, paceValue),
+                attributes: style.attributes)
         case .usageBar:
             guard let window = data.automatic else {
                 return self.textToken(
@@ -358,6 +389,20 @@ final class MenuBarLayoutRenderer {
         case .session: data.session
         case .weekly: data.weekly
         case .automatic: data.automatic
+        }
+    }
+
+    private static func pace(
+        _ percentWindow: PercentWindow,
+        data: MenuBarLayoutRenderData)
+        -> String?
+    {
+        switch percentWindow {
+        case .session: data.sessionPace
+        case .weekly: data.weeklyPace
+        // Providers without a session-length pace fall back to the weekly figure so the automatic token
+        // stays populated instead of collapsing to the unavailable placeholder.
+        case .automatic: data.sessionPace ?? data.weeklyPace
         }
     }
 

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1329,6 +1329,12 @@
 "menu_bar_layout_token_weekly" = "الأسبوعي %";
 "menu_bar_layout_token_auto" = "نسبة تلقائية";
 "menu_bar_layout_token_bar" = "شريط الاستخدام";
+"menu_bar_layout_token_session_pace" = "وتيرة الجلسة";
+"menu_bar_layout_token_weekly_pace" = "الوتيرة الأسبوعية";
+"menu_bar_layout_token_auto_pace" = "الوتيرة التلقائية";
+"Session pace" = "وتيرة الجلسة";
+"Weekly pace" = "الوتيرة الأسبوعية";
+"Pace" = "الوتيرة";
 "menu_bar_layout_token_resets_in" = "إعادة الضبط خلال";
 "menu_bar_layout_token_reset_at" = "إعادة الضبط عند";
 "menu_bar_layout_token_runs_out" = "ينفد";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1328,6 +1328,12 @@
 "menu_bar_layout_token_weekly" = "Setmanal %";
 "menu_bar_layout_token_auto" = "% automàtic";
 "menu_bar_layout_token_bar" = "Barra d’ús";
+"menu_bar_layout_token_session_pace" = "Ritme de sessió";
+"menu_bar_layout_token_weekly_pace" = "Ritme setmanal";
+"menu_bar_layout_token_auto_pace" = "Ritme automàtic";
+"Session pace" = "Ritme de sessió";
+"Weekly pace" = "Ritme setmanal";
+"Pace" = "Ritme";
 "menu_bar_layout_token_resets_in" = "Es reinicia d’aquí a";
 "menu_bar_layout_token_reset_at" = "Reinici a";
 "menu_bar_layout_token_runs_out" = "S’esgota";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1326,6 +1326,12 @@
 "menu_bar_layout_token_weekly" = "Wöchentlich %";
 "menu_bar_layout_token_auto" = "Automatisch %";
 "menu_bar_layout_token_bar" = "Nutzungsleiste";
+"menu_bar_layout_token_session_pace" = "Sitzungstempo";
+"menu_bar_layout_token_weekly_pace" = "Wochentempo";
+"menu_bar_layout_token_auto_pace" = "Automatisches Tempo";
+"Session pace" = "Sitzungstempo";
+"Weekly pace" = "Wochentempo";
+"Pace" = "Tempo";
 "menu_bar_layout_token_resets_in" = "Zurücksetzung in";
 "menu_bar_layout_token_reset_at" = "Zurücksetzung um";
 "menu_bar_layout_token_runs_out" = "Reicht bis";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1330,6 +1330,12 @@
 "menu_bar_layout_token_weekly" = "Weekly %";
 "menu_bar_layout_token_auto" = "Auto %";
 "menu_bar_layout_token_bar" = "Usage bar";
+"menu_bar_layout_token_session_pace" = "Session pace";
+"menu_bar_layout_token_weekly_pace" = "Weekly pace";
+"menu_bar_layout_token_auto_pace" = "Auto pace";
+"Session pace" = "Session pace";
+"Weekly pace" = "Weekly pace";
+"Pace" = "Pace";
 "menu_bar_layout_token_resets_in" = "Resets in";
 "menu_bar_layout_token_reset_at" = "Reset at";
 "menu_bar_layout_token_runs_out" = "Runs out";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1324,6 +1324,12 @@
 "menu_bar_layout_token_weekly" = "Semanal %";
 "menu_bar_layout_token_auto" = "% automático";
 "menu_bar_layout_token_bar" = "Barra de uso";
+"menu_bar_layout_token_session_pace" = "Ritmo de sesión";
+"menu_bar_layout_token_weekly_pace" = "Ritmo semanal";
+"menu_bar_layout_token_auto_pace" = "Ritmo automático";
+"Session pace" = "Ritmo de sesión";
+"Weekly pace" = "Ritmo semanal";
+"Pace" = "Ritmo";
 "menu_bar_layout_token_resets_in" = "Se reinicia en";
 "menu_bar_layout_token_reset_at" = "Reinicio a las";
 "menu_bar_layout_token_runs_out" = "Se agota";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1329,6 +1329,12 @@
 "menu_bar_layout_token_weekly" = "هفتگی %";
 "menu_bar_layout_token_auto" = "درصد خودکار";
 "menu_bar_layout_token_bar" = "نوار مصرف";
+"menu_bar_layout_token_session_pace" = "سرعت جلسه";
+"menu_bar_layout_token_weekly_pace" = "سرعت هفتگی";
+"menu_bar_layout_token_auto_pace" = "سرعت خودکار";
+"Session pace" = "سرعت جلسه";
+"Weekly pace" = "سرعت هفتگی";
+"Pace" = "سرعت";
 "menu_bar_layout_token_resets_in" = "بازنشانی در";
 "menu_bar_layout_token_reset_at" = "بازنشانی در ساعت";
 "menu_bar_layout_token_runs_out" = "تمام می‌شود";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1325,6 +1325,12 @@
 "menu_bar_layout_token_weekly" = "Hebdomadaire %";
 "menu_bar_layout_token_auto" = "% auto";
 "menu_bar_layout_token_bar" = "Barre d’utilisation";
+"menu_bar_layout_token_session_pace" = "Rythme de session";
+"menu_bar_layout_token_weekly_pace" = "Rythme hebdomadaire";
+"menu_bar_layout_token_auto_pace" = "Rythme auto";
+"Session pace" = "Rythme de session";
+"Weekly pace" = "Rythme hebdomadaire";
+"Pace" = "Rythme";
 "menu_bar_layout_token_resets_in" = "Réinitialisation dans";
 "menu_bar_layout_token_reset_at" = "Réinitialisation à";
 "menu_bar_layout_token_runs_out" = "Épuisé";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1325,6 +1325,12 @@
 "menu_bar_layout_token_weekly" = "Semanal %";
 "menu_bar_layout_token_auto" = "% automática";
 "menu_bar_layout_token_bar" = "Barra de uso";
+"menu_bar_layout_token_session_pace" = "Ritmo de sesión";
+"menu_bar_layout_token_weekly_pace" = "Ritmo semanal";
+"menu_bar_layout_token_auto_pace" = "Ritmo automático";
+"Session pace" = "Ritmo de sesión";
+"Weekly pace" = "Ritmo semanal";
+"Pace" = "Ritmo";
 "menu_bar_layout_token_resets_in" = "Reiníciase en";
 "menu_bar_layout_token_reset_at" = "Reinicio ás";
 "menu_bar_layout_token_runs_out" = "Esgótase";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1329,6 +1329,12 @@
 "menu_bar_layout_token_weekly" = "Mingguan %";
 "menu_bar_layout_token_auto" = "% otomatis";
 "menu_bar_layout_token_bar" = "Bar penggunaan";
+"menu_bar_layout_token_session_pace" = "Pace sesi";
+"menu_bar_layout_token_weekly_pace" = "Pace mingguan";
+"menu_bar_layout_token_auto_pace" = "Pace otomatis";
+"Session pace" = "Pace sesi";
+"Weekly pace" = "Pace mingguan";
+"Pace" = "Pace";
 "menu_bar_layout_token_resets_in" = "Reset dalam";
 "menu_bar_layout_token_reset_at" = "Reset pukul";
 "menu_bar_layout_token_runs_out" = "Habis";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1329,6 +1329,12 @@
 "menu_bar_layout_token_weekly" = "Settimanale %";
 "menu_bar_layout_token_auto" = "% automatica";
 "menu_bar_layout_token_bar" = "Barra utilizzo";
+"menu_bar_layout_token_session_pace" = "Andamento sessione";
+"menu_bar_layout_token_weekly_pace" = "Andamento settimanale";
+"menu_bar_layout_token_auto_pace" = "Andamento automatico";
+"Session pace" = "Andamento sessione";
+"Weekly pace" = "Andamento settimanale";
+"Pace" = "Andamento";
 "menu_bar_layout_token_resets_in" = "Ripristino tra";
 "menu_bar_layout_token_reset_at" = "Ripristino alle";
 "menu_bar_layout_token_runs_out" = "Termina";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1326,6 +1326,12 @@
 "menu_bar_layout_token_weekly" = "週間 %";
 "menu_bar_layout_token_auto" = "自動 %";
 "menu_bar_layout_token_bar" = "使用量バー";
+"menu_bar_layout_token_session_pace" = "セッションペース";
+"menu_bar_layout_token_weekly_pace" = "週間ペース";
+"menu_bar_layout_token_auto_pace" = "自動ペース";
+"Session pace" = "セッションペース";
+"Weekly pace" = "週間ペース";
+"Pace" = "ペース";
 "menu_bar_layout_token_resets_in" = "リセットまで";
 "menu_bar_layout_token_reset_at" = "リセット時刻";
 "menu_bar_layout_token_runs_out" = "使い切り";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1293,6 +1293,12 @@
 "menu_bar_layout_token_weekly" = "주간 %";
 "menu_bar_layout_token_auto" = "자동 %";
 "menu_bar_layout_token_bar" = "사용량 막대";
+"menu_bar_layout_token_session_pace" = "세션 사용 속도";
+"menu_bar_layout_token_weekly_pace" = "주간 사용 속도";
+"menu_bar_layout_token_auto_pace" = "자동 사용 속도";
+"Session pace" = "세션 사용 속도";
+"Weekly pace" = "주간 사용 속도";
+"Pace" = "사용 속도";
 "menu_bar_layout_token_resets_in" = "재설정까지";
 "menu_bar_layout_token_reset_at" = "재설정 시각";
 "menu_bar_layout_token_runs_out" = "소진";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1325,6 +1325,12 @@
 "menu_bar_layout_token_weekly" = "Wekelijks %";
 "menu_bar_layout_token_auto" = "Automatisch %";
 "menu_bar_layout_token_bar" = "Gebruiksbalk";
+"menu_bar_layout_token_session_pace" = "Sessietempo";
+"menu_bar_layout_token_weekly_pace" = "Wekelijks tempo";
+"menu_bar_layout_token_auto_pace" = "Automatisch tempo";
+"Session pace" = "Sessietempo";
+"Weekly pace" = "Wekelijks tempo";
+"Pace" = "Tempo";
 "menu_bar_layout_token_resets_in" = "Reset over";
 "menu_bar_layout_token_reset_at" = "Reset om";
 "menu_bar_layout_token_runs_out" = "Op";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1329,6 +1329,12 @@
 "menu_bar_layout_token_weekly" = "Tydzień %";
 "menu_bar_layout_token_auto" = "Automatycznie %";
 "menu_bar_layout_token_bar" = "Pasek użycia";
+"menu_bar_layout_token_session_pace" = "Tempo sesji";
+"menu_bar_layout_token_weekly_pace" = "Tempo tygodniowe";
+"menu_bar_layout_token_auto_pace" = "Tempo automatyczne";
+"Session pace" = "Tempo sesji";
+"Weekly pace" = "Tempo tygodniowe";
+"Pace" = "Tempo";
 "menu_bar_layout_token_resets_in" = "Reset za";
 "menu_bar_layout_token_reset_at" = "Reset o";
 "menu_bar_layout_token_runs_out" = "Wyczerpie się";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1326,6 +1326,12 @@
 "menu_bar_layout_token_weekly" = "Semanal %";
 "menu_bar_layout_token_auto" = "% automático";
 "menu_bar_layout_token_bar" = "Barra de uso";
+"menu_bar_layout_token_session_pace" = "Ritmo da sessão";
+"menu_bar_layout_token_weekly_pace" = "Ritmo semanal";
+"menu_bar_layout_token_auto_pace" = "Ritmo automático";
+"Session pace" = "Ritmo da sessão";
+"Weekly pace" = "Ritmo semanal";
+"Pace" = "Ritmo";
 "menu_bar_layout_token_resets_in" = "Redefine em";
 "menu_bar_layout_token_reset_at" = "Redefine às";
 "menu_bar_layout_token_runs_out" = "Acaba";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1327,6 +1327,12 @@
 "menu_bar_layout_token_weekly" = "Недельный %";
 "menu_bar_layout_token_auto" = "Авто %";
 "menu_bar_layout_token_bar" = "Индикатор использования";
+"menu_bar_layout_token_session_pace" = "Темп сеанса";
+"menu_bar_layout_token_weekly_pace" = "Недельный темп";
+"menu_bar_layout_token_auto_pace" = "Автоматический темп";
+"Session pace" = "Темп сеанса";
+"Weekly pace" = "Недельный темп";
+"Pace" = "Темп";
 "menu_bar_layout_token_resets_in" = "Сброс через";
 "menu_bar_layout_token_reset_at" = "Сброс в";
 "menu_bar_layout_token_runs_out" = "Закончится";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1324,6 +1324,12 @@
 "menu_bar_layout_token_weekly" = "Vecka %";
 "menu_bar_layout_token_auto" = "Automatiskt %";
 "menu_bar_layout_token_bar" = "Användningsstapel";
+"menu_bar_layout_token_session_pace" = "Sessionstakt";
+"menu_bar_layout_token_weekly_pace" = "Veckotakt";
+"menu_bar_layout_token_auto_pace" = "Automatisk takt";
+"Session pace" = "Sessionstakt";
+"Weekly pace" = "Veckotakt";
+"Pace" = "Takt";
 "menu_bar_layout_token_resets_in" = "Återställs om";
 "menu_bar_layout_token_reset_at" = "Återställs kl.";
 "menu_bar_layout_token_runs_out" = "Tar slut";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1329,6 +1329,12 @@
 "menu_bar_layout_token_weekly" = "รายสัปดาห์ %";
 "menu_bar_layout_token_auto" = "% อัตโนมัติ";
 "menu_bar_layout_token_bar" = "แถบการใช้งาน";
+"menu_bar_layout_token_session_pace" = "อัตราการใช้เซสชัน";
+"menu_bar_layout_token_weekly_pace" = "อัตราการใช้รายสัปดาห์";
+"menu_bar_layout_token_auto_pace" = "อัตราการใช้อัตโนมัติ";
+"Session pace" = "อัตราการใช้เซสชัน";
+"Weekly pace" = "อัตราการใช้รายสัปดาห์";
+"Pace" = "อัตราการใช้";
 "menu_bar_layout_token_resets_in" = "รีเซ็ตใน";
 "menu_bar_layout_token_reset_at" = "รีเซ็ตเวลา";
 "menu_bar_layout_token_runs_out" = "หมด";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1327,6 +1327,12 @@
 "menu_bar_layout_token_weekly" = "Haftalık %";
 "menu_bar_layout_token_auto" = "Otomatik %";
 "menu_bar_layout_token_bar" = "Kullanım çubuğu";
+"menu_bar_layout_token_session_pace" = "Oturum hızı";
+"menu_bar_layout_token_weekly_pace" = "Haftalık hız";
+"menu_bar_layout_token_auto_pace" = "Otomatik hız";
+"Session pace" = "Oturum hızı";
+"Weekly pace" = "Haftalık hız";
+"Pace" = "Hız";
 "menu_bar_layout_token_resets_in" = "Sıfırlamaya";
 "menu_bar_layout_token_reset_at" = "Sıfırlama saati";
 "menu_bar_layout_token_runs_out" = "Biter";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1325,6 +1325,12 @@
 "menu_bar_layout_token_weekly" = "Щотижня %";
 "menu_bar_layout_token_auto" = "Авто %";
 "menu_bar_layout_token_bar" = "Індикатор використання";
+"menu_bar_layout_token_session_pace" = "Темп сесії";
+"menu_bar_layout_token_weekly_pace" = "Тижневий темп";
+"menu_bar_layout_token_auto_pace" = "Автоматичний темп";
+"Session pace" = "Темп сесії";
+"Weekly pace" = "Тижневий темп";
+"Pace" = "Темп";
 "menu_bar_layout_token_resets_in" = "Скидання через";
 "menu_bar_layout_token_reset_at" = "Скидання о";
 "menu_bar_layout_token_runs_out" = "Закінчиться";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1326,6 +1326,12 @@
 "menu_bar_layout_token_weekly" = "Hàng tuần %";
 "menu_bar_layout_token_auto" = "% tự động";
 "menu_bar_layout_token_bar" = "Thanh sử dụng";
+"menu_bar_layout_token_session_pace" = "Tốc độ phiên";
+"menu_bar_layout_token_weekly_pace" = "Tốc độ hàng tuần";
+"menu_bar_layout_token_auto_pace" = "Tốc độ tự động";
+"Session pace" = "Tốc độ phiên";
+"Weekly pace" = "Tốc độ hàng tuần";
+"Pace" = "Tốc độ";
 "menu_bar_layout_token_resets_in" = "Đặt lại sau";
 "menu_bar_layout_token_reset_at" = "Đặt lại lúc";
 "menu_bar_layout_token_runs_out" = "Sắp hết";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1301,6 +1301,12 @@
 "menu_bar_layout_token_weekly" = "每周 %";
 "menu_bar_layout_token_auto" = "自动 %";
 "menu_bar_layout_token_bar" = "用量条";
+"menu_bar_layout_token_session_pace" = "会话节奏";
+"menu_bar_layout_token_weekly_pace" = "每周节奏";
+"menu_bar_layout_token_auto_pace" = "自动节奏";
+"Session pace" = "会话节奏";
+"Weekly pace" = "每周节奏";
+"Pace" = "节奏";
 "menu_bar_layout_token_resets_in" = "重置倒计时";
 "menu_bar_layout_token_reset_at" = "重置时间";
 "menu_bar_layout_token_runs_out" = "预计用尽";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1356,6 +1356,12 @@
 "menu_bar_layout_token_weekly" = "每週 %";
 "menu_bar_layout_token_auto" = "自動 %";
 "menu_bar_layout_token_bar" = "用量列";
+"menu_bar_layout_token_session_pace" = "工作階段進度";
+"menu_bar_layout_token_weekly_pace" = "每週進度";
+"menu_bar_layout_token_auto_pace" = "自動進度";
+"Session pace" = "工作階段進度";
+"Weekly pace" = "每週進度";
+"Pace" = "進度";
 "menu_bar_layout_token_resets_in" = "重設倒數";
 "menu_bar_layout_token_reset_at" = "重設時間";
 "menu_bar_layout_token_runs_out" = "預計用盡";

--- a/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
+++ b/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
@@ -57,9 +57,14 @@ extension StatusItemController {
     {
         let windows = self.menuBarLayoutWindows(provider: provider, snapshot: snapshot, now: now)
         let paceWindow = windows.weekly ?? windows.automatic
-        let runsOut = paceWindow
+        // One pace evaluation feeds both tokens: `.runsOut` takes the projection, `.pace` takes the headline.
+        let weeklyPaceDetail = paceWindow
             .flatMap { self.store.weeklyPace(provider: provider, window: $0, now: now) }
-            .flatMap { UsagePaceText.weeklyDetail(provider: provider, pace: $0, now: now).rightLabel }
+            .map { UsagePaceText.weeklyDetail(provider: provider, pace: $0, now: now) }
+        let runsOut = weeklyPaceDetail?.rightLabel
+        let sessionPace = windows.session
+            .flatMap { UsagePaceText.sessionDetail(provider: provider, window: $0, now: now) }?
+            .leftLabel
         let costStrings = self.menuBarLayoutCostStrings(provider: provider, now: now)
         let providerName = L(self.store.metadata(for: provider).displayName)
         let accountLabel = self.menuBarLayoutAccountLabel(provider: provider, snapshot: snapshot)
@@ -71,6 +76,8 @@ extension StatusItemController {
             session: MenuBarLayoutRenderWindow(windows.session),
             weekly: MenuBarLayoutRenderWindow(windows.weekly),
             automatic: MenuBarLayoutRenderWindow(windows.automatic),
+            sessionPace: sessionPace,
+            weeklyPace: weeklyPaceDetail?.leftLabel,
             runsOut: runsOut,
             costToday: costStrings.today,
             cost30d: costStrings.last30Days)

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -21,6 +21,9 @@ struct MenuBarLayoutRendererTests {
             (.percent(window: .weekly), "W 60%"),
             (.percent(window: .automatic), "50%"),
             (.usageBar, "▮▮▯"),
+            (.pace(window: .session), "5h 10% in reserve"),
+            (.pace(window: .weekly), "W 4% in deficit"),
+            (.pace(window: .automatic), "10% in reserve"),
             (.resetCountdown, "in 2h"),
             (.runsOut, "Runs out tomorrow"),
             (.costToday, "$1.25"),
@@ -88,6 +91,8 @@ struct MenuBarLayoutRendererTests {
             session: nil,
             weekly: nil,
             automatic: nil,
+            sessionPace: nil,
+            weeklyPace: nil,
             runsOut: nil,
             costToday: nil,
             cost30d: nil)
@@ -99,6 +104,9 @@ struct MenuBarLayoutRendererTests {
             .percent(window: .weekly),
             .percent(window: .automatic),
             .usageBar,
+            .pace(window: .session),
+            .pace(window: .weekly),
+            .pace(window: .automatic),
             .resetCountdown,
             .resetAbsolute,
             .runsOut,
@@ -108,8 +116,33 @@ struct MenuBarLayoutRendererTests {
 
         let output = renderer.render(layout: layout, data: missingData, icon: nil, options: self.options())
 
-        #expect(output.attributedTitle.string.count(where: { $0 == "–" }) == 12)
+        #expect(output.attributedTitle.string.count(where: { $0 == "–" }) == 15)
         #expect(output.accessibilityLabel.contains("unavailable"))
+    }
+
+    @Test
+    func `automatic pace falls back to the weekly figure without a session pace`() {
+        let renderer = MenuBarLayoutRenderer()
+        let data = MenuBarLayoutRenderData(
+            iconKey: "codex",
+            providerName: "Codex",
+            accountLabel: nil,
+            session: nil,
+            weekly: nil,
+            automatic: nil,
+            sessionPace: nil,
+            weeklyPace: "4% in deficit",
+            runsOut: nil,
+            costToday: nil,
+            cost30d: nil)
+
+        let output = renderer.render(
+            layout: MenuBarLayout(lines: [[.pace(window: .automatic)]]),
+            data: data,
+            icon: nil,
+            options: self.options())
+
+        #expect(output.attributedTitle.string == "4% in deficit")
     }
 
     @Test
@@ -227,6 +260,8 @@ struct MenuBarLayoutRendererTests {
             session: nil,
             weekly: nil,
             automatic: textOnlyWindow,
+            sessionPace: nil,
+            weeklyPace: nil,
             runsOut: nil,
             costToday: nil,
             cost30d: nil)
@@ -284,6 +319,8 @@ struct MenuBarLayoutRendererTests {
                 windowMinutes: 300,
                 resetsAt: self.now.addingTimeInterval(2 * 60 * 60),
                 resetDescription: nil)),
+            sessionPace: "10% in reserve",
+            weeklyPace: "4% in deficit",
             runsOut: "Runs out tomorrow",
             costToday: "$1.25",
             cost30d: "$20.00")

--- a/Tests/CodexBarTests/MenuBarLayoutTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutTests.swift
@@ -19,6 +19,9 @@ struct MenuBarLayoutTests {
                 .percent(window: .weekly),
                 .percent(window: .automatic),
                 .usageBar,
+                .pace(window: .session),
+                .pace(window: .weekly),
+                .pace(window: .automatic),
             ],
             [
                 .resetCountdown,


### PR DESCRIPTION
Adds **Session pace**, **Weekly pace**, and **Auto pace** tokens to the menu bar layout editor, next to the existing percent tokens.

Each renders the pace headline the usage card already computes — `On pace`, `23% in reserve`, `12% in deficit` — so the strip can show how much headroom is left against the window, not just how much quota is gone.

## Design

- **No new pace logic.** `.runsOut` already evaluates pace and keeps only the projection (`rightLabel`). That same evaluation now also yields the headline (`leftLabel`) for `.pace` — one computation, two tokens.
- **Window vocabulary matches `.percent`.** `.pace(window:)` mirrors `.percent(window:)`, including the `S` / `5h` / `W` prefixes, so a strip carrying both reads consistently. Provider-aware window resolution is inherited from the existing resolvers; no new notion of "weekly" is introduced.
- **Auto falls back.** Providers without a session-length pace (`UsagePaceText.sessionPace` gates to a handful) show the weekly figure rather than collapsing to the unavailable placeholder.
- **Purely additive.** No default layout changes; the tokens do nothing until dragged in. `MenuBarLayoutToken` uses synthesized `Codable`, so existing stored layouts decode unchanged.

## Verification

`swift build` and `node Scripts/check-app-locales.mjs` clean against this branch on current `main`. Renderer tests extended to cover the pace tokens and the codable round trip.

One inherited quirk worth naming: `weeklyPace` derives from `weekly ?? automatic`, the same window `.runsOut` already uses. For a provider with no weekly window, a token labelled "Weekly pace" therefore shows a figure computed from the automatic window. That behaviour predates this PR — this just surfaces it under a more specific label. Happy to tighten it if you'd rather it render unavailable instead.
