### PR TITLE
build: sync widget Package.resolved with root

### DIFF
--- a/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2c34a752ff5b5315e5bae001ccb84dbfa3f7ee7793a23b8862dbc8d096d771ba",
+  "originHash" : "6d8d9c11f3ca7164fa11aa5527a4ccb309a9175ecce14ff97c0f0eadf641afd1",
   "pins" : [
     {
       "identity" : "commander",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/SweetCookieKit",
       "state" : {
-        "revision" : "21bedea672a3e63ccad24d744051e76cdf0462dd",
-        "version" : "0.4.1"
+        "revision" : "228c7927e03b85b25b41da23a44c4f5308519796",
+        "version" : "0.5.1"
       }
     },
     {


### PR DESCRIPTION
Release packaging on main fails at the widget step: the widget workspace `Package.resolved` pins SweetCookieKit 0.4.1 while the root resolution moved to 0.5.1, and `package_app.sh` (correctly) refuses out-of-date resolved files with automatic resolution disabled.

Fix: refreshed via `xcodebuild -resolvePackageDependencies` on the widget project.

Verified: `./Scripts/package_app.sh release` completes end-to-end on main with this change (exit 0, `CodexBarWidget.appex` built and embedded). Also audited the script's widget failure path: it already exits non-zero and never produces a bundle on failure — an earlier stale-deploy incident was caused by an exit code masked behind a `| tail` pipeline in tooling, not by the script.
