### PR TITLE
Fix idle OpenCode WAL database reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
 ### Fixed
+- OpenCode Go: read idle WAL-mode local history without creating SQLite sidecars (#2544). Thanks @Astro-Han for the report!
 - Menu: switching provider tabs no longer flashes. The sibling-tab warmup now runs off a tracking-safe timer (the previous Task-based warmup never fired while the menu was open, which is the only time it matters), and provider tabs share one stable menu height via an invisible spacer, so a switch is a single-frame content swap with no window resize. Verified frame-by-frame with a new env-gated self-probe (`CODEXBAR_FLICKER_PROBE_DIR`).
 
 ### Changed

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
@@ -66,21 +66,45 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
     }
 
     private func readRows() throws -> [UsageRow] {
+        do {
+            return try self.readRows(immutable: false)
+        } catch let failure as SQLiteReadFailure {
+            // A clean WAL shutdown can remove both sidecars while leaving the database header in WAL mode.
+            // Immutable mode reads that idle main file without recreating sidecars; active WALs stay on the normal
+            // path.
+            guard failure.code == SQLITE_CANTOPEN, self.walSidecarsAreMissing else {
+                throw OpenCodeGoLocalUsageError.sqliteFailed(failure.message)
+            }
+
+            do {
+                return try self.readRows(immutable: true)
+            } catch let fallbackFailure as SQLiteReadFailure {
+                throw OpenCodeGoLocalUsageError.sqliteFailed(fallbackFailure.message)
+            }
+        }
+    }
+
+    private func readRows(immutable: Bool) throws -> [UsageRow] {
         var db: OpaquePointer?
-        guard sqlite3_open_v2(self.databaseURL.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
-            let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
+        let filename = immutable ? "\(self.databaseURL.absoluteURL.absoluteString)?immutable=1" : self.databaseURL.path
+        let flags = immutable ? SQLITE_OPEN_READONLY | SQLITE_OPEN_URI : SQLITE_OPEN_READONLY
+        let openResult = sqlite3_open_v2(filename, &db, flags, nil)
+        guard openResult == SQLITE_OK else {
+            let failure = Self.sqliteFailure(db: db, resultCode: openResult)
             sqlite3_close(db)
-            throw OpenCodeGoLocalUsageError.sqliteFailed(message)
+            throw failure
         }
         defer { sqlite3_close(db) }
         sqlite3_busy_timeout(db, 250)
 
-        let sql = self.hasTable(named: "part", db: db) ? Self.messageAndPartUsageSQL : Self.messageUsageSQL
+        let sql = try self.hasTable(named: "part", db: db)
+            ? Self.messageAndPartUsageSQL
+            : Self.messageUsageSQL
 
         var stmt: OpaquePointer?
-        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
-            let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
-            throw OpenCodeGoLocalUsageError.sqliteFailed(message)
+        let prepareResult = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard prepareResult == SQLITE_OK else {
+            throw Self.sqliteFailure(db: db, resultCode: prepareResult)
         }
         defer { sqlite3_finalize(stmt) }
 
@@ -91,8 +115,7 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
                 break
             }
             guard step == SQLITE_ROW else {
-                let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
-                throw OpenCodeGoLocalUsageError.sqliteFailed(message)
+                throw Self.sqliteFailure(db: db, resultCode: step)
             }
 
             let createdMs = sqlite3_column_int64(stmt, 0)
@@ -104,22 +127,38 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
         return rows
     }
 
-    private func hasTable(named name: String, db: OpaquePointer?) -> Bool {
+    private var walSidecarsAreMissing: Bool {
+        !FileManager.default.fileExists(atPath: self.databaseURL.path + "-wal") &&
+            !FileManager.default.fileExists(atPath: self.databaseURL.path + "-shm")
+    }
+
+    private func hasTable(named name: String, db: OpaquePointer?) throws -> Bool {
         var stmt: OpaquePointer?
-        guard sqlite3_prepare_v2(
+        let prepareResult = sqlite3_prepare_v2(
             db,
             "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
             -1,
             &stmt,
-            nil) == SQLITE_OK
-        else {
-            return false
+            nil)
+        guard prepareResult == SQLITE_OK else {
+            throw Self.sqliteFailure(db: db, resultCode: prepareResult)
         }
         defer { sqlite3_finalize(stmt) }
 
         let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
         sqlite3_bind_text(stmt, 1, name, -1, transient)
-        return sqlite3_step(stmt) == SQLITE_ROW
+        let step = sqlite3_step(stmt)
+        if step == SQLITE_ROW {
+            return true
+        }
+        guard step == SQLITE_DONE else { throw Self.sqliteFailure(db: db, resultCode: step) }
+        return false
+    }
+
+    private static func sqliteFailure(db: OpaquePointer?, resultCode: Int32) -> SQLiteReadFailure {
+        SQLiteReadFailure(
+            code: db.map { sqlite3_errcode($0) } ?? resultCode,
+            message: db.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown error")
     }
 
     private static let messageUsageSQL = """
@@ -175,6 +214,11 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
         let cost: Double
         /// One provider invocation per step-finish part; message-only databases fall back to one.
         let requestCount: Int
+    }
+
+    private struct SQLiteReadFailure: Error {
+        let code: Int32
+        let message: String
     }
 
     private static func hasAuthKey(at url: URL) -> Bool {

--- a/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
@@ -38,6 +38,32 @@ struct OpenCodeGoLocalUsageReaderTests {
     }
 
     @Test
+    func `reads idle WAL database without creating sidecars`() throws {
+        let env = try Self.makeEnvironment()
+        defer { try? FileManager.default.removeItem(at: env.root) }
+
+        try Self.writeAuth(to: env.authURL)
+        try Self.createDatabase(at: env.databaseURL)
+        try Self.insertMessage(
+            databaseURL: env.databaseURL,
+            createdMs: Self.ms("2026-03-06T11:00:00.000Z"),
+            cost: 3.0)
+        try Self.configureIdleWAL(at: env.databaseURL)
+
+        let walURL = URL(fileURLWithPath: env.databaseURL.path + "-wal")
+        let sharedMemoryURL = URL(fileURLWithPath: env.databaseURL.path + "-shm")
+        #expect(!FileManager.default.fileExists(atPath: walURL.path))
+        #expect(!FileManager.default.fileExists(atPath: sharedMemoryURL.path))
+
+        let reader = OpenCodeGoLocalUsageReader(authURL: env.authURL, databaseURL: env.databaseURL)
+        let snapshot = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
+
+        #expect(snapshot.rollingUsagePercent == 25)
+        #expect(!FileManager.default.fileExists(atPath: walURL.path))
+        #expect(!FileManager.default.fileExists(atPath: sharedMemoryURL.path))
+    }
+
+    @Test
     func `builds daily cost history buckets within the requested window`() throws {
         let env = try Self.makeEnvironment()
         defer { try? FileManager.default.removeItem(at: env.root) }
@@ -283,6 +309,25 @@ struct OpenCodeGoLocalUsageReaderTests {
             """)
     }
 
+    private static func configureIdleWAL(at url: URL) throws {
+        var db: OpaquePointer?
+        guard sqlite3_open(url.path, &db) == SQLITE_OK else { throw SQLiteTestError.open }
+        do {
+            try Self.exec(db: db, sql: "PRAGMA journal_mode = WAL; PRAGMA wal_checkpoint(TRUNCATE);")
+        } catch {
+            sqlite3_close(db)
+            throw error
+        }
+        guard sqlite3_close(db) == SQLITE_OK else { throw SQLiteTestError.close }
+
+        for suffix in ["-wal", "-shm"] {
+            let sidecarURL = URL(fileURLWithPath: url.path + suffix)
+            if FileManager.default.fileExists(atPath: sidecarURL.path) {
+                try FileManager.default.removeItem(at: sidecarURL)
+            }
+        }
+    }
+
     @discardableResult
     private static func insertMessage(databaseURL: URL, createdMs: Int64, cost: Double?) throws -> String {
         var db: OpaquePointer?
@@ -378,6 +423,7 @@ struct OpenCodeGoLocalUsageReaderTests {
     }
 
     private enum SQLiteTestError: Error {
+        case close
         case open
         case prepare
         case step


### PR DESCRIPTION
## Summary

- Read idle OpenCode Go WAL-mode history when SQLite sidecars are absent.
- Keep active WAL databases on the normal read-only path and avoid creating sidecars.
- Add focused regression coverage and a changelog entry.

## Root cause

`opencode.db` retains WAL mode in its database header after a clean shutdown removes the `-wal` and `-shm` sidecars. A normal read-only connection can open the database handle, but its first schema statement fails with `SQLITE_CANTOPEN` because SQLite cannot open the missing sidecars.

## Fix approach

The reader keeps its existing `SQLITE_OPEN_READONLY` path. If reading fails with `SQLITE_CANTOPEN` and both sidecars are absent, it retries through a read-only `immutable=1` SQLite URI. Active WAL databases continue through the normal path, while missing, non-WAL, and corrupt databases retain their existing behavior. The regression fixture also verifies that the read creates no sidecars.

## Proof

- `make check` — clean.
- `swift test --disable-automatic-resolution --filter OpenCodeGoLocalUsageReaderTests` — 10 passed.
- `swift test --disable-automatic-resolution --filter OpenCodeGoProviderStrategyTests` — 9 passed.
- `make test` — groups 1–34 passed. Group 35 hit known `KiroStatusProbeTests` subprocess/PTY wall-clock timing flakes on the loaded runner. Maintainer repeat runs failed different timing tests, confirming load sensitivity; see #2509, which scales those timing budgets.

Closes #2544
