### PR TITLE
fix: use in-process libproc instead of ps/lsof scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Cursor: make on-demand extra usage follow the shared optional-usage setting and remove the unsupported credits placeholder (#2338). Thanks @Zihao-Qi!
+- Antigravity/Sessions: inspect processes in-process via libproc instead of spawning full-system ps/lsof, eliminating repeated macOS 26 “access data from other apps” prompts (#2267 hardening).
 - Doubao: show Agent Plan windows alongside Coding Plan usage for Volcengine AK/SK accounts that subscribe to both products (#2517). Thanks @Astro-Han!
 - Augment: store session cookies owner-only (0600), atomically publish updates, and repair permissions on legacy files (#2567).
 - Ollama: direct declined Chrome Keychain access recovery to the provider card's Refresh (⌘R) action instead of the ambiguous manual-cookie path (#2072).

--- a/Sources/CodexBarCore/DarwinProcessEnumerator.swift
+++ b/Sources/CodexBarCore/DarwinProcessEnumerator.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+enum DarwinProcessEnumerator {
+    /// Keep this predicate a superset of every executable path that
+    /// `AntigravityStatusProbe.antigravityProcessKind` can classify. The Darwin
+    /// process scan uses it before requesting the more privacy-sensitive argv.
+    static func isAntigravityCandidatePath(_ executablePath: String) -> Bool {
+        let lowercasedPath = executablePath.lowercased()
+        if lowercasedPath.contains("antigravity") {
+            return true
+        }
+
+        var basename = URL(fileURLWithPath: lowercasedPath).lastPathComponent
+        if basename.hasSuffix(".exe") {
+            basename.removeLast(4)
+        }
+        return basename.hasPrefix("language_server") ||
+            basename.hasPrefix("language-server") ||
+            ["agy", "antigravity-cli", "antigravity_cli", "node", "bun"].contains(basename)
+    }
+
+    /// Parses the `KERN_PROCARGS2` payload without consuming the environment
+    /// strings that follow argv.
+    static func parseProcArgs2(_ data: Data) -> String? {
+        let argumentCountSize = MemoryLayout<Int32>.size
+        guard data.count >= argumentCountSize else { return nil }
+        let argumentCount = data.withUnsafeBytes { rawBuffer in
+            Int(Int32(littleEndian: rawBuffer.loadUnaligned(as: Int32.self)))
+        }
+        guard argumentCount >= 0 else { return nil }
+
+        let bytes = [UInt8](data)
+        var offset = argumentCountSize
+        guard let executableTerminator = bytes[offset...].firstIndex(of: 0) else { return nil }
+        offset = executableTerminator + 1
+        while offset < bytes.count, bytes[offset] == 0 {
+            offset += 1
+        }
+
+        var arguments: [String] = []
+        arguments.reserveCapacity(argumentCount)
+        for _ in 0..<argumentCount {
+            guard offset < bytes.count,
+                  let terminator = bytes[offset...].firstIndex(of: 0),
+                  let argument = String(bytes: bytes[offset..<terminator], encoding: .utf8)
+            else { return nil }
+            arguments.append(argument)
+            offset = terminator + 1
+        }
+        return arguments.joined(separator: " ")
+    }
+}
+
+#if canImport(Darwin)
+import Darwin
+
+extension DarwinProcessEnumerator {
+    static func allPIDs() -> [Int32] {
+        let requiredCount = proc_listallpids(nil, 0)
+        guard requiredCount > 0 else { return [] }
+        var pids = [Int32](repeating: 0, count: Int(requiredCount) + 32)
+        let actualCount = pids.withUnsafeMutableBytes { buffer in
+            proc_listallpids(buffer.baseAddress, Int32(buffer.count))
+        }
+        guard actualCount > 0 else { return [] }
+        return Array(pids.prefix(Int(actualCount))).filter { $0 > 0 }
+    }
+
+    static func executablePath(pid: Int32) -> String? {
+        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN) * 4)
+        let byteCount = buffer.withUnsafeMutableBytes { rawBuffer in
+            proc_pidpath(pid, rawBuffer.baseAddress, UInt32(rawBuffer.count))
+        }
+        guard byteCount > 0 else { return nil }
+        return buffer.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return nil }
+            let bytes = UnsafeRawBufferPointer(start: baseAddress, count: Int(byteCount))
+            let pathBytes = bytes.prefix { $0 != 0 }
+            guard !pathBytes.isEmpty else { return nil }
+            return String(bytes: pathBytes, encoding: .utf8)
+        }
+    }
+
+    static func bsdInfo(pid: Int32) -> (ppid: Int32, startTime: Date)? {
+        var info = proc_bsdinfo()
+        let byteCount = proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            Int32(MemoryLayout<proc_bsdinfo>.size))
+        guard byteCount == MemoryLayout<proc_bsdinfo>.size else { return nil }
+        let startInterval = TimeInterval(info.pbi_start_tvsec) +
+            TimeInterval(info.pbi_start_tvusec) / 1_000_000
+        return (Int32(bitPattern: info.pbi_ppid), Date(timeIntervalSince1970: startInterval))
+    }
+
+    static func commandLine(pid: Int32) -> String? {
+        var mib = [CTL_KERN, KERN_PROCARGS2, pid]
+        var byteCount = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &byteCount, nil, 0) == 0,
+              byteCount >= MemoryLayout<Int32>.size
+        else { return nil }
+
+        var data = Data(count: byteCount)
+        let result = data.withUnsafeMutableBytes { rawBuffer in
+            sysctl(&mib, u_int(mib.count), rawBuffer.baseAddress, &byteCount, nil, 0)
+        }
+        guard result == 0 else { return nil }
+        if byteCount < data.count {
+            data.removeSubrange(byteCount..<data.count)
+        }
+        return self.parseProcArgs2(data)
+    }
+
+    static func currentWorkingDirectory(pid: Int32) -> String? {
+        var info = proc_vnodepathinfo()
+        let byteCount = proc_pidinfo(
+            pid,
+            PROC_PIDVNODEPATHINFO,
+            0,
+            &info,
+            Int32(MemoryLayout<proc_vnodepathinfo>.size))
+        guard byteCount == MemoryLayout<proc_vnodepathinfo>.size else { return nil }
+        return withUnsafeBytes(of: &info.pvi_cdir.vip_path) { rawBuffer in
+            let pathBytes = rawBuffer.prefix { $0 != 0 }
+            guard !pathBytes.isEmpty else { return nil }
+            return String(bytes: pathBytes, encoding: .utf8)
+        }
+    }
+
+    static func listeningTCPPorts(pid: Int32) -> [Int] {
+        let requiredBytes = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nil, 0)
+        guard requiredBytes > 0 else { return [] }
+        let descriptorStride = MemoryLayout<proc_fdinfo>.stride
+        var descriptors = [proc_fdinfo](
+            repeating: proc_fdinfo(),
+            count: Int(requiredBytes) / descriptorStride + 8)
+        let actualBytes = descriptors.withUnsafeMutableBytes { buffer in
+            proc_pidinfo(
+                pid,
+                PROC_PIDLISTFDS,
+                0,
+                buffer.baseAddress,
+                Int32(buffer.count))
+        }
+        guard actualBytes > 0 else { return [] }
+
+        var ports: Set<Int> = []
+        for descriptor in descriptors.prefix(Int(actualBytes) / descriptorStride)
+            where descriptor.proc_fdtype == PROX_FDTYPE_SOCKET
+        {
+            var info = socket_fdinfo()
+            let byteCount = proc_pidfdinfo(
+                pid,
+                descriptor.proc_fd,
+                PROC_PIDFDSOCKETINFO,
+                &info,
+                Int32(MemoryLayout<socket_fdinfo>.size))
+            guard byteCount == MemoryLayout<socket_fdinfo>.size,
+                  info.psi.soi_kind == SOCKINFO_TCP,
+                  info.psi.soi_proto.pri_tcp.tcpsi_state == TSI_S_LISTEN
+            else { continue }
+            let networkPort = UInt16(truncatingIfNeeded: info.psi.soi_proto.pri_tcp.tcpsi_ini.insi_lport)
+            ports.insert(Int(UInt16(bigEndian: networkPort)))
+        }
+        return ports.sorted()
+    }
+}
+#endif

--- a/Sources/CodexBarCore/LocalAgentSessionScanner.swift
+++ b/Sources/CodexBarCore/LocalAgentSessionScanner.swift
@@ -70,12 +70,11 @@ public struct LocalAgentSessionScanner: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         includeFileOnlySessions: Bool = true) async -> [AgentSession]
     {
-        let processOutput = if let processOutputProvider = self.processOutputProvider {
-            await processOutputProvider(environment)
+        let allProcesses = if let processOutputProvider = self.processOutputProvider {
+            await AgentPSOutputParser.parse(processOutputProvider(environment))
         } else {
-            await self.processOutput(environment: environment)
+            await self.processRecords(environment: environment)
         }
-        let allProcesses = AgentPSOutputParser.parse(processOutput)
         let processes = Array(AgentSessionCorrelation.newestProcessesFirst(
             AgentPSOutputParser.agentProcesses(from: allProcesses))
             .prefix(max(0, self.config.maxProcessCount)))
@@ -289,6 +288,25 @@ public struct LocalAgentSessionScanner: Sendable {
             .filter { seen.insert("\($0.host):\($0.id)").inserted }
     }
 
+    private func processRecords(environment: [String: String]) async -> [AgentProcessRecord] {
+        #if canImport(Darwin)
+        return DarwinProcessEnumerator.allPIDs().compactMap { pid in
+            guard let bsdInfo = DarwinProcessEnumerator.bsdInfo(pid: pid),
+                  let executablePath = DarwinProcessEnumerator.executablePath(pid: pid)
+            else { return nil }
+            let command = DarwinProcessEnumerator.commandLine(pid: pid) ?? executablePath
+            return AgentProcessRecord(
+                pid: pid,
+                ppid: bsdInfo.ppid,
+                startedAt: bsdInfo.startTime,
+                command: command)
+        }
+        #else
+        return await AgentPSOutputParser.parse(self.processOutput(environment: environment))
+        #endif
+    }
+
+    #if !canImport(Darwin)
     private func processOutput(environment: [String: String]) async -> String {
         let binary = ["/bin/ps", "/usr/bin/ps"].first { FileManager.default.isExecutableFile(atPath: $0) }
         guard let binary,
@@ -301,9 +319,15 @@ public struct LocalAgentSessionScanner: Sendable {
         else { return "" }
         return result.stdout
     }
+    #endif
 
     private func cwdByPID(_ pids: [Int32], environment: [String: String]) async -> [Int32: String] {
         guard !pids.isEmpty else { return [:] }
+        #if canImport(Darwin)
+        return Dictionary(uniqueKeysWithValues: pids.compactMap { pid in
+            DarwinProcessEnumerator.currentWorkingDirectory(pid: pid).map { (pid, $0) }
+        })
+        #else
         if let lsof = self.findExecutable("lsof", environment: environment) {
             let joinedPIDs = pids.map(String.init).joined(separator: ",")
             if let result = try? await SubprocessRunner.run(
@@ -318,14 +342,11 @@ public struct LocalAgentSessionScanner: Sendable {
             }
         }
 
-        #if os(Linux)
         return Dictionary(uniqueKeysWithValues: pids.compactMap { pid in
             let path = "/proc/\(pid)/cwd"
             guard let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: path) else { return nil }
             return (pid, destination)
         })
-        #else
-        return [:]
         #endif
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+PortDetection.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+PortDetection.swift
@@ -41,10 +41,15 @@ enum ProcNetTCPListeningPortParser {
 }
 
 extension AntigravityStatusProbe {
-    /// Resolves the TCP ports the process `pid` is listening on. Uses `lsof` when
-    /// present (the common denominator across macOS and Linux) and falls back to
-    /// the kernel's `/proc` interface on Linux hosts without `lsof`.
+    /// Resolves the TCP ports the process `pid` is listening on.
     static func listeningPorts(pid: Int, timeout: TimeInterval) async throws -> [Int] {
+        #if canImport(Darwin)
+        let ports = DarwinProcessEnumerator.listeningTCPPorts(pid: Int32(pid))
+        if ports.isEmpty {
+            throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
+        }
+        return ports
+        #else
         let lsof = ["/usr/sbin/lsof", "/usr/bin/lsof"].first(where: {
             FileManager.default.isExecutableFile(atPath: $0)
         })
@@ -53,7 +58,6 @@ extension AntigravityStatusProbe {
             return try await Self.lsofListeningPorts(lsof: lsof, pid: pid, timeout: timeout)
         }
 
-        #if os(Linux)
         // `lsof` is frequently absent on minimal Linux hosts. Fall back to the
         // kernel's /proc interface, mirroring the /proc/<pid>/cwd fallback that
         // LocalAgentSessionScanner.cwdByPID already uses when lsof is missing.
@@ -62,8 +66,6 @@ extension AntigravityStatusProbe {
             throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
         }
         return ports
-        #else
-        throw AntigravityStatusProbeError.portDetectionFailed("lsof not available")
         #endif
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -1044,6 +1044,16 @@ public struct AntigravityStatusProbe: Sendable {
         timeout: TimeInterval,
         scope: ProcessScope = .ideAndCLI) async throws -> [ProcessInfoResult]
     {
+        #if canImport(Darwin)
+        let entries = DarwinProcessEnumerator.allPIDs().compactMap { pid -> (pid: Int, command: String)? in
+            guard let executablePath = DarwinProcessEnumerator.executablePath(pid: pid),
+                  DarwinProcessEnumerator.isAntigravityCandidatePath(executablePath)
+            else { return nil }
+            let command = DarwinProcessEnumerator.commandLine(pid: pid) ?? executablePath
+            return (Int(pid), command)
+        }
+        return try self.processInfos(fromEntries: entries, scope: scope)
+        #else
         let env = ProcessInfo.processInfo.environment
         let result = try await SubprocessRunner.run(
             binary: "/bin/ps",
@@ -1053,6 +1063,7 @@ public struct AntigravityStatusProbe: Sendable {
             label: "antigravity-ps")
 
         return try Self.processInfos(fromProcessListOutput: result.stdout, scope: scope)
+        #endif
     }
 
     static func processInfo(
@@ -1070,31 +1081,39 @@ public struct AntigravityStatusProbe: Sendable {
         fromProcessListOutput output: String,
         scope: ProcessScope = .ideAndCLI) throws -> [ProcessInfoResult]
     {
-        let lines = output.split(separator: "\n")
+        let entries = output.split(separator: "\n").compactMap { line -> (pid: Int, command: String)? in
+            guard let match = Self.matchProcessLine(String(line)) else { return nil }
+            return (match.pid, match.command)
+        }
+        return try self.processInfos(fromEntries: entries, scope: scope)
+    }
+
+    static func processInfos(
+        fromEntries entries: [(pid: Int, command: String)],
+        scope: ProcessScope = .ideAndCLI) throws -> [ProcessInfoResult]
+    {
         var sawTokenlessIDE = false
         var results: [ProcessInfoResult] = []
-        for line in lines {
-            let text = String(line)
-            guard let match = Self.matchProcessLine(text) else { continue }
-            guard let kind = Self.antigravityProcessKind(match.command) else { continue }
+        for entry in entries {
+            guard let kind = Self.antigravityProcessKind(entry.command) else { continue }
             if !Self.processKind(kind, matches: scope) { continue }
             // The IDE language server authenticates local requests with a
             // `--csrf_token` and must keep requiring it: skip a tokenless IDE
             // or app match so a later valid server can still be found (and surface
             // `missingCSRFToken` if none is). The CLI's language server exposes
             // no token flag and needs none, so an empty token is allowed there.
-            guard let token = Self.resolvedCSRFToken(forKind: kind, command: match.command) else {
+            guard let token = Self.resolvedCSRFToken(forKind: kind, command: entry.command) else {
                 sawTokenlessIDE = true
                 continue
             }
-            let port = Self.extractPort("--extension_server_port", from: match.command)
-            let extensionServerCSRFToken = Self.extractFlag("--extension_server_csrf_token", from: match.command)
+            let port = Self.extractPort("--extension_server_port", from: entry.command)
+            let extensionServerCSRFToken = Self.extractFlag("--extension_server_csrf_token", from: entry.command)
             results.append(ProcessInfoResult(
-                pid: match.pid,
+                pid: entry.pid,
                 extensionPort: port,
                 extensionServerCSRFToken: extensionServerCSRFToken,
                 csrfToken: token,
-                commandLine: match.command))
+                commandLine: entry.command))
         }
 
         if !results.isEmpty {

--- a/Sources/CodexBarCore/SessionWindowFocuser.swift
+++ b/Sources/CodexBarCore/SessionWindowFocuser.swift
@@ -91,17 +91,7 @@ public enum SessionWindowFocuser {
     }
 
     private static func parentPID(of pid: Int32) -> Int32? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-o", "ppid=", "-p", String(pid)]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-        guard (try? process.run()) != nil else { return nil }
-        process.waitUntilExit()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        guard let output = String(data: data, encoding: .utf8) else { return nil }
-        return Int32(output.trimmingCharacters(in: .whitespacesAndNewlines))
+        DarwinProcessEnumerator.bsdInfo(pid: pid)?.ppid
     }
 }
 #endif

--- a/Tests/CodexBarTests/DarwinProcessEnumeratorTests.swift
+++ b/Tests/CodexBarTests/DarwinProcessEnumeratorTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+struct DarwinProcessEnumeratorTests {
+    @Test
+    func `proc args parser joins normal argv`() {
+        let data = Self.procArgsData(arguments: ["/usr/bin/tool", "--flag", "value"])
+
+        #expect(DarwinProcessEnumerator.parseProcArgs2(data) == "/usr/bin/tool --flag value")
+    }
+
+    @Test
+    func `proc args parser accepts zero argc`() {
+        let data = Self.procArgsData(arguments: [])
+
+        #expect(DarwinProcessEnumerator.parseProcArgs2(data)?.isEmpty == true)
+    }
+
+    @Test
+    func `proc args parser rejects truncated buffer`() {
+        #expect(DarwinProcessEnumerator.parseProcArgs2(Data([2, 0, 0])) == nil)
+    }
+
+    @Test
+    func `proc args parser excludes environment`() {
+        let data = Self.procArgsData(
+            arguments: ["/usr/bin/tool", "--flag"],
+            environment: ["SECRET=value", "HOME=/tmp"])
+
+        let command = DarwinProcessEnumerator.parseProcArgs2(data)
+        #expect(command == "/usr/bin/tool --flag")
+        #expect(command?.contains("SECRET") == false)
+        #expect(command?.contains("HOME") == false)
+    }
+
+    @Test
+    func `proc args parser preserves embedded empty arguments`() {
+        let data = Self.procArgsData(arguments: ["/usr/bin/tool", "", "value"])
+
+        #expect(DarwinProcessEnumerator.parseProcArgs2(data) == "/usr/bin/tool  value")
+    }
+
+    @Test
+    func `proc args parser rejects argc larger than available strings`() {
+        var data = Self.procArgsData(arguments: ["/usr/bin/tool", "value"])
+        data.replaceSubrange(0..<4, with: Self.littleEndianBytes(3))
+
+        #expect(DarwinProcessEnumerator.parseProcArgs2(data) == nil)
+    }
+
+    @Test
+    func `antigravity candidate paths cover known executable shapes`() {
+        let paths = [
+            "/Applications/Antigravity.app/Contents/Resources/bin/language_server_macos_arm",
+            "/opt/editor/extensions/antigravity/bin/language_server",
+            "/usr/local/bin/agy",
+            "~/.antigravity/x/antigravity-cli",
+            "language_server",
+        ]
+
+        for path in paths {
+            #expect(DarwinProcessEnumerator.isAntigravityCandidatePath(path))
+        }
+    }
+
+    @Test
+    func `antigravity candidate paths reject unrelated executables`() {
+        let paths = [
+            "/bin/ps",
+            "/Applications/Xcode.app/Contents/MacOS/Xcode",
+            "/opt/gravity/bin/tool",
+        ]
+
+        for path in paths {
+            #expect(!DarwinProcessEnumerator.isAntigravityCandidatePath(path))
+        }
+    }
+
+    @Test
+    func `antigravity candidate prefilter is a superset of classifier fixtures`() {
+        let fixtures = [
+            (
+                "/Applications/Antigravity.app/Contents/Resources/bin/language_server --csrf_token token",
+                "/Applications/Antigravity.app/Contents/Resources/bin/language_server"),
+            (
+                "/Applications/Google Antigravity.app/Contents/Resources/bin/language-server --csrf_token token",
+                "/Applications/Google Antigravity.app/Contents/Resources/bin/language-server"),
+            (
+                "/Users/test/.local/bin/agy -p hello",
+                "/Users/test/.local/bin/agy"),
+            (
+                "node /Users/test/.gemini/antigravity-cli/build/mcp-server.cjs --app_data_dir antigravity",
+                "node"),
+        ]
+
+        for fixture in fixtures {
+            #expect(AntigravityStatusProbe.antigravityProcessKind(fixture.0) != nil)
+            #expect(DarwinProcessEnumerator.isAntigravityCandidatePath(fixture.1))
+        }
+    }
+
+    #if canImport(Darwin)
+    @Test
+    func `self executable path is absolute and nonempty`() throws {
+        let path = try #require(DarwinProcessEnumerator.executablePath(pid: getpid()))
+
+        #expect(path.hasPrefix("/"))
+        #expect(!URL(fileURLWithPath: path).lastPathComponent.isEmpty)
+    }
+
+    @Test
+    func `self command line contains executable basename`() throws {
+        let path = try #require(DarwinProcessEnumerator.executablePath(pid: getpid()))
+        let command = try #require(DarwinProcessEnumerator.commandLine(pid: getpid()))
+
+        #expect(command.contains(URL(fileURLWithPath: path).lastPathComponent))
+    }
+
+    @Test
+    func `self bsd info reports parent and plausible start time`() throws {
+        let info = try #require(DarwinProcessEnumerator.bsdInfo(pid: getpid()))
+        let now = Date()
+
+        #expect(info.ppid == getppid())
+        #expect(info.startTime <= now)
+        #expect(info.startTime > Date.distantPast)
+    }
+
+    @Test
+    func `self current working directory matches file manager`() throws {
+        let currentDirectory = try #require(DarwinProcessEnumerator.currentWorkingDirectory(pid: getpid()))
+        let expected = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).standardizedFileURL.path
+        let actual = URL(fileURLWithPath: currentDirectory).standardizedFileURL.path
+
+        #expect(actual == expected)
+    }
+
+    @Test
+    func `self listening tcp ports include an open loopback listener`() throws {
+        let listener = try Self.openLoopbackListener()
+        defer { close(listener.fileDescriptor) }
+
+        #expect(DarwinProcessEnumerator.listeningTCPPorts(pid: getpid()).contains(listener.port))
+    }
+    #endif
+
+    private static func procArgsData(arguments: [String], environment: [String] = []) -> Data {
+        var data = Data(self.littleEndianBytes(Int32(arguments.count)))
+        data.append(contentsOf: "/usr/bin/exec".utf8)
+        data.append(0)
+        data.append(contentsOf: [0, 0])
+        for value in arguments + environment {
+            data.append(contentsOf: value.utf8)
+            data.append(0)
+        }
+        return data
+    }
+
+    private static func littleEndianBytes(_ value: Int32) -> [UInt8] {
+        withUnsafeBytes(of: value.littleEndian) { Array($0) }
+    }
+
+    #if canImport(Darwin)
+    private static func openLoopbackListener() throws -> (fileDescriptor: Int32, port: Int) {
+        let fileDescriptor = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+        guard fileDescriptor >= 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+
+        do {
+            var address = sockaddr_in()
+            address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+            address.sin_family = sa_family_t(AF_INET)
+            address.sin_port = 0
+            address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+            let bindResult = withUnsafePointer(to: &address) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                    Darwin.bind(fileDescriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_in>.size))
+                }
+            }
+            guard bindResult == 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+            guard listen(fileDescriptor, SOMAXCONN) == 0 else {
+                throw POSIXError(.init(rawValue: errno) ?? .EIO)
+            }
+
+            var addressLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let nameResult = withUnsafeMutablePointer(to: &address) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                    getsockname(fileDescriptor, socketAddress, &addressLength)
+                }
+            }
+            guard nameResult == 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+            return (fileDescriptor, Int(UInt16(bigEndian: address.sin_port)))
+        } catch {
+            close(fileDescriptor)
+            throw error
+        }
+    }
+    #endif
+}


### PR DESCRIPTION
## Summary

Replace CodexBar's full-system `ps -ax` / `lsof` subprocess scans with scoped in-process libproc/sysctl calls on macOS. On macOS 26 those subprocess spawns trigger the TCC "would like to access data from other apps" (`kTCCServiceSystemPolicyAppData`) dialog repeatedly — the enablement gating for the Antigravity probe already landed in #2277 (fixes #2267); this is the hardening layer so the remaining legitimate scans stop prompting.

## Changes

- New `DarwinProcessEnumerator` (CodexBarCore): `proc_listallpids`, `proc_pidpath`, `KERN_PROCARGS2` argv (defensive parser, environment excluded), `PROC_PIDTBSDINFO` ppid/start time, `PROC_PIDVNODEPATHINFO` cwd, and `PROC_PIDFDSOCKETINFO` listening-TCP-port lookup.
- `AntigravityStatusProbe.detectProcessInfos`: enumerates PIDs and reads argv **only** for executables whose path already looks like Antigravity (app/IDE/CLI/language-server, plus `node`/`bun` interpreters that can host `antigravity-cli`). A guard-rail test enforces that this prefilter stays a superset of the command-line classifier. With no Antigravity installed, zero foreign argv is read.
- `AntigravityStatusProbe.listeningPorts`: libproc socket inspection on macOS; `lsof`/`/proc` path unchanged on Linux.
- `LocalAgentSessionScanner`: the 30-second agent-session scan (`ps -axo pid,ppid,lstart,command` + `lsof` cwd lookups) moves in-process on macOS. This scan legitimately needs all-process argv (interpreter-hosted CLIs), but in-process syscalls give a single, sticky TCC attribution to CodexBar instead of re-spawned subprocesses that re-prompt every cycle.
- `SessionWindowFocuser.parentPID`: `proc_pidinfo` instead of spawning `ps`.
- Linux keeps its existing `ps`/`lsof`/`/proc` code paths and test seams untouched.

## Proof

- `swift build`, `make check` (SwiftFormat + SwiftLint strict) clean.
- `swift test --filter DarwinProcessEnumeratorTests` — 14/14, including a live self-process integration test that binds a loopback listener and finds its ephemeral port via `PROC_PIDFDSOCKETINFO`.
- `swift test --filter AntigravityStatusProbeTests` — 60/60.
- Full `make test` locally blocks on a pre-existing, unrelated hang (`WidgetSnapshotStore.load` stuck in `open()` inside `AdaptiveRefreshHeuristicsTests`; reproduces identically on a worktree without this commit) — tracked separately.

Refs #2267.
