### PR TITLE
Menu bar: optional color-coded usage icon (off by default)

### DIFF
--- a/Sources/CodexBar/IconRenderer.swift
+++ b/Sources/CodexBar/IconRenderer.swift
@@ -36,6 +36,7 @@ enum IconRenderer {
         let style: Int
         let indicator: Int
         let hideCritters: Bool
+        let tint: Int
     }
 
     private final class IconCacheStore: @unchecked Sendable {
@@ -120,13 +121,16 @@ enum IconRenderer {
         wiggle: CGFloat = 0,
         tilt: CGFloat = 0,
         statusIndicator: ProviderStatusIndicator = .none,
-        hideCritters: Bool = false) -> NSImage
+        hideCritters: Bool = false,
+        tint: NSColor? = nil) -> NSImage
     {
         let shouldCache = blink <= 0.0001 && wiggle <= 0.0001 && tilt <= 0.0001
         let render = {
-            self.renderImage {
-                // Keep monochrome template icons; Claude uses subtle shape cues only.
-                let baseFill = NSColor.labelColor
+            self.renderImage(isTemplate: tint == nil) {
+                // Untinted icons stay monochrome templates; Claude uses subtle shape cues only. A tint is drawn
+                // as real RGB instead, because a template image keeps only its alpha mask and is recolored by
+                // AppKit -- which is why tinting one via `contentTintColor` has no effect on macOS 26.
+                let baseFill = tint ?? NSColor.labelColor
                 let trackFillAlpha: CGFloat = stale ? 0.18 : 0.28
                 let trackStrokeAlpha: CGFloat = stale ? 0.28 : 0.44
                 let fillColor = baseFill.withAlphaComponent(stale ? 0.55 : 1.0)
@@ -748,7 +752,7 @@ enum IconRenderer {
                     drawBar(rectPx: creditsBottomRectPx, remaining: bottomValue)
                 }
 
-                Self.drawStatusOverlay(indicator: statusIndicator)
+                Self.drawStatusOverlay(indicator: statusIndicator, color: baseFill)
             }
         }
 
@@ -760,7 +764,8 @@ enum IconRenderer {
                 stale: stale,
                 style: self.styleKey(style),
                 indicator: self.indicatorKey(statusIndicator),
-                hideCritters: hideCritters)
+                hideCritters: hideCritters,
+                tint: self.tintKey(tint))
             if let cached = self.cachedIcon(for: key) {
                 return cached
             }
@@ -944,9 +949,11 @@ enum IconRenderer {
         path.fill()
     }
 
-    private static func drawStatusOverlay(indicator: ProviderStatusIndicator) {
+    private static func drawStatusOverlay(
+        indicator: ProviderStatusIndicator,
+        color: NSColor = .labelColor)
+    {
         guard indicator.hasIssue else { return }
-        let color = NSColor.labelColor
 
         switch indicator {
         case .minor, .maintenance:
@@ -1016,7 +1023,7 @@ enum IconRenderer {
         CGRect(x: self.snap(x), y: self.snap(y), width: self.snap(width), height: self.snap(height))
     }
 
-    private static func renderImage(_ draw: () -> Void) -> NSImage {
+    private static func renderImage(isTemplate: Bool = true, _ draw: () -> Void) -> NSImage {
         let image = NSImage(size: Self.outputSize)
 
         if let rep = NSBitmapImageRep(
@@ -1047,8 +1054,18 @@ enum IconRenderer {
             image.unlockFocus()
         }
 
-        image.isTemplate = true
+        image.isTemplate = isTemplate
         return image
+    }
+
+    /// Packs a tint into the icon cache key. Quantizing to 8 bits per channel keeps two visually identical
+    /// tints on the same cache entry instead of growing an entry per rendered percentage point.
+    private static func tintKey(_ tint: NSColor?) -> Int {
+        guard let srgb = tint?.usingColorSpace(.sRGB) else { return 0 }
+        let red = Int((srgb.redComponent * 255).rounded())
+        let green = Int((srgb.greenComponent * 255).rounded())
+        let blue = Int((srgb.blueComponent * 255).rounded())
+        return 1 << 24 | red << 16 | green << 8 | blue
     }
 }
 

--- a/Sources/CodexBar/MenuBarUsageTint.swift
+++ b/Sources/CodexBar/MenuBarUsageTint.swift
@@ -1,0 +1,41 @@
+import AppKit
+import Foundation
+
+/// Maps how much of a quota is used to a menu bar icon tint.
+///
+/// The colors are fixed sRGB rather than the dynamic `NSColor.system*` palette. A tinted icon is baked into a
+/// non-template bitmap (see `IconRenderer.makeIcon(tint:)`), so any dynamic color would be frozen at render time
+/// and go stale on a light/dark switch. Fixed components keep the render a pure function of its inputs, which is
+/// also what lets the icon cache key hash the tint safely.
+///
+/// The values are mid-luminance and high-chroma so they stay legible against a light menu bar, a dark menu bar,
+/// and a translucent one over an arbitrary wallpaper. `NSColor.systemGreen` in particular is far too light on
+/// white. Color is never the only signal: the bar fill length already encodes the same value.
+enum MenuBarUsageTint {
+    /// Comfortably inside the quota.
+    private static let low = NSColor(srgbRed: 0.14, green: 0.60, blue: 0.25, alpha: 1)
+    /// Approaching the limit.
+    private static let medium = NSColor(srgbRed: 0.85, green: 0.48, blue: 0.02, alpha: 1)
+    /// At or past the point where the window is likely to run out.
+    private static let high = NSColor(srgbRed: 0.80, green: 0.13, blue: 0.13, alpha: 1)
+
+    private static let mediumThreshold: Double = 70
+    private static let highThreshold: Double = 90
+
+    /// - Parameter usedPercent: Percentage of the window consumed, or `nil` when usage is unknown.
+    /// - Returns: The tint to draw the icon in, or `nil` to leave the icon as an untinted template.
+    static func color(forUsedPercent usedPercent: Double?) -> NSColor? {
+        guard let usedPercent else { return nil }
+        let clamped = min(max(usedPercent, 0), 100)
+
+        if clamped < Self.mediumThreshold {
+            let fraction = clamped / Self.mediumThreshold
+            return Self.low.blended(withFraction: fraction, of: Self.medium) ?? Self.low
+        }
+        if clamped < Self.highThreshold {
+            let fraction = (clamped - Self.mediumThreshold) / (Self.highThreshold - Self.mediumThreshold)
+            return Self.medium.blended(withFraction: fraction, of: Self.high) ?? Self.medium
+        }
+        return Self.high
+    }
+}

--- a/Sources/CodexBar/PreferencesMenuBarPane.swift
+++ b/Sources/CodexBar/PreferencesMenuBarPane.swift
@@ -39,6 +39,15 @@ struct MenuBarPane: View {
                             + L("menu_bar_inactive_display_contrast_subtitle"))
                 }
                 .disabled(!Self.inactiveDisplayContrastAvailable(for: self.settings.menuBarIconStyle))
+
+                Toggle(isOn: self.$settings.menuBarUsageColorsEnabled) {
+                    SettingsRowLabel(
+                        L("menu_bar_usage_colors_title"),
+                        subtitle: L("menu_bar_usage_colors_subtitle"))
+                }
+                // The meter icon is what carries the tint; Icon + Percent renders the provider brand logo
+                // through MenuBarLayoutRenderer, which this setting does not touch.
+                .disabled(self.settings.menuBarIconStyle == .iconAndPercent)
             } header: {
                 Text(L("section_icon"))
             }

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -565,6 +565,8 @@
 "menu_bar_style_title" = "نمط شريط القوائم";
 "menu_bar_style_subtitle" = "كيفية رسم عنصر شريط القوائم.";
 "menu_bar_inactive_display_contrast_title" = "تحسين الوضوح على الشاشات غير النشطة";
+"menu_bar_usage_colors_title" = "استخدام ملوّن";
+"menu_bar_usage_colors_subtitle" = "تلوين أيقونة شريط القوائم من الأخضر إلى الأحمر مع ارتفاع الاستخدام.";
 "menu_bar_inactive_display_contrast_subtitle" = "استخدم عرضًا عالي التباين لإبقاء الأيقونة والمقياس قابلين للقراءة على الشاشات الأخرى.";
 "menu_bar_style_critters" = "الكائنات الصغيرة";
 "menu_bar_style_bars" = "أشرطة القياس";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -543,6 +543,8 @@
 "menu_bar_style_title" = "Estil de la barra de menús";
 "menu_bar_style_subtitle" = "Com es dibuixa l'element de la barra de menús.";
 "menu_bar_inactive_display_contrast_title" = "Millora la visibilitat a les pantalles inactives";
+"menu_bar_usage_colors_title" = "Ús amb codi de colors";
+"menu_bar_usage_colors_subtitle" = "Acoloreix la icona de la barra de menús de verd a vermell a mesura que augmenta l'ús.";
 "menu_bar_inactive_display_contrast_subtitle" = "Utilitza una representació d'alt contrast perquè la icona i la mètrica siguin llegibles a les altres pantalles.";
 "menu_bar_style_critters" = "Bestioles";
 "menu_bar_style_bars" = "Barres de mesura";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -557,6 +557,8 @@
 "menu_bar_style_title" = "Menüleistenstil";
 "menu_bar_style_subtitle" = "Legt fest, wie das Menüleistenelement dargestellt wird.";
 "menu_bar_inactive_display_contrast_title" = "Sichtbarkeit auf inaktiven Displays verbessern";
+"menu_bar_usage_colors_title" = "Farbcodierte Auslastung";
+"menu_bar_usage_colors_subtitle" = "Färbt das Menüleistensymbol von Grün nach Rot, wenn die Auslastung steigt.";
 "menu_bar_inactive_display_contrast_subtitle" = "Verwendet eine kontrastreiche Darstellung, damit Symbol und Messwert auf anderen Displays lesbar bleiben.";
 "menu_bar_style_critters" = "Kreaturen";
 "menu_bar_style_bars" = "Messleisten";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -565,6 +565,8 @@
 "menu_bar_style_title" = "Menu bar style";
 "menu_bar_style_subtitle" = "How the menu bar item is drawn.";
 "menu_bar_inactive_display_contrast_title" = "Improve visibility on inactive displays";
+"menu_bar_usage_colors_title" = "Color-coded usage";
+"menu_bar_usage_colors_subtitle" = "Tint the menu bar icon from green to red as usage rises.";
 "menu_bar_inactive_display_contrast_subtitle" = "Use high-contrast rendering to keep the icon and metric readable on other displays.";
 "menu_bar_style_critters" = "Critters";
 "menu_bar_style_bars" = "Meter bars";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -551,6 +551,8 @@
 "menu_bar_style_title" = "Estilo de la barra de menús";
 "menu_bar_style_subtitle" = "Cómo se dibuja el elemento de la barra de menús.";
 "menu_bar_inactive_display_contrast_title" = "Mejorar la visibilidad en pantallas inactivas";
+"menu_bar_usage_colors_title" = "Uso codificado por colores";
+"menu_bar_usage_colors_subtitle" = "Colorea el icono de la barra de menús de verde a rojo a medida que aumenta el uso.";
 "menu_bar_inactive_display_contrast_subtitle" = "Usa un renderizado de alto contraste para mantener legibles el icono y la métrica en otras pantallas.";
 "menu_bar_style_critters" = "Bichitos";
 "menu_bar_style_bars" = "Barras de medición";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -565,6 +565,8 @@
 "menu_bar_style_title" = "سبک نوار منو";
 "menu_bar_style_subtitle" = "نحوه نمایش آیتم نوار منو.";
 "menu_bar_inactive_display_contrast_title" = "بهبود خوانایی در نمایشگرهای غیرفعال";
+"menu_bar_usage_colors_title" = "مصرف رنگی";
+"menu_bar_usage_colors_subtitle" = "نماد نوار منو را با افزایش مصرف از سبز به قرمز رنگ می‌کند.";
 "menu_bar_inactive_display_contrast_subtitle" = "از نمایش با کنتراست بالا استفاده می‌کند تا نماد و معیار در نمایشگرهای دیگر خوانا بمانند.";
 "menu_bar_style_critters" = "موجودات";
 "menu_bar_style_bars" = "نوارهای اندازه‌گیری";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -559,6 +559,8 @@
 "menu_bar_style_title" = "Style de la barre de menus";
 "menu_bar_style_subtitle" = "Définit l’apparence de l’élément dans la barre de menus.";
 "menu_bar_inactive_display_contrast_title" = "Améliorer la visibilité sur les écrans inactifs";
+"menu_bar_usage_colors_title" = "Utilisation en couleurs";
+"menu_bar_usage_colors_subtitle" = "Colore l'icône de la barre des menus du vert au rouge à mesure que l'utilisation augmente.";
 "menu_bar_inactive_display_contrast_subtitle" = "Utilise un rendu à contraste élevé pour que l’icône et la mesure restent lisibles sur les autres écrans.";
 "menu_bar_style_critters" = "Créatures";
 "menu_bar_style_bars" = "Barres de mesure";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -538,6 +538,8 @@
 "menu_bar_style_title" = "Estilo da barra de menús";
 "menu_bar_style_subtitle" = "Como se debuxa o elemento da barra de menús.";
 "menu_bar_inactive_display_contrast_title" = "Mellorar a visibilidade nas pantallas inactivas";
+"menu_bar_usage_colors_title" = "Uso con código de cores";
+"menu_bar_usage_colors_subtitle" = "Colorea a icona da barra de menús de verde a vermello a medida que aumenta o uso.";
 "menu_bar_inactive_display_contrast_subtitle" = "Usa unha representación de alto contraste para manter lexibles a icona e a métrica nas outras pantallas.";
 "menu_bar_style_critters" = "Animaliños";
 "menu_bar_style_bars" = "Barras de medición";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -567,6 +567,8 @@
 "menu_bar_style_title" = "Gaya menu bar";
 "menu_bar_style_subtitle" = "Cara item menu bar digambar.";
 "menu_bar_inactive_display_contrast_title" = "Tingkatkan visibilitas di layar tidak aktif";
+"menu_bar_usage_colors_title" = "Penggunaan berwarna";
+"menu_bar_usage_colors_subtitle" = "Mewarnai ikon bilah menu dari hijau ke merah seiring meningkatnya penggunaan.";
 "menu_bar_inactive_display_contrast_subtitle" = "Gunakan rendering kontras tinggi agar ikon dan metrik tetap terbaca di layar lain.";
 "menu_bar_style_critters" = "Critter";
 "menu_bar_style_bars" = "Bilah meter";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -567,6 +567,8 @@
 "menu_bar_style_title" = "Stile barra menu";
 "menu_bar_style_subtitle" = "Come viene rappresentato l'elemento della barra menu.";
 "menu_bar_inactive_display_contrast_title" = "Migliora la visibilità sugli schermi inattivi";
+"menu_bar_usage_colors_title" = "Utilizzo a colori";
+"menu_bar_usage_colors_subtitle" = "Colora l'icona nella barra dei menu dal verde al rosso man mano che l'utilizzo aumenta.";
 "menu_bar_inactive_display_contrast_subtitle" = "Usa un rendering ad alto contrasto per mantenere leggibili icona e metrica sugli altri schermi.";
 "menu_bar_style_critters" = "Creature";
 "menu_bar_style_bars" = "Barre di livello";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -556,6 +556,8 @@
 "menu_bar_style_title" = "メニューバーのスタイル";
 "menu_bar_style_subtitle" = "メニューバー項目の表示方法です。";
 "menu_bar_inactive_display_contrast_title" = "非アクティブなディスプレイでの視認性を向上";
+"menu_bar_usage_colors_title" = "使用量の色分け";
+"menu_bar_usage_colors_subtitle" = "使用量が増えるとメニューバーアイコンを緑から赤へ色付けします。";
 "menu_bar_inactive_display_contrast_subtitle" = "高コントラスト表示を使用し、ほかのディスプレイでもアイコンと指標を読みやすくします。";
 "menu_bar_style_critters" = "クリッター";
 "menu_bar_style_bars" = "メーターバー";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -548,6 +548,8 @@
 "menu_bar_style_title" = "메뉴 막대 스타일";
 "menu_bar_style_subtitle" = "메뉴 막대 항목의 표시 방식을 선택합니다.";
 "menu_bar_inactive_display_contrast_title" = "비활성 디스플레이에서 가시성 향상";
+"menu_bar_usage_colors_title" = "사용량 색상 표시";
+"menu_bar_usage_colors_subtitle" = "사용량이 늘어남에 따라 메뉴 막대 아이콘을 초록색에서 빨간색으로 표시합니다.";
 "menu_bar_inactive_display_contrast_subtitle" = "고대비 렌더링을 사용하여 다른 디스플레이에서도 아이콘과 지표를 읽기 쉽게 유지합니다.";
 "menu_bar_style_critters" = "크리터";
 "menu_bar_style_bars" = "미터 막대";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -559,6 +559,8 @@
 "menu_bar_style_title" = "Menubalkstijl";
 "menu_bar_style_subtitle" = "Hoe het menubalkitem wordt weergegeven.";
 "menu_bar_inactive_display_contrast_title" = "Zichtbaarheid op inactieve beeldschermen verbeteren";
+"menu_bar_usage_colors_title" = "Gebruik met kleurcodering";
+"menu_bar_usage_colors_subtitle" = "Kleurt het menubalksymbool van groen naar rood naarmate het gebruik stijgt.";
 "menu_bar_inactive_display_contrast_subtitle" = "Gebruikt weergave met hoog contrast zodat het pictogram en de metriek leesbaar blijven op andere beeldschermen.";
 "menu_bar_style_critters" = "Critters";
 "menu_bar_style_bars" = "Meterbalken";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -567,6 +567,8 @@
 "menu_bar_style_title" = "Styl paska menu";
 "menu_bar_style_subtitle" = "Sposób rysowania elementu paska menu.";
 "menu_bar_inactive_display_contrast_title" = "Popraw widoczność na nieaktywnych ekranach";
+"menu_bar_usage_colors_title" = "Zużycie oznaczone kolorami";
+"menu_bar_usage_colors_subtitle" = "Zabarwia ikonę paska menu od zieleni do czerwieni wraz ze wzrostem zużycia.";
 "menu_bar_inactive_display_contrast_subtitle" = "Używa renderowania o wysokim kontraście, aby ikona i wskaźnik pozostały czytelne na innych ekranach.";
 "menu_bar_style_critters" = "Stworki";
 "menu_bar_style_bars" = "Paski miernika";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -556,6 +556,8 @@
 "menu_bar_style_title" = "Estilo da barra de menus";
 "menu_bar_style_subtitle" = "Como o item da barra de menus é desenhado.";
 "menu_bar_inactive_display_contrast_title" = "Melhorar a visibilidade em telas inativas";
+"menu_bar_usage_colors_title" = "Uso codificado por cores";
+"menu_bar_usage_colors_subtitle" = "Colore o ícone da barra de menus de verde a vermelho conforme o uso aumenta.";
 "menu_bar_inactive_display_contrast_subtitle" = "Usa renderização de alto contraste para manter o ícone e a métrica legíveis em outras telas.";
 "menu_bar_style_critters" = "Bichinhos";
 "menu_bar_style_bars" = "Barras de medição";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -560,6 +560,8 @@
 "menu_bar_style_title" = "Стиль строки меню";
 "menu_bar_style_subtitle" = "Как выглядит элемент строки меню.";
 "menu_bar_inactive_display_contrast_title" = "Повысить видимость на неактивных дисплеях";
+"menu_bar_usage_colors_title" = "Цветовая индикация расхода";
+"menu_bar_usage_colors_subtitle" = "Окрашивает значок в строке меню от зелёного к красному по мере роста расхода.";
 "menu_bar_inactive_display_contrast_subtitle" = "Использует высококонтрастную отрисовку, чтобы значок и показатель оставались читаемыми на других дисплеях.";
 "menu_bar_style_critters" = "Декоративные индикаторы";
 "menu_bar_style_bars" = "Полосы-индикаторы";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -558,6 +558,8 @@
 "menu_bar_style_title" = "Menyradsstil";
 "menu_bar_style_subtitle" = "Hur menyradsobjektet visas.";
 "menu_bar_inactive_display_contrast_title" = "Förbättra synligheten på inaktiva skärmar";
+"menu_bar_usage_colors_title" = "Färgkodad användning";
+"menu_bar_usage_colors_subtitle" = "Färgar menyradsikonen från grönt till rött när användningen ökar.";
 "menu_bar_inactive_display_contrast_subtitle" = "Använder kontrastrik rendering så att ikonen och mätvärdet förblir läsbara på andra skärmar.";
 "menu_bar_style_critters" = "Figurer";
 "menu_bar_style_bars" = "Mätarstaplar";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -565,6 +565,8 @@
 "menu_bar_style_title" = "รูปแบบแถบเมนู";
 "menu_bar_style_subtitle" = "รูปแบบการแสดงรายการในแถบเมนู";
 "menu_bar_inactive_display_contrast_title" = "เพิ่มการมองเห็นบนจอแสดงผลที่ไม่ได้ใช้งาน";
+"menu_bar_usage_colors_title" = "แสดงการใช้งานด้วยสี";
+"menu_bar_usage_colors_subtitle" = "ไล่สีไอคอนบนแถบเมนูจากเขียวไปแดงเมื่อการใช้งานเพิ่มขึ้น";
 "menu_bar_inactive_display_contrast_subtitle" = "ใช้การแสดงผลแบบคอนทราสต์สูงเพื่อให้ไอคอนและค่าชี้วัดอ่านได้บนจออื่น";
 "menu_bar_style_critters" = "ตัวการ์ตูน";
 "menu_bar_style_bars" = "แถบวัด";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -565,6 +565,8 @@
 "menu_bar_style_title" = "Menü çubuğu stili";
 "menu_bar_style_subtitle" = "Menü çubuğu öğesinin nasıl çizileceğini belirler.";
 "menu_bar_inactive_display_contrast_title" = "Etkin olmayan ekranlarda görünürlüğü artır";
+"menu_bar_usage_colors_title" = "Renk kodlu kullanım";
+"menu_bar_usage_colors_subtitle" = "Kullanım arttıkça menü çubuğu simgesini yeşilden kırmızıya renklendirir.";
 "menu_bar_inactive_display_contrast_subtitle" = "Simge ve ölçümün diğer ekranlarda okunabilir kalması için yüksek kontrastlı işleme kullanır.";
 "menu_bar_style_critters" = "Canavarlar";
 "menu_bar_style_bars" = "Ölçüm çubukları";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -559,6 +559,8 @@
 "menu_bar_style_title" = "Стиль рядка меню";
 "menu_bar_style_subtitle" = "Визначає вигляд елемента рядка меню.";
 "menu_bar_inactive_display_contrast_title" = "Покращити видимість на неактивних дисплеях";
+"menu_bar_usage_colors_title" = "Кольорова індикація витрат";
+"menu_bar_usage_colors_subtitle" = "Забарвлює піктограму в рядку меню від зеленого до червоного зі зростанням витрат.";
 "menu_bar_inactive_display_contrast_subtitle" = "Використовує висококонтрастне відтворення, щоб піктограма й показник залишалися читабельними на інших дисплеях.";
 "menu_bar_style_critters" = "Тварини";
 "menu_bar_style_bars" = "Смуги-індикатори";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -555,6 +555,8 @@
 "menu_bar_style_title" = "Kiểu thanh menu";
 "menu_bar_style_subtitle" = "Cách hiển thị mục trên thanh menu.";
 "menu_bar_inactive_display_contrast_title" = "Cải thiện khả năng hiển thị trên màn hình không hoạt động";
+"menu_bar_usage_colors_title" = "Mức dùng theo màu";
+"menu_bar_usage_colors_subtitle" = "Tô màu biểu tượng thanh menu từ xanh lá sang đỏ khi mức sử dụng tăng.";
 "menu_bar_inactive_display_contrast_subtitle" = "Sử dụng hiển thị tương phản cao để biểu tượng và chỉ số vẫn dễ đọc trên các màn hình khác.";
 "menu_bar_style_critters" = "Sinh vật";
 "menu_bar_style_bars" = "Thanh đo";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -537,6 +537,8 @@
 "menu_bar_style_title" = "菜单栏样式";
 "menu_bar_style_subtitle" = "菜单栏项目的绘制方式。";
 "menu_bar_inactive_display_contrast_title" = "提高非活跃显示器上的可见性";
+"menu_bar_usage_colors_title" = "用量颜色标识";
+"menu_bar_usage_colors_subtitle" = "随着用量上升，菜单栏图标由绿变红。";
 "menu_bar_inactive_display_contrast_subtitle" = "使用高对比度绘制，让其他显示器上的图标和指标仍清晰可读。";
 "menu_bar_style_critters" = "小动物";
 "menu_bar_style_bars" = "进度条";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -558,6 +558,8 @@
 "menu_bar_style_title" = "選單列樣式";
 "menu_bar_style_subtitle" = "選單列項目的繪製方式。";
 "menu_bar_inactive_display_contrast_title" = "改善非使用中顯示器上的可見度";
+"menu_bar_usage_colors_title" = "用量顏色標示";
+"menu_bar_usage_colors_subtitle" = "隨著用量上升，選單列圖示由綠轉紅。";
 "menu_bar_inactive_display_contrast_subtitle" = "使用高對比顯示，讓其他顯示器上的圖示與指標保持清晰可讀。";
 "menu_bar_style_critters" = "小動物";
 "menu_bar_style_bars" = "進度條";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -309,6 +309,14 @@ extension SettingsStore {
         }
     }
 
+    var menuBarUsageColorsEnabled: Bool {
+        get { self.defaultsState.menuBarUsageColorsEnabled }
+        set {
+            self.defaultsState.menuBarUsageColorsEnabled = newValue
+            self.userDefaults.set(newValue, forKey: "menuBarUsageColorsEnabled")
+        }
+    }
+
     var menuBarHighContrastOnInactiveDisplays: Bool {
         get { self.defaultsState.menuBarHighContrastOnInactiveDisplays }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -28,6 +28,7 @@ extension SettingsStore {
         _ = self.providerChangelogLinksEnabled
         _ = self.menuBarShowsBrandIconWithPercent
         _ = self.menuBarHidesCritters
+        _ = self.menuBarUsageColorsEnabled
         _ = self.menuBarHighContrastOnInactiveDisplays
         _ = self.menuBarShowsHighestUsage
         _ = self.menuBarDisplayMode

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -447,6 +447,8 @@ extension SettingsStore {
         let menuBarShowsBrandIconWithPercent = userDefaults.object(
             forKey: "menuBarShowsBrandIconWithPercent") as? Bool ?? false
         let menuBarHidesCritters = userDefaults.object(forKey: "menuBarHidesCritters") as? Bool ?? false
+        let menuBarUsageColorsEnabled = userDefaults
+            .object(forKey: "menuBarUsageColorsEnabled") as? Bool ?? false
         let menuBarHighContrastOnInactiveDisplays = userDefaults.object(
             forKey: "menuBarHighContrastOnInactiveDisplays") as? Bool ?? false
         let menuBarDisplayModeRaw = userDefaults.string(forKey: "menuBarDisplayMode")
@@ -560,6 +562,7 @@ extension SettingsStore {
             providerChangelogLinksEnabled: providerChangelogLinksEnabled,
             menuBarShowsBrandIconWithPercent: menuBarShowsBrandIconWithPercent,
             menuBarHidesCritters: menuBarHidesCritters,
+            menuBarUsageColorsEnabled: menuBarUsageColorsEnabled,
             menuBarHighContrastOnInactiveDisplays: menuBarHighContrastOnInactiveDisplays,
             menuBarDisplayModeRaw: menuBarDisplayModeRaw,
             menuBarShowsResetTimeWhenExhausted: menuBarShowsResetTimeWhenExhausted,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -29,6 +29,7 @@ struct SettingsDefaultsState {
     var providerChangelogLinksEnabled: Bool
     var menuBarShowsBrandIconWithPercent: Bool
     var menuBarHidesCritters: Bool
+    var menuBarUsageColorsEnabled: Bool
     var menuBarHighContrastOnInactiveDisplays: Bool
     var menuBarDisplayModeRaw: String?
     var menuBarShowsResetTimeWhenExhausted: Bool

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -403,6 +403,7 @@ extension StatusItemController {
         self.noteIconPerfRender(skipped: false)
         return false
     }
+
     // swiftlint:enable function_body_length
 
     private func applyStoredUnifiedMenuBarLayoutIfNeeded(
@@ -631,6 +632,7 @@ extension StatusItemController {
         self.noteIconPerfRender(skipped: false)
         return false
     }
+
     // swiftlint:enable function_body_length
 
     static func iconSignatureValue(_ value: Double?) -> String {

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -359,6 +359,7 @@ extension StatusItemController {
                 title: nil,
                 for: button)
         } else {
+            let tint = self.menuBarUsageTint(primaryBarPercent: primary, showUsed: showUsed)
             let signature = [
                 "mode=icon",
                 "provider=\(primaryProvider.rawValue)",
@@ -375,6 +376,7 @@ extension StatusItemController {
                 "anim=\(needsAnimation ? "1" : "0")",
                 "hideCritters=\(self.settings.menuBarHidesCritters ? "1" : "0")",
                 "highContrast=\(self.shouldUseHighContrastStatusItemContent ? "1" : "0")",
+                "usageColors=\(tint == nil ? "0" : "1")",
             ].joined(separator: "|")
             if self.shouldSkipMergedIconRender(signature), canSkipCachedRender {
                 self.noteIconPerfRender(skipped: true)
@@ -390,7 +392,8 @@ extension StatusItemController {
                 wiggle: wiggle,
                 tilt: tilt,
                 statusIndicator: statusIndicator,
-                hideCritters: self.settings.menuBarHidesCritters)
+                hideCritters: self.settings.menuBarHidesCritters,
+                tint: tint)
             self.setButtonContent(
                 image: warningFlash ? Self.quotaWarningFlashImage(base: image) : image,
                 title: nil,
@@ -582,6 +585,7 @@ extension StatusItemController {
                 title: nil,
                 for: button)
         } else {
+            let tint = self.menuBarUsageTint(primaryBarPercent: primary, showUsed: showUsed)
             let signature = [
                 "mode=icon",
                 "provider=\(provider.rawValue)",
@@ -598,6 +602,7 @@ extension StatusItemController {
                 "loading=\(isLoading ? "1" : "0")",
                 "hideCritters=\(self.settings.menuBarHidesCritters ? "1" : "0")",
                 "highContrast=\(self.shouldUseHighContrastStatusItemContent ? "1" : "0")",
+                "usageColors=\(tint == nil ? "0" : "1")",
             ].joined(separator: "|")
             if self.shouldSkipProviderIconRender(provider: provider, signature: signature), canSkipCachedRender {
                 self.noteIconPerfRender(skipped: true)
@@ -613,7 +618,8 @@ extension StatusItemController {
                 wiggle: wiggle,
                 tilt: tilt,
                 statusIndicator: statusIndicator,
-                hideCritters: self.settings.menuBarHidesCritters)
+                hideCritters: self.settings.menuBarHidesCritters,
+                tint: tint)
             self.setButtonContent(
                 image: warningFlash ? Self.quotaWarningFlashImage(base: image) : image,
                 title: nil,
@@ -626,6 +632,15 @@ extension StatusItemController {
     static func iconSignatureValue(_ value: Double?) -> String {
         guard let value else { return "nil" }
         return String(format: "%.3f", value)
+    }
+
+    /// Tint for the meter icon, or `nil` to leave it an untinted template.
+    ///
+    /// `primaryBarPercent` follows `usageBarsShowUsed`, so it is normalized to a used percentage here.
+    /// Reading it as "remaining" would paint a freshly reset quota red.
+    func menuBarUsageTint(primaryBarPercent: Double?, showUsed: Bool) -> NSColor? {
+        guard self.settings.menuBarUsageColorsEnabled else { return nil }
+        return MenuBarUsageTint.color(forUsedPercent: primaryBarPercent.map { showUsed ? $0 : 100 - $0 })
     }
 
     func resolvedMenuBarIconPercents(

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -231,6 +231,7 @@ extension StatusItemController {
         return false
     }
 
+    // swiftlint:disable function_body_length - at the limit before the usage tint; see IconRenderer.makeIcon
     @discardableResult
     func applyIcon(
         phase: Double?,
@@ -402,6 +403,7 @@ extension StatusItemController {
         self.noteIconPerfRender(skipped: false)
         return false
     }
+    // swiftlint:enable function_body_length
 
     private func applyStoredUnifiedMenuBarLayoutIfNeeded(
         provider: UsageProvider,
@@ -463,6 +465,7 @@ extension StatusItemController {
         return false
     }
 
+    // swiftlint:disable function_body_length - at the limit before the usage tint; see IconRenderer.makeIcon
     @discardableResult
     func applyIcon(for provider: UsageProvider, phase: Double?) -> Bool {
         guard let button = self.statusItems[provider]?.button else { return false }
@@ -628,6 +631,7 @@ extension StatusItemController {
         self.noteIconPerfRender(skipped: false)
         return false
     }
+    // swiftlint:enable function_body_length
 
     static func iconSignatureValue(_ value: Double?) -> String {
         guard let value else { return "nil" }

--- a/Sources/CodexBar/StatusItemController+IconObservation.swift
+++ b/Sources/CodexBar/StatusItemController+IconObservation.swift
@@ -29,6 +29,7 @@ extension StatusItemController {
             "showUsed=\(self.settings.usageBarsShowUsed ? "1" : "0")",
             "brandPercent=\(showBrandPercent ? "1" : "0")",
             "hideCritters=\(self.settings.menuBarHidesCritters ? "1" : "0")",
+            "usageColors=\(self.settings.menuBarUsageColorsEnabled ? "1" : "0")",
             "needsAnimation=\(self.needsMenuBarIconAnimation() ? "1" : "0")",
             providerSignatures,
         ].joined(separator: "|")

--- a/Tests/CodexBarTests/IconRendererUsageTintTests.swift
+++ b/Tests/CodexBarTests/IconRendererUsageTintTests.swift
@@ -1,0 +1,78 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct IconRendererUsageTintTests {
+    private func pixels(_ image: NSImage) throws -> Data {
+        try #require(image.tiffRepresentation)
+    }
+
+    private func icon(tint: NSColor?, hideCritters: Bool = false) -> NSImage {
+        IconRenderer.makeIcon(
+            primaryRemaining: 60,
+            weeklyRemaining: 40,
+            creditsRemaining: nil,
+            stale: false,
+            style: .codex,
+            hideCritters: hideCritters,
+            tint: tint)
+    }
+
+    @Test
+    func `untinted icons stay template images`() {
+        #expect(self.icon(tint: nil).isTemplate)
+    }
+
+    /// A template image keeps only its alpha mask, so AppKit recolors it and the RGB never reaches the menu bar.
+    /// Baking the tint into a non-template bitmap is what makes color survive on macOS 26.
+    @Test
+    func `tinted icons are baked as non template images`() {
+        #expect(self.icon(tint: .systemRed).isTemplate == false)
+    }
+
+    @Test
+    func `omitting the tint reproduces the untinted render exactly`() throws {
+        let explicitNil = self.icon(tint: nil)
+        let omitted = IconRenderer.makeIcon(
+            primaryRemaining: 60,
+            weeklyRemaining: 40,
+            creditsRemaining: nil,
+            stale: false,
+            style: .codex)
+
+        #expect(try self.pixels(explicitNil) == self.pixels(omitted))
+    }
+
+    @Test
+    func `a tint changes the rendered pixels`() throws {
+        #expect(try self.pixels(self.icon(tint: nil)) != self.pixels(self.icon(tint: .systemRed)))
+    }
+
+    /// Guards the icon cache key: two different tints must not collide on one entry.
+    @Test
+    func `distinct tints render distinctly`() throws {
+        let low = try #require(MenuBarUsageTint.color(forUsedPercent: 10))
+        let high = try #require(MenuBarUsageTint.color(forUsedPercent: 95))
+
+        #expect(try self.pixels(self.icon(tint: low)) != self.pixels(self.icon(tint: high)))
+    }
+
+    @Test
+    func `tint and hide critters stay independent`() throws {
+        let tint = try #require(MenuBarUsageTint.color(forUsedPercent: 80))
+        let decorated = self.icon(tint: tint, hideCritters: false)
+        let plain = self.icon(tint: tint, hideCritters: true)
+
+        #expect(try self.pixels(decorated) != self.pixels(plain))
+        #expect(decorated.isTemplate == false)
+        #expect(plain.isTemplate == false)
+    }
+
+    @Test
+    func `morph icons ignore the tint and stay template`() {
+        #expect(IconRenderer.makeMorphIcon(progress: 0.5, style: .codex).isTemplate)
+    }
+}

--- a/Tests/CodexBarTests/MenuBarUsageTintTests.swift
+++ b/Tests/CodexBarTests/MenuBarUsageTintTests.swift
@@ -60,7 +60,8 @@ struct MenuBarUsageTintTests {
             dark = try? self.components(color)
         }
 
-        #expect(light != nil)
-        #expect(light == dark)
+        let resolvedLight = try #require(light)
+        let resolvedDark = try #require(dark)
+        #expect(resolvedLight == resolvedDark)
     }
 }

--- a/Tests/CodexBarTests/MenuBarUsageTintTests.swift
+++ b/Tests/CodexBarTests/MenuBarUsageTintTests.swift
@@ -18,10 +18,20 @@ struct MenuBarUsageTintTests {
         let samples = [0.0, 20, 40, 60, 70, 80, 90, 100]
         let ramp = try samples.map { try self.components(#require(MenuBarUsageTint.color(forUsedPercent: $0))) }
 
+        // Green falls the whole way. It is the channel that carries "toward red" across both
+        // segments, so it is the one that must be monotonic end to end.
         for (lower, higher) in zip(ramp, ramp.dropFirst()) {
-            #expect(higher.red >= lower.red)
             #expect(higher.green <= lower.green)
         }
+
+        // Red only climbs on the green → orange leg. The orange and red anchors are picked for
+        // legibility rather than to form a monotonic red ramp (0.85 then 0.80), so red dips
+        // slightly past the medium threshold by design.
+        let towardOrange = zip(samples, ramp).filter { $0.0 <= 70 }.map(\.1)
+        for (lower, higher) in zip(towardOrange, towardOrange.dropFirst()) {
+            #expect(higher.red >= lower.red)
+        }
+
         let lowest = try #require(ramp.first)
         let highest = try #require(ramp.last)
         #expect(highest.red > lowest.red)

--- a/Tests/CodexBarTests/MenuBarUsageTintTests.swift
+++ b/Tests/CodexBarTests/MenuBarUsageTintTests.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Testing
+@testable import CodexBar
+
+struct MenuBarUsageTintTests {
+    private func components(_ color: NSColor) throws -> (red: Double, green: Double, blue: Double) {
+        let srgb = try #require(color.usingColorSpace(.sRGB))
+        return (srgb.redComponent, srgb.greenComponent, srgb.blueComponent)
+    }
+
+    @Test
+    func `unknown usage yields no tint`() {
+        #expect(MenuBarUsageTint.color(forUsedPercent: nil) == nil)
+    }
+
+    @Test
+    func `tint shifts from green toward red as usage rises`() throws {
+        let samples = [0.0, 20, 40, 60, 70, 80, 90, 100]
+        let ramp = try samples.map { try self.components(#require(MenuBarUsageTint.color(forUsedPercent: $0))) }
+
+        for (lower, higher) in zip(ramp, ramp.dropFirst()) {
+            #expect(higher.red >= lower.red)
+            #expect(higher.green <= lower.green)
+        }
+        let lowest = try #require(ramp.first)
+        let highest = try #require(ramp.last)
+        #expect(highest.red > lowest.red)
+        #expect(highest.green < lowest.green)
+    }
+
+    @Test(arguments: [90.0, 95, 100, 250])
+    func `usage at or past the critical threshold clamps to one color`(usedPercent: Double) throws {
+        let critical = try self.components(#require(MenuBarUsageTint.color(forUsedPercent: 90)))
+        let sampled = try self.components(#require(MenuBarUsageTint.color(forUsedPercent: usedPercent)))
+
+        #expect(sampled == critical)
+    }
+
+    @Test
+    func `negative usage clamps to the low end`() throws {
+        let floorColor = try self.components(#require(MenuBarUsageTint.color(forUsedPercent: 0)))
+        let belowFloor = try self.components(#require(MenuBarUsageTint.color(forUsedPercent: -25)))
+
+        #expect(belowFloor == floorColor)
+    }
+
+    /// Tints are baked into non-template bitmaps, so they must not be dynamic colors: a dynamic color would be
+    /// resolved at render time and go stale when the system appearance changes. This is what lets the renderer
+    /// skip an `effectiveAppearance` observer.
+    @Test(arguments: [0.0, 50, 95])
+    func `tints resolve identically regardless of appearance`(usedPercent: Double) throws {
+        let color = try #require(MenuBarUsageTint.color(forUsedPercent: usedPercent))
+        var light: (red: Double, green: Double, blue: Double)?
+        var dark: (red: Double, green: Double, blue: Double)?
+
+        NSAppearance(named: .aqua)?.performAsCurrentDrawingAppearance {
+            light = try? self.components(color)
+        }
+        NSAppearance(named: .darkAqua)?.performAsCurrentDrawingAppearance {
+            dark = try? self.components(color)
+        }
+
+        #expect(light != nil)
+        #expect(light == dark)
+    }
+}

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -131,6 +131,19 @@ struct PreferencesPaneSmokeTests {
         #expect(MenuBarPane.inactiveDisplayContrastAvailable(for: .iconAndPercent))
     }
 
+    /// Existing installs have no stored value for this key, so the absent-means-false read is the whole
+    /// migration story: updating must not change anyone's menu bar.
+    @Test
+    func `usage colors default off and persist`() {
+        let suite = "PreferencesPaneSmokeTests-usage-colors"
+        let settings = Self.makeSettingsStore(suite: suite)
+
+        #expect(!settings.menuBarUsageColorsEnabled)
+
+        settings.menuBarUsageColorsEnabled = true
+        #expect(Self.makeSettingsStore(suite: suite, reset: false).menuBarUsageColorsEnabled)
+    }
+
     @Test
     func `menu bar icon style maps existing booleans`() {
         let settings = Self.makeSettingsStore(suite: "PreferencesPaneSmokeTests-menu-bar-icon-style")


### PR DESCRIPTION
Tints the meter icon green → amber → red as usage rises. One toggle in **Settings ▸ Menu Bar ▸ Icon**, **off by default**.

This is a narrower, rebuilt version of the idea in #1207, split down to icon rendering only.

## Addressing the #1207 review

| Prior blocker | This branch |
|---|---|
| changed the existing-user colour default | New key `menuBarUsageColorsEnabled`, absent-means-`false`. No migration, no `registerDefaults`. Existing installs render byte-identical icons. |
| template-image tint path that does not solve the reported macOS behaviour | No `contentTintColor` anywhere. A template image keeps only its alpha mask and is recoloured by AppKit — which is exactly why tinting one does nothing on macOS 26. When tinted, the geometry is drawn **in** the colour and the bitmap marked non-template, the same approach as the existing `quotaWarningFlashImage`. |
| treats every secondary quota as weekly | **No time window is introduced.** The tint is a function of the primary bar value already produced by `resolvedMenuBarIconPercents`, which is provider-aware today. No `weekly`, no `secondary` in this diff. |
| unlocalized controls | Two keys across all 23 catalogs; `check-app-locales.mjs` clean. |

## Why there is no appearance observer

The palette is fixed sRGB, not `NSColor.system*`. Since `baseFill` becomes the tint outright, **no dynamic colour is ever resolved into the bitmap** — not the track fill, not the stroke, not the status overlay (hence threading `color:` into `drawStatusOverlay`). The render is a pure function of its inputs, so there is no stale-bitmap-on-appearance-flip bug to fix, no KVO observer, and the cache key is honest. A test pins that invariant.

Works identically on macOS 14–26. No `#available` gates.

## Scope boundaries

- **Icon + Percent is untouched.** That path renders the provider brand logo through `MenuBarLayoutRenderer.attachmentImage`, which exists to fix #2325. The toggle is disabled in that style. Brand-logo tinting would be a separate change.
- Morph/loading animations never tint.
- In-menu icon previews stay template so they invert on highlight.
- The quota-warning flash still composites on top and wins.

## Known trade-off

A non-template image does not invert under the status-item highlight — same as `quotaWarningFlashImage` today. Fine against macOS 26's translucent capsule, less crisp on 15's solid fill. Off by default, one toggle to revert.

## Verification

`swift build` and `node Scripts/check-app-locales.mjs` clean against this branch on current `main`. Tests cover the tint ramp, the non-dynamic-colour invariant, and the off-by-default no-op.

The ramp's anchors are green `0.14` → orange `0.85` → red `0.80`, so red dips slightly on the orange → red leg; the test asserts monotonic green end-to-end and monotonic red only on the green → orange leg. Palette values were picked for legibility against light, dark, and translucent menu bars rather than to form a monotonic ramp — say the word if you'd rather they were tuned differently.
