### PR TITLE
Fix Claude OAuth authority and cancellation recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Merged menu: provider detail cards that render the inline token/cost chart now open the cost-history submenu on hover, matching the Overview card (#2885). Thanks @SJY051!
+- Claude: keep environment- and CodexBar-owned OAuth usage authoritative when the local Claude CLI account switches mid-fetch, preserve background CLI availability across cancelled refreshes, and carry OAuth credential ownership through web-extras enrichment (#2591). Thanks @ProspectOre!
 
 ## 0.49.4 — 2026-08-13
 

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -570,7 +570,7 @@ extension UsageStore {
                 changedDuringFetch: authChangedDuringFetch) || activeAccountReconciliation.changed)
         let successfulOAuth = Self.isSuccessfulClaudeOAuthOutcome(input.outcome)
         let successfulOAuthCredentialOwner = Self.successfulClaudeOAuthCredentialOwner(input.outcome)
-        let activeAccountMismatch = successfulOAuth && (
+        let activeAccountMismatch = successfulOAuth && successfulOAuthCredentialOwner == .claudeCLI && (
             activeAccountChangedDuringFetch || activeAccountReconciliation.changedFromPersistedIdentity)
         let quarantinedCredentialsFile = if successfulOAuthCredentialOwner == .claudeCLI {
             await Self.isClaudeCredentialsFileQuarantinedForOAuth(environment: input.environment)

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -564,12 +564,16 @@ extension UsageStore {
                 .compactMap(\.self),
             shouldTrack: shouldTrackActiveAccount,
             environment: input.environment)
-        let credentialsChanged = shouldTrackActiveAccount && (
+        let successfulOAuth = Self.isSuccessfulClaudeOAuthOutcome(input.outcome)
+        let successfulOAuthCredentialOwner = Self.successfulClaudeOAuthCredentialOwner(input.outcome)
+        let successfulOAuthHasIndependentAuthority = successfulOAuth && (
+            successfulOAuthCredentialOwner == .environment || successfulOAuthCredentialOwner == .codexbar)
+        let activeAccountChangedDuringFetchForOutcome =
+            activeAccountChangedDuringFetch && !successfulOAuthHasIndependentAuthority
+        let credentialsChanged = shouldTrackActiveAccount && !successfulOAuthHasIndependentAuthority && (
             Self.claudeCredentialsChanged(
                 beforeFetch: input.beforeFetch,
                 changedDuringFetch: authChangedDuringFetch) || activeAccountReconciliation.changed)
-        let successfulOAuth = Self.isSuccessfulClaudeOAuthOutcome(input.outcome)
-        let successfulOAuthCredentialOwner = Self.successfulClaudeOAuthCredentialOwner(input.outcome)
         let activeAccountMismatch = successfulOAuth && successfulOAuthCredentialOwner == .claudeCLI && (
             activeAccountChangedDuringFetch || activeAccountReconciliation.changedFromPersistedIdentity)
         let quarantinedCredentialsFile = if successfulOAuthCredentialOwner == .claudeCLI {
@@ -591,7 +595,7 @@ extension UsageStore {
             }
         }
         let ownerCLIRecoverySucceeded = !input.ownerCLIRecoveryPass || Self.isSuccessfulClaudeCLIOutcome(input.outcome)
-        if !oauthAccountMismatch, !activeAccountChangedDuringFetch, ownerCLIRecoverySucceeded {
+        if !oauthAccountMismatch, !activeAccountChangedDuringFetchForOutcome, ownerCLIRecoverySucceeded {
             self.persistClaudeActiveAccountIdentity(
                 activeAccountReconciliation.newestIdentity,
                 environment: input.environment)
@@ -611,12 +615,12 @@ extension UsageStore {
 
         // Only the ambient CLI authority observes Claude's account/config files. Source-authority changes apply to
         // every Claude route, but retire only the live projection; configured token-account caches remain isolated.
-        if credentialsChanged || activeAccountChangedDuringFetch || sourceAuthorityChanged {
+        if credentialsChanged || activeAccountChangedDuringFetchForOutcome || sourceAuthorityChanged {
             self.clearClaudeCredentialDerivedStateForCredentialSwap()
         }
         let disposition: ClaudeRefreshDisposition = if oauthAccountMismatch {
             .retryOwnerCLI
-        } else if activeAccountChangedDuringFetch {
+        } else if activeAccountChangedDuringFetchForOutcome {
             .retry
         } else {
             .apply

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -1027,6 +1027,9 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
         do {
             usage = try await fetcher.loadLatestUsage(model: "sonnet")
         } catch {
+            if Task.isCancelled || ClaudeOAuthFetchError.isCancellation(error) {
+                throw error
+            }
             if let backgroundAvailabilityMarker {
                 ClaudeCLIBackgroundAvailability.revoke(backgroundAvailabilityMarker)
             }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -1423,23 +1423,9 @@ extension ClaudeUsageFetcher {
                 web: webData.extraUsageCost,
                 includeUsageDetails: self.useWebExtras)
             if mergedProviderCost != snapshot.providerCost || mergedExtraRateWindows != snapshot.extraRateWindows {
-                return ClaudeUsageSnapshot(
-                    primary: snapshot.primary,
-                    primaryWindowKind: snapshot.primaryWindowKind,
-                    secondary: snapshot.secondary,
-                    opus: snapshot.opus,
+                return snapshot.replacingWebExtras(
                     extraRateWindows: mergedExtraRateWindows,
-                    providerCost: mergedProviderCost,
-                    updatedAt: snapshot.updatedAt,
-                    accountEmail: snapshot.accountEmail,
-                    accountOrganization: snapshot.accountOrganization,
-                    loginMethod: snapshot.loginMethod,
-                    rawText: snapshot.rawText,
-                    oauthKeychainPersistentRefHash: snapshot.oauthKeychainPersistentRefHash,
-                    oauthHistoryOwnerIdentifier: snapshot.oauthHistoryOwnerIdentifier,
-                    oauthKeychainCredentialMismatch: snapshot.oauthKeychainCredentialMismatch,
-                    oauthKeychainCredentialAbsent: snapshot.oauthKeychainCredentialAbsent,
-                    oauthKeychainCredentialUnavailable: snapshot.oauthKeychainCredentialUnavailable)
+                    providerCost: mergedProviderCost)
             }
         case let .failure(error):
             if error is CancellationError ||

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageSnapshot+WebExtras.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageSnapshot+WebExtras.swift
@@ -1,0 +1,25 @@
+extension ClaudeUsageSnapshot {
+    func replacingWebExtras(
+        extraRateWindows: [NamedRateWindow],
+        providerCost: ProviderCostSnapshot?) -> ClaudeUsageSnapshot
+    {
+        ClaudeUsageSnapshot(
+            primary: self.primary,
+            primaryWindowKind: self.primaryWindowKind,
+            secondary: self.secondary,
+            opus: self.opus,
+            extraRateWindows: extraRateWindows,
+            providerCost: providerCost,
+            updatedAt: self.updatedAt,
+            accountEmail: self.accountEmail,
+            accountOrganization: self.accountOrganization,
+            loginMethod: self.loginMethod,
+            rawText: self.rawText,
+            oauthKeychainPersistentRefHash: self.oauthKeychainPersistentRefHash,
+            oauthHistoryOwnerIdentifier: self.oauthHistoryOwnerIdentifier,
+            oauthCredentialOwner: self.oauthCredentialOwner,
+            oauthKeychainCredentialMismatch: self.oauthKeychainCredentialMismatch,
+            oauthKeychainCredentialAbsent: self.oauthKeychainCredentialAbsent,
+            oauthKeychainCredentialUnavailable: self.oauthKeychainCredentialUnavailable)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeActiveAccountIdentityInvalidationTests.swift
+++ b/Tests/CodexBarTests/ClaudeActiveAccountIdentityInvalidationTests.swift
@@ -1115,6 +1115,60 @@ extension ClaudeActiveAccountIdentityInvalidationTests {
         }
     }
 
+    @Test(arguments: [
+        ClaudeOAuthCredentialOwner.environment,
+        .codexbar,
+    ])
+    func `independent OAuth authority ignores a local account switch during fetch`(
+        owner: ClaudeOAuthCredentialOwner) async throws
+    {
+        try await self.withMissingCredentialsFile { _ in
+            let independentOAuthSnapshot = Self.freshSnapshot()
+            let fixture = try await MainActor.run {
+                try self.makeFixture(
+                    source: .oauth,
+                    outcome: Self.successOutcome(
+                        independentOAuthSnapshot,
+                        sourceLabel: "OAuth",
+                        strategyKind: .oauth,
+                        oauthCredentialOwner: owner))
+            }
+            await self.persistIdentity("account-a", in: fixture)
+            let identities = ClaudeIdentitySequence(["account-a", "account-b"])
+            let outcomes = ClaudeReplacementFetchSequence(
+                first: Self.successOutcome(
+                    independentOAuthSnapshot,
+                    sourceLabel: "OAuth",
+                    strategyKind: .oauth,
+                    oauthCredentialOwner: owner),
+                replacement: Self.transientFailureOutcome())
+            await outcomes.releaseReplacement()
+            await MainActor.run {
+                fixture.store._test_providerFetchOutcomeOverride = { _ in await outcomes.next() }
+            }
+
+            await UsageStore.withActiveClaudeAccountUuidResolverForTesting(
+                { identities.next() },
+                {
+                    await fixture.store.refreshProvider(.claude)
+                })
+
+            let result = await MainActor.run {
+                (
+                    snapshot: fixture.store.snapshot(for: .claude),
+                    tokenSnapshot: fixture.store.tokenSnapshot(for: .claude),
+                    error: fixture.store.error(for: .claude),
+                    persistedIdentity: fixture.settings.userDefaults.string(
+                        forKey: UsageStore._claudeActiveAccountIdentityDefaultsKeyForTesting()))
+            }
+            #expect(result.snapshot?.updatedAt == independentOAuthSnapshot.updatedAt)
+            #expect(result.tokenSnapshot != nil)
+            #expect(result.error == nil)
+            #expect(await !outcomes.replacementStarted())
+            #expect(result.persistedIdentity == UsageStore._activeClaudeAccountIdentityForTesting("account-b"))
+        }
+    }
+
     @Test
     func `pre fetch account switch rejects stale OAuth and publishes owner CLI replacement`() async throws {
         try await self.withMissingCredentialsFile { credentialsURL in

--- a/Tests/CodexBarTests/ClaudeActiveAccountIdentityInvalidationTests.swift
+++ b/Tests/CodexBarTests/ClaudeActiveAccountIdentityInvalidationTests.swift
@@ -736,7 +736,8 @@ struct ClaudeActiveAccountIdentityInvalidationTests {
     private static func successOutcome(
         _ snapshot: UsageSnapshot,
         sourceLabel: String = "CLI",
-        strategyKind: ProviderFetchKind = .cli) -> ProviderFetchOutcome
+        strategyKind: ProviderFetchKind = .cli,
+        oauthCredentialOwner: ClaudeOAuthCredentialOwner = .claudeCLI) -> ProviderFetchOutcome
     {
         ProviderFetchOutcome(
             result: .success(ProviderFetchResult(
@@ -746,7 +747,7 @@ struct ClaudeActiveAccountIdentityInvalidationTests {
                 sourceLabel: sourceLabel,
                 strategyID: "test.cli-success",
                 strategyKind: strategyKind,
-                claudeOAuthCredentialOwner: strategyKind == .oauth ? .claudeCLI : nil)),
+                claudeOAuthCredentialOwner: strategyKind == .oauth ? oauthCredentialOwner : nil)),
             attempts: [ProviderFetchAttempt(
                 strategyID: "test.cli-success",
                 kind: .cli,
@@ -1067,6 +1068,50 @@ extension ClaudeActiveAccountIdentityInvalidationTests {
             #expect(result.snapshot == nil)
             #expect(result.error != nil)
             #expect(result.persistedIdentity == UsageStore._activeClaudeAccountIdentityForTesting("account-a"))
+        }
+    }
+
+    @Test
+    func `environment OAuth remains authoritative across a local account switch`() async throws {
+        try await self.withMissingCredentialsFile { _ in
+            let environmentOAuthSnapshot = Self.freshSnapshot()
+            let ownerCLISnapshot = Self.replacementSnapshot()
+            let fixture = try await MainActor.run {
+                try self.makeFixture(
+                    source: .oauth,
+                    outcome: Self.successOutcome(
+                        environmentOAuthSnapshot,
+                        sourceLabel: "OAuth",
+                        strategyKind: .oauth,
+                        oauthCredentialOwner: .environment))
+            }
+            await self.persistIdentity("account-a", in: fixture)
+            let outcomes = ClaudeReplacementFetchSequence(
+                first: Self.successOutcome(
+                    environmentOAuthSnapshot,
+                    sourceLabel: "OAuth",
+                    strategyKind: .oauth,
+                    oauthCredentialOwner: .environment),
+                replacement: Self.successOutcome(ownerCLISnapshot))
+            await outcomes.releaseReplacement()
+            await MainActor.run {
+                fixture.store._test_providerFetchOutcomeOverride = { _ in await outcomes.next() }
+            }
+
+            await UsageStore.withActiveClaudeAccountUuidForTesting("account-b") {
+                await fixture.store.refreshProvider(.claude)
+            }
+
+            let result = await MainActor.run {
+                (
+                    snapshot: fixture.store.snapshot(for: .claude),
+                    persistedIdentity: fixture.settings.userDefaults.string(
+                        forKey: UsageStore._claudeActiveAccountIdentityDefaultsKeyForTesting()))
+            }
+            #expect(result.snapshot?.updatedAt == environmentOAuthSnapshot.updatedAt)
+            #expect(result.snapshot?.accountEmail(for: .claude) == "new@example.com")
+            #expect(await !outcomes.replacementStarted())
+            #expect(result.persistedIdentity == UsageStore._activeClaudeAccountIdentityForTesting("account-b"))
         }
     }
 

--- a/Tests/CodexBarTests/ClaudeAuthenticatedTransitionLiveProofTests.swift
+++ b/Tests/CodexBarTests/ClaudeAuthenticatedTransitionLiveProofTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct ClaudeAuthenticatedTransitionLiveProofTests {
+    private static var isEnabled: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        return environment["LIVE_CLAUDE_KEYCHAIN_PROOF"] == "1" &&
+            environment["LIVE_CLAUDE_TRANSITION_PROOF"] == "1"
+    }
+
+    @Test
+    func `live environment OAuth survives an in flight local account switch`() async throws {
+        guard Self.isEnabled else { return }
+        let processEnvironment = ProcessInfo.processInfo.environment
+        guard processEnvironment[ClaudeOAuthCredentialsStore.environmentTokenKey]?.isEmpty == false else {
+            Issue.record("Live transition proof requires an ephemeral CODEXBAR_CLAUDE_OAUTH_TOKEN")
+            return
+        }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-live-oauth-switch-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let accountBefore = UUID().uuidString
+        let accountAfter = UUID().uuidString
+        try Self.writeActiveAccount(accountBefore, to: root)
+
+        var environment = processEnvironment
+        environment[ClaudeConfigPaths.configDirectoryEnvironmentKey] = root.path
+        environment[KeychainAccessGate.disableAccessEnvironmentKey] = "1"
+        let fixture = try await MainActor.run {
+            try Self.makeLiveOAuthFixture(environment: environment)
+        }
+
+        let refresh = Task { @MainActor in
+            await fixture.store.refreshProvider(.claude)
+        }
+        try await Task.sleep(for: .milliseconds(20))
+        try Self.writeActiveAccount(accountAfter, to: root)
+        await refresh.value
+
+        let result = await MainActor.run {
+            (
+                hasSnapshot: fixture.store.snapshot(for: .claude) != nil,
+                source: fixture.store.lastSourceLabels[.claude]?.lowercased(),
+                error: fixture.store.error(for: .claude),
+                persistedIdentity: fixture.settings.userDefaults.string(
+                    forKey: UsageStore._claudeActiveAccountIdentityDefaultsKeyForTesting(
+                        environment: environment)))
+        }
+        #expect(result.hasSnapshot)
+        #expect(result.source == "oauth")
+        #expect(result.error == nil)
+        #expect(result.persistedIdentity == UsageStore._activeClaudeAccountIdentityForTesting(
+            accountAfter,
+            environment: environment))
+    }
+
+    @Test
+    func `live cancelled owner fetch preserves and completes the next background Auto fetch`() async throws {
+        guard Self.isEnabled else { return }
+        let binary = try #require(TTYCommandRunner.which("claude"))
+        var environment = ProcessInfo.processInfo.environment
+        environment["CLAUDE_CLI_PATH"] = binary
+        environment[KeychainAccessGate.disableAccessEnvironmentKey] = "1"
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        let context = ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .auto,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: environment,
+            settings: nil,
+            fetcher: UsageFetcher(environment: environment),
+            claudeFetcher: ClaudeUsageFetcher(
+                browserDetection: browserDetection,
+                environment: environment),
+            browserDetection: browserDetection)
+        let strategy = ClaudeCLIFetchStrategy(
+            useWebExtras: false,
+            includePrepaidBalance: false,
+            manualCookieHeader: nil,
+            browserDetection: browserDetection,
+            hasWebFallback: false)
+
+        _ = try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+            try await strategy.fetch(context)
+        }
+        #expect(await ProviderInteractionContext.$current.withValue(.background) {
+            await strategy.isAvailable(context)
+        })
+
+        let cancelledFetch = Task {
+            try await ProviderInteractionContext.$current.withValue(.background) {
+                try await strategy.fetch(context)
+            }
+        }
+        try await Task.sleep(for: .milliseconds(100))
+        cancelledFetch.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await cancelledFetch.value
+        }
+
+        #expect(await ProviderInteractionContext.$current.withValue(.background) {
+            await strategy.isAvailable(context)
+        })
+        let recovered = try await ProviderInteractionContext.$current.withValue(.background) {
+            try await strategy.fetch(context)
+        }
+        #expect(recovered.usage.scoped(to: .claude).primary != nil)
+    }
+
+    @MainActor
+    private static func makeLiveOAuthFixture(
+        environment: [String: String]) throws -> (store: UsageStore, settings: SettingsStore)
+    {
+        let settings = testSettingsStore(suiteName: "ClaudeAuthenticatedTransitionLiveProofTests")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.claudeUsageDataSource = .oauth
+        settings.claudeWebExtrasEnabled = false
+        let metadata = ProviderRegistry.shared.metadata
+        for provider in UsageProvider.allCases {
+            try settings.setProviderEnabled(
+                provider: provider,
+                metadata: #require(metadata[provider]),
+                enabled: provider == .claude)
+        }
+
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: environment),
+            browserDetection: browserDetection,
+            claudeFetcher: ClaudeUsageFetcher(
+                browserDetection: browserDetection,
+                environment: environment),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: environment)
+        return (store, settings)
+    }
+
+    private static func writeActiveAccount(_ accountID: String, to root: URL) throws {
+        let data = try JSONSerialization.data(
+            withJSONObject: ["oauthAccount": ["accountUuid": accountID]],
+            options: [.sortedKeys])
+        try data.write(to: root.appendingPathComponent(".config.json"), options: .atomic)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeCLIBackgroundAvailabilityTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIBackgroundAvailabilityTests.swift
@@ -174,6 +174,36 @@ struct ClaudeCLIBackgroundAvailabilityTests {
     }
 
     @Test
+    func `cancelled disabled Keychain exception keeps later background Auto usage available`() async throws {
+        let strategy = self.makeStrategy()
+        let profile = try self.makeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+        let context = self.makeContext(environment: profile.environment)
+        let fetchOverride: @Sendable (String, TimeInterval, Bool) async throws
+            -> ClaudeStatusSnapshot = { _, _, _ in
+                throw CancellationError()
+            }
+
+        await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
+            await KeychainAccessGate.withTaskOverrideForTesting(true) {
+                await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.never) {
+                    await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/bin/echo") {
+                        await ProviderInteractionContext.$current.withValue(.background) {
+                            #expect(await strategy.isAvailable(context))
+                            await #expect(throws: CancellationError.self) {
+                                try await ClaudeStatusProbe.$fetchOverride.withValue(fetchOverride) {
+                                    try await strategy.fetch(context)
+                                }
+                            }
+                            #expect(await strategy.isAvailable(context))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
     func `user initiated explicit OAuth retains interactive CLI recovery`() async {
         let strategy = self.makeStrategy()
         let context = self.makeContext(sourceMode: .oauth)

--- a/Tests/CodexBarTests/ClaudeWebUsageExtraWindowTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebUsageExtraWindowTests.swift
@@ -91,6 +91,47 @@ struct ClaudeWebUsageExtraWindowTests {
     }
 
     @Test
+    func `web extras preserve OAuth credential ownership evidence`() {
+        let primaryCost = ProviderCostSnapshot(
+            used: 5,
+            limit: 20,
+            currencyCode: "USD",
+            period: "Monthly cap",
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_000))
+        let snapshot = ClaudeUsageSnapshot(
+            primary: RateWindow(usedPercent: 7, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            opus: nil,
+            providerCost: primaryCost,
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_001),
+            accountEmail: "user@example.com",
+            accountOrganization: "org-123",
+            loginMethod: "Pro",
+            rawText: nil,
+            oauthKeychainPersistentRefHash: "persistent-ref",
+            oauthHistoryOwnerIdentifier: "history-owner",
+            oauthCredentialOwner: .claudeCLI,
+            oauthKeychainCredentialUnavailable: true)
+        let webCost = ProviderCostSnapshot(
+            used: 0,
+            limit: 0,
+            currencyCode: "USD",
+            period: "Extra usage",
+            balance: 100,
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_002))
+
+        let enriched = snapshot.replacingWebExtras(
+            extraRateWindows: [],
+            providerCost: webCost)
+
+        #expect(enriched.providerCost == webCost)
+        #expect(enriched.oauthCredentialOwner == .claudeCLI)
+        #expect(enriched.oauthKeychainPersistentRefHash == "persistent-ref")
+        #expect(enriched.oauthHistoryOwnerIdentifier == "history-owner")
+        #expect(enriched.oauthKeychainCredentialUnavailable)
+    }
+
+    @Test
     func `web extras require the same Claude account and organization`() {
         let snapshot = ClaudeUsageSnapshot(
             primary: RateWindow(usedPercent: 7, windowMinutes: 300, resetsAt: nil, resetDescription: nil),

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1070,25 +1070,25 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 921,
+            line: 925,
             anchor: "let snapshotEmail = CodexIdentityResolver.normalizeEmail(snapshot.accountEmail(for: .codex)),",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 929,
+            line: 933,
             anchor: "let identity = snapshot.identity(for: .codex)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 931,
+            line: 935,
             anchor: "providerID: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 1462,
+            line: 1466,
             anchor: "let currentAccount = self.uniqueTokenAccount(provider: .claude, accountID: fetchedAccount.id),",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -2802,7 +2802,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 687,
+            line: 691,
             anchor: "if provider == .codex,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 2,
@@ -2810,7 +2810,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 721,
+            line: 725,
             anchor: "codexOwnerKey: provider == .codex ? context.codexSessionQuotaOwnerKey : nil)",
             expectedProviderIDs: ["claude", "codex", "deepseek"],
             expectedReferenceCount: 4,
@@ -2818,7 +2818,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 753,
+            line: 757,
             anchor: "if provider == .gemini {",
             expectedProviderIDs: ["claude", "codex", "gemini"],
             expectedReferenceCount: 5,
@@ -2826,7 +2826,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 805,
+            line: 809,
             anchor: "if provider == .codex {",
             expectedProviderIDs: ["codex", "deepseek"],
             expectedReferenceCount: 4,
@@ -2834,7 +2834,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 854,
+            line: 858,
             anchor: "guard provider == .deepseek else { return snapshot }",
             expectedProviderIDs: ["codex", "deepseek"],
             expectedReferenceCount: 8,
@@ -2851,7 +2851,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 981,
+            line: 985,
             anchor: "guard provider == .claude, !hasSelectedTokenAccount else { return false }",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -2859,7 +2859,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 1321,
+            line: 1325,
             anchor: "if provider == .gemini, Self.isGeminiConsumerTierDeprecationError(error) {",
             expectedProviderIDs: ["claude", "gemini"],
             expectedReferenceCount: 2,
@@ -2867,7 +2867,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 1365,
+            line: 1369,
             anchor: "if provider == .claude,",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -2875,7 +2875,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 1381,
+            line: 1385,
             anchor: "if provider == .claude,",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 5,
@@ -2883,7 +2883,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
-            line: 1463,
+            line: 1467,
             anchor: "cached.cacheKey == self.tokenAccountSnapshotCacheKey(provider: .claude, account: currentAccount)",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,


### PR DESCRIPTION
## Summary

- Keep environment- and CodexBar-owned Claude OAuth results authoritative when the local Claude active account changes during a fetch.
- Preserve disabled-Keychain background Auto availability when an owner CLI fetch is cancelled.
- Preserve OAuth credential ownership through optional web enrichment.
- Add focused regressions while retaining owner-CLI account reconciliation and real-failure revocation.

## Root cause

Active-account mismatch recovery was keyed only to a successful OAuth strategy, not the credential authority. That allowed an independently authoritative environment or CodexBar OAuth result to be discarded and retried against a different local CLI account. Separately, every CLI fetch error revoked background availability, including cancellation from refresh replacement or shutdown. Optional web enrichment also rebuilt the usage snapshot without carrying its OAuth owner.

## Impact

Configured environment or CodexBar OAuth can no longer be replaced by usage from the wrong local Claude account. Cancelled background refreshes no longer disable later owner-CLI refreshes. Owner-CLI account reconciliation and genuine CLI failure revocation remain intact.

## Redacted Release owner-boundary proof — production tree `630645d7592c738593056ab8d7a6b61df6a7f4ab`

Run on August 11, 2026 against a clean worktree. The verifier built and packaged Release from the production candidate, ran the focused prompt-safety suites with ordinary-test Keychain access suppressed, ran the opt-in live authentication checks, and then performed a bounded app-Auto fetch through the real installed and authenticated Claude owner CLI. Account identity, usage values, credentials, local paths, and artifact hashes are omitted.

The current head `7de739682e8fad999450eb28aaeb5e2e78f14e35` differs from that production tree only by the new opt-in live-proof test file; there are zero changes under `Sources`, `Scripts`, `docs`, or `Package.swift`.

The verifier's older Phase 2 string assertion is no longer compatible with current `main`: the base intentionally includes an opt-in experimental Security CLI reader and therefore embeds the strings that assertion rejects. This PR does not modify that reader or its policy. Phase 3's process-ancestry and unified-log checks were completed unchanged against the same packaged bundle; those runtime checks distinguish Claude-owned descendants from any direct CodexBar reader.

```text
date: 2026-08-11T18:00:33Z
candidate: 630645d7592c738593056ab8d7a6b61df6a7f4ab
candidate-worktree: clean
release-built-by-verifier: yes
first-party-release-executables-enumerated: 4
claude-owner-authenticated: yes
codexbar-owned-oauth-cache-access: disabled-for-direct-oauth-absence-proof
cli-timed-out: 0
cli-exit: 0
live-provider: claude
live-source: claude
live-usage-type: dictionary
security-descendants: 2
claude-owner-security-descendants: 2
unowned-security-descendants: 0
unified-log-visibility-canary: observed
attributed-prompt-authorization-events: 0
static-marker-audit: incompatible-with-current-main-baseline
```

Production-tree verifier result: 258 tests in 22 focused prompt-safety/owner-path suites passed, followed by 3/3 opt-in live proof tests. The authenticated owner fetch succeeded without a direct Security child or attributable authorization prompt.

## Authenticated transition proof — exact head `7de739682e8fad999450eb28aaeb5e2e78f14e35`

Run on August 11, 2026 against the clean exact head. This serialized opt-in suite executes the production `UsageStore` and `ClaudeCLIFetchStrategy` paths across the two repaired transitions with real authenticated provider boundaries.

The existing Claude credential was read once into the parent process, handed to the test only in memory, and neither printed nor persisted. The OAuth switch used disposable account metadata; it did not edit the real Claude profile. Keychain reads were disabled inside both test paths. Account identity, usage values, credentials, and local paths are omitted.

```text
suite: ClaudeAuthenticatedTransitionLiveProofTests
candidate: 7de739682e8fad999450eb28aaeb5e2e78f14e35
candidate-worktree: clean
credential-handoff: in-memory
credential-printed-or-persisted: no
real-profile-mutated: no
isolated-account-metadata: yes

live environment OAuth survives an in flight local account switch
  authenticated-network-boundary: passed
  source-after-switch: oauth
  provider-error: none
  observed-active-identity: advanced to switched account
  elapsed: 0.612 seconds

live cancelled owner fetch preserves and completes the next background Auto fetch
  authenticated-installed-owner-cli: yes
  runtime: app
  cancellation-observed: CancellationError
  background-auto-after-cancellation: available
  subsequent-background-owner-fetch: succeeded
  elapsed: 18.018 seconds

result: 2 tests in 1 suite, 0 failures
```

### Controlled transition matrix

The same transitions were also run directly by name with real-Keychain access suppressed and deterministic volatile inputs. These cases assert details that should not be inferred from private live-account output.

```text
independent OAuth authority ignores a local account switch during fetch
  owner: environment — passed
  owner: codexbar — passed
  asserted: original independent-authority snapshot published
  asserted: replacement owner-CLI fetch not started
  asserted: no provider error
  asserted: observed active identity advanced to the switched account

cancelled disabled Keychain exception keeps later background Auto usage available
  asserted: background Auto available before fetch
  asserted: CancellationError propagated from the production CLI strategy
  asserted: background Auto still available after cancellation

result: 2 tests in 2 suites (3 argument-expanded scenarios), 0 failures
```

## Additional validation

- Exact-head authenticated transition live proof: 2/2 tests passed
- Exact-head Keychain prompt-safety + provider-architecture gates: 49/49 tests passed
- New proof file: SwiftFormat and strict SwiftLint passed
- Post-rebase ownership/cancellation/web-enrichment focused matrix: 50/50 tests passed
- Controlled exact transition matrix: 3/3 argument-expanded scenarios passed
- Exact-head GitHub CI: all required checks passed
- `git diff --check`

Post-landing correctness follow-up to #2585 and #2589.

Addresses https://github.com/steipete/CodexBar/pull/2585#discussion_r3699865960

Addresses https://github.com/steipete/CodexBar/pull/2589#discussion_r3700189167
