### PR TITLE
Fix Doubao AK/SK dual-plan usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Menu bar: Session/Weekly/Auto pace layout tokens that render the signed pace delta (`+11%`, `-8%`, `0%`), restoring the pre-0.45 "Both" display in the layout editor (#2540, fixes #2534). Thanks @kratocz!
 
 ### Fixed
+- Doubao: show Agent Plan windows alongside Coding Plan usage for Volcengine AK/SK accounts that subscribe to both products (#2517). Thanks @Astro-Han!
 - Codex: persist and budget fork-parent discovery so missing parents quiesce between inventory changes instead of sweeping every rollout on each refresh (#2525, #2538). Thanks @xx205, and @Helmi and @kiranmagic7 for the investigation!
 - Claude: Auto cold boot with Keychain disabled loads without manual refresh (#2494, fixes #2493). Thanks @gmkbenjamin!
 - Menu: no more stray floating "Refresh" tooltip beside the menu when switching tabs with the cursor over the actions area.

--- a/Sources/CodexBarCore/Providers/Doubao/DoubaoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Doubao/DoubaoUsageFetcher.swift
@@ -267,9 +267,9 @@ public struct DoubaoUsageFetcher: Sendable {
     private static let codingPlanAPIURL = URL(
         string: "https://open.volcengineapi.com/?Action=GetCodingPlanUsage&Version=2024-01-01")!
     /// Agent Plan usage lives behind a sibling Volcengine Top OpenAPI action (`GetAFPUsage`,
-    /// AFP = "Agent Flow Points"), signed with the same AK/SK the Coding Plan path uses. An
-    /// account holds a Coding Plan *or* an Agent Plan, so `GetCodingPlanUsage` returns no
-    /// active quota for an Agent Plan account and we fall back to this action.
+    /// AFP = "Agent Flow Points"), signed with the same AK/SK the Coding Plan path uses.
+    /// Accounts can hold Coding Plan and Agent Plan simultaneously, so both actions must be
+    /// queried independently.
     private static let agentPlanAPIURL = URL(
         string: "https://open.volcengineapi.com/?Action=GetAFPUsage&Version=2024-01-01")!
 
@@ -360,23 +360,54 @@ public struct DoubaoUsageFetcher: Sendable {
         }
 
         let codingPlanUsage = try self.decodeCodingPlanUsage(from: response.data)
-        if codingPlanUsage.quotas.isEmpty {
-            // A 200 with no quota window means the Coding Plan is not active for this account
-            // (e.g. Status "Reclaimed" after switching to an Agent Plan). Fall back to the
-            // Agent Plan (AFP) usage before surfacing an empty Coding Plan snapshot.
-            let agentSnapshot = try await self.fetchAgentPlanUsage(
+        let agentPlanUsage: DoubaoCodingPlanUsage?
+        do {
+            // Keep these requests sequential. Coding Plan is the required result and AFP is an
+            // independent, best-effort product probe with its own bounded request timeout.
+            agentPlanUsage = try await self.fetchAgentPlanUsage(
                 credentials: credentials, session: transport, date: date)
-            if agentSnapshot.codingPlanUsage?.quotas.isEmpty == false {
-                return agentSnapshot
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as DoubaoUsageError {
+            if self.isAgentPlanAbsence(error) || !codingPlanUsage.quotas.isEmpty {
+                Self.log.debug("Doubao agent plan usage unavailable; preserving Coding Plan usage: \(error)")
+                agentPlanUsage = nil
+            } else {
+                throw error
             }
+        } catch {
+            if !codingPlanUsage.quotas.isEmpty {
+                Self.log.debug("Doubao agent plan usage unavailable; preserving Coding Plan usage: \(error)")
+                agentPlanUsage = nil
+            } else {
+                throw error
+            }
+        }
+
+        let combinedUsage: DoubaoCodingPlanUsage = if codingPlanUsage.quotas.isEmpty, let agentPlanUsage,
+                                                      !agentPlanUsage.quotas.isEmpty
+        {
+            agentPlanUsage
+        } else if let agentPlanUsage, !agentPlanUsage.quotas.isEmpty {
+            DoubaoCodingPlanUsage(
+                status: codingPlanUsage.status,
+                updateTime: codingPlanUsage.updateTime ?? agentPlanUsage.updateTime,
+                quotas: codingPlanUsage.quotas + agentPlanUsage.quotas)
+        } else {
+            codingPlanUsage
         }
         return DoubaoUsageSnapshot(
             remainingRequests: 0,
             limitRequests: 0,
             resetTime: nil,
-            updatedAt: codingPlanUsage.updateTime ?? date,
+            updatedAt: combinedUsage.updateTime ?? date,
             apiKeyValid: true,
-            codingPlanUsage: codingPlanUsage)
+            codingPlanUsage: combinedUsage)
+    }
+
+    private static func isAgentPlanAbsence(_ error: DoubaoUsageError) -> Bool {
+        guard case let .apiError(statusCode, _) = error else { return false }
+        return statusCode == 403 || statusCode == 404
     }
 
     /// Fetches Agent Plan (AFP) usage via the AK/SK-signed `GetAFPUsage` action. Mirrors the
@@ -386,7 +417,7 @@ public struct DoubaoUsageFetcher: Sendable {
     static func fetchAgentPlanUsage(
         credentials: DoubaoCodingPlanCredentials,
         session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
-        date: Date = Date()) async throws -> DoubaoUsageSnapshot
+        date: Date = Date()) async throws -> DoubaoCodingPlanUsage
     {
         let body = Data()
         var request = URLRequest(url: self.agentPlanAPIURL)
@@ -412,18 +443,15 @@ public struct DoubaoUsageFetcher: Sendable {
         }
         guard response.statusCode == 200 else {
             let summary = Self.apiErrorSummary(statusCode: response.statusCode, data: response.data)
-            Self.log.error("Doubao agent plan API returned \(response.statusCode): \(summary)")
+            if response.statusCode == 403 || response.statusCode == 404 {
+                Self.log.debug("Doubao agent plan is unavailable: \(summary)")
+            } else {
+                Self.log.error("Doubao agent plan API returned \(response.statusCode): \(summary)")
+            }
             throw DoubaoUsageError.apiError(response.statusCode, summary)
         }
 
-        let agentPlanUsage = try self.decodeAgentPlanUsage(from: response.data)
-        return DoubaoUsageSnapshot(
-            remainingRequests: 0,
-            limitRequests: 0,
-            resetTime: nil,
-            updatedAt: agentPlanUsage.updateTime ?? date,
-            apiKeyValid: true,
-            codingPlanUsage: agentPlanUsage)
+        return try self.decodeAgentPlanUsage(from: response.data)
     }
 
     static func decodeAgentPlanUsage(from data: Data) throws -> DoubaoCodingPlanUsage {

--- a/Tests/CodexBarTests/DoubaoUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DoubaoUsageFetcherTests.swift
@@ -180,6 +180,7 @@ struct DoubaoUsageFetcherTests {
                   }
                 }
                 """),
+            .rawResponse(statusCode: 200, body: #"{"Result":{}}"#),
         ])
         let credentials = DoubaoCodingPlanCredentials(
             accessKeyID: "AKLTTEST",
@@ -191,7 +192,7 @@ struct DoubaoUsageFetcherTests {
             credentials: credentials,
             session: transport,
             date: date)
-        let request = await transport.lastCapturedRequest()
+        let request = await transport.firstCapturedRequest()
 
         #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 12.5)
         #expect(request?.method == "POST")
@@ -1005,7 +1006,7 @@ private actor DoubaoScriptedTransport: ProviderHTTPTransport {
 
     private var results: [Result]
     private var requests = 0
-    private var capturedRequest: CapturedRequest?
+    private var capturedRequests: [CapturedRequest] = []
 
     init(results: [Result]) {
         self.results = results
@@ -1016,18 +1017,22 @@ private actor DoubaoScriptedTransport: ProviderHTTPTransport {
     }
 
     func lastCapturedRequest() -> CapturedRequest? {
-        self.capturedRequest
+        self.capturedRequests.last
+    }
+
+    func firstCapturedRequest() -> CapturedRequest? {
+        self.capturedRequests.first
     }
 
     func data(for request: URLRequest) throws -> (Data, URLResponse) {
         self.requests += 1
-        self.capturedRequest = CapturedRequest(
+        self.capturedRequests.append(CapturedRequest(
             url: request.url?.absoluteString,
             method: request.httpMethod,
             host: request.value(forHTTPHeaderField: "Host"),
             date: request.value(forHTTPHeaderField: "X-Date"),
             contentSHA256: request.value(forHTTPHeaderField: "X-Content-Sha256"),
-            authorization: request.value(forHTTPHeaderField: "Authorization"))
+            authorization: request.value(forHTTPHeaderField: "Authorization")))
         let result = self.results.removeFirst()
         switch result {
         case let .response(statusCode, limit, remaining):
@@ -1118,97 +1123,91 @@ struct DoubaoAgentPlanUsageTests {
     }
 
     @Test
-    func `coding plan fetch falls back to agent plan when coding plan is reclaimed`() async throws {
+    func `agent-only account returns agent plan windows`() async throws {
         let transport = DoubaoScriptedTransport(results: [
             .rawResponse(
                 statusCode: 200,
                 body: #"{"Result":{"Status":"Reclaimed","UpdateTimestamp":1785322689}}"#),
-            .rawResponse(
-                statusCode: 200,
-                body: """
-                {
-                  "Result": {
-                    "PlanType": "medium",
-                    "AFPFiveHour": {"Quota": 10000, "Used": 0, "ResetTime": -1},
-                    "AFPWeekly": {"Quota": 35000, "Used": 0, "ResetTime": 1785686400000},
-                    "AFPMonthly": {"Quota": 100000, "Used": 0, "ResetTime": 1787846399000}
-                  }
-                }
-                """),
+            .rawResponse(statusCode: 200, body: Self.agentPlanBody),
         ])
-        let credentials = DoubaoCodingPlanCredentials(
-            accessKeyID: "AKLTTEST",
-            secretAccessKey: "secret",
-            region: "cn-beijing")
 
         let snapshot = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
-            credentials: credentials,
+            credentials: Self.credentials,
             session: transport,
             date: Date(timeIntervalSince1970: 1_781_654_400))
 
-        // Both the Coding Plan probe and the Agent Plan fallback were issued, and the
-        // fallback's second request targeted the GetAFPUsage action.
         #expect(await transport.requestCount() == 2)
         let request = await transport.lastCapturedRequest()
         #expect(request?.url == "https://open.volcengineapi.com/?Action=GetAFPUsage&Version=2024-01-01")
 
         let usage = snapshot.toUsageSnapshot()
         let extra = usage.extraRateWindows ?? []
+        #expect(usage.primary == nil)
+        #expect(extra.contains { $0.id == "doubao-agent-session" })
         #expect(extra.contains { $0.id == "doubao-agent-weekly" && $0.window.usedPercent == 0 })
         #expect(extra.contains { $0.id == "doubao-agent-monthly" })
     }
 
     @Test
-    func `coding plan fetch keeps active coding plan without probing agent plan`() async throws {
+    func `both-active account returns coding and agent plan windows`() async throws {
         let transport = DoubaoScriptedTransport(results: [
-            .rawResponse(
-                statusCode: 200,
-                body: """
-                {
-                  "Result": {
-                    "Status": "Running",
-                    "UpdateTimestamp": 1782226444,
-                    "QuotaUsage": [
-                      {"Level": "session", "Percent": 12.5, "ResetTimestamp": 1782226478}
-                    ]
-                  }
-                }
-                """),
+            .rawResponse(statusCode: 200, body: Self.codingPlanBody),
+            .rawResponse(statusCode: 200, body: Self.agentPlanBody),
         ])
-        let credentials = DoubaoCodingPlanCredentials(
-            accessKeyID: "AKLTTEST",
-            secretAccessKey: "secret",
-            region: "cn-beijing")
 
         let snapshot = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
-            credentials: credentials,
+            credentials: Self.credentials,
             session: transport,
             date: Date(timeIntervalSince1970: 1_781_654_400))
 
-        // An active Coding Plan is returned as-is; no second (Agent Plan) request is made.
-        #expect(await transport.requestCount() == 1)
-        #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 12.5)
+        #expect(await transport.requestCount() == 2)
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 12.5)
+        #expect(usage.secondary?.usedPercent == 25)
+        #expect(usage.tertiary?.usedPercent == 50)
+        #expect(Set((usage.extraRateWindows ?? []).map(\.id)) == [
+            "doubao-agent-session",
+            "doubao-agent-weekly",
+            "doubao-agent-monthly",
+        ])
     }
 
     @Test
-    func `agent plan fallback surfaces access denied`() async {
+    func `coding-only account treats agent plan access denied as absence`() async throws {
         let transport = DoubaoScriptedTransport(results: [
-            .rawResponse(
-                statusCode: 200,
-                body: #"{"Result":{"Status":"Reclaimed"}}"#),
+            .rawResponse(statusCode: 200, body: Self.codingPlanBody),
             .rawResponse(
                 statusCode: 403,
                 body: #"{"ResponseMetadata":{"Error":{"Code":"AccessDenied","Message":"not authorized"}}}"#),
         ])
 
-        await #expect {
-            _ = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
-                credentials: Self.credentials,
-                session: transport)
-        } throws: { error in
-            guard case let DoubaoUsageError.apiError(code, message) = error else { return false }
-            return code == 403 && message.contains("AccessDenied")
-        }
+        let snapshot = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
+            credentials: Self.credentials,
+            session: transport)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(await transport.requestCount() == 2)
+        #expect(usage.primary?.usedPercent == 12.5)
+        #expect(usage.extraRateWindows == nil)
+    }
+
+    @Test
+    func `absent agent plan preserves coding plan windows`() async throws {
+        let transport = DoubaoScriptedTransport(results: [
+            .rawResponse(statusCode: 200, body: Self.codingPlanBody),
+            .rawResponse(statusCode: 200, body: #"{"Result":{}}"#),
+        ])
+
+        let snapshot = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
+            credentials: Self.credentials,
+            session: transport)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(await transport.requestCount() == 2)
+        #expect(usage.primary?.usedPercent == 12.5)
+        #expect(usage.secondary?.usedPercent == 25)
+        #expect(usage.tertiary?.usedPercent == 50)
+        #expect(usage.extraRateWindows == nil)
     }
 
     @Test
@@ -1231,7 +1230,23 @@ struct DoubaoAgentPlanUsageTests {
     }
 
     @Test
-    func `agent plan fallback surfaces transport failure`() async {
+    func `agent plan transport failure preserves active coding plan`() async throws {
+        let transport = DoubaoScriptedTransport(results: [
+            .rawResponse(statusCode: 200, body: Self.codingPlanBody),
+            .failure(URLError(.timedOut)),
+        ])
+
+        let snapshot = try await DoubaoUsageFetcher.fetchCodingPlanUsage(
+            credentials: Self.credentials,
+            session: transport)
+
+        #expect(await transport.requestCount() == 2)
+        #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 12.5)
+        #expect(snapshot.toUsageSnapshot().extraRateWindows == nil)
+    }
+
+    @Test
+    func `agent plan transport failure surfaces when no plan result is available`() async {
         let transport = DoubaoScriptedTransport(results: [
             .rawResponse(
                 statusCode: 200,
@@ -1250,11 +1265,9 @@ struct DoubaoAgentPlanUsageTests {
     }
 
     @Test
-    func `agent plan fallback propagates cancellation`() async {
+    func `agent plan cancellation propagates after active coding plan`() async {
         let transport = DoubaoScriptedTransport(results: [
-            .rawResponse(
-                statusCode: 200,
-                body: #"{"Result":{"Status":"Reclaimed"}}"#),
+            .rawResponse(statusCode: 200, body: Self.codingPlanBody),
             .cancellation,
         ])
 
@@ -1263,10 +1276,36 @@ struct DoubaoAgentPlanUsageTests {
                 credentials: Self.credentials,
                 session: transport)
         }
+        #expect(await transport.requestCount() == 2)
     }
 
     private static let credentials = DoubaoCodingPlanCredentials(
         accessKeyID: "AKLTTEST",
         secretAccessKey: "secret",
         region: "cn-beijing")
+
+    private static let codingPlanBody = """
+    {
+      "Result": {
+        "Status": "Running",
+        "UpdateTimestamp": 1782226444,
+        "QuotaUsage": [
+          {"Level": "session", "Percent": 12.5, "ResetTimestamp": 1782226478},
+          {"Level": "weekly", "Percent": 25, "ResetTimestamp": 1782662400},
+          {"Level": "monthly", "Percent": 50, "ResetTimestamp": 1782403199}
+        ]
+      }
+    }
+    """
+
+    private static let agentPlanBody = """
+    {
+      "Result": {
+        "PlanType": "medium",
+        "AFPFiveHour": {"Quota": 10000, "Used": 0, "ResetTime": -1},
+        "AFPWeekly": {"Quota": 35000, "Used": 0, "ResetTime": 1785686400000},
+        "AFPMonthly": {"Quota": 100000, "Used": 0, "ResetTime": 1787846399000}
+      }
+    }
+    """
 }

--- a/docs/doubao.md
+++ b/docs/doubao.md
@@ -21,6 +21,7 @@ To keep using API credentials instead, paste an API key or AK/SK pair in provide
 - Auto mode honors configured API credentials first so an ambient arkcli SSO session cannot silently switch accounts. Without configured credentials, it uses `arkcli usage plan --format json`.
 - CLI mode uses only `arkcli`; API mode uses only configured AK/SK or Ark API-key credentials.
 - `arkcli` output provides distinct personal and team Coding Plan and Agent Plan 5-hour, weekly, and monthly windows when those subscriptions are present.
+- Volcengine AK/SK mode checks Coding Plan and Agent Plan independently, so accounts subscribed to both show both sets of windows.
 - Ark API-key endpoint: `POST https://ark.cn-beijing.volces.com/api/coding/v3/chat/completions`
 - Probe models: `doubao-seed-2.0-code`, `doubao-1.5-pro-32k`, `doubao-lite-32k`
 - Reads `x-ratelimit-remaining-requests`, `x-ratelimit-limit-requests`, and `x-ratelimit-reset-requests` when returned.


### PR DESCRIPTION
## Summary

- query Volcengine Coding Plan and Agent Plan as independent, sequential AK/SK requests
- merge AFP quotas into the existing `doubao-agent-*` windows while preserving Coding Plan windows
- keep a valid Coding Plan result when the optional AFP endpoint is absent, unauthorized, or temporarily unavailable, while still propagating cancellation
- document the dual-plan behavior and add the changelog credit

## Proof

- `swift test --filter Doubao` — 73 tests passed across 5 suites
- `make check` — formatting, strict lint, locale/catalog, packaging/signing, docs, and repository gates passed
- `make test` — 66/66 groups passed on the first attempt; 786 selections; 0 retries and 0 timeouts
- autoreview (`--mode local`, Codex high) — clean, no accepted/actionable findings

Live AK/SK validation requires a Volcengine account holding both subscriptions. @Astro-Han, please verify that your account now shows the Coding Plan windows together with `doubao-agent-session`, `doubao-agent-weekly`, and `doubao-agent-monthly`.

Fixes #2517
