### PR TITLE
feat: declarative provider detail sections + JS detail providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Kimi/GLM: distinguish Kimi Code from the regional Open Platform, bind China and international keys to their issuing hosts, and show GLM Coding Plan's 5-hour window as primary with MCP separate (#2351). Thanks @Leehow!
+- Provider plugins: declarative detail rows/charts plus bundled JavaScript conversions for OpenAI, z.ai, OpenRouter, Poe, and ClawRouter behind `CODEXBAR_JS_PROVIDERS=1`.
 
 ### Changed
 - Menu: move each usage window's used percentage and reset time into its title row, with all pace detail on one line (#2182). Thanks @jack24254029!

--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import Foundation
 
 extension UsageMenuCardView.Model {
@@ -22,6 +23,7 @@ extension UsageMenuCardView.Model {
             "codexResetCredits=\(self.codexResetCredits?.heightFingerprint ?? "")",
             "metrics=\(MenuCardHeightFingerprint.join(self.metrics.map(\.heightFingerprint)))",
             "notes=\(notesFingerprint)",
+            "providerDetails=\(self.providerDetails.heightFingerprint)",
             "dashboard=\(self.inlineUsageDashboard?.heightFingerprint ?? "")",
             "providerCost=\(self.providerCost?.heightFingerprint ?? "")",
             "tokenUsage=\(self.tokenUsage?.heightFingerprint ?? "")",
@@ -31,6 +33,31 @@ extension UsageMenuCardView.Model {
 
     static func heightFingerprintField(_ name: String, _ value: String?) -> String {
         MenuCardHeightFingerprint.field(name, value)
+    }
+}
+
+extension [ProviderDetailSection] {
+    fileprivate var heightFingerprint: String {
+        MenuCardHeightFingerprint.join(self.map { section in
+            MenuCardHeightFingerprint.join([
+                MenuCardHeightFingerprint.field("title", section.title),
+                MenuCardHeightFingerprint.join(section.rows.map { row in
+                    MenuCardHeightFingerprint.join([
+                        MenuCardHeightFingerprint.field("label", row.label),
+                        MenuCardHeightFingerprint.field("value", row.value),
+                        MenuCardHeightFingerprint.field("secondary", row.secondaryValue),
+                    ])
+                }),
+                section.chart.map { chart in
+                    MenuCardHeightFingerprint.join([
+                        chart.kind.rawValue,
+                        MenuCardHeightFingerprint.field("title", chart.title),
+                        MenuCardHeightFingerprint.field("unit", chart.unit),
+                        "points=\(chart.points.count)",
+                    ])
+                } ?? "chart=nil",
+            ])
+        })
     }
 }
 

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -279,6 +279,7 @@ extension UsageMenuCardView.Model {
         self.subtitleStyle == .error &&
             self.metrics.isEmpty &&
             self.usageNotes.isEmpty &&
+            self.providerDetails.isEmpty &&
             self.openAIAPIUsage == nil &&
             self.inlineUsageDashboard == nil &&
             self.creditsRemaining == nil &&
@@ -290,6 +291,7 @@ extension UsageMenuCardView.Model {
     var hasUsageContent: Bool {
         !self.metrics.isEmpty ||
             !self.usageNotes.isEmpty ||
+            !self.providerDetails.isEmpty ||
             self.openAIAPIUsage != nil ||
             self.inlineUsageDashboard != nil ||
             self.codexResetCredits != nil ||
@@ -301,6 +303,7 @@ extension UsageMenuCardView.Model {
             self.inlineUsageDashboard != nil &&
             self.metrics.isEmpty &&
             self.usageNotes.isEmpty &&
+            self.providerDetails.isEmpty &&
             self.openAIAPIUsage == nil &&
             self.codexResetCredits == nil &&
             self.placeholder == nil
@@ -337,6 +340,7 @@ extension UsageMenuCardView.Model {
         guard self.provider == candidate.provider,
               !includeMetrics || self.metrics.count == candidate.metrics.count,
               self.usageNotes == candidate.usageNotes,
+              self.providerDetails == candidate.providerDetails,
               (self.openAIAPIUsage == nil) == (candidate.openAIAPIUsage == nil),
               Self.hasCompatibleCreditsLayout(
                   currentText: self.creditsText,

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -162,6 +162,7 @@ struct UsageMenuCardView: View {
         let metrics: [Metric]
         let usageNotes: [String]
         var subscriptionNotes: [String] = []
+        var providerDetails: [ProviderDetailSection] = []
         let openAIAPIUsage: OpenAIAPIUsageSnapshot?
         let inlineUsageDashboard: InlineUsageDashboardModel?
         let creditsText: String?
@@ -213,6 +214,11 @@ struct UsageMenuCardView: View {
                     Text(placeholder)
                         .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
                         .font(.subheadline)
+                }
+                if !liveModel.providerDetails.isEmpty {
+                    ProviderDetailSectionsContent(
+                        sections: liveModel.providerDetails,
+                        chartColor: liveModel.progressColor)
                 }
             } else {
                 let hasUsage = liveModel.hasUsageContent
@@ -674,6 +680,11 @@ private struct UsageMenuCardUsageContentView: View {
                     .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
                     .font(.subheadline)
             }
+            if !self.model.providerDetails.isEmpty {
+                ProviderDetailSectionsContent(
+                    sections: self.model.providerDetails,
+                    chartColor: self.model.progressColor)
+            }
             if self.showBottomDivider {
                 Divider()
             }
@@ -960,6 +971,7 @@ extension UsageMenuCardView.Model {
             metrics: metrics,
             usageNotes: usageNotes,
             subscriptionNotes: Self.subscriptionMetadataNotes(snapshot: input.snapshot, provider: input.provider),
+            providerDetails: input.snapshot?.details ?? [],
             openAIAPIUsage: openAIAPIUsage,
             inlineUsageDashboard: inlineUsageDashboard,
             creditsText: creditsText,

--- a/Sources/CodexBar/ProviderDetailSectionsContent.swift
+++ b/Sources/CodexBar/ProviderDetailSectionsContent.swift
@@ -1,0 +1,168 @@
+import CodexBarCore
+import SwiftUI
+
+struct ProviderDetailSectionsContent: View {
+    let sections: [ProviderDetailSection]
+    let chartColor: Color
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(Array(self.sections.enumerated()), id: \.offset) { index, section in
+                if index > 0 {
+                    Divider()
+                }
+                self.section(section)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func section(_ section: ProviderDetailSection) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let title = section.title {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    .textCase(.uppercase)
+                    .lineLimit(1)
+            }
+            ForEach(Array(section.rows.enumerated()), id: \.offset) { _, row in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(row.label)
+                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    Spacer(minLength: 8)
+                    VStack(alignment: .trailing, spacing: 1) {
+                        Text(row.value)
+                            .foregroundStyle(MenuHighlightStyle.primary(self.isHighlighted))
+                            .fontWeight(.medium)
+                        if let secondaryValue = row.secondaryValue {
+                            Text(secondaryValue)
+                                .font(.caption2)
+                                .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                        }
+                    }
+                }
+                .font(.caption)
+                .lineLimit(1)
+            }
+            if let chart = section.chart {
+                ProviderDetailChartContent(chart: chart, color: self.chartColor)
+            }
+        }
+    }
+}
+
+private struct ProviderDetailChartContent: View {
+    let chart: ProviderDetailSection.Chart
+    let color: Color
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            if self.chart.title != nil || self.chart.unit != nil {
+                HStack(spacing: 6) {
+                    if let title = self.chart.title {
+                        Text(title)
+                            .font(.caption2.weight(.semibold))
+                    }
+                    Spacer(minLength: 0)
+                    if let unit = self.chart.unit {
+                        Text(unit)
+                            .font(.caption2)
+                            .monospacedDigit()
+                    }
+                }
+                .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                .lineLimit(1)
+            }
+            Group {
+                switch self.chart.kind {
+                case .bars:
+                    self.bars
+                case .line:
+                    self.line
+                }
+            }
+            .frame(height: 58)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(self.accessibilityLabel)
+        }
+    }
+
+    private var bars: some View {
+        GeometryReader { geometry in
+            let scale = UsageChartScale(values: self.chart.points.map(\.value))
+            HStack(alignment: .bottom, spacing: 2) {
+                ForEach(Array(self.chart.points.enumerated()), id: \.offset) { _, point in
+                    RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                        .fill(self.fillColor(value: point.value, scale: scale))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: Self.height(value: point.value, scale: scale, available: geometry.size.height))
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+            .overlay(alignment: .bottomLeading) {
+                Rectangle()
+                    .fill(MenuHighlightStyle.secondary(self.isHighlighted).opacity(0.22))
+                    .frame(height: 1)
+            }
+        }
+    }
+
+    private var line: some View {
+        GeometryReader { _ in
+            Canvas { context, size in
+                let scale = UsageChartScale(values: self.chart.points.map(\.value))
+                let points = self.chart.points.enumerated().map { index, point in
+                    let x = self.chart.points.count == 1
+                        ? size.width / 2
+                        : size.width * CGFloat(index) / CGFloat(self.chart.points.count - 1)
+                    let y = size.height * (1 - CGFloat(scale.fraction(for: point.value)))
+                    return CGPoint(x: x, y: y)
+                }
+                guard let first = points.first else { return }
+                var path = Path()
+                path.move(to: first)
+                for point in points.dropFirst() {
+                    path.addLine(to: point)
+                }
+                context.stroke(
+                    path,
+                    with: .color(self.isHighlighted ? .white.opacity(0.82) : self.color),
+                    style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+                for point in points {
+                    context.fill(
+                        Path(ellipseIn: CGRect(x: point.x - 1.5, y: point.y - 1.5, width: 3, height: 3)),
+                        with: .color(self.isHighlighted ? .white : self.color))
+                }
+            }
+            .overlay(alignment: .bottomLeading) {
+                Rectangle()
+                    .fill(MenuHighlightStyle.secondary(self.isHighlighted).opacity(0.22))
+                    .frame(height: 1)
+            }
+        }
+    }
+
+    private var accessibilityLabel: String {
+        let title = self.chart.title.map { "\($0): " } ?? ""
+        let unit = self.chart.unit.map { " \($0)" } ?? ""
+        let points = self.chart.points.map { "\($0.label) \($0.value)\(unit)" }.joined(separator: ", ")
+        return title + points
+    }
+
+    private func fillColor(value: Double, scale: UsageChartScale) -> Color {
+        let ratio = max(0.18, scale.fraction(for: value))
+        if self.isHighlighted {
+            return Color.white.opacity(0.55 + ratio * 0.35)
+        }
+        return self.color.opacity(0.42 + ratio * 0.58)
+    }
+
+    private static func height(value: Double, scale: UsageChartScale, available: CGFloat) -> CGFloat {
+        let ratio = scale.fraction(for: value)
+        guard ratio > 0 else { return 1 }
+        return max(3, CGFloat(ratio) * available)
+    }
+}

--- a/Sources/CodexBarCore/Plugins/ProviderPluginSnapshotMapper.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginSnapshotMapper.swift
@@ -15,14 +15,16 @@ enum ProviderPluginSnapshotMapper {
         let tertiary = try self.window(value, property: "tertiary")
         let extraRateWindows = try self.extraWindows(value)
         let providerCost = try self.cost(value, now: now)
+        let details = try self.details(value)
         let identity = try self.identity(value, provider: provider)
         let subscriptionRenewsAt = try self.optionalDate(value, property: "subscriptionRenewsAt")
         let subscriptionExpiresAt = try self.optionalDate(value, property: "subscriptionExpiresAt")
 
         guard primary != nil || secondary != nil || tertiary != nil || !(extraRateWindows?.isEmpty ?? true)
             || providerCost != nil
+            || !details.isEmpty
         else {
-            throw ProviderPluginError.invalidSnapshot("snapshot must contain at least one rate window or cost")
+            throw ProviderPluginError.invalidSnapshot("snapshot must contain at least one rate window, cost, or detail")
         }
 
         return UsageSnapshot(
@@ -31,10 +33,105 @@ enum ProviderPluginSnapshotMapper {
             tertiary: tertiary,
             extraRateWindows: extraRateWindows,
             providerCost: providerCost,
+            details: details,
             subscriptionExpiresAt: subscriptionExpiresAt,
             subscriptionRenewsAt: subscriptionRenewsAt,
             updatedAt: now,
             identity: identity)
+    }
+
+    private static func details(_ root: JSValue) throws -> [ProviderDetailSection] {
+        guard let value = root.forProperty("details"), !value.isUndefined, !value.isNull else { return [] }
+        guard value.isArray else {
+            throw ProviderPluginError.invalidSnapshot("details must be an array")
+        }
+        let count = Int(value.forProperty("length")?.toInt32() ?? 0)
+        guard count <= ProviderDetailSection.maximumSectionsPerSnapshot else {
+            throw ProviderPluginError.invalidSnapshot(
+                "details exceeds \(ProviderDetailSection.maximumSectionsPerSnapshot) sections")
+        }
+        return try (0..<count).map { index in
+            guard let section = value.atIndex(index), section.isObject, !section.isArray else {
+                throw ProviderPluginError.invalidSnapshot("details[\(index)] must be an object")
+            }
+            let path = "details[\(index)]"
+            let title = try self.optionalDetailString(section, property: "title", path: path)
+            guard let rowsValue = section.forProperty("rows"), rowsValue.isArray else {
+                throw ProviderPluginError.invalidSnapshot("\(path).rows must be an array")
+            }
+            let rowCount = Int(rowsValue.forProperty("length")?.toInt32() ?? 0)
+            guard rowCount <= ProviderDetailSection.maximumRowsPerSection else {
+                throw ProviderPluginError.invalidSnapshot(
+                    "\(path).rows exceeds \(ProviderDetailSection.maximumRowsPerSection) entries")
+            }
+            let rows = try (0..<rowCount).map { rowIndex in
+                guard let row = rowsValue.atIndex(rowIndex), row.isObject, !row.isArray else {
+                    throw ProviderPluginError.invalidSnapshot("\(path).rows[\(rowIndex)] must be an object")
+                }
+                let rowPath = "\(path).rows[\(rowIndex)]"
+                return try ProviderDetailSection.Row(
+                    label: self.requiredDetailString(row, property: "label", path: rowPath),
+                    value: self.requiredDetailString(row, property: "value", path: rowPath),
+                    secondaryValue: self.optionalDetailString(row, property: "secondaryValue", path: rowPath))
+            }
+            let chart = try self.detailChart(section, path: path)
+            return try ProviderDetailSection(title: title, rows: rows, chart: chart)
+        }
+    }
+
+    private static func detailChart(_ section: JSValue, path: String) throws -> ProviderDetailSection.Chart? {
+        guard let chart = section.forProperty("chart"), !chart.isUndefined, !chart.isNull else { return nil }
+        guard chart.isObject, !chart.isArray else {
+            throw ProviderPluginError.invalidSnapshot("\(path).chart must be an object")
+        }
+        let chartPath = "\(path).chart"
+        let rawKind = try self.requiredDetailString(chart, property: "kind", path: chartPath)
+        guard let kind = ProviderDetailSection.Chart.Kind(rawValue: rawKind) else {
+            throw ProviderPluginError.invalidSnapshot("\(chartPath).kind must be 'bars' or 'line'")
+        }
+        let title = try self.optionalDetailString(chart, property: "title", path: chartPath)
+        let unit = try self.optionalDetailString(chart, property: "unit", path: chartPath)
+        guard let pointsValue = chart.forProperty("points"), pointsValue.isArray else {
+            throw ProviderPluginError.invalidSnapshot("\(chartPath).points must be an array")
+        }
+        let pointCount = Int(pointsValue.forProperty("length")?.toInt32() ?? 0)
+        guard pointCount <= ProviderDetailSection.maximumPointsPerChart else {
+            throw ProviderPluginError.invalidSnapshot(
+                "\(chartPath).points exceeds \(ProviderDetailSection.maximumPointsPerChart) entries")
+        }
+        let points = try (0..<pointCount).map { pointIndex in
+            guard let point = pointsValue.atIndex(pointIndex), point.isObject, !point.isArray else {
+                throw ProviderPluginError.invalidSnapshot("\(chartPath).points[\(pointIndex)] must be an object")
+            }
+            let pointPath = "\(chartPath).points[\(pointIndex)]"
+            return try ProviderDetailSection.Chart.Point(
+                label: self.requiredDetailString(point, property: "label", path: pointPath),
+                value: self.requiredFiniteNumber(point, property: "value", path: pointPath))
+        }
+        return try ProviderDetailSection.Chart(kind: kind, title: title, unit: unit, points: points)
+    }
+
+    private static func requiredDetailString(_ value: JSValue, property: String, path: String) throws -> String {
+        guard let string = try self.optionalDetailString(value, property: property, path: path) else {
+            throw ProviderPluginError.invalidSnapshot("\(path).\(property) is required")
+        }
+        return string
+    }
+
+    private static func optionalDetailString(_ value: JSValue, property: String, path: String) throws -> String? {
+        guard let propertyValue = value.forProperty(property),
+              !propertyValue.isUndefined,
+              !propertyValue.isNull
+        else { return nil }
+        guard propertyValue.isString else {
+            throw ProviderPluginError.invalidSnapshot("\(path).\(property) must be a string")
+        }
+        let string = propertyValue.toString().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard string.count <= ProviderDetailSection.maximumStringLength else {
+            throw ProviderPluginError.invalidSnapshot(
+                "\(path).\(property) exceeds \(ProviderDetailSection.maximumStringLength) characters")
+        }
+        return string.isEmpty ? nil : string
     }
 
     private static func window(_ root: JSValue, property: String) throws -> RateWindow? {

--- a/Sources/CodexBarCore/Plugins/ScriptFetchStrategy.swift
+++ b/Sources/CodexBarCore/Plugins/ScriptFetchStrategy.swift
@@ -11,6 +11,7 @@ public enum ProviderPluginPrototype {
 
 public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendable {
     public typealias SecretResolver = @Sendable ([String: String]) -> String?
+    public typealias SecretsResolver = @Sendable (ProviderFetchContext) -> [String: String]?
     public typealias EnabledResolver = @Sendable ([String: String]) -> Bool
 
     public let id: String
@@ -19,7 +20,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
     private let provider: UsageProvider
     private let bundledPlugin: String
     private let secretKey: String
-    private let resolveSecret: SecretResolver
+    private let resolveSecrets: SecretsResolver
     private let isEnabled: EnabledResolver
     private let transport: any ProviderHTTPTransport
     private let timeout: TimeInterval
@@ -42,19 +43,43 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         self.secretKey = secretKey
         self.transport = transport
         self.timeout = timeout
-        self.resolveSecret = resolveSecret
+        self.resolveSecrets = { context in
+            guard let secret = resolveSecret(context.env) else { return nil }
+            return [secretKey: secret]
+        }
+        self.isEnabled = isEnabled
+    }
+
+    public init(
+        id: String,
+        provider: UsageProvider,
+        bundledPlugin: String,
+        secretKey: String,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
+        resolveSecrets: @escaping SecretsResolver,
+        isEnabled: @escaping EnabledResolver = { ProviderPluginPrototype.isEnabled(environment: $0) })
+    {
+        self.id = id
+        self.provider = provider
+        self.bundledPlugin = bundledPlugin
+        self.secretKey = secretKey
+        self.transport = transport
+        self.timeout = timeout
+        self.resolveSecrets = resolveSecrets
         self.isEnabled = isEnabled
     }
 
     public func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        self.isEnabled(context.env) && self.resolveSecret(context.env) != nil
+        guard self.isEnabled(context.env), let secrets = self.resolveSecrets(context) else { return false }
+        return secrets[self.secretKey]?.isEmpty == false
     }
 
     public func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         guard self.isEnabled(context.env) else {
             throw ProviderPluginError.load("JavaScript provider prototype is disabled")
         }
-        guard let secret = self.resolveSecret(context.env) else {
+        guard let secrets = self.resolveSecrets(context), secrets[self.secretKey]?.isEmpty == false else {
             throw ProviderPluginError.secretAccess("required provider secret is unavailable")
         }
         let runtime = try self.loadedRuntime()
@@ -62,7 +87,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
             throw ProviderPluginError.invalidManifest(
                 "bundled plugin id '\(runtime.manifest.id.rawValue)' does not match '\(self.provider.rawValue)'")
         }
-        let usage = try await runtime.fetchUsage(secrets: [self.secretKey: secret])
+        let usage = try await runtime.fetchUsage(secrets: secrets)
         return self.makeResult(usage: usage, sourceLabel: "js")
     }
 

--- a/Sources/CodexBarCore/ProviderDetailSection.swift
+++ b/Sources/CodexBarCore/ProviderDetailSection.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+public struct ProviderDetailSection: Codable, Equatable, Sendable {
+    public static let maximumSectionsPerSnapshot = 8
+    public static let maximumRowsPerSection = 24
+    public static let maximumPointsPerChart = 120
+    public static let maximumStringLength = 120
+
+    public struct Row: Codable, Equatable, Sendable {
+        public let label: String
+        public let value: String
+        public let secondaryValue: String?
+
+        public init(label: String, value: String, secondaryValue: String? = nil) throws {
+            self.label = try ProviderDetailSection.requiredString(label, path: "row.label")
+            self.value = try ProviderDetailSection.requiredString(value, path: "row.value")
+            self.secondaryValue = try ProviderDetailSection.optionalString(secondaryValue, path: "row.secondaryValue")
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case label
+            case value
+            case secondaryValue
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            try self.init(
+                label: container.decode(String.self, forKey: .label),
+                value: container.decode(String.self, forKey: .value),
+                secondaryValue: container.decodeIfPresent(String.self, forKey: .secondaryValue))
+        }
+    }
+
+    public struct Chart: Codable, Equatable, Sendable {
+        public enum Kind: String, Codable, Equatable, Sendable {
+            case bars
+            case line
+        }
+
+        public struct Point: Codable, Equatable, Sendable {
+            public let label: String
+            public let value: Double
+
+            public init(label: String, value: Double) throws {
+                self.label = try ProviderDetailSection.requiredString(label, path: "chart.point.label")
+                guard value.isFinite else {
+                    throw ValidationError("chart.point.value must be finite")
+                }
+                self.value = value
+            }
+
+            private enum CodingKeys: String, CodingKey {
+                case label
+                case value
+            }
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                try self.init(
+                    label: container.decode(String.self, forKey: .label),
+                    value: container.decode(Double.self, forKey: .value))
+            }
+        }
+
+        public let kind: Kind
+        public let title: String?
+        public let unit: String?
+        public let points: [Point]
+
+        public init(kind: Kind, title: String? = nil, unit: String? = nil, points: [Point]) throws {
+            guard points.count <= ProviderDetailSection.maximumPointsPerChart else {
+                throw ValidationError(
+                    "chart.points exceeds \(ProviderDetailSection.maximumPointsPerChart) entries")
+            }
+            self.kind = kind
+            self.title = try ProviderDetailSection.optionalString(title, path: "chart.title")
+            self.unit = try ProviderDetailSection.optionalString(unit, path: "chart.unit")
+            self.points = points
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case kind
+            case title
+            case unit
+            case points
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            try self.init(
+                kind: container.decode(Kind.self, forKey: .kind),
+                title: container.decodeIfPresent(String.self, forKey: .title),
+                unit: container.decodeIfPresent(String.self, forKey: .unit),
+                points: container.decode([Point].self, forKey: .points))
+        }
+    }
+
+    public struct ValidationError: LocalizedError, Equatable, Sendable {
+        public let message: String
+
+        public init(_ message: String) {
+            self.message = message
+        }
+
+        public var errorDescription: String? {
+            self.message
+        }
+    }
+
+    public let title: String?
+    public let rows: [Row]
+    public let chart: Chart?
+
+    public init(title: String? = nil, rows: [Row] = [], chart: Chart? = nil) throws {
+        guard rows.count <= Self.maximumRowsPerSection else {
+            throw ValidationError("section.rows exceeds \(Self.maximumRowsPerSection) entries")
+        }
+        self.title = try Self.optionalString(title, path: "section.title")
+        self.rows = rows
+        self.chart = chart
+    }
+
+    public static func validateSections(_ sections: [Self]) throws {
+        guard sections.count <= self.maximumSectionsPerSnapshot else {
+            throw ValidationError("snapshot.details exceeds \(self.maximumSectionsPerSnapshot) sections")
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case rows
+        case chart
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            title: container.decodeIfPresent(String.self, forKey: .title),
+            rows: container.decode([Row].self, forKey: .rows),
+            chart: container.decodeIfPresent(Chart.self, forKey: .chart))
+    }
+
+    private static func requiredString(_ rawValue: String, path: String) throws -> String {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else {
+            throw ValidationError("\(path) must not be empty")
+        }
+        guard value.count <= Self.maximumStringLength else {
+            throw ValidationError("\(path) exceeds \(Self.maximumStringLength) characters")
+        }
+        return value
+    }
+
+    private static func optionalString(_ rawValue: String?, path: String) throws -> String? {
+        guard let rawValue else { return nil }
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard value.count <= Self.maximumStringLength else {
+            throw ValidationError("\(path) exceeds \(Self.maximumStringLength) characters")
+        }
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
@@ -33,13 +33,35 @@ public enum ClawRouterProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "ClawRouter spend is reported by its usage API." }),
-            fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .api],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [ClawRouterAPIFetchStrategy()] })),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "clawrouter",
                 aliases: ["claw-router"],
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        #if canImport(JavaScriptCore)
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                let swift = ClawRouterAPIFetchStrategy()
+                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
+                return [
+                    ScriptFetchStrategy(
+                        id: "clawrouter.js",
+                        provider: .clawrouter,
+                        bundledPlugin: "clawrouter",
+                        secretKey: ClawRouterSettingsReader.apiKeyEnvironmentKey,
+                        resolveSecret: { ProviderTokenResolver.clawRouterToken(environment: $0) }),
+                    swift,
+                ]
+            }))
+        #else
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [ClawRouterAPIFetchStrategy()] }))
+        #endif
     }
 }
 

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIProviderDescriptor.swift
@@ -35,13 +35,46 @@ public enum OpenAIAPIProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: true,
                 noDataMessage: { "OpenAI usage needs an Admin API key for organization usage." }),
-            fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .api],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [OpenAIAPIBalanceFetchStrategy()] })),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "openai",
                 aliases: ["openai-api"],
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        #if canImport(JavaScriptCore)
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                let swift = OpenAIAPIBalanceFetchStrategy()
+                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
+                return [
+                    ScriptFetchStrategy(
+                        id: "openai.js",
+                        provider: .openai,
+                        bundledPlugin: "openai",
+                        secretKey: OpenAIAPISettingsReader.apiKeyEnvironmentKey,
+                        resolveSecrets: { context in
+                            guard let credential = OpenAIAPIUsageCredential(environment: context.env)
+                            else { return nil }
+                            var values = [OpenAIAPISettingsReader.apiKeyEnvironmentKey: credential.apiKey]
+                            if let projectID = credential.projectID {
+                                values[OpenAIAPISettingsReader.projectIDEnvironmentKey] = projectID
+                            }
+                            values["OPENAI_HISTORY_DAYS"] = String(context.costUsageHistoryDays)
+                            values["OPENAI_ALLOW_BALANCE_FALLBACK"] =
+                                credential.allowsLegacyBalanceFallback ? "1" : "0"
+                            return values
+                        }),
+                    swift,
+                ]
+            }))
+        #else
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [OpenAIAPIBalanceFetchStrategy()] }))
+        #endif
     }
 }
 

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterProviderDescriptor.swift
@@ -36,19 +36,39 @@ public enum OpenRouterProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "OpenRouter cost summary is not yet supported." }),
-            fetchPlan: .apiToken(
-                strategyID: "openrouter.api",
-                resolveToken: { ProviderTokenResolver.openRouterToken(environment: $0) },
-                missingCredentialsError: { OpenRouterSettingsError.missingToken },
-                loadUsage: { apiKey, context in
-                    try await OpenRouterUsageFetcher.fetchUsage(
-                        apiKey: apiKey,
-                        environment: context.env).toUsageSnapshot()
-                }),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "openrouter",
                 aliases: ["or"],
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        #if canImport(JavaScriptCore)
+        .scriptPrototypeAPI(
+            configuration: .init(
+                provider: .openrouter,
+                plugin: "openrouter",
+                secretKey: OpenRouterSettingsReader.envKey,
+                strategyID: "openrouter.api"),
+            resolveToken: { ProviderTokenResolver.openRouterToken(environment: $0) },
+            missingCredentialsError: { OpenRouterSettingsError.missingToken },
+            loadUsage: { apiKey, context in
+                try await OpenRouterUsageFetcher.fetchUsage(
+                    apiKey: apiKey,
+                    environment: context.env).toUsageSnapshot()
+            })
+        #else
+        .apiToken(
+            strategyID: "openrouter.api",
+            resolveToken: { ProviderTokenResolver.openRouterToken(environment: $0) },
+            missingCredentialsError: { OpenRouterSettingsError.missingToken },
+            loadUsage: { apiKey, context in
+                try await OpenRouterUsageFetcher.fetchUsage(
+                    apiKey: apiKey,
+                    environment: context.env).toUsageSnapshot()
+            })
+        #endif
     }
 }
 

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
@@ -220,7 +220,8 @@ public struct OpenRouterUsageFetcher: Sendable {
     /// Fetches credits usage from OpenRouter using the provided API key
     public static func fetchUsage(
         apiKey: String,
-        environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> OpenRouterUsageSnapshot
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> OpenRouterUsageSnapshot
     {
         guard !apiKey.isEmpty else {
             throw OpenRouterUsageError.invalidCredentials
@@ -241,7 +242,7 @@ public struct OpenRouterUsageFetcher: Sendable {
         let title = Self.sanitizedHeaderValue(environment[self.clientTitleEnvKey]) ?? Self.defaultClientTitle
         request.setValue(title, forHTTPHeaderField: "X-Title")
 
-        let response = try await ProviderHTTPClient.shared.response(for: request)
+        let response = try await transport.response(for: request)
         let data = response.data
         guard response.statusCode == 200 else {
             let errorSummary = LogRedactor.redact(Self.sanitizedResponseBodySummary(data))
@@ -263,7 +264,8 @@ public struct OpenRouterUsageFetcher: Sendable {
             let keyFetch = try await fetchKeyData(
                 apiKey: apiKey,
                 baseURL: baseURL,
-                timeoutSeconds: Self.rateLimitTimeoutSeconds)
+                timeoutSeconds: Self.rateLimitTimeoutSeconds,
+                transport: transport)
 
             return OpenRouterUsageSnapshot(
                 totalCredits: creditsResponse.data.totalCredits,
@@ -300,14 +302,16 @@ public struct OpenRouterUsageFetcher: Sendable {
     private static func fetchKeyData(
         apiKey: String,
         baseURL: URL,
-        timeoutSeconds: TimeInterval) async throws -> OpenRouterKeyFetchResult
+        timeoutSeconds: TimeInterval,
+        transport: any ProviderHTTPTransport) async throws -> OpenRouterKeyFetchResult
     {
         let timeout = max(0.1, timeoutSeconds)
         return try await self.boundedKeyFetch(timeout: .seconds(timeout)) {
             await Self.fetchKeyDataRequest(
                 apiKey: apiKey,
                 baseURL: baseURL,
-                timeoutSeconds: timeout)
+                timeoutSeconds: timeout,
+                transport: transport)
         }
     }
 
@@ -348,7 +352,8 @@ public struct OpenRouterUsageFetcher: Sendable {
     private static func fetchKeyDataRequest(
         apiKey: String,
         baseURL: URL,
-        timeoutSeconds: TimeInterval) async -> OpenRouterKeyFetchResult
+        timeoutSeconds: TimeInterval,
+        transport: any ProviderHTTPTransport) async -> OpenRouterKeyFetchResult
     {
         let keyURL = baseURL.appendingPathComponent("key")
 
@@ -359,7 +364,7 @@ public struct OpenRouterUsageFetcher: Sendable {
         request.timeoutInterval = timeoutSeconds
 
         do {
-            let response = try await ProviderHTTPClient.shared.response(for: request)
+            let response = try await transport.response(for: request)
             guard response.statusCode == 200 else {
                 return OpenRouterKeyFetchResult(data: nil, fetched: false)
             }

--- a/Sources/CodexBarCore/Providers/Poe/PoeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Poe/PoeProviderDescriptor.swift
@@ -37,13 +37,31 @@ public enum PoeProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Poe usage history is unavailable." }),
-            fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .api],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [PoeAPIFetchStrategy()] })),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "poe",
                 aliases: [],
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        #if canImport(JavaScriptCore)
+        .scriptPrototypeAPI(
+            configuration: .init(
+                provider: .poe,
+                plugin: "poe",
+                secretKey: PoeSettingsReader.apiKeyEnvironmentKey,
+                strategyID: "poe.api"),
+            resolveToken: { ProviderTokenResolver.poeToken(environment: $0) },
+            missingCredentialsError: { PoeUsageError.missingCredentials },
+            loadUsage: { apiKey, _ in
+                try await PoeUsageFetcher.fetchUsage(apiKey: apiKey).toUsageSnapshot()
+            })
+        #else
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [PoeAPIFetchStrategy()] }))
+        #endif
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
@@ -34,23 +34,64 @@ public enum ZaiProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "z.ai cost summary is not supported." }),
-            fetchPlan: .apiToken(
-                strategyID: "zai.api",
-                resolveToken: { ProviderTokenResolver.zaiToken(environment: $0) },
-                missingCredentialsError: { ZaiSettingsError.missingToken },
-                loadUsage: { apiKey, context in
-                    let settings = context.settings?.zai
-                    let region = settings?.apiRegion ?? .global
-                    return try await ZaiUsageFetcher.fetchUsageWithModelUsage(
-                        apiKey: apiKey,
-                        region: region,
-                        usageScope: settings?.usageScope,
-                        teamContext: settings?.teamContext,
-                        environment: context.env).toUsageSnapshot()
-                }),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "zai",
                 aliases: ["z.ai"],
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        let loadUsage: APITokenFetchStrategy.UsageLoader = { apiKey, context in
+            let settings = context.settings?.zai
+            let region = settings?.apiRegion ?? .global
+            return try await ZaiUsageFetcher.fetchUsageWithModelUsage(
+                apiKey: apiKey,
+                region: region,
+                usageScope: settings?.usageScope,
+                teamContext: settings?.teamContext,
+                environment: context.env).toUsageSnapshot()
+        }
+        #if canImport(JavaScriptCore)
+        return ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                let swift = APITokenFetchStrategy(
+                    id: "zai.api",
+                    resolveToken: { ProviderTokenResolver.zaiToken(environment: $0) },
+                    missingCredentialsError: { ZaiSettingsError.missingToken },
+                    loadUsage: loadUsage)
+                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
+                return [
+                    ScriptFetchStrategy(
+                        id: "zai.js",
+                        provider: .zai,
+                        bundledPlugin: "zai",
+                        secretKey: ZaiSettingsReader.apiTokenKey,
+                        resolveSecrets: { context in
+                            guard let token = ProviderTokenResolver.zaiToken(environment: context.env)
+                            else { return nil }
+                            let settings = context.settings?.zai
+                            var values = [
+                                ZaiSettingsReader.apiTokenKey: token,
+                                "Z_AI_REGION": (settings?.apiRegion ?? .global).rawValue,
+                                "Z_AI_USAGE_SCOPE": (settings?.usageScope ?? .personal).rawValue,
+                            ]
+                            if let team = settings?.teamContext {
+                                values["Z_AI_ORGANIZATION"] = team.organizationID
+                                values["Z_AI_PROJECT"] = team.projectID
+                            }
+                            return values
+                        }),
+                    swift,
+                ]
+            }))
+        #else
+        return .apiToken(
+            strategyID: "zai.api",
+            resolveToken: { ProviderTokenResolver.zaiToken(environment: $0) },
+            missingCredentialsError: { ZaiSettingsError.missingToken },
+            loadUsage: loadUsage)
+        #endif
     }
 }

--- a/Sources/CodexBarCore/Resources/Plugins/clawrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/clawrouter.js
@@ -1,0 +1,129 @@
+defineProvider({
+  id: "clawrouter",
+  name: "ClawRouter",
+  endpoints: ["https://clawrouter.openclaw.ai"],
+  auth: { type: "bearer", secret: "CLAWROUTER_API_KEY" },
+  settings: [{
+    key: "CLAWROUTER_API_KEY",
+    title: "API key",
+    subtitle: "ClawRouter policy key used for the usage ledger.",
+    type: "secure",
+  }],
+
+  async fetchUsage(ctx) {
+    const response = await ctx.http.getJSON("https://clawrouter.openclaw.ai/v1/usage");
+    if (response.status === 401 || response.status === 403) {
+      throw new Error("ClawRouter rejected the API key");
+    }
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`ClawRouter API error: HTTP ${response.status}`);
+    }
+    const payload = response.json;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload) ||
+        !payload.budget || !payload.usage || !payload.usage.summary || !Array.isArray(payload.usage.providers)) {
+      throw new Error("Failed to parse ClawRouter usage response");
+    }
+
+    function integer(value, field) {
+      if (!Number.isInteger(value)) throw new Error(`ClawRouter ${field} must be an integer`);
+      return value;
+    }
+    function micros(value, field, optional) {
+      if (optional && (value === null || value === undefined)) return null;
+      return integer(value, field) / 1000000;
+    }
+    function monthlyReset(windowKey) {
+      if (typeof windowKey !== "string") return null;
+      const match = windowKey.match(/(\d{4})-(\d{2})$/);
+      if (!match) return null;
+      let year = Number(match[1]);
+      let month = Number(match[2]) + 1;
+      if (month === 13) { year += 1; month = 1; }
+      return ctx.date.iso(`${year}-${String(month).padStart(2, "0")}-01T00:00:00Z`);
+    }
+
+    const budget = payload.budget;
+    if (typeof budget.configured !== "boolean" || typeof budget.ledger !== "string") {
+      throw new Error("Failed to parse ClawRouter budget");
+    }
+    const limit = micros(budget.limitMicros, "budget.limitMicros", true);
+    const spent = micros(budget.spentMicros, "budget.spentMicros", true);
+    const remaining = micros(budget.remainingMicros, "budget.remainingMicros", true);
+    const resetsAt = monthlyReset(budget.windowKey);
+    const summary = payload.usage.summary;
+    const requestCount = integer(summary.requestCount, "summary.requestCount");
+    const successCount = integer(summary.successCount, "summary.successCount");
+    const errorCount = integer(summary.errorCount, "summary.errorCount");
+    const inputTokens = integer(summary.inputTokens, "summary.inputTokens");
+    const outputTokens = integer(summary.outputTokens, "summary.outputTokens");
+    const totalTokens = integer(summary.totalTokens, "summary.totalTokens");
+    const actualCost = micros(summary.actualCostMicros, "summary.actualCostMicros", false);
+
+    const providers = payload.usage.providers.map(item => {
+      if (!item || typeof item.provider !== "string") throw new Error("ClawRouter provider name must be a string");
+      return {
+        provider: item.provider.trim() || "Unknown",
+        requests: integer(item.requestCount, "provider.requestCount"),
+        success: integer(item.successCount, "provider.successCount"),
+        errors: integer(item.errorCount, "provider.errorCount"),
+        tokens: integer(item.totalTokens, "provider.totalTokens"),
+        cost: micros(item.actualCostMicros, "provider.actualCostMicros", false),
+      };
+    }).sort((a, b) => b.cost - a.cost || b.requests - a.requests || a.provider.localeCompare(b.provider));
+
+    const result = {
+      identity: {
+        organization: `${providers.length} routed providers`,
+        loginMethod: budget.configured ? "Managed monthly budget" : "Unmetered",
+      },
+      details: [{
+        title: "Usage",
+        rows: [
+          { label: "Requests", value: String(requestCount), secondaryValue: `${successCount} succeeded · ${errorCount} failed` },
+          { label: "Tokens", value: String(totalTokens), secondaryValue: `${inputTokens} input · ${outputTokens} output` },
+          { label: "Actual cost", value: `$${actualCost.toFixed(6)}` },
+          { label: "Budget ledger", value: budget.ledger },
+        ],
+      }],
+    };
+
+    if (spent !== null && limit !== null) {
+      result.primary = { usedPercent: ctx.pct(spent, limit) };
+      if (resetsAt) result.primary.resetsAt = resetsAt;
+      result.cost = { used: spent, limit, currency: "USD", period: "This month" };
+      if (resetsAt) result.cost.resetsAt = resetsAt;
+      result.details[0].rows.push({
+        label: "Monthly budget",
+        value: `$${spent.toFixed(6)} / $${limit.toFixed(2)}`,
+        secondaryValue: remaining === null ? undefined : `$${remaining.toFixed(6)} remaining`,
+      });
+    } else if (actualCost > 0) {
+      result.cost = { used: actualCost, currency: "USD", period: "This month" };
+      if (resetsAt) result.cost.resetsAt = resetsAt;
+    }
+
+    if (providers.length) {
+      let visible = providers;
+      if (providers.length > 119) {
+        const kept = providers.slice(0, 119);
+        const other = providers.slice(119).reduce((sum, item) => sum + item.cost, 0);
+        visible = kept.concat([{ provider: "Other", cost: other }]);
+      }
+      result.details.push({
+        title: "Routed providers",
+        rows: providers.slice(0, 20).map(item => ({
+          label: item.provider,
+          value: `${item.requests} requests`,
+          secondaryValue: `$${item.cost.toFixed(6)} · ${item.tokens} tokens`,
+        })),
+        chart: {
+          kind: "bars",
+          title: "Provider cost",
+          unit: "USD",
+          points: visible.map(item => ({ label: item.provider, value: item.cost })),
+        },
+      });
+    }
+    return result;
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/openai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/openai.js
@@ -1,0 +1,238 @@
+defineProvider({
+  id: "openai",
+  name: "OpenAI",
+  endpoints: ["https://api.openai.com"],
+  auth: { type: "bearer", secret: "OPENAI_API_KEY" },
+  settings: [
+    { key: "OPENAI_API_KEY", title: "API key", type: "secure" },
+    { key: "OPENAI_PROJECT_ID", title: "Project ID", type: "plain" },
+    { key: "OPENAI_HISTORY_DAYS", title: "History days", type: "plain" },
+    { key: "OPENAI_ALLOW_BALANCE_FALLBACK", title: "Balance fallback", type: "plain" },
+  ],
+
+  async fetchUsage(ctx) {
+    const projectID = ctx.secrets.get("OPENAI_PROJECT_ID");
+    const rawHistoryDays = Number(ctx.secrets.get("OPENAI_HISTORY_DAYS") || "30");
+    const historyDays = Number.isInteger(rawHistoryDays) ? Math.max(1, Math.min(365, rawHistoryDays)) : 30;
+
+    function finite(value, field, optional) {
+      if (optional && (value === null || value === undefined || value === "")) return null;
+      const number = typeof value === "number" ? value : typeof value === "string" ? Number(value.trim()) : NaN;
+      if (!Number.isFinite(number)) throw new Error(`OpenAI ${field} must be numeric`);
+      return number;
+    }
+    function integer(value, field, optional) {
+      const number = finite(value, field, optional);
+      if (number === null) return null;
+      if (!Number.isInteger(number)) throw new Error(`OpenAI ${field} must be an integer`);
+      return number;
+    }
+    function name(value, fallback) {
+      return typeof value === "string" && value.trim() ? value.trim() : fallback;
+    }
+    function usd(value) {
+      return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(Math.max(0, value));
+    }
+    function numberText(value) {
+      return new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value);
+    }
+    function queryURL(path, range, groupBy, page) {
+      const query = [
+        `start_time=${range.start}`,
+        `end_time=${range.end}`,
+        "bucket_width=1d",
+        `limit=${range.limit}`,
+        `group_by=${encodeURIComponent(groupBy)}`,
+      ];
+      if (projectID) query.push(`project_ids=${encodeURIComponent(projectID)}`);
+      if (page) query.push(`page=${encodeURIComponent(page)}`);
+      return `https://api.openai.com${path}?${query.join("&")}`;
+    }
+    function ranges() {
+      const today = new Date();
+      today.setUTCHours(0, 0, 0, 0);
+      let cursor = Math.floor(today.getTime() / 1000) - (historyDays - 1) * 86400;
+      let remaining = historyDays;
+      const result = [];
+      while (remaining > 0) {
+        const limit = Math.min(31, remaining);
+        result.push({ start: cursor, end: cursor + limit * 86400, limit });
+        cursor += limit * 86400;
+        remaining -= limit;
+      }
+      return result;
+    }
+    async function pages(path, groupBy) {
+      const buckets = [];
+      for (const range of ranges()) {
+        let page = null;
+        const seen = new Set();
+        for (let count = 0; count < 100; count += 1) {
+          const response = await ctx.http.getJSON(queryURL(path, range, groupBy, page));
+          if (response.status !== 200) throw new Error(`OpenAI ${path} error: HTTP ${response.status}`);
+          const body = response.json;
+          if (!body || typeof body !== "object" || Array.isArray(body) ||
+              !Array.isArray(body.data) || typeof body.has_more !== "boolean") {
+            throw new Error(`Failed to parse OpenAI ${path} page`);
+          }
+          buckets.push(...body.data);
+          if (!body.has_more) break;
+          if (typeof body.next_page !== "string" || !body.next_page.trim()) {
+            throw new Error(`OpenAI ${path} pagination cursor missing`);
+          }
+          page = body.next_page.trim();
+          if (seen.has(page)) throw new Error(`OpenAI ${path} pagination cursor repeated`);
+          seen.add(page);
+          if (count === 99) throw new Error(`OpenAI ${path} pagination exceeded 100 pages`);
+        }
+      }
+      return buckets;
+    }
+
+    try {
+      const costBuckets = await pages("/v1/organization/costs", "line_item");
+      const completionBuckets = await pages("/v1/organization/usage/completions", "model");
+      const daily = new Map();
+      function bucket(raw) {
+        if (!raw || typeof raw !== "object" || Array.isArray(raw) ||
+            !Number.isInteger(raw.start_time) || !Number.isInteger(raw.end_time) || !Array.isArray(raw.results)) {
+          throw new Error("Failed to parse OpenAI usage bucket");
+        }
+        let value = daily.get(raw.start_time);
+        if (!value) {
+          value = {
+            start: raw.start_time, end: raw.end_time, cost: 0, requests: 0,
+            input: 0, cached: 0, output: 0, tokens: 0, models: new Map(), lines: new Map(),
+          };
+          daily.set(raw.start_time, value);
+        }
+        return value;
+      }
+      for (const raw of costBuckets) {
+        const day = bucket(raw);
+        for (const item of raw.results) {
+          if (!item || typeof item !== "object") throw new Error("Failed to parse OpenAI cost result");
+          const amount = item.amount ? finite(item.amount.value, "cost amount", true) || 0 : 0;
+          day.cost += amount;
+          const line = name(item.line_item, "API");
+          day.lines.set(line, (day.lines.get(line) || 0) + amount);
+        }
+      }
+      for (const raw of completionBuckets) {
+        const day = bucket(raw);
+        for (const item of raw.results) {
+          if (!item || typeof item !== "object") throw new Error("Failed to parse OpenAI completion result");
+          const input = integer(item.input_tokens, "input_tokens", true) || 0;
+          const cached = integer(item.input_cached_tokens, "input_cached_tokens", true) || 0;
+          const audioInput = integer(item.input_audio_tokens, "input_audio_tokens", true) || 0;
+          const output = integer(item.output_tokens, "output_tokens", true) || 0;
+          const audioOutput = integer(item.output_audio_tokens, "output_audio_tokens", true) || 0;
+          const requests = integer(item.num_model_requests, "num_model_requests", true) || 0;
+          const tokens = input + audioInput + output + audioOutput;
+          day.requests += requests;
+          day.input += input + audioInput;
+          day.cached += cached;
+          day.output += output + audioOutput;
+          day.tokens += tokens;
+          const modelName = name(item.model, "Responses and Chat Completions");
+          const model = day.models.get(modelName) || { requests: 0, tokens: 0 };
+          model.requests += requests;
+          model.tokens += tokens;
+          day.models.set(modelName, model);
+        }
+      }
+      const days = Array.from(daily.values()).sort((a, b) => a.start - b.start);
+      const totals = days.reduce((sum, day) => {
+        sum.cost += day.cost; sum.requests += day.requests; sum.input += day.input;
+        sum.cached += day.cached; sum.output += day.output; sum.tokens += day.tokens;
+        return sum;
+      }, { cost: 0, requests: 0, input: 0, cached: 0, output: 0, tokens: 0 });
+      const models = new Map();
+      const lines = new Map();
+      for (const day of days) {
+        for (const [modelName, value] of day.models) {
+          const model = models.get(modelName) || { requests: 0, tokens: 0 };
+          model.requests += value.requests; model.tokens += value.tokens; models.set(modelName, model);
+        }
+        for (const [line, cost] of day.lines) lines.set(line, (lines.get(line) || 0) + cost);
+      }
+      const topModels = Array.from(models.entries()).sort((a, b) => b[1].tokens - a[1].tokens || a[0].localeCompare(b[0]));
+      const topLines = Array.from(lines.entries()).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+      const chartDays = days.slice(-120);
+      const summaryRows = [
+        { label: "Spend", value: usd(totals.cost), secondaryValue: `Last ${historyDays} days` },
+        { label: "Requests", value: numberText(totals.requests) },
+        { label: "Tokens", value: numberText(totals.tokens), secondaryValue: `${numberText(totals.input)} input · ${numberText(totals.output)} output` },
+        { label: "Cached input", value: numberText(totals.cached) },
+      ];
+      if (days.length > chartDays.length) {
+        summaryRows.push({ label: "Chart range", value: `Last ${chartDays.length} days` });
+      }
+      const details = [{
+        title: "Usage summary",
+        rows: summaryRows,
+        chart: {
+          kind: "bars",
+          title: "Daily spend",
+          unit: "USD",
+          points: chartDays.map(day => ({ label: new Date(day.start * 1000).toISOString().slice(0, 10), value: day.cost })),
+        },
+      }];
+      if (topModels.length) {
+        details.push({
+          title: "Models",
+          rows: topModels.slice(0, 24).map(item => ({
+            label: item[0], value: `${numberText(item[1].tokens)} tokens`, secondaryValue: `${item[1].requests} requests`,
+          })),
+        });
+      }
+      if (topLines.length) {
+        details.push({
+          title: "Line items",
+          rows: topLines.slice(0, 24).map(item => ({ label: item[0], value: usd(item[1]) })),
+        });
+      }
+      const identity = { loginMethod: projectID ? `Admin API: ${projectID}` : "Admin API" };
+      if (projectID) identity.organization = `Project: ${projectID}`;
+      return {
+        cost: { used: totals.cost, currency: "USD", period: historyDays === 1 ? "Today" : `Last ${historyDays} days` },
+        identity,
+        details,
+      };
+    } catch (usageError) {
+      if (ctx.secrets.get("OPENAI_ALLOW_BALANCE_FALLBACK") !== "1") throw usageError;
+      const response = await ctx.http.getJSON("https://api.openai.com/v1/dashboard/billing/credit_grants");
+      if (response.status !== 200) throw usageError;
+      const body = response.json;
+      if (!body || typeof body !== "object" || Array.isArray(body)) throw usageError;
+      const granted = finite(body.total_granted, "total_granted", false);
+      const used = finite(body.total_used, "total_used", false);
+      const available = finite(body.total_available, "total_available", false);
+      const futureExpiries = body.grants && Array.isArray(body.grants.data)
+        ? body.grants.data.map(item => item && finite(item.expires_at, "expires_at", true))
+          .filter(value => value !== null && value * 1000 > Date.now()).sort((a, b) => a - b)
+        : [];
+      const resetsAt = futureExpiries.length ? ctx.date.unixSeconds(futureExpiries[0]) : null;
+      const primary = {
+        usedPercent: granted > 0 ? ctx.pct(used, granted) : available > 0 ? 0 : 100,
+        resetDescription: `${usd(available)} available`,
+      };
+      if (resetsAt) primary.resetsAt = resetsAt;
+      const cost = { used: Math.max(0, used), limit: Math.max(0, granted), currency: "USD", period: "API credits" };
+      if (resetsAt) cost.resetsAt = resetsAt;
+      return {
+        primary,
+        cost,
+        identity: { loginMethod: `API balance: ${usd(available)}` },
+        details: [{
+          title: "API credits",
+          rows: [
+            { label: "Available", value: usd(available) },
+            { label: "Used", value: usd(used) },
+            { label: "Granted", value: usd(granted) },
+          ],
+        }],
+      };
+    }
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/openrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/openrouter.js
@@ -1,0 +1,108 @@
+defineProvider({
+  id: "openrouter",
+  name: "OpenRouter",
+  endpoints: ["https://openrouter.ai"],
+  auth: { type: "bearer", secret: "OPENROUTER_API_KEY" },
+  settings: [{
+    key: "OPENROUTER_API_KEY",
+    title: "API key",
+    subtitle: "OpenRouter API key used for credits and key quota.",
+    type: "secure",
+  }],
+
+  async fetchUsage(ctx) {
+    const creditsResponse = await ctx.http.getJSON("https://openrouter.ai/api/v1/credits", {
+      headers: { "X-Title": "CodexBar" },
+    });
+    if (creditsResponse.status !== 200) {
+      throw new Error(`OpenRouter API error: HTTP ${creditsResponse.status}`);
+    }
+    const credits = creditsResponse.json && creditsResponse.json.data;
+    if (!credits || typeof credits !== "object" || Array.isArray(credits)) {
+      throw new Error("Failed to parse OpenRouter credits: data must be an object");
+    }
+
+    function finite(value, field, optional) {
+      if (optional && (value === null || value === undefined)) return null;
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        throw new Error(`Failed to parse OpenRouter response: ${field} must be a finite number`);
+      }
+      return value;
+    }
+
+    const totalCredits = finite(credits.total_credits, "total_credits", false);
+    const totalUsage = finite(credits.total_usage, "total_usage", false);
+    const balance = Math.max(0, totalCredits - totalUsage);
+    let keyData = null;
+    try {
+      const keyResponse = await ctx.http.getJSON("https://openrouter.ai/api/v1/key");
+      if (keyResponse.status === 200 && keyResponse.json &&
+          keyResponse.json.data && typeof keyResponse.json.data === "object") {
+        keyData = keyResponse.json.data;
+      }
+    } catch (_) {}
+
+    let primary;
+    let keyLimit = null;
+    let keyUsage = null;
+    if (keyData) {
+      keyLimit = finite(keyData.limit, "key.limit", true);
+      keyUsage = finite(keyData.usage, "key.usage", true);
+      if (keyLimit !== null && keyLimit > 0 && keyUsage !== null && keyUsage >= 0) {
+        primary = { usedPercent: ctx.pct(keyUsage, keyLimit) };
+      }
+    }
+
+    const currency = value => `$${Math.max(0, value).toFixed(2)}`;
+    const details = [{
+      title: "Credits",
+      rows: [
+        { label: "Remaining", value: currency(balance) },
+        { label: "Used", value: currency(totalUsage) },
+        { label: "Total added", value: currency(totalCredits) },
+      ],
+    }];
+
+    if (keyData) {
+      const rows = [];
+      if (keyLimit !== null && keyLimit > 0) {
+        rows.push({ label: "API key budget", value: currency(keyLimit) });
+        if (keyUsage !== null) rows.push({ label: "API key used", value: currency(keyUsage) });
+      } else {
+        rows.push({ label: "API key budget", value: "No limit configured" });
+      }
+      const periods = [
+        ["Today", "usage_daily"],
+        ["This week", "usage_weekly"],
+        ["This month", "usage_monthly"],
+      ];
+      const points = [];
+      for (const [label, key] of periods) {
+        const value = finite(keyData[key], `key.${key}`, true);
+        if (value !== null) {
+          rows.push({ label, value: currency(value) });
+          points.push({ label, value });
+        }
+      }
+      if (keyData.rate_limit && typeof keyData.rate_limit === "object") {
+        const requests = keyData.rate_limit.requests;
+        const interval = keyData.rate_limit.interval;
+        if (Number.isInteger(requests) && typeof interval === "string") {
+          rows.push({ label: "Rate limit", value: `${requests} requests / ${interval}` });
+        }
+      }
+      const section = { title: "API key", rows };
+      if (points.length) {
+        section.chart = { kind: "bars", title: "Key spend", unit: "USD", points };
+      }
+      details.push(section);
+    }
+
+    const result = {
+      identity: { loginMethod: `Balance: ${currency(balance)}` },
+      details,
+    };
+    if (primary) result.primary = primary;
+    return result;
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/poe.js
+++ b/Sources/CodexBarCore/Resources/Plugins/poe.js
@@ -1,0 +1,132 @@
+defineProvider({
+  id: "poe",
+  name: "Poe",
+  endpoints: ["https://api.poe.com"],
+  auth: { type: "bearer", secret: "POE_API_KEY" },
+  settings: [{
+    key: "POE_API_KEY",
+    title: "API key",
+    subtitle: "Poe API key used for point balance and history.",
+    type: "secure",
+  }],
+
+  async fetchUsage(ctx) {
+    const balanceResponse = await ctx.http.getJSON("https://api.poe.com/usage/current_balance");
+    if (balanceResponse.status === 401 || balanceResponse.status === 403) {
+      throw new Error("Invalid or expired Poe API token");
+    }
+    if (balanceResponse.status < 200 || balanceResponse.status >= 300) {
+      throw new Error(`Poe API error: HTTP ${balanceResponse.status}`);
+    }
+    const payload = balanceResponse.json;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("Failed to parse Poe balance response");
+    }
+
+    function optionalNumber(value, field) {
+      if (value === null || value === undefined) return null;
+      const number = typeof value === "number" ? value : typeof value === "string" ? Number(value.trim()) : NaN;
+      if (!Number.isFinite(number)) throw new Error(`Poe ${field} must be numeric`);
+      return number;
+    }
+    function compact(value) {
+      return new Intl.NumberFormat("en-US", {
+        maximumFractionDigits: value >= 1000 ? 0 : 1,
+      }).format(value);
+    }
+    function entryDate(value) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        if (value > 100000000000000) return new Date(value / 1000);
+        if (value > 1000000000000) return new Date(value);
+        return new Date(value * 1000);
+      }
+      if (typeof value === "string" && value.trim()) {
+        const numeric = Number(value);
+        if (Number.isFinite(numeric)) return entryDate(numeric);
+        const date = new Date(value);
+        if (Number.isFinite(date.getTime())) return date;
+      }
+      return null;
+    }
+
+    const balance = optionalNumber(payload.current_point_balance, "current_point_balance");
+    const entries = [];
+    try {
+      let cursor = null;
+      const cutoff = Date.now() - 30 * 86400000;
+      for (let page = 0; page < 5; page += 1) {
+        const query = cursor ? `?limit=100&starting_after=${encodeURIComponent(cursor)}` : "?limit=100";
+        const response = await ctx.http.getJSON(`https://api.poe.com/usage/points_history${query}`);
+        if (response.status < 200 || response.status >= 300) throw new Error(`HTTP ${response.status}`);
+        const root = response.json;
+        if (!root || typeof root !== "object" || Array.isArray(root)) throw new Error("invalid history JSON");
+        const rows = Array.isArray(root.data) ? root.data :
+          Array.isArray(root.items) ? root.items : Array.isArray(root.results) ? root.results : [];
+        for (const row of rows) {
+          if (!row || typeof row !== "object" || Array.isArray(row)) continue;
+          const date = entryDate(row.creation_time ?? row.timestamp ?? row.created_at);
+          if (!date || date.getTime() < cutoff) continue;
+          const points = Math.max(0, optionalNumber(row.cost_points ?? row.points ?? row.point_cost, "points") ?? 0);
+          const cost = optionalNumber(row.cost_usd ?? row.usd, "cost_usd");
+          const model = typeof row.bot_name === "string" && row.bot_name.trim() ? row.bot_name.trim() : "unknown";
+          const usageType = typeof row.usage_type === "string" && row.usage_type.trim()
+            ? row.usage_type.trim() : "unknown";
+          entries.push({ date, points, cost, model, usageType });
+        }
+        const next = typeof root.next_cursor === "string" && root.next_cursor.trim() ? root.next_cursor.trim() : null;
+        cursor = next || (root.has_more === true && rows.length && typeof rows[rows.length - 1].query_id === "string"
+          ? rows[rows.length - 1].query_id.trim() : null);
+        if (!cursor) break;
+        const lastDate = rows.length
+          ? entryDate(rows[rows.length - 1].creation_time ?? rows[rows.length - 1].timestamp ?? rows[rows.length - 1].created_at)
+          : null;
+        if (lastDate && lastDate.getTime() < cutoff) break;
+      }
+    } catch (_) {}
+
+    const daily = new Map();
+    const models = new Map();
+    const types = new Map();
+    for (const entry of entries) {
+      const day = entry.date.toISOString().slice(0, 10);
+      const bucket = daily.get(day) || { points: 0, requests: 0, cost: 0, hasCost: false };
+      bucket.points += entry.points;
+      bucket.requests += 1;
+      if (entry.cost !== null) { bucket.cost += Math.max(0, entry.cost); bucket.hasCost = true; }
+      daily.set(day, bucket);
+      models.set(entry.model, (models.get(entry.model) || 0) + entry.points);
+      types.set(entry.usageType, (types.get(entry.usageType) || 0) + entry.points);
+    }
+    const days = Array.from(daily.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+    const summarize = count => days.slice(-count).reduce((sum, item) => {
+      sum.points += item[1].points;
+      sum.requests += item[1].requests;
+      if (item[1].hasCost) { sum.cost += item[1].cost; sum.hasCost = true; }
+      return sum;
+    }, { points: 0, requests: 0, cost: 0, hasCost: false });
+    const seven = summarize(7);
+    const thirty = summarize(30);
+    const topModel = Array.from(models.entries()).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0];
+    const topType = Array.from(types.entries()).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0];
+    const rows = [];
+    if (balance !== null) rows.push({ label: "Current balance", value: `${compact(balance)} points` });
+    if (entries.length) {
+      rows.push({ label: "Last 7 days", value: `${compact(seven.points)} points`, secondaryValue: `${seven.requests} requests` });
+      rows.push({ label: "Last 30 days", value: `${compact(thirty.points)} points`, secondaryValue: `${thirty.requests} requests` });
+      if (topModel) rows.push({ label: "Top model", value: topModel[0], secondaryValue: `${compact(topModel[1])} points` });
+      if (topType) rows.push({ label: "Top usage type", value: topType[0], secondaryValue: `${compact(topType[1])} points` });
+    }
+    const section = { title: "Points", rows };
+    if (days.length) {
+      section.chart = {
+        kind: "bars",
+        title: "Daily points",
+        unit: "points",
+        points: days.map(item => ({ label: item[0], value: item[1].points })),
+      };
+    }
+    const result = { details: [section], identity: {} };
+    if (balance !== null) result.identity.loginMethod = `Balance: ${compact(balance)} points`;
+    return result;
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/zai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/zai.js
@@ -1,6 +1,6 @@
 defineProvider({
   id: "zai",
-  name: "z.ai",
+  name: "z.ai / GLM",
   endpoints: ["https://api.z.ai", "https://open.bigmodel.cn"],
   auth: { type: "bearer", secret: "Z_AI_API_KEY" },
   settings: [
@@ -65,18 +65,18 @@ defineProvider({
       return { raw, usage, current, remaining, percent, windowMinutes, reset, details };
     }
     function window(limit) {
-      const monthlyMarker = limit.raw.type === "TIME_LIMIT" && limit.raw.unit === 5 && limit.raw.number === 1;
-      let minutes = limit.windowMinutes;
-      if (monthlyMarker || (limit.raw.type === "TIME_LIMIT" && minutes === null)) minutes = 43200;
       const result = { usedPercent: limit.percent };
-      if (minutes !== null) result.windowMinutes = minutes;
+      if (limit.raw.type === "TOKENS_LIMIT" && limit.windowMinutes !== null) {
+        result.windowMinutes = limit.windowMinutes;
+      }
       if (limit.reset !== null) result.resetsAt = ctx.date.unixMillis(limit.reset);
-      if (monthlyMarker) result.resetDescription = "Monthly";
+      if (limit.raw.type === "TIME_LIMIT") result.resetDescription = "MCP";
+      else if (limit.windowMinutes === 300) result.resetDescription = "5-hour";
       else if (limit.windowMinutes !== null) {
         const units = { 1: "day", 3: "hour", 5: "minute", 6: "week" };
         const name = units[limit.raw.unit];
         if (name) result.resetDescription = `${limit.raw.number} ${name}${limit.raw.number === 1 ? "" : "s"} window`;
-      } else if (limit.raw.type === "TIME_LIMIT") result.resetDescription = "Monthly";
+      }
       return result;
     }
     function limitRow(label, limit) {
@@ -92,14 +92,16 @@ defineProvider({
     const timeLimit = limits.filter(item => item.raw.type === "TIME_LIMIT").pop() || null;
     const tokenLimit = tokenLimits.length ? tokenLimits[tokenLimits.length - 1] : null;
     const sessionLimit = tokenLimits.length >= 2 ? tokenLimits[0] : null;
-    const primaryLimit = tokenLimit || timeLimit;
+    const primaryLimit = sessionLimit || tokenLimit || timeLimit;
     const result = {
       primary: primaryLimit ? window(primaryLimit) : { usedPercent: 0 },
       identity: {},
       details: [{ title: "Quota details", rows: [] }],
     };
-    if (tokenLimit && timeLimit) result.secondary = window(timeLimit);
-    if (sessionLimit) result.tertiary = window(sessionLimit);
+    if (sessionLimit && tokenLimit) result.secondary = window(tokenLimit);
+    if ((tokenLimit || sessionLimit) && timeLimit) {
+      result.extraWindows = [{ id: "zai-mcp", title: "MCP", window: window(timeLimit) }];
+    }
     if (tokenLimit) result.details[0].rows.push(limitRow("Token quota", tokenLimit));
     if (sessionLimit) result.details[0].rows.push(limitRow("Session token quota", sessionLimit));
     if (timeLimit) {

--- a/Sources/CodexBarCore/Resources/Plugins/zai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/zai.js
@@ -1,0 +1,162 @@
+defineProvider({
+  id: "zai",
+  name: "z.ai",
+  endpoints: ["https://api.z.ai", "https://open.bigmodel.cn"],
+  auth: { type: "bearer", secret: "Z_AI_API_KEY" },
+  settings: [
+    { key: "Z_AI_API_KEY", title: "API key", type: "secure" },
+    { key: "Z_AI_REGION", title: "API region", type: "plain" },
+    { key: "Z_AI_USAGE_SCOPE", title: "Usage scope", type: "plain" },
+    { key: "Z_AI_ORGANIZATION", title: "Organization", type: "plain" },
+    { key: "Z_AI_PROJECT", title: "Project", type: "plain" },
+  ],
+
+  async fetchUsage(ctx) {
+    const region = ctx.secrets.get("Z_AI_REGION") || "global";
+    const scope = ctx.secrets.get("Z_AI_USAGE_SCOPE") || "personal";
+    const organization = ctx.secrets.get("Z_AI_ORGANIZATION");
+    const project = ctx.secrets.get("Z_AI_PROJECT");
+    if (region !== "global" && region !== "bigmodel-cn") throw new Error("Unsupported z.ai region");
+    if (scope !== "personal" && scope !== "team") throw new Error("Unsupported z.ai usage scope");
+    if (scope === "team" && (!organization || !project)) throw new Error("z.ai team scope needs organization and project");
+    const base = region === "bigmodel-cn" ? "https://open.bigmodel.cn" : "https://api.z.ai";
+    const headers = scope === "team"
+      ? { "Bigmodel-Organization": organization, "Bigmodel-Project": project }
+      : {};
+    const quotaSuffix = scope === "team" ? "?type=2" : "";
+    const quotaResponse = await ctx.http.getJSON(`${base}/api/monitor/usage/quota/limit${quotaSuffix}`, { headers });
+    if (quotaResponse.status !== 200) throw new Error(`z.ai quota API error: HTTP ${quotaResponse.status}`);
+    const root = quotaResponse.json;
+    if (!root || typeof root !== "object" || Array.isArray(root) || root.success !== true || root.code !== 200) {
+      throw new Error(`z.ai quota API error: ${root && root.msg ? root.msg : "invalid response"}`);
+    }
+    if (!root.data || typeof root.data !== "object" || !Array.isArray(root.data.limits)) {
+      throw new Error("Failed to parse z.ai quota data");
+    }
+
+    function optionalInteger(value, field) {
+      if (value === null || value === undefined) return null;
+      if (!Number.isInteger(value)) throw new Error(`z.ai ${field} must be an integer`);
+      return value;
+    }
+    function parseLimit(raw) {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw) ||
+          typeof raw.type !== "string" || !Number.isInteger(raw.unit) ||
+          !Number.isInteger(raw.number) || !Number.isInteger(raw.percentage)) {
+        throw new Error("Failed to parse z.ai limit entry");
+      }
+      if (raw.type !== "TOKENS_LIMIT" && raw.type !== "TIME_LIMIT") return null;
+      const usage = optionalInteger(raw.usage, "limit.usage");
+      const current = optionalInteger(raw.currentValue, "limit.currentValue");
+      const remaining = optionalInteger(raw.remaining, "limit.remaining");
+      let percent = raw.percentage;
+      if (usage !== null && usage > 0) {
+        let used = null;
+        if (remaining !== null) used = Math.max(usage - remaining, current === null ? usage - remaining : current);
+        else if (current !== null) used = current;
+        if (used !== null) percent = Math.max(0, Math.min(usage, used)) / usage * 100;
+      }
+      percent = Math.max(0, Math.min(100, percent));
+      const multipliers = { 1: 1440, 3: 60, 5: 1, 6: 10080 };
+      const windowMinutes = raw.number > 0 && multipliers[raw.unit] ? raw.number * multipliers[raw.unit] : null;
+      const reset = optionalInteger(raw.nextResetTime, "limit.nextResetTime");
+      const details = raw.usageDetails === null || raw.usageDetails === undefined ? [] : raw.usageDetails;
+      if (!Array.isArray(details)) throw new Error("z.ai usageDetails must be an array");
+      return { raw, usage, current, remaining, percent, windowMinutes, reset, details };
+    }
+    function window(limit) {
+      const monthlyMarker = limit.raw.type === "TIME_LIMIT" && limit.raw.unit === 5 && limit.raw.number === 1;
+      let minutes = limit.windowMinutes;
+      if (monthlyMarker || (limit.raw.type === "TIME_LIMIT" && minutes === null)) minutes = 43200;
+      const result = { usedPercent: limit.percent };
+      if (minutes !== null) result.windowMinutes = minutes;
+      if (limit.reset !== null) result.resetsAt = ctx.date.unixMillis(limit.reset);
+      if (monthlyMarker) result.resetDescription = "Monthly";
+      else if (limit.windowMinutes !== null) {
+        const units = { 1: "day", 3: "hour", 5: "minute", 6: "week" };
+        const name = units[limit.raw.unit];
+        if (name) result.resetDescription = `${limit.raw.number} ${name}${limit.raw.number === 1 ? "" : "s"} window`;
+      } else if (limit.raw.type === "TIME_LIMIT") result.resetDescription = "Monthly";
+      return result;
+    }
+    function limitRow(label, limit) {
+      const parts = [];
+      if (limit.usage !== null) parts.push(`${limit.usage} limit`);
+      if (limit.remaining !== null) parts.push(`${limit.remaining} remaining`);
+      return { label, value: `${limit.percent.toFixed(limit.percent % 1 ? 1 : 0)}% used`, secondaryValue: parts.join(" · ") || undefined };
+    }
+
+    const limits = root.data.limits.map(parseLimit).filter(Boolean);
+    const tokenLimits = limits.filter(item => item.raw.type === "TOKENS_LIMIT")
+      .sort((a, b) => (a.windowMinutes || Number.MAX_SAFE_INTEGER) - (b.windowMinutes || Number.MAX_SAFE_INTEGER));
+    const timeLimit = limits.filter(item => item.raw.type === "TIME_LIMIT").pop() || null;
+    const tokenLimit = tokenLimits.length ? tokenLimits[tokenLimits.length - 1] : null;
+    const sessionLimit = tokenLimits.length >= 2 ? tokenLimits[0] : null;
+    const primaryLimit = tokenLimit || timeLimit;
+    const result = {
+      primary: primaryLimit ? window(primaryLimit) : { usedPercent: 0 },
+      identity: {},
+      details: [{ title: "Quota details", rows: [] }],
+    };
+    if (tokenLimit && timeLimit) result.secondary = window(timeLimit);
+    if (sessionLimit) result.tertiary = window(sessionLimit);
+    if (tokenLimit) result.details[0].rows.push(limitRow("Token quota", tokenLimit));
+    if (sessionLimit) result.details[0].rows.push(limitRow("Session token quota", sessionLimit));
+    if (timeLimit) {
+      result.details[0].rows.push(limitRow("MCP quota", timeLimit));
+      for (const detail of timeLimit.details.slice(0, 20)) {
+        if (detail && typeof detail.modelCode === "string" && Number.isInteger(detail.usage)) {
+          result.details[0].rows.push({ label: detail.modelCode, value: String(detail.usage) });
+        }
+      }
+    }
+    const plan = [root.data.planName, root.data.plan, root.data.plan_type, root.data.packageName]
+      .find(value => typeof value === "string" && value.trim());
+    if (plan) result.identity.loginMethod = plan.trim();
+
+    async function modelUsage(daysBack) {
+      const end = new Date();
+      const start = new Date(end.getTime() - Math.max(1, daysBack) * 86400000);
+      const stamp = date => date.toISOString().slice(0, 19).replace("T", " ");
+      const type = scope === "team" ? "&type=3" : "";
+      const url = `${base}/api/monitor/usage/model-usage?startTime=${encodeURIComponent(stamp(start))}` +
+        `&endTime=${encodeURIComponent(stamp(end))}${type}`;
+      const response = await ctx.http.getJSON(url, { headers });
+      if (response.status !== 200) throw new Error(`HTTP ${response.status}`);
+      const body = response.json;
+      if (!body || body.success !== true || body.code !== 200) throw new Error("invalid model usage response");
+      const data = body.data || {};
+      const labels = Array.isArray(data.x_time) ? data.x_time : [];
+      const models = Array.isArray(data.modelDataList) ? data.modelDataList : [];
+      const points = labels.map((label, index) => {
+        let total = 0;
+        for (const model of models) {
+          const value = model && Array.isArray(model.tokensUsage) ? model.tokensUsage[index] : null;
+          if (Number.isInteger(value) && value > 0) total += value;
+        }
+        return { label: String(label), value: total };
+      }).filter(point => point.value > 0);
+      const totals = models.map(model => ({
+        name: model && typeof model.modelName === "string" ? model.modelName : "Unknown",
+        tokens: model && Array.isArray(model.tokensUsage)
+          ? model.tokensUsage.reduce((sum, value) => sum + (Number.isInteger(value) && value > 0 ? value : 0), 0)
+          : 0,
+      })).filter(item => item.tokens > 0).sort((a, b) => b.tokens - a.tokens || a.name.localeCompare(b.name));
+      return { points, totals };
+    }
+
+    for (const [days, title] of [[1, "Hourly tokens"], [30, "Daily tokens"]]) {
+      try {
+        const usage = await modelUsage(days);
+        if (usage.points.length) {
+          result.details.push({
+            title,
+            rows: usage.totals.slice(0, 20).map(item => ({ label: item.name, value: String(item.tokens) })),
+            chart: { kind: "bars", title, unit: "tokens", points: usage.points },
+          });
+        }
+      } catch (_) {}
+    }
+    return result;
+  },
+});

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -146,6 +146,7 @@ public struct UsageSnapshot: Codable, Sendable {
     public let tertiary: RateWindow?
     public let extraRateWindows: [NamedRateWindow]?
     public let providerCost: ProviderCostSnapshot?
+    public let details: [ProviderDetailSection]
     public let kiroUsage: KiroUsageDetails?
     public let ampUsage: AmpUsageDetails?
     public let zaiUsage: ZaiUsageSnapshot?
@@ -188,6 +189,7 @@ public struct UsageSnapshot: Codable, Sendable {
         case tertiary
         case extraRateWindows
         case providerCost
+        case details
         case kiroUsage
         case ampUsage
         case mimoUsage
@@ -222,6 +224,7 @@ public struct UsageSnapshot: Codable, Sendable {
         kiroUsage: KiroUsageDetails? = nil,
         ampUsage: AmpUsageDetails? = nil,
         providerCost: ProviderCostSnapshot? = nil,
+        details: [ProviderDetailSection] = [],
         zaiUsage: ZaiUsageSnapshot? = nil,
         zoommateCreditsHistory: ZoomMateCreditsHistorySnapshot? = nil,
         minimaxUsage: MiniMaxUsageSnapshot? = nil,
@@ -253,6 +256,9 @@ public struct UsageSnapshot: Codable, Sendable {
         identity: ProviderIdentitySnapshot? = nil,
         dataConfidence: UsageDataConfidence = .unknown)
     {
+        precondition(
+            details.count <= ProviderDetailSection.maximumSectionsPerSnapshot,
+            "UsageSnapshot details exceeds \(ProviderDetailSection.maximumSectionsPerSnapshot) sections")
         self.primary = primary
         self.secondary = secondary
         self.tertiary = tertiary
@@ -260,6 +266,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.kiroUsage = kiroUsage
         self.ampUsage = ampUsage
         self.providerCost = providerCost
+        self.details = details
         self.zaiUsage = zaiUsage
         self.zoommateCreditsHistory = zoommateCreditsHistory
         self.minimaxUsage = minimaxUsage
@@ -319,6 +326,8 @@ public struct UsageSnapshot: Codable, Sendable {
         self.tertiary = try container.decodeIfPresent(RateWindow.self, forKey: .tertiary)
         self.extraRateWindows = try container.decodeIfPresent([NamedRateWindow].self, forKey: .extraRateWindows)
         self.providerCost = try container.decodeIfPresent(ProviderCostSnapshot.self, forKey: .providerCost)
+        self.details = try container.decodeIfPresent([ProviderDetailSection].self, forKey: .details) ?? []
+        try ProviderDetailSection.validateSections(self.details)
         self.kiroUsage = try container.decodeIfPresent(KiroUsageDetails.self, forKey: .kiroUsage)
         self.ampUsage = try container.decodeIfPresent(AmpUsageDetails.self, forKey: .ampUsage)
         self.zaiUsage = nil // Not persisted, fetched fresh each time
@@ -388,6 +397,9 @@ public struct UsageSnapshot: Codable, Sendable {
         try container.encode(self.tertiary, forKey: .tertiary)
         try container.encodeIfPresent(self.extraRateWindows, forKey: .extraRateWindows)
         try container.encodeIfPresent(self.providerCost, forKey: .providerCost)
+        if !self.details.isEmpty {
+            try container.encode(self.details, forKey: .details)
+        }
         try container.encodeIfPresent(self.kiroUsage, forKey: .kiroUsage)
         try container.encodeIfPresent(self.ampUsage, forKey: .ampUsage)
         try container.encodeIfPresent(self.mimoUsage, forKey: .mimoUsage)
@@ -564,6 +576,7 @@ public struct UsageSnapshot: Codable, Sendable {
             kiroUsage: self.kiroUsage,
             ampUsage: self.ampUsage,
             providerCost: self.providerCost,
+            details: self.details,
             zaiUsage: self.zaiUsage,
             zoommateCreditsHistory: self.zoommateCreditsHistory,
             minimaxUsage: self.minimaxUsage,

--- a/Tests/CodexBarTests/Fixtures/usage-snapshot-current.json
+++ b/Tests/CodexBarTests/Fixtures/usage-snapshot-current.json
@@ -1,0 +1,29 @@
+{
+  "primary": {
+    "usedPercent": 42,
+    "windowMinutes": 300,
+    "resetsAt": "2026-08-02T17:00:00Z",
+    "resetDescription": null
+  },
+  "secondary": null,
+  "tertiary": null,
+  "providerCost": {
+    "used": 12.5,
+    "limit": 50,
+    "currencyCode": "USD",
+    "period": "Monthly",
+    "updatedAt": "2026-08-02T12:00:00Z"
+  },
+  "updatedAt": "2026-08-02T12:00:00Z",
+  "identity": {
+    "providerID": "synthetic",
+    "accountEmail": "fixture@example.com",
+    "accountOrganization": "Fixture Org",
+    "loginMethod": "API key",
+    "accountID": "acct_fixture"
+  },
+  "accountEmail": "fixture@example.com",
+  "accountOrganization": "Fixture Org",
+  "loginMethod": "API key",
+  "dataConfidence": "exact"
+}

--- a/Tests/CodexBarTests/ProviderDetailSectionTests.swift
+++ b/Tests/CodexBarTests/ProviderDetailSectionTests.swift
@@ -82,6 +82,6 @@ struct ProviderDetailSectionTests {
         #expect(snapshot.identity?.providerID == .synthetic)
         #expect(snapshot.details.isEmpty)
         let encoded = try JSONEncoder().encode(snapshot)
-        #expect(!String(decoding: encoded, as: UTF8.self).contains("\"details\""))
+        #expect(String(bytes: encoded, encoding: .utf8)?.contains("\"details\"") == false)
     }
 }

--- a/Tests/CodexBarTests/ProviderDetailSectionTests.swift
+++ b/Tests/CodexBarTests/ProviderDetailSectionTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ProviderDetailSectionTests {
+    @Test
+    func `construction trims strings and preserves valid detail data`() throws {
+        let point = try ProviderDetailSection.Chart.Point(label: " Monday ", value: 12.5)
+        let chart = try ProviderDetailSection.Chart(
+            kind: .bars,
+            title: " Daily usage ",
+            unit: " USD ",
+            points: [point])
+        let row = try ProviderDetailSection.Row(
+            label: " Total ",
+            value: " $12.50 ",
+            secondaryValue: " 120 requests ")
+        let section = try ProviderDetailSection(title: " Billing ", rows: [row], chart: chart)
+
+        #expect(section.title == "Billing")
+        #expect(try section.rows == [ProviderDetailSection.Row(
+            label: "Total",
+            value: "$12.50",
+            secondaryValue: "120 requests")])
+        #expect(section.chart?.title == "Daily usage")
+        #expect(section.chart?.unit == "USD")
+        #expect(try section.chart?.points == [ProviderDetailSection.Chart.Point(label: "Monday", value: 12.5)])
+    }
+
+    @Test
+    func `construction rejects invalid bounds and nonfinite points`() throws {
+        let row = try ProviderDetailSection.Row(label: "Label", value: "Value")
+        let point = try ProviderDetailSection.Chart.Point(label: "Point", value: 1)
+
+        #expect(throws: ProviderDetailSection.ValidationError.self) {
+            _ = try ProviderDetailSection.Row(label: String(repeating: "x", count: 121), value: "Value")
+        }
+        #expect(throws: ProviderDetailSection.ValidationError.self) {
+            _ = try ProviderDetailSection.Chart.Point(label: "Point", value: .infinity)
+        }
+        #expect(throws: ProviderDetailSection.ValidationError.self) {
+            _ = try ProviderDetailSection(rows: Array(repeating: row, count: 25))
+        }
+        #expect(throws: ProviderDetailSection.ValidationError.self) {
+            _ = try ProviderDetailSection.Chart(kind: .line, points: Array(repeating: point, count: 121))
+        }
+    }
+
+    @Test
+    func `decoding rejects too many sections`() throws {
+        let section = #"{"rows":[]}"#
+        let details = Array(repeating: section, count: 9).joined(separator: ",")
+        let json = """
+        {
+          "primary": null,
+          "secondary": null,
+          "tertiary": null,
+          "details": [\(details)],
+          "updatedAt": "2026-08-02T12:00:00Z"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        #expect(throws: ProviderDetailSection.ValidationError.self) {
+            _ = try decoder.decode(UsageSnapshot.self, from: Data(json.utf8))
+        }
+    }
+
+    @Test
+    func `current snapshot fixture decodes with empty details`() throws {
+        let url = try #require(Bundle.module.url(
+            forResource: "usage-snapshot-current",
+            withExtension: "json",
+            subdirectory: "Fixtures"))
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let snapshot = try decoder.decode(UsageSnapshot.self, from: Data(contentsOf: url))
+
+        #expect(snapshot.primary?.usedPercent == 42)
+        #expect(snapshot.identity?.providerID == .synthetic)
+        #expect(snapshot.details.isEmpty)
+        let encoded = try JSONEncoder().encode(snapshot)
+        #expect(!String(decoding: encoded, as: UTF8.self).contains("\"details\""))
+    }
+}

--- a/Tests/CodexBarTests/ProviderDetailSectionsContentTests.swift
+++ b/Tests/CodexBarTests/ProviderDetailSectionsContentTests.swift
@@ -1,0 +1,70 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct ProviderDetailSectionsContentTests {
+    @Test
+    func `snapshot details flow into menu model without affecting empty snapshots`() throws {
+        let details = try [Self.section(kind: .bars)]
+        let populated = UsageMenuCardView.Model.make(Self.input(details: details))
+        let empty = UsageMenuCardView.Model.make(Self.input(details: []))
+
+        #expect(populated.providerDetails == details)
+        #expect(populated.hasUsageContent)
+        #expect(empty.providerDetails.isEmpty)
+    }
+
+    @Test(arguments: [ProviderDetailSection.Chart.Kind.bars, .line])
+    func `generic detail renderer lays out rows and chart kinds`(kind: ProviderDetailSection.Chart.Kind) throws {
+        let view = try ProviderDetailSectionsContent(sections: [Self.section(kind: kind)], chartColor: .blue)
+        let size = NSHostingController(rootView: view)
+            .sizeThatFits(in: CGSize(width: 280, height: CGFloat.greatestFiniteMagnitude))
+
+        #expect(size.width > 0)
+        #expect(size.height > 58)
+    }
+
+    private static func section(kind: ProviderDetailSection.Chart.Kind) throws -> ProviderDetailSection {
+        try ProviderDetailSection(
+            title: "Usage",
+            rows: [ProviderDetailSection.Row(label: "Requests", value: "42", secondaryValue: "Today")],
+            chart: ProviderDetailSection.Chart(
+                kind: kind,
+                title: "Daily",
+                unit: "tokens",
+                points: [
+                    ProviderDetailSection.Chart.Point(label: "Mon", value: 12),
+                    ProviderDetailSection.Chart.Point(label: "Tue", value: 24),
+                ]))
+    }
+
+    private static func input(details: [ProviderDetailSection]) -> UsageMenuCardView.Model.Input {
+        let provider: UsageProvider = .synthetic
+        return UsageMenuCardView.Model.Input(
+            provider: provider,
+            metadata: ProviderDescriptorRegistry.descriptor(for: provider).metadata,
+            snapshot: UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                details: details,
+                updatedAt: Date()),
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: Date())
+    }
+}

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -1,0 +1,393 @@
+#if canImport(JavaScriptCore)
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ProviderPluginDetailsParityTests {
+    @Test
+    func `details providers prepend JS only when the prototype flag is enabled`() async {
+        let fixtures: [(UsageProvider, [String], [String])] = [
+            (.openai, ["openai.api.balance"], ["openai.js", "openai.api.balance"]),
+            (.zai, ["zai.api"], ["zai.js", "zai.api"]),
+            (.openrouter, ["openrouter.api"], ["openrouter.js", "openrouter.api"]),
+            (.poe, ["poe.api"], ["poe.js", "poe.api"]),
+            (.clawrouter, ["clawrouter.api"], ["clawrouter.js", "clawrouter.api"]),
+        ]
+
+        for (provider, defaultIDs, enabledIDs) in fixtures {
+            let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
+            let defaultStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+                Self.context(environment: Self.environment(for: provider)))
+            var enabledEnvironment = Self.environment(for: provider)
+            enabledEnvironment[ProviderPluginPrototype.environmentKey] = "1"
+            let enabledStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+                Self.context(environment: enabledEnvironment))
+
+            #expect(defaultStrategies.map(\.id) == defaultIDs)
+            #expect(enabledStrategies.map(\.id) == enabledIDs)
+        }
+    }
+
+    @Test
+    func `OpenRouter fixture has Swift core parity and stable details`() async throws {
+        let transport = Self.transport { request in
+            switch request.url?.path {
+            case "/api/v1/credits": Self.openRouterCredits
+            case "/api/v1/key": Self.openRouterKey
+            default: throw FixtureError.unexpectedURL(request.url)
+            }
+        }
+        let now = Date(timeIntervalSince1970: 1_785_686_400)
+        let swift = try await OpenRouterUsageFetcher.fetchUsage(
+            apiKey: "fixture-key",
+            environment: [:],
+            transport: transport).toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
+            .fetchUsage(secrets: ["OPENROUTER_API_KEY": "fixture-key"], now: now)
+
+        Self.expectCoreParity(swift, script)
+        #expect(try script.details == [
+            Self.section("Credits", rows: [
+                Self.row("Remaining", "$60.00"),
+                Self.row("Used", "$40.00"),
+                Self.row("Total added", "$100.00"),
+            ]),
+            Self.section(
+                "API key",
+                rows: [
+                    Self.row("API key budget", "$20.00"),
+                    Self.row("API key used", "$5.00"),
+                    Self.row("Today", "$1.00"),
+                    Self.row("This week", "$2.00"),
+                    Self.row("This month", "$4.00"),
+                    Self.row("Rate limit", "120 requests / 10s"),
+                ],
+                chart: Self.chart("Key spend", unit: "USD", points: [
+                    ("Today", 1), ("This week", 2), ("This month", 4),
+                ])),
+        ])
+    }
+
+    @Test
+    func `ClawRouter fixture has Swift core parity and stable details`() async throws {
+        let transport = Self.transport { request in
+            guard request.url?.path == "/v1/usage" else { throw FixtureError.unexpectedURL(request.url) }
+            return Self.clawRouter
+        }
+        let now = Date(timeIntervalSince1970: 1_785_686_400)
+        let swift = try await ClawRouterUsageFetcher.fetchUsage(
+            apiKey: "fixture-key",
+            baseURL: #require(URL(string: "https://clawrouter.openclaw.ai")),
+            transport: transport,
+            updatedAt: now).toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(bundledPlugin: "clawrouter", transport: transport)
+            .fetchUsage(secrets: ["CLAWROUTER_API_KEY": "fixture-key"], now: now)
+
+        Self.expectCoreParity(swift, script)
+        #expect(try script.details == [
+            Self.section("Usage", rows: [
+                Self.row("Requests", "6", "5 succeeded · 1 failed"),
+                Self.row("Tokens", "54191", "50000 input · 4191 output"),
+                Self.row("Actual cost", "$0.006000"),
+                Self.row("Budget ledger", "durable_object"),
+                Self.row("Monthly budget", "$0.006000 / $25.00", "$24.994000 remaining"),
+            ]),
+            Self.section(
+                "Routed providers",
+                rows: [
+                    Self.row("openai", "4 requests", "$0.004000 · 42000 tokens"),
+                    Self.row("anthropic", "2 requests", "$0.002000 · 12191 tokens"),
+                ],
+                chart: Self.chart("Provider cost", unit: "USD", points: [
+                    ("openai", 0.004), ("anthropic", 0.002),
+                ])),
+        ])
+    }
+
+    @Test
+    func `Poe fixture has Swift core parity and stable details`() async throws {
+        let transport = Self.transport { request in
+            switch request.url?.path {
+            case "/usage/current_balance": Self.poeBalance
+            case "/usage/points_history": Self.poeHistory
+            default: throw FixtureError.unexpectedURL(request.url)
+            }
+        }
+        let now = Date(timeIntervalSince1970: 1_785_816_000)
+        let swift = try await PoeUsageFetcher._fetchUsage(apiKey: "fixture-key", transport: transport).toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(bundledPlugin: "poe", transport: transport)
+            .fetchUsage(secrets: ["POE_API_KEY": "fixture-key"], now: now)
+
+        Self.expectCoreParity(swift, script)
+        #expect(try script.details == [Self.section(
+            "Points",
+            rows: [
+                Self.row("Current balance", "2,500 points"),
+                Self.row("Last 7 days", "20.5 points", "2 requests"),
+                Self.row("Last 30 days", "20.5 points", "2 requests"),
+                Self.row("Top model", "gpt-5", "12.5 points"),
+                Self.row("Top usage type", "API", "12.5 points"),
+            ],
+            chart: Self.chart("Daily points", unit: "points", points: [
+                ("2026-08-02", 12.5), ("2026-08-03", 8),
+            ]))])
+    }
+
+    @Test
+    func `zai fixture has Swift core parity and stable details`() async throws {
+        let transport = Self.transport { request in
+            if request.url?.path.hasSuffix("/quota/limit") == true {
+                return Self.zaiQuota
+            }
+            if request.url?.path.hasSuffix("/model-usage") == true {
+                return Self.zaiModelUsage
+            }
+            throw FixtureError.unexpectedURL(request.url)
+        }
+        let now = Date(timeIntervalSince1970: 1_785_816_000)
+        let swift = try await ZaiUsageFetcher.fetchUsageWithModelUsage(
+            apiKey: "fixture-key",
+            environment: [:],
+            transport: transport).toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(bundledPlugin: "zai", transport: transport)
+            .fetchUsage(secrets: [
+                "Z_AI_API_KEY": "fixture-key",
+                "Z_AI_REGION": "global",
+                "Z_AI_USAGE_SCOPE": "personal",
+            ], now: now)
+
+        Self.expectCoreParity(swift, script)
+        #expect(try script.details == [
+            Self.section("Quota details", rows: [
+                Self.row("Token quota", "9% used"),
+                Self.row("Session token quota", "25% used"),
+                Self.row("MCP quota", "22.4% used", "1000 limit · 776 remaining"),
+                Self.row("search-prime", "210"),
+                Self.row("web-reader", "14"),
+            ]),
+            Self.section(
+                "Hourly tokens",
+                rows: [
+                    Self.row("glm-4.6", "100"),
+                    Self.row("glm-4.5", "75"),
+                ],
+                chart: Self.chart("Hourly tokens", unit: "tokens", points: [
+                    ("2026-08-02 08:00", 150), ("2026-08-02 09:00", 25),
+                ])),
+            Self.section(
+                "Daily tokens",
+                rows: [
+                    Self.row("glm-4.6", "100"),
+                    Self.row("glm-4.5", "75"),
+                ],
+                chart: Self.chart("Daily tokens", unit: "tokens", points: [
+                    ("2026-08-02 08:00", 150), ("2026-08-02 09:00", 25),
+                ])),
+        ])
+    }
+
+    @Test
+    func `OpenAI fixture has Swift core parity and stable details`() async throws {
+        let transport = Self.transport { request in
+            if request.url?.path.hasSuffix("/organization/costs") == true {
+                return Self.openAICosts
+            }
+            if request.url?.path.hasSuffix("/usage/completions") == true {
+                return Self.openAICompletions
+            }
+            throw FixtureError.unexpectedURL(request.url)
+        }
+        let now = Date(timeIntervalSince1970: 1_700_179_200)
+        let swift = try await OpenAIAPIUsageFetcher.fetchUsage(
+            apiKey: "fixture-key",
+            session: transport,
+            now: now,
+            historyDays: 30).toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(bundledPlugin: "openai", transport: transport)
+            .fetchUsage(secrets: [
+                "OPENAI_API_KEY": "fixture-key",
+                "OPENAI_HISTORY_DAYS": "30",
+                "OPENAI_ALLOW_BALANCE_FALLBACK": "1",
+            ], now: now)
+
+        Self.expectCoreParity(swift, script)
+        #expect(try script.details == [
+            Self.section(
+                "Usage summary",
+                rows: [
+                    Self.row("Spend", "$14.75", "Last 30 days"),
+                    Self.row("Requests", "10"),
+                    Self.row("Tokens", "2,000", "1,300 input · 700 output"),
+                    Self.row("Cached input", "250"),
+                ],
+                chart: Self.chart("Daily spend", unit: "USD", points: [("2023-11-14", 14.75)])),
+            Self.section("Models", rows: [
+                Self.row("gpt-5.2", "1,500 tokens", "7 requests"),
+                Self.row("gpt-5.2-codex", "500 tokens", "3 requests"),
+            ]),
+            Self.section("Line items", rows: [
+                Self.row("Text tokens", "$12.50"),
+                Self.row("Web search tool calls", "$2.25"),
+            ]),
+        ])
+    }
+
+    private static func transport(
+        body: @escaping @Sendable (URLRequest) throws -> String) -> ProviderHTTPTransportHandler
+    {
+        ProviderHTTPTransportHandler { request in
+            #expect(request.httpMethod == "GET")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer fixture-key")
+            let response = try #require(HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]))
+            return try (Data(body(request).utf8), response)
+        }
+    }
+
+    private static func row(_ label: String, _ value: String, _ secondary: String? = nil)
+        throws -> ProviderDetailSection.Row
+    {
+        try ProviderDetailSection.Row(label: label, value: value, secondaryValue: secondary)
+    }
+
+    private static func chart(
+        _ title: String,
+        unit: String,
+        points: [(String, Double)]) throws -> ProviderDetailSection.Chart
+    {
+        try ProviderDetailSection.Chart(
+            kind: .bars,
+            title: title,
+            unit: unit,
+            points: points.map { try ProviderDetailSection.Chart.Point(label: $0.0, value: $0.1) })
+    }
+
+    private static func section(
+        _ title: String,
+        rows: [ProviderDetailSection.Row],
+        chart: ProviderDetailSection.Chart? = nil) throws -> ProviderDetailSection
+    {
+        try ProviderDetailSection(title: title, rows: rows, chart: chart)
+    }
+
+    private static func expectCoreParity(_ swift: UsageSnapshot, _ script: UsageSnapshot) {
+        #expect(swift.primary == script.primary)
+        #expect(swift.secondary == script.secondary)
+        #expect(swift.tertiary == script.tertiary)
+        #expect(swift.extraRateWindows == script.extraRateWindows)
+        #expect(swift.subscriptionRenewsAt == script.subscriptionRenewsAt)
+        #expect(swift.subscriptionExpiresAt == script.subscriptionExpiresAt)
+        #expect(swift.providerCost?.used == script.providerCost?.used)
+        #expect(swift.providerCost?.limit == script.providerCost?.limit)
+        #expect(swift.providerCost?.currencyCode == script.providerCost?.currencyCode)
+        #expect(swift.providerCost?.period == script.providerCost?.period)
+        #expect(swift.providerCost?.resetsAt == script.providerCost?.resetsAt)
+        #expect(swift.providerCost?.nextRegenAmount == script.providerCost?.nextRegenAmount)
+        #expect(swift.identity?.providerID == script.identity?.providerID)
+        #expect(swift.identity?.accountEmail == script.identity?.accountEmail)
+        #expect(swift.identity?.accountOrganization == script.identity?.accountOrganization)
+        #expect(swift.identity?.loginMethod == script.identity?.loginMethod)
+        #expect(swift.identity?.accountID == script.identity?.accountID)
+    }
+
+    private static func environment(for provider: UsageProvider) -> [String: String] {
+        switch provider {
+        case .openai: [OpenAIAPISettingsReader.apiKeyEnvironmentKey: "fixture-key"]
+        case .zai: [ZaiSettingsReader.apiTokenKey: "fixture-key"]
+        case .openrouter: [OpenRouterSettingsReader.envKey: "fixture-key"]
+        case .poe: [PoeSettingsReader.apiKeyEnvironmentKey: "fixture-key"]
+        case .clawrouter: [ClawRouterSettingsReader.apiKeyEnvironmentKey: "fixture-key"]
+        default: [:]
+        }
+    }
+
+    private static func context(environment: [String: String]) -> ProviderFetchContext {
+        ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .api,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: environment,
+            settings: nil,
+            fetcher: UsageFetcher(environment: environment),
+            claudeFetcher: FixtureClaudeFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0))
+    }
+
+    private enum FixtureError: Error {
+        case unexpectedURL(URL?)
+    }
+
+    private static let openRouterCredits = #"{"data":{"total_credits":100,"total_usage":40}}"#
+    private static let openRouterKey = #"""
+    {"data":{"limit":20,"usage":5,"usage_daily":1,"usage_weekly":2,"usage_monthly":4,
+    "rate_limit":{"requests":120,"interval":"10s"}}}
+    """#
+    private static let poeBalance = #"{"current_point_balance":2500}"#
+    private static let poeHistory = #"""
+    {"data":[
+      {"query_id":"p1","creation_time":1785686400000000,"bot_name":"gpt-5","usage_type":"API",
+       "cost_points":12.5,"cost_usd":0.03},
+      {"query_id":"p2","creation_time":1785772800000000,"bot_name":"claude-sonnet-4","usage_type":"Chat",
+       "cost_points":8,"cost_usd":0.02}
+    ],"next_cursor":null}
+    """#
+    private static let zaiQuota = #"""
+    {"code":200,"msg":"success","success":true,"data":{"planName":"Pro","limits":[
+      {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":25,"nextResetTime":1785816000000},
+      {"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":9,"nextResetTime":1786291200000},
+      {"type":"TIME_LIMIT","unit":5,"number":1,"usage":1000,"currentValue":224,"remaining":776,
+       "percentage":22,"usageDetails":[{"modelCode":"search-prime","usage":210},
+       {"modelCode":"web-reader","usage":14}]}
+    ]}}
+    """#
+    private static let zaiModelUsage = #"""
+    {"code":200,"msg":"success","success":true,"data":{
+      "x_time":["2026-08-02 08:00","2026-08-02 09:00"],
+      "modelDataList":[{"modelName":"glm-4.6","tokensUsage":[100,null]},
+      {"modelName":"glm-4.5","tokensUsage":[50,25]}]}}
+    """#
+    private static let clawRouter = #"""
+    {"budget":{"configured":true,"ledger":"durable_object","windowKey":"fixture/2026-07",
+      "limitMicros":25000000,"spentMicros":6000,"remainingMicros":24994000},
+     "usage":{"summary":{"requestCount":6,"successCount":5,"errorCount":1,"inputTokens":50000,
+       "outputTokens":4191,"totalTokens":54191,"actualCostMicros":6000},"providers":[
+       {"provider":"anthropic","requestCount":2,"successCount":2,"errorCount":0,
+        "totalTokens":12191,"actualCostMicros":2000},
+       {"provider":"openai","requestCount":4,"successCount":3,"errorCount":1,
+        "totalTokens":42000,"actualCostMicros":4000}]}}
+    """#
+    private static let openAICosts = #"""
+    {"object":"page","data":[{"object":"bucket","start_time":1700000000,"end_time":1700086400,"results":[
+      {"amount":{"value":12.5,"currency":"usd"},"line_item":"Text tokens"},
+      {"amount":{"value":"2.25","currency":"usd"},"line_item":"Web search tool calls"}
+    ]}],"has_more":false,"next_page":null}
+    """#
+    private static let openAICompletions = #"""
+    {"object":"page","data":[{"object":"bucket","start_time":1700000000,"end_time":1700086400,"results":[
+      {"input_tokens":1000,"input_cached_tokens":250,"output_tokens":500,"num_model_requests":7,
+       "model":"gpt-5.2"},
+      {"input_tokens":300,"output_tokens":200,"num_model_requests":3,"model":"gpt-5.2-codex"}
+    ]}],"has_more":false,"next_page":null}
+    """#
+}
+
+private struct FixtureClaudeFetcher: ClaudeUsageFetching {
+    func loadLatestUsage(model _: String) async throws -> ClaudeUsageSnapshot {
+        throw ProviderPluginError.script("unused")
+    }
+
+    func debugRawProbe(model _: String) async -> String {
+        "unused"
+    }
+
+    func detectVersion() -> String? {
+        nil
+    }
+}
+#endif

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -95,6 +95,54 @@ struct ProviderPluginRuntimeTests {
     }
 
     @Test
+    func `details map strictly and trim display strings`() async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
+        return {
+          details: [{
+            title: " Summary ",
+            rows: [{ label: " Requests ", value: " 42 ", secondaryValue: " Today " }],
+            chart: {
+              kind: "line",
+              title: " Daily ",
+              unit: " tokens ",
+              points: [{ label: " Mon ", value: 12.5 }],
+            },
+          }],
+        };
+        """))
+
+        let snapshot = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret"])
+
+        let section = try #require(snapshot.details.first)
+        #expect(section.title == "Summary")
+        #expect(try section.rows == [ProviderDetailSection.Row(
+            label: "Requests",
+            value: "42",
+            secondaryValue: "Today")])
+        let expectedChart = try ProviderDetailSection.Chart(
+            kind: .line,
+            title: "Daily",
+            unit: "tokens",
+            points: [ProviderDetailSection.Chart.Point(label: "Mon", value: 12.5)])
+        #expect(section.chart == expectedChart)
+    }
+
+    @Test(arguments: [
+        #"details: {}"#,
+        #"details: [{ rows: [{ label: "ok", value: 1 }] }]"#,
+        #"details: [{ rows: [], chart: { kind: "pie", points: [] } }]"#,
+        #"details: [{ rows: [], chart: { kind: "bars", points: [{ label: "x", value: NaN }] } }]"#,
+        #"details: [{ rows: [], chart: { kind: "bars", points: Array.from({length: 121}, (_, i) => ({label: String(i), value: i})) } }]"#,
+    ])
+    func `present invalid details fail the fetch`(body: String) async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: "return { \(body) };"))
+
+        await #expect(throws: ProviderPluginError.self) {
+            _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret"])
+        }
+    }
+
+    @Test
     func `promise rejection preserves message`() async throws {
         let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
         throw new Error("fixture rejected");

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -132,7 +132,12 @@ struct ProviderPluginRuntimeTests {
         #"details: [{ rows: [{ label: "ok", value: 1 }] }]"#,
         #"details: [{ rows: [], chart: { kind: "pie", points: [] } }]"#,
         #"details: [{ rows: [], chart: { kind: "bars", points: [{ label: "x", value: NaN }] } }]"#,
-        #"details: [{ rows: [], chart: { kind: "bars", points: Array.from({length: 121}, (_, i) => ({label: String(i), value: i})) } }]"#,
+        #"""
+        details: [{
+          rows: [],
+          chart: { kind: "bars", points: Array.from({length: 121}, (_, i) => ({label: String(i), value: i})) },
+        }]
+        """#,
     ])
     func `present invalid details fail the fetch`(body: String) async throws {
         let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: "return { \(body) };"))

--- a/docs/plugin-conversion-matrix.md
+++ b/docs/plugin-conversion-matrix.md
@@ -17,12 +17,19 @@ is inherently a user-chosen origin (LLM Proxy and LiteLLM) do not qualify. The c
 current Swift request methods and snapshot projections; Azure OpenAI, StepFun, and Warp were removed from the audit's
 earlier “fully expressible” baseline because their current implementations issue POST requests.
 
+`convertible-now (details)` means the bundled JavaScript conversion is present behind `CODEXBAR_JS_PROVIDERS=1` and its
+provider-specific dashboard projection is expressed through declarative detail sections. `needs-plugin-host-extension`
+marks providers uncovered during implementation whose canonical flow needs a runtime primitive beyond declared-origin
+GET, declared settings/secrets, and details.
+
 ## Totals
 
 | Status | Count |
 |---|---:|
 | `convertible-now` | 11 |
-| `needs-details-model` | 8 |
+| `convertible-now (details)` | 5 |
+| `needs-details-model` | 0 |
+| `needs-plugin-host-extension` | 3 |
 | `needs-cookie-import` | 23 |
 | `needs-files/subprocess/oauth-broker` | 15 |
 | `needs-pty/webview/native` | 10 |
@@ -33,7 +40,7 @@ earlier “fully expressible” baseline because their current implementations i
 | Provider | Status | Reason |
 |---|---|---|
 | codex | `needs-pty/webview/native` | PTY CLI, OAuth files/refresh, browser cookies, WKWebView scraping, local logs, and reset-credit details exceed this host. |
-| openai | `needs-details-model` | GET pagination fits, but daily/model/line-item cost and token history does not fit the generic snapshot. |
+| openai | `convertible-now (details)` | Converted: fixed-origin bearer GET pagination with daily spend, model, line-item, and token details. |
 | azureopenai | `needs-pty/webview/native` | The current quota probe is a POST chat completion against a user-configured deployment origin. |
 | claude | `needs-files/subprocess/oauth-broker` | Full parity needs credential files/Keychain, OAuth refresh, CLI/PTY, cookies, local logs, and admin details. |
 | clinepass | `convertible-now` | Verified fixed-origin bearer GET; limits and identity map to generic windows. |
@@ -48,7 +55,7 @@ earlier “fully expressible” baseline because their current implementations i
 | antigravity | `needs-pty/webview/native` | Process/port discovery, localhost IDE RPC, OAuth files, and a persistent PTY make this a native integration. |
 | copilot | `needs-cookie-import` | API-token usage fits, but billing budgets require GitHub cookies/nonces and the device flow needs POST. |
 | devin | `needs-files/subprocess/oauth-broker` | Full auth discovery reads Chromium localStorage and organization state; manual bearer alone is partial. |
-| zai | `needs-details-model` | Generic quota windows fit, but model/time-limit details and the hourly chart require a details schema. |
+| zai | `convertible-now (details)` | Converted: both fixed regional origins, personal/team settings, quota lanes, model totals, and hourly/daily token charts. |
 | minimax | `needs-cookie-import` | Browser cookies/storage and group discovery feed a large service/billing/history-specific payload. |
 | manus | `needs-cookie-import` | Full session acquisition imports browser cookies; a manually supplied bearer covers only one path. |
 | kimi | `needs-cookie-import` | Browser cookies plus Kimi credential/device files and regional identity headers exceed the current broker. |
@@ -63,7 +70,7 @@ earlier “fully expressible” baseline because their current implementations i
 | ollama | `needs-cookie-import` | The full hosted flow imports cookies and scrapes HTML; the API-key model-count probe is only partial. |
 | synthetic | `convertible-now` | Converted: fixed-origin bearer GET with generic windows, cost, dates, and identity. |
 | warp | `needs-pty/webview/native` | Warp sends a POST GraphQL operation, which the GET-only HTTP broker cannot express. |
-| openrouter | `needs-details-model` | The bearer GET fits, but credits, per-key budgets, and rate-limit detail require a provider detail model. |
+| openrouter | `convertible-now (details)` | Converted: bearer GET credits plus best-effort key budget, period spend, rate-limit rows, and a spend chart. |
 | elevenlabs | `convertible-now` | Verified `xi-api-key` GET; heterogeneous character/minute quotas map to named generic windows. |
 | windsurf | `needs-files/subprocess/oauth-broker` | Chromium localStorage, IDE databases, and binary protobuf decoding supply the current session. |
 | zed | `needs-files/subprocess/oauth-broker` | Zed server settings and a named Keychain credential must be read locally. |
@@ -86,16 +93,16 @@ earlier “fully expressible” baseline because their current implementations i
 | groq | `needs-cookie-import` | The API-token Prometheus path is partial; console parity imports Stytch/browser sessions and history details. |
 | llmproxy | `needs-pty/webview/native` | Its origin is user-selected and may be private HTTP, conflicting with the manifest's fixed HTTPS origins. |
 | litellm | `needs-pty/webview/native` | Its required user-selected proxy origin and optional private HTTP cannot be declared by a bundled static manifest. |
-| deepgram | `needs-details-model` | GET acquisition fits, but project and heterogeneous hours/tokens/characters/request totals need details. |
-| poe | `needs-details-model` | Bearer GET pagination fits, but raw/daily/model/type point history does not fit the generic snapshot. |
+| deepgram | `needs-plugin-host-extension` | Skipped: Deepgram requires `Authorization: Token <key>`; the prototype can inject bearer or a raw custom-header value but cannot prefix a custom auth scheme. |
+| poe | `convertible-now (details)` | Converted: fixed-origin bearer GET balance/history pagination with daily points and model/type summaries. |
 | chutes | `convertible-now` | Verified bearer GET fan-out on the canonical origin; dynamic quota lanes map to named windows. |
 | neuralwatt | `convertible-now` | Verified canonical bearer GET; quota lanes and prepaid cost/energy project generically. |
-| clawrouter | `needs-details-model` | Bearer JSON acquisition fits, but budget ledger, request/token totals, and upstream summaries need details. |
+| clawrouter | `convertible-now (details)` | Converted for the canonical origin: monthly budget, ledger, request/token totals, routed-provider rows, and cost chart. |
 | longcat | `needs-cookie-import` | Account, token use, and pending fuel merge behind an imported browser/manual cookie session. |
-| sub2api | `needs-details-model` | Bearer JSON acquisition fits, but balance/quota/rate/subscription/today/total fields need details. |
+| sub2api | `needs-plugin-host-extension` | Skipped: every instance requires a user-selected origin and may use loopback HTTP; bundled manifests allow only predeclared HTTPS origins. |
 | wayfinder | `needs-pty/webview/native` | The local unauthenticated HTTP gateway, metrics text, and routing/savings model violate HTTPS-only generic scope. |
 | zenmux | `convertible-now` | Verified fixed-origin bearer GET pair; subscription and optional PAYG balance map generically. |
 | aiand | `convertible-now` | Verified fixed-origin bearer GET pagination; 30-day spend maps to generic cost. |
 | zoommate | `needs-cookie-import` | Host-specific cookies are exchanged for a JWT, then paginated credit history requires details. |
-| xai | `needs-details-model` | Management-key GETs fit, but prepaid balance, limit state, and daily cost history need details. |
+| xai | `needs-plugin-host-extension` | Skipped: prepaid balance is GET, but canonical daily usage history is a POST request with a JSON body. |
 | notion | `needs-cookie-import` | Workspace selection and AI allowance calls require imported Notion cookies and forwarded session headers. |

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -95,6 +95,38 @@ be positive integers.
 `subscriptionRenewsAt` and `subscriptionExpiresAt` accept a JavaScript `Date` or ISO-8601 string. Missing optionals are
 fine, while a present value of the wrong type fails the entire fetch with its property path.
 
+### Declarative details
+
+`details` is an optional array of sections rendered generically in the provider menu card. A snapshot may contain
+details without a rate window or cost. Each section has optional `title`, required `rows`, and an optional simple chart:
+
+```js
+return {
+  primary: { usedPercent: 25 },
+  details: [{
+    title: "Usage summary",
+    rows: [
+      { label: "Requests", value: "1,240", secondaryValue: "Last 30 days" },
+      { label: "Top model", value: "gpt-5" },
+    ],
+    chart: {
+      kind: "bars", // bars | line
+      title: "Daily spend",
+      unit: "USD",
+      points: [
+        { label: "2026-08-01", value: 4.25 },
+        { label: "2026-08-02", value: 6.50 },
+      ],
+    },
+  }],
+};
+```
+
+The bridge rejects rather than truncates more than 8 sections, 24 rows per section, or 120 points per chart. Section,
+row, chart, and point strings are trimmed and limited to 120 characters; required row/point strings must remain
+non-empty. Point values must be finite numbers. A present value with the wrong type, an unknown chart kind, or any
+bound violation fails the entire fetch with its property path.
+
 ## Concurrency and execution limit
 
 Each runtime owns one `JSContext` confined to a dedicated serial dispatch queue; `JSContext` and every `JSValue` remain
@@ -110,7 +142,14 @@ runtime needs a public interrupt API or a killable helper-process boundary befor
 ## Current limitations
 
 The runtime is macOS-only and compiled out when JavaScriptCore is unavailable. It supports bundled first-party IDs and
-the generic snapshot only: no runtime identities, user-installed files, install UI, TypeScript/Sucrase, provider-specific
-dashboard payloads, cookies, OAuth/refresh broker, local files or databases, subprocesses, POST bodies, PTY, WebView,
+the generic snapshot and declarative details only: no runtime identities, user-installed files, install UI,
+TypeScript/Sucrase, provider-specific Swift payloads, cookies, OAuth/refresh broker, local files or databases,
+subprocesses, POST bodies, PTY, WebView,
 binary/protobuf responses, localhost HTTP, or dynamic endpoint origins. See
 [`plugin-conversion-matrix.md`](plugin-conversion-matrix.md) for the provider-by-provider impact.
+
+## Future work
+
+Migrating existing Swift providers' roughly 25 bespoke `UsageSnapshot` payload fields onto the details model is
+intentionally not part of this prototype slice. Those fields and their current views remain intact for the flag-off
+path and for providers not yet converted.

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -15,20 +15,23 @@ the default.
 
 ## Enable and test
 
-Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, Venice, and Crof then prepend a script strategy to
-their existing API pipeline. A missing required secret leaves the script strategy unavailable and permits the Swift
-strategy to run; a loaded script that fails does not fall back, so parity defects stay visible. Without the variable,
-the resolver returns the original Swift strategy only and does not load JavaScriptCore or a plugin resource.
+Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, Venice, Crof, OpenAI, z.ai, OpenRouter, Poe, and
+ClawRouter then prepend a script strategy to their existing API pipeline. A missing required secret leaves the script
+strategy unavailable and permits the Swift strategy to run; a loaded script that fails does not fall back, so parity
+defects stay visible. Without the variable, the resolver returns the original Swift strategy only and does not load
+JavaScriptCore or a plugin resource.
 
 Run the focused proof with:
 
 ```sh
 swift test --filter ProviderPluginRuntimeTests
 swift test --filter ProviderPluginParityTests
+swift test --filter ProviderPluginDetailsParityTests
 ```
 
-The second suite sends the same canned response through an injected `ProviderHTTPTransport` to both implementations and
-compares core windows, percentages, reset dates, cost, subscription dates, and identity fields.
+The parity suites send the same canned responses through an injected `ProviderHTTPTransport` to both implementations
+and compare core windows, percentages, reset dates, cost, subscription dates, and identity fields. Details-provider
+fixtures additionally characterize the complete declarative section output.
 
 ## Manifest
 


### PR DESCRIPTION
## Summary

- Add a bounded `ProviderDetailSection` model for declarative sections, rows, and bar charts. Construction and decoding enforce limits on section/row/point counts, string lengths, and finite chart values.
- Preserve snapshot compatibility: the existing snapshot JSON fixture decodes with empty details, and re-encoding omits the absent field.
- Add one generic details renderer that is inserted only when details are non-empty, so the default UI remains unchanged. The converted paths are currently reachable only with `CODEXBAR_JS_PROVIDERS=1`, so there are no screenshots for this PR.
- Convert OpenAI, z.ai, OpenRouter, Poe, and ClawRouter to bundled JavaScript providers behind the prototype flag. Fixture tests prove parity with each Swift provider's core snapshot projection and golden detail sections/charts.
- Update the conversion matrix totals: 5 providers are now `convertible-now (details)`, `needs-details-model` falls to 0, and 3 providers move to `needs-plugin-host-extension`.

## Deferred host API work

- Deepgram: requires the `Authorization: Token <key>` auth scheme, which the current host cannot prefix.
- Sub2API: requires a configurable user-selected origin, including possible loopback HTTP.
- xAI: canonical daily usage history requires POST with a JSON body.

These three conversions are queued for the next host-API PR.

## Proof

- `make check`
- `make build`
- Full `make test`: 805/805 selections across 68 groups
- Structured autoreview against `origin/main`: clean, no accepted/actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
