### PR TITLE
Refresh widget SweetCookieKit lockfile

### DIFF
--- a/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/SweetCookieKit",
       "state" : {
-        "revision" : "21bedea672a3e63ccad24d744051e76cdf0462dd",
-        "version" : "0.4.1"
+        "revision" : "228c7927e03b85b25b41da23a44c4f5308519796",
+        "version" : "0.5.1"
       }
     },
     {


### PR DESCRIPTION
## Summary

- refresh the widget workspace's SweetCookieKit pin from 0.4.1 to 0.5.1
- match the root package requirement so packaging can keep automatic dependency resolution disabled

## Validation

- `xcodebuild -resolvePackageDependencies` changed only the SweetCookieKit pin
- production `Scripts/package_app.sh` completed with the widget extension
- deep signature verification passed for the packaged and installed app
- Peter-signed bundle installed at `/Applications/CodexBar.app` and relaunched successfully
- autoreview: clean, no accepted/actionable findings

This fixes the merged-main packaging failure discovered immediately after landing #2602.
