### PR TITLE
feat: plugin cookie capability and host API extensions

### DIFF
--- a/Sources/CodexBarCore/Plugins/ProviderPluginCookieBroker.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginCookieBroker.swift
@@ -1,0 +1,149 @@
+#if canImport(JavaScriptCore)
+import Foundation
+
+#if os(macOS)
+import SweetCookieKit
+#endif
+
+enum ProviderPluginCookieBroker {
+    static func resolver(context: ProviderFetchContext) -> ProviderPluginRuntime.CookieResolver {
+        let settings = context.settings
+        let browserDetection = context.browserDetection
+        return { provider, domain in
+            try self.cookieHeader(
+                provider: provider,
+                domain: domain,
+                settings: settings,
+                browserDetection: browserDetection)
+        }
+    }
+
+    private static func cookieHeader(
+        provider: UsageProvider,
+        domain: String,
+        settings: ProviderSettingsSnapshot?,
+        browserDetection: BrowserDetection) throws -> String
+    {
+        let cookieSettings = settings?.pluginCookieSettings(for: provider)
+        switch cookieSettings?.cookieSource ?? .auto {
+        case .off:
+            throw ProviderPluginError.secretAccess("browser cookies are disabled for this provider")
+        case .manual:
+            guard let header = CookieHeaderNormalizer.normalize(cookieSettings?.manualCookieHeader) else {
+                throw ProviderPluginError.secretAccess("the manual cookie header is unavailable")
+            }
+            return header
+        case .auto:
+            if let cached = CookieHeaderCache.load(provider: provider),
+               let header = CookieHeaderNormalizer.normalize(cached.cookieHeader)
+            {
+                return header
+            }
+            return try self.importCookieHeader(
+                provider: provider,
+                domain: domain,
+                browserDetection: browserDetection)
+        }
+    }
+
+    private static func importCookieHeader(
+        provider: UsageProvider,
+        domain: String,
+        browserDetection: BrowserDetection) throws -> String
+    {
+        #if os(macOS)
+        let importOrder = ProviderDefaults.metadata[provider]?.browserCookieOrder ?? Browser.defaultImportOrder
+        let query = BrowserCookieQuery(domains: [domain])
+        let client = BrowserCookieClient()
+        for browser in importOrder.cookieImportCandidates(using: browserDetection) {
+            do {
+                let sources = try client.codexBarRecords(matching: query, in: browser)
+                for source in sources where !source.records.isEmpty {
+                    let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
+                    let rawHeader = cookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+                    guard let header = CookieHeaderNormalizer.normalize(rawHeader) else { continue }
+                    CookieHeaderCache.store(provider: provider, cookieHeader: header, sourceLabel: source.label)
+                    return header
+                }
+            } catch {
+                BrowserCookieAccessGate.recordIfNeeded(error)
+            }
+        }
+        throw ProviderPluginError.secretAccess("no browser session cookies were found")
+        #else
+        _ = provider
+        _ = domain
+        _ = browserDetection
+        throw ProviderPluginError.secretAccess("browser cookie import is unavailable on this platform")
+        #endif
+    }
+}
+
+extension ProviderSettingsSnapshot {
+    // Centralizes the provider-specific settings shape at the cookie broker boundary.
+    // swiftlint:disable:next cyclomatic_complexity
+    fileprivate func pluginCookieSettings(for provider: UsageProvider) -> PluginCookieSettings? {
+        switch provider {
+        case .cursor: self.cursor.map(PluginCookieSettings.init)
+        case .opencode: self.opencode.map {
+                PluginCookieSettings(cookieSource: $0.cookieSource, manualCookieHeader: $0.manualCookieHeader)
+            }
+        case .opencodego: self.opencodego.map {
+                PluginCookieSettings(cookieSource: $0.cookieSource, manualCookieHeader: $0.manualCookieHeader)
+            }
+        case .alibaba: self.alibaba.map {
+                PluginCookieSettings(cookieSource: $0.cookieSource, manualCookieHeader: $0.manualCookieHeader)
+            }
+        case .alibabatokenplan: self.alibabaTokenPlan.map(PluginCookieSettings.init)
+        case .qwencloud: self.qwenCloud.map(PluginCookieSettings.init)
+        case .factory: self.factory.map(PluginCookieSettings.init)
+        case .minimax: self.minimax.map {
+                PluginCookieSettings(cookieSource: $0.cookieSource, manualCookieHeader: $0.manualCookieHeader)
+            }
+        case .manus: self.manus.map(PluginCookieSettings.init)
+        case .copilot: self.copilot.map {
+                PluginCookieSettings(
+                    cookieSource: $0.budgetCookieSource,
+                    manualCookieHeader: $0.manualBudgetCookieHeader)
+            }
+        case .kimi: self.kimi.map(PluginCookieSettings.init)
+        case .longcat: self.longcat.map(PluginCookieSettings.init)
+        case .augment: self.augment.map(PluginCookieSettings.init)
+        case .amp: self.amp.map(PluginCookieSettings.init)
+        case .t3chat: self.t3chat.map(PluginCookieSettings.init)
+        case .zoommate: self.zoommate.map(PluginCookieSettings.init)
+        case .notion: self.notion.map {
+                PluginCookieSettings(cookieSource: $0.cookieSource, manualCookieHeader: $0.manualCookieHeader)
+            }
+        case .commandcode: self.commandcode.map(PluginCookieSettings.init)
+        case .ollama: self.ollama.map(PluginCookieSettings.init)
+        case .windsurf: self.windsurf.map {
+                PluginCookieSettings(cookieSource: $0.cookieSource, manualCookieHeader: $0.manualCookieHeader)
+            }
+        case .perplexity: self.perplexity.map(PluginCookieSettings.init)
+        case .mimo: self.mimo.map(PluginCookieSettings.init)
+        case .abacus: self.abacus.map(PluginCookieSettings.init)
+        case .mistral: self.mistral.map(PluginCookieSettings.init)
+        case .qoder: self.qoder.map(PluginCookieSettings.init)
+        case .stepfun: self.stepfun.map {
+                PluginCookieSettings(cookieSource: $0.cookieSource, manualCookieHeader: $0.manualToken)
+            }
+        default: nil
+        }
+    }
+}
+
+private struct PluginCookieSettings: ProviderCookieSettings {
+    let cookieSource: ProviderCookieSource
+    let manualCookieHeader: String?
+
+    init(cookieSource: ProviderCookieSource, manualCookieHeader: String?) {
+        self.cookieSource = cookieSource
+        self.manualCookieHeader = manualCookieHeader
+    }
+
+    init(_ settings: some ProviderCookieSettings) {
+        self.init(cookieSource: settings.cookieSource, manualCookieHeader: settings.manualCookieHeader)
+    }
+}
+#endif

--- a/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
@@ -26,28 +26,49 @@ public struct ProviderPluginAuth: Equatable, Sendable {
         case bearer
         case xAPIKey = "x-api-key"
         case header
+        case authorizationScheme = "authorization-scheme"
     }
 
     public let type: Kind
     public let header: String
     public let secret: String
+    public let scheme: String?
 
-    public init(type: Kind, header: String, secret: String) {
+    public init(type: Kind, header: String, secret: String, scheme: String? = nil) {
         self.type = type
         self.header = header
         self.secret = secret
+        self.scheme = scheme
     }
+}
+
+public enum ProviderPluginEndpoint: Equatable, Hashable, Sendable {
+    public enum Policy: String, Sendable {
+        case https
+        case httpsOrLoopbackHTTP = "https-or-loopback-http"
+    }
+
+    case fixed(String)
+    case setting(key: String, policy: Policy)
+}
+
+public enum ProviderPluginCapability: String, Sendable {
+    case browserCookies = "browser-cookies"
 }
 
 public struct ProviderPluginManifest: @unchecked Sendable {
     public let id: UsageProvider
     public let name: String
-    public let endpoints: Set<String>
-    public let auth: ProviderPluginAuth
+    public let endpoints: Set<ProviderPluginEndpoint>
+    public let auth: ProviderPluginAuth?
     public let settings: [ProviderPluginSetting]
+    public let capabilities: Set<ProviderPluginCapability>
+    public let cookieDomains: Set<String>
 
     let fetchUsage: JSValue
 
+    // Manifest parsing validates the complete security surface in one pass.
+    // swiftlint:disable:next cyclomatic_complexity
     init(definition: JSValue) throws {
         guard definition.isObject else {
             throw ProviderPluginError.invalidManifest("defineProvider(...) requires an object")
@@ -69,35 +90,27 @@ public struct ProviderPluginManifest: @unchecked Sendable {
         guard endpointCount > 0 else {
             throw ProviderPluginError.invalidManifest("'endpoints' must not be empty")
         }
-        var endpoints: Set<String> = []
+        var endpoints: Set<ProviderPluginEndpoint> = []
         for index in 0..<endpointCount {
-            guard let rawEndpoint = endpointValue.atIndex(index), rawEndpoint.isString else {
-                throw ProviderPluginError.invalidManifest("endpoint at index \(index) must be a string")
+            guard let rawEndpoint = endpointValue.atIndex(index) else {
+                throw ProviderPluginError.invalidManifest("endpoint at index \(index) is missing")
             }
-            try endpoints.insert(ProviderPluginOrigin.normalizedOrigin(rawEndpoint.toString()))
+            if rawEndpoint.isString {
+                try endpoints.insert(.fixed(ProviderPluginOrigin.normalizedOrigin(rawEndpoint.toString())))
+                continue
+            }
+            guard rawEndpoint.isObject else {
+                throw ProviderPluginError.invalidManifest(
+                    "endpoint at index \(index) must be an HTTPS origin or setting endpoint")
+            }
+            let key = try Self.requiredString(rawEndpoint, property: "setting")
+            let rawPolicy = try Self.requiredString(rawEndpoint, property: "policy")
+            guard let policy = ProviderPluginEndpoint.Policy(rawValue: rawPolicy) else {
+                throw ProviderPluginError.invalidManifest("unsupported endpoint policy '\(rawPolicy)'")
+            }
+            endpoints.insert(.setting(key: key, policy: policy))
         }
         self.endpoints = endpoints
-
-        guard let authValue = definition.forProperty("auth"), authValue.isObject else {
-            throw ProviderPluginError.invalidManifest("'auth' must be an object")
-        }
-        let rawAuthType = try Self.requiredString(authValue, property: "type")
-        guard let authType = ProviderPluginAuth.Kind(rawValue: rawAuthType) else {
-            throw ProviderPluginError.invalidManifest("unsupported auth type '\(rawAuthType)'")
-        }
-        let secret = try Self.requiredString(authValue, property: "secret")
-        let header: String = switch authType {
-        case .bearer:
-            "Authorization"
-        case .xAPIKey:
-            "X-API-Key"
-        case .header:
-            try Self.requiredString(authValue, property: "header")
-        }
-        guard Self.isValidHeaderName(header) else {
-            throw ProviderPluginError.invalidManifest("auth header '\(header)' is invalid")
-        }
-        self.auth = ProviderPluginAuth(type: authType, header: header, secret: secret)
 
         guard let settingsValue = definition.forProperty("settings"), settingsValue.isArray else {
             throw ProviderPluginError.invalidManifest("'settings' must be an array")
@@ -121,10 +134,93 @@ public struct ProviderPluginManifest: @unchecked Sendable {
             }
             settings.append(ProviderPluginSetting(key: key, title: title, subtitle: subtitle, kind: kind))
         }
-        guard settingKeys.contains(secret) else {
-            throw ProviderPluginError.invalidManifest("auth secret '\(secret)' must be declared in settings")
+        for endpoint in endpoints {
+            guard case let .setting(key, _) = endpoint else { continue }
+            guard settings.first(where: { $0.key == key })?.kind == .plain else {
+                throw ProviderPluginError.invalidManifest(
+                    "endpoint setting '\(key)' must be declared as a plain setting")
+            }
         }
         self.settings = settings
+
+        if let authValue = definition.forProperty("auth"), !authValue.isUndefined, !authValue.isNull {
+            guard authValue.isObject else {
+                throw ProviderPluginError.invalidManifest("'auth' must be an object when present")
+            }
+            let rawAuthType = try Self.requiredString(authValue, property: "type")
+            guard let authType = ProviderPluginAuth.Kind(rawValue: rawAuthType) else {
+                throw ProviderPluginError.invalidManifest("unsupported auth type '\(rawAuthType)'")
+            }
+            let secret = try Self.requiredString(authValue, property: "secret")
+            let header: String = switch authType {
+            case .bearer, .authorizationScheme:
+                "Authorization"
+            case .xAPIKey:
+                "X-API-Key"
+            case .header:
+                try Self.requiredString(authValue, property: "header")
+            }
+            let scheme: String? = if authType == .authorizationScheme {
+                try Self.requiredString(authValue, property: "scheme")
+            } else {
+                nil
+            }
+            guard Self.isValidHeaderName(header) else {
+                throw ProviderPluginError.invalidManifest("auth header '\(header)' is invalid")
+            }
+            if let scheme, !Self.isValidAuthorizationScheme(scheme) {
+                throw ProviderPluginError.invalidManifest("authorization scheme '\(scheme)' is invalid")
+            }
+            guard settings.first(where: { $0.key == secret })?.kind == .secure else {
+                throw ProviderPluginError.invalidManifest(
+                    "auth secret '\(secret)' must be declared as a secure setting")
+            }
+            self.auth = ProviderPluginAuth(type: authType, header: header, secret: secret, scheme: scheme)
+        } else {
+            self.auth = nil
+        }
+
+        let capabilitiesValue = definition.forProperty("capabilities")
+        var capabilities: Set<ProviderPluginCapability> = []
+        if let capabilitiesValue, !capabilitiesValue.isUndefined, !capabilitiesValue.isNull {
+            guard capabilitiesValue.isArray else {
+                throw ProviderPluginError.invalidManifest("'capabilities' must be an array when present")
+            }
+            let count = Int(capabilitiesValue.forProperty("length")?.toInt32() ?? 0)
+            for index in 0..<count {
+                guard let value = capabilitiesValue.atIndex(index), value.isString,
+                      let capability = ProviderPluginCapability(rawValue: value.toString())
+                else {
+                    throw ProviderPluginError.invalidManifest("unsupported capability at index \(index)")
+                }
+                capabilities.insert(capability)
+            }
+        }
+        self.capabilities = capabilities
+
+        let cookieDomainsValue = definition.forProperty("cookieDomains")
+        var cookieDomains: Set<String> = []
+        if let cookieDomainsValue, !cookieDomainsValue.isUndefined, !cookieDomainsValue.isNull {
+            guard capabilities.contains(.browserCookies), cookieDomainsValue.isArray else {
+                throw ProviderPluginError.invalidManifest(
+                    "'cookieDomains' requires the browser-cookies capability and must be an array")
+            }
+            let count = Int(cookieDomainsValue.forProperty("length")?.toInt32() ?? 0)
+            for index in 0..<count {
+                guard let value = cookieDomainsValue.atIndex(index), value.isString else {
+                    throw ProviderPluginError.invalidManifest("cookie domain at index \(index) must be a string")
+                }
+                try cookieDomains.insert(Self.normalizedCookieDomain(value.toString()))
+            }
+            guard !cookieDomains.isEmpty else {
+                throw ProviderPluginError.invalidManifest("'cookieDomains' must not be empty")
+            }
+        }
+        if capabilities.contains(.browserCookies), cookieDomains.isEmpty {
+            throw ProviderPluginError.invalidManifest(
+                "the browser-cookies capability requires at least one declared cookie domain")
+        }
+        self.cookieDomains = cookieDomains
 
         guard let fetchUsage = definition.forProperty("fetchUsage"), fetchUsage.isObject else {
             throw ProviderPluginError.invalidManifest("'fetchUsage' must be a function")
@@ -178,6 +274,29 @@ public struct ProviderPluginManifest: @unchecked Sendable {
                 || "!#$%&'*+-.^_`|~".unicodeScalars.contains(scalar))
         }
     }
+
+    private static func isValidAuthorizationScheme(_ value: String) -> Bool {
+        value.utf8.count <= 32 && self.isValidHeaderName(value)
+    }
+
+    private static func normalizedCookieDomain(_ rawValue: String) throws -> String {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !value.isEmpty, value.utf8.count <= 253,
+              !value.hasPrefix("."), !value.hasSuffix("."), !value.contains("/"), !value.contains(":")
+        else {
+            throw ProviderPluginError.invalidManifest("cookie domain '\(rawValue)' is invalid")
+        }
+        let labels = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard labels.allSatisfy({ label in
+            !label.isEmpty && label.utf8.count <= 63 && label.first != "-" && label.last != "-" &&
+                label.utf8.allSatisfy { byte in
+                    (48...57).contains(byte) || (97...122).contains(byte) || byte == 45
+                }
+        }) else {
+            throw ProviderPluginError.invalidManifest("cookie domain '\(rawValue)' is invalid")
+        }
+        return value
+    }
 }
 
 enum ProviderPluginOrigin {
@@ -199,14 +318,26 @@ enum ProviderPluginOrigin {
     }
 
     static func normalizedOrigin(of url: URL) throws -> String {
-        guard url.scheme?.lowercased() == "https", url.user == nil, url.password == nil else {
-            throw ProviderPluginError.networkPolicy("only HTTPS URLs without user info are allowed")
+        try self.normalizedOrigin(of: url, policy: .https)
+    }
+
+    static func normalizedOrigin(of url: URL, policy: ProviderPluginEndpoint.Policy) throws -> String {
+        let validator = ProviderEndpointOverrideValidator()
+        let validated: URL? = switch policy {
+        case .https:
+            validator.validatedURL(url.absoluteString)
+        case .httpsOrLoopbackHTTP:
+            validator.validatedURLAllowingLoopbackHTTP(url.absoluteString)
         }
-        guard let host = url.host?.lowercased(), !host.isEmpty else {
+        guard let validated, validated.fragment == nil, validated.user == nil, validated.password == nil else {
+            throw ProviderPluginError.networkPolicy("URL does not satisfy the declared endpoint policy")
+        }
+        guard let scheme = validated.scheme?.lowercased(), let host = validated.host?.lowercased(), !host.isEmpty else {
             throw ProviderPluginError.networkPolicy("request URL has no host")
         }
-        let port = url.port
-        return "https://\(host)\(port == nil || port == 443 ? "" : ":\(port!)")"
+        let port = validated.port
+        let defaultPort = scheme == "https" ? 443 : 80
+        return "\(scheme)://\(host)\(port == nil || port == defaultPort ? "" : ":\(port!)")"
     }
 }
 

--- a/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
@@ -6,6 +6,8 @@ import FoundationNetworking
 @preconcurrency import JavaScriptCore
 
 public final class ProviderPluginRuntime: @unchecked Sendable {
+    public typealias CookieResolver = @Sendable (UsageProvider, String) async throws -> String
+
     public static let defaultTimeout: TimeInterval = 20
     public static let maximumResponseBytes = 5 * 1024 * 1024
 
@@ -61,19 +63,34 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
         self.manifest = worker.manifest
     }
 
-    public func fetchUsage(secrets: [String: String], now: Date = Date()) async throws -> UsageSnapshot {
+    public func fetchUsage(
+        settings: [String: String] = [:],
+        secrets: [String: String] = [:],
+        now: Date = Date(),
+        cookieResolver: CookieResolver? = nil) async throws -> UsageSnapshot
+    {
+        let sanitizedSettings = settings.mapValues {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
         let sanitizedSecrets = secrets.mapValues {
             $0.trimmingCharacters(in: .whitespacesAndNewlines)
         }
-        guard let authSecret = sanitizedSecrets[self.manifest.auth.secret], !authSecret.isEmpty else {
-            throw ProviderPluginError.secretAccess("required secret '\(self.manifest.auth.secret)' is unavailable")
+        if let auth = self.manifest.auth,
+           sanitizedSecrets[auth.secret]?.isEmpty != false
+        {
+            throw ProviderPluginError.secretAccess("required secret '\(auth.secret)' is unavailable")
         }
 
         let worker = try self.currentWorker()
         let gate = ProviderPluginCompletionGate<UsageSnapshot>()
         return try await withCheckedThrowingContinuation { continuation in
             gate.install(continuation)
-            worker.fetch(secrets: sanitizedSecrets, now: now) { result in
+            worker.fetch(
+                settings: sanitizedSettings,
+                secrets: sanitizedSecrets,
+                now: now,
+                cookieResolver: cookieResolver)
+            { result in
                 gate.finish(result.mapError { self.redactedError($0, secrets: sanitizedSecrets.values) })
             }
             Task.detached { [weak self, weak worker] in
@@ -205,8 +222,31 @@ private struct ProviderPluginHTTPRequestCallbacks: @unchecked Sendable {
     let reject: ProviderPluginJSValueBox
 }
 
+private final class ProviderPluginRedactionValues: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: Set<String>
+
+    init(_ values: some Sequence<String>) {
+        self.values = Set(values.filter { !$0.isEmpty })
+    }
+
+    func insert(_ value: String) {
+        guard !value.isEmpty else { return }
+        _ = self.lock.withLock { self.values.insert(value) }
+    }
+
+    func redact(_ message: String) -> String {
+        self.lock.withLock {
+            self.values.reduce(message) { partial, value in
+                partial.replacingOccurrences(of: value, with: "<redacted>")
+            }
+        }
+    }
+}
+
 private final class ProviderPluginWorker: @unchecked Sendable {
-    private typealias HTTPBlock = @convention(block) (String, JSValue, Bool, JSValue, JSValue) -> Void
+    private typealias HTTPBlock = @convention(block) (String, JSValue, String, Bool, JSValue, JSValue) -> Void
+    private typealias CookieBlock = @convention(block) (String, JSValue, JSValue) -> Void
 
     let manifest: ProviderPluginManifest
 
@@ -287,22 +327,36 @@ private final class ProviderPluginWorker: @unchecked Sendable {
     }
 
     func fetch(
+        settings: [String: String],
         secrets: [String: String],
         now: Date,
+        cookieResolver: ProviderPluginRuntime.CookieResolver?,
         completion: @escaping @Sendable (Result<UsageSnapshot, Error>) -> Void)
     {
         self.queue.async {
-            self.beginFetch(secrets: secrets, now: now, completion: completion)
+            self.beginFetch(
+                settings: settings,
+                secrets: secrets,
+                now: now,
+                cookieResolver: cookieResolver,
+                completion: completion)
         }
     }
 
     private func beginFetch(
+        settings: [String: String],
         secrets: [String: String],
         now: Date,
+        cookieResolver: ProviderPluginRuntime.CookieResolver?,
         completion: @escaping @Sendable (Result<UsageSnapshot, Error>) -> Void)
     {
         self.context.exception = nil
-        let ctx = self.makeContext(secrets: secrets)
+        let redactionValues = ProviderPluginRedactionValues(secrets.values)
+        let ctx = self.makeContext(
+            settings: settings,
+            secrets: secrets,
+            cookieResolver: cookieResolver,
+            redactionValues: redactionValues)
         guard self.context.exception == nil else {
             completion(.failure(ProviderPluginError.script(Self.exceptionMessage(self.context) ?? "ctx setup failed")))
             return
@@ -316,13 +370,14 @@ private final class ProviderPluginWorker: @unchecked Sendable {
                 let snapshot = try ProviderPluginSnapshotMapper.map(value, provider: self.manifest.id, now: now)
                 completion(.success(snapshot))
             } catch {
-                completion(.failure(error))
+                completion(.failure(ProviderPluginError
+                        .invalidSnapshot(redactionValues.redact(error.localizedDescription))))
             }
         }
         let reject: @convention(block) (JSValue) -> Void = { [weak self] value in
             guard let self else { return }
             defer { self.retainedCallbacks[callbackID] = nil }
-            completion(.failure(ProviderPluginError.script(self.message(from: value))))
+            completion(.failure(ProviderPluginError.script(redactionValues.redact(self.message(from: value)))))
         }
         self.retainedCallbacks[callbackID] = [resolve, reject]
 
@@ -349,27 +404,39 @@ private final class ProviderPluginWorker: @unchecked Sendable {
         }
     }
 
-    private func makeContext(secrets: [String: String]) -> JSValue {
+    private func makeContext(
+        settings: [String: String],
+        secrets: [String: String],
+        cookieResolver: ProviderPluginRuntime.CookieResolver?,
+        redactionValues: ProviderPluginRedactionValues) -> JSValue
+    {
         let ctx = JSValue(newObjectIn: self.context)!
         let host = JSValue(newObjectIn: self.context)!
 
-        let secretGet: @convention(block) (String) -> JSValue = { [weak self] key in
+        let settingGet: @convention(block) (String, Bool) -> JSValue = { [weak self] key, secure in
             guard let self else { return JSValue(undefinedIn: nil) }
-            guard self.manifest.settings.contains(where: { $0.key == key }) else {
+            let expectedKind: ProviderPluginSetting.Kind = secure ? .secure : .plain
+            guard self.manifest.settings.contains(where: { $0.key == key && $0.kind == expectedKind }) else {
                 self.context.exception = JSValue(
-                    newErrorFromMessage: "secret key '\(key)' is not declared in settings",
+                    newErrorFromMessage: "\(secure ? "secret" : "plain") setting '\(key)' is not declared",
                     in: self.context)
                 return JSValue(undefinedIn: self.context)
             }
-            guard let secret = secrets[key], !secret.isEmpty else {
+            let values = secure ? secrets : settings
+            guard let value = values[key], !value.isEmpty else {
                 return JSValue(nullIn: self.context)
             }
-            return JSValue(object: secret, in: self.context)
+            return JSValue(object: value, in: self.context)
         }
-        host.setObject(secretGet, forKeyedSubscript: "secretGet" as NSString)
+        host.setObject(settingGet, forKeyedSubscript: "settingGet" as NSString)
 
-        let http = self.makeHTTPBlock(secrets: secrets)
+        let http = self.makeHTTPBlock(settings: settings, secrets: secrets, redactionValues: redactionValues)
         host.setObject(http, forKeyedSubscript: "http" as NSString)
+
+        let cookieHeader = self.makeCookieBlock(
+            resolver: cookieResolver,
+            redactionValues: redactionValues)
+        host.setObject(cookieHeader, forKeyedSubscript: "cookieHeader" as NSString)
 
         let cacheGet: @convention(block) (String) -> JSValue = { [weak self] key in
             guard let self else { return JSValue(undefinedIn: nil) }
@@ -388,7 +455,7 @@ private final class ProviderPluginWorker: @unchecked Sendable {
 
         let log: @convention(block) (String) -> Void = { [manifest] message in
             let logger = CodexBarLog.logger(LogCategories.provider(manifest.id, scope: "plugin"))
-            logger.debug("\(message)")
+            logger.debug("\(redactionValues.redact(message))")
         }
         host.setObject(log, forKeyedSubscript: "log" as NSString)
 
@@ -396,12 +463,19 @@ private final class ProviderPluginWorker: @unchecked Sendable {
         return ctx
     }
 
-    private func makeHTTPBlock(secrets: [String: String]) -> HTTPBlock {
-        { [weak self] rawURL, options, wantsJSON, resolve, reject in
+    private func makeHTTPBlock(
+        settings: [String: String],
+        secrets: [String: String],
+        redactionValues: ProviderPluginRedactionValues) -> HTTPBlock
+    {
+        { [weak self] rawURL, options, method, wantsJSON, resolve, reject in
             self?.startHTTPRequest(
                 rawURL: rawURL,
                 options: options,
+                method: method,
+                settings: settings,
                 secrets: secrets,
+                redactionValues: redactionValues,
                 callbacks: ProviderPluginHTTPRequestCallbacks(
                     wantsJSON: wantsJSON,
                     resolve: ProviderPluginJSValueBox(resolve),
@@ -409,15 +483,25 @@ private final class ProviderPluginWorker: @unchecked Sendable {
         }
     }
 
+    // Keep the JavaScript bridge inputs explicit at the executor boundary.
+    // swiftlint:disable:next function_parameter_count
     private func startHTTPRequest(
         rawURL: String,
         options: JSValue,
+        method: String,
+        settings: [String: String],
         secrets: [String: String],
+        redactionValues: ProviderPluginRedactionValues,
         callbacks: ProviderPluginHTTPRequestCallbacks)
     {
         let request: URLRequest
         do {
-            request = try self.makeRequest(rawURL: rawURL, options: options, secrets: secrets)
+            request = try self.makeRequest(
+                rawURL: rawURL,
+                options: options,
+                method: method,
+                settings: settings,
+                secrets: secrets)
         } catch {
             self.reject(callbacks.reject, error: error)
             return
@@ -440,7 +524,7 @@ private final class ProviderPluginWorker: @unchecked Sendable {
                     _ = callbacks.resolve.value.call(withArguments: [value as Any])
                 }
             } catch {
-                let failure = ProviderPluginError.http(error.localizedDescription)
+                let failure = ProviderPluginError.http(redactionValues.redact(error.localizedDescription))
                 worker.queue.async {
                     worker.reject(callbacks.reject, error: failure)
                 }
@@ -448,19 +532,83 @@ private final class ProviderPluginWorker: @unchecked Sendable {
         }
     }
 
-    private func makeRequest(rawURL: String, options: JSValue, secrets: [String: String]) throws -> URLRequest {
+    private func makeCookieBlock(
+        resolver: ProviderPluginRuntime.CookieResolver?,
+        redactionValues: ProviderPluginRedactionValues) -> CookieBlock
+    {
+        { [weak self] rawDomain, resolve, reject in
+            guard let self else { return }
+            let domain = rawDomain.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard self.manifest.capabilities.contains(.browserCookies),
+                  self.manifest.cookieDomains.contains(domain)
+            else {
+                self.reject(
+                    ProviderPluginJSValueBox(reject),
+                    error: ProviderPluginError.secretAccess("cookie domain is not declared"))
+                return
+            }
+            guard let resolver else {
+                self.reject(
+                    ProviderPluginJSValueBox(reject),
+                    error: ProviderPluginError.secretAccess("browser cookie access is unavailable"))
+                return
+            }
+
+            let provider = self.manifest.id
+            let worker = self
+            let resolveBox = ProviderPluginJSValueBox(resolve)
+            let rejectBox = ProviderPluginJSValueBox(reject)
+            Task.detached {
+                do {
+                    let header = try await resolver(provider, domain)
+                    redactionValues.insert(header)
+                    for pair in CookieHeaderNormalizer.pairs(from: header) {
+                        redactionValues.insert(pair.value)
+                    }
+                    worker.queue.async {
+                        _ = resolveBox.value.call(withArguments: [header])
+                    }
+                } catch {
+                    let failure = ProviderPluginError.secretAccess(redactionValues.redact(error.localizedDescription))
+                    worker.queue.async {
+                        worker.reject(rejectBox, error: failure)
+                    }
+                }
+            }
+        }
+    }
+
+    private func makeRequest(
+        rawURL: String,
+        options: JSValue,
+        method: String,
+        settings: [String: String],
+        secrets: [String: String]) throws -> URLRequest
+    {
         guard let url = URL(string: rawURL) else {
             throw ProviderPluginError.networkPolicy("request URL is invalid")
         }
-        let origin = try ProviderPluginOrigin.normalizedOrigin(of: url)
-        guard self.manifest.endpoints.contains(origin) else {
-            throw ProviderPluginError.networkPolicy("origin '\(origin)' is not declared")
+        guard try self.allowedOrigin(for: url, settings: settings) else {
+            let rejectedOrigin = (try? ProviderPluginOrigin.normalizedOrigin(
+                of: url,
+                policy: url.scheme?.lowercased() == "http" ? .httpsOrLoopbackHTTP : .https)) ?? "invalid"
+            throw ProviderPluginError.networkPolicy("origin '\(rejectedOrigin)' is not declared")
         }
 
         var request = URLRequest(url: url)
-        request.httpMethod = "GET"
+        guard method == "GET" || method == "POST" else {
+            throw ProviderPluginError.networkPolicy("HTTP method is not allowed")
+        }
+        request.httpMethod = method
         request.timeoutInterval = 15
         request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if method == "POST" {
+            guard let bodyJSON = options.forProperty("bodyJSON"), bodyJSON.isString else {
+                throw ProviderPluginError.http("POST JSON body is missing")
+            }
+            request.httpBody = Data(bodyJSON.toString().utf8)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
         if options.isObject,
            let headers = options.forProperty("headers"),
            headers.isObject,
@@ -470,19 +618,52 @@ private final class ProviderPluginWorker: @unchecked Sendable {
                 guard let value = rawValue as? String else {
                     throw ProviderPluginError.http("request header '\(name)' must be a string")
                 }
-                if name.caseInsensitiveCompare(self.manifest.auth.header) == .orderedSame {
+                if let auth = self.manifest.auth,
+                   name.caseInsensitiveCompare(auth.header) == .orderedSame
+                {
                     throw ProviderPluginError.networkPolicy("plugins may not override the auth header")
                 }
                 request.setValue(value, forHTTPHeaderField: name)
             }
         }
 
-        guard let secret = secrets[self.manifest.auth.secret], !secret.isEmpty else {
-            throw ProviderPluginError.secretAccess("required auth secret is unavailable")
+        if let auth = self.manifest.auth {
+            guard let secret = secrets[auth.secret], !secret.isEmpty else {
+                throw ProviderPluginError.secretAccess("required auth secret is unavailable")
+            }
+            let authValue = switch auth.type {
+            case .bearer:
+                "Bearer \(secret)"
+            case .authorizationScheme:
+                "\(auth.scheme!) \(secret)"
+            case .xAPIKey, .header:
+                secret
+            }
+            request.setValue(authValue, forHTTPHeaderField: auth.header)
         }
-        let authValue = self.manifest.auth.type == .bearer ? "Bearer \(secret)" : secret
-        request.setValue(authValue, forHTTPHeaderField: self.manifest.auth.header)
         return request
+    }
+
+    private func allowedOrigin(for url: URL, settings: [String: String]) throws -> Bool {
+        for endpoint in self.manifest.endpoints {
+            switch endpoint {
+            case let .fixed(declared):
+                if (try? ProviderPluginOrigin.normalizedOrigin(of: url)) == declared {
+                    return true
+                }
+            case let .setting(key, policy):
+                guard let rawValue = settings[key], !rawValue.isEmpty,
+                      let configuredURL = URL(string: rawValue), configuredURL.fragment == nil
+                else { continue }
+                let configuredOrigin = try ProviderPluginOrigin.normalizedOrigin(of: configuredURL, policy: policy)
+                if try ProviderPluginOrigin
+                    .normalizedOrigin(of: url, policy: policy) == configuredOrigin
+                {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     private static func responsePayload(_ response: ProviderHTTPResponse, wantsJSON: Bool) throws -> [String: Any] {

--- a/Sources/CodexBarCore/Plugins/ScriptFetchStrategy.swift
+++ b/Sources/CodexBarCore/Plugins/ScriptFetchStrategy.swift
@@ -11,16 +11,26 @@ public enum ProviderPluginPrototype {
 
 public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendable {
     public typealias SecretResolver = @Sendable ([String: String]) -> String?
-    public typealias SecretsResolver = @Sendable (ProviderFetchContext) -> [String: String]?
+    public struct Values: Sendable {
+        public let settings: [String: String]
+        public let secrets: [String: String]
+
+        public init(settings: [String: String] = [:], secrets: [String: String] = [:]) {
+            self.settings = settings
+            self.secrets = secrets
+        }
+    }
+
+    public typealias ValuesResolver = @Sendable (ProviderFetchContext) -> Values?
     public typealias EnabledResolver = @Sendable ([String: String]) -> Bool
 
     public let id: String
-    public let kind: ProviderFetchKind = .apiToken
+    public let kind: ProviderFetchKind
 
     private let provider: UsageProvider
     private let bundledPlugin: String
-    private let secretKey: String
-    private let resolveSecrets: SecretsResolver
+    private let secretKey: String?
+    private let resolveValues: ValuesResolver
     private let isEnabled: EnabledResolver
     private let transport: any ProviderHTTPTransport
     private let timeout: TimeInterval
@@ -32,6 +42,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         provider: UsageProvider,
         bundledPlugin: String,
         secretKey: String,
+        kind: ProviderFetchKind = .apiToken,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
         resolveSecret: @escaping SecretResolver,
@@ -40,12 +51,13 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         self.id = id
         self.provider = provider
         self.bundledPlugin = bundledPlugin
+        self.kind = kind
         self.secretKey = secretKey
         self.transport = transport
         self.timeout = timeout
-        self.resolveSecrets = { context in
+        self.resolveValues = { context in
             guard let secret = resolveSecret(context.env) else { return nil }
-            return [secretKey: secret]
+            return Values(secrets: [secretKey: secret])
         }
         self.isEnabled = isEnabled
     }
@@ -54,32 +66,38 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         id: String,
         provider: UsageProvider,
         bundledPlugin: String,
-        secretKey: String,
+        secretKey: String? = nil,
+        kind: ProviderFetchKind = .apiToken,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
-        resolveSecrets: @escaping SecretsResolver,
+        resolveValues: @escaping ValuesResolver,
         isEnabled: @escaping EnabledResolver = { ProviderPluginPrototype.isEnabled(environment: $0) })
     {
         self.id = id
         self.provider = provider
         self.bundledPlugin = bundledPlugin
+        self.kind = kind
         self.secretKey = secretKey
         self.transport = transport
         self.timeout = timeout
-        self.resolveSecrets = resolveSecrets
+        self.resolveValues = resolveValues
         self.isEnabled = isEnabled
     }
 
     public func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        guard self.isEnabled(context.env), let secrets = self.resolveSecrets(context) else { return false }
-        return secrets[self.secretKey]?.isEmpty == false
+        guard self.isEnabled(context.env), let values = self.resolveValues(context) else { return false }
+        guard let secretKey else { return true }
+        return values.secrets[secretKey]?.isEmpty == false
     }
 
     public func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         guard self.isEnabled(context.env) else {
             throw ProviderPluginError.load("JavaScript provider prototype is disabled")
         }
-        guard let secrets = self.resolveSecrets(context), secrets[self.secretKey]?.isEmpty == false else {
+        guard let values = self.resolveValues(context) else {
+            throw ProviderPluginError.secretAccess("required provider secret is unavailable")
+        }
+        if let secretKey, values.secrets[secretKey]?.isEmpty != false {
             throw ProviderPluginError.secretAccess("required provider secret is unavailable")
         }
         let runtime = try self.loadedRuntime()
@@ -87,7 +105,10 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
             throw ProviderPluginError.invalidManifest(
                 "bundled plugin id '\(runtime.manifest.id.rawValue)' does not match '\(self.provider.rawValue)'")
         }
-        let usage = try await runtime.fetchUsage(secrets: secrets)
+        let usage = try await runtime.fetchUsage(
+            settings: values.settings,
+            secrets: values.secrets,
+            cookieResolver: ProviderPluginCookieBroker.resolver(context: context))
         return self.makeResult(usage: usage, sourceLabel: "js")
     }
 

--- a/Sources/CodexBarCore/Providers/Deepgram/DeepgramProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Deepgram/DeepgramProviderDescriptor.swift
@@ -42,16 +42,51 @@ public enum DeepgramProviderDescriptor {
                 noDataMessage: {
                     "Deepgram cost summary is not yet supported."
                 }),
-            fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .api],
-                pipeline: ProviderFetchPipeline(
-                    resolveStrategies: { _ in
-                        [DeepgramAPIFetchStrategy()]
-                    })),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "deepgram",
                 aliases: ["dg"],
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                let swift = DeepgramAPIFetchStrategy()
+                #if canImport(JavaScriptCore)
+                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
+                return [
+                    ScriptFetchStrategy(
+                        id: "deepgram.js",
+                        provider: .deepgram,
+                        bundledPlugin: "deepgram",
+                        secretKey: DeepgramSettingsReader.apiKeyEnvironmentKey,
+                        resolveValues: { context in
+                            guard let key = ProviderTokenResolver.deepgramResolution(
+                                type: .apiKey,
+                                environment: context.env)
+                            else { return nil }
+                            var settings: [String: String] = [:]
+                            if let project = ProviderTokenResolver.deepgramResolution(
+                                type: .projectID,
+                                environment: context.env)
+                            {
+                                settings[DeepgramSettingsReader.projectIDEnvironmentKey] = project
+                            }
+                            if let apiURL = context.env[DeepgramUsageFetcher.apiURLKey] {
+                                settings[DeepgramUsageFetcher.apiURLKey] = apiURL
+                            }
+                            return ScriptFetchStrategy.Values(
+                                settings: settings,
+                                secrets: [DeepgramSettingsReader.apiKeyEnvironmentKey: key])
+                        }),
+                    swift,
+                ]
+                #else
+                return [swift]
+                #endif
+            }))
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Manus/ManusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Manus/ManusProviderDescriptor.swift
@@ -36,13 +36,36 @@ public enum ManusProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Manus cost summary is not supported." }),
-            fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [ManusWebFetchStrategy()] })),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "manus",
                 aliases: [],
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        ProviderFetchPlan(
+            sourceModes: [.auto, .web],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                let swift = ManusWebFetchStrategy()
+                #if canImport(JavaScriptCore)
+                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
+                return [
+                    ScriptFetchStrategy(
+                        id: "manus.js",
+                        provider: .manus,
+                        bundledPlugin: "manus",
+                        kind: .web,
+                        resolveValues: { context in
+                            guard context.settings?.manus?.cookieSource != .off else { return nil }
+                            return ScriptFetchStrategy.Values()
+                        }),
+                    swift,
+                ]
+                #else
+                return [swift]
+                #endif
+            }))
     }
 }
 
@@ -69,7 +92,9 @@ struct ManusWebFetchStrategy: ProviderFetchStrategy {
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         guard context.settings?.manus?.cookieSource != .off else { return false }
-        if context.settings?.manus?.cookieSource == .manual { return true }
+        if context.settings?.manus?.cookieSource == .manual {
+            return true
+        }
 
         if let cached = CookieHeaderCache.load(provider: .manus),
            ManusCookieHeader.token(from: cached.cookieHeader) != nil
@@ -116,9 +141,15 @@ struct ManusWebFetchStrategy: ProviderFetchStrategy {
     }
 
     func shouldFallback(on error: Error, context _: ProviderFetchContext) -> Bool {
-        if case ManusAPIError.missingToken = error { return false }
-        if case ManusAPIError.invalidCookie = error { return false }
-        if case ManusAPIError.invalidToken = error { return false }
+        if case ManusAPIError.missingToken = error {
+            return false
+        }
+        if case ManusAPIError.invalidCookie = error {
+            return false
+        }
+        if case ManusAPIError.invalidToken = error {
+            return false
+        }
         return true
     }
 

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIProviderDescriptor.swift
@@ -55,17 +55,19 @@ public enum OpenAIAPIProviderDescriptor {
                         provider: .openai,
                         bundledPlugin: "openai",
                         secretKey: OpenAIAPISettingsReader.apiKeyEnvironmentKey,
-                        resolveSecrets: { context in
+                        resolveValues: { context in
                             guard let credential = OpenAIAPIUsageCredential(environment: context.env)
                             else { return nil }
-                            var values = [OpenAIAPISettingsReader.apiKeyEnvironmentKey: credential.apiKey]
+                            var settings: [String: String] = [:]
                             if let projectID = credential.projectID {
-                                values[OpenAIAPISettingsReader.projectIDEnvironmentKey] = projectID
+                                settings[OpenAIAPISettingsReader.projectIDEnvironmentKey] = projectID
                             }
-                            values["OPENAI_HISTORY_DAYS"] = String(context.costUsageHistoryDays)
-                            values["OPENAI_ALLOW_BALANCE_FALLBACK"] =
+                            settings["OPENAI_HISTORY_DAYS"] = String(context.costUsageHistoryDays)
+                            settings["OPENAI_ALLOW_BALANCE_FALLBACK"] =
                                 credential.allowsLegacyBalanceFallback ? "1" : "0"
-                            return values
+                            return ScriptFetchStrategy.Values(
+                                settings: settings,
+                                secrets: [OpenAIAPISettingsReader.apiKeyEnvironmentKey: credential.apiKey])
                         }),
                     swift,
                 ]

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift
@@ -38,13 +38,36 @@ public enum PerplexityProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Perplexity cost tracking is not supported." }),
-            fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [PerplexityWebFetchStrategy()] })),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "perplexity",
                 aliases: [],
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        ProviderFetchPlan(
+            sourceModes: [.auto, .web],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                let swift = PerplexityWebFetchStrategy()
+                #if canImport(JavaScriptCore)
+                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
+                return [
+                    ScriptFetchStrategy(
+                        id: "perplexity.js",
+                        provider: .perplexity,
+                        bundledPlugin: "perplexity",
+                        kind: .web,
+                        resolveValues: { context in
+                            guard context.settings?.perplexity?.cookieSource != .off else { return nil }
+                            return ScriptFetchStrategy.Values()
+                        }),
+                    swift,
+                ]
+                #else
+                return [swift]
+                #endif
+            }))
     }
 }
 
@@ -75,7 +98,9 @@ struct PerplexityWebFetchStrategy: ProviderFetchStrategy {
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         guard context.settings?.perplexity?.cookieSource != .off else { return false }
-        if context.settings?.perplexity?.cookieSource == .manual { return true }
+        if context.settings?.perplexity?.cookieSource == .manual {
+            return true
+        }
 
         // Priority order mirrors resolveSessionCookie: manual override → cache → browser import → env var
         if PerplexityCookieHeader.resolveCookieOverride(context: context) != nil {
@@ -88,7 +113,9 @@ struct PerplexityWebFetchStrategy: ProviderFetchStrategy {
 
         #if os(macOS)
         if context.settings?.perplexity?.cookieSource != .off {
-            if PerplexityCookieImporter.hasSession() { return true }
+            if PerplexityCookieImporter.hasSession() {
+                return true
+            }
         }
         #endif
 
@@ -129,9 +156,15 @@ struct PerplexityWebFetchStrategy: ProviderFetchStrategy {
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
-        if case PerplexityAPIError.missingToken = error { return false }
-        if case PerplexityAPIError.invalidCookie = error { return false }
-        if case PerplexityAPIError.invalidToken = error { return false }
+        if case PerplexityAPIError.missingToken = error {
+            return false
+        }
+        if case PerplexityAPIError.invalidCookie = error {
+            return false
+        }
+        if case PerplexityAPIError.invalidToken = error {
+            return false
+        }
         return true
     }
 

--- a/Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift
@@ -37,13 +37,36 @@ public enum QoderProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Qoder cost summary is not supported." }),
-            fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [QoderWebFetchStrategy()] })),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "qoder",
                 aliases: [],
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        ProviderFetchPlan(
+            sourceModes: [.auto, .web],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                let swift = QoderWebFetchStrategy()
+                #if canImport(JavaScriptCore)
+                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
+                return [
+                    ScriptFetchStrategy(
+                        id: "qoder.js",
+                        provider: .qoder,
+                        bundledPlugin: "qoder",
+                        kind: .web,
+                        resolveValues: { context in
+                            guard context.settings?.qoder?.cookieSource != .off else { return nil }
+                            return ScriptFetchStrategy.Values()
+                        }),
+                    swift,
+                ]
+                #else
+                return [swift]
+                #endif
+            }))
     }
 
     public static func dashboardURL(
@@ -171,8 +194,12 @@ struct QoderWebFetchStrategy: ProviderFetchStrategy {
         terminalNonAuthError: Error?,
         sawInvalidCredentials: Bool) -> Error?
     {
-        if let terminalNonAuthError { return terminalNonAuthError }
-        if sawInvalidCredentials { return QoderUsageError.invalidCredentials }
+        if let terminalNonAuthError {
+            return terminalNonAuthError
+        }
+        if sawInvalidCredentials {
+            return QoderUsageError.invalidCredentials
+        }
         return nil
     }
 

--- a/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
@@ -34,13 +34,40 @@ public enum Sub2APIProviderDescriptor {
         tokenCost: ProviderTokenCostConfig(
             supportsTokenCost: false,
             noDataMessage: { "sub2api spend is reported by its usage API." }),
-        fetchPlan: ProviderFetchPlan(
-            sourceModes: [.auto, .api],
-            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [Sub2APIAPIFetchStrategy()] })),
+        fetchPlan: Self.fetchPlan(),
         cli: ProviderCLIConfig(
             name: "sub2api",
             aliases: ["sub-2-api"],
             versionDetector: nil))
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                let swift = Sub2APIAPIFetchStrategy()
+                #if canImport(JavaScriptCore)
+                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
+                return [
+                    ScriptFetchStrategy(
+                        id: "sub2api.js",
+                        provider: .sub2api,
+                        bundledPlugin: "sub2api",
+                        secretKey: Sub2APISettingsReader.apiKeyEnvironmentKey,
+                        resolveValues: { context in
+                            guard let key = Sub2APISettingsReader.apiKey(environment: context.env),
+                                  let baseURL = Sub2APISettingsReader.baseURL(environment: context.env)
+                            else { return nil }
+                            return ScriptFetchStrategy.Values(
+                                settings: [Sub2APISettingsReader.baseURLEnvironmentKey: baseURL.absoluteString],
+                                secrets: [Sub2APISettingsReader.apiKeyEnvironmentKey: key])
+                        }),
+                    swift,
+                ]
+                #else
+                return [swift]
+                #endif
+            }))
+    }
 }
 
 struct Sub2APIAPIFetchStrategy: ProviderFetchStrategy {

--- a/Sources/CodexBarCore/Providers/T3Chat/T3ChatProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/T3Chat/T3ChatProviderDescriptor.swift
@@ -37,13 +37,36 @@ public enum T3ChatProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "T3 Chat cost summary is not supported." }),
-            fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [T3ChatWebFetchStrategy()] })),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "t3chat",
                 aliases: ["t3-chat", "t3"],
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        ProviderFetchPlan(
+            sourceModes: [.auto, .web],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                let swift = T3ChatWebFetchStrategy()
+                #if canImport(JavaScriptCore)
+                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
+                return [
+                    ScriptFetchStrategy(
+                        id: "t3chat.js",
+                        provider: .t3chat,
+                        bundledPlugin: "t3chat",
+                        kind: .web,
+                        resolveValues: { context in
+                            guard context.settings?.t3chat?.cookieSource != .off else { return nil }
+                            return ScriptFetchStrategy.Values()
+                        }),
+                    swift,
+                ]
+                #else
+                return [swift]
+                #endif
+            }))
     }
 }
 

--- a/Sources/CodexBarCore/Providers/XAI/XAIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/XAI/XAIProviderDescriptor.swift
@@ -34,12 +34,39 @@ public enum XAIProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "xAI spend history comes from the Management API billing endpoints." }),
-            fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .api],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [XAIAPIFetchStrategy()] })),
+            fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "xai",
                 versionDetector: nil))
+    }
+
+    private static func fetchPlan() -> ProviderFetchPlan {
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                let swift = XAIAPIFetchStrategy()
+                #if canImport(JavaScriptCore)
+                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
+                return [
+                    ScriptFetchStrategy(
+                        id: "xai.js",
+                        provider: .xai,
+                        bundledPlugin: "xai",
+                        secretKey: XAISettingsReader.apiKeyEnvironmentKey,
+                        resolveValues: { context in
+                            guard let key = XAISettingsReader.apiKey(environment: context.env),
+                                  let teamID = XAISettingsReader.teamID(environment: context.env)
+                            else { return nil }
+                            return ScriptFetchStrategy.Values(
+                                settings: [XAISettingsReader.teamIDEnvironmentKey: teamID],
+                                secrets: [XAISettingsReader.apiKeyEnvironmentKey: key])
+                        }),
+                    swift,
+                ]
+                #else
+                return [swift]
+                #endif
+            }))
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
@@ -69,11 +69,14 @@ public enum ZaiProviderDescriptor {
                         bundledPlugin: "zai",
                         secretKey: ZaiSettingsReader.apiTokenKey,
                         resolveValues: { context in
-                            guard let token = ProviderTokenResolver.zaiToken(environment: context.env)
-                            else { return nil }
                             let settings = context.settings?.zai
+                            let region = settings?.apiRegion ?? .global
+                            guard let token = ZaiSettingsReader.apiToken(
+                                for: region,
+                                environment: context.env)
+                            else { return nil }
                             var plainValues = [
-                                "Z_AI_REGION": (settings?.apiRegion ?? .global).rawValue,
+                                "Z_AI_REGION": region.rawValue,
                                 "Z_AI_USAGE_SCOPE": (settings?.usageScope ?? .personal).rawValue,
                             ]
                             if let team = settings?.teamContext {

--- a/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
@@ -68,20 +68,21 @@ public enum ZaiProviderDescriptor {
                         provider: .zai,
                         bundledPlugin: "zai",
                         secretKey: ZaiSettingsReader.apiTokenKey,
-                        resolveSecrets: { context in
+                        resolveValues: { context in
                             guard let token = ProviderTokenResolver.zaiToken(environment: context.env)
                             else { return nil }
                             let settings = context.settings?.zai
-                            var values = [
-                                ZaiSettingsReader.apiTokenKey: token,
+                            var plainValues = [
                                 "Z_AI_REGION": (settings?.apiRegion ?? .global).rawValue,
                                 "Z_AI_USAGE_SCOPE": (settings?.usageScope ?? .personal).rawValue,
                             ]
                             if let team = settings?.teamContext {
-                                values["Z_AI_ORGANIZATION"] = team.organizationID
-                                values["Z_AI_PROJECT"] = team.projectID
+                                plainValues["Z_AI_ORGANIZATION"] = team.organizationID
+                                plainValues["Z_AI_PROJECT"] = team.projectID
                             }
-                            return values
+                            return ScriptFetchStrategy.Values(
+                                settings: plainValues,
+                                secrets: [ZaiSettingsReader.apiTokenKey: token])
                         }),
                     swift,
                 ]

--- a/Sources/CodexBarCore/Resources/Plugins/deepgram.js
+++ b/Sources/CodexBarCore/Resources/Plugins/deepgram.js
@@ -1,0 +1,66 @@
+defineProvider({
+  id: "deepgram",
+  name: "Deepgram",
+  endpoints: ["https://api.deepgram.com", { setting: "DEEPGRAM_API_URL", policy: "https" }],
+  auth: { type: "authorization-scheme", scheme: "Token", secret: "DEEPGRAM_API_KEY" },
+  settings: [
+    { key: "DEEPGRAM_API_KEY", title: "API key", type: "secure" },
+    { key: "DEEPGRAM_PROJECT_ID", title: "Project ID", type: "plain" },
+    { key: "DEEPGRAM_API_URL", title: "API URL", type: "plain" },
+  ],
+  async fetchUsage(ctx) {
+    const base = (ctx.settings.get("DEEPGRAM_API_URL") || "https://api.deepgram.com/v1").replace(/\/$/, "");
+    const configuredProject = ctx.settings.get("DEEPGRAM_PROJECT_ID");
+    let projects;
+    if (configuredProject) {
+      projects = [{ project_id: configuredProject }];
+    } else {
+      const response = await ctx.http.getJSON(`${base}/projects`);
+      if (response.status !== 200 || !response.json || !Array.isArray(response.json.projects)) {
+        throw new Error(`Deepgram projects API error: HTTP ${response.status}`);
+      }
+      projects = response.json.projects;
+    }
+    if (!projects.length) throw new Error("Deepgram returned no projects");
+
+    const totals = { hours: 0, totalHours: 0, agentHours: 0, tokensIn: 0, tokensOut: 0, tts: 0, requests: 0 };
+    let start = null;
+    let end = null;
+    for (const project of projects) {
+      const response = await ctx.http.getJSON(
+        `${base}/projects/${encodeURIComponent(project.project_id)}/usage/breakdown`);
+      if (response.status !== 200 || !response.json || !Array.isArray(response.json.results)) {
+        throw new Error(`Deepgram usage API error: HTTP ${response.status}`);
+      }
+      start = !start || (response.json.start && response.json.start < start) ? response.json.start : start;
+      end = !end || (response.json.end && response.json.end > end) ? response.json.end : end;
+      for (const row of response.json.results) {
+        totals.hours += Number(row.hours || 0);
+        totals.totalHours += Number(row.total_hours || 0);
+        totals.agentHours += Number(row.agent_hours || 0);
+        totals.tokensIn += Number(row.tokens_in || 0);
+        totals.tokensOut += Number(row.tokens_out || 0);
+        totals.tts += Number(row.tts_characters || 0);
+        totals.requests += Number(row.requests || 0);
+      }
+    }
+    const number = value => new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value);
+    const rows = [{ label: "Requests", value: new Intl.NumberFormat("en-US").format(totals.requests) }];
+    if (totals.hours || totals.totalHours) rows.push({
+      label: "Audio",
+      value: `${number(totals.hours)} hours`,
+      secondaryValue: `${number(totals.totalHours)} billable hours`,
+    });
+    if (totals.agentHours) rows.push({ label: "Agent hours", value: number(totals.agentHours) });
+    if (totals.tokensIn || totals.tokensOut) rows.push({
+      label: "Tokens",
+      value: new Intl.NumberFormat("en-US").format(totals.tokensIn + totals.tokensOut),
+    });
+    if (totals.tts) rows.push({ label: "TTS characters", value: new Intl.NumberFormat("en-US").format(totals.tts) });
+    if (start && end) rows.push({ label: "Period", value: `${start} to ${end}` });
+    const loginMethod = projects.length > 1
+      ? `${projects.length} projects`
+      : `Project: ${projects[0].name || projects[0].project_id}`;
+    return { identity: { loginMethod }, details: [{ title: "Usage summary", rows }] };
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/manus.js
+++ b/Sources/CodexBarCore/Resources/Plugins/manus.js
@@ -1,0 +1,44 @@
+defineProvider({
+  id: "manus",
+  name: "Manus",
+  endpoints: ["https://api.manus.im"],
+  settings: [],
+  capabilities: ["browser-cookies"],
+  cookieDomains: ["manus.im"],
+  async fetchUsage(ctx) {
+    const cookies = await ctx.browser.cookieHeader("manus.im");
+    const match = /(?:^|;\s*)session_id=([^;]+)/i.exec(cookies);
+    if (!match) throw new Error("Manus session cookie is missing");
+    const response = await ctx.http.postJSON("https://api.manus.im/user.v1.UserService/GetAvailableCredits", {
+      body: {}, headers: {
+        Authorization: `Bearer ${match[1]}`, Origin: "https://manus.im", Referer: "https://manus.im/",
+        "Connect-Protocol-Version": "1",
+      },
+    });
+    if (response.status !== 200) throw new Error(`Manus API error: HTTP ${response.status}`);
+    const root = response.json || {};
+    const data = root.data || root.result || root.response || root.availableCredits || root;
+    const number = key => Number(data[key] || 0);
+    const total = number("totalCredits");
+    const free = number("freeCredits");
+    const monthly = number("proMonthlyCredits");
+    const periodic = number("periodicCredits");
+    const refresh = number("refreshCredits");
+    const maxRefresh = number("maxRefreshCredits");
+    const format = value => new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(Math.round(value));
+    return {
+      primary: monthly > 0 ? {
+        usedPercent: ctx.pct(monthly - periodic, monthly),
+        resetDescription: `Total ${format(total)} • Free ${format(free)}`,
+      } : undefined,
+      secondary: maxRefresh > 0 ? {
+        usedPercent: ctx.pct(maxRefresh - refresh, maxRefresh),
+        resetsAt: data.nextRefreshTime ? ctx.date.iso(data.nextRefreshTime) : undefined,
+        resetDescription: data.refreshInterval
+          ? `${String(data.refreshInterval).replace(/^./, value => value.toUpperCase())}: ${format(refresh)} / ${format(maxRefresh)}`
+          : `${format(refresh)} / ${format(maxRefresh)}`,
+      } : undefined,
+      identity: { loginMethod: `Balance: ${format(total)} credits` },
+    };
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/openai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/openai.js
@@ -11,8 +11,8 @@ defineProvider({
   ],
 
   async fetchUsage(ctx) {
-    const projectID = ctx.secrets.get("OPENAI_PROJECT_ID");
-    const rawHistoryDays = Number(ctx.secrets.get("OPENAI_HISTORY_DAYS") || "30");
+    const projectID = ctx.settings.get("OPENAI_PROJECT_ID");
+    const rawHistoryDays = Number(ctx.settings.get("OPENAI_HISTORY_DAYS") || "30");
     const historyDays = Number.isInteger(rawHistoryDays) ? Math.max(1, Math.min(365, rawHistoryDays)) : 30;
 
     function finite(value, field, optional) {
@@ -200,7 +200,7 @@ defineProvider({
         details,
       };
     } catch (usageError) {
-      if (ctx.secrets.get("OPENAI_ALLOW_BALANCE_FALLBACK") !== "1") throw usageError;
+      if (ctx.settings.get("OPENAI_ALLOW_BALANCE_FALLBACK") !== "1") throw usageError;
       const response = await ctx.http.getJSON("https://api.openai.com/v1/dashboard/billing/credit_grants");
       if (response.status !== 200) throw usageError;
       const body = response.json;

--- a/Sources/CodexBarCore/Resources/Plugins/perplexity.js
+++ b/Sources/CodexBarCore/Resources/Plugins/perplexity.js
@@ -1,0 +1,49 @@
+defineProvider({
+  id: "perplexity",
+  name: "Perplexity",
+  endpoints: ["https://www.perplexity.ai"],
+  settings: [],
+  capabilities: ["browser-cookies"],
+  cookieDomains: ["www.perplexity.ai"],
+  async fetchUsage(ctx) {
+    const cookie = await ctx.browser.cookieHeader("www.perplexity.ai");
+    const response = await ctx.http.getJSON(
+      "https://www.perplexity.ai/rest/billing/credits?version=2.18&source=default",
+      { headers: { Cookie: cookie, Origin: "https://www.perplexity.ai", Referer: "https://www.perplexity.ai/account/usage" } });
+    if (response.status !== 200) throw new Error(`Perplexity API error: HTTP ${response.status}`);
+    const data = response.json;
+    const grants = data.credit_grants || data.creditGrants || [];
+    const now = Date.now() / 1000;
+    const amount = grant => Number(grant.amount_cents ?? grant.amountCents ?? 0);
+    const recurring = grants.filter(grant => grant.type === "recurring").reduce((sum, grant) => sum + amount(grant), 0);
+    const promoGrants = grants.filter(grant => grant.type === "promotional" && Number(grant.expires_at_ts ?? grant.expiresAtTs ?? Infinity) > now);
+    const promo = promoGrants.reduce((sum, grant) => sum + amount(grant), 0);
+    const purchasedGrants = grants.filter(grant => grant.type === "purchased").reduce((sum, grant) => sum + amount(grant), 0);
+    const purchased = Math.max(purchasedGrants, Number(data.current_period_purchased_cents ?? data.currentPeriodPurchasedCents ?? 0));
+    let remaining = Number(data.total_usage_cents ?? data.totalUsageCents ?? 0);
+    const recurringUsed = Math.min(remaining, recurring); remaining -= recurringUsed;
+    const purchasedUsed = Math.min(remaining, purchased); remaining -= purchasedUsed;
+    const promoUsed = Math.min(remaining, promo);
+    const renewal = Number(data.renewal_date_ts ?? data.renewalDateTs);
+    const promoExpiry = promoGrants.map(grant => Number(grant.expires_at_ts ?? grant.expiresAtTs)).filter(Number.isFinite).sort()[0];
+    const integer = value => String(Math.round(value));
+    const promoDescription = `${integer(promoUsed)}/${integer(promo)} bonus`;
+    return {
+      primary: recurring > 0 ? {
+        usedPercent: ctx.pct(recurringUsed, recurring), resetsAt: ctx.date.unixSeconds(renewal),
+        resetDescription: `${integer(recurringUsed)}/${integer(recurring)} credits`,
+      } : (promo > 0 || purchased > 0 ? undefined : {
+        usedPercent: 100, resetsAt: ctx.date.unixSeconds(renewal), resetDescription: "0/0 credits",
+      }),
+      secondary: {
+        usedPercent: promo > 0 ? ctx.pct(promoUsed, promo) : 100,
+        resetDescription: promoExpiry ? `${promoDescription} · exp. ${new Date(promoExpiry * 1000).toLocaleDateString("en-US", { month: "short", day: "numeric" })}` : promoDescription,
+      },
+      tertiary: {
+        usedPercent: purchased > 0 ? ctx.pct(purchasedUsed, purchased) : 100,
+        resetDescription: `${integer(purchasedUsed)}/${integer(purchased)} credits`,
+      },
+      identity: { loginMethod: recurring <= 0 ? undefined : recurring < 5000 ? "Pro" : "Max" },
+    };
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
+++ b/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
@@ -3,16 +3,61 @@
 
   ctx.http = Object.freeze({
     getJSON(url, opts) {
-      return new Promise((resolve, reject) => host.http(String(url), opts || {}, true, resolve, reject));
+      return new Promise((resolve, reject) => host.http(String(url), opts || {}, "GET", true, resolve, reject));
     },
     get(url, opts) {
-      return new Promise((resolve, reject) => host.http(String(url), opts || {}, false, resolve, reject));
+      return new Promise((resolve, reject) => host.http(String(url), opts || {}, "GET", false, resolve, reject));
+    },
+    postJSON(url, opts) {
+      if (!opts || typeof opts !== "object" || !("body" in opts)) {
+        return Promise.reject(new TypeError("postJSON requires a body"));
+      }
+      let bodyJSON;
+      try {
+        bodyJSON = JSON.stringify(opts.body);
+      } catch (error) {
+        return Promise.reject(new TypeError(`postJSON body is not JSON-serializable: ${error.message}`));
+      }
+      if (bodyJSON === undefined) {
+        return Promise.reject(new TypeError("postJSON body is not JSON-serializable"));
+      }
+      const hostOptions = { bodyJSON };
+      if (opts.headers !== undefined) hostOptions.headers = opts.headers;
+      return new Promise((resolve, reject) => host.http(String(url), hostOptions, "POST", true, resolve, reject));
     },
   });
 
-  ctx.secrets = Object.freeze({
+  ctx.settings = Object.freeze({
     get(key) {
-      return host.secretGet(String(key));
+      return host.settingGet(String(key), false);
+    },
+    getSecret(key) {
+      return host.settingGet(String(key), true);
+    },
+  });
+
+  ctx.browser = Object.freeze({
+    cookieHeader(domain) {
+      return new Promise((resolve, reject) => host.cookieHeader(String(domain), resolve, reject));
+    },
+  });
+
+  ctx.html = Object.freeze({
+    metaContent(html, name) {
+      const target = String(name).toLowerCase();
+      const tags = String(html).match(/<meta\b[^>]*>/gi) || [];
+      for (const tag of tags) {
+        const nameMatch = tag.match(/\b(?:name|property)\s*=\s*["']([^"']*)["']/i);
+        if (!nameMatch || nameMatch[1].toLowerCase() !== target) continue;
+        const contentMatch = tag.match(/\bcontent\s*=\s*["']([^"']*)["']/i);
+        if (contentMatch) return contentMatch[1];
+      }
+      return null;
+    },
+    matchFirst(html, regexSource, flags) {
+      const regex = new RegExp(String(regexSource), flags === undefined ? "" : String(flags));
+      const match = regex.exec(String(html));
+      return match ? (match.length > 1 ? match[1] : match[0]) : null;
     },
   });
 

--- a/Sources/CodexBarCore/Resources/Plugins/qoder.js
+++ b/Sources/CodexBarCore/Resources/Plugins/qoder.js
@@ -1,0 +1,42 @@
+defineProvider({
+  id: "qoder",
+  name: "Qoder",
+  endpoints: ["https://qoder.com", "https://qoder.com.cn"],
+  settings: [],
+  capabilities: ["browser-cookies"],
+  cookieDomains: ["qoder.com", "qoder.com.cn"],
+  async fetchUsage(ctx) {
+    let response = null;
+    for (const site of ["qoder.com", "qoder.com.cn"]) {
+      const cookie = await ctx.browser.cookieHeader(site);
+      const origin = `https://${site}`;
+      const candidate = await ctx.http.getJSON(`${origin}/api/v2/me/usages/big_model_credits`, {
+        headers: {
+          Cookie: cookie, Origin: origin, Referer: `${origin}/account/usage`,
+          "X-Requested-With": "XMLHttpRequest", "Bx-V": "2.5.35",
+        },
+      });
+      if (candidate.status >= 200 && candidate.status < 300) { response = candidate; break; }
+    }
+    if (!response) throw new Error("Qoder credentials were rejected");
+    const root = response.json || {};
+    const container = root.totalQuota || root.total_quota;
+    const sharedContainer = root.sharedQuota || root.shared_quota;
+    const summary = container && (container.quotaSummary || container.quota_summary);
+    const shared = sharedContainer && (sharedContainer.quotaSummary || sharedContainer.quota_summary);
+    if (!summary) throw new Error("Qoder response is missing quota summary");
+    const read = (value, camel, snake) => Number(value[camel] ?? value[snake]);
+    const used = read(summary, "usedValue", "used_value") + (shared ? read(shared, "usedValue", "used_value") : 0);
+    const total = read(summary, "limitValue", "limit_value") + (shared ? read(shared, "limitValue", "limit_value") : 0);
+    const percentage = shared ? ctx.pct(used, total) : Number(summary.usagePercentage ?? summary.usage_percentage ?? ctx.pct(used, total));
+    const reset = root.nextResetAt ?? root.next_reset_at;
+    const resetDate = typeof reset === "number"
+      ? (reset > 10000000000 ? ctx.date.unixMillis(reset) : ctx.date.unixSeconds(reset))
+      : (reset ? ctx.date.iso(reset) : undefined);
+    const format = value => new Intl.NumberFormat("en-US", { maximumFractionDigits: Number.isInteger(value) ? 0 : 2 }).format(value);
+    return { primary: {
+      usedPercent: Math.max(0, Math.min(100, percentage)), resetsAt: resetDate,
+      resetDescription: `${format(used)} / ${format(total)} credits`,
+    } };
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/sub2api.js
+++ b/Sources/CodexBarCore/Resources/Plugins/sub2api.js
@@ -1,0 +1,62 @@
+defineProvider({
+  id: "sub2api",
+  name: "sub2api",
+  endpoints: [{ setting: "SUB2API_BASE_URL", policy: "https-or-loopback-http" }],
+  auth: { type: "bearer", secret: "SUB2API_API_KEY" },
+  settings: [
+    { key: "SUB2API_API_KEY", title: "API key", type: "secure" },
+    { key: "SUB2API_BASE_URL", title: "Base URL", type: "plain" },
+  ],
+  async fetchUsage(ctx) {
+    let base = ctx.settings.get("SUB2API_BASE_URL").replace(/\/$/, "");
+    if (!/\/v1(?:\/usage)?$/.test(base)) base += "/v1";
+    if (!/\/usage$/.test(base)) base += "/usage";
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+    const response = await ctx.http.getJSON(`${base}?days=30&timezone=${encodeURIComponent(timezone)}`);
+    if (response.status < 200 || response.status >= 300) throw new Error(`sub2api API error: HTTP ${response.status}`);
+    const data = response.json || {};
+    if (data.isValid === false) throw new Error("sub2api credentials are invalid");
+    const unit = data.unit || (data.quota && data.quota.unit) || "USD";
+    const amount = (used, limit, valueUnit = "USD") => `${valueUnit.toUpperCase() === "USD" ? `$${Number(used).toFixed(2)}` : `${Number(used).toFixed(2)} ${valueUnit}`} / ${valueUnit.toUpperCase() === "USD" ? `$${Number(limit).toFixed(2)}` : `${Number(limit).toFixed(2)} ${valueUnit}`}`;
+    const window = (used, limit, minutes, valueUnit = "USD") => limit > 0 ? ({
+      usedPercent: ctx.pct(used, limit), windowMinutes: minutes,
+      resetDescription: amount(used, limit, valueUnit),
+    }) : null;
+    let primary = null;
+    let secondary = null;
+    let tertiary = null;
+    if (data.subscription) {
+      primary = window(data.subscription.daily_usage_usd || 0, data.subscription.daily_limit_usd, 1440);
+      secondary = window(data.subscription.weekly_usage_usd || 0, data.subscription.weekly_limit_usd, 10080);
+      tertiary = window(data.subscription.monthly_usage_usd || 0, data.subscription.monthly_limit_usd, 43200);
+    } else if (data.quota) {
+      primary = window(data.quota.used, data.quota.limit, null, data.quota.unit || unit);
+      if (primary) delete primary.windowMinutes;
+    }
+    const minuteMap = { "5h": 300, "1d": 1440, "7d": 10080 };
+    const titleMap = { "5h": "5 hour limit", "1d": "Daily limit", "7d": "7 day limit" };
+    const extraWindows = (data.rate_limits || []).map(rate => ({
+      id: rate.window,
+      title: titleMap[rate.window.toLowerCase()] || `${rate.window} limit`,
+      window: {
+        usedPercent: ctx.pct(rate.used, rate.limit),
+        windowMinutes: minuteMap[rate.window.toLowerCase()],
+        resetsAt: rate.reset_at ? ctx.date.iso(rate.reset_at) : undefined,
+        resetDescription: amount(rate.used, rate.limit),
+      },
+    }));
+    const rows = [];
+    if (data.balance !== undefined && data.balance !== null) rows.push({ label: "Balance", value: amount(data.balance, data.balance, unit).split(" / ")[0] });
+    for (const [title, totals] of [["Today", data.usage && data.usage.today], ["All time", data.usage && data.usage.total]]) {
+      if (!totals) continue;
+      rows.push({ label: `${title} requests`, value: new Intl.NumberFormat("en-US").format(totals.requests || 0) });
+      rows.push({ label: `${title} tokens`, value: new Intl.NumberFormat("en-US").format(totals.total_tokens || 0), secondaryValue: `$${Number(totals.actual_cost || 0).toFixed(2)}` });
+    }
+    return {
+      primary, secondary, tertiary, extraWindows,
+      subscriptionExpiresAt: (data.subscription && data.subscription.expires_at) || data.expires_at,
+      identity: { organization: data.planName, loginMethod: data.planName },
+      details: rows.length ? [{ title: "Usage summary", rows }] : undefined,
+    };
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/t3chat.js
+++ b/Sources/CodexBarCore/Resources/Plugins/t3chat.js
@@ -1,0 +1,47 @@
+defineProvider({
+  id: "t3chat",
+  name: "T3 Chat",
+  endpoints: ["https://t3.chat"],
+  settings: [],
+  capabilities: ["browser-cookies"],
+  cookieDomains: ["t3.chat"],
+  async fetchUsage(ctx) {
+    const cookie = await ctx.browser.cookieHeader("t3.chat");
+    const input = encodeURIComponent(JSON.stringify({ "0": { json: { sessionId: null }, meta: { values: { sessionId: ["undefined"] } } } }));
+    const response = await ctx.http.get(`https://t3.chat/api/trpc/getCustomerData?batch=1&input=${input}`, {
+      headers: {
+        Cookie: cookie, Origin: "https://t3.chat", Referer: "https://t3.chat/settings/customization",
+        "trpc-accept": "application/jsonl", "x-trpc-source": "web-client", "x-trpc-batch": "true",
+      },
+    });
+    if (response.status !== 200) throw new Error(`T3 Chat API error: HTTP ${response.status}`);
+    function find(value) {
+      if (!value || typeof value !== "object") return null;
+      if ("usageFourHourPercentage" in value || "usageMonthPercentage" in value || (value.subscription && value.usageBand)) return value;
+      for (const child of Object.values(value)) { const found = find(child); if (found) return found; }
+      return null;
+    }
+    let data = null;
+    for (const line of response.bodyText.split(/\r?\n/)) {
+      try { data = find(JSON.parse(line)); } catch (_) {}
+      if (data) break;
+    }
+    if (!data) throw new Error("T3 Chat response is missing customer data");
+    const date = value => !value || value <= 0 ? undefined : (value > 10000000000 ? ctx.date.unixMillis(value) : ctx.date.unixSeconds(value));
+    const rawPlan = data.subscription && data.subscription.productName || data.subTier;
+    const plan = rawPlan && String(rawPlan).split("-").map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(" ");
+    return {
+      primary: {
+        usedPercent: Math.max(0, Math.min(100, Number(data.usageFourHourPercentage || 0))),
+        windowMinutes: 240,
+        resetsAt: date(data.usageFourHourNextResetAt || data.usageWindowNextResetAt),
+        resetDescription: data.usageBand ? `Base - ${String(data.usageBand).trim()}` : "Base",
+      },
+      secondary: {
+        usedPercent: Math.max(0, Math.min(100, Number(data.usageMonthPercentage ?? data.usagePeriodPercentage ?? 0))),
+        resetsAt: date(data.subscription && data.subscription.currentPeriodEnd), resetDescription: "Overage",
+      },
+      identity: { loginMethod: plan || undefined },
+    };
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/xai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/xai.js
@@ -1,0 +1,58 @@
+defineProvider({
+  id: "xai",
+  name: "xAI",
+  endpoints: ["https://management-api.x.ai"],
+  auth: { type: "bearer", secret: "XAI_MANAGEMENT_API_KEY" },
+  settings: [
+    { key: "XAI_MANAGEMENT_API_KEY", title: "Management API key", type: "secure" },
+    { key: "XAI_TEAM_ID", title: "Team ID", type: "plain" },
+  ],
+  async fetchUsage(ctx) {
+    const team = ctx.settings.get("XAI_TEAM_ID");
+    if (!team || team.includes("/") || team === "." || team === "..") throw new Error("Invalid xAI team ID");
+    const root = `https://management-api.x.ai/v1/billing/teams/${encodeURIComponent(team)}`;
+    const balanceResponse = await ctx.http.getJSON(`${root}/prepaid/balance`);
+    if (balanceResponse.status < 200 || balanceResponse.status >= 300) throw new Error(`xAI balance API error: HTTP ${balanceResponse.status}`);
+    const raw = balanceResponse.json && balanceResponse.json.total && balanceResponse.json.total.val;
+    if (typeof raw !== "string" || !/^-?\d+(\.\d+)?$/.test(raw.trim())) throw new Error("xAI balance is invalid");
+    const balance = -Number(raw) / 100;
+    const now = new Date();
+    const start = new Date(now);
+    start.setUTCDate(start.getUTCDate() - 29);
+    start.setUTCHours(0, 0, 0, 0);
+    const timestamp = date => `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")} ${String(date.getUTCHours()).padStart(2, "0")}:${String(date.getUTCMinutes()).padStart(2, "0")}:${String(date.getUTCSeconds()).padStart(2, "0")}`;
+    let daily = [];
+    let partial = false;
+    try {
+      const usage = await ctx.http.postJSON(`${root}/usage`, { body: { analyticsRequest: {
+        timeRange: { startTime: timestamp(start), endTime: timestamp(now), timezone: "Etc/GMT" },
+        timeUnit: "TIME_UNIT_DAY", values: [{ name: "usd", aggregation: "AGGREGATION_SUM" }],
+        groupBy: [], filters: [],
+      } } });
+      if (usage.status === 401 || usage.status === 403) throw new Error(`xAI usage API error: HTTP ${usage.status}`);
+      if (usage.status >= 200 && usage.status < 300) {
+        const totals = {};
+        for (const series of usage.json.timeSeries || []) for (const point of series.dataPoints || []) {
+          const day = String(point.timestamp).slice(0, 10);
+          totals[day] = (totals[day] || 0) + Number((point.values || [0])[0] || 0);
+        }
+        daily = Object.keys(totals).sort().map(day => ({ label: day, value: totals[day] }));
+        partial = usage.json.limitReached === true;
+      }
+    } catch (error) {
+      if (/HTTP 401|HTTP 403/.test(error.message)) throw error;
+    }
+    return {
+      cost: { used: balance, currency: "USD", period: "Prepaid credits" },
+      identity: { loginMethod: "Management API" },
+      details: [{
+        title: "Billing summary",
+        rows: [
+          { label: "Prepaid balance", value: `$${balance.toFixed(2)}` },
+          { label: "History", value: partial ? "Last 30 days (partial)" : "Last 30 days" },
+        ],
+        chart: daily.length ? { kind: "bars", title: "Daily spend", unit: "USD", points: daily } : undefined,
+      }],
+    };
+  },
+});

--- a/Sources/CodexBarCore/Resources/Plugins/zai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/zai.js
@@ -12,10 +12,10 @@ defineProvider({
   ],
 
   async fetchUsage(ctx) {
-    const region = ctx.secrets.get("Z_AI_REGION") || "global";
-    const scope = ctx.secrets.get("Z_AI_USAGE_SCOPE") || "personal";
-    const organization = ctx.secrets.get("Z_AI_ORGANIZATION");
-    const project = ctx.secrets.get("Z_AI_PROJECT");
+    const region = ctx.settings.get("Z_AI_REGION") || "global";
+    const scope = ctx.settings.get("Z_AI_USAGE_SCOPE") || "personal";
+    const organization = ctx.settings.get("Z_AI_ORGANIZATION");
+    const project = ctx.settings.get("Z_AI_PROJECT");
     if (region !== "global" && region !== "bigmodel-cn") throw new Error("Unsupported z.ai region");
     if (scope !== "personal" && scope !== "team") throw new Error("Unsupported z.ai usage scope");
     if (scope === "team" && (!organization || !project)) throw new Error("z.ai team scope needs organization and project");

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -150,11 +150,13 @@ struct ProviderPluginDetailsParityTests {
             environment: [:],
             transport: transport).toUsageSnapshot()
         let script = try await ProviderPluginRuntime(bundledPlugin: "zai", transport: transport)
-            .fetchUsage(secrets: [
-                "Z_AI_API_KEY": "fixture-key",
-                "Z_AI_REGION": "global",
-                "Z_AI_USAGE_SCOPE": "personal",
-            ], now: now)
+            .fetchUsage(
+                settings: [
+                    "Z_AI_REGION": "global",
+                    "Z_AI_USAGE_SCOPE": "personal",
+                ],
+                secrets: ["Z_AI_API_KEY": "fixture-key"],
+                now: now)
 
         Self.expectCoreParity(swift, script)
         #expect(try script.details == [
@@ -204,11 +206,13 @@ struct ProviderPluginDetailsParityTests {
             now: now,
             historyDays: 30).toUsageSnapshot()
         let script = try await ProviderPluginRuntime(bundledPlugin: "openai", transport: transport)
-            .fetchUsage(secrets: [
-                "OPENAI_API_KEY": "fixture-key",
-                "OPENAI_HISTORY_DAYS": "30",
-                "OPENAI_ALLOW_BALANCE_FALLBACK": "1",
-            ], now: now)
+            .fetchUsage(
+                settings: [
+                    "OPENAI_HISTORY_DAYS": "30",
+                    "OPENAI_ALLOW_BALANCE_FALLBACK": "1",
+                ],
+                secrets: ["OPENAI_API_KEY": "fixture-key"],
+                now: now)
 
         Self.expectCoreParity(swift, script)
         #expect(try script.details == [

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -29,6 +29,28 @@ struct ProviderPluginDetailsParityTests {
     }
 
     @Test
+    func `zai plugin resolves China region credential aliases only for China`() async {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .zai)
+        let environment = [
+            ProviderPluginPrototype.environmentKey: "1",
+            "BIGMODEL_API_KEY": "china-token",
+        ]
+        let chinaContext = Self.context(
+            environment: environment,
+            settings: .make(zai: .init(apiRegion: .bigmodelCN)))
+        let globalContext = Self.context(
+            environment: environment,
+            settings: .make(zai: .init(apiRegion: .global)))
+
+        let chinaStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(chinaContext)
+        let globalStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(globalContext)
+
+        #expect(chinaStrategies.map(\.id) == ["zai.js", "zai.api"])
+        #expect(await chinaStrategies[0].isAvailable(chinaContext))
+        #expect(await globalStrategies[0].isAvailable(globalContext) == false)
+    }
+
+    @Test
     func `OpenRouter fixture has Swift core parity and stable details`() async throws {
         let transport = Self.transport { request in
             switch request.url?.path {
@@ -308,7 +330,10 @@ struct ProviderPluginDetailsParityTests {
         }
     }
 
-    private static func context(environment: [String: String]) -> ProviderFetchContext {
+    private static func context(
+        environment: [String: String],
+        settings: ProviderSettingsSnapshot? = nil) -> ProviderFetchContext
+    {
         ProviderFetchContext(
             runtime: .app,
             sourceMode: .api,
@@ -317,7 +342,7 @@ struct ProviderPluginDetailsParityTests {
             webDebugDumpHTML: false,
             verbose: false,
             env: environment,
-            settings: nil,
+            settings: settings,
             fetcher: UsageFetcher(environment: environment),
             claudeFetcher: FixtureClaudeFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0))

--- a/Tests/CodexBarTests/ProviderPluginExtensionParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginExtensionParityTests.swift
@@ -1,0 +1,183 @@
+#if canImport(JavaScriptCore)
+// swiftlint:disable line_length multiline_arguments
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ProviderPluginExtensionParityTests {
+    @Test
+    func `Qoder cookie plugin matches Swift generic projection`() async throws {
+        let fixture = #"{"total_quota":{"quota_summary":{"used_value":25,"limit_value":100,"remaining_value":75,"unit":"credits"}},"shared_quota":{"quota_summary":{"used_value":5,"limit_value":20,"remaining_value":15}},"next_reset_at":"2027-01-15T00:00:00Z"}"#
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let swift = try QoderUsageFetcher.parseUsage(data: Data(fixture.utf8), now: now).toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(
+            bundledPlugin: "qoder",
+            transport: Self.transport { _ in fixture })
+            .fetchUsage(now: now, cookieResolver: { _, _ in "session=fixture" })
+
+        Self.expectCoreParity(swift, script)
+    }
+
+    @Test
+    func `Manus cookie plugin matches Swift generic projection`() async throws {
+        let fixture = #"{"totalCredits":1200,"freeCredits":200,"periodicCredits":300,"refreshCredits":40,"maxRefreshCredits":100,"proMonthlyCredits":1000,"eventCredits":0,"addonCredits":0,"nextRefreshTime":"2027-01-15T00:00:00Z","refreshInterval":"daily"}"#
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let swift = try ManusUsageFetcher.parseResponse(Data(fixture.utf8)).toUsageSnapshot(now: now)
+        let script = try await ProviderPluginRuntime(
+            bundledPlugin: "manus",
+            transport: Self.transport { _ in fixture })
+            .fetchUsage(now: now, cookieResolver: { _, _ in "session_id=fixture-session" })
+
+        Self.expectCoreParity(swift, script)
+    }
+
+    @Test
+    func `Perplexity cookie plugin matches Swift generic projection`() async throws {
+        let fixture = #"{"balance_cents":900,"renewal_date_ts":1893456000,"current_period_purchased_cents":200,"credit_grants":[{"type":"recurring","amount_cents":1000},{"type":"promotional","amount_cents":300,"expires_at_ts":1893456000},{"type":"purchased","amount_cents":200}],"total_usage_cents":1100}"#
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let swift = try PerplexityUsageFetcher._parseResponseForTesting(Data(fixture.utf8), now: now)
+            .toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(
+            bundledPlugin: "perplexity",
+            transport: Self.transport { _ in fixture })
+            .fetchUsage(now: now, cookieResolver: { _, _ in "__Secure-next-auth.session-token=fixture" })
+
+        Self.expectCoreParity(swift, script)
+    }
+
+    @Test
+    func `T3 Chat cookie plugin matches Swift generic projection`() async throws {
+        let fixture = #"{"json":[2,0,[[{"subTier":"pro","subscription":{"productName":"pro","currentPeriodEnd":1780763009000},"usageBand":"max","usageFourHourPercentage":12.5,"usageMonthPercentage":34.25,"usageFourHourNextResetAt":1779366216920}]]]}"#
+        let now = Date(timeIntervalSince1970: 1_778_000_000)
+        let swift = try T3ChatUsageParser.parseJSONLines(fixture, now: now).toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(
+            bundledPlugin: "t3chat",
+            transport: Self.textTransport(body: fixture))
+            .fetchUsage(now: now, cookieResolver: { _, _ in "session=fixture" })
+
+        Self.expectCoreParity(swift, script)
+    }
+
+    @Test
+    func `Deepgram plugin matches generic Swift projection and details golden`() async throws {
+        let transport = Self.transport { request in
+            switch request.url?.path {
+            case "/v1/projects":
+                #"{"projects":[{"project_id":"project-a","name":"Alpha"}]}"#
+            case "/v1/projects/project-a/usage/breakdown":
+                #"{"start":"2026-07-01","end":"2026-07-31","results":[{"hours":1.5,"total_hours":2,"tokens_in":100,"tokens_out":50,"requests":3}]}"#
+            default:
+                throw URLError(.badURL)
+            }
+        }
+        let swift = try await DeepgramUsageFetcher.fetchUsage(apiKey: "fixture-key", transport: transport)
+            .toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(bundledPlugin: "deepgram", transport: transport)
+            .fetchUsage(secrets: ["DEEPGRAM_API_KEY": "fixture-key"])
+
+        #expect(script.primary == swift.primary)
+        #expect(script.identity?.loginMethod == swift.identity?.loginMethod)
+        #expect(try script.details == [ProviderDetailSection(
+            title: "Usage summary",
+            rows: [
+                .init(label: "Requests", value: "3"),
+                .init(label: "Audio", value: "1.5 hours", secondaryValue: "2 billable hours"),
+                .init(label: "Tokens", value: "150"),
+                .init(label: "Period", value: "2026-07-01 to 2026-07-31"),
+            ])])
+    }
+
+    @Test
+    func `sub2api plugin matches generic Swift projection and details golden`() async throws {
+        let fixture = #"{"mode":"quota_limited","isValid":true,"planName":"Team","quota":{"limit":100,"used":25,"remaining":75,"unit":"USD"},"usage":{"today":{"requests":4,"total_tokens":1200,"actual_cost":1.25}}}"#
+        let transport = Self.transport { _ in fixture }
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let swift = try Sub2APIUsageFetcher._parseSnapshotForTesting(Data(fixture.utf8), updatedAt: now)
+            .toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(bundledPlugin: "sub2api", transport: transport)
+            .fetchUsage(
+                settings: ["SUB2API_BASE_URL": "http://127.0.0.1:8787"],
+                secrets: ["SUB2API_API_KEY": "fixture-key"],
+                now: now)
+
+        #expect(script.primary == swift.primary)
+        #expect(script.secondary == swift.secondary)
+        #expect(script.tertiary == swift.tertiary)
+        #expect(script.identity?.accountOrganization == swift.identity?.accountOrganization)
+        #expect(script.identity?.loginMethod == swift.identity?.loginMethod)
+        #expect(try script.details == [ProviderDetailSection(
+            title: "Usage summary",
+            rows: [
+                .init(label: "Today requests", value: "4"),
+                .init(label: "Today tokens", value: "1,200", secondaryValue: "$1.25"),
+            ])])
+    }
+
+    @Test
+    func `xAI plugin matches generic Swift projection and details golden`() async throws {
+        let transport = Self.transport { request in
+            if request.url?.path.hasSuffix("/prepaid/balance") == true {
+                return #"{"total":{"val":"-1000"}}"#
+            }
+            return #"{"timeSeries":[{"dataPoints":[{"timestamp":"2027-01-15T00:00:00Z","values":[1.5]}]}],"limitReached":false}"#
+        }
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let swift = try await XAIBillingFetcher.fetchUsage(
+            managementKey: "fixture-key",
+            teamID: "team-1234",
+            transport: transport,
+            now: now).toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(bundledPlugin: "xai", transport: transport)
+            .fetchUsage(
+                settings: ["XAI_TEAM_ID": "team-1234"],
+                secrets: ["XAI_MANAGEMENT_API_KEY": "fixture-key"],
+                now: now)
+
+        #expect(script.primary == swift.primary)
+        #expect(script.providerCost == swift.providerCost)
+        #expect(script.identity?.loginMethod == swift.identity?.loginMethod)
+        let details = try #require(script.details.first)
+        #expect(details.title == "Billing summary")
+        #expect(try details.rows.first == .init(label: "Prepaid balance", value: "$10.00"))
+        #expect(try details.chart?.points == [.init(label: "2027-01-15", value: 1.5)])
+    }
+
+    private static func transport(
+        handler: @escaping @Sendable (URLRequest) throws -> String) -> ProviderHTTPTransportHandler
+    {
+        ProviderHTTPTransportHandler { request in
+            let body = try handler(request)
+            let response = try #require(HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]))
+            return (Data(body.utf8), response)
+        }
+    }
+
+    private static func textTransport(body: String) -> ProviderHTTPTransportHandler {
+        ProviderHTTPTransportHandler { request in
+            let response = try #require(HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil,
+                headerFields: ["Content-Type": "application/jsonl"]))
+            return (Data(body.utf8), response)
+        }
+    }
+
+    private static func expectCoreParity(_ swift: UsageSnapshot, _ script: UsageSnapshot) {
+        #expect(script.primary == swift.primary)
+        #expect(script.secondary == swift.secondary)
+        #expect(script.tertiary == swift.tertiary)
+        #expect(script.extraRateWindows == swift.extraRateWindows)
+        #expect(script.providerCost == swift.providerCost)
+        #expect(script.subscriptionRenewsAt == swift.subscriptionRenewsAt)
+        #expect(script.subscriptionExpiresAt == swift.subscriptionExpiresAt)
+        #expect(script.identity?.accountEmail == swift.identity?.accountEmail)
+        #expect(script.identity?.accountOrganization == swift.identity?.accountOrganization)
+        #expect(script.identity?.loginMethod == swift.identity?.loginMethod)
+        #expect(script.identity?.accountID == swift.identity?.accountID)
+    }
+}
+// swiftlint:enable line_length multiline_arguments
+#endif

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -52,9 +52,171 @@ struct ProviderPluginRuntimeTests {
     }
 
     @Test
+    func `settings split enforces kind and only secrets are redacted`() async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(
+            settings: """
+            { key: "TEST_KEY", title: "API key", type: "secure" },
+            { key: "PLAIN_VALUE", title: "Plain value", type: "plain" }
+            """,
+            fetchBody: """
+            const plain = ctx.settings.get("PLAIN_VALUE");
+            const secret = ctx.settings.getSecret("TEST_KEY");
+            throw new Error(`${plain}:${secret}`);
+            """))
+
+        do {
+            _ = try await runtime.fetchUsage(
+                settings: ["PLAIN_VALUE": "visible-setting"],
+                secrets: ["TEST_KEY": "hidden-secret"])
+            Issue.record("Expected rejection")
+        } catch {
+            #expect(error.localizedDescription.contains("visible-setting"))
+            #expect(!error.localizedDescription.contains("hidden-secret"))
+            #expect(error.localizedDescription.contains("<redacted>"))
+        }
+    }
+
+    @Test
+    func `authorization scheme injects bounded token prefix`() async throws {
+        let requests = RequestRecorder()
+        let runtime = try ProviderPluginRuntime(
+            source: Self.plugin(
+                auth: #"{ type: "authorization-scheme", scheme: "Token", secret: "TEST_KEY" }"#,
+                fetchBody: """
+                const response = await ctx.http.getJSON("https://api.example.test/usage");
+                return { primary: { usedPercent: response.status } };
+                """),
+            transport: Self.transport(recorder: requests))
+
+        _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "fixture-key"])
+
+        #expect(await requests.first?.value(forHTTPHeaderField: "Authorization") == "Token fixture-key")
+        #expect(throws: ProviderPluginError.self) {
+            _ = try ProviderPluginRuntime(source: Self.plugin(
+                auth: #"{ type: "authorization-scheme", scheme: "bad scheme", secret: "TEST_KEY" }"#))
+        }
+    }
+
+    @Test
+    func `postJSON sends serialized body without relaxing headers`() async throws {
+        let requests = RequestRecorder()
+        let runtime = try ProviderPluginRuntime(
+            source: Self.plugin(fetchBody: """
+            const response = await ctx.http.postJSON("https://api.example.test/usage", {
+              body: { team: "fixture", count: 2 },
+              headers: { "X-Client": "plugin-test" },
+            });
+            return { primary: { usedPercent: response.json.used } };
+            """),
+            transport: Self.transport(recorder: requests, body: #"{"used":17}"#))
+
+        let snapshot = try await runtime.fetchUsage(secrets: ["TEST_KEY": "fixture-key"])
+        let request = try #require(await requests.first)
+        #expect(snapshot.primary?.usedPercent == 17)
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        let body = try #require(request.httpBody)
+        let object = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(object["team"] as? String == "fixture")
+        #expect(object["count"] as? Int == 2)
+    }
+
+    @Test
+    func `setting endpoint resolves at fetch time and permits loopback HTTP only by policy`() async throws {
+        let requests = RequestRecorder()
+        let runtime = try ProviderPluginRuntime(
+            source: Self.plugin(
+                endpoints: #"[{ setting: "BASE_URL", policy: "https-or-loopback-http" }]"#,
+                settings: """
+                { key: "TEST_KEY", title: "API key", type: "secure" },
+                { key: "BASE_URL", title: "Base URL", type: "plain" }
+                """,
+                fetchBody: """
+                const base = ctx.settings.get("BASE_URL");
+                const response = await ctx.http.getJSON(`${base}/usage`);
+                return { primary: { usedPercent: response.json.used } };
+                """),
+            transport: Self.transport(recorder: requests, body: #"{"used":23}"#))
+
+        let snapshot = try await runtime.fetchUsage(
+            settings: ["BASE_URL": "http://127.0.0.1:8787"],
+            secrets: ["TEST_KEY": "fixture-key"])
+        #expect(snapshot.primary?.usedPercent == 23)
+        #expect(await requests.first?.url?.absoluteString == "http://127.0.0.1:8787/usage")
+
+        let rejectedRequests = RequestRecorder()
+        let rejected = try ProviderPluginRuntime(
+            source: Self.plugin(
+                endpoints: #"[{ setting: "BASE_URL", policy: "https-or-loopback-http" }]"#,
+                settings: """
+                { key: "TEST_KEY", title: "API key", type: "secure" },
+                { key: "BASE_URL", title: "Base URL", type: "plain" }
+                """,
+                fetchBody: """
+                await ctx.http.getJSON(`${ctx.settings.get("BASE_URL")}/usage`);
+                return { primary: { usedPercent: 1 } };
+                """),
+            transport: Self.transport(recorder: rejectedRequests))
+        await #expect(throws: ProviderPluginError.self) {
+            _ = try await rejected.fetchUsage(
+                settings: ["BASE_URL": "http://example.test"],
+                secrets: ["TEST_KEY": "fixture-key"])
+        }
+        #expect(await rejectedRequests.isEmpty)
+    }
+
+    @Test
+    func `browser cookie access is declared domain only and cookie values are redacted`() async throws {
+        let access = CookieAccessRecorder(header: "session=secret-cookie-value")
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(
+            capabilities: #"capabilities: ["browser-cookies"], cookieDomains: ["example.test"],"#,
+            fetchBody: """
+            const cookie = await ctx.browser.cookieHeader("example.test");
+            throw new Error(`cookie was ${cookie}`);
+            """))
+
+        do {
+            _ = try await runtime.fetchUsage(
+                secrets: ["TEST_KEY": "fixture-key"],
+                cookieResolver: { provider, domain in try await access.resolve(provider: provider, domain: domain) })
+            Issue.record("Expected rejection")
+        } catch {
+            #expect(!error.localizedDescription.contains("secret-cookie-value"))
+            #expect(error.localizedDescription.contains("<redacted>"))
+        }
+        #expect(await access.domains == ["example.test"])
+
+        let rejected = try ProviderPluginRuntime(source: Self.plugin(
+            capabilities: #"capabilities: ["browser-cookies"], cookieDomains: ["example.test"],"#,
+            fetchBody: """
+            await ctx.browser.cookieHeader("other.test");
+            return { primary: { usedPercent: 1 } };
+            """))
+        await #expect(throws: ProviderPluginError.self) {
+            _ = try await rejected.fetchUsage(
+                secrets: ["TEST_KEY": "fixture-key"],
+                cookieResolver: { provider, domain in try await access.resolve(provider: provider, domain: domain) })
+        }
+        #expect(await access.domains == ["example.test"])
+    }
+
+    @Test
+    func `HTML helpers extract meta content and first regex capture`() async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
+        const html = '<meta content="fixture-token" name="csrf"><div>credits: 37</div>';
+        const meta = ctx.html.metaContent(html, "csrf");
+        const credits = ctx.html.matchFirst(html, "credits:\\\\s*(\\\\d+)", "i");
+        return { primary: { usedPercent: meta === "fixture-token" ? Number(credits) : 0 } };
+        """))
+
+        let snapshot = try await runtime.fetchUsage(secrets: ["TEST_KEY": "fixture-key"])
+        #expect(snapshot.primary?.usedPercent == 37)
+    }
+
+    @Test
     func `undeclared secret access fails`() async throws {
         let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
-        ctx.secrets.get("OTHER_KEY");
+        ctx.settings.getSecret("OTHER_KEY");
         return { primary: { usedPercent: 1 } };
         """))
 
@@ -165,7 +327,7 @@ struct ProviderPluginRuntimeTests {
     func `script errors redact known secrets`() async throws {
         let secret = "super-secret-fixture-value"
         let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
-        throw new Error(`leaked: ${ctx.secrets.get("TEST_KEY")}`);
+        throw new Error(`leaked: ${ctx.settings.getSecret("TEST_KEY")}`);
         """))
 
         do {
@@ -181,7 +343,7 @@ struct ProviderPluginRuntimeTests {
     func `hung script times out and next fetch uses a fresh context`() async throws {
         let runtime = try ProviderPluginRuntime(
             source: Self.plugin(fetchBody: """
-            if (ctx.secrets.get("TEST_KEY") === "hang") while (true) {}
+            if (ctx.settings.getSecret("TEST_KEY") === "hang") while (true) {}
             return { primary: { usedPercent: 7 } };
             """),
             timeout: 0.15)
@@ -196,14 +358,21 @@ struct ProviderPluginRuntimeTests {
         #expect(recovered.primary?.usedPercent == 7)
     }
 
-    private static func plugin(fetchBody: String = "return { primary: { usedPercent: 1 } };") -> String {
+    private static func plugin(
+        endpoints: String = #"["https://api.example.test"]"#,
+        auth: String = #"{ type: "bearer", secret: "TEST_KEY" }"#,
+        settings: String = #"{ key: "TEST_KEY", title: "API key", type: "secure" }"#,
+        capabilities: String = "",
+        fetchBody: String = "return { primary: { usedPercent: 1 } };") -> String
+    {
         """
         defineProvider({
           id: "synthetic",
           name: "Fixture",
-          endpoints: ["https://api.example.test"],
-          auth: { type: "bearer", secret: "TEST_KEY" },
-          settings: [{ key: "TEST_KEY", title: "API key", type: "secure" }],
+          endpoints: \(endpoints),
+          auth: \(auth),
+          settings: [\(settings)],
+          \(capabilities)
           async fetchUsage(ctx) {
             \(fetchBody)
           },
@@ -224,6 +393,20 @@ struct ProviderPluginRuntimeTests {
                 headerFields: ["Content-Type": "application/json"]))
             return (Data(body.utf8), response)
         }
+    }
+}
+
+private actor CookieAccessRecorder {
+    let header: String
+    private(set) var domains: [String] = []
+
+    init(header: String) {
+        self.header = header
+    }
+
+    func resolve(provider _: UsageProvider, domain: String) throws -> String {
+        self.domains.append(domain)
+        return self.header
     }
 }
 

--- a/docs/plugin-conversion-matrix.md
+++ b/docs/plugin-conversion-matrix.md
@@ -17,92 +17,89 @@ is inherently a user-chosen origin (LLM Proxy and LiteLLM) do not qualify. The c
 current Swift request methods and snapshot projections; Azure OpenAI, StepFun, and Warp were removed from the audit's
 earlier “fully expressible” baseline because their current implementations issue POST requests.
 
-`convertible-now (details)` means the bundled JavaScript conversion is present behind `CODEXBAR_JS_PROVIDERS=1` and its
-provider-specific dashboard projection is expressed through declarative detail sections. `needs-plugin-host-extension`
-marks providers uncovered during implementation whose canonical flow needs a runtime primitive beyond declared-origin
-GET, declared settings/secrets, and details.
+`converted` means the bundled JavaScript conversion is present behind `CODEXBAR_JS_PROVIDERS=1`. The Converted column
+makes implementation state explicit and the totals are mutually exclusive: `convertible-now` counts only providers
+that remain cheap to convert. Remaining buckets name the next blocker after this host-extension slice.
 
 ## Totals
 
 | Status | Count |
 |---|---:|
-| `convertible-now` | 11 |
-| `convertible-now (details)` | 5 |
-| `needs-details-model` | 0 |
-| `needs-plugin-host-extension` | 3 |
-| `needs-cookie-import` | 23 |
+| `converted` | 15 |
+| `convertible-now` | 8 |
+| `needs-cookie-import` | 19 |
 | `needs-files/subprocess/oauth-broker` | 15 |
 | `needs-pty/webview/native` | 10 |
 | **Total** | **67** |
 
 ## Matrix
 
-| Provider | Status | Reason |
-|---|---|---|
-| codex | `needs-pty/webview/native` | PTY CLI, OAuth files/refresh, browser cookies, WKWebView scraping, local logs, and reset-credit details exceed this host. |
-| openai | `convertible-now (details)` | Converted: fixed-origin bearer GET pagination with daily spend, model, line-item, and token details. |
-| azureopenai | `needs-pty/webview/native` | The current quota probe is a POST chat completion against a user-configured deployment origin. |
-| claude | `needs-files/subprocess/oauth-broker` | Full parity needs credential files/Keychain, OAuth refresh, CLI/PTY, cookies, local logs, and admin details. |
-| clinepass | `convertible-now` | Verified fixed-origin bearer GET; limits and identity map to generic windows. |
-| cursor | `needs-cookie-import` | Browser cookies/app database provide auth, and integer request history also has bespoke detail. |
-| opencode | `needs-cookie-import` | React server-function usage requires imported browser cookies and non-JSON text parsing. |
-| opencodego | `needs-files/subprocess/oauth-broker` | Local auth/SQLite state and browser sessions are required, with an additional bespoke usage model. |
-| alibaba | `needs-cookie-import` | The console path needs imported cookies, CSRF/sec-token discovery, redirects, and embedded response parsing. |
-| alibabatokenplan | `needs-cookie-import` | Full parity depends on Aliyun console cookies, CSRF/sec-token acquisition, and several dependent calls. |
-| qwencloud | `needs-cookie-import` | OneConsole usage needs imported cookies, CSRF, form POSTs, and redirect-aware routing. |
-| factory | `needs-cookie-import` | WorkOS/browser cookies and local storage recover the session; the API-key-only path is merely partial. |
-| gemini | `needs-files/subprocess/oauth-broker` | Gemini CLI credential/config files, Google OAuth refresh, and a curl fallback own the current flow. |
-| antigravity | `needs-pty/webview/native` | Process/port discovery, localhost IDE RPC, OAuth files, and a persistent PTY make this a native integration. |
-| copilot | `needs-cookie-import` | API-token usage fits, but billing budgets require GitHub cookies/nonces and the device flow needs POST. |
-| devin | `needs-files/subprocess/oauth-broker` | Full auth discovery reads Chromium localStorage and organization state; manual bearer alone is partial. |
-| zai | `convertible-now (details)` | Converted: both fixed regional origins, personal/team settings, quota lanes, model totals, and hourly/daily token charts. |
-| minimax | `needs-cookie-import` | Browser cookies/storage and group discovery feed a large service/billing/history-specific payload. |
-| manus | `needs-cookie-import` | Full session acquisition imports browser cookies; a manually supplied bearer covers only one path. |
-| kimi | `needs-cookie-import` | Browser cookies plus Kimi credential/device files and regional identity headers exceed the current broker. |
-| kilo | `needs-files/subprocess/oauth-broker` | The default source reads Kilo's local auth file and organization metadata. |
-| kiro | `needs-pty/webview/native` | Usage exists only through bounded CLI pipe/PTY automation and a bespoke credit/overage model. |
-| vertexai | `needs-files/subprocess/oauth-broker` | ADC/gcloud files, OAuth refresh, optional subprocess fallback, and local cost logs are required. |
-| augment | `needs-files/subprocess/oauth-broker` | The preferred strategy spawns `auggie`; the alternative imports browser cookies and maintains sessions. |
-| jetbrains | `needs-pty/webview/native` | There is no HTTP strategy; native IDE discovery and local XML parsing are the provider. |
-| moonshot | `convertible-now` | Verified bearer GET against two fixed regional origins; balances project into generic windows. |
-| amp | `needs-files/subprocess/oauth-broker` | CLI subprocess and browser-cookie strategies plus workspace credit details are outside this host. |
-| t3chat | `needs-cookie-import` | Usage is authenticated by an imported browser session cookie. |
-| ollama | `needs-cookie-import` | The full hosted flow imports cookies and scrapes HTML; the API-key model-count probe is only partial. |
-| synthetic | `convertible-now` | Converted: fixed-origin bearer GET with generic windows, cost, dates, and identity. |
-| warp | `needs-pty/webview/native` | Warp sends a POST GraphQL operation, which the GET-only HTTP broker cannot express. |
-| openrouter | `convertible-now (details)` | Converted: bearer GET credits plus best-effort key budget, period spend, rate-limit rows, and a spend chart. |
-| elevenlabs | `convertible-now` | Verified `xi-api-key` GET; heterogeneous character/minute quotas map to named generic windows. |
-| windsurf | `needs-files/subprocess/oauth-broker` | Chromium localStorage, IDE databases, and binary protobuf decoding supply the current session. |
-| zed | `needs-files/subprocess/oauth-broker` | Zed server settings and a named Keychain credential must be read locally. |
-| perplexity | `needs-cookie-import` | The provider imports a browser session before mapping multiple credit buckets. |
-| mimo | `needs-cookie-import` | Browser/Firefox session import and a local cache feed balance, plan, and token-specific details. |
-| doubao | `needs-files/subprocess/oauth-broker` | Full parity needs a CLI subprocess or Volcengine HMAC signing and POST-based plan calls. |
-| sakana | `needs-cookie-import` | The web flow needs a cookie session; PAYG balance/period data also needs a detail model. |
-| abacus | `needs-cookie-import` | Required compute and optional billing calls are authenticated through imported browser cookies. |
-| mistral | `needs-cookie-import` | Console cookies/CSRF gate wallet, credit-note, and model-history details. |
-| deepseek | `needs-files/subprocess/oauth-broker` | Platform auth/profile selection reads Chromium localStorage, and the result has a bespoke history model. |
-| deepinfra | `convertible-now` | Verified fixed-origin bearer GET pair; spend limit and balance project into generic cost/windows. |
-| codebuff | `needs-files/subprocess/oauth-broker` | Full credential parity reads a local Manicode credential file; environment-key mode is partial. |
-| crof | `convertible-now` | Converted: fixed-origin bearer GET with exact credit formatting and America/Chicago daily reset. |
-| venice | `convertible-now` | Converted: fixed-origin bearer GET with DIEM/USD allocation projection. |
-| commandcode | `needs-cookie-import` | Browser cookies authenticate both calls, and three live subscription/depletion flags need details. |
-| qoder | `needs-cookie-import` | Global/China session selection imports cookies and sends a bespoke browser header. |
-| stepfun | `needs-files/subprocess/oauth-broker` | Device registration, password login, refresh, quota, and plan operations are POST-based token-broker work. |
-| bedrock | `needs-files/subprocess/oauth-broker` | AWS profiles/CLI credentials, SigV4 signing, pagination, and two services need host-owned credential/signing APIs. |
-| grok | `needs-pty/webview/native` | Persistent stdio JSON-RPC, auth/session files, cookies, logs, and binary gRPC-web are strongly native. |
-| groq | `needs-cookie-import` | The API-token Prometheus path is partial; console parity imports Stytch/browser sessions and history details. |
-| llmproxy | `needs-pty/webview/native` | Its origin is user-selected and may be private HTTP, conflicting with the manifest's fixed HTTPS origins. |
-| litellm | `needs-pty/webview/native` | Its required user-selected proxy origin and optional private HTTP cannot be declared by a bundled static manifest. |
-| deepgram | `needs-plugin-host-extension` | Skipped: Deepgram requires `Authorization: Token <key>`; the prototype can inject bearer or a raw custom-header value but cannot prefix a custom auth scheme. |
-| poe | `convertible-now (details)` | Converted: fixed-origin bearer GET balance/history pagination with daily points and model/type summaries. |
-| chutes | `convertible-now` | Verified bearer GET fan-out on the canonical origin; dynamic quota lanes map to named windows. |
-| neuralwatt | `convertible-now` | Verified canonical bearer GET; quota lanes and prepaid cost/energy project generically. |
-| clawrouter | `convertible-now (details)` | Converted for the canonical origin: monthly budget, ledger, request/token totals, routed-provider rows, and cost chart. |
-| longcat | `needs-cookie-import` | Account, token use, and pending fuel merge behind an imported browser/manual cookie session. |
-| sub2api | `needs-plugin-host-extension` | Skipped: every instance requires a user-selected origin and may use loopback HTTP; bundled manifests allow only predeclared HTTPS origins. |
-| wayfinder | `needs-pty/webview/native` | The local unauthenticated HTTP gateway, metrics text, and routing/savings model violate HTTPS-only generic scope. |
-| zenmux | `convertible-now` | Verified fixed-origin bearer GET pair; subscription and optional PAYG balance map generically. |
-| aiand | `convertible-now` | Verified fixed-origin bearer GET pagination; 30-day spend maps to generic cost. |
-| zoommate | `needs-cookie-import` | Host-specific cookies are exchanged for a JWT, then paginated credit history requires details. |
-| xai | `needs-plugin-host-extension` | Skipped: prepaid balance is GET, but canonical daily usage history is a POST request with a JSON body. |
-| notion | `needs-cookie-import` | Workspace selection and AI allowance calls require imported Notion cookies and forwarded session headers. |
+| Provider | Status | Converted | Reason |
+|---|---|:---:|---|
+| codex | `needs-pty/webview/native` | No | PTY CLI, OAuth files/refresh, browser cookies, WKWebView scraping, local logs, and reset-credit details exceed this host. |
+| openai | `converted` | Yes | Converted: fixed-origin bearer GET pagination with daily spend, model, line-item, and token details. |
+| azureopenai | `needs-pty/webview/native` | No | The current quota probe is a POST chat completion against a user-configured deployment origin. |
+| claude | `needs-files/subprocess/oauth-broker` | No | Full parity needs credential files/Keychain, OAuth refresh, CLI/PTY, cookies, local logs, and admin details. |
+| clinepass | `convertible-now` | No | Verified fixed-origin bearer GET; limits and identity map to generic windows. |
+| cursor | `needs-cookie-import` | No | Browser cookies/app database provide auth, and integer request history also has bespoke detail. |
+| opencode | `needs-cookie-import` | No | Skipped: React server-function response parsing needs a protocol-specific text decoder beyond `matchFirst`. |
+| opencodego | `needs-files/subprocess/oauth-broker` | No | Local auth/SQLite state and browser sessions are required, with an additional bespoke usage model. |
+| alibaba | `needs-cookie-import` | No | The console path needs imported cookies, CSRF/sec-token discovery, redirects, and embedded response parsing. |
+| alibabatokenplan | `needs-cookie-import` | No | Full parity depends on Aliyun console cookies, CSRF/sec-token acquisition, and several dependent calls. |
+| qwencloud | `needs-cookie-import` | No | Skipped: CSRF plus form POST and redirect-aware routing are not covered by JSON POST. |
+| factory | `needs-cookie-import` | No | WorkOS/browser cookies and local storage recover the session; the API-key-only path is merely partial. |
+| gemini | `needs-files/subprocess/oauth-broker` | No | Gemini CLI credential/config files, Google OAuth refresh, and a curl fallback own the current flow. |
+| antigravity | `needs-pty/webview/native` | No | Process/port discovery, localhost IDE RPC, OAuth files, and a persistent PTY make this a native integration. |
+| copilot | `needs-cookie-import` | No | API-token usage fits, but billing budgets require GitHub cookies/nonces and the device flow needs POST. |
+| devin | `needs-files/subprocess/oauth-broker` | No | Full auth discovery reads Chromium localStorage and organization state; manual bearer alone is partial. |
+| zai | `converted` | Yes | Converted: both fixed regional origins, personal/team settings, quota lanes, model totals, and hourly/daily token charts. |
+| minimax | `needs-cookie-import` | No | Browser cookies/storage and group discovery feed a large service/billing/history-specific payload. |
+| manus | `converted` | Yes | Converted: declared-domain cookie import, session-token extraction, JSON POST, and generic credit windows. |
+| kimi | `needs-cookie-import` | No | Browser cookies plus Kimi credential/device files and regional identity headers exceed the current broker. |
+| kilo | `needs-files/subprocess/oauth-broker` | No | The default source reads Kilo's local auth file and organization metadata. |
+| kiro | `needs-pty/webview/native` | No | Usage exists only through bounded CLI pipe/PTY automation and a bespoke credit/overage model. |
+| vertexai | `needs-files/subprocess/oauth-broker` | No | ADC/gcloud files, OAuth refresh, optional subprocess fallback, and local cost logs are required. |
+| augment | `needs-files/subprocess/oauth-broker` | No | The preferred strategy spawns `auggie`; the alternative imports browser cookies and maintains sessions. |
+| jetbrains | `needs-pty/webview/native` | No | There is no HTTP strategy; native IDE discovery and local XML parsing are the provider. |
+| moonshot | `convertible-now` | No | Verified bearer GET against two fixed regional origins; balances project into generic windows. |
+| amp | `needs-files/subprocess/oauth-broker` | No | CLI subprocess and browser-cookie strategies plus workspace credit details are outside this host. |
+| t3chat | `converted` | Yes | Converted: declared-domain cookie import, JSONL text parsing, and generic base/overage windows. |
+| ollama | `needs-cookie-import` | No | Skipped: hosted parity requires HTML bootstrap/state extraction plus API-key fallback arbitration. |
+| synthetic | `converted` | Yes | Converted: fixed-origin bearer GET with generic windows, cost, dates, and identity. |
+| warp | `needs-pty/webview/native` | No | Warp sends a POST GraphQL operation, which the GET-only HTTP broker cannot express. |
+| openrouter | `converted` | Yes | Converted: bearer GET credits plus best-effort key budget, period spend, rate-limit rows, and a spend chart. |
+| elevenlabs | `convertible-now` | No | Verified `xi-api-key` GET; heterogeneous character/minute quotas map to named generic windows. |
+| windsurf | `needs-files/subprocess/oauth-broker` | No | Chromium localStorage, IDE databases, and binary protobuf decoding supply the current session. |
+| zed | `needs-files/subprocess/oauth-broker` | No | Zed server settings and a named Keychain credential must be read locally. |
+| perplexity | `converted` | Yes | Converted: declared-domain cookie import and generic recurring, bonus, and purchased credit windows. |
+| mimo | `needs-cookie-import` | No | Browser/Firefox session import and a local cache feed balance, plan, and token-specific details. |
+| doubao | `needs-files/subprocess/oauth-broker` | No | Full parity needs a CLI subprocess or Volcengine HMAC signing and POST-based plan calls. |
+| sakana | `needs-cookie-import` | No | Skipped: app-owned wiring and PAYG detail fixtures are outside the core descriptor seam. |
+| abacus | `needs-cookie-import` | No | Skipped: exact calendar-month window parity needs a host date helper not in this slice. |
+| mistral | `needs-cookie-import` | No | Skipped: CSRF discovery and dependent wallet, credit-note, and model-history calls exceed the minimal broker. |
+| deepseek | `needs-files/subprocess/oauth-broker` | No | Platform auth/profile selection reads Chromium localStorage, and the result has a bespoke history model. |
+| deepinfra | `convertible-now` | No | Verified fixed-origin bearer GET pair; spend limit and balance project into generic cost/windows. |
+| codebuff | `needs-files/subprocess/oauth-broker` | No | Full credential parity reads a local Manicode credential file; environment-key mode is partial. |
+| crof | `converted` | Yes | Converted: fixed-origin bearer GET with exact credit formatting and America/Chicago daily reset. |
+| venice | `converted` | Yes | Converted: fixed-origin bearer GET with DIEM/USD allocation projection. |
+| commandcode | `needs-cookie-import` | No | Skipped: live subscription/depletion flags lack reconstructable fixtures within the per-provider cap. |
+| qoder | `converted` | Yes | Converted: declared global/China cookie domains, browser headers, and merged generic quota window. |
+| stepfun | `needs-files/subprocess/oauth-broker` | No | Device registration, password login, refresh, quota, and plan operations are POST-based token-broker work. |
+| bedrock | `needs-files/subprocess/oauth-broker` | No | AWS profiles/CLI credentials, SigV4 signing, pagination, and two services need host-owned credential/signing APIs. |
+| grok | `needs-pty/webview/native` | No | Persistent stdio JSON-RPC, auth/session files, cookies, logs, and binary gRPC-web are strongly native. |
+| groq | `needs-cookie-import` | No | Skipped: Stytch session exchange and console history remain a multi-step auth flow. |
+| llmproxy | `needs-pty/webview/native` | No | Its origin is user-selected and may be private HTTP, conflicting with the manifest's fixed HTTPS origins. |
+| litellm | `needs-pty/webview/native` | No | Its required user-selected proxy origin and optional private HTTP cannot be declared by a bundled static manifest. |
+| deepgram | `converted` | Yes | Converted: bounded `Token` authorization scheme plus project discovery and usage details. |
+| poe | `converted` | Yes | Converted: fixed-origin bearer GET balance/history pagination with daily points and model/type summaries. |
+| chutes | `convertible-now` | No | Verified bearer GET fan-out on the canonical origin; dynamic quota lanes map to named windows. |
+| neuralwatt | `convertible-now` | No | Verified canonical bearer GET; quota lanes and prepaid cost/energy project generically. |
+| clawrouter | `converted` | Yes | Converted for the canonical origin: monthly budget, ledger, request/token totals, routed-provider rows, and cost chart. |
+| longcat | `needs-cookie-import` | No | Skipped: browser-cookie retry needs domain/path-aware cookie selection across multiple imported sessions; the generic broker currently returns one flattened header. |
+| sub2api | `converted` | Yes | Converted: settings-derived HTTPS or loopback-HTTP origin with quota and usage details. |
+| wayfinder | `needs-pty/webview/native` | No | The local unauthenticated HTTP gateway, metrics text, and routing/savings model violate HTTPS-only generic scope. |
+| zenmux | `convertible-now` | No | Verified fixed-origin bearer GET pair; subscription and optional PAYG balance map generically. |
+| aiand | `convertible-now` | No | Verified fixed-origin bearer GET pagination; 30-day spend maps to generic cost. |
+| zoommate | `needs-cookie-import` | No | Skipped: cookie-to-JWT exchange plus paginated history requires provider-specific retry state. |
+| xai | `converted` | Yes | Converted: bearer GET balance plus best-effort JSON POST history and billing details. |
+| notion | `needs-cookie-import` | No | Workspace selection and AI allowance calls require imported Notion cookies and forwarded session headers. |

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -15,8 +15,9 @@ the default.
 
 ## Enable and test
 
-Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, Venice, Crof, OpenAI, z.ai, OpenRouter, Poe, and
-ClawRouter then prepend a script strategy to their existing API pipeline. A missing required secret leaves the script
+Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, Venice, Crof, OpenAI, z.ai, OpenRouter, Poe,
+ClawRouter, Deepgram, sub2api, xAI, Manus, Perplexity, T3 Chat, and Qoder then prepend a script strategy to their
+existing pipeline. A missing required secret or disabled cookie source leaves the script
 strategy unavailable and permits the Swift strategy to run; a loaded script that fails does not fall back, so parity
 defects stay visible. Without the variable, the resolver returns the original Swift strategy only and does not load
 JavaScriptCore or a plugin resource.
@@ -41,9 +42,12 @@ Every script calls `defineProvider` once:
 defineProvider({
   id: "example", // must be an existing UsageProvider raw value
   name: "Example",
-  endpoints: ["https://api.example.com"], // HTTPS origins, not URL prefixes
+  endpoints: [
+    "https://api.example.com", // fixed HTTPS origin
+    { setting: "BASE_URL", policy: "https-or-loopback-http" },
+  ],
   auth: {
-    type: "bearer", // bearer | x-api-key | header
+    type: "bearer", // bearer | x-api-key | header | authorization-scheme
     header: "X-Custom-Key", // required only for type: "header"
     secret: "EXAMPLE_API_KEY", // key declared below
   },
@@ -60,9 +64,15 @@ defineProvider({
 });
 ```
 
-`endpoints` accepts only normalized HTTPS origins. The broker rejects user info, non-HTTPS URLs, and any request whose
-scheme, host, or effective port is not declared. `bearer` injects `Authorization: Bearer <secret>`, `x-api-key` injects
-`X-API-Key`, and `header` injects the named header. A plugin cannot override its auth header in request options.
+Fixed `endpoints` accept only normalized HTTPS origins. A settings-derived endpoint declares a plain setting and a
+policy: `https` or `https-or-loopback-http`. It is resolved at fetch time using the same endpoint-override validation
+as native providers; user info and fragments are rejected, and HTTP is limited to loopback under the latter policy.
+`bearer` injects `Authorization: Bearer <secret>`, `x-api-key` injects `X-API-Key`, and `header` injects the named
+header. `authorization-scheme` requires a bounded ASCII token in `scheme` and injects
+`Authorization: <scheme> <secret>`. A plugin cannot override a manifest-owned auth header.
+
+Cookie plugins omit `auth`, declare `capabilities: ["browser-cookies"]`, and list normalized host names in
+`cookieDomains`. The host refuses undeclared domains before cache or browser-store access.
 
 ## `ctx` reference
 
@@ -72,9 +82,18 @@ built-ins, but no browser or Node host environment. Tests assert that `fetch`, `
 
 - `await ctx.http.getJSON(url, opts?)` performs a GET and returns `{status, headers, json}`.
 - `await ctx.http.get(url, opts?)` performs a GET and returns `{status, headers, bodyText}`.
+- `await ctx.http.postJSON(url, {body, headers?})` performs a POST and returns `{status, headers, json}`. `body` must be
+  JSON-serializable. The serialized body is passed directly to the broker and is never logged.
 - `opts.headers` may contain string header values. Requests have a 15-second timeout, responses are capped at 5 MiB,
   and transport uses `ProviderHTTPClient`, including its same-origin HTTPS redirect policy.
-- `ctx.secrets.get(key)` returns a value only for a key declared in `settings`; undeclared access throws.
+- `ctx.settings.get(key)` reads only a declared `plain` setting; `ctx.settings.getSecret(key)` reads only a declared
+  `secure` setting. Kind mismatches and undeclared keys throw. Only secure values are tracked for redaction.
+- `await ctx.browser.cookieHeader(domain)` returns a Cookie header only for a declared domain and only when the
+  `browser-cookies` capability is present. The broker honors the provider's auto/manual/off setting, cache, and browser
+  priority order. Cookie headers and individual cookie values are secret-equivalent and redacted at the bridge.
+- `ctx.html.metaContent(html, name)` returns the first matching quoted `name`/`property` meta value, or `null`.
+  `ctx.html.matchFirst(html, regexSource, flags?)` returns the first capture (or full match), or `null`. Both are pure
+  JavaScript helpers with no I/O.
 - `ctx.log(...values)` writes to the provider-derived `<provider>-plugin` category. Do not log credentials; known secret
   values are also substring-redacted from errors crossing back to Swift.
 - `ctx.cache.get(key)` and `ctx.cache.set(key, value, ttlSeconds)` provide an in-memory, per-context cache. TTLs are
@@ -146,9 +165,9 @@ runtime needs a public interrupt API or a killable helper-process boundary befor
 
 The runtime is macOS-only and compiled out when JavaScriptCore is unavailable. It supports bundled first-party IDs and
 the generic snapshot and declarative details only: no runtime identities, user-installed files, install UI,
-TypeScript/Sucrase, provider-specific Swift payloads, cookies, OAuth/refresh broker, local files or databases,
-subprocesses, POST bodies, PTY, WebView,
-binary/protobuf responses, localhost HTTP, or dynamic endpoint origins. See
+TypeScript/Sucrase, provider-specific Swift payloads, OAuth/refresh broker, local files or databases, subprocesses,
+arbitrary/form POST bodies, PTY, WebView, binary/protobuf responses, private-network HTTP, or unvalidated dynamic
+origins. Browser cookies are restricted to bundled manifests and declared domains. See
 [`plugin-conversion-matrix.md`](plugin-conversion-matrix.md) for the provider-by-provider impact.
 
 ## Future work


### PR DESCRIPTION
## Summary

- Adds the plugin host settings/secret split, configurable authorization schemes, JSON POST support, settings-configured origins constrained to HTTPS or loopback HTTP, declared-domain browser-cookie access through the existing SweetCookieKit path and `CookieHeaderCache` with values redacted, and HTML parsing helpers.
- Converts Deepgram, sub2api, xAI, Manus, Perplexity, T3 Chat, and Qoder, bringing the prototype to 15/67 converted providers.
- Keeps the entire JavaScript provider path behind `CODEXBAR_JS_PROVIDERS=1`; flag-off behavior remains byte-identical.

## Deferred conversions

Ten audited providers remain skipped with named blockers:

- OpenCode — React server-function response parsing needs a protocol-specific text decoder beyond `matchFirst`.
- Qwen Cloud — CSRF, form POST, and redirect-aware routing are not covered by JSON POST.
- Ollama — hosted parity requires HTML bootstrap/state extraction plus API-key fallback arbitration.
- Sakana — app-owned wiring and PAYG detail fixtures sit outside the core descriptor seam.
- Abacus — exact calendar-month window parity needs a host date helper not included in this slice.
- Mistral — CSRF discovery and dependent wallet, credit-note, and model-history calls exceed the minimal broker.
- Command Code — live subscription/depletion flags lack reconstructable fixtures within the per-provider cap.
- Groq — Stytch session exchange and console history remain a multi-step authentication flow.
- LongCat — domain/path-aware cookie selection across multiple imported sessions cannot use the broker's single flattened header.
- ZoomMate — cookie-to-JWT exchange plus paginated history requires provider-specific retry state.

## Verification

- `make check`
- `make build`
- Full `make test`: 809/809 selections, 68/68 groups passed on the first attempt
- Focused z.ai plugin parity, including China-region credential aliases
- Structured Codex autoreview: clean, no accepted/actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
