### PR TITLE
Fix OpenCode Go idle WAL reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
 ### Fixed
+- OpenCode Go: recover local usage reads after OpenCode cleans up idle SQLite WAL sidecars, while retaining normal reads for active databases (#2544).
 - Menu: switching provider tabs no longer flashes. The sibling-tab warmup now runs off a tracking-safe timer (the previous Task-based warmup never fired while the menu was open, which is the only time it matters), and provider tabs share one stable menu height via an invisible spacer, so a switch is a single-frame content swap with no window resize. Verified frame-by-frame with a new env-gated self-probe (`CODEXBAR_FLICKER_PROBE_DIR`).
 
 ### Changed

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
@@ -28,10 +28,13 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
     private static let fiveHours: TimeInterval = 5 * 60 * 60
     private static let week: TimeInterval = 7 * 24 * 60 * 60
     private static let limits = (session: 12.0, weekly: 30.0, monthly: 60.0)
+    private static let idleWALRetryLimit = 1
+    private static let normalToIdleHandoffRetryLimit = 1
 
     private let authURL: URL
     private let databaseURL: URL
     #if DEBUG
+    private let beforeImmutableRead: @Sendable () throws -> Void
     private let beforeNormalRead: @Sendable () throws -> Void
     private let beforeNormalVerification: @Sendable () throws -> Void
     #endif
@@ -44,6 +47,7 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
         self.authURL = openCodeDirectory.appendingPathComponent("auth.json", isDirectory: false)
         self.databaseURL = openCodeDirectory.appendingPathComponent("opencode.db", isDirectory: false)
         #if DEBUG
+        self.beforeImmutableRead = {}
         self.beforeNormalRead = {}
         self.beforeNormalVerification = {}
         #endif
@@ -53,6 +57,7 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
         self.authURL = authURL
         self.databaseURL = databaseURL
         #if DEBUG
+        self.beforeImmutableRead = {}
         self.beforeNormalRead = {}
         self.beforeNormalVerification = {}
         #endif
@@ -63,12 +68,14 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
         authURL: URL,
         databaseURL: URL,
         beforeNormalVerification: @escaping @Sendable () throws -> Void = {},
+        beforeImmutableRead: @escaping @Sendable () throws -> Void = {},
         beforeNormalRead: @escaping @Sendable () throws -> Void = {})
     {
         self.authURL = authURL
         self.databaseURL = databaseURL
-        self.beforeNormalRead = beforeNormalRead
         self.beforeNormalVerification = beforeNormalVerification
+        self.beforeImmutableRead = beforeImmutableRead
+        self.beforeNormalRead = beforeNormalRead
     }
     #endif
 
@@ -98,49 +105,104 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
         // A read-only WAL connection may create missing sidecars when the directory is writable. Select the
         // immutable recovery path before opening SQLite only when the stable file state proves it is idle.
         if let idleWALState = self.idleWALState() {
-            return try self.readIdleWALRows(state: idleWALState)
+            return try self.readIdleWALRows(
+                state: idleWALState,
+                idleRetriesRemaining: Self.idleWALRetryLimit,
+                normalToIdleHandoffRetriesRemaining: Self.normalToIdleHandoffRetryLimit)
         }
 
-        do {
-            return try self.readRows(readMode: .normal)
-        } catch let failure as SQLiteReadFailure {
-            guard failure.resultCode == SQLITE_CANTOPEN,
-                  let idleWALState = self.idleWALState()
-            else {
-                throw failure.usageError
-            }
+        return try self.readNormalRows(
+            idleRetriesRemaining: Self.idleWALRetryLimit,
+            normalToIdleHandoffRetriesRemaining: Self.normalToIdleHandoffRetryLimit)
+    }
 
-            return try self.readIdleWALRows(state: idleWALState)
+    private func readIdleWALRows(
+        state idleWALState: IdleWALState,
+        idleRetriesRemaining: Int,
+        normalToIdleHandoffRetriesRemaining: Int) throws -> [UsageRow]
+    {
+        do {
+            let rows = try self.readRows(readMode: .immutable)
+            #if DEBUG
+            try self.beforeNormalVerification()
+            #endif
+            return try self.resolveIdleWALRead(
+                .success(rows),
+                state: idleWALState,
+                idleRetriesRemaining: idleRetriesRemaining,
+                normalToIdleHandoffRetriesRemaining: normalToIdleHandoffRetriesRemaining)
+        } catch let immutableFailure as SQLiteReadFailure {
+            return try self.resolveIdleWALRead(
+                .failure(immutableFailure),
+                state: idleWALState,
+                idleRetriesRemaining: idleRetriesRemaining,
+                normalToIdleHandoffRetriesRemaining: normalToIdleHandoffRetriesRemaining)
         }
     }
 
-    private func readIdleWALRows(state idleWALState: IdleWALState) throws -> [UsageRow] {
-        let rows: [UsageRow]
-        do {
-            rows = try self.readRows(readMode: .immutable)
-        } catch let immutableFailure as SQLiteReadFailure {
-            throw immutableFailure.usageError
+    private func resolveIdleWALRead(
+        _ result: Result<[UsageRow], SQLiteReadFailure>,
+        state idleWALState: IdleWALState,
+        idleRetriesRemaining: Int,
+        normalToIdleHandoffRetriesRemaining: Int) throws -> [UsageRow]
+    {
+        guard let currentIdleWALState = self.idleWALState() else {
+            // immutable=1 skips SQLite's change detection. An active or otherwise unverified state must be
+            // read normally so live WAL data remains authoritative.
+            return try self.readNormalRows(
+                idleRetriesRemaining: idleRetriesRemaining,
+                normalToIdleHandoffRetriesRemaining: normalToIdleHandoffRetriesRemaining)
         }
 
-        #if DEBUG
-        try self.beforeNormalVerification()
-        #endif
-
-        // immutable=1 skips SQLite's change detection. Keep it only while the state still proves no writer
-        // appeared; a changed state must be read normally so live WAL data remains authoritative.
-        guard !self.isStillIdleWAL(state: idleWALState) else {
-            return rows
+        if currentIdleWALState == idleWALState {
+            switch result {
+            case let .success(rows):
+                return rows
+            case let .failure(immutableFailure):
+                throw immutableFailure.usageError
+            }
         }
+
+        // A writer may have committed, checkpointed, and removed its sidecars between the two probes. Retry
+        // that newly stable idle state once without creating sidecars. Do not normal-read a repeatedly
+        // sidecar-free WAL database: that is the reported SQLITE_CANTOPEN state, and local failure falls
+        // through to the existing web strategy rather than recreating sidecars in the user's history directory.
+        guard idleRetriesRemaining > 0 else {
+            throw OpenCodeGoLocalUsageError.sqliteFailed("database changed repeatedly while reading idle WAL")
+        }
+
+        return try self.readIdleWALRows(
+            state: currentIdleWALState,
+            idleRetriesRemaining: idleRetriesRemaining - 1,
+            normalToIdleHandoffRetriesRemaining: normalToIdleHandoffRetriesRemaining)
+    }
+
+    private func readNormalRows(
+        idleRetriesRemaining: Int,
+        normalToIdleHandoffRetriesRemaining: Int) throws -> [UsageRow]
+    {
         do {
             return try self.readRows(readMode: .normal)
-        } catch let verificationFailure as SQLiteReadFailure {
-            throw verificationFailure.usageError
+        } catch let normalFailure as SQLiteReadFailure {
+            guard normalFailure.resultCode == SQLITE_CANTOPEN,
+                  normalToIdleHandoffRetriesRemaining > 0,
+                  let idleWALState = self.idleWALState()
+            else {
+                throw normalFailure.usageError
+            }
+
+            return try self.readIdleWALRows(
+                state: idleWALState,
+                idleRetriesRemaining: idleRetriesRemaining,
+                normalToIdleHandoffRetriesRemaining: normalToIdleHandoffRetriesRemaining - 1)
         }
     }
 
     private func readRows(readMode: SQLiteReadMode) throws -> [UsageRow] {
         #if DEBUG
-        if case .normal = readMode {
+        if case .immutable = readMode {
+            try self.beforeImmutableRead()
+        } else {
             try self.beforeNormalRead()
         }
         #endif
@@ -293,18 +355,6 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
             return nil
         }
         return IdleWALState(database: after)
-    }
-
-    private func isStillIdleWAL(state: IdleWALState) -> Bool {
-        guard self.sidecarsAreMissing(),
-              let current = Self.fileState(at: self.databaseURL),
-              current == state.database,
-              Self.hasWALHeader(at: self.databaseURL),
-              self.sidecarsAreMissing()
-        else {
-            return false
-        }
-        return true
     }
 
     private func sidecarsAreMissing() -> Bool {

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
@@ -31,6 +31,9 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
 
     private let authURL: URL
     private let databaseURL: URL
+    #if DEBUG
+    private let beforeNormalVerification: @Sendable () throws -> Void
+    #endif
 
     public init(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) {
         let openCodeDirectory = homeDirectory
@@ -39,12 +42,30 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
             .appendingPathComponent("opencode", isDirectory: true)
         self.authURL = openCodeDirectory.appendingPathComponent("auth.json", isDirectory: false)
         self.databaseURL = openCodeDirectory.appendingPathComponent("opencode.db", isDirectory: false)
+        #if DEBUG
+        self.beforeNormalVerification = {}
+        #endif
     }
 
     public init(authURL: URL, databaseURL: URL) {
         self.authURL = authURL
         self.databaseURL = databaseURL
+        #if DEBUG
+        self.beforeNormalVerification = {}
+        #endif
     }
+
+    #if DEBUG
+    init(
+        authURL: URL,
+        databaseURL: URL,
+        beforeNormalVerification: @escaping @Sendable () throws -> Void)
+    {
+        self.authURL = authURL
+        self.databaseURL = databaseURL
+        self.beforeNormalVerification = beforeNormalVerification
+    }
+    #endif
 
     public func fetch(now: Date = Date(), historyDays: Int = 30) throws -> OpenCodeGoUsageSnapshot {
         let hasAuth = Self.hasAuthKey(at: self.authURL)
@@ -66,21 +87,58 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
     }
 
     private func readRows() throws -> [UsageRow] {
+        do {
+            return try self.readRows(readMode: .normal)
+        } catch let failure as SQLiteReadFailure {
+            guard failure.resultCode == SQLITE_CANTOPEN,
+                  let idleWALState = self.idleWALState()
+            else {
+                throw failure.usageError
+            }
+
+            do {
+                let rows = try self.readRows(readMode: .immutable)
+                #if DEBUG
+                try self.beforeNormalVerification()
+                #endif
+
+                // immutable=1 skips SQLite's change detection. Prefer a normal read whenever a writer appeared,
+                // and only keep the immutable snapshot if the database is still demonstrably idle.
+                do {
+                    return try self.readRows(readMode: .normal)
+                } catch let verificationFailure as SQLiteReadFailure {
+                    guard verificationFailure.resultCode == SQLITE_CANTOPEN,
+                          self.isStillIdleWAL(state: idleWALState)
+                    else {
+                        throw verificationFailure.usageError
+                    }
+                }
+                return rows
+            } catch let immutableFailure as SQLiteReadFailure {
+                throw immutableFailure.usageError
+            }
+        }
+    }
+
+    private func readRows(readMode: SQLiteReadMode) throws -> [UsageRow] {
         var db: OpaquePointer?
-        guard sqlite3_open_v2(self.databaseURL.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
-            let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
+        let location = try self.databaseLocation(for: readMode)
+        let openResult = sqlite3_open_v2(location, &db, self.openFlags(for: readMode), nil)
+        guard openResult == SQLITE_OK, let db else {
+            let failure = SQLiteReadFailure(resultCode: openResult, db: db)
             sqlite3_close(db)
-            throw OpenCodeGoLocalUsageError.sqliteFailed(message)
+            throw failure
         }
         defer { sqlite3_close(db) }
         sqlite3_busy_timeout(db, 250)
 
-        let sql = self.hasTable(named: "part", db: db) ? Self.messageAndPartUsageSQL : Self.messageUsageSQL
+        let hasParts = try self.hasTable(named: "part", db: db)
+        let sql = hasParts ? Self.messageAndPartUsageSQL : Self.messageUsageSQL
 
         var stmt: OpaquePointer?
-        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
-            let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
-            throw OpenCodeGoLocalUsageError.sqliteFailed(message)
+        let prepareResult = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard prepareResult == SQLITE_OK, let stmt else {
+            throw SQLiteReadFailure(resultCode: prepareResult, db: db)
         }
         defer { sqlite3_finalize(stmt) }
 
@@ -91,8 +149,7 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
                 break
             }
             guard step == SQLITE_ROW else {
-                let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
-                throw OpenCodeGoLocalUsageError.sqliteFailed(message)
+                throw SQLiteReadFailure(resultCode: step, db: db)
             }
 
             let createdMs = sqlite3_column_int64(stmt, 0)
@@ -104,22 +161,153 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
         return rows
     }
 
-    private func hasTable(named name: String, db: OpaquePointer?) -> Bool {
+    private func hasTable(named name: String, db: OpaquePointer) throws -> Bool {
         var stmt: OpaquePointer?
-        guard sqlite3_prepare_v2(
+        let prepareResult = sqlite3_prepare_v2(
             db,
             "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
             -1,
             &stmt,
-            nil) == SQLITE_OK
-        else {
-            return false
+            nil)
+        guard prepareResult == SQLITE_OK, let stmt else {
+            throw SQLiteReadFailure(resultCode: prepareResult, db: db)
         }
         defer { sqlite3_finalize(stmt) }
 
         let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-        sqlite3_bind_text(stmt, 1, name, -1, transient)
-        return sqlite3_step(stmt) == SQLITE_ROW
+        let bindResult = sqlite3_bind_text(stmt, 1, name, -1, transient)
+        guard bindResult == SQLITE_OK else {
+            throw SQLiteReadFailure(resultCode: bindResult, db: db)
+        }
+        let step = sqlite3_step(stmt)
+        if step == SQLITE_ROW {
+            return true
+        }
+        if step == SQLITE_DONE {
+            return false
+        }
+        throw SQLiteReadFailure(resultCode: step, db: db)
+    }
+
+    private enum SQLiteReadMode {
+        case normal
+        case immutable
+    }
+
+    private struct SQLiteReadFailure: Error {
+        let resultCode: Int32
+        let message: String
+
+        init(resultCode: Int32, db: OpaquePointer?) {
+            self.resultCode = resultCode
+            self.message = db.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
+        }
+
+        init(resultCode: Int32, message: String) {
+            self.resultCode = resultCode
+            self.message = message
+        }
+
+        var usageError: OpenCodeGoLocalUsageError {
+            .sqliteFailed(self.message)
+        }
+    }
+
+    private struct IdleWALState: Equatable {
+        let database: DatabaseFileState
+    }
+
+    private struct DatabaseFileState: Equatable {
+        let fileNumber: UInt64?
+        let size: UInt64
+        let modificationDate: Date
+    }
+
+    private func databaseLocation(for readMode: SQLiteReadMode) throws -> String {
+        switch readMode {
+        case .normal:
+            return self.databaseURL.path
+        case .immutable:
+            guard let immutableDatabaseURI = self.immutableDatabaseURI else {
+                throw SQLiteReadFailure(
+                    resultCode: SQLITE_CANTOPEN,
+                    message: "could not construct immutable database URI")
+            }
+            return immutableDatabaseURI
+        }
+    }
+
+    private func openFlags(for readMode: SQLiteReadMode) -> Int32 {
+        switch readMode {
+        case .normal:
+            SQLITE_OPEN_READONLY
+        case .immutable:
+            SQLITE_OPEN_READONLY | SQLITE_OPEN_URI
+        }
+    }
+
+    private var immutableDatabaseURI: String? {
+        guard var components = URLComponents(url: self.databaseURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.queryItems = [
+            URLQueryItem(name: "mode", value: "ro"),
+            URLQueryItem(name: "immutable", value: "1"),
+        ]
+        return components.url?.absoluteString
+    }
+
+    private func idleWALState() -> IdleWALState? {
+        guard self.sidecarsAreMissing(),
+              let before = Self.fileState(at: self.databaseURL),
+              Self.hasWALHeader(at: self.databaseURL),
+              let after = Self.fileState(at: self.databaseURL),
+              before == after,
+              self.sidecarsAreMissing()
+        else {
+            return nil
+        }
+        return IdleWALState(database: after)
+    }
+
+    private func isStillIdleWAL(state: IdleWALState) -> Bool {
+        guard self.sidecarsAreMissing(),
+              let current = Self.fileState(at: self.databaseURL),
+              current == state.database,
+              Self.hasWALHeader(at: self.databaseURL),
+              self.sidecarsAreMissing()
+        else {
+            return false
+        }
+        return true
+    }
+
+    private func sidecarsAreMissing() -> Bool {
+        let fileManager = FileManager.default
+        return !fileManager.fileExists(atPath: self.sidecarURL(suffix: "-wal").path) &&
+            !fileManager.fileExists(atPath: self.sidecarURL(suffix: "-shm").path)
+    }
+
+    private func sidecarURL(suffix: String) -> URL {
+        URL(fileURLWithPath: self.databaseURL.path + suffix, isDirectory: false)
+    }
+
+    private static func fileState(at url: URL) -> DatabaseFileState? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = (attributes[.size] as? NSNumber)?.uint64Value,
+              let modificationDate = attributes[.modificationDate] as? Date
+        else {
+            return nil
+        }
+        let fileNumber = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value
+        return DatabaseFileState(fileNumber: fileNumber, size: size, modificationDate: modificationDate)
+    }
+
+    private static func hasWALHeader(at url: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        guard let header = try? handle.read(upToCount: 20), header.count == 20 else { return false }
+        return header[18] == 2 && header[19] == 2
     }
 
     private static let messageUsageSQL = """

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
@@ -247,7 +247,9 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
     }
 
     private var immutableDatabaseURI: String? {
-        guard var components = URLComponents(url: self.databaseURL, resolvingAgainstBaseURL: false) else {
+        guard self.databaseURL.isFileURL,
+              var components = URLComponents(url: self.databaseURL, resolvingAgainstBaseURL: false)
+        else {
             return nil
         }
         components.queryItems = [

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
@@ -32,6 +32,7 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
     private let authURL: URL
     private let databaseURL: URL
     #if DEBUG
+    private let beforeNormalRead: @Sendable () throws -> Void
     private let beforeNormalVerification: @Sendable () throws -> Void
     #endif
 
@@ -43,6 +44,7 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
         self.authURL = openCodeDirectory.appendingPathComponent("auth.json", isDirectory: false)
         self.databaseURL = openCodeDirectory.appendingPathComponent("opencode.db", isDirectory: false)
         #if DEBUG
+        self.beforeNormalRead = {}
         self.beforeNormalVerification = {}
         #endif
     }
@@ -51,6 +53,7 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
         self.authURL = authURL
         self.databaseURL = databaseURL
         #if DEBUG
+        self.beforeNormalRead = {}
         self.beforeNormalVerification = {}
         #endif
     }
@@ -59,15 +62,20 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
     init(
         authURL: URL,
         databaseURL: URL,
-        beforeNormalVerification: @escaping @Sendable () throws -> Void)
+        beforeNormalVerification: @escaping @Sendable () throws -> Void = {},
+        beforeNormalRead: @escaping @Sendable () throws -> Void = {})
     {
         self.authURL = authURL
         self.databaseURL = databaseURL
+        self.beforeNormalRead = beforeNormalRead
         self.beforeNormalVerification = beforeNormalVerification
     }
     #endif
 
     public func fetch(now: Date = Date(), historyDays: Int = 30) throws -> OpenCodeGoUsageSnapshot {
+        guard self.databaseURL.isFileURL else {
+            throw OpenCodeGoLocalUsageError.historyUnavailable("database URL must be a file URL")
+        }
         let hasAuth = Self.hasAuthKey(at: self.authURL)
         guard FileManager.default.fileExists(atPath: self.databaseURL.path) else {
             if hasAuth {
@@ -87,6 +95,12 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
     }
 
     private func readRows() throws -> [UsageRow] {
+        // A read-only WAL connection may create missing sidecars when the directory is writable. Select the
+        // immutable recovery path before opening SQLite only when the stable file state proves it is idle.
+        if let idleWALState = self.idleWALState() {
+            return try self.readIdleWALRows(state: idleWALState)
+        }
+
         do {
             return try self.readRows(readMode: .normal)
         } catch let failure as SQLiteReadFailure {
@@ -96,31 +110,40 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
                 throw failure.usageError
             }
 
-            do {
-                let rows = try self.readRows(readMode: .immutable)
-                #if DEBUG
-                try self.beforeNormalVerification()
-                #endif
+            return try self.readIdleWALRows(state: idleWALState)
+        }
+    }
 
-                // immutable=1 skips SQLite's change detection. Prefer a normal read whenever a writer appeared,
-                // and only keep the immutable snapshot if the database is still demonstrably idle.
-                do {
-                    return try self.readRows(readMode: .normal)
-                } catch let verificationFailure as SQLiteReadFailure {
-                    guard verificationFailure.resultCode == SQLITE_CANTOPEN,
-                          self.isStillIdleWAL(state: idleWALState)
-                    else {
-                        throw verificationFailure.usageError
-                    }
-                }
-                return rows
-            } catch let immutableFailure as SQLiteReadFailure {
-                throw immutableFailure.usageError
-            }
+    private func readIdleWALRows(state idleWALState: IdleWALState) throws -> [UsageRow] {
+        let rows: [UsageRow]
+        do {
+            rows = try self.readRows(readMode: .immutable)
+        } catch let immutableFailure as SQLiteReadFailure {
+            throw immutableFailure.usageError
+        }
+
+        #if DEBUG
+        try self.beforeNormalVerification()
+        #endif
+
+        // immutable=1 skips SQLite's change detection. Keep it only while the state still proves no writer
+        // appeared; a changed state must be read normally so live WAL data remains authoritative.
+        guard !self.isStillIdleWAL(state: idleWALState) else {
+            return rows
+        }
+        do {
+            return try self.readRows(readMode: .normal)
+        } catch let verificationFailure as SQLiteReadFailure {
+            throw verificationFailure.usageError
         }
     }
 
     private func readRows(readMode: SQLiteReadMode) throws -> [UsageRow] {
+        #if DEBUG
+        if case .normal = readMode {
+            try self.beforeNormalRead()
+        }
+        #endif
         var db: OpaquePointer?
         let location = try self.databaseLocation(for: readMode)
         let openResult = sqlite3_open_v2(location, &db, self.openFlags(for: readMode), nil)

--- a/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
@@ -134,6 +134,32 @@ struct OpenCodeGoLocalUsageReaderTests {
         #expect(snapshot.rollingUsagePercent == 25)
         #expect(snapshot.weeklyUsagePercent == 10)
         #expect(snapshot.monthlyUsagePercent == 5)
+        #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
+        #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-shm"))
+    }
+
+    @Test
+    func `immutable fallback rejects a non-file database URL`() throws {
+        let env = try Self.makeEnvironment()
+        defer { try? FileManager.default.removeItem(at: env.root) }
+
+        try Self.writeAuth(to: env.authURL)
+        try Self.createDatabase(at: env.databaseURL, usingWAL: true)
+        try Self.insertMessage(
+            databaseURL: env.databaseURL,
+            createdMs: Self.ms("2026-03-06T11:00:00.000Z"),
+            cost: 3.0)
+        try Self.checkpointWAL(at: env.databaseURL)
+        try Self.removeWALSidecars(at: env.databaseURL)
+
+        let nonFileDatabaseURL = try #require(URL(string: "https://example.invalid\(env.databaseURL.path)"))
+        let reader = OpenCodeGoLocalUsageReader(authURL: env.authURL, databaseURL: nonFileDatabaseURL)
+
+        #expect(throws: OpenCodeGoLocalUsageError.sqliteFailed("could not construct immutable database URI")) {
+            _ = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
+        }
+        #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
+        #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-shm"))
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
@@ -44,32 +44,38 @@ struct OpenCodeGoLocalUsageReaderTests {
 
         try Self.writeAuth(to: env.authURL)
         try Self.createDatabase(at: env.databaseURL)
-        // Expected keys below use the same device-local calendar convention as production.
+        let calendar = Calendar.current
+        let dayStart = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_772_798_400))
+        let previousDay = try #require(calendar.date(byAdding: .day, value: -1, to: dayStart))
+        let currentDayAtNoon = dayStart.addingTimeInterval(12 * 60 * 60)
+        let currentDayAtOnePM = dayStart.addingTimeInterval(13 * 60 * 60)
+        let previousDayAtNoon = previousDay.addingTimeInterval(12 * 60 * 60)
+        let outsideWindow = try #require(calendar.date(byAdding: .day, value: -31, to: dayStart))
+            .addingTimeInterval(12 * 60 * 60)
+        let now = dayStart.addingTimeInterval(15 * 60 * 60)
+
         try Self.insertMessage(
             databaseURL: env.databaseURL,
-            createdMs: Self.ms("2026-03-06T12:00:00.000Z"),
+            createdMs: Self.ms(currentDayAtNoon),
             cost: 3.0)
         try Self.insertMessage(
             databaseURL: env.databaseURL,
-            createdMs: Self.ms("2026-03-06T13:00:00.000Z"),
+            createdMs: Self.ms(currentDayAtOnePM),
             cost: 1.5)
         try Self.insertMessage(
             databaseURL: env.databaseURL,
-            createdMs: Self.ms("2026-03-05T12:00:00.000Z"),
+            createdMs: Self.ms(previousDayAtNoon),
             cost: 6.0)
         try Self.insertMessage(
             databaseURL: env.databaseURL,
-            createdMs: Self.ms("2026-01-01T12:00:00.000Z"),
+            createdMs: Self.ms(outsideWindow),
             cost: 100.0)
 
         let reader = OpenCodeGoLocalUsageReader(authURL: env.authURL, databaseURL: env.databaseURL)
-        let now = Date(timeIntervalSince1970: TimeInterval(Self.ms("2026-03-06T15:00:00.000Z")) / 1000)
         let snapshot = try reader.fetch(now: now, historyDays: 30)
 
-        let previousDayKey = CostUsageScanner.CostUsageDayRange.dayKey(
-            from: Date(timeIntervalSince1970: TimeInterval(Self.ms("2026-03-05T12:00:00.000Z")) / 1000))
-        let currentDayKey = CostUsageScanner.CostUsageDayRange.dayKey(
-            from: Date(timeIntervalSince1970: TimeInterval(Self.ms("2026-03-06T12:00:00.000Z")) / 1000))
+        let previousDayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: previousDayAtNoon)
+        let currentDayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: currentDayAtNoon)
         #expect(snapshot.daily.map(\.date) == [previousDayKey, currentDayKey])
         #expect(snapshot.daily.first?.costUSD == 6.0)
         #expect(snapshot.daily.first?.requestCount == 1)
@@ -106,6 +112,90 @@ struct OpenCodeGoLocalUsageReaderTests {
         #expect(throws: OpenCodeGoLocalUsageError.self) {
             _ = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
         }
+    }
+
+    @Test
+    func `reads idle WAL history after OpenCode removes sidecars`() throws {
+        let env = try Self.makeEnvironment(rootName: "OpenCode Go WAL #\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: env.root) }
+
+        try Self.writeAuth(to: env.authURL)
+        try Self.createDatabase(at: env.databaseURL, usingWAL: true)
+        try Self.insertMessage(
+            databaseURL: env.databaseURL,
+            createdMs: Self.ms("2026-03-06T11:00:00.000Z"),
+            cost: 3.0)
+        try Self.checkpointWAL(at: env.databaseURL)
+        try Self.removeWALSidecars(at: env.databaseURL)
+
+        let reader = OpenCodeGoLocalUsageReader(authURL: env.authURL, databaseURL: env.databaseURL)
+        let snapshot = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
+
+        #expect(snapshot.rollingUsagePercent == 25)
+        #expect(snapshot.weeklyUsagePercent == 10)
+        #expect(snapshot.monthlyUsagePercent == 5)
+    }
+
+    @Test
+    func `normal reader keeps uncheckpointed live WAL usage`() throws {
+        let env = try Self.makeEnvironment()
+        defer { try? FileManager.default.removeItem(at: env.root) }
+
+        try Self.writeAuth(to: env.authURL)
+        try Self.createDatabase(at: env.databaseURL, usingWAL: true)
+        try Self.insertMessage(
+            databaseURL: env.databaseURL,
+            createdMs: Self.ms("2026-03-06T10:00:00.000Z"),
+            cost: 1.0)
+        try Self.checkpointWAL(at: env.databaseURL)
+        try Self.removeWALSidecars(at: env.databaseURL)
+
+        let writer = try Self.openDatabase(at: env.databaseURL)
+        defer { sqlite3_close(writer) }
+        try Self.insertMessage(
+            db: writer,
+            createdMs: Self.ms("2026-03-06T11:00:00.000Z"),
+            cost: 3.0)
+        #expect(FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
+
+        let reader = OpenCodeGoLocalUsageReader(authURL: env.authURL, databaseURL: env.databaseURL)
+        let snapshot = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
+
+        #expect(snapshot.rollingUsagePercent == 33.3)
+        #expect(snapshot.weeklyUsagePercent == 13.3)
+        #expect(snapshot.monthlyUsagePercent == 6.7)
+    }
+
+    @Test
+    func `normal verification wins when a live WAL appears during immutable fallback`() throws {
+        let env = try Self.makeEnvironment()
+        defer { try? FileManager.default.removeItem(at: env.root) }
+
+        try Self.writeAuth(to: env.authURL)
+        try Self.createDatabase(at: env.databaseURL, usingWAL: true)
+        try Self.insertMessage(
+            databaseURL: env.databaseURL,
+            createdMs: Self.ms("2026-03-06T10:00:00.000Z"),
+            cost: 1.0)
+        try Self.checkpointWAL(at: env.databaseURL)
+        try Self.removeWALSidecars(at: env.databaseURL)
+
+        let writer = SQLiteWALWriter()
+        defer { writer.close() }
+        let databaseURL = env.databaseURL
+        let liveCreatedMs = Self.ms("2026-03-06T11:00:00.000Z")
+        let reader = OpenCodeGoLocalUsageReader(
+            authURL: env.authURL,
+            databaseURL: databaseURL,
+            beforeNormalVerification: {
+                try writer.openAndInsert(databaseURL: databaseURL, createdMs: liveCreatedMs, cost: 3.0)
+            })
+        let snapshot = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
+
+        #expect(FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
+        #expect(snapshot.rollingUsagePercent == 33.3)
+        #expect(snapshot.weeklyUsagePercent == 13.3)
+        #expect(snapshot.monthlyUsagePercent == 6.7)
     }
 
     @Test
@@ -239,9 +329,11 @@ struct OpenCodeGoLocalUsageReaderTests {
         }
     }
 
-    private static func makeEnvironment() throws -> (root: URL, authURL: URL, databaseURL: URL) {
+    private static func makeEnvironment(rootName: String? = nil) throws -> (root: URL, authURL: URL, databaseURL: URL) {
         let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OpenCodeGoLocalUsageReaderTests-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent(
+                rootName ?? "OpenCodeGoLocalUsageReaderTests-\(UUID().uuidString)",
+                isDirectory: true)
         let directory = root
             .appendingPathComponent(".local", isDirectory: true)
             .appendingPathComponent("share", isDirectory: true)
@@ -258,10 +350,12 @@ struct OpenCodeGoLocalUsageReaderTests {
         try data.write(to: url)
     }
 
-    private static func createDatabase(at url: URL) throws {
-        var db: OpaquePointer?
-        guard sqlite3_open(url.path, &db) == SQLITE_OK else { throw SQLiteTestError.open }
+    private static func createDatabase(at url: URL, usingWAL: Bool = false) throws {
+        let db = try Self.openDatabase(at: url)
         defer { sqlite3_close(db) }
+        if usingWAL {
+            try Self.exec(db: db, sql: "PRAGMA journal_mode=WAL;")
+        }
         try Self.exec(
             db: db,
             sql: """
@@ -285,10 +379,13 @@ struct OpenCodeGoLocalUsageReaderTests {
 
     @discardableResult
     private static func insertMessage(databaseURL: URL, createdMs: Int64, cost: Double?) throws -> String {
-        var db: OpaquePointer?
-        guard sqlite3_open(databaseURL.path, &db) == SQLITE_OK else { throw SQLiteTestError.open }
+        let db = try Self.openDatabase(at: databaseURL)
         defer { sqlite3_close(db) }
+        return try Self.insertMessage(db: db, createdMs: createdMs, cost: cost)
+    }
 
+    @discardableResult
+    private static func insertMessage(db: OpaquePointer, createdMs: Int64, cost: Double?) throws -> String {
         let messageID = UUID().uuidString
         var payload: [String: Any] = [
             "providerID": "opencode-go",
@@ -319,6 +416,22 @@ struct OpenCodeGoLocalUsageReaderTests {
         sqlite3_bind_int64(stmt, 5, createdMs)
         guard sqlite3_step(stmt) == SQLITE_DONE else { throw SQLiteTestError.step }
         return messageID
+    }
+
+    private static func checkpointWAL(at databaseURL: URL) throws {
+        let db = try Self.openDatabase(at: databaseURL)
+        defer { sqlite3_close(db) }
+        try Self.exec(db: db, sql: "PRAGMA wal_checkpoint(TRUNCATE);")
+    }
+
+    private static func removeWALSidecars(at databaseURL: URL) throws {
+        let fileManager = FileManager.default
+        for suffix in ["-wal", "-shm"] {
+            let sidecar = URL(fileURLWithPath: databaseURL.path + suffix, isDirectory: false)
+            if fileManager.fileExists(atPath: sidecar.path) {
+                try fileManager.removeItem(at: sidecar)
+            }
+        }
     }
 
     private static func insertStepFinishPart(
@@ -367,6 +480,12 @@ struct OpenCodeGoLocalUsageReaderTests {
         }
     }
 
+    private static func openDatabase(at url: URL) throws -> OpaquePointer {
+        var db: OpaquePointer?
+        guard sqlite3_open(url.path, &db) == SQLITE_OK, let db else { throw SQLiteTestError.open }
+        return db
+    }
+
     private static func ms(_ iso: String) -> Int64 {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -382,6 +501,23 @@ struct OpenCodeGoLocalUsageReaderTests {
         case prepare
         case step
         case exec
+    }
+
+    private final class SQLiteWALWriter: @unchecked Sendable {
+        private var db: OpaquePointer?
+
+        func openAndInsert(databaseURL: URL, createdMs: Int64, cost: Double) throws {
+            guard self.db == nil else { throw SQLiteTestError.open }
+            let db = try OpenCodeGoLocalUsageReaderTests.openDatabase(at: databaseURL)
+            self.db = db
+            _ = try OpenCodeGoLocalUsageReaderTests.insertMessage(db: db, createdMs: createdMs, cost: cost)
+        }
+
+        func close() {
+            guard let db = self.db else { return }
+            sqlite3_close(db)
+            self.db = nil
+        }
     }
 }
 

--- a/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
@@ -234,6 +234,180 @@ struct OpenCodeGoLocalUsageReaderTests {
     }
 
     @Test
+    func `retries immutable read when an active WAL cleans up before normal handoff`() throws {
+        let env = try Self.makeEnvironment()
+        defer { try? FileManager.default.removeItem(at: env.root) }
+
+        try Self.writeAuth(to: env.authURL)
+        try Self.createDatabase(at: env.databaseURL, usingWAL: true)
+        try Self.insertMessage(
+            databaseURL: env.databaseURL,
+            createdMs: Self.ms("2026-03-06T10:00:00.000Z"),
+            cost: 1.0)
+        try Self.checkpointWAL(at: env.databaseURL)
+        try Self.removeWALSidecars(at: env.databaseURL)
+
+        let writer = SQLiteWALWriter()
+        defer { writer.close() }
+        let immutableSuccessCounter = SQLiteNormalReadCounter()
+        let normalReadCounter = SQLiteNormalReadCounter()
+        let databaseURL = env.databaseURL
+        let reader = OpenCodeGoLocalUsageReader(
+            authURL: env.authURL,
+            databaseURL: databaseURL,
+            beforeNormalVerification: {
+                if immutableSuccessCounter.incrementAndReturnPrevious() == 0 {
+                    try writer.openAndInsert(
+                        databaseURL: databaseURL,
+                        createdMs: Self.ms("2026-03-06T11:00:00.000Z"),
+                        cost: 3.0,
+                        payloadPadding: String(repeating: "x", count: 16384))
+                }
+            },
+            beforeNormalRead: {
+                normalReadCounter.increment()
+                writer.close()
+                try Self.checkpointWAL(at: databaseURL)
+                try Self.removeWALSidecars(at: databaseURL)
+            })
+        let snapshot = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
+
+        #expect(immutableSuccessCounter.value == 2)
+        #expect(normalReadCounter.value == 1)
+        #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
+        #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-shm"))
+        #expect(snapshot.rollingUsagePercent == 33.3)
+        #expect(snapshot.weeklyUsagePercent == 13.3)
+        #expect(snapshot.monthlyUsagePercent == 6.7)
+    }
+
+    @Test
+    func `normal reader wins when a writer makes immutable read fail`() throws {
+        let env = try Self.makeEnvironment()
+        defer { try? FileManager.default.removeItem(at: env.root) }
+
+        try Self.writeAuth(to: env.authURL)
+        try Self.createDatabase(at: env.databaseURL, usingWAL: true, includingSchema: false)
+        try Self.checkpointWAL(at: env.databaseURL)
+        try Self.removeWALSidecars(at: env.databaseURL)
+
+        let writer = SQLiteWALWriter()
+        defer { writer.close() }
+        let normalReadCounter = SQLiteNormalReadCounter()
+        let immutableSuccessCounter = SQLiteNormalReadCounter()
+        let databaseURL = env.databaseURL
+        let reader = OpenCodeGoLocalUsageReader(
+            authURL: env.authURL,
+            databaseURL: databaseURL,
+            beforeNormalVerification: { immutableSuccessCounter.increment() },
+            beforeImmutableRead: {
+                try writer.openCreateSchemaAndInsert(
+                    databaseURL: databaseURL,
+                    createdMs: Self.ms("2026-03-06T11:00:00.000Z"),
+                    cost: 3.0)
+            },
+            beforeNormalRead: { normalReadCounter.increment() })
+        let snapshot = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
+
+        #expect(FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
+        #expect(immutableSuccessCounter.value == 0)
+        #expect(normalReadCounter.value == 1)
+        #expect(snapshot.rollingUsagePercent == 25)
+        #expect(snapshot.weeklyUsagePercent == 10)
+        #expect(snapshot.monthlyUsagePercent == 5)
+    }
+
+    @Test
+    func `retries immutable read after a writer returns to an idle WAL`() throws {
+        let env = try Self.makeEnvironment()
+        defer { try? FileManager.default.removeItem(at: env.root) }
+
+        try Self.writeAuth(to: env.authURL)
+        try Self.createDatabase(at: env.databaseURL, usingWAL: true)
+        try Self.insertMessage(
+            databaseURL: env.databaseURL,
+            createdMs: Self.ms("2026-03-06T10:00:00.000Z"),
+            cost: 1.0)
+        try Self.checkpointWAL(at: env.databaseURL)
+        try Self.removeWALSidecars(at: env.databaseURL)
+
+        let writer = SQLiteWALWriter()
+        defer { writer.close() }
+        let immutableSuccessCounter = SQLiteNormalReadCounter()
+        let normalReadCounter = SQLiteNormalReadCounter()
+        let databaseURL = env.databaseURL
+        let reader = OpenCodeGoLocalUsageReader(
+            authURL: env.authURL,
+            databaseURL: databaseURL,
+            beforeNormalVerification: {
+                if immutableSuccessCounter.incrementAndReturnPrevious() == 0 {
+                    try writer.openAndInsert(
+                        databaseURL: databaseURL,
+                        createdMs: Self.ms("2026-03-06T11:00:00.000Z"),
+                        cost: 3.0,
+                        payloadPadding: String(repeating: "x", count: 16384))
+                    writer.close()
+                    try Self.checkpointWAL(at: databaseURL)
+                    try Self.removeWALSidecars(at: databaseURL)
+                }
+            },
+            beforeNormalRead: { normalReadCounter.increment() })
+        let snapshot = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
+
+        #expect(immutableSuccessCounter.value == 2)
+        #expect(normalReadCounter.value == 0)
+        #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
+        #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-shm"))
+        #expect(snapshot.rollingUsagePercent == 33.3)
+        #expect(snapshot.weeklyUsagePercent == 13.3)
+        #expect(snapshot.monthlyUsagePercent == 6.7)
+    }
+
+    @Test
+    func `does not normal read after repeated clean idle WAL transitions`() throws {
+        let env = try Self.makeEnvironment()
+        defer { try? FileManager.default.removeItem(at: env.root) }
+
+        try Self.writeAuth(to: env.authURL)
+        try Self.createDatabase(at: env.databaseURL, usingWAL: true)
+        try Self.insertMessage(
+            databaseURL: env.databaseURL,
+            createdMs: Self.ms("2026-03-06T10:00:00.000Z"),
+            cost: 1.0)
+        try Self.checkpointWAL(at: env.databaseURL)
+        try Self.removeWALSidecars(at: env.databaseURL)
+
+        let writer = SQLiteWALWriter()
+        defer { writer.close() }
+        let immutableSuccessCounter = SQLiteNormalReadCounter()
+        let normalReadCounter = SQLiteNormalReadCounter()
+        let databaseURL = env.databaseURL
+        let reader = OpenCodeGoLocalUsageReader(
+            authURL: env.authURL,
+            databaseURL: databaseURL,
+            beforeNormalVerification: {
+                let attempt = immutableSuccessCounter.incrementAndReturnPrevious()
+                try writer.openAndInsert(
+                    databaseURL: databaseURL,
+                    createdMs: Self.ms("2026-03-06T11:00:00.000Z") + Int64(attempt),
+                    cost: 3.0,
+                    payloadPadding: String(repeating: "x", count: 16384 * (attempt + 1)))
+                writer.close()
+                try Self.checkpointWAL(at: databaseURL)
+                try Self.removeWALSidecars(at: databaseURL)
+            },
+            beforeNormalRead: { normalReadCounter.increment() })
+
+        #expect(throws: OpenCodeGoLocalUsageError.sqliteFailed("database changed repeatedly while reading idle WAL")) {
+            _ = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
+        }
+        #expect(immutableSuccessCounter.value == 2)
+        #expect(normalReadCounter.value == 0)
+        #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
+        #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-shm"))
+    }
+
+    @Test
     func `monthly window keeps original anchor after shorter month clamp`() throws {
         let env = try Self.makeEnvironment()
         defer { try? FileManager.default.removeItem(at: env.root) }
@@ -385,13 +559,22 @@ struct OpenCodeGoLocalUsageReaderTests {
         try data.write(to: url)
     }
 
-    private static func createDatabase(at url: URL, usingWAL: Bool = false) throws {
+    private static func createDatabase(
+        at url: URL,
+        usingWAL: Bool = false,
+        includingSchema: Bool = true) throws
+    {
         let db = try Self.openDatabase(at: url)
         defer { sqlite3_close(db) }
         if usingWAL {
             try Self.exec(db: db, sql: "PRAGMA journal_mode=WAL;")
         }
-        try Self.exec(
+        guard includingSchema else { return }
+        try Self.createSchema(db: db)
+    }
+
+    private static func createSchema(db: OpaquePointer) throws {
+        try self.exec(
             db: db,
             sql: """
                 CREATE TABLE message (
@@ -413,14 +596,28 @@ struct OpenCodeGoLocalUsageReaderTests {
     }
 
     @discardableResult
-    private static func insertMessage(databaseURL: URL, createdMs: Int64, cost: Double?) throws -> String {
+    private static func insertMessage(
+        databaseURL: URL,
+        createdMs: Int64,
+        cost: Double?,
+        payloadPadding: String? = nil) throws -> String
+    {
         let db = try Self.openDatabase(at: databaseURL)
         defer { sqlite3_close(db) }
-        return try Self.insertMessage(db: db, createdMs: createdMs, cost: cost)
+        return try Self.insertMessage(
+            db: db,
+            createdMs: createdMs,
+            cost: cost,
+            payloadPadding: payloadPadding)
     }
 
     @discardableResult
-    private static func insertMessage(db: OpaquePointer, createdMs: Int64, cost: Double?) throws -> String {
+    private static func insertMessage(
+        db: OpaquePointer,
+        createdMs: Int64,
+        cost: Double?,
+        payloadPadding: String? = nil) throws -> String
+    {
         let messageID = UUID().uuidString
         var payload: [String: Any] = [
             "providerID": "opencode-go",
@@ -429,6 +626,9 @@ struct OpenCodeGoLocalUsageReaderTests {
         ]
         if let cost {
             payload["cost"] = cost
+        }
+        if let payloadPadding {
+            payload["padding"] = payloadPadding
         }
         let data = try JSONSerialization.data(withJSONObject: payload)
         let json = String(data: data, encoding: .utf8) ?? "{}"
@@ -548,6 +748,14 @@ struct OpenCodeGoLocalUsageReaderTests {
             self.lock.unlock()
         }
 
+        func incrementAndReturnPrevious() -> Int {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            let previous = self.count
+            self.count += 1
+            return previous
+        }
+
         var value: Int {
             self.lock.lock()
             defer { self.lock.unlock() }
@@ -558,11 +766,33 @@ struct OpenCodeGoLocalUsageReaderTests {
     private final class SQLiteWALWriter: @unchecked Sendable {
         private var db: OpaquePointer?
 
-        func openAndInsert(databaseURL: URL, createdMs: Int64, cost: Double) throws {
+        func openAndInsert(
+            databaseURL: URL,
+            createdMs: Int64,
+            cost: Double,
+            payloadPadding: String? = nil) throws
+        {
             guard self.db == nil else { throw SQLiteTestError.open }
             let db = try OpenCodeGoLocalUsageReaderTests.openDatabase(at: databaseURL)
             self.db = db
-            _ = try OpenCodeGoLocalUsageReaderTests.insertMessage(db: db, createdMs: createdMs, cost: cost)
+            _ = try OpenCodeGoLocalUsageReaderTests.insertMessage(
+                db: db,
+                createdMs: createdMs,
+                cost: cost,
+                payloadPadding: payloadPadding)
+        }
+
+        func openCreateSchemaAndInsert(databaseURL: URL, createdMs: Int64, cost: Double) throws {
+            guard self.db == nil else { throw SQLiteTestError.open }
+            let db = try OpenCodeGoLocalUsageReaderTests.openDatabase(at: databaseURL)
+            do {
+                try OpenCodeGoLocalUsageReaderTests.createSchema(db: db)
+                _ = try OpenCodeGoLocalUsageReaderTests.insertMessage(db: db, createdMs: createdMs, cost: cost)
+                self.db = db
+            } catch {
+                sqlite3_close(db)
+                throw error
+            }
         }
 
         func close() {

--- a/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
@@ -115,7 +115,7 @@ struct OpenCodeGoLocalUsageReaderTests {
     }
 
     @Test
-    func `reads idle WAL history after OpenCode removes sidecars`() throws {
+    func `reads idle WAL history without normal SQLite read or sidecars`() throws {
         let env = try Self.makeEnvironment(rootName: "OpenCode Go WAL #\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: env.root) }
 
@@ -128,18 +128,23 @@ struct OpenCodeGoLocalUsageReaderTests {
         try Self.checkpointWAL(at: env.databaseURL)
         try Self.removeWALSidecars(at: env.databaseURL)
 
-        let reader = OpenCodeGoLocalUsageReader(authURL: env.authURL, databaseURL: env.databaseURL)
+        let normalReadCounter = SQLiteNormalReadCounter()
+        let reader = OpenCodeGoLocalUsageReader(
+            authURL: env.authURL,
+            databaseURL: env.databaseURL,
+            beforeNormalRead: { normalReadCounter.increment() })
         let snapshot = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
 
         #expect(snapshot.rollingUsagePercent == 25)
         #expect(snapshot.weeklyUsagePercent == 10)
         #expect(snapshot.monthlyUsagePercent == 5)
+        #expect(normalReadCounter.value == 0)
         #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
         #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-shm"))
     }
 
     @Test
-    func `immutable fallback rejects a non-file database URL`() throws {
+    func `local history rejects a non-file database URL before filesystem access`() throws {
         let env = try Self.makeEnvironment()
         defer { try? FileManager.default.removeItem(at: env.root) }
 
@@ -155,7 +160,7 @@ struct OpenCodeGoLocalUsageReaderTests {
         let nonFileDatabaseURL = try #require(URL(string: "https://example.invalid\(env.databaseURL.path)"))
         let reader = OpenCodeGoLocalUsageReader(authURL: env.authURL, databaseURL: nonFileDatabaseURL)
 
-        #expect(throws: OpenCodeGoLocalUsageError.sqliteFailed("could not construct immutable database URI")) {
+        #expect(throws: OpenCodeGoLocalUsageError.historyUnavailable("database URL must be a file URL")) {
             _ = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
         }
         #expect(!FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
@@ -208,17 +213,21 @@ struct OpenCodeGoLocalUsageReaderTests {
 
         let writer = SQLiteWALWriter()
         defer { writer.close() }
+        let normalReadCounter = SQLiteNormalReadCounter()
         let databaseURL = env.databaseURL
         let liveCreatedMs = Self.ms("2026-03-06T11:00:00.000Z")
         let reader = OpenCodeGoLocalUsageReader(
             authURL: env.authURL,
             databaseURL: databaseURL,
             beforeNormalVerification: {
+                #expect(normalReadCounter.value == 0)
                 try writer.openAndInsert(databaseURL: databaseURL, createdMs: liveCreatedMs, cost: 3.0)
-            })
+            },
+            beforeNormalRead: { normalReadCounter.increment() })
         let snapshot = try reader.fetch(now: Date(timeIntervalSince1970: 1_772_798_400))
 
         #expect(FileManager.default.fileExists(atPath: env.databaseURL.path + "-wal"))
+        #expect(normalReadCounter.value == 1)
         #expect(snapshot.rollingUsagePercent == 33.3)
         #expect(snapshot.weeklyUsagePercent == 13.3)
         #expect(snapshot.monthlyUsagePercent == 6.7)
@@ -527,6 +536,23 @@ struct OpenCodeGoLocalUsageReaderTests {
         case prepare
         case step
         case exec
+    }
+
+    private final class SQLiteNormalReadCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        func increment() {
+            self.lock.lock()
+            self.count += 1
+            self.lock.unlock()
+        }
+
+        var value: Int {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.count
+        }
     }
 
     private final class SQLiteWALWriter: @unchecked Sendable {


### PR DESCRIPTION
## Summary

- Preflight a stable, sidecar-free OpenCode Go WAL database before opening SQLite; only that proven-idle state uses a read-only immutable URI.
- Recheck the exact file state after the immutable snapshot. Keep it only while still idle; if a writer appeared, rerun the normal reader so live WAL data remains authoritative.
- Reject non-file database URLs before any filesystem or SQLite access.
- Add regression coverage for sidecar non-mutation, active-WAL normal reads, writer transitions, and URL rejection.

## Root cause

OpenCode can remove `-wal` and `-shm` after an idle WAL database is checkpointed. A normal read-only SQLite connection can then fail to prepare statements, while an immutable read of the stable main database can recover the local history. Immutable mode skips SQLite change detection, so it is only accepted after a stable idle-state recheck.

## Validation

- `swift test --filter OpenCodeGoLocalUsageReaderTests`
- `swift test --filter OpenCodeGoProviderStrategyTests`
- `swift build -c release`
- `make check`
- `make test` — 763 selections in 64 groups; zero failures, retries, or timeouts
- Review swarm and structured autoreview — no remaining actionable findings

## Live-proof status

The local OpenCode database currently has both WAL sidecars, so it is an active-state observation rather than valid evidence for the missing-sidecar case. This draft intentionally remains open pending a redacted run against a naturally idle database; no sidecars or account data were modified to manufacture that condition.

Fixes #2544
