### PR TITLE
Fix Overview-to-provider menu sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - Augment: store session cookies owner-only (0600), atomically publish updates, and repair permissions on legacy files (#2567).
 - Ollama: direct declined Chrome Keychain access recovery to the provider card's Refresh (⌘R) action instead of the ambiguous manual-cookie path (#2072).
+- Menu: switching from a tall Overview to a shorter provider now shrinks the menu instead of stretching the provider-height spacer into a large blank region.
 - Codex: persist and budget fork-parent discovery so missing parents quiesce between inventory changes instead of sweeping every rollout on each refresh (#2525, #2538). Thanks @xx205, and @Helmi and @kiranmagic7 for the investigation!
 - Claude: Auto cold boot with Keychain disabled loads without manual refresh (#2494, fixes #2493). Thanks @gmkbenjamin!
 - Menu: no more stray floating "Refresh" tooltip beside the menu when switching tabs with the cursor over the actions area.

--- a/Sources/CodexBar/StatusItemController+StableMenuHeight.swift
+++ b/Sources/CodexBar/StatusItemController+StableMenuHeight.swift
@@ -40,6 +40,28 @@ private enum NativeMenuRowMetrics {
     }
 }
 
+/// AppKit lays out custom menu rows from their intrinsic size while a menu is tracking.
+/// A bare `NSView` only carries a frame hint, so switching from a tall Overview can stretch
+/// the provider spacer to fill Overview's old viewport and leave a large blank band.
+@MainActor
+final class StableMenuHeightSpacerView: NSView {
+    private var measuredHeight: CGFloat = 0
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: self.measuredHeight)
+    }
+
+    func applyHeight(_ height: CGFloat) {
+        let resolvedHeight = max(0, ceil(height))
+        guard self.measuredHeight != resolvedHeight || self.frame.height != resolvedHeight else { return }
+
+        self.measuredHeight = resolvedHeight
+        self.setFrameSize(NSSize(width: 1, height: resolvedHeight))
+        self.invalidateIntrinsicContentSize()
+        self.superview?.layoutSubtreeIfNeeded()
+    }
+}
+
 extension StatusItemController {
     static let stableMenuHeightSpacerID = "stableHeightSpacer"
 
@@ -48,7 +70,7 @@ extension StatusItemController {
         item.title = ""
         item.isEnabled = false
         item.representedObject = Self.stableMenuHeightSpacerID
-        let view = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: 0))
+        let view = StableMenuHeightSpacerView(frame: NSRect(x: 0, y: 0, width: 1, height: 0))
         item.view = view
         return item
     }
@@ -76,7 +98,9 @@ extension StatusItemController {
         }
         let cacheEntries = self.mergedSwitcherContentCaches[ObjectIdentifier(menu)] ?? [:]
         for (selection, entry) in cacheEntries where selection != .overview {
-            if visibleIsProviderTab, selection == self.lastMergedMenuContentSelection { continue }
+            if visibleIsProviderTab, selection == self.lastMergedMenuContentSelection {
+                continue
+            }
             tabs.append(self.measureTab(items: entry.items))
         }
         MenuSwitchFlickerProbe.debugLog(
@@ -102,11 +126,13 @@ extension StatusItemController {
         guard tabs.count > 1 || floorHeight > 0 else { return }
 
         for tab in tabs {
-            guard let spacer = tab.spacer, let spacerView = spacer.view else { continue }
+            guard let spacer = tab.spacer,
+                  let spacerView = spacer.view as? StableMenuHeightSpacerView
+            else { continue }
             let padding = max(0, targetHeight - tab.contentHeight)
             if abs(spacerView.frame.height - padding) > 0.5 {
                 MenuSwitchFlickerProbe.debugLog("padding: set spacer \(spacerView.frame.height) -> \(padding)")
-                spacerView.setFrameSize(NSSize(width: 1, height: padding))
+                spacerView.applyHeight(padding)
             }
         }
     }

--- a/Tests/CodexBarTests/StatusMenuSwitcherWarmupTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherWarmupTests.swift
@@ -78,7 +78,9 @@ final class StatusMenuSwitcherWarmupTests: XCTestCase {
         }
         let caches = controller.mergedSwitcherContentCaches[ObjectIdentifier(menu)] ?? [:]
         for (selection, entry) in caches where selection != .overview {
-            if selection == visibleSelection { continue }
+            if selection == visibleSelection {
+                continue
+            }
             let tab = controller.measureTab(items: entry.items)
             XCTAssertNotNil(tab.spacer, "provider tab content must carry a stable-height spacer")
             totals.append(tab.contentHeight + (tab.spacer?.view?.frame.height ?? 0))
@@ -87,6 +89,23 @@ final class StatusMenuSwitcherWarmupTests: XCTestCase {
         let reference = totals[0]
         for total in totals {
             XCTAssertEqual(total, reference, accuracy: 0.5)
+        }
+    }
+
+    func test_stableHeightPaddingPublishesSpacerHeightThroughIntrinsicSize() {
+        let (controller, menu) = self.makeController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.warmMergedSwitcherSiblingContent(in: menu)
+
+        let caches = controller.mergedSwitcherContentCaches[ObjectIdentifier(menu)] ?? [:]
+        let providerSpacers = caches.compactMap { selection, entry -> StableMenuHeightSpacerView? in
+            guard selection != .overview else { return nil }
+            return controller.measureTab(items: entry.items).spacer?.view as? StableMenuHeightSpacerView
+        }
+        XCTAssertFalse(providerSpacers.isEmpty)
+        for spacer in providerSpacers {
+            XCTAssertEqual(spacer.intrinsicContentSize.height, spacer.frame.height, accuracy: 0.5)
         }
     }
 


### PR DESCRIPTION
## Summary

- give the provider height-equalization spacer an intrinsic AppKit height
- prevent a tall Overview menu from stretching that spacer into a large blank band after switching to Kimi or another shorter provider
- add a regression test for the intrinsic sizing contract and document the fix

## Verification

- focused StatusMenuSwitcherWarmupTests: 4 passed
- make test: 786 selections in 66 groups; one unrelated PTY overflow proof recovered on retry
- make check: passed, including SwiftFormat, SwiftLint strict, localization, package, and docs checks
- autoreview: clean, no accepted/actionable findings

## Runtime note

The local checkout bundle could only be ad-hoc signed because this host has no valid signing identity. I did not launch that bundle against saved Keychain state, so no after screenshot is attached. The reported before state is covered by the new AppKit intrinsic-size regression.
