### PR TITLE
fix: restore background Chromium cookie imports without Keychain prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.45.3 — Unreleased
 
 ### Fixed
+- Browser cookies: restore automatic Chromium cookie imports for background refreshes when the Safe Storage Keychain item is readable without interaction, keeping the read strictly non-interactive (SweetCookieKit 0.5.1). Cookie-only providers such as Kimi no longer report “No available fetch strategy” until a manual refresh, and background probes never write denial cooldowns that would suppress the next manual refresh.
 
 ## 0.45.2 — 2026-07-19
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d5ef2ec180d58ea5f869b40e5024f2e23d1ce02e999305b2e78d1b5c3783b83b",
+  "originHash" : "6c75943d484e197ee5463361d945dccbba8776ba5a340830e90099119bc1b18a",
   "pins" : [
     {
       "identity" : "commander",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/SweetCookieKit",
       "state" : {
-        "revision" : "21bedea672a3e63ccad24d744051e76cdf0462dd",
-        "version" : "0.4.1"
+        "revision" : "228c7927e03b85b25b41da23a44c4f5308519796",
+        "version" : "0.5.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let useLocalSweetCookieKit =
 let sweetCookieKitDependency: Package.Dependency =
     useLocalSweetCookieKit && FileManager.default.fileExists(atPath: sweetCookieKitPath)
     ? .package(path: sweetCookieKitPath)
-    : .package(url: "https://github.com/steipete/SweetCookieKit", from: "0.4.1")
+    : .package(url: "https://github.com/steipete/SweetCookieKit", from: "0.5.1")
 
 let sqlite3LibDir = ProcessInfo.processInfo.environment["CODEXBAR_SQLITE3_LIB_DIR"]?
     .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -87,10 +87,25 @@ public enum BrowserCookieAccessGate {
         guard browser.usesKeychainForCookieDecryption else { return true }
         guard !KeychainAccessGate.isDisabled else { return false }
         guard ProviderInteractionContext.current == .userInitiated else {
-            self.log.info(
-                "Skipping background Chromium cookie import to avoid a Keychain prompt",
-                metadata: ["browser": browser.displayName])
-            return false
+            // Background refreshes must never surface a Safe Storage prompt. The password
+            // read itself runs non-interactively (see `withCookieReadInteractionPolicy`),
+            // so a browser whose Safe Storage key requires interaction yields no cookies
+            // instead of prompting. The prompt-free attribute preflight below filters
+            // locked/denied keychain states, and background probes never record denials
+            // (a background probe must not suppress the user's next manual refresh).
+            if self.denialCooldownActive(for: browser, now: now) {
+                self.log.debug(
+                    "Cookie access blocked for background refresh",
+                    metadata: ["browser": browser.displayName])
+                return false
+            }
+            if self.chromiumKeychainRequiresInteraction(for: browser) {
+                self.log.debug(
+                    "Cookie access requires interaction; skipping background refresh",
+                    metadata: ["browser": browser.displayName])
+                return false
+            }
+            return true
         }
         if self.deniedBrowsersForTesting?.contains(browser) == true {
             return self.isExplicitRetryAllowed(for: browser)
@@ -184,6 +199,20 @@ public enum BrowserCookieAccessGate {
         }
     }
 
+    /// Runs a browser-cookie read with the Keychain interaction policy matched to the
+    /// current refresh context. Background refreshes must never be able to promote a no-UI
+    /// Safe Storage read to an interactive prompt, so SweetCookieKit is told to keep the
+    /// read strictly non-interactive (a key that needs UI simply yields no cookies);
+    /// user-initiated refreshes keep the interactive recovery path and its consent prompt.
+    public static func withCookieReadInteractionPolicy<T>(_ operation: () throws -> T) rethrows -> T {
+        if ProviderInteractionContext.current == .userInitiated {
+            return try operation()
+        }
+        return try BrowserCookieKeychainAccessGate.withUserInteractionDisallowed {
+            try operation()
+        }
+    }
+
     public static func recordIfNeeded(_ error: Error, now: Date = Date()) {
         guard let error = error as? BrowserCookieError else { return }
         guard case .accessDenied = error else { return }
@@ -191,6 +220,10 @@ public enum BrowserCookieAccessGate {
     }
 
     public static func recordDenied(for browser: Browser, now: Date = Date()) {
+        // Only user-initiated actions may write denial cooldowns. Background probes must
+        // not suppress a browser for hours (including the user's next manual refresh)
+        // based on a non-interactive probe outcome.
+        guard ProviderInteractionContext.current == .userInitiated else { return }
         guard browser.usesKeychainForCookieDecryption else { return }
         let blockedUntil = now.addingTimeInterval(self.cooldownInterval)
         self.lock.withLock { state in
@@ -217,6 +250,22 @@ public enum BrowserCookieAccessGate {
             state.deniedUntilByBrowser.removeValue(forKey: browser.rawValue)
             state.chromiumFamilyDeniedUntil = state.deniedUntilByBrowser.values.max()
             self.persist(state)
+            return false
+        }
+    }
+
+    /// Checks whether a recorded denial cooldown (per-browser or Chromium-family-wide)
+    /// is still active, without pruning expired entries. Used by the background path,
+    /// which reads the cooldown but never writes it.
+    private static func denialCooldownActive(for browser: Browser, now: Date) -> Bool {
+        self.lock.withLock { state in
+            self.loadIfNeeded(&state)
+            if let blockedUntil = state.deniedUntilByBrowser[browser.rawValue], blockedUntil > now {
+                return true
+            }
+            if let blockedUntil = state.chromiumFamilyDeniedUntil, blockedUntil > now {
+                return true
+            }
             return false
         }
     }
@@ -337,7 +386,9 @@ extension BrowserCookieClient {
         guard BrowserCookieAccessGate.shouldAttempt(browser) else { return [] }
         guard BrowserCookieAccessGate.claimExplicitRetryCookieReadIfNeeded(for: browser) else { return [] }
         do {
-            let records = try self.records(matching: query, in: browser, logger: logger)
+            let records = try BrowserCookieAccessGate.withCookieReadInteractionPolicy {
+                try self.records(matching: query, in: browser, logger: logger)
+            }
             BrowserCookieAccessGate.recordAllowed(for: browser)
             return records
         } catch {

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -270,7 +270,7 @@ struct BrowserDetectionTests {
     }
 
     @Test
-    func `background cookie import skips chromium before keychain preflight`() {
+    func `background cookie import allows chromium with allowed keychain preflight`() {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 
@@ -282,17 +282,20 @@ struct BrowserDetectionTests {
                 return .allowed
             } operation: {
                 ProviderInteractionContext.$current.withValue(.background) {
-                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == false)
+                    // Background refreshes may read Chromium cookies when the prompt-free
+                    // attribute preflight allows it; the read itself stays non-interactive
+                    // (see `withCookieReadInteractionPolicy`).
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == true)
                     #expect(BrowserCookieAccessGate.shouldAttempt(.safari) == true)
                 }
             }
         }
 
-        #expect(preflightCount == 0)
+        #expect(preflightCount == 1)
     }
 
     @Test
-    func `background cookie import skips chromium without probing keychain interaction`() {
+    func `background cookie import suppresses chromium when keychain preflight requires interaction`() {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 
@@ -304,13 +307,62 @@ struct BrowserDetectionTests {
                 return .interactionRequired
             } operation: {
                 ProviderInteractionContext.$current.withValue(.background) {
+                    // An interaction-required key is never read from background: the read
+                    // would either block or prompt, so the browser is skipped instead.
                     #expect(BrowserCookieAccessGate.shouldAttempt(.chrome) == false)
                     #expect(BrowserCookieAccessGate.shouldAttempt(.safari) == true)
                 }
             }
         }
 
-        #expect(preflightCount == 0)
+        #expect(preflightCount == 1)
+    }
+
+    @Test
+    func `background preflight does not record denial cooldown`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        let start = Date(timeIntervalSince1970: 1000)
+        KeychainAccessGate.withTaskOverrideForTesting(false) {
+            KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in
+                .interactionRequired
+            } operation: {
+                ProviderInteractionContext.$current.withValue(.background) {
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start) == false)
+                }
+            }
+            // A background probe must not suppress the user's next manual refresh.
+            ProviderInteractionContext.$current.withValue(.userInitiated) {
+                KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in
+                    .allowed
+                } operation: {
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(60)) == true)
+                }
+            }
+        }
+    }
+
+    @Test
+    func `background cookie reads run with keychain interaction disallowed`() {
+        // Regression: background refreshes must never be able to promote a no-UI Safe
+        // Storage read to an interactive Keychain prompt. The read policy wrapper must
+        // apply SweetCookieKit's interaction suppression outside user-initiated contexts.
+        var observedDisallowed: Bool?
+
+        ProviderInteractionContext.$current.withValue(.background) {
+            BrowserCookieAccessGate.withCookieReadInteractionPolicy {
+                observedDisallowed = BrowserCookieKeychainAccessGate.isUserInteractionDisallowed
+            }
+        }
+        #expect(observedDisallowed == true)
+
+        ProviderInteractionContext.$current.withValue(.userInitiated) {
+            BrowserCookieAccessGate.withCookieReadInteractionPolicy {
+                observedDisallowed = BrowserCookieKeychainAccessGate.isUserInteractionDisallowed
+            }
+        }
+        #expect(observedDisallowed == false)
     }
 
     @Test
@@ -322,9 +374,11 @@ struct BrowserDetectionTests {
         var preflightCount = 0
 
         KeychainAccessGate.withTaskOverrideForTesting(false) {
-            BrowserCookieAccessGate.recordIfNeeded(
-                BrowserCookieError.accessDenied(browser: .arc, details: "denied"),
-                now: start)
+            ProviderInteractionContext.$current.withValue(.userInitiated) {
+                BrowserCookieAccessGate.recordIfNeeded(
+                    BrowserCookieError.accessDenied(browser: .arc, details: "denied"),
+                    now: start)
+            }
             KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in
                 preflightCount += 1
                 return .allowed


### PR DESCRIPTION
## Summary

Restore automatic Chromium cookie imports for background refreshes without reintroducing Keychain prompts. Cookie-only providers such as Kimi currently report "No available fetch strategy for kimi." on every automatic refresh and only work after a manual refresh.

## Root cause

#2225 (17c8729b) blocked all background Chromium cookie access by returning `false` from `BrowserCookieAccessGate.shouldAttempt` whenever the interaction context is not `.userInitiated`. Periodic and menu-open refreshes run in `.background`, so a provider whose only credential path is browser cookies (no API key, no fresh CLI credential) reports `noAvailableStrategy` until the user performs a manual (`.userInitiated`) refresh. The #2225 review even flagged this: "users who rely on Chromium cookies for automatic provider refresh may receive stale usage or authentication failures until they perform a manual refresh."

#2225's own follow-up prescribed the fix: SweetCookieKit was hardened so hosts can suppress interactive Safe Storage promotion, and "once released, CodexBar should bump that dependency."

## Change

- **SweetCookieKit 0.4.1 → 0.5.1** — adds `BrowserCookieKeychainAccessGate.withUserInteractionDisallowed`, the hardening #2225 planned for.
- **`BrowserCookieAccessGate.shouldAttempt`** — background path now: honors recorded denial cooldowns, runs the prompt-free attribute preflight (skips when interaction is required), and allows the import otherwise, instead of blanket-skipping every Chromium browser.
- **`codexBarRecords`** — every cookie read goes through `withCookieReadInteractionPolicy`: background reads run with `withUserInteractionDisallowed` (SweetCookieKit can never promote to an interactive prompt; a key that needs UI simply yields no cookies), user-initiated reads keep the interactive recovery path.
- **`recordDenied`** — only user-initiated actions write denial cooldowns, so a background probe can never suppress the user's next manual refresh for 6h.
- Tests updated for the new background contract; regression tests added for the no-cooldown-poisoning and non-interactive-read guarantees.

## Safety

- No background path can surface a Safe Storage prompt: preflight is non-interactive, and the read itself is wrapped with `withUserInteractionDisallowed`.
- Background probes never write denial cooldowns (a background probe must not suppress the user's next manual refresh).
- Safari / Firefox / Zen behavior unchanged; user-initiated Chromium behavior unchanged.

## Validation

- `swift build --target CodexBarCore` and `CodexBarCLI` pass.
- Gate behavior verified against the real module with a scratch harness: 10/10 checks pass (background admits Chromium when the preflight allows, background reads disallow keychain interaction, background probes don't poison manual refresh, user-initiated denial/cooldown semantics preserved).
- SwiftFormat clean. Full Swift Testing suite runs in CI.
