### PR TITLE
test: make widget snapshot storage hermetic

### DIFF
--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -8,8 +8,11 @@ extension UsageStore {
     func persistWidgetSnapshot(reason: String) {
         #if DEBUG
         // Unsigned test processes must not cross into the real app-group container. Snapshot tests
-        // opt in with an in-memory override, which also keeps their assertions deterministic.
-        guard !SettingsStore.isRunningTests || self._test_widgetSnapshotSaveOverride != nil else { return }
+        // opt in with an in-memory save override or an injected file URL.
+        guard !SettingsStore.isRunningTests ||
+            self._test_widgetSnapshotSaveOverride != nil ||
+            self.widgetSnapshotURL != nil
+        else { return }
         #endif
         // A fresh process has token-cost data before a user-authorized Claude OAuth refresh can run.
         // Keep the last queued snapshot in memory so back-to-back writes cannot race the on-disk cache.
@@ -18,6 +21,9 @@ extension UsageStore {
             // Snapshot-save overrides must stay isolated from a developer's real app-group data.
             guard self._test_widgetSnapshotSaveOverride == nil else { return nil }
             #endif
+            if let widgetSnapshotURL = self.widgetSnapshotURL {
+                return WidgetSnapshotStore.load(from: widgetSnapshotURL)
+            }
             return WidgetSnapshotStore.load()
         }()
         let snapshot = self.makeWidgetSnapshot(previousSnapshot: previousSnapshot)
@@ -34,8 +40,13 @@ extension UsageStore {
                 return
             }
 
+            let widgetSnapshotURL = self.widgetSnapshotURL
             await Task.detached(priority: .utility) {
-                WidgetSnapshotStore.save(snapshot)
+                if let widgetSnapshotURL {
+                    WidgetSnapshotStore.save(snapshot, to: widgetSnapshotURL)
+                } else {
+                    WidgetSnapshotStore.save(snapshot)
+                }
             }.value
             #if canImport(WidgetKit)
             WidgetCenter.shared.reloadAllTimelines()

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -300,6 +300,7 @@ final class UsageStore {
         TimeInterval) async throws -> Void)?
     @ObservationIgnored var widgetSnapshotPersistTask: Task<Void, Never>?
     @ObservationIgnored var lastQueuedWidgetSnapshot: WidgetSnapshot?
+    @ObservationIgnored let widgetSnapshotURL: URL?
     @ObservationIgnored var widgetUsagePreservationBlockedProviders: Set<UsageProvider> = []
 
     @ObservationIgnored let codexFetcher: UsageFetcher
@@ -457,6 +458,7 @@ final class UsageStore {
         sessionQuotaNotifier: any SessionQuotaNotifying = SessionQuotaNotifier(),
         startupBehavior: StartupBehavior = .automatic,
         environmentBase: [String: String] = ProcessInfo.processInfo.environment,
+        widgetSnapshotURL: URL? = nil,
         planUtilizationHistoryLoadGateForTesting: PlanUtilizationHistoryLoadGate? = nil)
     {
         self.codexFetcher = fetcher
@@ -466,6 +468,7 @@ final class UsageStore {
         self.settings = settings
         self.registry = registry
         self.environmentBase = environmentBase
+        self.widgetSnapshotURL = widgetSnapshotURL
         self.historicalUsageHistoryStore = historicalUsageHistoryStore
         self.startupBehavior = startupBehavior.resolved(isRunningTests: Self.isRunningTestsProcess())
         let planHistoryStore = Self.resolvedPlanHistoryStore(planUtilizationHistoryStore, startup: self.startupBehavior)

--- a/Sources/CodexBarCore/WidgetSnapshot.swift
+++ b/Sources/CodexBarCore/WidgetSnapshot.swift
@@ -187,13 +187,19 @@ public enum WidgetSnapshotStore {
     private static let filename = AppGroupSupport.widgetSnapshotFilename
 
     public static func load(bundleID: String? = Bundle.main.bundleIdentifier) -> WidgetSnapshot? {
-        let url = self.snapshotURL(bundleID: bundleID)
+        self.load(from: self.snapshotURL(bundleID: bundleID))
+    }
+
+    public static func load(from url: URL) -> WidgetSnapshot? {
         guard let data = try? Data(contentsOf: url) else { return nil }
         return try? self.decoder.decode(WidgetSnapshot.self, from: data)
     }
 
     public static func save(_ snapshot: WidgetSnapshot, bundleID: String? = Bundle.main.bundleIdentifier) {
-        let url = self.snapshotURL(bundleID: bundleID)
+        self.save(snapshot, to: self.snapshotURL(bundleID: bundleID))
+    }
+
+    public static func save(_ snapshot: WidgetSnapshot, to url: URL) {
         do {
             let data = try self.encoder.encode(snapshot)
             try data.write(to: url, options: [.atomic])

--- a/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
@@ -22,6 +22,8 @@ struct CodexAccountPromotionServiceTests {
         let targetAuthData = try container.managedAuthData(for: target)
         let result = try await container.makeService().promoteManagedAccount(id: target.id)
         let accounts = try container.loadAccounts().accounts
+        await container.usageStore.widgetSnapshotPersistTask?.value
+        let widgetSnapshot = WidgetSnapshotStore.load(from: container.widgetSnapshotURL)
 
         #expect(result.targetManagedAccountID == target.id)
         #expect(result.outcome == .promoted)
@@ -33,6 +35,7 @@ struct CodexAccountPromotionServiceTests {
         #expect(accounts.first?.id == target.id)
         #expect(container.settings.codexActiveSource == .liveSystem)
         #expect(container.usageStore.snapshots[.codex]?.accountEmail(for: .codex) == "beta@example.com")
+        #expect(widgetSnapshot?.entries.contains(where: { $0.provider == .codex }) == true)
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
@@ -9,6 +9,7 @@ final class CodexAccountPromotionTestContainer {
     let liveHomeURL: URL
     let managedHomesURL: URL
     let managedStoreURL: URL
+    let widgetSnapshotURL: URL
     let settings: SettingsStore
     let usageStore: UsageStore
     let fileStore: FileManagedCodexAccountStore
@@ -28,6 +29,7 @@ final class CodexAccountPromotionTestContainer {
         self.liveHomeURL = self.rootURL.appendingPathComponent("liveHome", isDirectory: true)
         self.managedHomesURL = self.rootURL.appendingPathComponent("managed-codex-homes", isDirectory: true)
         self.managedStoreURL = self.rootURL.appendingPathComponent("managed-codex-accounts.json", isDirectory: false)
+        self.widgetSnapshotURL = self.rootURL.appendingPathComponent("widget-snapshot.json", isDirectory: false)
         self.baseEnvironment = ["CODEX_HOME": self.liveHomeURL.path]
         self.fileStore = FileManagedCodexAccountStore(fileURL: self.managedStoreURL, fileManager: .default)
         self.homeFactory = ManagedCodexHomeFactory(root: self.managedHomesURL, fileManager: .default)
@@ -60,7 +62,8 @@ final class CodexAccountPromotionTestContainer {
             fetcher: UsageFetcher(environment: [:]),
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: self.settings,
-            startupBehavior: .testing)
+            startupBehavior: .testing,
+            widgetSnapshotURL: self.widgetSnapshotURL)
         self.installDynamicCodexUsageLoader()
         self.usageStore._test_codexCreditsLoaderOverride = {
             CreditsSnapshot(remaining: 17, events: [], updatedAt: Date())


### PR DESCRIPTION
## Summary

- add explicit URL-based load/save entry points to `WidgetSnapshotStore` while preserving the existing App Group defaults
- let `UsageStore` accept an injected widget snapshot URL and use it for both prior-snapshot reads and persisted writes
- route Codex account promotion tests through their temporary test container and verify the resulting widget snapshot there

## Test plan

- `swift test --filter CodexAccountPromotionServiceTests`
- `make check`
- `make test`
- Codex autoreview: clean, no accepted/actionable findings
