### PR TITLE
Label Codex auto review role in cost history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
 ### Fixed
+- Codex: label automatic-review sessions as Codex Auto Review in cost history instead of the raw role identifier (#2572). Thanks @Yuxin-Qiao!
 - Usage: populate verified z.ai, Kimi, and Grok rate-window durations for pace and forecasts while leaving unknown provider cadences unset (#2431, supersedes #2514). Thanks @Yuxin-Qiao!
 - Command Code: persist validated browser sessions so CLI refreshes and the local service can reuse them (#2541). Thanks @rbonill!
 - Menu: provider tab switches no longer blank out card rows mid-switch. Cached tab content is replanted into the attached hosting views (SwiftUI payload swap) instead of detaching `item.view`, which made Tahoe's NSMenu paint fallback "NSMenuItem" placeholder rows for a few frames; residual structural churn now renders blank instead of placeholder text. Verified frame-by-frame via 120fps screen recordings driven by the self-probe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
 ### Fixed
-- Codex: label automatic-review sessions as Codex Auto Review in cost history instead of the raw role identifier (#2572). Thanks @Yuxin-Qiao!
 - Usage: populate verified z.ai, Kimi, and Grok rate-window durations for pace and forecasts while leaving unknown provider cadences unset (#2431, supersedes #2514). Thanks @Yuxin-Qiao!
 - Command Code: persist validated browser sessions so CLI refreshes and the local service can reuse them (#2541). Thanks @rbonill!
 - Menu: provider tab switches no longer blank out card rows mid-switch. Cached tab content is replanted into the attached hosting views (SwiftUI payload swap) instead of detaching `item.view`, which made Tahoe's NSMenu paint fallback "NSMenuItem" placeholder rows for a few frames; residual structural churn now renders blank instead of placeholder text. Verified frame-by-frame via 120fps screen recordings driven by the self-probe.

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -411,18 +411,22 @@ struct CostHistoryChartMenuView: View {
     }
 
     private static func sessionUsageLine(_ session: CostUsageSessionBreakdown) -> String {
-        let models = session.modelBreakdowns.map(\.modelName)
-        let modelLabel = if models.isEmpty {
-            "Unknown model"
-        } else if models.count == 1 {
-            models[0]
-        } else {
-            "\(models[0]) +\(models.count - 1)"
-        }
+        let modelLabel = Self.sessionModelLabel(session.modelBreakdowns.map(\.modelName))
         let input = session.inputTokens.map(UsageFormatter.tokenCountString) ?? "—"
         let cached = session.cachedInputTokens.map(UsageFormatter.tokenCountString) ?? "—"
         let output = session.outputTokens.map(UsageFormatter.tokenCountString) ?? "—"
         return "\(modelLabel) · \(input) input · \(cached) cached · \(output) output"
+    }
+
+    static func sessionModelLabel(_ models: [String]) -> String {
+        let labels = models.map(UsageFormatter.modelDisplayName)
+        return if labels.isEmpty {
+            "Unknown model"
+        } else if labels.count == 1 {
+            labels[0]
+        } else {
+            "\(labels[0]) +\(labels.count - 1)"
+        }
     }
 
     static func windowLabel(days: Int) -> String {

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -447,6 +447,7 @@ public enum UsageFormatter {
     public static func modelDisplayName(_ raw: String) -> String {
         var cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { return raw }
+        if cleaned == "codex-auto-review" { return "Codex Auto Review" }
         if CostUsagePricing.isCodexUnattributedModel(cleaned) { return "Unknown model" }
 
         let patterns = [

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -40,6 +40,15 @@ struct CostHistoryChartMenuViewTests {
     }
 
     @Test
+    func `session model label maps codex auto review role`() {
+        #expect(CostHistoryChartMenuView.sessionModelLabel([]) == "Unknown model")
+        #expect(CostHistoryChartMenuView.sessionModelLabel(["codex-auto-review"]) == "Codex Auto Review")
+        #expect(
+            CostHistoryChartMenuView.sessionModelLabel(["codex-auto-review", "gpt-5.6-sol"])
+                == "Codex Auto Review +1")
+    }
+
+    @Test
     @MainActor
     func `menu hosting view publishes measured height through intrinsic size`() {
         let hosting = MenuHostingView(rootView: EmptyView())

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -304,6 +304,12 @@ struct UsageFormatterTests {
     }
 
     @Test
+    func `model display name labels codex auto review role`() {
+        #expect(UsageFormatter.modelDisplayName("codex-auto-review") == "Codex Auto Review")
+        #expect(UsageFormatter.modelDisplayName("gpt-5.6-sol") == "gpt-5.6-sol")
+    }
+
+    @Test
     func `model cost detail uses research preview label`() {
         #expect(
             UsageFormatter.modelCostDetail("gpt-5.3-codex-spark", costUSD: 0, totalTokens: nil) == "Research Preview")


### PR DESCRIPTION
## Summary

Label Codex automatic-review sessions as **Codex Auto Review** in cost history instead of surfacing the raw `codex-auto-review` role identifier (or the `unknown` fallback label).

- `UsageFormatter.modelDisplayName` gains an exact-match alias for the known `codex-auto-review` role identifier. It is display-only: no model-specific pricing or attribution is applied, and scanner identifiers stay untouched.
- The cost-history session line now routes model names through the same shared formatter, so the role label is used consistently in both the breakdown rows and the session row.
- Adds focused coverage for the formatter alias and the session-line label (single, multi, and empty model cases).

Fixes #2572.

## Reproduction evidence

The issue quotes a `turn_context` record with `approval_policy: never`, `approvals_reviewer: auto_review`, and `model: codex-auto-review`. Real local Codex rollouts contain exactly this record (e.g. a July 15, 2026 session file), and this repo's scanner already preserves the identifier end to end:

1. Fixture session (same triple + `token_count`) scanned with the real CLI against an isolated Codex home:

```console
$ swift run CodexBarCLI cost --provider codex --days 1 --format json
...
"modelBreakdowns":[{"totalTokens":39926,"modelName":"codex-auto-review"}],
"modelsUsed":["codex-auto-review"]
```

2. The shared display formatter has no alias today:

```console
UsageFormatter.modelDisplayName("codex-auto-review") = codex-auto-review   # before
UsageFormatter.modelDisplayName("codex-auto-review") = Codex Auto Review   # after
UsageFormatter.modelDisplayName("unknown") = Unknown model                 # unchanged
```

## Validation

- `swift test --filter 'UsageFormatterTests|CostHistoryChartMenuViewTests'` - 74 tests passed
- `make check` - SwiftFormat 0 files, SwiftLint 0 violations
- `make test` - full sharded suite; the only failure was the pre-existing headless menu timing test `StatusMenuInstantOpenTests` ("closing menu during missing data refresh preserves deferred retry"), which passes when re-run in isolation and is unrelated to this diff
- `git diff --check` - clean

## Changelog

- Codex: label automatic-review sessions as Codex Auto Review in cost history instead of the raw role identifier (#2572).
