### PR TITLE
Populate windowMinutes for Zai, Kimi, and Grok rate windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
 ### Fixed
+- Usage: populate verified z.ai, Kimi, and Grok rate-window durations for pace and forecasts while leaving unknown provider cadences unset (#2431, supersedes #2514). Thanks @Yuxin-Qiao!
 - Menu: switching provider tabs no longer flashes. The sibling-tab warmup now runs off a tracking-safe timer (the previous Task-based warmup never fired while the menu was open, which is the only time it matters), and provider tabs share one stable menu height via an invisible spacer, so a switch is a single-frame content swap with no window resize. Verified frame-by-frame with a new env-gated self-probe (`CODEXBAR_FLICKER_PROBE_DIR`).
 
 ### Changed

--- a/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
@@ -42,6 +42,8 @@ public struct GrokUsageSnapshot: Sendable {
         } else if let webBilling,
                   let percent = webBilling.usedPercent
         {
+            // Do not infer the full quota cadence from the remaining time until reset; a
+            // monthly window near its reset would otherwise be misclassified as weekly.
             primary = RateWindow(
                 usedPercent: percent,
                 windowMinutes: nil,

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
@@ -126,7 +126,7 @@ extension KimiUsageSnapshot {
             guard let ratio = balance.amountUsedRatio, ratio.isFinite else { return nil }
             let window = RateWindow(
                 usedPercent: Self.clampedPercent(ratio * 100),
-                windowMinutes: nil, // Calendar-month duration varies; do not fabricate a fixed 30-day window.
+                windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
                 resetsAt: Self.parseDate(balance.expireTime),
                 resetDescription: nil)
             return NamedRateWindow(id: "kimi-monthly", title: "Monthly", window: window)

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -224,9 +224,18 @@ extension ZaiUsageSnapshot {
     }
 
     private static func rateWindow(for limit: ZaiLimitEntry) -> RateWindow {
-        RateWindow(
+        let windowMinutes: Int? = if limit.isMCPMonthlyMarker {
+            ProviderPaceCapability.monthlyWindowSentinelMinutes
+        } else if limit.type == .timeLimit, let minutes = limit.windowMinutes {
+            minutes
+        } else if limit.type == .timeLimit {
+            ProviderPaceCapability.monthlyWindowSentinelMinutes
+        } else {
+            limit.windowMinutes
+        }
+        return RateWindow(
             usedPercent: limit.usedPercent,
-            windowMinutes: limit.type == .tokensLimit ? limit.windowMinutes : nil,
+            windowMinutes: windowMinutes,
             resetsAt: limit.nextResetTime,
             resetDescription: self.resetDescription(for: limit))
     }

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -920,6 +920,24 @@ extension GrokWebBillingFetcherTests {
         #expect(usage.loginMethod(for: .grok) == "SuperGrok")
     }
 
+    @Test
+    func `usage snapshot does not classify a monthly reset near its end as weekly`() {
+        // A monthly quota with six days left must not be reported as a weekly window.
+        let snapshot = GrokUsageSnapshot(
+            billing: nil,
+            webBilling: GrokWebBillingSnapshot(
+                usedPercent: 12,
+                resetsAt: Date(timeIntervalSince1970: 1_799_000_000 + 6 * 86400)),
+            credentials: Self.credentials,
+            localSummary: nil,
+            cliVersion: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_799_000_000))
+
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.primary?.windowMinutes == nil)
+    }
+
     private static let credentials = GrokCredentials(
         accessToken: "token-123",
         refreshToken: "refresh-123",

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -1023,7 +1023,7 @@ struct KimiUsageSnapshotConversionTests {
         #expect(monthly.id == "kimi-monthly")
         #expect(monthly.title == "Monthly")
         #expect(monthly.window.usedPercent == 100)
-        #expect(monthly.window.windowMinutes == nil)
+        #expect(monthly.window.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
         #expect(monthly.window.resetsAt == Self.date("2026-07-23T00:00:00Z"))
     }
 

--- a/Tests/CodexBarTests/ZaiProviderTests.swift
+++ b/Tests/CodexBarTests/ZaiProviderTests.swift
@@ -195,6 +195,55 @@ struct ZaiUsageSnapshotTests {
 
         #expect(usage.primary?.usedPercent == 25)
     }
+
+    @Test
+    func `time limit with explicit duration preserves windowMinutes instead of monthly sentinel`() {
+        let reset = Date(timeIntervalSince1970: 123)
+        let timeLimit = ZaiLimitEntry(
+            type: .timeLimit,
+            unit: .hours,
+            number: 5,
+            usage: 100,
+            currentValue: 20,
+            remaining: 80,
+            percentage: 25,
+            usageDetails: [],
+            nextResetTime: reset)
+        let snapshot = ZaiUsageSnapshot(
+            tokenLimit: nil,
+            timeLimit: timeLimit,
+            planName: nil,
+            updatedAt: reset)
+
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.primary?.windowMinutes == 300)
+        #expect(usage.primary?.resetDescription == "5 hours window")
+    }
+
+    @Test
+    func `time limit without explicit duration falls back to monthly sentinel`() {
+        let reset = Date(timeIntervalSince1970: 123)
+        let timeLimit = ZaiLimitEntry(
+            type: .timeLimit,
+            unit: .days,
+            number: 0,
+            usage: 100,
+            currentValue: 20,
+            remaining: 80,
+            percentage: 25,
+            usageDetails: [],
+            nextResetTime: reset)
+        let snapshot = ZaiUsageSnapshot(
+            tokenLimit: nil,
+            timeLimit: timeLimit,
+            planName: nil,
+            updatedAt: reset)
+
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.primary?.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
+    }
 }
 
 struct ZaiUsageParsingTests {
@@ -253,7 +302,7 @@ struct ZaiUsageParsingTests {
         #expect(snapshot.tokenLimit?.percentage == 34.0)
 
         let usage = snapshot.toUsageSnapshot()
-        #expect(usage.secondary?.windowMinutes == nil)
+        #expect(usage.secondary?.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
         #expect(usage.secondary?.resetDescription == "Monthly")
     }
 
@@ -292,7 +341,7 @@ struct ZaiUsageParsingTests {
         let usage = snapshot.toUsageSnapshot()
 
         #expect(snapshot.timeLimit?.windowDescription == "1 minute")
-        #expect(usage.secondary?.windowMinutes == nil)
+        #expect(usage.secondary?.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
         #expect(usage.secondary?.resetDescription == "Monthly")
     }
 


### PR DESCRIPTION
## Summary

- Preserve explicit z.ai quota durations, including the Coding Plan's 5-hour windows, while mapping the provider's one-minute MCP marker and durationless time limits to the existing monthly sentinel.
- Populate Kimi's shared subscription pool with the existing monthly sentinel; its separate weekly and API-derived 5-hour windows remain unchanged.
- Keep Grok's explicit billing-cycle start/end duration path and add regression coverage proving that a web-only reset timestamp is not misclassified near the end of a monthly cycle.
- Add the 0.46.1 changelog entry and credit @Yuxin-Qiao for the original work.

## Supersedes #2514

This is a clean reapplication of the verified z.ai, Kimi, and Grok subset from #2514. It intentionally excludes all Antigravity cadence inference and `AntigravityWindowMinutesTests.swift`: `AntigravityModelQuota` has no provider cadence field, so deriving a 5-hour or weekly period from model IDs or display-name aliases would fabricate data and corrupt pace/history forecasts. Antigravity `windowMinutes` remains `nil` until the provider exposes an explicit cadence.

The unrelated `.gitignore` change, embedded-repository cleanup, and CI-trigger-only commits from #2514 are also excluded. The replacement commit retains Yuxin Qiao as its author.

## Verification

- `make check` — passed; SwiftFormat clean, SwiftLint 0 violations
- `swift test --filter ZaiProviderTests` — 42 tests passed
- `swift test --filter KimiProviderTests` — 67 tests passed
- `swift test --filter GrokWebBillingFetcherTests` — 41 tests passed
- `swift test --filter GrokBillingResponseTests` — 4 tests passed
- `make test` — every non-Kiro shard passed; only the known Kiro wall-clock timeout flakes covered by #2509 remained
- autoreview — clean, no accepted/actionable findings

Related: #2431
Supersedes: #2514
