### PR TITLE
Menu: eliminate post-open height pop with a stable-height session floor

### DIFF
--- a/Sources/CodexBar/MenuSwitchFlickerProbe.swift
+++ b/Sources/CodexBar/MenuSwitchFlickerProbe.swift
@@ -19,13 +19,20 @@ import UniformTypeIdentifiers
 ///   reads the WindowServer's current composite without touching AppKit.
 @MainActor
 enum MenuSwitchFlickerProbe {
-    /// Appends diagnostic lines from production code paths while the probe env
-    /// var is set; inert otherwise.
+    private nonisolated static let processStart = DispatchTime.now()
+
+    /// Appends timestamped diagnostic lines from production code paths while the
+    /// probe env var is set; inert otherwise.
     nonisolated static func debugLog(_ line: @autoclosure () -> String) {
         guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_FLICKER_PROBE_DIR"],
               !dir.isEmpty else { return }
         let url = URL(fileURLWithPath: dir).appendingPathComponent("padding-log.txt")
-        let text = line() + "\n"
+        // Read the start anchor before now(): the lazy static initializes on first
+        // access, so the reverse order makes start > now and underflows UInt64.
+        let startNs = self.processStart.uptimeNanoseconds
+        let nowNs = DispatchTime.now().uptimeNanoseconds
+        let elapsedMs = nowNs >= startNs ? Double(nowNs - startNs) / 1_000_000 : 0
+        let text = String(format: "[%9.1fms] ", elapsedMs) + line() + "\n"
         if let handle = try? FileHandle(forWritingTo: url) {
             handle.seekToEndOfFile()
             handle.write(Data(text.utf8))
@@ -39,9 +46,15 @@ enum MenuSwitchFlickerProbe {
         guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_FLICKER_PROBE_DIR"],
               !dir.isEmpty else { return }
         let directory = URL(fileURLWithPath: dir, isDirectory: true)
+        // Two sessions: the second verifies open-time behavior with state carried
+        // over from the first (e.g. the stable-height session floor).
         DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-            let session = ProbeSession(controller: controller, directory: directory)
-            session.begin()
+            ProbeSession(controller: controller, directory: directory).begin()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                ProbeSession(
+                    controller: controller,
+                    directory: directory.appendingPathComponent("second")).begin()
+            }
         }
     }
 
@@ -95,11 +108,12 @@ enum MenuSwitchFlickerProbe {
                 guard keepRunning, index < Self.maxFrameCount else { return }
                 let elapsed = Double(DispatchTime.now().uptimeNanoseconds - self.start.uptimeNanoseconds)
                     / 1_000_000
+                // Include framing so the window shadow / material edge is captured too.
                 let image = CGWindowListCreateImage(
                     .null,
                     .optionIncludingWindow,
                     self.windowID,
-                    [.boundsIgnoreFraming, .bestResolution])
+                    [.bestResolution])
                 let bounds = self.currentBounds() ?? .null
                 var wroteFrame = false
                 if let image {
@@ -137,8 +151,7 @@ enum MenuSwitchFlickerProbe {
         private var timer: Timer?
         private var log: [String] = []
         private var startedAt: DispatchTime?
-        private var didSwitchAway = false
-        private var didSwitchBack = false
+        private var switchScheduleIndex = 0
         private var searchTicks = 0
         private weak var menu: NSMenu?
         private var grabber: BackgroundFrameGrabber?
@@ -166,29 +179,28 @@ enum MenuSwitchFlickerProbe {
             self.finish()
         }
 
+        /// Three away/back cycles give slower external captures several chances
+        /// to land on any transient artifact. Always ends on the original segment.
+        private static let switchScheduleMs = [400, 1000, 1600, 2200, 2800, 3400]
+        private static let sessionEndMs = 4200
+
         private func tick() {
             guard let startedAt = self.startedAtOrLocateMenu() else { return }
             let now = Int((DispatchTime.now().uptimeNanoseconds - startedAt.uptimeNanoseconds) / 1_000_000)
-            if now >= 2400 {
+            if now >= Self.sessionEndMs {
                 self.timer?.invalidate()
                 self.timer = nil
                 self.menu?.cancelTracking()
                 return
             }
-            if now >= 400, !self.didSwitchAway {
-                self.didSwitchAway = true
-                let handled = self.targetSegment.map { self.switchSegment($0) } ?? false
-                self.log.append("switch-away to segment \(String(describing: self.targetSegment)) " +
-                    "at \(now)ms handled=\(handled)")
-                return
-            }
-            if now >= 1400, !self.didSwitchBack {
-                self.didSwitchBack = true
-                let handled = self.originalSegment.map { self.switchSegment($0) } ?? false
-                self.log.append("switch-back to segment \(String(describing: self.originalSegment)) " +
-                    "at \(now)ms handled=\(handled)")
-                return
-            }
+            guard self.switchScheduleIndex < Self.switchScheduleMs.count,
+                  now >= Self.switchScheduleMs[self.switchScheduleIndex] else { return }
+            let switchIndex = self.switchScheduleIndex
+            self.switchScheduleIndex += 1
+            let segment = switchIndex.isMultiple(of: 2) ? self.targetSegment : self.originalSegment
+            let handled = segment.map { self.switchSegment($0) } ?? false
+            self.log.append("switch#\(switchIndex) to segment \(String(describing: segment)) " +
+                "at \(now)ms handled=\(handled)")
         }
 
         private func startedAtOrLocateMenu() -> DispatchTime? {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -163,6 +163,7 @@ extension StatusItemController {
             self.cancelMergedSwitcherSiblingWarmup()
         }
         self.resetCompactAccountMenuExpansionStateIfIdle()
+        self.resetStableMenuHeightSessionFloor()
     }
 
     func forgetClosedMenu(_ menu: NSMenu) {
@@ -966,6 +967,7 @@ extension StatusItemController {
             },
             onSelect: { [weak self, weak menu] selection in
                 guard let self, let menu else { return }
+                MenuSwitchFlickerProbe.debugLog("onSelect \(selection)")
                 var provider: UsageProvider?
                 self.preservingMergedSwitcherContentCachesDuringInvalidation {
                     switch selection {

--- a/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
+++ b/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
@@ -40,6 +40,8 @@ extension StatusItemController {
                    codexAccountDisplay: context.codexAccountDisplay,
                    tokenAccountDisplay: context.tokenAccountDisplay)
             {
+                MenuSwitchFlickerProbe.debugLog("cached-swap begin \(context.switcherSelection)")
+                defer { MenuSwitchFlickerProbe.debugLog("cached-swap end") }
                 // Park the outgoing payloads for an equally instant switch-back. Compatible
                 // menu-item shells stay attached, avoiding the empty intermediate layout that
                 // AppKit can visibly render when the whole content block is removed first.

--- a/Sources/CodexBar/StatusItemController+StableMenuHeight.swift
+++ b/Sources/CodexBar/StatusItemController+StableMenuHeight.swift
@@ -83,15 +83,39 @@ extension StatusItemController {
                 "selection=\(String(describing: self.lastMergedMenuContentSelection)) " +
                 "cacheKeys=\(cacheEntries.keys.map { String(describing: $0) }) " +
                 "tabs=\(tabs.map { "(spacer:\($0.spacer != nil) h:\($0.contentHeight))" })")
-        guard tabs.count > 1, let maxHeight = tabs.map(\.contentHeight).max() else { return }
+        guard let contentMax = tabs.map(\.contentHeight).max() else { return }
+
+        // Session floor: on the first populate only the visible tab is measurable
+        // (sibling caches fill ~120ms later), so without a floor the menu opens
+        // short and visibly grows once the warmup lands. The floor from the
+        // previous open pads immediately; within a session the height only grows.
+        // The floor resets to the true max when the menu closes, so legitimate
+        // shrinks happen between opens, invisibly.
+        let widthKey = Int(self.renderedMenuWidth(for: menu).rounded())
+        let floorHeight = self.stableMenuHeightSessionFloor[widthKey] ?? 0
+        let targetHeight = max(contentMax, floorHeight)
+        self.stableMenuHeightSessionFloor[widthKey] = targetHeight
+        self.stableMenuHeightLastContentMax[widthKey] = tabs.count > 1
+            ? contentMax
+            : max(contentMax, self.stableMenuHeightLastContentMax[widthKey] ?? 0)
+        guard tabs.count > 1 || floorHeight > 0 else { return }
 
         for tab in tabs {
             guard let spacer = tab.spacer, let spacerView = spacer.view else { continue }
-            let padding = max(0, maxHeight - tab.contentHeight)
+            let padding = max(0, targetHeight - tab.contentHeight)
             if abs(spacerView.frame.height - padding) > 0.5 {
                 MenuSwitchFlickerProbe.debugLog("padding: set spacer \(spacerView.frame.height) -> \(padding)")
                 spacerView.setFrameSize(NSSize(width: 1, height: padding))
             }
+        }
+    }
+
+    /// Called when the last menu closes: drop the grow-only session floor to the
+    /// last true content max so the next open can start shorter if data shrank.
+    func resetStableMenuHeightSessionFloor() {
+        guard self.openMenus.isEmpty else { return }
+        for (widthKey, lastMax) in self.stableMenuHeightLastContentMax {
+            self.stableMenuHeightSessionFloor[widthKey] = lastMax
         }
     }
 

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -277,6 +277,10 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     /// Debounced pre-build of sibling switcher tabs for flicker-free tab switches.
     /// A common-modes Timer (not a Task) so it fires during NSMenu tracking.
     var mergedSwitcherWarmupTimer: Timer?
+    /// Stable-height padding: grow-only per-session floor and last measured true
+    /// max, keyed by rounded menu width. See `applyStableMenuHeightPadding`.
+    var stableMenuHeightSessionFloor: [Int: CGFloat] = [:]
+    var stableMenuHeightLastContentMax: [Int: CGFloat] = [:]
     /// Compact multi-account layout: accounts the user expanded to full cards this menu session.
     var compactAccountExpandedIDs: Set<ProviderAccountIdentity> = []
     /// Compact multi-account layout: providers whose collapsed healthy tail is revealed this menu session.


### PR DESCRIPTION
## Summary

Follow-up to #2553, closing the last measured artifact in the tab-switch work: the menu opened at the visible tab's own height and visibly grew ~17pt about 80ms later, once the sibling warmup filled the caches and the stable-height padding kicked in. That open-time pop is what still read as "an element of flicker" after #2553.

Fix: a grow-only, per-width **session floor** for the stable-height padding. The first populate of a menu session pads immediately to the previous session's height (no post-open growth); within a session the height never shrinks; on close the floor resets to the last true content max, so legitimate shrinks happen between opens where nobody can see them.

Probe evidence (two menu sessions in one app run, three switch cycles each): window bounds constant at open, across all six switches, and at reopen — `windowBounds` timeline shows exactly one entry per session.

Also hardens the probe tool itself after it bit back:
- timestamped shared diagnostics with an underflow-safe clock anchor (the lazy `DispatchTime` anchor initialized after `now()` was evaluated, underflowing UInt64 on first use — SIGTRAP inside menu populate)
- shadow-inclusive window captures, three switch cycles, and a two-session schedule to verify open-time behavior with carried-over state

## Verification

- `make check` clean; menu suites green (warmup, compact layouts, status menu).
- Two-session probe run: constant 310×615 bounds throughout; content swaps remain single-frame; switch latency (onSelect → swap complete) measured at ~4–7ms with warm caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
