### PR TITLE
Fix Claude Auto cold boot with Keychain disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu: the compact multi-account layout now covers every stacked multi-account list — token accounts on any provider and Codex accounts (flat lists; workspace-grouped Codex lists keep their sections).
 
 ### Fixed
+- Claude: Auto cold boot with Keychain disabled loads without manual refresh (#2494, fixes #2493). Thanks @gmkbenjamin!
 - Menu: no more stray floating "Refresh" tooltip beside the menu when switching tabs with the cursor over the actions area.
 - Providers: write the Factory and Cursor session files (bearer/refresh tokens, auth cookies) owner-only (0600), matching the codex/kimi/antigravity credential stores.
 - Menu: keep Overview↔provider switches flash-free by hosting every card row in one reusable AppKit container, including GPU-selection Overview rows.

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -791,9 +791,10 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
         if isBackgroundAutoRefresh {
             // Every Claude child process is opaque to CodexBar's no-UI Keychain controls, including
             // `claude auth status`. Background Auto therefore reuses only availability established by a
-            // successful user-initiated CLI fetch in this process; it never probes the CLI itself.
+            // successful user-initiated CLI fetch in this process. The narrow exception is the owner usage
+            // fetch when Keychain access is explicitly disabled; version/auth children retain the global gate.
             guard let binary = ClaudeCLIResolver.resolvedBinaryPath(environment: context.env) else { return false }
-            return ClaudeCLIBackgroundAvailability.allowsOpaqueChildExecution(
+            return ClaudeCLIBackgroundAvailability.allowsBackgroundAutoUsageFetch(
                 binary: binary,
                 environment: context.env)
         }
@@ -861,17 +862,28 @@ enum ClaudeCLIBackgroundAvailability {
     final class Store: @unchecked Sendable {
         private let lock = NSLock()
         private var markers: Set<Marker> = []
+        private var revokedMarkers: Set<Marker> = []
 
         func contains(_ marker: Marker) -> Bool {
             self.lock.withLock { self.markers.contains(marker) }
         }
 
         func insert(_ marker: Marker) {
-            self.lock.withLock { _ = self.markers.insert(marker) }
+            self.lock.withLock {
+                _ = self.markers.insert(marker)
+                self.revokedMarkers.remove(marker)
+            }
         }
 
         func remove(_ marker: Marker) {
-            self.lock.withLock { _ = self.markers.remove(marker) }
+            self.lock.withLock {
+                self.markers.remove(marker)
+                _ = self.revokedMarkers.insert(marker)
+            }
+        }
+
+        func isRevoked(_ marker: Marker) -> Bool {
+            self.lock.withLock { self.revokedMarkers.contains(marker) }
         }
     }
 
@@ -894,6 +906,17 @@ enum ClaudeCLIBackgroundAvailability {
         // retain the explicit background opt-in introduced with the opaque-child safety gate.
         return KeychainAccessGate.isExplicitlyDisabled
             || ClaudeOAuthKeychainPromptPreference.storedMode() == .always
+    }
+
+    static func allowsBackgroundAutoUsageFetch(binary: String, environment: [String: String]) -> Bool {
+        guard ProviderInteractionContext.current == .background else { return true }
+        guard KeychainAccessGate.isExplicitlyDisabled else {
+            return self.allowsOpaqueChildExecution(binary: binary, environment: environment)
+        }
+        // Disable Keychain explicitly permits one owner-CLI usage attempt on a cold profile. A failed attempt
+        // records revocation below, preventing each background timer tick from retrying until a foreground success.
+        guard let marker = self.captureMarker(binary: binary, environment: environment) else { return false }
+        return !self.store.isRevoked(marker)
     }
 
     static func establish(binary: String, environment: [String: String]) {

--- a/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
@@ -323,36 +323,6 @@ struct ClaudeBaselineCharacterizationTests {
     }
 
     @Test
-    func `app background auto does not launch Claude CLI when Keychain access is disabled`() async throws {
-        let settings = ProviderSettingsSnapshot.make(claude: .init(
-            usageDataSource: .auto,
-            webExtrasEnabled: false,
-            cookieSource: .off,
-            manualCookieHeader: nil))
-        let invocationLog = FileManager.default.temporaryDirectory
-            .appendingPathComponent("claude-invocations-\(UUID().uuidString).log")
-        let stubCLIPath = try self.makeStubClaudeCLI(loggedIn: false, invocationLog: invocationLog)
-        let env = ["CLAUDE_CLI_PATH": stubCLIPath]
-        let descriptor = ProviderDescriptorRegistry.descriptor(for: .claude)
-        let context = self.makeContext(runtime: .app, sourceMode: .auto, env: env, settings: settings)
-        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(context)
-        let cli = try #require(strategies.first { $0.id == "claude.cli" })
-
-        let cliAvailable = await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
-            await KeychainAccessGate.withTaskOverrideForTesting(true) {
-                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
-                    await ProviderInteractionContext.$current.withValue(.background) {
-                        await cli.isAvailable(context)
-                    }
-                }
-            }
-        }
-
-        #expect(!cliAvailable)
-        #expect(!FileManager.default.fileExists(atPath: invocationLog.path))
-    }
-
-    @Test
     func `app background auto falls back to web without probing Claude CLI`() async throws {
         let settings = ProviderSettingsSnapshot.make(claude: .init(
             usageDataSource: .auto,
@@ -429,7 +399,7 @@ struct ClaudeBaselineCharacterizationTests {
     }
 
     @Test
-    func `app background auto availability stops when Keychain access is disabled`() async throws {
+    func `app background auto availability uses owner CLI when Keychain access is disabled`() async throws {
         let settings = ProviderSettingsSnapshot.make(claude: .init(
             usageDataSource: .auto,
             webExtrasEnabled: false,
@@ -438,7 +408,16 @@ struct ClaudeBaselineCharacterizationTests {
         let invocationLog = FileManager.default.temporaryDirectory
             .appendingPathComponent("claude-invocations-\(UUID().uuidString).log")
         let stubCLIPath = try self.makeStubClaudeCLI(invocationLog: invocationLog)
-        let env = ["CLAUDE_CLI_PATH": stubCLIPath]
+        let profileRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-claude-disabled-keychain-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: profileRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: profileRoot) }
+        try Data(#"{"oauthAccount":{"accountUuid":"disabled-keychain-account"}}"#.utf8)
+            .write(to: profileRoot.appendingPathComponent(".config.json"), options: .atomic)
+        let env = [
+            "CLAUDE_CLI_PATH": stubCLIPath,
+            "CLAUDE_CONFIG_DIR": profileRoot.path,
+        ]
         let descriptor = ProviderDescriptorRegistry.descriptor(for: .claude)
         let context = self.makeContext(runtime: .app, sourceMode: .auto, env: env, settings: settings)
         let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(context)
@@ -450,7 +429,7 @@ struct ClaudeBaselineCharacterizationTests {
             }
         }
 
-        #expect(!available)
+        #expect(available)
         #expect(!FileManager.default.fileExists(atPath: invocationLog.path))
     }
 

--- a/Tests/CodexBarTests/ClaudeCLIBackgroundAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIBackgroundAvailabilityTests.swift
@@ -4,13 +4,35 @@ import Testing
 
 struct ClaudeCLIBackgroundAvailabilityTests {
     @Test
-    func `background Auto CLI is unavailable before a user establishes availability`() async {
+    func `disabled Keychain allows cold background Auto usage without an established marker`() async throws {
         let strategy = self.makeStrategy()
-        let context = self.makeContext()
+        let profile = try self.makeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+        let context = self.makeContext(environment: profile.environment)
 
         await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
             await KeychainAccessGate.withTaskOverrideForTesting(true) {
                 await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.never) {
+                    await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/bin/echo") {
+                        await ProviderInteractionContext.$current.withValue(.background) {
+                            #expect(await strategy.isAvailable(context))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    func `enabled Keychain rejects cold background Auto usage without an established marker`() async throws {
+        let strategy = self.makeStrategy()
+        let profile = try self.makeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+        let context = self.makeContext(environment: profile.environment)
+
+        await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
+            await KeychainAccessGate.withTaskOverrideForTesting(false) {
+                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
                     await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/bin/echo") {
                         await ProviderInteractionContext.$current.withValue(.background) {
                             #expect(await !strategy.isAvailable(context))
@@ -90,10 +112,42 @@ struct ClaudeCLIBackgroundAvailabilityTests {
         let context = self.makeContext(sourceMode: .oauth)
 
         await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
-            await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(promptMode) {
-                await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/bin/echo") {
-                    await ProviderInteractionContext.$current.withValue(.background) {
-                        #expect(await !strategy.isAvailable(context))
+            await KeychainAccessGate.withTaskOverrideForTesting(true) {
+                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(promptMode) {
+                    await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/bin/echo") {
+                        await ProviderInteractionContext.$current.withValue(.background) {
+                            #expect(await !strategy.isAvailable(context))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    func `failed disabled Keychain exception revokes later background Auto usage`() async throws {
+        let strategy = self.makeStrategy()
+        let profile = try self.makeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+        let context = self.makeContext(environment: profile.environment)
+        let fetchOverride: @Sendable (String, TimeInterval, Bool) async throws
+            -> ClaudeStatusSnapshot = { _, _, _ in
+                throw ExpectedFetchError.failed
+            }
+
+        await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
+            await KeychainAccessGate.withTaskOverrideForTesting(true) {
+                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.never) {
+                    await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/bin/echo") {
+                        await ProviderInteractionContext.$current.withValue(.background) {
+                            #expect(await strategy.isAvailable(context))
+                            await #expect(throws: ExpectedFetchError.self) {
+                                try await ClaudeStatusProbe.$fetchOverride.withValue(fetchOverride) {
+                                    try await strategy.fetch(context)
+                                }
+                            }
+                            #expect(await !strategy.isAvailable(context))
+                        }
                     }
                 }
             }
@@ -126,8 +180,8 @@ struct ClaudeCLIBackgroundAvailabilityTests {
 
         await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
             ClaudeCLIBackgroundAvailability.establish(binary: "/bin/echo", environment: contextA.env)
-            await KeychainAccessGate.withTaskOverrideForTesting(true) {
-                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.never) {
+            await KeychainAccessGate.withTaskOverrideForTesting(false) {
+                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
                     await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/bin/echo") {
                         await ProviderInteractionContext.$current.withValue(.background) {
                             #expect(await strategy.isAvailable(contextA))
@@ -148,8 +202,8 @@ struct ClaudeCLIBackgroundAvailabilityTests {
 
         try await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
             ClaudeCLIBackgroundAvailability.establish(binary: "/bin/echo", environment: context.env)
-            try await KeychainAccessGate.withTaskOverrideForTesting(true) {
-                try await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.never) {
+            try await KeychainAccessGate.withTaskOverrideForTesting(false) {
+                try await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
                     try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/bin/echo") {
                         try await ProviderInteractionContext.$current.withValue(.background) {
                             #expect(await strategy.isAvailable(context))
@@ -172,6 +226,10 @@ struct ClaudeCLIBackgroundAvailabilityTests {
             manualCookieHeader: nil,
             browserDetection: BrowserDetection(cacheTTL: 0),
             hasWebFallback: false)
+    }
+
+    private enum ExpectedFetchError: Error {
+        case failed
     }
 
     private func makeContext(

--- a/Tests/CodexBarTests/ProviderVersionDetectorTests.swift
+++ b/Tests/CodexBarTests/ProviderVersionDetectorTests.swift
@@ -179,6 +179,26 @@ final class ProviderVersionDetectorTests: XCTestCase {
         XCTAssertEqual(state.callCount, 0)
     }
 
+    func test_claudeVersion_disabledKeychainWithoutMarkerStillSkipsChild() async throws {
+        let state = MockDetectorState()
+        self.configureClaudeVersionHooks(state: state)
+        let profile = try self.makeClaudeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+
+        let version = await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
+            KeychainAccessGate.withTaskOverrideForTesting(true) {
+                ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                    ProviderInteractionContext.$current.withValue(.background) {
+                        ProviderVersionDetector.claudeVersion(environment: profile.environment)
+                    }
+                }
+            }
+        }
+
+        XCTAssertNil(version)
+        XCTAssertEqual(state.callCount, 0)
+    }
+
     func test_claudeVersion_userInitiatedColdDetectionRunsChild() async {
         let state = MockDetectorState()
         self.configureClaudeVersionHooks(state: state)


### PR DESCRIPTION
## Summary

- Allow background Claude Auto to run the owner CLI usage fetch on cold boot when Advanced → Disable Keychain access is explicitly enabled, without requiring a pre-established profile marker.
- Keep Keychain-enabled startup and timer refreshes unchanged: the profile-scoped marker and Always prompt policy are still required.
- Record a failed exception attempt as revoked so later timer ticks do not create a retry storm; a successful foreground fetch clears that revocation.

## Semantics

This implements the maintainer decision that Disable Keychain has permissive semantics, but applies it narrowly to the Claude owner usage-fetch path. The shared opaque-child gate remains unchanged, so background `claude --version` and auth/status children still require established availability and consent.

## Port from #2494

This ports the cold-boot behavior reported and implemented by @gmkbenjamin in #2494 onto the profile-scoped ownership/routing architecture landed through #2380/#2585. The commit preserves contributor credit and the changelog thanks @gmkbenjamin.

## Proof

- `swift test --filter 'ClaudeCLIBackgroundAvailabilityTests|ProviderVersionDetectorTests|ClaudeBaselineCharacterizationTests'` — passed 31 Swift Testing cases and 20 executable XCTest cases; one live-only version test skipped as designed.
- `make check` — passed repository checks, SwiftFormat, and strict SwiftLint.
- `make test` — passed all 65 sharded groups; one group recovered on the built-in retry. Focused reproduction isolated that instability to the known #2509 Kiro transport wall-clock race.
- `swift test --skip-build --filter 'KiroStatusProbeTests|KiroTransportRaceTests|CodexModelsPerformanceTests'` — CodexModelsPerformance passed at 0.740s; the known #2509 Kiro shared-deadline race reproduced and is waived for this task.
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.

Closes #2493

References #2494
