### PR TITLE
ci: move macOS tests to Apple-Silicon runners and cache SwiftPM builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,9 @@ jobs:
   swift-test-macos:
     needs: changes
     if: ${{ needs.changes.outputs.macos-tests == 'true' && needs.changes.outputs.macos-tests-deferred != 'true' }}
-    runs-on: macos-15-intel
+    # Apple-Silicon runners: ~2-4x faster Swift builds than the retired-path
+    # Intel pool and much shorter queues (see #2585 for the measurements).
+    runs-on: macos-26
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -120,7 +122,7 @@ jobs:
       - name: Select Xcode 26.3 or 26.2
         run: |
           set -euo pipefail
-          # Both versions are part of the official macOS 15 runner image.
+          # Both versions are part of the official macOS 26 runner image.
           for candidate in /Applications/Xcode_26.3.app /Applications/Xcode_26.2.app; do
             if [[ -d "$candidate" ]]; then
               sudo xcode-select -s "${candidate}/Contents/Developer"
@@ -130,6 +132,19 @@ jobs:
           done
           [[ "$(/usr/bin/xcodebuild -version)" == Xcode\ 26.* ]]
           /usr/bin/xcodebuild -version
+
+      - name: Restore SwiftPM build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          # Keyed on dependency state: saves once per Package.resolved change,
+          # and partial hits (restore-keys) still carry the dependency builds,
+          # which dominate the cold-build time.
+          key: swiftpm-macos26-arm64-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          restore-keys: |
+            swiftpm-macos26-arm64-
 
       - name: Swift toolchain version
         run: |


### PR DESCRIPTION
## Summary

CI's macOS lane is the bottleneck, measured over the last 100 completed runs:

| | queue (median) | execution (median) |
|---|---|---|
| macOS shard (`macos-15-intel`) | **37 min** | **34 min** |
| Linux jobs | 0.2 min | 9 min |

Successful runs end-to-end: median **122 min**, p90 **297 min**. Two compounding causes: the Intel runner pool is slow (2–4× slower Swift builds than Apple Silicon) and shrinking (deprecation path → long queues), and every shard cold-builds all dependencies with zero caching.

Changes:
- `runs-on: macos-15-intel` → **`macos-26`** (arm64, the current latest ARM image; also `macos-latest`). The Xcode 26.3/26.2 selection step works unchanged on this image.
- **SwiftPM build cache** (`actions/cache@v6.1.0`, SHA-pinned): `.build` + `~/Library/Caches/org.swift.swiftpm`, keyed on `Package.resolved`/`Package.swift` with a prefix restore-key, so dependency builds survive across runs.

The original Intel pin (`2c6295586`) carried no recorded rationale. The `CLIEntryTests` macOS-CI skip documents an *Intel-runner-specific* SwiftPM hang — left in place; re-enabling it on ARM and collapsing to a single shard are follow-up experiments once this PR's numbers are in (this PR's own CI run is the first measurement).

## Expected outcome

Execution ~34→~10-15 min per shard, queues from minutes not hours; realistic end-to-end median ~15 min instead of 2 hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
