### PR TITLE
fix: persist Command Code browser sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
 ### Fixed
+- Command Code: persist validated browser sessions so CLI refreshes and the local service can reuse them (#2541). Thanks @rbonill!
 - Menu: switching provider tabs no longer flashes. The sibling-tab warmup now runs off a tracking-safe timer (the previous Task-based warmup never fired while the menu was open, which is the only time it matters), and provider tabs share one stable menu height via an invisible spacer, so a switch is a single-frame content swap with no window resize. Verified frame-by-frame with a new env-gated self-probe (`CODEXBAR_FLICKER_PROBE_DIR`).
 
 ### Changed

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
@@ -84,6 +84,19 @@ struct CommandCodeWebFetchStrategy: ProviderFetchStrategy {
             return self.makeResult(usage: snapshot.toUsageSnapshot(), sourceLabel: "manual")
         }
 
+        if let cached = CookieHeaderCache.load(provider: .commandcode) {
+            do {
+                let snapshot = try await self.usageLoader(cached.cookieHeader)
+                return self.makeResult(
+                    usage: snapshot.toUsageSnapshot(),
+                    sourceLabel: cached.sourceLabel)
+            } catch CommandCodeUsageError.invalidCredentials {
+                _ = CookieHeaderCache.clearIfCurrent(provider: .commandcode, expected: cached)
+            } catch {
+                throw error
+            }
+        }
+
         let sessions: [CommandCodeResolvedSession]
         do {
             sessions = try self.sessionLoader()
@@ -101,6 +114,10 @@ struct CommandCodeWebFetchStrategy: ProviderFetchStrategy {
             },
             attempt: { session in
                 let snapshot = try await self.usageLoader(session.cookieHeader)
+                CookieHeaderCache.store(
+                    provider: .commandcode,
+                    cookieHeader: session.cookieHeader,
+                    sourceLabel: session.sourceLabel)
                 return self.makeResult(
                     usage: snapshot.toUsageSnapshot(),
                     sourceLabel: session.sourceLabel)

--- a/Tests/CodexBarTests/CommandCodeProviderTests.swift
+++ b/Tests/CodexBarTests/CommandCodeProviderTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import CodexBar
 @testable import CodexBarCore
 
+@Suite(.serialized)
 struct CommandCodeProviderTests {
     private final class CookieAttemptRecorder: @unchecked Sendable {
         private let lock = NSLock()
@@ -40,47 +41,100 @@ struct CommandCodeProviderTests {
 
     @Test
     func `automatic cookie fetch retries Vivaldi after stale earlier browser session`() async throws {
-        let recorder = CookieAttemptRecorder()
-        let strategy = CommandCodeWebFetchStrategy(
-            usageLoader: { cookieHeader in
-                recorder.append(cookieHeader)
-                guard cookieHeader == "session=vivaldi" else {
-                    throw CommandCodeUsageError.invalidCredentials
-                }
-                return Self.snapshot()
-            },
-            sessionLoader: {
-                [
-                    CommandCodeResolvedSession(cookieHeader: "session=stale", sourceLabel: "Chrome Default"),
-                    CommandCodeResolvedSession(cookieHeader: "session=vivaldi", sourceLabel: "Vivaldi Default"),
-                ]
-            })
+        let service = "com.steipete.codexbar.tests.commandcode-retry.\(UUID().uuidString)"
+        try await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            try await KeychainCacheStore.withImplicitTestStoreForTesting {
+                let recorder = CookieAttemptRecorder()
+                let strategy = CommandCodeWebFetchStrategy(
+                    usageLoader: { cookieHeader in
+                        recorder.append(cookieHeader)
+                        guard cookieHeader == "session=vivaldi" else {
+                            throw CommandCodeUsageError.invalidCredentials
+                        }
+                        return Self.snapshot()
+                    },
+                    sessionLoader: {
+                        [
+                            CommandCodeResolvedSession(cookieHeader: "session=stale", sourceLabel: "Chrome Default"),
+                            CommandCodeResolvedSession(
+                                cookieHeader: "session=vivaldi",
+                                sourceLabel: "Vivaldi Default"),
+                        ]
+                    })
 
-        let result = try await strategy.fetch(self.makeContext(cookieSource: .auto))
+                let result = try await strategy.fetch(self.makeContext(cookieSource: .auto))
 
-        #expect(recorder.snapshot() == ["session=stale", "session=vivaldi"])
-        #expect(result.sourceLabel == "Vivaldi Default")
+                #expect(recorder.snapshot() == ["session=stale", "session=vivaldi"])
+                #expect(result.sourceLabel == "Vivaldi Default")
+            }
+        }
     }
 
     @Test
     func `automatic cookie fetch does not hide non-auth failure with later session`() async {
-        let recorder = CookieAttemptRecorder()
-        let strategy = CommandCodeWebFetchStrategy(
-            usageLoader: { cookieHeader in
-                recorder.append(cookieHeader)
-                throw CommandCodeUsageError.networkError("offline")
-            },
-            sessionLoader: {
-                [
-                    CommandCodeResolvedSession(cookieHeader: "session=first", sourceLabel: "Chrome Default"),
-                    CommandCodeResolvedSession(cookieHeader: "session=vivaldi", sourceLabel: "Vivaldi Default"),
-                ]
-            })
+        let service = "com.steipete.codexbar.tests.commandcode-failure.\(UUID().uuidString)"
+        await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            await KeychainCacheStore.withImplicitTestStoreForTesting {
+                let recorder = CookieAttemptRecorder()
+                let strategy = CommandCodeWebFetchStrategy(
+                    usageLoader: { cookieHeader in
+                        recorder.append(cookieHeader)
+                        throw CommandCodeUsageError.networkError("offline")
+                    },
+                    sessionLoader: {
+                        [
+                            CommandCodeResolvedSession(cookieHeader: "session=first", sourceLabel: "Chrome Default"),
+                            CommandCodeResolvedSession(
+                                cookieHeader: "session=vivaldi",
+                                sourceLabel: "Vivaldi Default"),
+                        ]
+                    })
 
-        await #expect(throws: CommandCodeUsageError.networkError("offline")) {
-            try await strategy.fetch(self.makeContext(cookieSource: .auto))
+                await #expect(throws: CommandCodeUsageError.networkError("offline")) {
+                    try await strategy.fetch(self.makeContext(cookieSource: .auto))
+                }
+                #expect(recorder.snapshot() == ["session=first"])
+            }
         }
-        #expect(recorder.snapshot() == ["session=first"])
+    }
+
+    @Test
+    func `validated browser session persists for subsequent automatic fetch`() async throws {
+        let provider = UsageProvider.commandcode
+        let service = "com.steipete.codexbar.tests.commandcode-cache.\(UUID().uuidString)"
+        let recorder = CookieAttemptRecorder()
+        let browserLoadRecorder = CookieAttemptRecorder()
+
+        try await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            try await KeychainCacheStore.withImplicitTestStoreForTesting {
+                let gate = try #require(CookieHeaderCache.beginRefreshReadSuppression(provider: provider))
+                defer { CookieHeaderCache.endRefreshReadSuppression(gate) }
+                let strategy = CommandCodeWebFetchStrategy(
+                    usageLoader: { cookieHeader in
+                        recorder.append(cookieHeader)
+                        return Self.snapshot()
+                    },
+                    sessionLoader: {
+                        browserLoadRecorder.append("load")
+                        return [CommandCodeResolvedSession(
+                            cookieHeader: "session=validated",
+                            sourceLabel: "Chrome Default")]
+                    })
+
+                _ = try await strategy.fetch(self.makeContext(cookieSource: .auto))
+                #expect(CookieHeaderCache.load(provider: provider)?.cookieHeader == "session=validated")
+                #expect(CookieHeaderCache.commitRefreshReadSuppression(gate) == CookieRefreshCommitSummary(
+                    stagedCount: 1,
+                    committedCount: 1,
+                    failedCount: 0))
+
+                _ = try await strategy.fetch(self.makeContext(cookieSource: .auto))
+
+                #expect(browserLoadRecorder.snapshot() == ["load"])
+                #expect(recorder.snapshot() == ["session=validated", "session=validated"])
+                #expect(CookieHeaderCache.load(provider: provider)?.sourceLabel == "Chrome Default")
+            }
+        }
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- reuse validated Command Code sessions from the shared cookie cache
- cache the browser session that successfully returns usage
- cover refresh-suppression staging, persistence, and subsequent cache reuse with an isolated test store
- document the fix in the 0.46.1 changelog

## Root cause

The Command Code automatic strategy imported and validated browser cookies directly, but never participated in `CookieHeaderCache`. The CLI cookie-refresh transaction hides the existing cache while validation runs and requires exactly one staged cache replacement before it reports success. Command Code therefore validated successfully but always committed zero staged mutations, producing the reported "could not be saved" result and leaving CLI/service consumers without credentials.

## Fix

The automatic strategy now checks the shared cache before browser import, evicts a cached entry only after an explicit invalid-credentials response, and stores the first browser session that successfully validates. During explicit cookie refresh, that store is staged by the existing suppression gate and committed only after provider validation succeeds.

## Proof

- `swift test --filter CommandCodeProviderTests` — passed, 6 tests
- `swift test --filter CLICookieRefreshTests` — passed, 12 tests
- `make check` — passed
- `make test` — all completed groups passed except the documented loaded-machine wall-clock flake in `KiroStatusProbeTests`; an isolated rerun reproduced only `accepted pipe output cannot overrun the usage deadline`
- autoreview — clean, no accepted/actionable findings

Closes #2541
