### PR TITLE
Menu: flash-free tab switches — replant SwiftUI payloads instead of detaching item views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
 ### Fixed
+- Menu: provider tab switches no longer blank out card rows mid-switch. Cached tab content is replanted into the attached hosting views (SwiftUI payload swap) instead of detaching `item.view`, which made Tahoe's NSMenu paint fallback "NSMenuItem" placeholder rows for a few frames; residual structural churn now renders blank instead of placeholder text. Verified frame-by-frame via 120fps screen recordings driven by the self-probe.
 - Keychain: stop "CodexBar Cache" login-keychain password prompts from dev and test tooling. Unbundled processes (`swift build` binaries, dev CLI runs) now use a process-local cache instead of the shared keychain item, never freeze a broken trusted-app ACL onto it, and test-blocked processes disable legacy keychain interaction process-wide and export the suppression flag to spawned child binaries.
 - Menu: switching provider tabs no longer flashes. The sibling-tab warmup now runs off a tracking-safe timer (the previous Task-based warmup never fired while the menu was open, which is the only time it matters), and provider tabs share one stable menu height via an invisible spacer, so a switch is a single-frame content swap with no window resize. Verified frame-by-frame with a new env-gated self-probe (`CODEXBAR_FLICKER_PROBE_DIR`).
 

--- a/Sources/CodexBar/MenuSwitchFlickerProbe.swift
+++ b/Sources/CodexBar/MenuSwitchFlickerProbe.swift
@@ -46,14 +46,20 @@ enum MenuSwitchFlickerProbe {
         guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_FLICKER_PROBE_DIR"],
               !dir.isEmpty else { return }
         let directory = URL(fileURLWithPath: dir, isDirectory: true)
-        // Two sessions: the second verifies open-time behavior with state carried
-        // over from the first (e.g. the stable-height session floor).
+        // "hold" mode: open the menu and record for 30s without self-switching,
+        // so an external driver can exercise the real pointer path with
+        // synthesized mouse clicks. Default mode self-switches via the keyboard
+        // path across two sessions (the second verifies open-time behavior with
+        // carried-over state such as the stable-height session floor).
+        let holdMode = ProcessInfo.processInfo.environment["CODEXBAR_FLICKER_PROBE_MODE"] == "hold"
         DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-            ProbeSession(controller: controller, directory: directory).begin()
+            ProbeSession(controller: controller, directory: directory, holdMode: holdMode).begin()
+            guard !holdMode else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                 ProbeSession(
                     controller: controller,
-                    directory: directory.appendingPathComponent("second")).begin()
+                    directory: directory.appendingPathComponent("second"),
+                    holdMode: false).begin()
             }
         }
     }
@@ -148,6 +154,7 @@ enum MenuSwitchFlickerProbe {
     final class ProbeSession {
         private let controller: StatusItemController
         private let directory: URL
+        private let holdMode: Bool
         private var timer: Timer?
         private var log: [String] = []
         private var startedAt: DispatchTime?
@@ -158,9 +165,10 @@ enum MenuSwitchFlickerProbe {
         private var originalSegment: Int?
         private var targetSegment: Int?
 
-        init(controller: StatusItemController, directory: URL) {
+        init(controller: StatusItemController, directory: URL, holdMode: Bool = false) {
             self.controller = controller
             self.directory = directory
+            self.holdMode = holdMode
         }
 
         func begin() {
@@ -183,21 +191,34 @@ enum MenuSwitchFlickerProbe {
         /// to land on any transient artifact. Always ends on the original segment.
         private static let switchScheduleMs = [400, 1000, 1600, 2200, 2800, 3400]
         private static let sessionEndMs = 4200
+        private static let holdSessionEndMs = 30000
 
         private func tick() {
             guard let startedAt = self.startedAtOrLocateMenu() else { return }
             let now = Int((DispatchTime.now().uptimeNanoseconds - startedAt.uptimeNanoseconds) / 1_000_000)
-            if now >= Self.sessionEndMs {
+            let endMs = self.holdMode ? Self.holdSessionEndMs : Self.sessionEndMs
+            if now >= endMs {
                 self.timer?.invalidate()
                 self.timer = nil
                 self.menu?.cancelTracking()
                 return
             }
-            guard self.switchScheduleIndex < Self.switchScheduleMs.count,
+            guard !self.holdMode,
+                  self.switchScheduleIndex < Self.switchScheduleMs.count,
                   now >= Self.switchScheduleMs[self.switchScheduleIndex] else { return }
             let switchIndex = self.switchScheduleIndex
             self.switchScheduleIndex += 1
-            let segment = switchIndex.isMultiple(of: 2) ? self.targetSegment : self.originalSegment
+            // Cycle through overview (segment 0) too so full-rebuild transitions
+            // are exercised alongside cached swaps.
+            let cycle: [Int?] = [
+                self.targetSegment,
+                0,
+                self.originalSegment,
+                0,
+                self.targetSegment,
+                self.originalSegment,
+            ]
+            let segment = cycle[switchIndex % cycle.count]
             let handled = segment.map { self.switchSegment($0) } ?? false
             self.log.append("switch#\(switchIndex) to segment \(String(describing: segment)) " +
                 "at \(now)ms handled=\(handled)")
@@ -221,6 +242,16 @@ enum MenuSwitchFlickerProbe {
                 self.log.append("menu located, windowNumber=\(window.windowNumber) " +
                     "frame=\(window.frame) original=\(String(describing: self.originalSegment)) " +
                     "target=\(String(describing: self.targetSegment))")
+                // Export CG (top-left origin) bounds for external click drivers;
+                // other processes cannot enumerate this menu window.
+                let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
+                let frame = window.frame
+                let cgY = primaryHeight - frame.maxY
+                let boundsLine = "\(Int(frame.minX)) \(Int(cgY)) \(Int(frame.width)) \(Int(frame.height))\n"
+                try? boundsLine.write(
+                    to: self.directory.appendingPathComponent("menu-bounds.txt"),
+                    atomically: true,
+                    encoding: .utf8)
                 return start
             }
             if self.searchTicks > 1200 {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -374,6 +374,7 @@ extension StatusItemController {
             self.menuLogger.debug("populateMenu(open): rebuilding whole menu and replacing provider switcher")
         }
         #endif
+        MenuSwitchFlickerProbe.debugLog("full-rebuild-path \(String(describing: switcherSelection))")
         self.rebuildMenuContent(
             menu,
             context: MenuRebuildContext(
@@ -991,6 +992,7 @@ extension StatusItemController {
                 self.requestProviderSwitcherMenuRebuild(menu, provider: provider)
             })
         let item = NSMenuItem()
+        item.title = ""
         item.view = view
         item.isEnabled = false
         return item
@@ -1026,6 +1028,7 @@ extension StatusItemController {
                 }
             })
         let item = NSMenuItem()
+        item.title = ""
         item.view = view
         item.isEnabled = false
         return item
@@ -1045,6 +1048,7 @@ extension StatusItemController {
                 self.handleCodexVisibleAccountSelection(account, menu: menu)
             })
         let item = NSMenuItem()
+        item.title = ""
         item.view = view
         item.isEnabled = false
         return item

--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -23,8 +23,8 @@ extension StatusItemController {
         }
     }
 
-    func makeMenuCardItem<CardContent: View>(
-        _ view: CardContent,
+    func makeMenuCardItem(
+        _ view: some View,
         id: String,
         width: CGFloat,
         heightCacheScope: String? = nil,
@@ -39,6 +39,7 @@ extension StatusItemController {
         let allowsMenuHighlight = submenu != nil || onClick != nil
         if !self.menuCardRenderingEnabledForController {
             let item = NSMenuItem()
+            item.title = ""
             item.isEnabled = allowsMenuHighlight
             item.representedObject = id
             item.submenu = submenu
@@ -86,26 +87,23 @@ extension StatusItemController {
                 isEnabled: allowsMenuHighlight || containsInteractiveControls)
         }
 
-        let hosting: MenuCardItemHostingView<MenuCardSectionContainerView<CardContent>>
+        // Content is erased so every standard row shares one hosting type; tab
+        // switches can then replant payloads across hosting views instead of
+        // detaching `item.view` (which flashes placeholder rows mid-tracking).
+        let payload = MenuCardRowPayload(
+            content: AnyView(view),
+            showsSubmenuIndicator: submenu != nil,
+            submenuIndicatorAlignment: submenuIndicatorAlignment,
+            submenuIndicatorTopPadding: submenuIndicatorTopPadding,
+            allowsMenuHighlight: allowsMenuHighlight,
+            containsInteractiveControls: containsInteractiveControls,
+            onClick: onClick)
+        let hosting: ErasedMenuCardHostingView
         if let recycled = self.takeRecyclableMenuCardView(
             for: id,
-            as: MenuCardItemHostingView<MenuCardSectionContainerView<CardContent>>.self)
+            as: ErasedMenuCardHostingView.self)
         {
-            let wrapped = MenuCardSectionContainerView(
-                highlightState: recycled.highlightState,
-                showsSubmenuIndicator: submenu != nil,
-                submenuIndicatorAlignment: submenuIndicatorAlignment,
-                submenuIndicatorTopPadding: submenuIndicatorTopPadding,
-                refreshMonitor: self.menuCardRefreshMonitor,
-                interactiveRegionStore: recycled.interactiveRegionStore)
-            {
-                view
-            }
-            recycled.prepareForReuse(
-                rootView: wrapped,
-                allowsMenuHighlight: allowsMenuHighlight,
-                containsInteractiveControls: containsInteractiveControls,
-                onClick: onClick)
+            self.replantMenuCardRowPayload(payload, into: recycled)
             hosting = recycled
         } else {
             let highlightState = MenuCardHighlightState()
@@ -118,7 +116,7 @@ extension StatusItemController {
                 refreshMonitor: self.menuCardRefreshMonitor,
                 interactiveRegionStore: interactiveRegionStore)
             {
-                view
+                payload.content
             }
             hosting = MenuCardItemHostingView(
                 rootView: wrapped,
@@ -127,6 +125,7 @@ extension StatusItemController {
                 containsInteractiveControls: containsInteractiveControls,
                 interactiveRegionStore: interactiveRegionStore,
                 onClick: onClick)
+            hosting.rowPayload = payload
         }
         let height = self.cachedMenuCardHeight(
             for: id,
@@ -152,6 +151,10 @@ extension StatusItemController {
         isEnabled: Bool) -> NSMenuItem
     {
         let item = NSMenuItem()
+        // NSMenuItem()'s default title is the literal string "NSMenuItem"; Tahoe's
+        // NSMenu paints that fallback title for frames where a row's view is
+        // detached mid-mutation. Keep the fallback render blank instead.
+        item.title = ""
         item.view = hosting
         item.isEnabled = isEnabled
         item.representedObject = id

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -129,13 +129,34 @@ final class MenuHostingView<Content: View>: NSHostingView<Content> {
     }
 }
 
+/// Row payload remembered by erased hosting views so tab switches can exchange
+/// SwiftUI content between an attached and a cached hosting view without ever
+/// detaching `item.view`. Detaching mid-tracking makes Tahoe's NSMenu paint the
+/// row's fallback title ("NSMenuItem") for a few frames — the tab-switch flash.
 @MainActor
+struct MenuCardRowPayload {
+    let content: AnyView
+    let showsSubmenuIndicator: Bool
+    let submenuIndicatorAlignment: Alignment
+    let submenuIndicatorTopPadding: CGFloat
+    let allowsMenuHighlight: Bool
+    let containsInteractiveControls: Bool
+    let onClick: (() -> Void)?
+}
+
+/// Concrete hosting type shared by every standard (non-GPU) menu card row;
+/// content is erased so any row's payload can be replanted into any other row's
+/// hosting view during tab switches.
+typealias ErasedMenuCardHostingView = MenuCardItemHostingView<MenuCardSectionContainerView<AnyView>>
+
 final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, MenuCardHighlighting, MenuCardMeasuring {
     let highlightState: MenuCardHighlightState
     private(set) var allowsMenuHighlight: Bool
     private var onClick: (() -> Void)?
     private var containsInteractiveControls: Bool
     let interactiveRegionStore: MenuCardInteractiveRegionStore?
+    /// Set for erased hosting views only; consumed by the flash-free content swap.
+    var rowPayload: MenuCardRowPayload?
     private var isPressed = false
     private var isForwardingHostedControlPress = false
     #if DEBUG

--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -234,9 +234,87 @@ extension StatusItemController {
     }
 
     private func swapMenuItemContents(_ liveItem: NSMenuItem, _ cachedItem: NSMenuItem) {
+        // Flash-free path: when both rows are erased hosting views, exchange
+        // their SwiftUI payloads and keep both `item.view`s in place. Detaching
+        // the live view makes Tahoe's NSMenu paint the row's fallback title
+        // ("NSMenuItem") for a few frames — the tab-switch content flash.
+        if let liveHosting = liveItem.view as? ErasedMenuCardHostingView,
+           let cachedHosting = cachedItem.view as? ErasedMenuCardHostingView,
+           let livePayload = liveHosting.rowPayload,
+           let cachedPayload = cachedHosting.rowPayload
+        {
+            self.replantMenuCardRowPayload(cachedPayload, into: liveHosting)
+            self.replantMenuCardRowPayload(livePayload, into: cachedHosting)
+            let liveFrame = liveHosting.frame
+            liveHosting.frame = cachedHosting.frame
+            cachedHosting.frame = liveFrame
+            self.swapMenuItemMetadataKeepingViews(liveItem, cachedItem)
+            return
+        }
         let holder = NSMenuItem()
         self.updateMenuItemInPlace(holder, from: liveItem)
         self.updateMenuItemInPlace(liveItem, from: cachedItem)
         self.updateMenuItemInPlace(cachedItem, from: holder)
+    }
+
+    /// Rebuilds the hosting view's container around its own highlight state and
+    /// interactive-region store with the given payload's content and behavior.
+    func replantMenuCardRowPayload(
+        _ payload: MenuCardRowPayload,
+        into hosting: ErasedMenuCardHostingView)
+    {
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: hosting.highlightState,
+            showsSubmenuIndicator: payload.showsSubmenuIndicator,
+            submenuIndicatorAlignment: payload.submenuIndicatorAlignment,
+            submenuIndicatorTopPadding: payload.submenuIndicatorTopPadding,
+            refreshMonitor: self.menuCardRefreshMonitor,
+            interactiveRegionStore: hosting.interactiveRegionStore)
+        {
+            payload.content
+        }
+        hosting.prepareForReuse(
+            rootView: wrapped,
+            allowsMenuHighlight: payload.allowsMenuHighlight,
+            containsInteractiveControls: payload.containsInteractiveControls,
+            onClick: payload.onClick)
+        hosting.rowPayload = payload
+    }
+
+    /// The metadata half of a content swap: everything `updateMenuItemInPlace`
+    /// moves except `view` (which stays attached on both sides).
+    private func swapMenuItemMetadataKeepingViews(_ liveItem: NSMenuItem, _ cachedItem: NSMenuItem) {
+        let liveRemainsHighlighted = liveItem.menu.map {
+            self.highlightedMenuItems[ObjectIdentifier($0)] === liveItem
+        } ?? false
+        swap(&liveItem.title, &cachedItem.title)
+        let liveAttributedTitle = liveItem.attributedTitle
+        liveItem.attributedTitle = cachedItem.attributedTitle
+        cachedItem.attributedTitle = liveAttributedTitle
+        let liveSubmenu = liveItem.submenu
+        let cachedSubmenu = cachedItem.submenu
+        liveItem.submenu = nil
+        cachedItem.submenu = nil
+        liveItem.submenu = cachedSubmenu
+        cachedItem.submenu = liveSubmenu
+        let liveAction = (liveItem.action, liveItem.target)
+        liveItem.action = cachedItem.action
+        liveItem.target = cachedItem.target
+        cachedItem.action = liveAction.0
+        cachedItem.target = liveAction.1
+        let liveRepresented = liveItem.representedObject
+        liveItem.representedObject = cachedItem.representedObject
+        cachedItem.representedObject = liveRepresented
+        swap(&liveItem.state, &cachedItem.state)
+        let liveEnabled = liveItem.isEnabled
+        liveItem.isEnabled = cachedItem.isEnabled
+        cachedItem.isEnabled = liveEnabled
+        let liveHosting = liveItem.view as? MenuCardHighlighting
+        let allowsHighlight = liveHosting?.allowsMenuHighlight != false
+        liveHosting?.setHighlighted(liveItem.isEnabled && allowsHighlight && liveRemainsHighlighted)
+        (cachedItem.view as? MenuCardHighlighting)?.setHighlighted(false)
+        if self.isPersistentRefreshItem(liveItem) {
+            self.persistentRefreshItems.add(liveItem)
+        }
     }
 }

--- a/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
+++ b/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
@@ -80,6 +80,7 @@ extension StatusItemController {
             // unchanged, so an open tracked menu sees content mutations instead of item
             // churn. The fresh content is built into a detached scratch menu while its
             // interaction closures capture the live menu they will serve.
+            MenuSwitchFlickerProbe.debugLog("reconcile-path \(context.switcherSelection)")
             let shapes = self.menuContentShapes(in: menu, fromIndex: contentStartIndex)
             self.harvestRecyclableMenuCardViews(
                 in: menu,

--- a/Sources/CodexBar/StatusItemController+StableMenuHeight.swift
+++ b/Sources/CodexBar/StatusItemController+StableMenuHeight.swift
@@ -45,6 +45,7 @@ extension StatusItemController {
 
     func makeStableMenuHeightSpacerItem() -> NSMenuItem {
         let item = NSMenuItem()
+        item.title = ""
         item.isEnabled = false
         item.representedObject = Self.stableMenuHeightSpacerID
         let view = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: 0))

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -91,7 +91,7 @@ extension StatusMenuTests {
 
         #expect(item.isEnabled)
         #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] == nil)
-        guard let hosting = item.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        guard let hosting = item.view as? ErasedMenuCardHostingView
         else {
             Issue.record("expected a card hosting view")
             return
@@ -426,7 +426,7 @@ extension StatusMenuTests {
         let liveItem = controller.makeMenuCardItem(Text("before"), id: "menuCard", width: 300, onClick: {})
         menu.addItem(liveItem)
         controller.menu(menu, willHighlight: liveItem)
-        guard let hosting = liveItem.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        guard let hosting = liveItem.view as? ErasedMenuCardHostingView
         else {
             Issue.record("expected a card hosting view")
             return
@@ -468,7 +468,7 @@ extension StatusMenuTests {
         let liveItem = controller.makeMenuCardItem(Text("before"), id: "menuCard", width: 300, onClick: {})
         menu.addItem(liveItem)
         controller.menu(menu, willHighlight: liveItem)
-        guard let liveView = liveItem.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        guard let liveView = liveItem.view as? ErasedMenuCardHostingView
         else {
             Issue.record("expected a card hosting view")
             return
@@ -484,7 +484,7 @@ extension StatusMenuTests {
         #expect(menu.items[0] === liveItem)
         #expect(!liveItem.isEnabled)
         #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] == nil)
-        guard let rebuiltView = liveItem.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        guard let rebuiltView = liveItem.view as? ErasedMenuCardHostingView
         else {
             Issue.record("expected the rebuilt card hosting view")
             return
@@ -609,7 +609,7 @@ extension StatusMenuTests {
         let menu = NSMenu()
         let original = controller.makeMenuCardItem(Text("before"), id: "menuCard", width: 300)
         menu.addItem(original)
-        guard let originalView = original.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        guard let originalView = original.view as? ErasedMenuCardHostingView
         else {
             Issue.record("expected a card hosting view")
             return
@@ -620,7 +620,7 @@ extension StatusMenuTests {
         let rebuilt = controller.makeMenuCardItem(Text("after"), id: "menuCard", width: 300)
 
         #expect(rebuilt.view === originalView)
-        guard let rebuiltView = rebuilt.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        guard let rebuiltView = rebuilt.view as? ErasedMenuCardHostingView
         else {
             Issue.record("expected the recycled hosting view")
             return
@@ -667,7 +667,7 @@ extension StatusMenuTests {
         let item = controller.makeMenuCardItem(Text("card"), id: "menuCard", width: 300, onClick: {})
         menu.addItem(item)
         controller.menu(menu, willHighlight: item)
-        guard let hosting = item.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        guard let hosting = item.view as? ErasedMenuCardHostingView
         else {
             Issue.record("expected a card hosting view")
             return
@@ -687,7 +687,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `same id with different content type builds a fresh view`() {
+    func `same id with different content type reuses the erased hosting view`() {
         StatusItemController.setMenuRefreshEnabledForTesting(false)
         let previousRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = true
@@ -708,9 +708,11 @@ extension StatusMenuTests {
         defer { controller.clearMenuCardViewRecyclePool() }
         let rebuilt = controller.makeMenuCardItem(Image(systemName: "clock"), id: "menuCard", width: 300)
 
+        // Row content is erased to AnyView, so hosting views recycle across
+        // content types: the SwiftUI payload is replanted in place instead of
+        // detaching `item.view` (the tab-switch placeholder-flash mechanism).
         #expect(rebuilt.view != nil)
-        #expect(rebuilt.view !== originalView)
-        // The incompatible pool entry is consumed rather than left behind.
+        #expect(rebuilt.view === originalView)
         #expect(controller.menuCardViewRecyclePool.isEmpty)
     }
 


### PR DESCRIPTION
## Summary

Final flicker round, with the mechanism caught on camera. 120fps `screencapture` recordings of the real screen (driven by the self-probe plus synthesized pointer clicks) showed that provider tab switches blanked every hosted card row for ~30–40ms — and the blank rows rendered NSMenuItem's *fallback titles*, literally the string "NSMenuItem". Root cause: Tahoe's NSMenu paints an item's title whenever its custom view is detached during tracking, and the cached-content swap moved hosting views between item shells (detach → attach). The window's own backing always looked atomic, which is why earlier window-level captures missed it.

**Fix: never detach the live views.**

- Standard card rows share one type-erased hosting type (`ErasedMenuCardHostingView`) and remember their `MenuCardRowPayload` (content + indicator config + click behavior).
- The cached tab swap now replants payloads across the attached and cached hosting views (each side's container is rebuilt around its own highlight state), and exchanges item metadata separately — `item.view` stays attached on both sides.
- Hosting-view recycling now reuses views across content types (test updated to assert the new contract).
- All card/switcher items get explicit empty titles, so residual structural churn (Overview transitions, which mix GPU-selection rows with standard rows) renders as blank glass instead of placeholder text.

## Evidence

- Pre-fix 120fps strip: rows blank out, "NSMenuItem" text visible for 4-5 frames per switch.
- Post-fix strip: fully rendered content in every frame across six switch cycles (Claude/Codex/Overview); dip-scan across 842 frames finds zero degraded frames outside the natural close fade.
- User-confirmed: provider↔provider switches no longer flicker with the previously landed rounds; this PR removes the remaining row blanking measurably.

## Remaining known gap (follow-up)

Overview↔provider still has a visible cut: Overview rows use `GPUSelectionHostingView` (AppKit-painted selection), a different class the payload swap can't exchange with, plus Overview is intentionally excluded from stable-height equalization. Unifying the two hosting classes is filed as follow-up work.

## Verification

- Full menu suites green (recycling, highlight, height cache, viewport restore, warmup, compact layouts, token/codex switchers), `make check` clean.
- Probe artifacts regenerated end-to-end on the final build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
