### PR TITLE
test: stabilize spend dashboard date boundaries

### DIFF
--- a/Tests/CodexBarTests/SpendDashboardControllerTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardControllerTests.swift
@@ -753,7 +753,7 @@ struct SpendDashboardControllerTests {
         #expect(controller.selectedDays == 30)
     }
 
-    private static let fixtureNow = Date(timeIntervalSince1970: 1_784_179_200)
+    private nonisolated static let fixtureNow = Date(timeIntervalSince1970: 1_784_179_200)
 
     private static func dashboardController(
         settings: SettingsStore,
@@ -767,7 +767,8 @@ struct SpendDashboardControllerTests {
                     store: store,
                     mode: mode,
                     now: Self.fixtureNow)
-            })
+            },
+            nowProvider: { Self.fixtureNow })
     }
 
     private static func controller(gate: SpendDashboardLoaderGate) -> SpendDashboardController {

--- a/Tests/CodexBarTests/SpendDashboardTokenProvenanceTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardTokenProvenanceTests.swift
@@ -100,9 +100,8 @@ struct SpendDashboardTokenProvenanceTests {
         #expect(store.tokenSnapshotPublicationRevision(for: .mistral) == 0)
     }
 
-    @Test
-    func `cached token account activation does not prove a forced refresh`() async throws {
-        let now = Date(timeIntervalSince1970: 1_784_179_200)
+    @Test(arguments: Self.monthBoundaryDates)
+    func `cached token account activation does not prove a forced refresh`(now: Date) async throws {
         let (settings, store) = Self.makeStore(provider: .mistral)
         settings.addTokenAccount(provider: .mistral, label: "Fixture", token: "fixture")
         let account = try #require(settings.effectiveSelectedTokenAccount(for: .mistral))
@@ -125,16 +124,7 @@ struct SpendDashboardTokenProvenanceTests {
         store.activateCachedTokenAccountSnapshot(provider: .mistral, accountID: account.id)
         #expect(store.tokenSnapshotPublicationRevision(for: .mistral) == baselineRevision)
         store._test_providerRefreshOverride = { _ in }
-        let controller = SpendDashboardController(
-            userDefaults: settings.userDefaults,
-            requestBuilder: { mode in
-                await SpendDashboardSource.makeRequest(
-                    settings: settings,
-                    store: store,
-                    mode: mode,
-                    now: now)
-            },
-            nowProvider: { now })
+        let controller = Self.dashboardController(settings: settings, store: store, now: now)
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.model.groups.first?.totalCost == 3)
@@ -147,9 +137,8 @@ struct SpendDashboardTokenProvenanceTests {
         #expect(store.tokenSnapshotPublicationRevision(for: .mistral) == baselineRevision)
     }
 
-    @Test
-    func `forced successful empty publication removes prior spend without warning`() async {
-        let now = Date(timeIntervalSince1970: 1_784_203_200)
+    @Test(arguments: Self.monthBoundaryDates)
+    func `forced successful empty publication removes prior spend without warning`(now: Date) async {
         let (settings, store) = Self.makeStore(provider: .bedrock)
         var loadCount = 0
         store._test_tokenUsageSnapshotLoaderOverride = { _, _, _, _, _ in
@@ -157,16 +146,7 @@ struct SpendDashboardTokenProvenanceTests {
             return loadCount == 1 ? Self.tokenSnapshot(cost: 4) : Self.emptyTokenSnapshot()
         }
         await store.refreshTokenUsageNow(for: .bedrock, force: true)
-        let controller = SpendDashboardController(
-            userDefaults: settings.userDefaults,
-            requestBuilder: { mode in
-                await SpendDashboardSource.makeRequest(
-                    settings: settings,
-                    store: store,
-                    mode: mode,
-                    now: now)
-            },
-            nowProvider: { now })
+        let controller = Self.dashboardController(settings: settings, store: store, now: now)
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.model.groups.first?.totalCost == 4)
@@ -185,7 +165,6 @@ struct SpendDashboardTokenProvenanceTests {
 
     @Test
     func `first open accepts current empty publication without redundant refresh`() async {
-        let now = Date(timeIntervalSince1970: 1_784_179_200)
         let (settings, store) = Self.makeStore(provider: .bedrock)
         var loadCount = 0
         store._test_tokenUsageSnapshotLoaderOverride = { _, _, _, _, _ in
@@ -194,16 +173,7 @@ struct SpendDashboardTokenProvenanceTests {
         }
         await store.refreshTokenUsageNow(for: .bedrock, force: true)
         let publicationRevision = store.tokenSnapshotPublicationRevision(for: .bedrock)
-        let controller = SpendDashboardController(
-            userDefaults: settings.userDefaults,
-            requestBuilder: { mode in
-                await SpendDashboardSource.makeRequest(
-                    settings: settings,
-                    store: store,
-                    mode: mode,
-                    now: now)
-            },
-            nowProvider: { now })
+        let controller = Self.dashboardController(settings: settings, store: store, now: Self.fixtureNow)
 
         controller.update(configuration: SpendDashboardSource.configuration(settings: settings, store: store))
         await Self.waitUntil { !controller.isRefreshing }
@@ -308,6 +278,29 @@ struct SpendDashboardTokenProvenanceTests {
 
         #expect(store.tokenSnapshotPublicationRevision(for: .claude) > firstRevision)
         #expect(store.tokenSnapshotForCurrentProviderConfig(for: .claude)?.snapshot == snapshot)
+    }
+
+    private static let fixtureNow = Date(timeIntervalSince1970: 1_784_179_200)
+    private nonisolated static let monthBoundaryDates = [
+        Date(timeIntervalSince1970: 1_785_542_399), // 2026-07-31 23:59:59 UTC
+        Date(timeIntervalSince1970: 1_785_542_400), // 2026-08-01 00:00:00 UTC
+    ]
+
+    private static func dashboardController(
+        settings: SettingsStore,
+        store: UsageStore,
+        now: Date) -> SpendDashboardController
+    {
+        SpendDashboardController(
+            userDefaults: settings.userDefaults,
+            requestBuilder: { mode in
+                await SpendDashboardSource.makeRequest(
+                    settings: settings,
+                    store: store,
+                    mode: mode,
+                    now: now)
+            },
+            nowProvider: { now })
     }
 
     private static func makeStore(provider: UsageProvider) -> (SettingsStore, UsageStore) {

--- a/TestsLinux/CLICardsClaudeSwapTests.swift
+++ b/TestsLinux/CLICardsClaudeSwapTests.swift
@@ -352,6 +352,7 @@ struct CLICardsClaudeSwapTests {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cards-claude-swap-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
         let executable = directory.appendingPathComponent("cswap")
         let invocationMarker = directory.appendingPathComponent("invoked", isDirectory: true)
         let duplicateMarker = directory.appendingPathComponent("duplicate")
@@ -371,7 +372,7 @@ struct CLICardsClaudeSwapTests {
         ]}
         JSON
         """
-        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try Data(script.utf8).write(to: executable)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let output = await CLIClaudeSwapCards.fetch(


### PR DESCRIPTION
## Summary

- centralize `SpendDashboardTokenProvenanceTests` controller construction so the request capture clock and controller clock always use the same frozen instant
- execute both regressions that previously lost spend at `2026-07-31T23:59:59Z` and `2026-08-01T00:00:00Z`
- make the existing `SpendDashboardControllerTests` fixture helper freeze both clock inputs as well

## Root cause

The spend fixtures contain fixed July 15/16 daily entries. `SpendDashboardSource.makeRequest` stamps each request with its capture time; `SpendDashboardController.apply` stores that value in `loadedAt`; and `SpendDashboardModel.build` creates an inclusive calendar-day window ending at `startOfDay(loadedAt)`. When a test used the real clock for either half of that pipeline, the fixed fixture day eventually fell outside the selected window. The provider input still existed, but its window entries were empty, so `totalCost` became `nil`.

#2390 correctly identified the mixed fixture/real-clock mechanism and introduced a fixture-clock controller helper. This follow-up adopts that approach for the token-provenance regressions and credits @ProspectOre for the analysis. It also passes the same instant to the controller's `nowProvider`, preventing future rollover calls from silently reintroducing wall-clock time.

I swept the test target for the same defect class. Other spend/dashboard tests either pass a fixed request/model time, intentionally exercise the rollover seam, derive fixtures from the same live `Date`, or never invoke dashboard date filtering. No additional identical instances were left.

## Verification

- `TZ=Pacific/Kiritimati swift test --filter 'SpendDashboard(TokenProvenance|Controller|ClockRollover)Tests'` — 39 tests in 5 suites passed
- `TZ=Pacific/Midway swift test --filter 'SpendDashboard(TokenProvenance|Controller|ClockRollover)Tests'` — 39 tests in 5 suites passed
- each cited provenance regression ran at both `2026-07-31T23:59:59Z` and `2026-08-01T00:00:00Z`
- `make check` — SwiftFormat clean; SwiftLint 0 violations
- `make test` — 764/764 selections; 64/64 groups passed on the first pass; 0 retries, recoveries, or timeouts
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings

Test-only/internal change, so there is no changelog entry.

References the #2465 and #2380 CI disruptions and follows up on #2390.
