### PR TITLE
Menu: drop the Refresh row tooltip that pops as a stray floating box during tab switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
 ### Fixed
+- Menu: no more stray floating "Refresh" tooltip beside the menu when switching tabs with the cursor over the actions area.
 - Menu: keep Overview↔provider switches flash-free by hosting every card row in one reusable AppKit container, including GPU-selection Overview rows.
 - Codex: keep confirmed weekly reset lows and confetti private until the previously published reset boundary is due (#2481). Thanks @gmkbenjamin!
 - Usage: populate verified z.ai, Kimi, and Grok rate-window durations for pace and forecasts while leaving unknown provider cadences unset (#2431, supersedes #2514). Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/StatusItemController+PersistentRefreshMenuItem.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentRefreshMenuItem.swift
@@ -30,7 +30,9 @@ extension StatusItemController {
         item.view = view
         item.isEnabled = enabled
         item.keyEquivalentModifierMask = []
-        item.toolTip = title
+        // No toolTip: the row already reads "Refresh" with its shortcut badge, and
+        // during tab switches the churn under a stationary cursor makes AppKit pop
+        // the tooltip instantly — a stray floating "Refresh" box beside the menu.
         return item
     }
 


### PR DESCRIPTION
One-liner: the persistent Refresh row set `item.toolTip = "Refresh"`; when tab switches churn rows under a stationary cursor, AppKit re-registers the tooltip region and shows it instantly — the stray floating "Refresh" box observed beside the menu. The row already displays Refresh with its ⌘R badge, so the tooltip is pure noise. User-reported, mouse-position dependent (cursor-free probe recordings never reproduced it, which corroborates the tooltip mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)