### PR TITLE
Fix menu bar layout chip drag by moving .draggable onto the label

### DIFF
--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -412,6 +412,7 @@ struct MenuBarLayoutEditor: View {
                             title: token.editorLabel(provider: self.persistenceProvider),
                             systemImage: token.editorSystemImage,
                             isSelected: self.selectedPosition == position)
+                            .draggable(MenuBarLayoutDragItem.placed(token, at: position, in: self.layout))
                     }
                     .buttonStyle(.plain)
                     .focusable()
@@ -419,7 +420,6 @@ struct MenuBarLayoutEditor: View {
                         self.selectedPosition = position
                         return .handled
                     }
-                    .draggable(MenuBarLayoutDragItem.placed(token, at: position, in: self.layout))
                     .dropDestination(for: MenuBarLayoutDragItem.self) { items, _ in
                         self.insert(items.first, at: position)
                     }


### PR DESCRIPTION
## Summary

Move the placed menu-layout chip drag source from the enclosing focusable `Button` onto its label so drag gestures are no longer swallowed by button gesture arbitration. Click selection, keyboard handling, drop targets, accessibility, and persistence remain on their existing owners.

The contributor commit was reconstructed on current `main` while preserving author `ikkira <info@ikkira.com>`.

## Root cause

The placed chip button owned click/focus/key handling, `.draggable`, and `.dropDestination` at the same level. On macOS, the focusable button could win gesture arbitration before the drag source activated. Moving only `.draggable` to `MenuBarLayoutChipLabel` separates drag initiation from the button without changing the layout mutation path.

## Current-main live proof

Verified from head `44cb44cbc7c53a2d1ce468486bc12dffb5b3c196` in a fresh Developer ID-signed `com.steipete.codexbar.debug` bundle. The replay used a disposable HOME, debug app-group boundary, disabled Keychain access, no Sparkle feed, and only synthetic/default layout state.

### Placed-chip reorder

Before — `Usage bar` is the last placed chip:

![Before reordering the placed Usage bar chip](https://github.com/user-attachments/assets/9e9c9873-3571-491e-9439-aed62cc6dee3)

After — `Usage bar` moved to the first position, with no duplicate left behind:

![After reordering the placed Usage bar chip](https://github.com/user-attachments/assets/3b0be001-2f4e-444c-9f94-77184f5567a1)

Short window-only recording: https://github.com/user-attachments/assets/ba10f1b6-00d0-4e2d-9c88-e0c640b7a099

Fresh accessibility state confirmed the order changed from `Icon → Auto % → Icon → Usage bar` to `Usage bar → Icon → Auto % → Icon`.

### Drag-out removal

After dragging the placed `Usage bar` chip to the removal target, it is absent while the other chips remain:

![After dragging the placed Usage bar chip to remove](https://github.com/user-attachments/assets/18dd1004-659d-49cb-bdda-8c0d8b691e83)

Short window-only recording: https://github.com/user-attachments/assets/1f86bba2-25de-4005-ae26-94df95ef01ae

Click selection was also confirmed in the same isolated editor. The existing button, focusability, `onKeyPress`, drop destinations, and accessibility modifiers are byte-for-byte unchanged.

## Validation

- `git diff --check`
- SwiftFormat lint on `MenuBarLayoutEditor.swift`
- `swift test --filter MenuBarLayoutEditorTests`: 11 tests passed
- `make check`: passed
- full `make test`: 840 selections across 70 groups passed with no retries or timeouts
- structured Codex autoreview: clean, no accepted or actionable finding
- TruffleHog patch scan: clean
- Developer ID-signed release and debug packages built successfully
- packaged checkout-independent launch smoke passed
- `codesign --verify --deep --strict --verbose=2 CodexBar.app`
- `spctl --assess --type execute --verbose=4 CodexBar.app`

The debug proof bundle was signed by `Developer ID Application: Peter Steinberger (Y5PE65HELJ)` and accepted by Gatekeeper.
