### PR TITLE
refactor: introduce ProviderInstanceID identity seam

### DIFF
--- a/Sources/CodexBar/Config/CodexBarConfigMigrator.swift
+++ b/Sources/CodexBar/Config/CodexBarConfigMigrator.swift
@@ -294,7 +294,7 @@ struct CodexBarConfigMigrator {
         state: inout MigrationState,
         mutate: (inout ProviderConfig) -> Bool)
     {
-        guard let index = config.providers.firstIndex(where: { $0.id == provider }) else { return }
+        guard let index = config.providers.firstIndex(where: { $0.id == provider.instanceID }) else { return }
         var entry = config.providers[index]
         let changed = mutate(&entry)
         if changed {
@@ -351,21 +351,21 @@ struct CodexBarConfigMigrator {
 
     private static func applyProviderOrder(_ raw: [String], config: CodexBarConfig) -> CodexBarConfig {
         let configsByID = Dictionary(uniqueKeysWithValues: config.providers.map { ($0.id, $0) })
-        var seen: Set<UsageProvider> = []
+        var seen: Set<ProviderInstanceID> = []
         var ordered: [ProviderConfig] = []
         ordered.reserveCapacity(config.providers.count)
 
         for rawValue in raw {
-            guard let provider = UsageProvider(rawValue: rawValue),
-                  let entry = configsByID[provider],
-                  !seen.contains(provider)
+            guard let instanceID = ProviderInstanceID(rawValue: rawValue),
+                  let entry = configsByID[instanceID],
+                  !seen.contains(instanceID)
             else { continue }
-            seen.insert(provider)
+            seen.insert(instanceID)
             ordered.append(entry)
         }
 
-        for provider in UsageProvider.allCases where !seen.contains(provider) {
-            ordered.append(configsByID[provider] ?? ProviderConfig(id: provider))
+        for provider in UsageProvider.allCases where !seen.contains(provider.instanceID) {
+            ordered.append(configsByID[provider.instanceID] ?? ProviderConfig(id: provider.instanceID))
         }
 
         var updated = config
@@ -379,7 +379,7 @@ struct CodexBarConfigMigrator {
     {
         var updated = config
         for index in updated.providers.indices {
-            let provider = updated.providers[index].id
+            guard let provider = updated.providers[index].id.firstPartyProvider else { continue }
             let meta = ProviderDescriptorRegistry.descriptor(for: provider).metadata
             if let value = toggles[meta.cliName] {
                 updated.providers[index].enabled = value

--- a/Sources/CodexBar/FleetAccountMenuProjection.swift
+++ b/Sources/CodexBar/FleetAccountMenuProjection.swift
@@ -16,7 +16,7 @@ enum FleetAccountMenuPlanner {
         hasLocalUsage: Bool) -> FleetAccountMenuProjection
     {
         let remote = snapshots
-            .filter { $0.provider == provider && $0.deviceID != currentDeviceID }
+            .filter { $0.provider == provider.instanceID && $0.deviceID != currentDeviceID }
         let freshestByAccount = Dictionary(grouping: remote, by: \.accountKey)
             .compactMap { _, candidates in candidates.max(by: self.isOlder) }
             .sorted(by: self.isNewer)

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -190,7 +190,7 @@ struct MenuBarLayoutEditor: View {
     }
 
     private var providers: [UsageProvider] {
-        self.store.enabledProvidersForDisplay()
+        self.store.enabledFirstPartyProvidersForDisplay()
     }
 
     private var scopedProvider: UsageProvider? {
@@ -627,7 +627,7 @@ private struct MenuBarLayoutPreview: View {
 
     var body: some View {
         let provider = self.provider ?? .codex
-        let snapshot = self.store.snapshot(for: provider)
+        let snapshot = self.store.snapshot(for: provider.instanceID)
         let data = snapshot.map { self.liveData(provider: provider, snapshot: $0) }
             ?? self.representativeData(provider: provider)
         let icon = ProviderBrandIcon.image(for: provider)

--- a/Sources/CodexBar/MenuCardRefreshMonitor.swift
+++ b/Sources/CodexBar/MenuCardRefreshMonitor.swift
@@ -20,8 +20,8 @@ final class MenuCardRefreshMonitor {
     private var globalManualRefreshInFlight = false
     /// Providers with an individual manual refresh in flight. Concurrent entries are allowed so
     /// refreshing one provider does not stall or unfreeze another.
-    private var manualRefreshProviders: Set<UsageProvider> = []
-    private var frozenManualRefreshModels: [UsageProvider: UsageMenuCardView.Model] = [:]
+    private var manualRefreshProviders: Set<ProviderInstanceID> = []
+    private var frozenManualRefreshModels: [ProviderInstanceID: UsageMenuCardView.Model] = [:]
 
     /// True while any manual refresh (global or per-provider) is running.
     var isManualRefreshInFlight: Bool {
@@ -41,10 +41,11 @@ final class MenuCardRefreshMonitor {
         provider: UsageProvider? = nil)
     {
         if let provider {
-            self.frozenManualRefreshModels[provider] = frozenModels[provider]
-            self.manualRefreshProviders.insert(provider)
+            self.frozenManualRefreshModels[provider.instanceID] = frozenModels[provider]
+            self.manualRefreshProviders.insert(provider.instanceID)
         } else {
-            self.frozenManualRefreshModels = frozenModels
+            self.frozenManualRefreshModels = Dictionary(
+                uniqueKeysWithValues: frozenModels.map { ($0.key.instanceID, $0.value) })
             self.globalManualRefreshInFlight = true
         }
     }
@@ -52,8 +53,8 @@ final class MenuCardRefreshMonitor {
     /// Balances a `beginManualRefresh` with the same `provider` argument (nil ends the global refresh).
     func endManualRefresh(for provider: UsageProvider? = nil) {
         if let provider {
-            self.manualRefreshProviders.remove(provider)
-            self.frozenManualRefreshModels[provider] = nil
+            self.manualRefreshProviders.remove(provider.instanceID)
+            self.frozenManualRefreshModels[provider.instanceID] = nil
         } else {
             self.globalManualRefreshInFlight = false
             self.frozenManualRefreshModels.removeAll(keepingCapacity: true)
@@ -67,7 +68,7 @@ final class MenuCardRefreshMonitor {
     }
 
     func isManualRefreshInFlight(for provider: UsageProvider) -> Bool {
-        self.manualRefreshProviders.contains(provider) ||
+        self.manualRefreshProviders.contains(provider.instanceID) ||
             (self.globalManualRefreshInFlight && self.isProviderRefreshActive(provider))
     }
 
@@ -76,7 +77,7 @@ final class MenuCardRefreshMonitor {
         fallback: UsageMenuCardView.Model) -> UsageMenuCardView.Model
     {
         guard !self.isManualRefreshInFlight(for: provider) else {
-            guard let frozen = self.frozenManualRefreshModels[provider] else {
+            guard let frozen = self.frozenManualRefreshModels[provider.instanceID] else {
                 return fallback
             }
             if fallback.hasCompatibleTrackedLayout(with: frozen) {

--- a/Sources/CodexBar/MenuContent.swift
+++ b/Sources/CodexBar/MenuContent.swift
@@ -219,7 +219,7 @@ struct StatusIconView: View {
     }
 
     private var accessibilityValue: String {
-        let snapshot = self.store.snapshot(for: self.provider)
+        let snapshot = self.store.snapshot(for: self.provider.instanceID)
         guard let snap = snapshot else {
             return L("No data")
         }
@@ -238,7 +238,7 @@ struct StatusIconView: View {
 
     private var icon: NSImage {
         let now = Date()
-        let snapshot = self.store.snapshot(for: self.provider)
+        let snapshot = self.store.snapshot(for: self.provider.instanceID)
         let remaining = snapshot.map {
             IconRemainingResolver.resolvedRemaining(
                 snapshot: $0,

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -112,7 +112,7 @@ struct MenuDescriptor {
         } else {
             var addedUsage = false
 
-            for enabledProvider in store.enabledProviders() {
+            for enabledProvider in store.enabledFirstPartyProviders() {
                 sections.append(Self.usageSection(for: enabledProvider, store: store, settings: settings))
                 addedUsage = true
             }
@@ -234,7 +234,7 @@ struct MenuDescriptor {
         }()
         entries.append(.text(headlineText, .headline))
 
-        if let snap = store.snapshot(for: provider) {
+        if let snap = store.snapshot(for: provider.instanceID) {
             let resetStyle = settings.resetTimeDisplayStyle
             let labels = Self.rateWindowLabels(provider: provider, metadata: meta, snapshot: snap)
             let crofShowsCreditsOnly = provider == .crof && snap.secondary == nil
@@ -360,7 +360,7 @@ struct MenuDescriptor {
             store: store,
             settings: settings,
             metadata: meta,
-            snapshot: store.snapshot(for: provider))
+            snapshot: store.snapshot(for: provider.instanceID))
         ProviderCatalog.implementation(for: provider)?
             .appendUsageMenuEntries(context: usageContext, entries: &entries)
 
@@ -460,7 +460,7 @@ struct MenuDescriptor {
         settings: SettingsStore,
         account: AccountInfo) -> Section?
     {
-        let snapshot = store.snapshot(for: provider)
+        let snapshot = store.snapshot(for: provider.instanceID)
         let metadata = store.metadata(for: provider)
         let entries = Self.accountEntries(
             provider: provider,
@@ -574,9 +574,9 @@ struct MenuDescriptor {
     }
 
     private static func accountProviderForCombined(store: UsageStore) -> UsageProvider? {
-        for provider in store.enabledProviders() {
+        for provider in store.enabledFirstPartyProviders() {
             let metadata = store.metadata(for: provider)
-            if store.snapshot(for: provider)?.identity(for: provider) != nil {
+            if store.snapshot(for: provider.instanceID)?.identity(for: provider.instanceID) != nil {
                 return provider
             }
             if metadata.usesAccountFallback {
@@ -594,7 +594,7 @@ struct MenuDescriptor {
         codexAccountPromotionCoordinator: CodexAccountPromotionCoordinator?) -> Section
     {
         var entries: [Entry] = []
-        let targetProvider = provider ?? store.enabledProviders().first
+        let targetProvider = provider ?? store.enabledFirstPartyProviders().first
         let metadata = targetProvider.map { store.metadata(for: $0) }
         let fallbackAccount = targetProvider.map { store.accountInfo(for: $0) } ?? account
         let hasAccount = self.hasAccount(for: targetProvider, store: store, account: fallbackAccount)
@@ -667,7 +667,7 @@ struct MenuDescriptor {
     }
 
     private static func statusLine(for provider: UsageProvider?, store: UsageStore) -> String? {
-        let target = provider ?? store.enabledProviders().first
+        let target = provider ?? store.enabledFirstPartyProviders().first
         guard let target,
               let status = store.status(for: target),
               status.indicator != .none else { return nil }
@@ -685,15 +685,15 @@ struct MenuDescriptor {
         if let provider {
             return .switchAccount(provider)
         }
-        if let enabled = store.enabledProviders().first {
+        if let enabled = store.enabledFirstPartyProviders().first {
             return .switchAccount(enabled)
         }
         return .switchAccount(.codex)
     }
 
     private static func hasAccount(for provider: UsageProvider?, store: UsageStore, account: AccountInfo) -> Bool {
-        let target = provider ?? store.enabledProviders().first ?? .codex
-        let snapshot = store.snapshot(for: target)
+        let target = provider ?? store.enabledFirstPartyProviders().first ?? .codex
+        let snapshot = store.snapshot(for: target.instanceID)
         if let email = snapshot?.accountEmail(for: target),
            !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {

--- a/Sources/CodexBar/MenuOpenRefreshPlan.swift
+++ b/Sources/CodexBar/MenuOpenRefreshPlan.swift
@@ -3,11 +3,11 @@ import CodexBarCore
 struct MenuOpenRefreshPlan: Equatable {
     struct Inputs {
         let refreshAllOnOpen: Bool
-        let enabledProviders: [UsageProvider]
-        let visibleProviders: [UsageProvider]
-        let refreshingProviders: Set<UsageProvider>
-        let staleProviders: Set<UsageProvider>
-        let missingProviders: Set<UsageProvider>
+        let enabledProviders: [ProviderInstanceID]
+        let visibleProviders: [ProviderInstanceID]
+        let refreshingProviders: Set<ProviderInstanceID>
+        let staleProviders: Set<ProviderInstanceID>
+        let missingProviders: Set<ProviderInstanceID>
     }
 
     enum Scheduling: Equatable {
@@ -15,7 +15,7 @@ struct MenuOpenRefreshPlan: Equatable {
         case concurrent
     }
 
-    let providers: [UsageProvider]
+    let providers: [ProviderInstanceID]
     let scheduling: Scheduling
     let refreshCodexDashboard: Bool
 

--- a/Sources/CodexBar/MenuSwitchFlickerProbe.swift
+++ b/Sources/CodexBar/MenuSwitchFlickerProbe.swift
@@ -268,12 +268,12 @@ enum MenuSwitchFlickerProbe {
         /// current selection so the probe performs a real switch, and restores
         /// the original selection afterwards.
         private func resolveSegments() {
-            let enabledProviders = self.controller.store.enabledProvidersForDisplay()
+            let enabledProviders = self.controller.store.enabledFirstPartyProvidersForDisplay()
             let includesOverview = self.controller.includesOverviewTab(enabledProviders: enabledProviders)
             let selection = self.controller.resolvedSwitcherSelection(
                 enabledProviders: enabledProviders,
                 includesOverview: includesOverview)
-            var segments: [ProviderSwitcherSelection] = enabledProviders.map { .provider($0) }
+            var segments: [ProviderSwitcherSelection] = enabledProviders.map { .provider($0.instanceID) }
             if includesOverview {
                 segments.insert(.overview, at: 0)
             }

--- a/Sources/CodexBar/PlanUtilizationHistoryStore.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryStore.swift
@@ -206,7 +206,7 @@ struct PlanUtilizationHistoryStore: Sendable {
         Self()
     }
 
-    func load() -> [UsageProvider: PlanUtilizationHistoryBuckets] {
+    func load() -> [ProviderInstanceID: PlanUtilizationHistoryBuckets] {
         self.loadProviderFiles()
     }
 
@@ -216,11 +216,11 @@ struct PlanUtilizationHistoryStore: Sendable {
     /// ~150 ms for mature two-year histories and must not run on the app
     /// startup main thread. The returned dictionary is safe to apply on the
     /// main actor once decoding completes.
-    func loadAsync() async -> [UsageProvider: PlanUtilizationHistoryBuckets] {
+    func loadAsync() async -> [ProviderInstanceID: PlanUtilizationHistoryBuckets] {
         await Task.detached(priority: .utility) { self.load() }.value
     }
 
-    func save(_ providers: [UsageProvider: PlanUtilizationHistoryBuckets]) {
+    func save(_ providers: [ProviderInstanceID: PlanUtilizationHistoryBuckets]) {
         guard let directoryURL = self.directoryURL else { return }
         do {
             try FileManager.default.createDirectory(
@@ -230,9 +230,10 @@ struct PlanUtilizationHistoryStore: Sendable {
             encoder.dateEncodingStrategy = .iso8601
             encoder.outputFormatting = [.sortedKeys]
 
-            for provider in UsageProvider.allCases {
-                let fileURL = self.providerFileURL(for: provider)
-                let buckets = providers[provider] ?? PlanUtilizationHistoryBuckets()
+            let knownInstanceIDs = Set(UsageProvider.allCases.map(\.instanceID)).union(providers.keys)
+            for instanceID in knownInstanceIDs.sorted(by: { $0.rawValue < $1.rawValue }) {
+                let fileURL = self.providerFileURL(for: instanceID)
+                let buckets = providers[instanceID] ?? PlanUtilizationHistoryBuckets()
                 let unscoped = Self.sortedHistories(buckets.unscoped)
                 let accounts = Self.sortedAccounts(buckets.accounts)
                 guard !unscoped.isEmpty || !accounts.isEmpty || !buckets.sessionEquivalentWindowPairIdentities.isEmpty
@@ -255,17 +256,21 @@ struct PlanUtilizationHistoryStore: Sendable {
         }
     }
 
-    private func loadProviderFiles() -> [UsageProvider: PlanUtilizationHistoryBuckets] {
-        guard self.directoryURL != nil else { return [:] }
+    private func loadProviderFiles() -> [ProviderInstanceID: PlanUtilizationHistoryBuckets] {
+        guard let directoryURL = self.directoryURL,
+              let fileURLs = try? FileManager.default.contentsOfDirectory(
+                  at: directoryURL,
+                  includingPropertiesForKeys: nil)
+        else { return [:] }
 
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
 
-        var output: [UsageProvider: PlanUtilizationHistoryBuckets] = [:]
+        var output: [ProviderInstanceID: PlanUtilizationHistoryBuckets] = [:]
 
-        for provider in UsageProvider.allCases {
-            let fileURL = self.providerFileURL(for: provider)
-            guard FileManager.default.fileExists(atPath: fileURL.path) else { continue }
+        for fileURL in fileURLs where fileURL.pathExtension == "json" {
+            guard let instanceID = ProviderInstanceID(rawValue: fileURL.deletingPathExtension().lastPathComponent)
+            else { continue }
             guard let data = try? Data(contentsOf: fileURL),
                   let decoded = try? decoder.decode(ProviderHistoryDocument.self, from: data)
             else {
@@ -277,19 +282,19 @@ struct PlanUtilizationHistoryStore: Sendable {
                 unscoped: decoded.unscoped,
                 accounts: decoded.accounts,
                 sessionEquivalentWindowPairIdentities: decoded.sessionEquivalentWindowPairIdentities)
-            output[provider] = Self.decodeProvider(history)
+            output[instanceID] = Self.decodeProvider(history)
         }
 
         return output
     }
 
     private static func decodeProviders(
-        _ providers: [String: ProviderHistoryFile]) -> [UsageProvider: PlanUtilizationHistoryBuckets]
+        _ providers: [String: ProviderHistoryFile]) -> [ProviderInstanceID: PlanUtilizationHistoryBuckets]
     {
-        var output: [UsageProvider: PlanUtilizationHistoryBuckets] = [:]
+        var output: [ProviderInstanceID: PlanUtilizationHistoryBuckets] = [:]
         for (rawProvider, providerHistory) in providers {
-            guard let provider = UsageProvider(rawValue: rawProvider) else { continue }
-            output[provider] = Self.decodeProvider(providerHistory)
+            guard let instanceID = ProviderInstanceID(rawValue: rawProvider) else { continue }
+            output[instanceID] = Self.decodeProvider(providerHistory)
         }
         return output
     }
@@ -342,9 +347,9 @@ struct PlanUtilizationHistoryStore: Sendable {
         return dir.appendingPathComponent("history", isDirectory: true)
     }
 
-    private func providerFileURL(for provider: UsageProvider) -> URL {
+    private func providerFileURL(for instanceID: ProviderInstanceID) -> URL {
         let directoryURL = self.directoryURL ?? URL(fileURLWithPath: "/dev/null", isDirectory: true)
-        return directoryURL.appendingPathComponent("\(provider.rawValue).json", isDirectory: false)
+        return directoryURL.appendingPathComponent("\(instanceID.rawValue).json", isDirectory: false)
     }
 }
 

--- a/Sources/CodexBar/PreferencesMenuBarPane.swift
+++ b/Sources/CodexBar/PreferencesMenuBarPane.swift
@@ -167,7 +167,7 @@ struct MenuBarPane: View {
     }
 
     private var activeProvidersInOrder: [UsageProvider] {
-        self.store.enabledProviders()
+        self.store.enabledFirstPartyProviders()
     }
 
     private var overviewSelectedProviders: [UsageProvider] {

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -135,7 +135,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
                     model: self.model,
                     openAIWebDiagnostic: self.openAIWebDiagnostic,
                     isEnabled: self.isEnabled,
-                    isRefreshing: self.store.refreshingProviders.contains(self.provider))
+                    isRefreshing: self.store.refreshingProviders.contains(self.provider.instanceID))
             } header: {
                 Text(L("Usage"))
             }
@@ -304,7 +304,7 @@ private struct ProviderDetailInfoRows: View {
         }
 
         if self.provider == .kiro,
-           let authMethod = self.store.snapshot(for: self.provider)?.loginMethod(for: .kiro),
+           let authMethod = self.store.snapshot(for: self.provider.instanceID)?.loginMethod(for: .kiro),
            !authMethod.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
             ProviderDetailInfoRow(label: L("Auth"), value: authMethod)
@@ -319,10 +319,10 @@ private struct ProviderDetailInfoRows: View {
     }
 
     private var updatedText: String {
-        if let updated = self.store.snapshot(for: self.provider)?.updatedAt {
+        if let updated = self.store.snapshot(for: self.provider.instanceID)?.updatedAt {
             return UsageFormatter.updatedString(from: updated)
         }
-        if self.store.refreshingProviders.contains(self.provider) {
+        if self.store.refreshingProviders.contains(self.provider.instanceID) {
             return L("Refreshing")
         }
         if self.store.unavailableMessage(for: self.provider) != nil {

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -208,7 +208,9 @@ struct ProvidersPane: View {
             L("usage_not_fetched_yet")
         }
 
-        let detailLine: String = if let sourceLabel = self.store.lastSourceLabels[provider], !sourceLabel.isEmpty {
+        let detailLine: String = if let sourceLabel = self.store.lastSourceLabels[provider.instanceID],
+                                    !sourceLabel.isEmpty
+        {
             sourceLabel
         } else if let version = self.store.version(for: provider), !version.isEmpty {
             "\(meta.cliName) \(version)"
@@ -573,7 +575,7 @@ struct ProvidersPane: View {
             tokenSnapshot: tokenSnapshot,
             tokenError: tokenError,
             account: self.store.accountInfo(for: provider),
-            isRefreshing: self.store.refreshingProviders.contains(provider),
+            isRefreshing: self.store.refreshingProviders.contains(provider.instanceID),
             lastError: codexProjection?.userFacingErrors.usage ?? self.store.userFacingError(for: provider),
             limitsAvailability: self.store.knownLimitsAvailability(for: provider),
             usageBarsShowUsed: self.settings.usageBarsShowUsed,

--- a/Sources/CodexBar/PreferencesSelection.swift
+++ b/Sources/CodexBar/PreferencesSelection.swift
@@ -37,11 +37,13 @@ extension SettingsPane {
         default:
             let providerPrefix = "provider:"
             guard persistenceToken.hasPrefix(providerPrefix),
-                  let provider = UsageProvider(rawValue: String(persistenceToken.dropFirst(providerPrefix.count)))
+                  let instanceID = ProviderInstanceID(
+                      rawValue: String(persistenceToken.dropFirst(providerPrefix.count))),
+                  instanceID.firstPartyProvider != nil
             else {
                 return nil
             }
-            self = .provider(provider)
+            self = .provider(instanceID)
         }
     }
 }

--- a/Sources/CodexBar/PreferencesSidebar.swift
+++ b/Sources/CodexBar/PreferencesSidebar.swift
@@ -54,7 +54,7 @@ struct SettingsSidebarView: View {
                     provider: provider,
                     store: self.store,
                     isEnabled: self.enabledBinding(for: provider))
-                    .tag(SettingsPane.provider(provider))
+                    .tag(SettingsPane.provider(provider.instanceID))
                     .moveDisabled(!self.canReorderProviders)
             }
             .onMove { fromOffsets, toOffset in
@@ -97,7 +97,7 @@ struct SettingsSidebarView: View {
 
     private var orderedProviders: [UsageProvider] {
         guard self.settings.providersSortedAlphabetically else {
-            return self.settings.orderedProviders()
+            return self.settings.orderedProviders().compactMap(\.firstPartyProvider)
         }
         return CodexBarConfig.alphabeticalProviderOrder(enablement: { provider in
             self.settings.isProviderEnabled(provider: provider, metadata: self.store.metadata(for: provider))
@@ -181,7 +181,7 @@ private struct SettingsSidebarProviderRow: View {
 
             Spacer(minLength: 4)
 
-            if self.store.refreshingProviders.contains(self.provider) {
+            if self.store.refreshingProviders.contains(self.provider.instanceID) {
                 ProgressView()
                     .controlSize(.mini)
             }

--- a/Sources/CodexBar/PreferencesSpendDashboardPane.swift
+++ b/Sources/CodexBar/PreferencesSpendDashboardPane.swift
@@ -369,7 +369,7 @@ struct SpendDashboardPane: View {
                         codexRowCount == 1 ? self.store.snapshot(for: .codex) : nil,
                     ]
                 } else {
-                    [self.store.snapshot(for: row.provider)]
+                    [self.store.snapshot(for: row.provider.instanceID)]
                 }
                 if let name = ShareStatsSubscriptionName.first(from: snapshots, provider: row.provider) {
                     names[row.id] = name

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -14,7 +14,7 @@ enum SettingsPane: Hashable {
     case hooks
     case about
     case debug
-    case provider(UsageProvider)
+    case provider(ProviderInstanceID)
 
     static let windowWidth: CGFloat = 880
     static let windowHeight: CGFloat = 620
@@ -35,8 +35,10 @@ enum SettingsPane: Hashable {
         case .hooks: L("tab_hooks")
         case .about: L("tab_about")
         case .debug: L("tab_debug")
-        case let .provider(provider):
-            ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
+        case let .provider(instanceID):
+            instanceID.firstPartyProvider
+                .map { ProviderDescriptorRegistry.descriptor(for: $0).metadata.displayName }
+                ?? instanceID.rawValue
         }
     }
 }
@@ -146,15 +148,17 @@ struct PreferencesView: View {
             AboutPane(updater: self.updater)
         case .debug:
             DebugPane(settings: self.settings, store: self.store)
-        case let .provider(provider):
-            ProvidersPane(
-                provider: provider,
-                settings: self.settings,
-                store: self.store,
-                managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
-                codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
-                runProviderLoginFlow: self.runProviderLoginFlow)
-                .id(provider)
+        case let .provider(instanceID):
+            if let provider = instanceID.firstPartyProvider {
+                ProvidersPane(
+                    provider: provider,
+                    settings: self.settings,
+                    store: self.store,
+                    managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
+                    codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
+                    runProviderLoginFlow: self.runProviderLoginFlow)
+                    .id(instanceID)
+            }
         }
     }
 

--- a/Sources/CodexBar/Providers/Shared/ProviderCookieRefreshAction.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderCookieRefreshAction.swift
@@ -58,12 +58,12 @@ enum ProviderCookieRefreshAction {
 
     private static func perform(provider: UsageProvider, context: ProviderSettingsContext) async {
         context.setStatusText(self.statusID(provider), L("Refreshing"))
-        let previousUpdatedAt = context.store.snapshot(for: provider)?.updatedAt
+        let previousUpdatedAt = context.store.snapshot(for: provider.instanceID)?.updatedAt
         let outcome = await self.refresh(provider: provider) {
             await context.store.refreshProvider(provider, allowDisabled: true)
             guard context.store.error(for: provider) == nil,
-                  context.store.lastSourceLabels[provider] == "web",
-                  let updatedAt = context.store.snapshot(for: provider)?.updatedAt
+                  context.store.lastSourceLabels[provider.instanceID] == "web",
+                  let updatedAt = context.store.snapshot(for: provider.instanceID)?.updatedAt
             else { return false }
             return previousUpdatedAt.map { updatedAt != $0 } ?? true
         }

--- a/Sources/CodexBar/SessionEquivalentForecast.swift
+++ b/Sources/CodexBar/SessionEquivalentForecast.swift
@@ -465,7 +465,7 @@ extension UsageStore {
                         SessionEquivalentBurnCacheKey.idleTimeBucketSeconds))
                 : nil)
         let burnEstimate: SessionEquivalentBurnEstimate?
-        if let cached = self.sessionEquivalentBurnCache[provider], cached.key == cacheKey {
+        if let cached = self.sessionEquivalentBurnCache[provider.instanceID], cached.key == cacheKey {
             burnEstimate = cached.estimate
         } else {
             burnEstimate = SessionEquivalentBurnEstimator.estimate(
@@ -473,7 +473,7 @@ extension UsageStore {
                 currentSessionResetsAt: currentSessionResetsAt,
                 now: now)
             self.sessionEquivalentHistoryScanCount &+= 1
-            self.sessionEquivalentBurnCache[provider] = SessionEquivalentBurnCacheEntry(
+            self.sessionEquivalentBurnCache[provider.instanceID] = SessionEquivalentBurnCacheEntry(
                 key: cacheKey,
                 estimate: burnEstimate)
         }

--- a/Sources/CodexBar/SessionQuotaNotifications.swift
+++ b/Sources/CodexBar/SessionQuotaNotifications.swift
@@ -440,7 +440,7 @@ extension UsageStore {
     }
 
     func clearSessionQuotaTransitionState(provider: UsageProvider) {
-        let removedState = self.sessionQuotaTransitionStates.removeValue(forKey: provider)
+        let removedState = self.sessionQuotaTransitionStates.removeValue(forKey: provider.instanceID)
         // Generic provider cleanup can run while Codex is disabled or temporarily unavailable. Preserve
         // an already-depleted baseline across recovery so depletion cannot refire, but let a newly depleted
         // account notify after a positive baseline was discarded.

--- a/Sources/CodexBar/SettingsStore+Config.swift
+++ b/Sources/CodexBar/SettingsStore+Config.swift
@@ -3,11 +3,11 @@ import Foundation
 
 extension SettingsStore {
     func providerConfig(for provider: UsageProvider) -> ProviderConfig? {
-        self.configSnapshot.providerConfig(for: provider)
+        self.configSnapshot.providerConfig(for: provider.instanceID)
     }
 
     func quotaWarningConfig(for provider: UsageProvider) -> QuotaWarningConfig {
-        self.configSnapshot.providerConfig(for: provider)?.quotaWarnings ?? QuotaWarningConfig()
+        self.configSnapshot.providerConfig(for: provider.instanceID)?.quotaWarnings ?? QuotaWarningConfig()
     }
 
     func resolvedQuotaWarningThresholds(provider: UsageProvider, window: QuotaWarningWindow) -> [Int] {
@@ -154,8 +154,10 @@ extension SettingsStore {
     var tokenAccountsByProvider: [UsageProvider: ProviderTokenAccountData] {
         get {
             Dictionary(uniqueKeysWithValues: self.configSnapshot.providers.compactMap { entry in
-                guard let accounts = entry.tokenAccounts else { return nil }
-                return (entry.id, accounts)
+                guard let provider = entry.id.firstPartyProvider,
+                      let accounts = entry.tokenAccounts
+                else { return nil }
+                return (provider, accounts)
             })
         }
         set {
@@ -184,7 +186,7 @@ extension SettingsStore {
         provider: UsageProvider,
         fallback: ProviderCookieSource) -> ProviderCookieSource
     {
-        let source = self.configSnapshot.providerConfig(for: provider)?.cookieSource ?? fallback
+        let source = self.configSnapshot.providerConfig(for: provider.instanceID)?.cookieSource ?? fallback
         guard self.debugDisableKeychainAccess == false else { return source == .off ? .off : .manual }
         return source
     }

--- a/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
+++ b/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
@@ -63,12 +63,12 @@ extension SettingsStore {
 
     func updateProviderConfig(provider: UsageProvider, mutate: (inout ProviderConfig) -> Void) {
         self.updateConfig(reason: "provider-\(provider.rawValue)", affectsBackgroundWork: true) { config in
-            if let index = config.providers.firstIndex(where: { $0.id == provider }) {
+            if let index = config.providers.firstIndex(where: { $0.id == provider.instanceID }) {
                 var entry = config.providers[index]
                 mutate(&entry)
                 config.providers[index] = entry
             } else {
-                var entry = ProviderConfig(id: provider)
+                var entry = ProviderConfig(id: provider.instanceID)
                 mutate(&entry)
                 config.providers.append(entry)
             }
@@ -94,12 +94,12 @@ extension SettingsStore {
     {
         guard !self.configLoading else { return }
         var config = self.config
-        if let index = config.providers.firstIndex(where: { $0.id == provider }) {
+        if let index = config.providers.firstIndex(where: { $0.id == provider.instanceID }) {
             var entry = config.providers[index]
             mutate(&entry)
             config.providers[index] = entry
         } else {
-            var entry = ProviderConfig(id: provider)
+            var entry = ProviderConfig(id: provider.instanceID)
             mutate(&entry)
             config.providers.append(entry)
         }
@@ -121,22 +121,23 @@ extension SettingsStore {
                 "summary": summary,
             ])
         self.updateConfig(reason: "token-accounts", affectsBackgroundWork: true) { config in
-            var seen: Set<UsageProvider> = []
+            var seen: Set<ProviderInstanceID> = []
             for index in config.providers.indices {
-                let provider = config.providers[index].id
-                config.providers[index].tokenAccounts = accounts[provider]
-                seen.insert(provider)
+                let instanceID = config.providers[index].id
+                let provider = instanceID.firstPartyProvider
+                config.providers[index].tokenAccounts = provider.flatMap { accounts[$0] }
+                seen.insert(instanceID)
             }
-            for (provider, data) in accounts where !seen.contains(provider) {
-                config.providers.append(ProviderConfig(id: provider, tokenAccounts: data))
+            for (provider, data) in accounts where !seen.contains(provider.instanceID) {
+                config.providers.append(ProviderConfig(id: provider.instanceID, tokenAccounts: data))
             }
         }
     }
 
-    func setProviderOrder(_ order: [UsageProvider]) {
+    func setProviderOrder(_ order: [ProviderInstanceID]) {
         self.updateConfig(reason: "order", affectsBackgroundWork: false) { config in
             let configsByID = Dictionary(uniqueKeysWithValues: config.providers.map { ($0.id, $0) })
-            var seen: Set<UsageProvider> = []
+            var seen: Set<ProviderInstanceID> = []
             var ordered: [ProviderConfig] = []
             ordered.reserveCapacity(max(order.count, config.providers.count))
 
@@ -146,8 +147,8 @@ extension SettingsStore {
                 ordered.append(configsByID[provider] ?? ProviderConfig(id: provider))
             }
 
-            for provider in UsageProvider.allCases where !seen.contains(provider) {
-                ordered.append(configsByID[provider] ?? ProviderConfig(id: provider))
+            for provider in UsageProvider.allCases where !seen.contains(provider.instanceID) {
+                ordered.append(configsByID[provider.instanceID] ?? ProviderConfig(id: provider.instanceID))
             }
 
             config.providers = ordered

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -784,8 +784,8 @@ extension SettingsStore {
         }
     }
 
-    var selectedMenuProvider: UsageProvider? {
-        get { self.selectedMenuProviderRaw.flatMap(UsageProvider.init(rawValue:)) }
+    var selectedMenuProvider: ProviderInstanceID? {
+        get { self.selectedMenuProviderRaw.flatMap(ProviderInstanceID.init(rawValue:)) }
         set {
             self.selectedMenuProviderRaw = newValue?.rawValue
         }

--- a/Sources/CodexBar/SettingsStore+TokenAccounts.swift
+++ b/Sources/CodexBar/SettingsStore+TokenAccounts.swift
@@ -5,7 +5,7 @@ import Foundation
 extension SettingsStore {
     func tokenAccountsData(for provider: UsageProvider) -> ProviderTokenAccountData? {
         guard TokenAccountSupportCatalog.support(for: provider) != nil else { return nil }
-        return self.configSnapshot.providerConfig(for: provider)?.tokenAccounts
+        return self.configSnapshot.providerConfig(for: provider.instanceID)?.tokenAccounts
     }
 
     func tokenAccounts(for provider: UsageProvider) -> [ProviderTokenAccount] {
@@ -227,8 +227,10 @@ extension SettingsStore {
         do {
             guard let loaded = try self.configStore.load() else { return }
             accounts = Dictionary(uniqueKeysWithValues: loaded.providers.compactMap { entry in
-                guard let data = entry.tokenAccounts else { return nil }
-                return (entry.id, data)
+                guard let provider = entry.id.firstPartyProvider,
+                      let data = entry.tokenAccounts
+                else { return nil }
+                return (provider, data)
             })
         } catch {
             log.error("Failed to reload token accounts: \(error)")

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -231,11 +231,11 @@ final class SettingsStore {
     var providerDetailSettingsRevision: Int = 0
     var backgroundWorkSettingsRevision: Int = 0
     var costUsageSettingsRevision: UInt64 = 0
-    var providerOrder: [UsageProvider] = []
-    var providerEnablement: [UsageProvider: Bool] = [:]
-    @ObservationIgnored var providerEnablementRevisions: [UsageProvider: UInt64] = [:]
-    @ObservationIgnored var providerConfigRevisions: [UsageProvider: UInt64] = [:]
-    @ObservationIgnored var providerConfigFingerprints: [UsageProvider: Data] = [:]
+    var providerOrder: [ProviderInstanceID] = []
+    var providerEnablement: [ProviderInstanceID: Bool] = [:]
+    @ObservationIgnored var providerEnablementRevisions: [ProviderInstanceID: UInt64] = [:]
+    @ObservationIgnored var providerConfigRevisions: [ProviderInstanceID: UInt64] = [:]
+    @ObservationIgnored var providerConfigFingerprints: [ProviderInstanceID: Data] = [:]
 
     static func shouldBridgeSharedDefaults(for userDefaults: UserDefaults) -> Bool {
         if !self.isRunningTests {
@@ -865,21 +865,22 @@ extension SettingsStore {
         let rawOrder = config.providers.map(\.id.rawValue)
         self.providerOrder = Self.effectiveProviderOrder(raw: rawOrder)
         let metadata = ProviderDescriptorRegistry.metadata
-        var enablement: [UsageProvider: Bool] = [:]
+        var enablement: [ProviderInstanceID: Bool] = [:]
         enablement.reserveCapacity(metadata.count)
         for provider in UsageProvider.allCases {
+            let instanceID = provider.instanceID
             let defaultEnabled = metadata[provider]?.defaultEnabled ?? false
-            let providerConfig = config.providerConfig(for: provider) ?? ProviderConfig(id: provider)
+            let providerConfig = config.providerConfig(for: instanceID) ?? ProviderConfig(id: instanceID)
             let isEnabled = providerConfig.enabled ?? defaultEnabled
-            if let previous = self.providerEnablement[provider], previous != isEnabled {
-                self.providerEnablementRevisions[provider, default: 0] &+= 1
+            if let previous = self.providerEnablement[instanceID], previous != isEnabled {
+                self.providerEnablementRevisions[instanceID, default: 0] &+= 1
             }
             let fingerprint = Self.providerConfigFingerprint(providerConfig)
-            if let previous = self.providerConfigFingerprints[provider], previous != fingerprint {
-                self.providerConfigRevisions[provider, default: 0] &+= 1
+            if let previous = self.providerConfigFingerprints[instanceID], previous != fingerprint {
+                self.providerConfigRevisions[instanceID, default: 0] &+= 1
             }
-            self.providerConfigFingerprints[provider] = fingerprint
-            enablement[provider] = isEnabled
+            self.providerConfigFingerprints[instanceID] = fingerprint
+            enablement[instanceID] = isEnabled
         }
         self.providerEnablement = enablement
     }
@@ -891,18 +892,22 @@ extension SettingsStore {
     }
 
     func providerEnablementRevision(for provider: UsageProvider) -> UInt64 {
-        self.providerEnablementRevisions[provider, default: 0]
+        self.providerEnablementRevisions[provider.instanceID, default: 0]
     }
 
     func providerConfigRevision(for provider: UsageProvider) -> UInt64 {
-        self.providerConfigRevisions[provider, default: 0]
+        self.providerConfigRevisions[provider.instanceID, default: 0]
     }
 
-    func orderedProviders() -> [UsageProvider] {
+    func orderedProviders() -> [ProviderInstanceID] {
         if self.providerOrder.isEmpty {
             self.updateProviderState(config: self.configSnapshot)
         }
         return self.providerOrder
+    }
+
+    func orderedFirstPartyProviders() -> [UsageProvider] {
+        self.orderedProviders().compactMap(\.firstPartyProvider)
     }
 
     func moveProvider(fromOffsets: IndexSet, toOffset: Int) {
@@ -912,7 +917,7 @@ extension SettingsStore {
     }
 
     func isProviderEnabled(provider: UsageProvider, metadata: ProviderMetadata) -> Bool {
-        self.providerEnablement[provider] ?? metadata.defaultEnabled
+        self.providerEnablement[provider.instanceID] ?? metadata.defaultEnabled
     }
 
     func isProviderEnabledCached(
@@ -920,10 +925,10 @@ extension SettingsStore {
         metadataByProvider: [UsageProvider: ProviderMetadata]) -> Bool
     {
         let defaultEnabled = metadataByProvider[provider]?.defaultEnabled ?? false
-        return self.providerEnablement[provider] ?? defaultEnabled
+        return self.providerEnablement[provider.instanceID] ?? defaultEnabled
     }
 
-    func enabledProvidersOrdered(metadataByProvider: [UsageProvider: ProviderMetadata]) -> [UsageProvider] {
+    func enabledProvidersOrdered(metadataByProvider: [UsageProvider: ProviderMetadata]) -> [ProviderInstanceID] {
         _ = metadataByProvider
         return self.orderedProviders().filter { self.providerEnablement[$0] ?? false }
     }
@@ -935,7 +940,7 @@ extension SettingsStore {
         self.updateProviderConfig(provider: provider) { entry in
             entry.enabled = enabled
         }
-        if !enabled, self.selectedMenuProvider == provider {
+        if !enabled, self.selectedMenuProvider == provider.instanceID {
             self.selectedMenuProvider = nil
         }
     }
@@ -946,19 +951,21 @@ extension SettingsStore {
 }
 
 extension SettingsStore {
-    private static func effectiveProviderOrder(raw: [String]) -> [UsageProvider] {
-        var seen: Set<UsageProvider> = []
-        var ordered: [UsageProvider] = []
+    private static func effectiveProviderOrder(raw: [String]) -> [ProviderInstanceID] {
+        var seen: Set<ProviderInstanceID> = []
+        var ordered: [ProviderInstanceID] = []
 
         for rawValue in raw {
-            guard let provider = UsageProvider(rawValue: rawValue) else { continue }
-            guard !seen.contains(provider) else { continue }
-            seen.insert(provider)
-            ordered.append(provider)
+            guard let instanceID = ProviderInstanceID(rawValue: rawValue), instanceID.firstPartyProvider != nil else {
+                continue
+            }
+            guard !seen.contains(instanceID) else { continue }
+            seen.insert(instanceID)
+            ordered.append(instanceID)
         }
 
         if ordered.isEmpty {
-            ordered = UsageProvider.allCases
+            ordered = UsageProvider.allCases.map(\.instanceID)
             seen = Set(ordered)
         }
 
@@ -973,8 +980,8 @@ extension SettingsStore {
             seen.insert(.minimax)
         }
 
-        for provider in UsageProvider.allCases where !seen.contains(provider) {
-            ordered.append(provider)
+        for provider in UsageProvider.allCases where !seen.contains(provider.instanceID) {
+            ordered.append(provider.instanceID)
         }
 
         return ordered

--- a/Sources/CodexBar/ShareStatsPayload.swift
+++ b/Sources/CodexBar/ShareStatsPayload.swift
@@ -213,7 +213,7 @@ struct ShareStatsSubscriptionName: Sendable, Equatable {
 
     /// Converts plan-bearing provider identity into a closed, non-identifying share-card value.
     static func from(snapshot: UsageSnapshot?, provider: UsageProvider) -> Self? {
-        guard let identity = snapshot?.identity(for: provider),
+        guard let identity = snapshot?.identity(for: provider.instanceID),
               let rawName = identity.loginMethod,
               !Self.matchesAccountIdentity(rawName, identity: identity)
         else { return nil }

--- a/Sources/CodexBar/SpendDashboardController.swift
+++ b/Sources/CodexBar/SpendDashboardController.swift
@@ -398,7 +398,7 @@ enum SpendDashboardSource {
 
     @MainActor
     static func costCapableProviders(store: UsageStore) -> [UsageProvider] {
-        store.enabledProvidersForDisplay().filter {
+        store.enabledFirstPartyProvidersForDisplay().filter {
             ProviderDescriptorRegistry.descriptor(for: $0).tokenCost.supportsTokenCost
         }
     }
@@ -488,7 +488,7 @@ enum SpendDashboardSource {
     {
         providers.compactMap { provider in
             guard provider != .codex else { return nil }
-            var config = settings.providerConfig(for: provider) ?? ProviderConfig(id: provider)
+            var config = settings.providerConfig(for: provider) ?? ProviderConfig(id: provider.instanceID)
             config.enabled = nil
             config.quotaWarnings = nil
             // The dashboard follows the effective account, not the whole saved-account collection.

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -6,7 +6,7 @@ extension StatusItemController {
     /// of each other and of the all-providers refresh.
     enum ManualRefreshScope: Hashable {
         case global
-        case provider(UsageProvider)
+        case provider(ProviderInstanceID)
     }
 }
 
@@ -168,10 +168,11 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     private func startManualRefresh(
-        for provider: UsageProvider?,
+        for provider: ProviderInstanceID?,
         originatingMenuID: ObjectIdentifier?,
         originatingMenuInteractionGeneration: Int?)
     {
+        let firstPartyProvider = provider?.firstPartyProvider
         let scope: ManualRefreshScope = provider.map(ManualRefreshScope.provider) ?? .global
         let scopedRefreshInFlight = provider.map { self.store.refreshingProviders.contains($0) }
             ?? !self.store.refreshingProviders.isEmpty
@@ -197,7 +198,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             var completed = false
             defer {
                 self.manualRefreshTasks[scope] = nil
-                self.menuCardRefreshMonitor.endManualRefresh(for: provider)
+                self.menuCardRefreshMonitor.endManualRefresh(for: firstPartyProvider)
                 self.updatePersistentRefreshItemsEnabled()
                 if completed {
                     self.scheduleCompletedManualRefreshViewportRestore(viewportRestoreRequests)
@@ -216,7 +217,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
                 return
             }
             #endif
-            if let provider {
+            if let provider = firstPartyProvider {
                 await self.performStoreRefresh(
                     for: provider,
                     refreshOpenMenusWhenComplete: true,
@@ -231,16 +232,16 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             completed = true
         }
         self.manualRefreshTasks[scope] = task
-        self.menuCardRefreshMonitor.beginManualRefresh(frozenModels: frozenModels, provider: provider)
+        self.menuCardRefreshMonitor.beginManualRefresh(frozenModels: frozenModels, provider: firstPartyProvider)
         self.updatePersistentRefreshItemsEnabled()
     }
 
-    private func manualRefreshProvider(for menu: NSMenu?) -> UsageProvider? {
+    private func manualRefreshProvider(for menu: NSMenu?) -> ProviderInstanceID? {
         guard let menu else { return nil }
         if self.shouldMergeIcons {
             guard self.mergedMenu == nil || menu === self.mergedMenu else { return nil }
             guard !self.isMergedOverviewSelected(in: menu) else { return nil }
-            return self.resolvedMenuProvider()
+            return self.resolvedMenuProvider()?.instanceID
         }
         return self.menuProviders[ObjectIdentifier(menu)]
     }
@@ -253,13 +254,14 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             providers.append(lastMenuProvider)
         }
         if providers.isEmpty,
-           let defaultProvider = self.settings.orderedProviders().first ?? UsageProvider.allCases.first
+           let defaultProvider = self.settings.orderedFirstPartyProviders().first ?? UsageProvider.allCases.first
         {
-            providers.append(defaultProvider)
+            providers.append(defaultProvider.instanceID)
         }
 
         var models: [UsageProvider: UsageMenuCardView.Model] = [:]
-        for provider in providers {
+        for instanceID in providers {
+            guard let provider = instanceID.firstPartyProvider else { continue }
             models[provider] = self.menuCardModel(for: provider)
         }
         return models
@@ -322,8 +324,8 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     @objc func openDashboard() {
-        let preferred = self.lastMenuProvider
-            ?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledProviders().first)
+        let preferred = self.lastMenuProvider?.firstPartyProvider
+            ?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledFirstPartyProviders().first)
 
         let provider = preferred ?? .codex
         guard let url = self.dashboardURL(for: provider) else { return }
@@ -431,15 +433,15 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     @objc func openStatusPage() {
-        let preferred = self.lastMenuProvider
-            ?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledProviders().first)
+        let preferred = self.lastMenuProvider?.firstPartyProvider
+            ?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledFirstPartyProviders().first)
 
         self.openStatusPage(for: preferred ?? .codex)
     }
 
     @objc func openStatusPageFromMenuItem(_ sender: NSMenuItem) {
         let provider = (sender.identifier?.rawValue).flatMap(UsageProvider.init(rawValue:))
-            ?? self.lastMenuProvider
+            ?? self.lastMenuProvider?.firstPartyProvider
             ?? .codex
         self.openStatusPage(for: provider)
     }
@@ -452,8 +454,8 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     @objc func openChangelog() {
-        let preferred = self.lastMenuProvider
-            ?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledProviders().first)
+        let preferred = self.lastMenuProvider?.firstPartyProvider
+            ?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledFirstPartyProviders().first)
 
         let provider = preferred ?? .codex
         let meta = self.store.metadata(for: provider)
@@ -523,7 +525,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         }
 
         let rawProvider = sender.representedObject as? String
-        let provider = rawProvider.flatMap(UsageProvider.init(rawValue:)) ?? self.lastMenuProvider ?? .codex
+        let provider = rawProvider.flatMap(UsageProvider.init(rawValue:))
+            ?? self.lastMenuProvider?.firstPartyProvider
+            ?? .codex
         self.loginLogger.info("Switch Account tapped", metadata: ["provider": provider.rawValue])
         self.startLoginFlow(provider: provider)
     }
@@ -579,7 +583,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     func celebrationOriginPoint(for provider: UsageProvider?) -> CGPoint? {
         let item: NSStatusItem = if self.shouldMergeIcons {
             self.statusItem
-        } else if let provider, let existing = self.statusItems[provider], existing.isVisible {
+        } else if let provider, let existing = self.statusItems[provider.instanceID], existing.isVisible {
             existing
         } else {
             self.lazyStatusItem(for: provider ?? .codex)
@@ -680,10 +684,10 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     private func resolvedShortcutProvider() -> UsageProvider {
-        if let last = self.lastMenuProvider, self.isEnabled(last) {
+        if let last = self.lastMenuProvider?.firstPartyProvider, self.isEnabled(last) {
             return last
         }
-        if let first = self.store.enabledProviders().first {
+        if let first = self.store.enabledFirstPartyProviders().first {
             return first
         }
         return .codex

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -56,8 +56,8 @@ extension StatusItemController {
 
     private func seedBlinkStatesIfNeeded() {
         let now = Date()
-        for provider in UsageProvider.allCases where self.blinkStates[provider] == nil {
-            self.blinkStates[provider] = BlinkState(
+        for provider in UsageProvider.allCases where self.blinkStates[provider.instanceID] == nil {
+            self.blinkStates[provider.instanceID] = BlinkState(
                 nextBlink: now.addingTimeInterval(BlinkState.randomDelay()))
         }
     }
@@ -87,7 +87,7 @@ extension StatusItemController {
 
             let state =
                 self
-                    .blinkStates[provider]
+                    .blinkStates[provider.instanceID]
                     ?? BlinkState(nextBlink: now.addingTimeInterval(BlinkState.randomDelay()))
             if state.blinkStart != nil {
                 return Self.blinkActiveTickInterval
@@ -131,7 +131,7 @@ extension StatusItemController {
 
             var state =
                 self
-                    .blinkStates[provider]
+                    .blinkStates[provider.instanceID]
                     ?? BlinkState(nextBlink: now.addingTimeInterval(BlinkState.randomDelay()))
 
             if let pendingSecond = state.pendingSecondStart, now >= pendingSecond {
@@ -168,7 +168,7 @@ extension StatusItemController {
                 self.clearMotion(for: provider)
             }
 
-            self.blinkStates[provider] = state
+            self.blinkStates[provider.instanceID] = state
             if !mergeIcons {
                 self.applyIcon(for: provider, phase: nil)
             }
@@ -180,40 +180,40 @@ extension StatusItemController {
 
     private func blinkAmount(for provider: UsageProvider) -> CGFloat {
         guard self.isBlinkingAllowed() else { return 0 }
-        return self.blinkAmounts[provider] ?? 0
+        return self.blinkAmounts[provider.instanceID] ?? 0
     }
 
     private func wiggleAmount(for provider: UsageProvider) -> CGFloat {
         guard self.isBlinkingAllowed() else { return 0 }
-        return self.wiggleAmounts[provider] ?? 0
+        return self.wiggleAmounts[provider.instanceID] ?? 0
     }
 
     private func tiltAmount(for provider: UsageProvider) -> CGFloat {
         guard self.isBlinkingAllowed() else { return 0 }
-        return self.tiltAmounts[provider] ?? 0
+        return self.tiltAmounts[provider.instanceID] ?? 0
     }
 
     private func assignMotion(amount: CGFloat, for provider: UsageProvider, effect: MotionEffect) {
         switch effect {
         case .blink:
-            self.blinkAmounts[provider] = amount
-            self.wiggleAmounts[provider] = 0
-            self.tiltAmounts[provider] = 0
+            self.blinkAmounts[provider.instanceID] = amount
+            self.wiggleAmounts[provider.instanceID] = 0
+            self.tiltAmounts[provider.instanceID] = 0
         case .wiggle:
-            self.wiggleAmounts[provider] = amount
-            self.blinkAmounts[provider] = 0
-            self.tiltAmounts[provider] = 0
+            self.wiggleAmounts[provider.instanceID] = amount
+            self.blinkAmounts[provider.instanceID] = 0
+            self.tiltAmounts[provider.instanceID] = 0
         case .tilt:
-            self.tiltAmounts[provider] = amount
-            self.blinkAmounts[provider] = 0
-            self.wiggleAmounts[provider] = 0
+            self.tiltAmounts[provider.instanceID] = amount
+            self.blinkAmounts[provider.instanceID] = 0
+            self.wiggleAmounts[provider.instanceID] = 0
         }
     }
 
     private func clearMotion(for provider: UsageProvider) {
-        self.blinkAmounts[provider] = 0
-        self.wiggleAmounts[provider] = 0
-        self.tiltAmounts[provider] = 0
+        self.blinkAmounts[provider.instanceID] = 0
+        self.wiggleAmounts[provider.instanceID] = 0
+        self.tiltAmounts[provider.instanceID] = 0
     }
 
     private func randomEffect(for provider: UsageProvider) -> MotionEffect {
@@ -245,7 +245,7 @@ extension StatusItemController {
         let showBrandPercent = self.settings.menuBarShowsBrandIconWithPercent
         let primaryProvider = self.primaryProviderForUnifiedIcon()
         let resolverStyle = self.store.style(for: primaryProvider)
-        let snapshot = self.store.snapshot(for: primaryProvider)
+        let snapshot = self.store.snapshot(for: primaryProvider.instanceID)
         let warningFlash = self.quotaWarningFlashActive(provider: primaryProvider)
 
         if let layoutResult = self.applyStoredUnifiedMenuBarLayoutIfNeeded(
@@ -453,29 +453,29 @@ extension StatusItemController {
     }
 
     private func shouldSkipProviderIconRender(provider: UsageProvider, signature: String) -> Bool {
-        if self.lastAppliedProviderIconRenderSignatures[provider] == signature {
+        if self.lastAppliedProviderIconRenderSignatures[provider.instanceID] == signature {
             return true
         }
-        self.lastAppliedProviderIconRenderSignatures[provider] = signature
+        self.lastAppliedProviderIconRenderSignatures[provider.instanceID] = signature
         return false
     }
 
     @discardableResult
     func applyIcon(for provider: UsageProvider, phase: Double?) -> Bool {
-        guard let button = self.statusItems[provider]?.button else { return false }
-        let snapshot = self.store.snapshot(for: provider)
+        guard let button = self.statusItems[provider.instanceID]?.button else { return false }
+        let snapshot = self.store.snapshot(for: provider.instanceID)
         // IconRenderer treats these values as a left-to-right "progress fill" percentage; depending on the
         // user setting we pass either "percent left" or "percent used".
         let showUsed = self.settings.usageBarsShowUsed
         let showBrandPercent = self.settings.menuBarShowsBrandIconWithPercent
         if !showBrandPercent {
-            self.statusItems[provider]?.length = NSStatusItem.variableLength
+            self.statusItems[provider.instanceID]?.length = NSStatusItem.variableLength
         }
         let style: IconStyle = self.store.style(for: provider)
         let warningFlash = self.quotaWarningFlashActive(provider: provider)
 
         if showBrandPercent,
-           let statusItem = self.statusItems[provider],
+           let statusItem = self.statusItems[provider.instanceID],
            let wasCached = self.applyStoredMenuBarLayoutIfNeeded(
                provider: provider,
                snapshot: snapshot,
@@ -693,21 +693,21 @@ extension StatusItemController {
     }
 
     func quotaWarningFlashActive(provider: UsageProvider, now: Date = Date()) -> Bool {
-        guard let until = self.quotaWarningFlashUntil[provider] else { return false }
+        guard let until = self.quotaWarningFlashUntil[provider.instanceID] else { return false }
         if until > now { return true }
-        self.quotaWarningFlashUntil.removeValue(forKey: provider)
-        self.quotaWarningFlashTasks[provider]?.cancel()
-        self.quotaWarningFlashTasks.removeValue(forKey: provider)
+        self.quotaWarningFlashUntil.removeValue(forKey: provider.instanceID)
+        self.quotaWarningFlashTasks[provider.instanceID]?.cancel()
+        self.quotaWarningFlashTasks.removeValue(forKey: provider.instanceID)
         return false
     }
 
     func startQuotaWarningFlash(provider: UsageProvider, postedAt: Date = Date()) {
         let until = postedAt.addingTimeInterval(Self.quotaWarningFlashDuration)
-        self.quotaWarningFlashUntil[provider] = until
-        self.quotaWarningFlashTasks[provider]?.cancel()
+        self.quotaWarningFlashUntil[provider.instanceID] = until
+        self.quotaWarningFlashTasks[provider.instanceID]?.cancel()
         self.updateIcons()
         self.applyQuotaWarningIconDuringMergedMenuTrackingIfNeeded()
-        self.quotaWarningFlashTasks[provider] = Task { [weak self] in
+        self.quotaWarningFlashTasks[provider.instanceID] = Task { [weak self] in
             try? await Task.sleep(for: .seconds(Self.quotaWarningFlashDuration))
             await MainActor.run { [weak self] in
                 self?.clearExpiredQuotaWarningFlash(provider: provider)
@@ -716,13 +716,13 @@ extension StatusItemController {
     }
 
     func clearExpiredQuotaWarningFlash(provider: UsageProvider, now: Date = Date()) {
-        guard let currentUntil = self.quotaWarningFlashUntil[provider],
+        guard let currentUntil = self.quotaWarningFlashUntil[provider.instanceID],
               currentUntil <= now
         else {
             return
         }
-        self.quotaWarningFlashUntil.removeValue(forKey: provider)
-        self.quotaWarningFlashTasks.removeValue(forKey: provider)
+        self.quotaWarningFlashUntil.removeValue(forKey: provider.instanceID)
+        self.quotaWarningFlashTasks.removeValue(forKey: provider.instanceID)
         self.updateIcons()
         self.applyQuotaWarningIconDuringMergedMenuTrackingIfNeeded()
     }
@@ -1234,7 +1234,7 @@ extension StatusItemController {
     /// while pace/both render the one lane chosen by `combinedDisplayPercentWindow` — mirror that presentation
     /// here rather than scheduling whichever lane happened to drive the icon.
     func menuBarDisplayedResetDates(for provider: UsageProvider, now: Date) -> [Date] {
-        let snapshot = self.store.snapshot(for: provider)
+        let snapshot = self.store.snapshot(for: provider.instanceID)
         let layoutResolution = self.settings.menuBarLayoutResolution(for: provider)
         if !layoutResolution.usesLegacyRendering,
            self.settings.menuBarIconStyle == .iconAndPercent
@@ -1358,7 +1358,7 @@ extension StatusItemController {
     func primaryProviderForUnifiedIcon() -> UsageProvider {
         // When "show highest usage" is enabled, rank the existing Overview subset by proximity to its limit.
         if self.settings.menuBarShowsHighestUsage, self.shouldMergeIcons {
-            let activeProviders = self.store.enabledProvidersForDisplay()
+            let activeProviders = self.store.enabledFirstPartyProvidersForDisplay()
             let overviewProviders = self.settings.resolvedMergedOverviewProviders(
                 activeProviders: activeProviders,
                 maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
@@ -1372,7 +1372,7 @@ extension StatusItemController {
             }
         }
         if self.shouldMergeIcons, self.settings.mergedMenuLastSelectedWasOverview {
-            let enabledProviders = self.store.enabledProvidersForDisplay()
+            let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
             let overviewProviders = self.settings.resolvedMergedOverviewProviders(
                 activeProviders: enabledProviders,
                 maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
@@ -1381,19 +1381,19 @@ extension StatusItemController {
             }
         }
         if self.shouldMergeIcons,
-           let selected = self.selectedMenuProvider,
+           let selected = self.selectedMenuProvider?.firstPartyProvider,
            self.store.isEnabled(selected)
         {
             return selected
         }
-        for provider in self.store.enabledProviders() {
-            if self.store.isEnabled(provider), self.store.snapshot(for: provider) != nil {
+        for provider in self.store.enabledFirstPartyProviders() {
+            if self.store.isEnabled(provider), self.store.snapshot(for: provider.instanceID) != nil {
                 return provider
             }
         }
         // Use availability-filtered list: fallback must pick a provider that can
         // actually animate, otherwise shouldAnimate() fails on credential-less providers.
-        if let enabled = self.store.enabledProviders().first {
+        if let enabled = self.store.enabledFirstPartyProviders().first {
             return enabled
         }
         return .codex
@@ -1417,13 +1417,13 @@ extension StatusItemController {
             guard shouldBlink, !self.shouldAnimate(provider: provider) else { continue }
             var state =
                 self
-                    .blinkStates[provider]
+                    .blinkStates[provider.instanceID]
                     ?? BlinkState(nextBlink: now.addingTimeInterval(BlinkState.randomDelay()))
             state.blinkStart = now
             state.pendingSecondStart = nil
             state.effect = self.randomEffect(for: provider)
             state.nextBlink = now.addingTimeInterval(BlinkState.randomDelay())
-            self.blinkStates[provider] = state
+            self.blinkStates[provider.instanceID] = state
             self.assignMotion(amount: 0, for: provider, effect: state.effect)
         }
 
@@ -1450,7 +1450,7 @@ extension StatusItemController {
 
         let isStale = self.store.isStale(provider: provider)
         let hasSatisfiedUsageFetch = self.store.hasSatisfiedUsageFetch(for: provider)
-        if provider == .warp, !hasSatisfiedUsageFetch, self.store.refreshingProviders.contains(provider) {
+        if provider == .warp, !hasSatisfiedUsageFetch, self.store.refreshingProviders.contains(provider.instanceID) {
             return true
         }
         return !hasSatisfiedUsageFetch && !isStale

--- a/Sources/CodexBar/StatusItemController+CompactAccountMenu.swift
+++ b/Sources/CodexBar/StatusItemController+CompactAccountMenu.swift
@@ -13,7 +13,7 @@ extension StatusItemController {
         AccountMenuLayoutPlanner.plan(
             accounts: accounts,
             expandedAccountIDs: self.compactAccountExpandedIDs,
-            healthyTailExpanded: self.compactAccountExpandedHealthyTailProviders.contains(provider))
+            healthyTailExpanded: self.compactAccountExpandedHealthyTailProviders.contains(provider.instanceID))
     }
 
     struct CompactAccountMenuRendering {
@@ -285,7 +285,7 @@ extension StatusItemController {
 
     private func expandCompactAccountHealthyTail(for provider: UsageProvider, menu: NSMenu?) {
         self.advanceMenuInteraction(for: menu)
-        self.compactAccountExpandedHealthyTailProviders.insert(provider)
+        self.compactAccountExpandedHealthyTailProviders.insert(provider.instanceID)
         self.invalidateMenus(refreshOpenMenus: true)
     }
 

--- a/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
@@ -125,7 +125,7 @@ extension StatusItemController {
         guard self.shouldMergeIcons, self.settings.menuBarShowsHighestUsage else {
             return false
         }
-        let activeProviders = self.store.enabledProvidersForDisplay()
+        let activeProviders = self.store.enabledFirstPartyProvidersForDisplay()
         return self.settings.resolvedMergedOverviewProviders(
             activeProviders: activeProviders,
             maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit).contains(.codex)

--- a/Sources/CodexBar/StatusItemController+FleetAccounts.swift
+++ b/Sources/CodexBar/StatusItemController+FleetAccounts.swift
@@ -29,7 +29,7 @@ extension StatusItemController {
             snapshots: self.cloudSyncState.fleetSnapshots.values,
             currentDeviceID: self.settings.iCloudSyncDeviceID,
             localAccountKeys: self.store.cloudSyncLocalAccountKeys(for: provider),
-            hasLocalUsage: localSnapshots.contains(where: { $0.provider == provider }))
+            hasLocalUsage: localSnapshots.contains(where: { $0.provider == provider.instanceID }))
     }
 
     func addFleetAccountMenuCards(
@@ -75,13 +75,14 @@ extension StatusItemController {
     func fleetAccountMenuCardModel(
         _ snapshot: AccountSnapshotSyncPayload) -> UsageMenuCardView.Model?
     {
+        guard let provider = snapshot.provider.firstPartyProvider else { return nil }
         let deviceName = self.cloudSyncState.fleetDevices.values
             .first(where: { $0.deviceID == snapshot.deviceID })?
             .hostName ?? L("another Mac")
         let badge = FleetAccountMenuPlanner.badge(deviceName: deviceName, fetchedAt: snapshot.fetchedAt)
         let label = snapshot.displayLabel.trimmingCharacters(in: .whitespacesAndNewlines)
         return self.menuCardModel(
-            for: snapshot.provider,
+            for: provider,
             snapshotOverride: snapshot.usage,
             forceOverrideCard: true,
             accountOverride: AccountInfo(email: label.isEmpty ? nil : label, plan: nil),

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -310,7 +310,7 @@ extension StatusItemController {
     }
 
     private func usageHistoryRenderSignature(for provider: UsageProvider) -> String {
-        let snapshot = self.store.snapshot(for: provider)
+        let snapshot = self.store.snapshot(for: provider.instanceID)
         let selection = self.store.planUtilizationHistorySelection(for: provider)
         return [
             "\(self.store.planUtilizationHistoryRevision)",
@@ -348,7 +348,7 @@ extension StatusItemController {
     }
 
     private func zaiHourlyUsageRenderSignature(for provider: UsageProvider) -> String {
-        guard let zai = self.store.snapshot(for: provider)?.zaiUsage,
+        guard let zai = self.store.snapshot(for: provider.instanceID)?.zaiUsage,
               let modelUsage = zai.modelUsage else { return "none" }
         return Self.zaiHourlyUsageRenderSignature(
             modelUsage: modelUsage,
@@ -631,7 +631,7 @@ extension StatusItemController {
         width: CGFloat) -> Bool
     {
         guard provider == .zai,
-              let snapshot = self.store.snapshot(for: provider),
+              let snapshot = self.store.snapshot(for: provider.instanceID),
               let modelUsage = snapshot.zaiUsage?.modelUsage
         else { return false }
 

--- a/Sources/CodexBar/StatusItemController+IconObservation.swift
+++ b/Sources/CodexBar/StatusItemController+IconObservation.swift
@@ -35,7 +35,7 @@ extension StatusItemController {
     }
 
     private func providerStoreIconObservationSignature(for provider: UsageProvider, showBrandPercent: Bool) -> String {
-        let snapshot = self.store.snapshot(for: provider)
+        let snapshot = self.store.snapshot(for: provider.instanceID)
         let style = self.store.style(for: provider)
         let resolved = self.resolvedMenuBarIconPercents(
             provider: provider,
@@ -66,7 +66,7 @@ extension StatusItemController {
             "stale=\(self.store.isStale(provider: provider) ? "1" : "0")",
             "status=\(self.store.statusIndicator(for: provider).rawValue)",
             "anim=\(self.shouldAnimate(provider: provider) ? "1" : "0")",
-            "refreshing=\(self.store.refreshingProviders.contains(provider) ? "1" : "0")",
+            "refreshing=\(self.store.refreshingProviders.contains(provider.instanceID) ? "1" : "0")",
             "text=\(displayText ?? "nil")",
             "layoutCost=\(layoutCostSignature ?? "nil")",
             "layoutAccount=\(layoutAccountSignature ?? "nil")",

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -107,23 +107,23 @@ extension StatusItemController {
         var provider: UsageProvider?
         if self.shouldMergeIcons {
             let resolvedProvider = self.resolvedMenuProvider()
-            self.lastMenuProvider = resolvedProvider ?? .codex
+            self.lastMenuProvider = (resolvedProvider ?? .codex).instanceID
             provider = resolvedProvider
         } else {
             if let menuProvider = self.menuProviders[ObjectIdentifier(menu)] {
                 self.lastMenuProvider = menuProvider
-                provider = menuProvider
+                provider = menuProvider.firstPartyProvider
             } else if menu === self.fallbackMenu {
                 self.lastMenuProvider = self.store.enabledProvidersForDisplay().first ?? .codex
                 provider = nil
             } else {
                 let resolved = self.store.enabledProvidersForDisplay().first ?? .codex
                 self.lastMenuProvider = resolved
-                provider = resolved
+                provider = resolved.firstPartyProvider
             }
         }
 
-        if self.isMenuRefreshEnabled, (provider ?? self.lastMenuProvider) == .codex {
+        if self.isMenuRefreshEnabled, (provider?.instanceID ?? self.lastMenuProvider) == .codex {
             self.deferOpenAIDashboardRefreshUntilMenuCloses(reason: "parent menu open")
         }
         if self.settings.providerStorageFootprintsEnabled {
@@ -237,7 +237,7 @@ extension StatusItemController {
         // tab switch attaches pre-rendered rows; no-ops for closed or non-merged menus.
         defer { self.scheduleMergedSwitcherSiblingWarmup(for: menu) }
 
-        let enabledProviders = self.store.enabledProvidersForDisplay()
+        let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
         let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
         let switcherSelection = self.shouldMergeIcons && enabledProviders.count > 1
             ? self.resolvedSwitcherSelection(
@@ -273,7 +273,7 @@ extension StatusItemController {
 
         let hasTokenSwitcher = menu.items.contains { $0.view is TokenAccountSwitcherView }
         let hasCodexSwitcher = menu.items.contains { $0.view is CodexAccountSwitcherView }
-        let switcherProvidersMatch = enabledProviders == self.lastSwitcherProviders
+        let switcherProvidersMatch = enabledProviders.map(\.instanceID) == self.lastSwitcherProviders
         let switcherUsageBarsShowUsedMatch = self.settings.usageBarsShowUsed == self.lastSwitcherUsageBarsShowUsed
         let switcherSelectionMatches = switcherSelection == self.lastMergedSwitcherSelection
         let switcherOverviewAvailabilityMatches = includesOverview == self.lastSwitcherIncludesOverview
@@ -323,7 +323,7 @@ extension StatusItemController {
                 context: MenuUpdateContext(
                     provider: selectedProvider,
                     currentProvider: currentProvider,
-                    switcherSelection: switcherSelection ?? .provider(currentProvider),
+                    switcherSelection: switcherSelection ?? .provider(currentProvider.instanceID),
                     menuWidth: menuWidth,
                     codexAccountDisplay: codexAccountDisplay,
                     tokenAccountDisplay: tokenAccountDisplay,
@@ -356,7 +356,7 @@ extension StatusItemController {
                 context: MenuUpdateContext(
                     provider: selectedProvider,
                     currentProvider: currentProvider,
-                    switcherSelection: switcherSelection ?? .provider(currentProvider),
+                    switcherSelection: switcherSelection ?? .provider(currentProvider.instanceID),
                     menuWidth: menuWidth,
                     codexAccountDisplay: codexAccountDisplay,
                     tokenAccountDisplay: tokenAccountDisplay,
@@ -419,12 +419,12 @@ extension StatusItemController {
             self.harvestRecyclableMenuCardViews(in: menu, fromIndex: 0, displacedSelection: displacedSelection)
             defer { self.clearMenuCardViewRecyclePool() }
             menu.removeAllItems()
-            let contentSelection = context.switcherSelection ?? .provider(context.currentProvider)
+            let contentSelection = context.switcherSelection ?? .provider(context.currentProvider.instanceID)
             self.addProviderSwitcherIfNeeded(
                 to: menu,
                 enabledProviders: context.enabledProviders,
                 includesOverview: context.includesOverview,
-                selection: context.switcherSelection ?? .provider(context.currentProvider),
+                selection: context.switcherSelection ?? .provider(context.currentProvider.instanceID),
                 width: context.menuWidth)
             // Track which providers the switcher was built with for smart update detection
             if self.shouldMergeIcons, context.enabledProviders.count > 1 {
@@ -751,7 +751,7 @@ extension StatusItemController {
         captureMenu: NSMenu? = nil)
     {
         if switcherSelection == .overview {
-            let enabledProviders = self.store.enabledProvidersForDisplay()
+            let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
             if self.addOverviewRows(
                 to: menu,
                 enabledProviders: enabledProviders,
@@ -935,7 +935,7 @@ extension StatusItemController {
     func makeMenu(for provider: UsageProvider?) -> NSMenu {
         let menu = self.makeBaseMenu()
         if let provider {
-            self.menuProviders[ObjectIdentifier(menu)] = provider
+            self.menuProviders[ObjectIdentifier(menu)] = provider.instanceID
         }
         return menu
     }
@@ -980,11 +980,11 @@ extension StatusItemController {
                     case let .provider(selectedProvider):
                         self.settings.mergedMenuLastSelectedWasOverview = false
                         self.selectedMenuProvider = selectedProvider
-                        provider = selectedProvider
+                        provider = selectedProvider.firstPartyProvider
                     }
                     switch selection {
                     case .overview:
-                        self.lastMenuProvider = provider ?? .codex
+                        self.lastMenuProvider = (provider ?? .codex).instanceID
                     case let .provider(provider):
                         self.lastMenuProvider = provider
                     }
@@ -1084,11 +1084,11 @@ extension StatusItemController {
     }
 
     func resolvedMenuProvider(enabledProviders: [UsageProvider]? = nil) -> UsageProvider? {
-        let enabled = enabledProviders ?? self.store.enabledProvidersForDisplay()
+        let enabled = enabledProviders ?? self.store.enabledFirstPartyProvidersForDisplay()
         if enabled.isEmpty {
             return .codex
         }
-        if let selected = self.selectedMenuProvider, enabled.contains(selected) {
+        if let selected = self.selectedMenuProvider?.firstPartyProvider, enabled.contains(selected) {
             return selected
         }
         // Prefer an available provider so the default menu content matches the status icon.
@@ -1109,7 +1109,7 @@ extension StatusItemController {
         if includesOverview, self.settings.mergedMenuLastSelectedWasOverview {
             return .overview
         }
-        return .provider(self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex)
+        return .provider((self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex).instanceID)
     }
 
     func menuProvider(for menu: NSMenu) -> UsageProvider? {
@@ -1117,12 +1117,12 @@ extension StatusItemController {
             return self.resolvedMenuProvider()
         }
         if let provider = self.menuProviders[ObjectIdentifier(menu)] {
-            return provider
+            return provider.firstPartyProvider
         }
         if menu === self.fallbackMenu {
             return nil
         }
-        return self.store.enabledProvidersForDisplay().first ?? .codex
+        return self.store.enabledFirstPartyProvidersForDisplay().first ?? .codex
     }
 
     private func scheduleOpenMenuRefresh(for menu: NSMenu) {
@@ -1153,20 +1153,24 @@ extension StatusItemController {
             let refreshAllOnOpen = self.settings.refreshAllProvidersOnMenuOpen
             let enabledProviders = self.store.enabledProvidersForBackgroundWork()
             let visibleProviders = self.delayedRefreshRetryProviders(for: menu)
+            let visibleInstanceIDs = visibleProviders.map(\.instanceID)
             let plan = MenuOpenRefreshPlan.resolve(.init(
                 refreshAllOnOpen: refreshAllOnOpen,
                 enabledProviders: enabledProviders,
-                visibleProviders: visibleProviders,
+                visibleProviders: visibleInstanceIDs,
                 refreshingProviders: self.store.refreshingProviders,
-                staleProviders: Set(visibleProviders.filter { self.store.isStale(provider: $0) }),
-                missingProviders: Set(visibleProviders.filter { !self.store.hasSatisfiedUsageFetch(for: $0) })))
+                staleProviders: Set(visibleProviders.filter { self.store.isStale(provider: $0) }.map(\.instanceID)),
+                missingProviders: Set(visibleProviders
+                    .filter { !self.store.hasSatisfiedUsageFetch(for: $0) }
+                    .map(\.instanceID))))
             if plan.refreshCodexDashboard {
                 self.deferOpenAIDashboardRefreshUntilMenuCloses(reason: "refresh all")
             }
-            let retryProviders = plan.providers
-            guard !retryProviders.isEmpty else {
+            let retryInstanceIDs = plan.providers
+            let retryProviders = retryInstanceIDs.compactMap(\.firstPartyProvider)
+            guard !retryInstanceIDs.isEmpty else {
                 self.clearSatisfiedDeferredMenuInteractionRefreshes(
-                    for: self.delayedRefreshRetryProviders(for: menu))
+                    for: self.delayedRefreshRetryProviders(for: menu).map(\.instanceID))
                 // Ordinary store changes intentionally stay queued until the next open. Rebuilding here
                 // made first-open work such as the storage scan flash the visible menu after 1.2 seconds.
                 if !providersNeedingRetryAtOpen.isEmpty, self.menuNeedsRefresh(menu) {
@@ -1177,7 +1181,7 @@ extension StatusItemController {
                 }
                 return
             }
-            self.deferMenuInteractionRefreshIfNeeded(providers: retryProviders)
+            self.deferredMenuInteractionRefreshProviders.formUnion(retryInstanceIDs)
             await ProviderInteractionContext.$current.withValue(.background) {
                 if plan.scheduling == .concurrent {
                     // Refresh concurrently so one slow provider doesn't delay the rest, mirroring the
@@ -1201,7 +1205,7 @@ extension StatusItemController {
                 self.store.needsUsageRefreshRetry(for: $0)
             }
             if !stillNeedsRetry {
-                self.clearSatisfiedDeferredMenuInteractionRefreshes(for: retryProviders)
+                self.clearSatisfiedDeferredMenuInteractionRefreshes(for: retryInstanceIDs)
             }
             guard !Task.isCancelled else { return }
             guard self.openMenus[ObjectIdentifier(menu)] != nil else { return }
@@ -1225,7 +1229,7 @@ extension StatusItemController {
     }
 
     func renderedProviders(for menu: NSMenu) -> [UsageProvider] {
-        let enabledProviders = self.store.enabledProvidersForDisplay()
+        let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
         guard !enabledProviders.isEmpty else { return [] }
         let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
 
@@ -1275,7 +1279,7 @@ extension StatusItemController {
                 width: width)
             let usageSubmenu = self.makeUsageSubmenu(
                 provider: provider,
-                snapshot: self.store.snapshot(for: provider),
+                snapshot: self.store.snapshot(for: provider.instanceID),
                 webItems: webItems,
                 width: width)
             menu.addItem(self.makeMenuCardItem(
@@ -1366,7 +1370,7 @@ extension StatusItemController {
         }
 
         // Fallback to the dynamic icon renderer if resources are missing (e.g. dev bundle mismatch).
-        let snapshot = self.store.snapshot(for: provider)
+        let snapshot = self.store.snapshot(for: provider.instanceID)
         let showUsed = self.settings.usageBarsShowUsed
         let style = self.store.style(for: provider)
         let now = Date()
@@ -1552,7 +1556,7 @@ extension StatusItemController {
 
     func tokenSnapshotForCostHistorySubmenu(provider: UsageProvider) -> CostUsageTokenSnapshot? {
         let projected = self.store.tokenSnapshot(
-            fromProviderSnapshot: self.store.snapshot(for: provider),
+            fromProviderSnapshot: self.store.snapshot(for: provider.instanceID),
             provider: provider)
         if UsageStore.tokenCostRequiresProviderSnapshot(provider) {
             return projected
@@ -1625,7 +1629,7 @@ extension StatusItemController {
         width: CGFloat)
     {
         guard action == .statusPage,
-              let statusProvider = self.menuProvider(for: menu) ?? self.lastMenuProvider,
+              let statusProvider = self.menuProvider(for: menu) ?? self.lastMenuProvider?.firstPartyProvider,
               let submenu = self.makeStatusComponentsSubmenu(provider: statusProvider, width: width)
         else { return }
         item.action = nil

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -8,7 +8,7 @@ extension StatusItemController {
                 self?.menuCardModel(for: provider)
             },
             isProviderRefreshActive: { [weak self] provider in
-                self?.store.refreshingProviders.contains(provider) == true
+                self?.store.refreshingProviders.contains(provider.instanceID) == true
             })
     }
 
@@ -22,7 +22,7 @@ extension StatusItemController {
         planOverride: String? = nil,
         subtitleOverride: String? = nil) -> UsageMenuCardView.Model?
     {
-        let target = provider ?? self.store.enabledProvidersForDisplay().first ?? .codex
+        let target = provider ?? self.store.enabledFirstPartyProvidersForDisplay().first ?? .codex
         let metadata = self.store.metadata(for: target)
 
         let usesOverrideCard = forceOverrideCard || snapshotOverride != nil || errorOverride != nil

--- a/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
@@ -84,14 +84,15 @@ extension StatusItemController {
 
     func deferMenuInteractionRefreshIfNeeded(providers: [UsageProvider]) {
         guard !self.store.isRefreshing else { return }
-        self.deferredMenuInteractionRefreshProviders.formUnion(providers)
+        self.deferredMenuInteractionRefreshProviders.formUnion(providers.map(\.instanceID))
     }
 
-    func clearSatisfiedDeferredMenuInteractionRefreshes(for providers: [UsageProvider]) {
-        for provider in providers
-            where !self.store.needsUsageRefreshRetry(for: provider)
-        {
-            self.deferredMenuInteractionRefreshProviders.remove(provider)
+    func clearSatisfiedDeferredMenuInteractionRefreshes(for providers: [ProviderInstanceID]) {
+        for instanceID in providers {
+            guard let provider = instanceID.firstPartyProvider,
+                  !self.store.needsUsageRefreshRetry(for: provider)
+            else { continue }
+            self.deferredMenuInteractionRefreshProviders.remove(instanceID)
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+MenuLocalization.swift
+++ b/Sources/CodexBar/StatusItemController+MenuLocalization.swift
@@ -22,7 +22,7 @@ extension StatusItemController {
         _ selection: ProviderSwitcherSelection?,
         _ includesOverview: Bool)
     {
-        self.lastSwitcherProviders = providers
+        self.lastSwitcherProviders = providers.map(\.instanceID)
         self.lastSwitcherUsageBarsShowUsed = self.settings.usageBarsShowUsed
         self.lastMergedSwitcherSelection = selection
         self.lastMergedMenuContentSelection = selection

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 extension StatusItemController {
     func switcherWeeklyRemaining(for provider: UsageProvider) -> Double? {
-        let snapshot = self.store.snapshot(for: provider)
+        let snapshot = self.store.snapshot(for: provider.instanceID)
         return Self.switcherWeeklyMetricPercent(
             for: provider,
             snapshot: snapshot,

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -122,7 +122,7 @@ extension StatusItemController {
             "claudeSwapRevision=\(self.store.claudeSwapRevision)",
         ]
 
-        for provider in self.store.enabledProvidersForDisplay() {
+        for provider in self.store.enabledFirstPartyProvidersForDisplay() {
             let tokenSignature = self.tokenSnapshotReadinessSignature(for: provider)
             let usageHistoryVisible = self.store.supportsPlanUtilizationHistory(for: provider) &&
                 !self.store.shouldHidePlanUtilizationMenuItem(for: provider)

--- a/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
+++ b/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
@@ -29,7 +29,7 @@ extension StatusItemController {
             }
             let outgoingSelection = self.lastMergedMenuContentSelection
             let isSelectionSwitch = outgoingSelection != nil && outgoingSelection != context.switcherSelection
-            let enabledProviders = self.store.enabledProvidersForDisplay()
+            let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
 
             if isSelectionSwitch,
                let outgoingSelection,

--- a/Sources/CodexBar/StatusItemController+MenuSwitcherWarmup.swift
+++ b/Sources/CodexBar/StatusItemController+MenuSwitcherWarmup.swift
@@ -40,13 +40,13 @@ extension StatusItemController {
 
     func warmMergedSwitcherSiblingContent(in menu: NSMenu) {
         guard menu.items.first?.view is ProviderSwitcherView else { return }
-        let enabledProviders = self.store.enabledProvidersForDisplay()
+        let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
         guard enabledProviders.count > 1 else { return }
         let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
         let currentSelection = self.resolvedSwitcherSelection(
             enabledProviders: enabledProviders,
             includesOverview: includesOverview)
-        var selections: [ProviderSwitcherSelection] = enabledProviders.map { .provider($0) }
+        var selections: [ProviderSwitcherSelection] = enabledProviders.map { .provider($0.instanceID) }
         if includesOverview {
             selections.insert(.overview, at: 0)
         }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -336,7 +336,8 @@ extension StatusItemController {
         var parts: [String] = []
         for target in providers {
             parts.append(target.rawValue)
-            parts.append(self.providerIdentitySignature(self.store.snapshot(for: target)?.identity(for: target)))
+            parts.append(self.providerIdentitySignature(
+                self.store.snapshot(for: target.instanceID)?.identity(for: target.instanceID)))
 
             if target != .codex, self.store.metadata(for: target).usesAccountFallback {
                 let account = self.store.accountInfo(for: target)
@@ -344,10 +345,10 @@ extension StatusItemController {
                 parts.append(Self.menuIdentityField(account.plan))
             }
 
-            for accountSnapshot in self.store.accountSnapshots[target] ?? [] {
+            for accountSnapshot in self.store.accountSnapshots[target.instanceID] ?? [] {
                 parts.append(accountSnapshot.account.id.uuidString)
                 parts.append(Self.menuIdentityField(accountSnapshot.account.label))
-                parts.append(self.providerIdentitySignature(accountSnapshot.snapshot?.identity(for: target)))
+                parts.append(self.providerIdentitySignature(accountSnapshot.snapshot?.identity(for: target.instanceID)))
             }
 
             if target == .codex {
@@ -362,14 +363,17 @@ extension StatusItemController {
                 }
                 for accountSnapshot in self.store.codexAccountSnapshots {
                     parts.append(Self.menuIdentityField(accountSnapshot.id))
-                    parts.append(self.providerIdentitySignature(accountSnapshot.snapshot?.identity(for: target)))
+                    parts.append(self.providerIdentitySignature(
+                        accountSnapshot.snapshot?.identity(for: target.instanceID)))
                 }
             }
 
             if target == .kilo {
                 for scopeSnapshot in self.store.kiloScopeSnapshots {
                     parts.append(Self.menuIdentityField(scopeSnapshot.id))
-                    parts.append(self.providerIdentitySignature(scopeSnapshot.snapshot?.identity(for: target)))
+                    parts
+                        .append(self
+                            .providerIdentitySignature(scopeSnapshot.snapshot?.identity(for: target.instanceID)))
                 }
             }
 
@@ -378,7 +382,8 @@ extension StatusItemController {
                 for accountSnapshot in self.store.claudeSwapAccountSnapshots {
                     parts.append(Self.menuIdentityField(accountSnapshot.id.opaqueID))
                     parts.append(accountSnapshot.isActive ? "active" : "inactive")
-                    parts.append(self.providerIdentitySignature(accountSnapshot.snapshot?.identity(for: target)))
+                    parts.append(self.providerIdentitySignature(
+                        accountSnapshot.snapshot?.identity(for: target.instanceID)))
                 }
             }
         }

--- a/Sources/CodexBar/StatusItemController+MenuTypes.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTypes.swift
@@ -3,6 +3,11 @@ import CodexBarCore
 import SwiftUI
 
 extension StatusItemController {
+    var selectedMenuProvider: ProviderInstanceID? {
+        get { self.settings.selectedMenuProvider }
+        set { self.settings.selectedMenuProvider = newValue }
+    }
+
     var fallbackProvider: UsageProvider? {
         // Intentionally uses availability-filtered list: fallback activates when no provider
         // can actually work, ensuring at least a codex icon is always visible.
@@ -15,8 +20,15 @@ extension ProviderSwitcherSelection {
         switch self {
         case .overview:
             nil
-        case let .provider(provider):
-            provider
+        case let .provider(instanceID):
+            instanceID.firstPartyProvider
+        }
+    }
+
+    var instanceID: ProviderInstanceID? {
+        switch self {
+        case .overview: nil
+        case let .provider(instanceID): instanceID
         }
     }
 }

--- a/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
+++ b/Sources/CodexBar/StatusItemController+MenuViewportRestore.swift
@@ -608,7 +608,7 @@ extension StatusItemController {
         if self.isMergedOverviewSelected(in: menu) {
             return .overview
         }
-        return .provider(self.resolvedMenuProvider() ?? .codex)
+        return .provider((self.resolvedMenuProvider() ?? .codex).instanceID)
     }
 
     private func isCurrentManualRefreshViewportRestoreContext(

--- a/Sources/CodexBar/StatusItemController+OverviewSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+OverviewSubmenus.swift
@@ -13,7 +13,7 @@ extension StatusItemController {
             return submenu
         }
         if provider == .zai,
-           let submenu = self.makeZaiUsageDetailsSubmenu(snapshot: self.store.snapshot(for: provider))
+           let submenu = self.makeZaiUsageDetailsSubmenu(snapshot: self.store.snapshot(for: provider.instanceID))
         {
             return submenu
         }
@@ -55,12 +55,12 @@ extension StatusItemController {
     }
 
     func selectOverviewProvider(_ provider: UsageProvider, menu: NSMenu) {
-        if !self.settings.mergedMenuLastSelectedWasOverview, self.selectedMenuProvider == provider { return }
+        if !self.settings.mergedMenuLastSelectedWasOverview, self.selectedMenuProvider == provider.instanceID { return }
         self.preservingMergedSwitcherContentCachesDuringInvalidation {
             self.settings.mergedMenuLastSelectedWasOverview = false
-            self.lastMergedSwitcherSelection = .provider(provider)
-            self.selectedMenuProvider = provider
-            self.lastMenuProvider = provider
+            self.lastMergedSwitcherSelection = .provider(provider.instanceID)
+            self.selectedMenuProvider = provider.instanceID
+            self.lastMenuProvider = provider.instanceID
             self.refreshProviderSelectionDependentUI(deferRendering: true)
         }
         // Custom-view clicks stay open and rebuild next turn. Standard menu-item activation can close;

--- a/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
@@ -41,8 +41,8 @@ extension StatusItemController {
             // A manual refresh of a different provider must not grey out this provider's row: only
             // reflect the global refresh, this provider's own manual refresh, and its store refresh.
             return self.store.isRefreshing
-                || self.manualRefreshTasks[.provider(provider)] != nil
-                || self.store.refreshingProviders.contains(provider)
+                || self.manualRefreshTasks[.provider(provider.instanceID)] != nil
+                || self.store.refreshingProviders.contains(provider.instanceID)
         }
         return self.store.isRefreshing
             || !self.manualRefreshTasks.isEmpty
@@ -53,7 +53,7 @@ extension StatusItemController {
         guard self.shouldMergeIcons else { return false }
         if let mergedMenu = self.mergedMenu, menu !== mergedMenu { return false }
         let providers = self.settings.resolvedMergedOverviewProviders(
-            activeProviders: self.store.enabledProvidersForDisplay(),
+            activeProviders: self.store.enabledFirstPartyProvidersForDisplay(),
             maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
         return !providers.isEmpty && self.settings.mergedMenuLastSelectedWasOverview
     }

--- a/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
@@ -40,13 +40,13 @@ extension StatusItemController {
         menu: NSMenu? = nil)
     {
         guard self.shouldMergeIcons else { return }
-        let enabledProviders = self.store.enabledProvidersForDisplay()
+        let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
         guard enabledProviders.count > 1 else { return }
 
         let includesOverview = !self.settings.resolvedMergedOverviewProviders(
             activeProviders: enabledProviders,
             maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit).isEmpty
-        var selections = enabledProviders.map(ProviderSwitcherSelection.provider)
+        var selections = enabledProviders.map { ProviderSwitcherSelection.provider($0.instanceID) }
         if includesOverview {
             selections.insert(.overview, at: 0)
         }
@@ -56,7 +56,7 @@ extension StatusItemController {
         {
             .overview
         } else {
-            .provider(self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex)
+            .provider((self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex).instanceID)
         }
         guard let currentIndex = selections.firstIndex(of: current) else { return }
 
@@ -66,14 +66,15 @@ extension StatusItemController {
         let menuProvider: UsageProvider = switch selection {
         case .overview:
             self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex
-        case let .provider(provider):
-            provider
+        case let .provider(instanceID):
+            instanceID.firstPartyProvider ?? .codex
         }
         self.preservingMergedSwitcherContentCachesDuringInvalidation {
             switch selection {
             case .overview:
                 self.settings.mergedMenuLastSelectedWasOverview = true
-                self.lastMenuProvider = self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex
+                self.lastMenuProvider =
+                    (self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex).instanceID
             case let .provider(provider):
                 self.settings.mergedMenuLastSelectedWasOverview = false
                 self.selectedMenuProvider = provider
@@ -94,7 +95,7 @@ extension StatusItemController {
         if enabledProviders.isEmpty {
             return .codex
         }
-        if let selected = self.selectedMenuProvider, enabledProviders.contains(selected) {
+        if let selected = self.selectedMenuProvider?.firstPartyProvider, enabledProviders.contains(selected) {
             return selected
         }
         return enabledProviders.first(where: { self.store.isProviderAvailable($0) }) ?? enabledProviders.first

--- a/Sources/CodexBar/StatusItemController+StatusItemVending.swift
+++ b/Sources/CodexBar/StatusItemController+StatusItemVending.swift
@@ -12,19 +12,19 @@ extension StatusItemController {
         onCreated: ((NSStatusItem) -> Void)? = nil)
         -> NSStatusItem
     {
-        if let existing = self.statusItems[provider] {
+        if let existing = self.statusItems[provider.instanceID] {
             return existing
         }
         return Self.makeStatusItem(
             statusBar: self.statusBar,
-            identity: .provider(provider),
+            identity: .provider(provider.instanceID),
             defaults: self.settings.userDefaults,
             legacyDefaultItemIndex: self.legacyDefaultItemIndex(forNewProvider: provider),
             onCreated: { item in
                 // Register before invoking the caller/setup callbacks: button configuration and
                 // icon-observation can synchronously re-enter vending for this provider, and an
                 // unregistered item there vends a duplicate (issue #2162).
-                self.statusItems[provider] = item
+                self.statusItems[provider.instanceID] = item
                 onCreated?(item)
             })
     }

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -4,7 +4,7 @@ import QuartzCore
 
 enum ProviderSwitcherSelection: Hashable {
     case overview
-    case provider(UsageProvider)
+    case provider(ProviderInstanceID)
 }
 
 final class ProviderSwitcherView: NSView {
@@ -63,7 +63,7 @@ final class ProviderSwitcherView: NSView {
             // Avoid any resampling: we ship exact 16pt/32px assets for crisp rendering.
             icon.size = NSSize(width: 16, height: 16)
             return Segment(
-                selection: .provider(provider),
+                selection: .provider(provider.instanceID),
                 image: icon,
                 title: fullTitle)
         }
@@ -668,8 +668,8 @@ final class ProviderSwitcherView: NSView {
 
     private func remainingPercent(for selection: ProviderSwitcherSelection) -> Double? {
         switch selection {
-        case let .provider(provider):
-            self.weeklyRemainingProvider(provider)
+        case let .provider(instanceID):
+            instanceID.firstPartyProvider.flatMap(self.weeklyRemainingProvider)
         case .overview:
             nil
         }
@@ -1145,7 +1145,8 @@ extension ProviderSwitcherView {
         remainingPercent _: Double) -> NSColor
     {
         switch selection {
-        case let .provider(provider):
+        case let .provider(instanceID):
+            guard let provider = instanceID.firstPartyProvider else { return NSColor.secondaryLabelColor }
             let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
             return NSColor(deviceRed: color.red, green: color.green, blue: color.blue, alpha: 1)
         case .overview:

--- a/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
+++ b/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
@@ -38,7 +38,7 @@ extension StatusItemController {
         width: CGFloat) -> Bool
     {
         let histories = self.store.planUtilizationHistory(for: provider)
-        let snapshot = self.store.snapshot(for: provider)
+        let snapshot = self.store.snapshot(for: provider.instanceID)
 
         if !self.menuCardRenderingEnabledForController {
             let chartItem = NSMenuItem()

--- a/Sources/CodexBar/StatusItemController+ZaiHourlyChartMenu.swift
+++ b/Sources/CodexBar/StatusItemController+ZaiHourlyChartMenu.swift
@@ -8,7 +8,7 @@ extension StatusItemController {
     @discardableResult
     func addZaiHourlyUsageMenuItemIfNeeded(to menu: NSMenu, provider: UsageProvider, width: CGFloat) -> Bool {
         guard provider == .zai else { return false }
-        guard let snapshot = self.store.snapshot(for: provider),
+        guard let snapshot = self.store.snapshot(for: provider.instanceID),
               snapshot.zaiUsage?.modelUsage != nil
         else { return false }
         let submenu = self.makeHostedSubviewPlaceholderMenu(chartID: Self.zaiHourlyUsageChartID, provider: provider)

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -51,7 +51,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
     enum StatusItemIdentity {
         case merged
-        case provider(UsageProvider)
+        case provider(ProviderInstanceID)
 
         var autosaveName: String {
             switch self {
@@ -140,11 +140,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     let menuCardRenderingEnabledForController: Bool
     let menuRefreshEnabledForController: Bool
     var statusItem: NSStatusItem
-    var statusItems: [UsageProvider: NSStatusItem] = [:]
+    var statusItems: [ProviderInstanceID: NSStatusItem] = [:]
     /// App intent survives Tahoe changing `NSStatusItem.isVisible` after Control Center rejects its scene.
     var expectedVisibleStatusItemAutosaveNames: Set<String> = []
-    var lastMenuProvider: UsageProvider?
-    var menuProviders: [ObjectIdentifier: UsageProvider] = [:]
+    var lastMenuProvider: ProviderInstanceID?
+    var menuProviders: [ObjectIdentifier: ProviderInstanceID] = [:]
     var menuSession = MenuSessionCoordinator<ObjectIdentifier>()
     var menuReadinessSignatures: [ObjectIdentifier: String] = [:]
     let hostedSubviewRenderSignatures = NSMapTable<NSMenu, HostedSubviewRenderSignatureBox>.weakToStrongObjects()
@@ -156,7 +156,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var lastMenuAdjunctReadinessBaselineVersion = 0
     var rootOpenHandledMenuObservationSignature: String?
     var mergedMenu: NSMenu?
-    var providerMenus: [UsageProvider: NSMenu] = [:]
+    var providerMenus: [ProviderInstanceID: NSMenu] = [:]
     var fallbackMenu: NSMenu?
     var openMenus: [ObjectIdentifier: NSMenu] = [:]
     var menuRefreshTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
@@ -172,7 +172,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var codexAccountMenuProjectionRevalidationTask: Task<Void, Never>?
     var openMenuRebuildsClosingHostedSubviewMenus: Set<ObjectIdentifier> = []
     var parentMenuRebuildPendingAfterHostedSubviewClose = false
-    var deferredMenuInteractionRefreshProviders: Set<UsageProvider> = []
+    var deferredMenuInteractionRefreshProviders: Set<ProviderInstanceID> = []
     var deferredMenuInteractionRefreshPending: Bool {
         !self.deferredMenuInteractionRefreshProviders.isEmpty
     }
@@ -233,12 +233,12 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         }
     }
 
-    var blinkStates: [UsageProvider: BlinkState] = [:]
-    var blinkAmounts: [UsageProvider: CGFloat] = [:]
-    var wiggleAmounts: [UsageProvider: CGFloat] = [:]
-    var tiltAmounts: [UsageProvider: CGFloat] = [:]
-    var quotaWarningFlashUntil: [UsageProvider: Date] = [:]
-    var quotaWarningFlashTasks: [UsageProvider: Task<Void, Never>] = [:]
+    var blinkStates: [ProviderInstanceID: BlinkState] = [:]
+    var blinkAmounts: [ProviderInstanceID: CGFloat] = [:]
+    var wiggleAmounts: [ProviderInstanceID: CGFloat] = [:]
+    var tiltAmounts: [ProviderInstanceID: CGFloat] = [:]
+    var quotaWarningFlashUntil: [ProviderInstanceID: Date] = [:]
+    var quotaWarningFlashTasks: [ProviderInstanceID: Task<Void, Never>] = [:]
     var blinkForceUntil: Date?
     var loginPhase: LoginPhase = .idle {
         didSet {
@@ -254,7 +254,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var animationPattern: LoadingPattern = .knightRider
     var animationStartedAt: Date?
     private var lastConfigRevision: Int
-    private var lastProviderOrder: [UsageProvider]
+    private var lastProviderOrder: [ProviderInstanceID]
     private var lastMergeIcons: Bool
     private var lastSwitcherShowsIcons: Bool
     private var lastObservedUsageBarsShowUsed: Bool
@@ -273,7 +273,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     /// Used to force menu rebuilds when app language changes.
     var lastMenuLocalizationSignature: String = ""
     /// Tracks which providers the merged menu's switcher was built with, to detect when it needs full rebuild.
-    var lastSwitcherProviders: [UsageProvider] = []
+    var lastSwitcherProviders: [ProviderInstanceID] = []
     /// Tracks which switcher tab state was used for the current merged-menu switcher instance.
     var lastMergedSwitcherSelection: ProviderSwitcherSelection?
     /// Tracks which provider/overview content is currently attached below the merged-menu switcher.
@@ -288,7 +288,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     /// Compact multi-account layout: accounts the user expanded to full cards this menu session.
     var compactAccountExpandedIDs: Set<ProviderAccountIdentity> = []
     /// Compact multi-account layout: providers whose collapsed healthy tail is revealed this menu session.
-    var compactAccountExpandedHealthyTailProviders: Set<UsageProvider> = []
+    var compactAccountExpandedHealthyTailProviders: Set<ProviderInstanceID> = []
     /// Keeps detached merged-menu tab content reusable while the same menu remains open.
     var mergedSwitcherContentCaches: [ObjectIdentifier: [ProviderSwitcherSelection: CachedMergedSwitcherMenuContent]]
         = [:]
@@ -302,7 +302,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var providerSelectionUIRefreshTask: Task<Void, Never>?
     var deferredMergedIconRenderAfterTracking = false
     var lastAppliedMergedIconRenderSignature: String?
-    var lastAppliedProviderIconRenderSignatures: [UsageProvider: String] = [:]
+    var lastAppliedProviderIconRenderSignatures: [ProviderInstanceID: String] = [:]
     let menuBarLayoutRenderer = MenuBarLayoutRenderer()
     var lastObservedStoreIconWorkSignature: String?
     var iconPerfRefreshCycleMetrics: IconPerfRefreshCycleMetrics?
@@ -312,11 +312,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var screenChangeVisibilityTask: Task<Void, Never>?
     let loginLogger = CodexBarLog.logger(LogCategories.login)
     let menuLogger = CodexBarLog.logger(LogCategories.app)
-    var selectedMenuProvider: UsageProvider? {
-        get { self.settings.selectedMenuProvider }
-        set { self.settings.selectedMenuProvider = newValue }
-    }
-
     static func makeStatusItem(
         statusBar: NSStatusBar,
         identity: StatusItemIdentity,
@@ -455,7 +450,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.updateVisibility()
         self.updateIcons()
         self.scheduleCodexAccountMenuProjectionRevalidationIfNeeded(
-            for: self.store.enabledProvidersForDisplay())
+            for: self.store.enabledFirstPartyProvidersForDisplay())
         self.scheduleStartupStatusItemVisibilityCheck()
         NotificationCenter.default.addObserver(
             self,
@@ -798,7 +793,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         } else {
             self.statusItem.isVisible = false
             let fallback = self.fallbackProvider
-            for provider in self.settings.orderedProviders() {
+            for provider in self.settings.orderedFirstPartyProviders() {
                 let isEnabled = self.isEnabled(provider)
                 let shouldBeVisible = isEnabled || fallback == provider || force
                 if shouldBeVisible {
@@ -852,10 +847,10 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
                 let item = self.lazyStatusItem(for: provider)
 
                 if self.isEnabled(provider) {
-                    if self.providerMenus[provider] == nil {
-                        self.providerMenus[provider] = self.makeMenu(for: provider)
+                    if self.providerMenus[provider.instanceID] == nil {
+                        self.providerMenus[provider.instanceID] = self.makeMenu(for: provider)
                     }
-                    let menu = self.providerMenus[provider]
+                    let menu = self.providerMenus[provider.instanceID]
                     if item.menu !== menu {
                         item.menu = menu
                     }
@@ -867,7 +862,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
                         item.menu = self.fallbackMenu
                     }
                 }
-            } else if let item = self.statusItems[provider] {
+            } else if let item = self.statusItems[provider.instanceID] {
                 item.menu = nil
             }
         }
@@ -887,13 +882,20 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         guard !self.shouldMergeIcons else { return }
         let fallback = self.fallbackProvider
         let force = self.store.debugForceAnimation
-        for provider in ordered where self.isEnabled(provider) || fallback == provider || force {
+        for instanceID in ordered {
+            guard let provider = instanceID.firstPartyProvider,
+                  self.isEnabled(provider) || fallback == provider || force
+            else { continue }
             _ = self.lazyStatusItem(for: provider)
         }
     }
 
     private func removeProviderStatusItem(for provider: UsageProvider) {
-        if let menu = self.providerMenus.removeValue(forKey: provider) {
+        self.removeProviderStatusItem(for: provider.instanceID)
+    }
+
+    private func removeProviderStatusItem(for instanceID: ProviderInstanceID) {
+        if let menu = self.providerMenus.removeValue(forKey: instanceID) {
             let menuID = ObjectIdentifier(menu)
             if menuID == self.providerSwitcherShortcutMenuID {
                 self.removeProviderSwitcherShortcutMonitor()
@@ -902,9 +904,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             self.removeMenuLifecycleState(menuID)
         }
 
-        guard let item = self.statusItems.removeValue(forKey: provider) else { return }
+        guard let item = self.statusItems.removeValue(forKey: instanceID) else { return }
         item.menu = nil
-        self.lastAppliedProviderIconRenderSignatures.removeValue(forKey: provider)
+        self.lastAppliedProviderIconRenderSignatures.removeValue(forKey: instanceID)
         self.statusBar.removeStatusItem(item)
     }
 
@@ -1012,7 +1014,7 @@ extension StatusItemController {
 
 extension StatusItemController {
     func legacyDefaultItemIndex(forNewProvider provider: UsageProvider) -> Int? {
-        let visibleProviders = self.settings.orderedProviders().filter { self.isVisible($0) }
+        let visibleProviders = self.settings.orderedFirstPartyProviders().filter { self.isVisible($0) }
         guard let providerOffset = visibleProviders.firstIndex(of: provider) else { return nil }
         return Self.mergedLegacyDefaultItemIndex + 1 + providerOffset
     }

--- a/Sources/CodexBar/Sync/CloudSyncEngine.swift
+++ b/Sources/CodexBar/Sync/CloudSyncEngine.swift
@@ -64,7 +64,7 @@ enum CloudSyncDirtyState {
 
     static func configurationRecordNamesToQueue(
         envelope: CloudSyncPersistence.Envelope,
-        configuredProviders: [UsageProvider]) -> Set<String>
+        configuredProviders: [ProviderInstanceID]) -> Set<String>
     {
         var recordNames = Set(configuredProviders.compactMap { provider in
             envelope.dirtyProviders.contains(provider.rawValue)
@@ -78,7 +78,7 @@ enum CloudSyncDirtyState {
     }
 
     static func markBootstrapDirtyIfNeeded(
-        configuredProviders: [UsageProvider],
+        configuredProviders: [ProviderInstanceID],
         envelope: inout CloudSyncPersistence.Envelope)
     {
         guard !envelope.recordMetadata.keys.contains(where: { $0.hasPrefix(self.providerIntentPrefix) }) else {
@@ -155,7 +155,7 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
     private var lastSnapshotPushAt: Date?
     private var pendingSnapshots: [AccountSnapshotSyncPayload] = []
     private var lastSnapshotHashes: [String: String] = [:]
-    private var lastKnownProviderConfigs: [UsageProvider: ProviderConfig] = [:]
+    private var lastKnownProviderConfigs: [ProviderInstanceID: ProviderConfig] = [:]
     private var lastKnownPreferences: SyncedPreferences?
     private var lastKnownIncludeSecrets: Bool?
     private var quotaRetryState = CloudSyncQuotaRetryState()
@@ -731,7 +731,7 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
 
     private func applyAccountSnapshot(_ record: CKRecord) async throws {
         guard let providerRaw = record["provider"] as? String,
-              let provider = UsageProvider(rawValue: providerRaw),
+              let provider = ProviderInstanceID(rawValue: providerRaw),
               let deviceID = record["deviceID"] as? String,
               let accountKey = record["accountKey"] as? String,
               let fetchedAt = record["fetchedAt"] as? Date,

--- a/Sources/CodexBar/UsageStore+Accessors.swift
+++ b/Sources/CodexBar/UsageStore+Accessors.swift
@@ -2,6 +2,23 @@ import CodexBarCore
 import Foundation
 
 extension UsageStore {
+    var statusChecksEnabled: Bool {
+        self.settings.statusChecksEnabled
+    }
+
+    /// Compile-time implementation kinds for provider-specific fetch and bespoke UI boundaries.
+    func enabledFirstPartyProviders() -> [UsageProvider] {
+        self.enabledProviders().compactMap(\.firstPartyProvider)
+    }
+
+    func enabledFirstPartyProvidersForDisplay() -> [UsageProvider] {
+        self.enabledProvidersForDisplay().compactMap(\.firstPartyProvider)
+    }
+
+    func enabledFirstPartyProvidersForBackgroundWork() -> [UsageProvider] {
+        self.enabledProvidersForBackgroundWork().compactMap(\.firstPartyProvider)
+    }
+
     struct DeepSeekProfileTransition {
         var snapshot: UsageSnapshot
         let accountID: UUID?
@@ -9,7 +26,7 @@ extension UsageStore {
     }
 
     func version(for provider: UsageProvider) -> String? {
-        self.versions[provider]
+        self.versions[provider.instanceID]
     }
 
     var codexSnapshot: UsageSnapshot? {
@@ -27,7 +44,7 @@ extension UsageStore {
         {
             return transition.snapshot
         }
-        if let snapshot = self.snapshots[provider] {
+        if let snapshot = self.snapshots[provider.instanceID] {
             if provider == .codex {
                 if self.openAIDashboardAttachmentAuthorized,
                    let dashboard = self.openAIDashboard,
@@ -52,8 +69,8 @@ extension UsageStore {
             }
             return snapshot
         }
-        guard provider == .deepseek, self.refreshingProviders.contains(provider) else { return nil }
-        return self.lastKnownResetSnapshots[provider]
+        guard provider == .deepseek, self.refreshingProviders.contains(provider.instanceID) else { return nil }
+        return self.lastKnownResetSnapshots[provider.instanceID]
     }
 
     func beginDeepSeekProfileTransition(preservingBalance: Bool = true) {
@@ -119,15 +136,15 @@ extension UsageStore {
     }
 
     func error(for provider: UsageProvider) -> String? {
-        self.errors[provider]
+        self.errors[provider.instanceID]
     }
 
     func diagnostic(for provider: UsageProvider) -> String? {
-        self.diagnostics[provider]
+        self.diagnostics[provider.instanceID]
     }
 
     func userFacingError(for provider: UsageProvider) -> String? {
-        if let raw = self.errors[provider] {
+        if let raw = self.errors[provider.instanceID] {
             switch provider {
             case .codex:
                 return CodexUIErrorMapper.userFacingMessage(raw)
@@ -137,14 +154,14 @@ extension UsageStore {
                 return raw
             }
         }
-        if let diagnostic = self.diagnostics[provider] {
+        if let diagnostic = self.diagnostics[provider.instanceID] {
             return diagnostic
         }
         return self.unavailableMessage(for: provider)
     }
 
     func unavailableMessage(for provider: UsageProvider) -> String? {
-        guard self.enabledProvidersForDisplay().contains(provider),
+        guard self.enabledProvidersForDisplay().contains(provider.instanceID),
               !self.isProviderAvailable(provider)
         else {
             return nil
@@ -190,7 +207,7 @@ extension UsageStore {
 
     func status(for provider: UsageProvider) -> ProviderStatus? {
         guard self.statusChecksEnabled else { return nil }
-        return self.statuses[provider]
+        return self.statuses[provider.instanceID]
     }
 
     func statusIndicator(for provider: UsageProvider) -> ProviderStatusIndicator {
@@ -199,13 +216,13 @@ extension UsageStore {
 
     func statusComponents(for provider: UsageProvider) -> [ProviderStatusComponent] {
         guard self.statusChecksEnabled else { return [] }
-        return self.statusComponents[provider] ?? []
+        return self.statusComponents[provider.instanceID] ?? []
     }
 
     func accountInfo(for provider: UsageProvider) -> AccountInfo {
         let now = Date()
         let configRevision = self.settings.configRevision
-        if let cached = self.accountInfoCache[provider],
+        if let cached = self.accountInfoCache[provider.instanceID],
            cached.isValid(now: now, configRevision: configRevision)
         {
             return cached.account
@@ -223,7 +240,7 @@ extension UsageStore {
         } else {
             account = self.codexFetcher.loadAccountInfo()
         }
-        self.accountInfoCache[provider] = AccountInfoCacheEntry(
+        self.accountInfoCache[provider.instanceID] = AccountInfoCacheEntry(
             account: account,
             configRevision: configRevision,
             expiresAt: now.addingTimeInterval(self.accountInfoCacheTTL))

--- a/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
+++ b/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
@@ -18,30 +18,30 @@ extension UsageStore {
 
     /// Cancels and retires in-flight work without clearing the provider's current presentation state.
     func invalidateProviderRefreshRequests(_ provider: UsageProvider) {
-        self.providerRefreshCoordinator.invalidateRequests(for: provider)
+        self.providerRefreshCoordinator.invalidateRequests(for: provider.instanceID)
     }
 
     /// The active refresh uses this when it discovers its own provider is disabled. Its replacing
     /// request already invalidated predecessors, so canceling the current coordinator state here
     /// would make it cancel itself before its waiters can drain.
     func clearProviderRuntimeState(_ provider: UsageProvider) {
-        self.providerCleanupRevisions[provider, default: 0] &+= 1
-        self.refreshingProviders.remove(provider)
-        self.snapshots.removeValue(forKey: provider)
-        self.lastKnownResetSnapshots.removeValue(forKey: provider)
-        self.errors[provider] = nil
-        self.diagnostics[provider] = nil
+        self.providerCleanupRevisions[provider.instanceID, default: 0] &+= 1
+        self.refreshingProviders.remove(provider.instanceID)
+        self.snapshots.removeValue(forKey: provider.instanceID)
+        self.lastKnownResetSnapshots.removeValue(forKey: provider.instanceID)
+        self.errors[provider.instanceID] = nil
+        self.diagnostics[provider.instanceID] = nil
         if provider == .deepseek {
             self.clearDeepSeekProfileTransition()
         }
         if provider == .gemini {
             self.clearGeminiConsumerTierDeprecationObservation()
         }
-        self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
-        self.lastSourceLabels.removeValue(forKey: provider)
-        self.lastFetchAttempts.removeValue(forKey: provider)
-        self.accountSnapshots.removeValue(forKey: provider)
-        self.tokenAccountLiveStateProviders.remove(provider)
+        self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider.instanceID)
+        self.lastSourceLabels.removeValue(forKey: provider.instanceID)
+        self.lastFetchAttempts.removeValue(forKey: provider.instanceID)
+        self.accountSnapshots.removeValue(forKey: provider.instanceID)
+        self.tokenAccountLiveStateProviders.remove(provider.instanceID)
         if provider == .codex {
             self.codexAccountSnapshots = []
             self.lastCodexUsagePublicationGuard = nil
@@ -50,26 +50,26 @@ extension UsageStore {
             self.kiloScopeSnapshots = []
         }
         if provider == .claude {
-            self.widgetUsagePreservationBlockedProviders.insert(provider)
+            self.widgetUsagePreservationBlockedProviders.insert(provider.instanceID)
             self.clearClaudeSwapAccountState()
         }
         self.clearTokenSnapshot(for: provider)
-        self.tokenErrors[provider] = nil
-        self.providerStorageFootprints.removeValue(forKey: provider)
-        self.failureGates[provider]?.reset()
-        self.tokenFailureGates[provider]?.reset()
-        self.statuses.removeValue(forKey: provider)
-        self.statusComponents.removeValue(forKey: provider)
+        self.tokenErrors[provider.instanceID] = nil
+        self.providerStorageFootprints.removeValue(forKey: provider.instanceID)
+        self.failureGates[provider.instanceID]?.reset()
+        self.tokenFailureGates[provider.instanceID]?.reset()
+        self.statuses.removeValue(forKey: provider.instanceID)
+        self.statusComponents.removeValue(forKey: provider.instanceID)
         self.clearSessionQuotaTransitionState(provider: provider)
         self.predictivePaceWarningNotifiedKeys = Set(
             self.predictivePaceWarningNotifiedKeys.filter { $0.provider != provider })
         self.quotaWarningState = self.quotaWarningState.filter { $0.key.provider != provider }
-        self.lastTokenFetchAt.removeValue(forKey: provider)
-        self.lastTokenFetchScope.removeValue(forKey: provider)
+        self.lastTokenFetchAt.removeValue(forKey: provider.instanceID)
+        self.lastTokenFetchScope.removeValue(forKey: provider.instanceID)
     }
 
     func providerCleanupRevision(for provider: UsageProvider) -> UInt64 {
-        self.providerCleanupRevisions[provider, default: 0]
+        self.providerCleanupRevisions[provider.instanceID, default: 0]
     }
 
     func providerCleanupRevisionIsCurrent(_ revision: UInt64, for provider: UsageProvider) -> Bool {
@@ -90,8 +90,8 @@ extension UsageStore {
             revision.enablementRevision == self.settings.providerEnablementRevision(for: provider)
     }
 
-    func clearDisabledProviderState(enabledProviders: Set<UsageProvider>) {
-        for provider in UsageProvider.allCases where !enabledProviders.contains(provider) {
+    func clearDisabledProviderState(enabledProviders: Set<ProviderInstanceID>) {
+        for provider in UsageProvider.allCases where !enabledProviders.contains(provider.instanceID) {
             if self.currentProviderRefreshAllowsDisabledPublication(provider) {
                 self.clearProviderRuntimeState(provider)
             } else {
@@ -101,10 +101,11 @@ extension UsageStore {
     }
 
     func clearUnavailableProviderState(
-        displayEnabledProviders: Set<UsageProvider>,
-        availableProviders: Set<UsageProvider>)
+        displayEnabledProviders: Set<ProviderInstanceID>,
+        availableProviders: Set<ProviderInstanceID>)
     {
-        for provider in displayEnabledProviders where !availableProviders.contains(provider) {
+        for instanceID in displayEnabledProviders where !availableProviders.contains(instanceID) {
+            guard let provider = instanceID.firstPartyProvider else { continue }
             self.clearProviderState(provider)
         }
     }

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -10,10 +10,11 @@ extension UsageStore {
     {
         let candidateSet = candidateProviders.map(Set.init)
         var highest: (provider: UsageProvider, usedPercent: Double)?
-        for provider in self.enabledProviders()
-            where candidateSet?.contains(provider) ?? true
-        {
-            guard let snapshot = self.snapshots[provider] else { continue }
+        for instanceID in self.enabledProviders() {
+            guard let provider = instanceID.firstPartyProvider,
+                  candidateSet?.contains(provider) ?? true,
+                  let snapshot = self.snapshots[instanceID]
+            else { continue }
             guard let window = self.menuBarMetricWindowForHighestUsage(
                 provider: provider,
                 snapshot: snapshot,

--- a/Sources/CodexBar/UsageStore+Hooks.swift
+++ b/Sources/CodexBar/UsageStore+Hooks.swift
@@ -87,12 +87,12 @@ extension UsageStore {
             return
         }
 
-        let wasOutage = self.providerStatusHadIssue[provider] ?? false
+        let wasOutage = self.providerStatusHadIssue[provider.instanceID] ?? false
         if isOutage, !wasOutage {
-            self.providerStatusHadIssue[provider] = true
+            self.providerStatusHadIssue[provider.instanceID] = true
             self.emitHook(.providerUnavailable, provider: provider, status: indicator.rawValue)
         } else if !isOutage, wasOutage {
-            self.providerStatusHadIssue[provider] = false
+            self.providerStatusHadIssue[provider.instanceID] = false
             self.emitHook(.providerRecovered, provider: provider, status: indicator.rawValue)
         }
     }

--- a/Sources/CodexBar/UsageStore+LimitResetIdentity.swift
+++ b/Sources/CodexBar/UsageStore+LimitResetIdentity.swift
@@ -11,7 +11,7 @@ extension UsageStore {
         if provider == .codex {
             return codexLimitResetOwnerKey?.rawValue
         }
-        let identity = snapshot.identity(for: provider)
+        let identity = snapshot.identity(for: provider.instanceID)
         return account?.id.uuidString.lowercased()
             ?? accountKey
             ?? identity?.accountEmail
@@ -24,7 +24,7 @@ extension UsageStore {
         account: ProviderTokenAccount?,
         snapshot: UsageSnapshot) -> String?
     {
-        let identity = snapshot.identity(for: provider)
+        let identity = snapshot.identity(for: provider.instanceID)
         return account?.label
             ?? identity?.accountEmail
             ?? identity?.accountOrganization

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -19,9 +19,9 @@ extension UsageStore {
         case .codex, .claude, .antigravity, .opencodego:
             true
         default:
-            if self.planUtilizationHistory[provider]?.isEmpty == false {
+            if self.planUtilizationHistory[provider.instanceID]?.isEmpty == false {
                 true
-            } else if self.settings.historicalTrackingEnabled, let snapshot = self.snapshots[provider] {
+            } else if self.settings.historicalTrackingEnabled, let snapshot = self.snapshots[provider.instanceID] {
                 !self.planUtilizationSeriesSamples(
                     provider: provider,
                     snapshot: snapshot,
@@ -60,10 +60,10 @@ extension UsageStore {
         // background load would record samples against an empty bucket and
         // overwrite real disk history.
         if !self.planUtilizationHistoryLoaded {
-            let providerBuckets = self.planUtilizationHistory[provider] ?? PlanUtilizationHistoryBuckets()
+            let providerBuckets = self.planUtilizationHistory[provider.instanceID] ?? PlanUtilizationHistoryBuckets()
             return PlanUtilizationHistorySelection(accountKey: nil, histories: providerBuckets.histories(for: nil))
         }
-        var providerBuckets = self.planUtilizationHistory[provider] ?? PlanUtilizationHistoryBuckets()
+        var providerBuckets = self.planUtilizationHistory[provider.instanceID] ?? PlanUtilizationHistoryBuckets()
         if provider == .claude,
            providerBuckets.preferredAccountKey == Self.planUtilizationUnscopedPreferredKey
            || Self.isClaudeOAuthPlanUtilizationAccountKey(providerBuckets.preferredAccountKey)
@@ -78,13 +78,13 @@ extension UsageStore {
         let originalProviderBuckets = providerBuckets
         let accountKey = self.resolvePlanUtilizationAccountKey(
             provider: provider,
-            snapshot: self.snapshots[provider],
+            snapshot: self.snapshots[provider.instanceID],
             preferredAccount: nil,
             providerBuckets: &providerBuckets)
-        self.planUtilizationHistory[provider] = providerBuckets
+        self.planUtilizationHistory[provider.instanceID] = providerBuckets
         if providerBuckets != originalProviderBuckets {
             self.planUtilizationHistoryRevision &+= 1
-            self.sessionEquivalentBurnCache.removeValue(forKey: provider)
+            self.sessionEquivalentBurnCache.removeValue(forKey: provider.instanceID)
             let snapshotToPersist = self.planUtilizationHistory
             Task {
                 await self.planUtilizationPersistenceCoordinator.enqueue(snapshotToPersist)
@@ -110,7 +110,7 @@ extension UsageStore {
                 return currentSelection
             }
         }
-        let providerBuckets = self.planUtilizationHistory[provider] ?? PlanUtilizationHistoryBuckets()
+        let providerBuckets = self.planUtilizationHistory[provider.instanceID] ?? PlanUtilizationHistoryBuckets()
         return PlanUtilizationHistorySelection(
             accountKey: accountKey,
             histories: providerBuckets.histories(for: accountKey))
@@ -126,7 +126,7 @@ extension UsageStore {
             return .unavailable
         }
         if self.settings.effectiveSelectedTokenAccount(for: provider) == nil,
-           let currentSnapshot = self.snapshots[provider],
+           let currentSnapshot = self.snapshots[provider.instanceID],
            Self.planUtilizationIdentityAccountKey(provider: provider, snapshot: currentSnapshot) == accountKey
         {
             let currentSelection = self.planUtilizationHistorySelection(for: provider)
@@ -134,7 +134,7 @@ extension UsageStore {
                 return currentSelection
             }
         }
-        let providerBuckets = self.planUtilizationHistory[provider] ?? PlanUtilizationHistoryBuckets()
+        let providerBuckets = self.planUtilizationHistory[provider.instanceID] ?? PlanUtilizationHistoryBuckets()
         return PlanUtilizationHistorySelection(
             accountKey: accountKey,
             histories: providerBuckets.histories(for: accountKey))
@@ -187,13 +187,13 @@ extension UsageStore {
     }
 
     func shouldShowRefreshingMenuCard(for provider: UsageProvider) -> Bool {
-        self.refreshingProviders.contains(provider)
-            && self.snapshots[provider] == nil
+        self.refreshingProviders.contains(provider.instanceID)
+            && self.snapshots[provider.instanceID] == nil
             && self.error(for: provider) == nil
     }
 
     func shouldShowRefreshingMenuCardIndicator(for provider: UsageProvider) -> Bool {
-        self.refreshingProviders.contains(provider) && self.error(for: provider) == nil
+        self.refreshingProviders.contains(provider.instanceID) && self.error(for: provider) == nil
     }
 
     func shouldHidePlanUtilizationMenuItem(for provider: UsageProvider) -> Bool {
@@ -285,9 +285,9 @@ extension UsageStore {
             _ = await self.planUtilizationHistoryLoadTask?.result
         }
 
-        var snapshotToPersist: [UsageProvider: PlanUtilizationHistoryBuckets]?
+        var snapshotToPersist: [ProviderInstanceID: PlanUtilizationHistoryBuckets]?
         await MainActor.run {
-            var providerBuckets = self.planUtilizationHistory[provider] ?? PlanUtilizationHistoryBuckets()
+            var providerBuckets = self.planUtilizationHistory[provider.instanceID] ?? PlanUtilizationHistoryBuckets()
             let originalProviderBuckets = providerBuckets
             let preferredAccount = account ?? self.settings.effectiveSelectedTokenAccount(for: provider)
             let accountKey = self.resolvePlanUtilizationAccountKey(
@@ -318,7 +318,7 @@ extension UsageStore {
                     providerBuckets: &providerBuckets,
                     histories: &histories,
                     samples: &samplesToPersist)
-                self.sessionEquivalentBurnCache.removeValue(forKey: provider)
+                self.sessionEquivalentBurnCache.removeValue(forKey: provider.instanceID)
             }
 
             let updatedHistories = Self.updatedPlanUtilizationHistories(
@@ -329,7 +329,7 @@ extension UsageStore {
             }
 
             guard providerBuckets != originalProviderBuckets else { return }
-            self.planUtilizationHistory[provider] = providerBuckets
+            self.planUtilizationHistory[provider.instanceID] = providerBuckets
             self.planUtilizationHistoryRevision &+= 1
             snapshotToPersist = self.planUtilizationHistory
         }
@@ -767,7 +767,7 @@ extension UsageStore {
         if let accountKey {
             return accountKey
         }
-        let resolvedSnapshot = snapshot ?? self.snapshots[provider]
+        let resolvedSnapshot = snapshot ?? self.snapshots[provider.instanceID]
         return resolvedSnapshot.flatMap { Self.planUtilizationIdentityAccountKey(provider: provider, snapshot: $0) }
     }
 
@@ -806,7 +806,7 @@ extension UsageStore {
         provider: UsageProvider,
         snapshot: UsageSnapshot) -> String?
     {
-        guard let identity = snapshot.identity(for: provider) else { return nil }
+        guard let identity = snapshot.identity(for: provider.instanceID) else { return nil }
 
         let normalizedEmail = identity.accountEmail?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1591,14 +1591,14 @@ extension UsageStore {
 
 actor PlanUtilizationHistoryPersistenceCoordinator {
     private let store: PlanUtilizationHistoryStore
-    private var pendingSnapshot: [UsageProvider: PlanUtilizationHistoryBuckets]?
+    private var pendingSnapshot: [ProviderInstanceID: PlanUtilizationHistoryBuckets]?
     private var isPersisting: Bool = false
 
     init(store: PlanUtilizationHistoryStore) {
         self.store = store
     }
 
-    func enqueue(_ snapshot: [UsageProvider: PlanUtilizationHistoryBuckets]) {
+    func enqueue(_ snapshot: [ProviderInstanceID: PlanUtilizationHistoryBuckets]) {
         self.pendingSnapshot = snapshot
         guard !self.isPersisting else { return }
         self.isPersisting = true
@@ -1617,7 +1617,7 @@ actor PlanUtilizationHistoryPersistenceCoordinator {
         self.isPersisting = false
     }
 
-    private func saveAsync(_ snapshot: [UsageProvider: PlanUtilizationHistoryBuckets]) async {
+    private func saveAsync(_ snapshot: [ProviderInstanceID: PlanUtilizationHistoryBuckets]) async {
         let store = self.store
         await Task.detached(priority: .utility) {
             store.save(snapshot)

--- a/Sources/CodexBar/UsageStore+ProviderRuntime.swift
+++ b/Sources/CodexBar/UsageStore+ProviderRuntime.swift
@@ -2,13 +2,14 @@ import CodexBarCore
 
 extension UsageStore {
     func performRuntimeAction(_ action: ProviderRuntimeAction, for provider: UsageProvider) async {
-        guard let runtime = self.providerRuntimes[provider] else { return }
+        guard let runtime = self.providerRuntimes[provider.instanceID] else { return }
         let context = ProviderRuntimeContext(provider: provider, settings: self.settings, store: self)
         await runtime.perform(action: action, context: context)
     }
 
     func updateProviderRuntimes() {
-        for (provider, runtime) in self.providerRuntimes {
+        for (instanceID, runtime) in self.providerRuntimes {
+            guard let provider = instanceID.firstPartyProvider else { continue }
             let context = ProviderRuntimeContext(provider: provider, settings: self.settings, store: self)
             if self.isEnabled(provider) {
                 runtime.start(context: context)

--- a/Sources/CodexBar/UsageStore+ProviderStatus.swift
+++ b/Sources/CodexBar/UsageStore+ProviderStatus.swift
@@ -22,19 +22,19 @@ extension UsageStore {
                 return
             }
             guard self.statusRefreshPublicationIsCurrent(publicationRevision, for: provider) else { return }
-            self.statuses[provider] = status
+            self.statuses[provider.instanceID] = status
             // A component endpoint is best-effort. Preserve the last good list when the
             // overall status succeeds but the component request or decoding fails.
             if let components {
-                self.statusComponents[provider] = components
+                self.statusComponents[provider.instanceID] = components
             }
             self.emitProviderStatusHooks(provider: provider, indicator: status.indicator)
         } catch {
             guard self.statusRefreshPublicationIsCurrent(publicationRevision, for: provider) else { return }
             self.recordStartupConnectivityRetryableFailure(error)
             // Keep the previous status to avoid flapping when the API hiccups.
-            if self.statuses[provider] == nil {
-                self.statuses[provider] = ProviderStatus(
+            if self.statuses[provider.instanceID] == nil {
+                self.statuses[provider.instanceID] = ProviderStatus(
                     indicator: .unknown,
                     description: error.localizedDescription,
                     updatedAt: nil)

--- a/Sources/CodexBar/UsageStore+ProviderStorage.swift
+++ b/Sources/CodexBar/UsageStore+ProviderStorage.swift
@@ -21,7 +21,7 @@ extension UsageStore {
 
     func storageFootprint(for provider: UsageProvider) -> ProviderStorageFootprint? {
         guard self.settings.providerStorageFootprintsEnabled else { return nil }
-        return self.providerStorageFootprints[provider]
+        return self.providerStorageFootprints[provider.instanceID]
     }
 
     func storageFootprintText(for provider: UsageProvider) -> String? {
@@ -33,15 +33,15 @@ extension UsageStore {
     }
 
     func refreshStorageFootprintsForOverview() {
-        self.scheduleStorageFootprintRefresh(for: self.enabledProvidersForDisplay())
+        self.scheduleStorageFootprintRefresh(for: self.enabledFirstPartyProvidersForDisplay())
     }
 
     func refreshStorageFootprintsForOverviewNow() async {
-        await self.refreshStorageFootprintsNow(for: self.enabledProvidersForDisplay())
+        await self.refreshStorageFootprintsNow(for: self.enabledFirstPartyProvidersForDisplay())
     }
 
     func scheduleStorageFootprintRefreshForOverview(force: Bool = false) {
-        self.scheduleStorageFootprintRefresh(for: self.enabledProvidersForDisplay(), force: force)
+        self.scheduleStorageFootprintRefresh(for: self.enabledFirstPartyProvidersForDisplay(), force: force)
     }
 
     func refreshStorageFootprintsNow(for providers: [UsageProvider]) async {
@@ -181,18 +181,18 @@ extension UsageStore {
         requestKey: String? = nil,
         updatedAt: Date)
     {
-        let providerSet = Set(providers)
+        let providerSet = Set(providers.map(\.instanceID))
         var updated = self.providerStorageFootprints.filter { !providerSet.contains($0.key) }
         for provider in providers {
             // Reuse the existing footprint when only its scan timestamp would change, so the equality
             // guard below treats an unchanged scan as a no-op.
             if let incoming = footprints[provider],
-               let existing = self.providerStorageFootprints[provider],
+               let existing = self.providerStorageFootprints[provider.instanceID],
                existing.hasSameContents(as: incoming)
             {
-                updated[provider] = existing
+                updated[provider.instanceID] = existing
             } else {
-                updated[provider] = footprints[provider]
+                updated[provider.instanceID] = footprints[provider]
             }
         }
         // Only republish the observable footprints when a value actually changed. Storage scans run

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -148,21 +148,21 @@ extension UsageStore {
         // capturing the publication revision so the request cannot invalidate itself.
         self.prepareRefreshState(for: provider)
         while coalesceIfRefreshing,
-              let existingState = self.providerRefreshCoordinator.coalescingState(for: provider)
+              let existingState = self.providerRefreshCoordinator.coalescingState(for: provider.instanceID)
         {
-            switch await self.providerRefreshCoordinator.wait(for: provider, state: existingState) {
+            switch await self.providerRefreshCoordinator.wait(for: provider.instanceID, state: existingState) {
             case .cancelled:
                 return
             case .retryRequired:
-                self.providerRefreshCoordinator.remove(existingState, for: provider)
+                self.providerRefreshCoordinator.remove(existingState, for: provider.instanceID)
                 continue
             case .completed:
                 return
             }
         }
 
-        let request = self.providerRefreshCoordinator.beginReplacingRequest(for: provider)
-        self.providerRefreshPublicationContexts[provider] = ProviderRefreshPublicationContext(
+        let request = self.providerRefreshCoordinator.beginReplacingRequest(for: provider.instanceID)
+        self.providerRefreshPublicationContexts[provider.instanceID] = ProviderRefreshPublicationContext(
             generation: request.generation,
             enablementRevision: self.settings.providerEnablementRevision(for: provider),
             configRevision: self.settings.providerConfigRevision(for: provider),
@@ -178,12 +178,12 @@ extension UsageStore {
                 await predecessorState.waitForTaskCompletion()
             }
             if !Task.isCancelled,
-               self.providerRefreshCoordinator.isCurrent(request.generation, for: provider)
+               self.providerRefreshCoordinator.isCurrent(request.generation, for: provider.instanceID)
             {
                 // A replacement can wait behind a predecessor while Settings changes. Capture
                 // the publication inputs at actual fetch start so that queued work uses the new
                 // configuration, while later changes still reject its suspended result.
-                self.providerRefreshPublicationContexts[provider] = ProviderRefreshPublicationContext(
+                self.providerRefreshPublicationContexts[provider.instanceID] = ProviderRefreshPublicationContext(
                     generation: request.generation,
                     enablementRevision: self.settings.providerEnablementRevision(for: provider),
                     configRevision: self.settings.providerConfigRevision(for: provider),
@@ -191,7 +191,7 @@ extension UsageStore {
                         ? self.tokenSnapshotScopeSignature(for: provider)
                         : nil,
                     allowDisabled: allowDisabled)
-                snapshotUpdatedAtBeforeRefresh = self.snapshot(for: provider)?.updatedAt
+                snapshotUpdatedAtBeforeRefresh = self.snapshot(for: provider.instanceID)?.updatedAt
                 didStartRefresh = true
                 await ProviderRefreshRequestContext.withNewRequest {
                     await self.refreshProviderTracked(
@@ -201,24 +201,24 @@ extension UsageStore {
                 }
             }
             let publishedNewSnapshot = didStartRefresh &&
-                self.snapshot(for: provider)?.updatedAt != snapshotUpdatedAtBeforeRefresh
+                self.snapshot(for: provider.instanceID)?.updatedAt != snapshotUpdatedAtBeforeRefresh
             let retryRequired = !publishedNewSnapshot &&
                 (Task.isCancelled || !self.isCurrentProviderRefreshGeneration(
                     provider,
                     generation: request.generation))
             self.providerRefreshCoordinator.complete(
                 request.state,
-                for: provider,
+                for: provider.instanceID,
                 retryRequired: retryRequired)
         }
         request.state.install(task: task)
-        _ = await self.providerRefreshCoordinator.wait(for: provider, state: request.state)
+        _ = await self.providerRefreshCoordinator.wait(for: provider.instanceID, state: request.state)
     }
 
     func isCurrentProviderRefreshGeneration(_ provider: UsageProvider, generation: UInt64?) -> Bool {
         guard let generation else { return true }
-        guard self.providerRefreshCoordinator.isCurrent(generation, for: provider),
-              let context = self.providerRefreshPublicationContexts[provider],
+        guard self.providerRefreshCoordinator.isCurrent(generation, for: provider.instanceID),
+              let context = self.providerRefreshPublicationContexts[provider.instanceID],
               context.generation == generation
         else {
             return false
@@ -230,9 +230,9 @@ extension UsageStore {
     }
 
     func currentProviderRefreshAllowsDisabledPublication(_ provider: UsageProvider) -> Bool {
-        guard let context = self.providerRefreshPublicationContexts[provider],
+        guard let context = self.providerRefreshPublicationContexts[provider.instanceID],
               context.allowDisabled,
-              let state = self.providerRefreshCoordinator.coalescingState(for: provider),
+              let state = self.providerRefreshCoordinator.coalescingState(for: provider.instanceID),
               state.generation == context.generation
         else {
             return false
@@ -245,12 +245,12 @@ extension UsageStore {
         allowDisabled: Bool,
         generation: UInt64) async
     {
-        if self.providerRefreshCoordinator.beginActivity(for: provider) {
-            self.refreshingProviders.insert(provider)
+        if self.providerRefreshCoordinator.beginActivity(for: provider.instanceID) {
+            self.refreshingProviders.insert(provider.instanceID)
         }
         defer {
-            if self.providerRefreshCoordinator.endActivity(for: provider) {
-                self.refreshingProviders.remove(provider)
+            if self.providerRefreshCoordinator.endActivity(for: provider.instanceID) {
+                self.refreshingProviders.remove(provider.instanceID)
             }
         }
         var retryMode: ProviderRefreshRetryMode?
@@ -393,7 +393,7 @@ extension UsageStore {
             hasSelectedTokenAccount: tokenAccount != nil,
             hasAdminAPIKey: claudeHasAdminAPIKey)
         let priorClaudeSourceLabel = provider == .claude ? self.lastSourceLabels[.claude] : nil
-        self.diagnostics[provider] = nil
+        self.diagnostics[provider.instanceID] = nil
         let claudeAuthStateBeforeFetch = claudeActiveAccountIdentitySourceEligible
             ? await Self.captureClaudeRefreshAuthState(
                 invalidateCredentialsFile: true,
@@ -689,18 +689,18 @@ extension UsageStore {
                     generation: context.generation)
                 return nil
             }
-            self.lastFetchAttempts[provider] = attempts
+            self.lastFetchAttempts[provider.instanceID] = attempts
             let resetBackfillSource = if provider == .codex {
                 context.codexLimitResetOwnerKey == nil
                     ? nil
                     : self.codexLastKnownResetSnapshot(matching: context.codexExpectedGuard)
             } else {
-                self.lastKnownResetSnapshots[provider]
+                self.lastKnownResetSnapshots[provider.instanceID]
             }
             let profileStable = self.preservingDeepSeekProfileCatalog(in: accountScoped, provider: provider)
             let stabilized = Self.commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
                 current: profileStable,
-                previous: self.snapshots[provider])
+                previous: self.snapshots[provider.instanceID])
             let backfilled = stabilized.backfillingResetTimes(from: resetBackfillSource)
             let warningAccountDiscriminator = Self.warningAccountDiscriminator(
                 provider: provider,
@@ -722,23 +722,23 @@ extension UsageStore {
             if provider == .codex {
                 self.handleCodexResetCreditNotifications(snapshot: backfilled)
             }
-            self.lastKnownResetSnapshots[provider] = backfilled
-            self.snapshots[provider] = backfilled
-            self.widgetUsagePreservationBlockedProviders.remove(provider)
+            self.lastKnownResetSnapshots[provider.instanceID] = backfilled
+            self.snapshots[provider.instanceID] = backfilled
+            self.widgetUsagePreservationBlockedProviders.remove(provider.instanceID)
             if provider == .deepseek {
                 self.clearDeepSeekProfileTransition()
             }
             if let tokenSnapshot = self.tokenSnapshot(fromProviderSnapshot: backfilled, provider: provider) {
                 self.publishTokenSnapshot(tokenSnapshot, for: provider)
-                self.tokenErrors[provider] = nil
-                self.tokenFailureGates[provider]?.recordSuccess()
+                self.tokenErrors[provider.instanceID] = nil
+                self.tokenFailureGates[provider.instanceID]?.recordSuccess()
             } else if Self.tokenCostRequiresProviderSnapshot(provider) {
                 self.publishConfirmedEmptyTokenSnapshot(for: provider)
-                self.tokenErrors[provider] = nil
+                self.tokenErrors[provider.instanceID] = nil
             }
-            self.lastSourceLabels[provider] = result.sourceLabel
-            self.errors[provider] = nil
-            self.diagnostics[provider] = result.diagnostic
+            self.lastSourceLabels[provider.instanceID] = result.sourceLabel
+            self.errors[provider.instanceID] = nil
+            self.diagnostics[provider.instanceID] = result.diagnostic
             if let tokenAccount = currentTokenAccount {
                 self.cacheTokenAccountSnapshot(
                     provider: provider,
@@ -749,8 +749,8 @@ extension UsageStore {
             if provider == .gemini {
                 self.clearGeminiConsumerTierDeprecationObservation()
             }
-            self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
-            self.failureGates[provider]?.recordSuccess()
+            self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider.instanceID)
+            self.failureGates[provider.instanceID]?.recordSuccess()
             if provider == .codex {
                 self.rememberLiveSystemCodexEmailIfNeeded(scoped.accountEmail(for: .codex))
                 self.seedCodexAccountScopedRefreshGuard(accountEmail: scoped.accountEmail(for: .codex))
@@ -793,7 +793,7 @@ extension UsageStore {
             isClaudeOAuthSample: isClaudeOAuthSample,
             codexLimitResetOwnerKey: context.codexLimitResetOwnerKey)
         guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
-        if let runtime = self.providerRuntimes[provider] {
+        if let runtime = self.providerRuntimes[provider.instanceID] {
             let runtimeContext = ProviderRuntimeContext(
                 provider: provider, settings: self.settings, store: self)
             runtime.providerDidRefresh(context: runtimeContext, provider: provider)
@@ -834,7 +834,7 @@ extension UsageStore {
         self.bindCodexFailurePublicationOwner(
             provider: provider,
             expectedGuard: context.codexExpectedGuard)
-        self.lastFetchAttempts[provider] = attempts
+        self.lastFetchAttempts[provider.instanceID] = attempts
         self.recordStartupConnectivityRetryableFailure(error)
         await self.handleProviderFetchFailure(
             provider: provider,
@@ -1309,17 +1309,17 @@ extension UsageStore {
         let shouldNotifyPermissionPrompt = Self.isPermissionPromptWaiting(error)
         await MainActor.run {
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
-            self.diagnostics[provider] = nil
+            self.diagnostics[provider.instanceID] = nil
             if provider == .gemini, Self.isGeminiConsumerTierDeprecationError(error) {
                 // This is a durable provider migration signal, not a transient fetch failure.
                 // Surface it immediately so a cached snapshot cannot hide the required handoff.
                 self.observeGeminiConsumerTierDeprecation(from: error)
-                self.errors[provider] = error.localizedDescription
-                self.snapshots.removeValue(forKey: provider)
-                self.lastKnownResetSnapshots.removeValue(forKey: provider)
-                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
-                self.lastSourceLabels.removeValue(forKey: provider)
-                self.failureGates[provider]?.reset()
+                self.errors[provider.instanceID] = error.localizedDescription
+                self.snapshots.removeValue(forKey: provider.instanceID)
+                self.lastKnownResetSnapshots.removeValue(forKey: provider.instanceID)
+                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider.instanceID)
+                self.lastSourceLabels.removeValue(forKey: provider.instanceID)
+                self.failureGates[provider.instanceID]?.reset()
                 return
             }
             if provider == .claude,
@@ -1328,45 +1328,46 @@ extension UsageStore {
                 if let (account, cached) = self.validatedClaudeOAuthTokenAccountFallback(context: context),
                    let snapshot = cached.snapshot
                 {
-                    self.snapshots[provider] = snapshot
-                    self.lastKnownResetSnapshots[provider] = snapshot
-                    self.lastSourceLabels[provider] = "oauth"
+                    self.snapshots[provider.instanceID] = snapshot
+                    self.lastKnownResetSnapshots[provider.instanceID] = snapshot
+                    self.lastSourceLabels[provider.instanceID] = "oauth"
                     self.cacheTokenAccountSnapshot(
                         provider: provider,
                         account: account,
                         snapshot: snapshot,
                         sourceLabel: "oauth")
-                    self.errors[provider] = nil
-                    self.failureGates[provider]?.reset()
+                    self.errors[provider.instanceID] = nil
+                    self.failureGates[provider.instanceID]?.reset()
                     return
                 }
                 // Credential-change cleanup runs before failure handling and removes all unscoped Claude state.
                 // A surviving OAuth snapshot therefore belongs to the credential observed across this refresh.
                 if context.tokenAccount == nil,
-                   self.snapshots[provider] != nil,
-                   self.lastSourceLabels[provider] == "oauth"
+                   self.snapshots[provider.instanceID] != nil,
+                   self.lastSourceLabels[provider.instanceID] == "oauth"
                 {
-                    self.errors[provider] = nil
-                    self.failureGates[provider]?.reset()
+                    self.errors[provider.instanceID] = nil
+                    self.failureGates[provider.instanceID]?.reset()
                     return
                 }
             }
-            let hadKnownUnavailableLimits = self.knownLimitsAvailabilityByProvider[provider]?.isUnavailable == true
-            self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
+            let hadKnownUnavailableLimits = self.knownLimitsAvailabilityByProvider[provider.instanceID]?
+                .isUnavailable == true
+            self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider.instanceID)
             if provider == .claude,
                ClaudeStatusProbe.isSubscriptionQuotaUnavailableDescription(error.localizedDescription)
             {
                 // This is a successful answer about quota availability, not a transient probe failure.
                 // Drop prior limits immediately so an Education subscription notice cannot leave stale bars visible.
-                self.snapshots.removeValue(forKey: provider)
-                self.lastKnownResetSnapshots.removeValue(forKey: provider)
+                self.snapshots.removeValue(forKey: provider.instanceID)
+                self.lastKnownResetSnapshots.removeValue(forKey: provider.instanceID)
                 self.clearSessionQuotaTransitionState(provider: provider)
                 self.quotaWarningState = self.quotaWarningState.filter { $0.key.provider != provider }
-                self.lastSourceLabels.removeValue(forKey: provider)
-                self.errors[provider] = nil
-                self.knownLimitsAvailabilityByProvider[provider] = .unavailable
-                self.widgetUsagePreservationBlockedProviders.insert(provider)
-                self.failureGates[provider]?.reset()
+                self.lastSourceLabels.removeValue(forKey: provider.instanceID)
+                self.errors[provider.instanceID] = nil
+                self.knownLimitsAvailabilityByProvider[provider.instanceID] = .unavailable
+                self.widgetUsagePreservationBlockedProviders.insert(provider.instanceID)
+                self.failureGates[provider.instanceID]?.reset()
                 return
             }
             if provider == .claude,
@@ -1374,11 +1375,11 @@ extension UsageStore {
                Self.shouldPreservePriorSnapshot(after: error, hadPriorData: true) ||
                Self.isClaudeCLIRateLimitFailure(error)
             {
-                self.errors[provider] = nil
-                self.knownLimitsAvailabilityByProvider[provider] = .unavailable
+                self.errors[provider.instanceID] = nil
+                self.knownLimitsAvailabilityByProvider[provider.instanceID] = .unavailable
                 return
             }
-            let hadPriorData = self.snapshots[provider] != nil
+            let hadPriorData = self.snapshots[provider.instanceID] != nil
             let isTerminalClaudeCLIParseFailure =
                 provider == .claude &&
                 hadPriorData &&
@@ -1392,7 +1393,7 @@ extension UsageStore {
                     (Self.isClaudeCLIRateLimitFailure(error) ||
                         isTerminalClaudeCLIParseFailure))
             let shouldSurface =
-                self.failureGates[provider]?
+                self.failureGates[provider.instanceID]?
                     .shouldSurfaceError(onFailureWithPriorData: hadPriorData) ?? true
             let preservesClaudeWebSessionFailure =
                 provider == .claude &&
@@ -1401,24 +1402,24 @@ extension UsageStore {
             if preservesClaudeWebSessionFailure,
                !shouldSurface
             {
-                self.errors[provider] = nil
+                self.errors[provider.instanceID] = nil
                 return
             }
             if provider == .claude,
                preservesPriorData,
                Self.isClaudeUsageProbeTimeout(error) || Self.isClaudeCLIRateLimitFailure(error)
             {
-                self.errors[provider] = nil
+                self.errors[provider.instanceID] = nil
                 return
             }
             if preservesPriorData, !shouldSurface {
-                self.errors[provider] = nil
+                self.errors[provider.instanceID] = nil
                 return
             }
             if shouldSurface {
-                self.errors[provider] = error.localizedDescription
+                self.errors[provider.instanceID] = error.localizedDescription
                 if !preservesPriorData, !preservesClaudeWebSessionFailure {
-                    self.snapshots.removeValue(forKey: provider)
+                    self.snapshots.removeValue(forKey: provider.instanceID)
                     if Self.tokenCostRequiresProviderSnapshot(provider) {
                         self.clearTokenSnapshot(for: provider)
                     }
@@ -1428,14 +1429,14 @@ extension UsageStore {
                     provider: provider,
                     status: Self.refreshFailureHookStatus(error))
             } else {
-                self.errors[provider] = nil
+                self.errors[provider.instanceID] = nil
             }
             if shouldNotifyPermissionPrompt {
                 self.postPermissionPromptNotificationIfNeeded(provider: provider, error: error)
             }
         }
         guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
-        if let runtime = self.providerRuntimes[provider] {
+        if let runtime = self.providerRuntimes[provider.instanceID] {
             let context = ProviderRuntimeContext(
                 provider: provider, settings: self.settings, store: self)
             runtime.providerDidFail(context: context, provider: provider, error: error)
@@ -1463,7 +1464,7 @@ extension UsageStore {
         account: ProviderTokenAccount?) -> TokenAccountUsageSnapshot?
     {
         guard let account else { return nil }
-        return self.accountSnapshots[provider]?.first { cached in
+        return self.accountSnapshots[provider.instanceID]?.first { cached in
             cached.account.id == account.id &&
                 cached.cacheKey == self.tokenAccountSnapshotCacheKey(provider: provider, account: account)
         }
@@ -1582,12 +1583,12 @@ extension UsageStore {
 
     private func postPermissionPromptNotificationIfNeeded(provider: UsageProvider, error: Error) {
         let now = Date()
-        if let last = self.lastPermissionPromptNotificationAt[provider],
+        if let last = self.lastPermissionPromptNotificationAt[provider.instanceID],
            now.timeIntervalSince(last) < 10 * 60
         {
             return
         }
-        self.lastPermissionPromptNotificationAt[provider] = now
+        self.lastPermissionPromptNotificationAt[provider.instanceID] = now
         let providerName = ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
         AppNotifications.shared.post(
             idPrefix: "permission-prompt-\(provider.rawValue)",

--- a/Sources/CodexBar/UsageStore+ResetBoundaryRefresh.swift
+++ b/Sources/CodexBar/UsageStore+ResetBoundaryRefresh.swift
@@ -69,7 +69,7 @@ extension UsageStore {
     }
 
     nonisolated static func nextResetBoundaryRefreshDate(
-        snapshots: [UsageProvider: UsageSnapshot],
+        snapshots: [ProviderInstanceID: UsageSnapshot],
         normalRefreshInterval: TimeInterval?,
         minimumAutomaticRefreshInterval: TimeInterval? = nil,
         attemptedBoundaryRefreshes: Set<Date> = [],
@@ -90,7 +90,7 @@ extension UsageStore {
     }
 
     private nonisolated static func nextResetBoundaryRefreshCandidate(
-        snapshots: [UsageProvider: UsageSnapshot],
+        snapshots: [ProviderInstanceID: UsageSnapshot],
         normalRefreshInterval: TimeInterval?,
         minimumAutomaticRefreshInterval: TimeInterval?,
         attemptedBoundaryRefreshes: Set<Date> = [],

--- a/Sources/CodexBar/UsageStore+SessionEquivalents.swift
+++ b/Sources/CodexBar/UsageStore+SessionEquivalents.swift
@@ -179,7 +179,7 @@ extension UsageStore {
     {
         guard ![UsageProvider.codex, .claude, .antigravity].contains(provider) else { return true }
         guard let historyIdentity else { return false }
-        let persistedIdentity = self.planUtilizationHistory[provider]?
+        let persistedIdentity = self.planUtilizationHistory[provider.instanceID]?
             .sessionEquivalentWindowPairIdentity(for: accountKey)
         return (persistedIdentity ?? self.legacySessionEquivalentHistoryIdentity(
             provider: provider,

--- a/Sources/CodexBar/UsageStore+SessionQuotaTransition.swift
+++ b/Sources/CodexBar/UsageStore+SessionQuotaTransition.swift
@@ -57,7 +57,7 @@ extension UsageStore {
             self.sessionQuotaLogger.debug("ignored stale session observation while awaiting a fresh Codex baseline")
             return
         }
-        let previousState = self.sessionQuotaTransitionStates[provider]
+        let previousState = self.sessionQuotaTransitionStates[provider.instanceID]
         let forceBaseline = provider == .codex && self.codexSessionQuotaBaselineRequirement != nil
         let evaluation = SessionQuotaTransitionReducer.evaluate(
             previous: previousState,
@@ -71,7 +71,7 @@ extension UsageStore {
                 codexOwnerKey: codexOwnerKey),
             notificationsEnabled: detectionEnabled,
             forceBaseline: forceBaseline)
-        self.sessionQuotaTransitionStates[provider] = evaluation.state
+        self.sessionQuotaTransitionStates[provider.instanceID] = evaluation.state
         if provider == .codex {
             self.codexSessionQuotaBaselineRequirement = nil
         }

--- a/Sources/CodexBar/UsageStore+TokenAccountCacheKey.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccountCacheKey.swift
@@ -1,0 +1,21 @@
+import CodexBarCore
+import CryptoKit
+import Foundation
+
+extension UsageStore {
+    func tokenAccountSnapshotCacheKey(provider: UsageProvider, account: ProviderTokenAccount) -> String {
+        var config = self.settings.configSnapshot.providerConfig(for: provider.instanceID)
+            ?? ProviderConfig(id: provider.instanceID)
+        // Active selection and sibling accounts must not invalidate a valid per-account snapshot.
+        config.tokenAccounts = nil
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        var material = Data(provider.rawValue.utf8)
+        material.append((try? encoder.encode(config)) ?? Data())
+        material.append((try? encoder.encode(account)) ?? Data())
+        if Self.tokenCostRequiresProviderSnapshot(provider) {
+            material.append(Data(self.tokenSnapshotScopeSignature(for: provider).utf8))
+        }
+        return SHA256.hash(data: material).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/CodexBar/UsageStore+TokenAccountLabels.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccountLabels.swift
@@ -9,11 +9,11 @@ extension UsageStore {
     {
         let label = account.label.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !label.isEmpty else { return snapshot }
-        let existing = snapshot.identity(for: provider)
+        let existing = snapshot.identity(for: provider.instanceID)
         let email = existing?.accountEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedEmail = (email?.isEmpty ?? true) ? label : email
         let identity = ProviderIdentitySnapshot(
-            providerID: provider,
+            providerID: provider.instanceID,
             accountEmail: resolvedEmail,
             accountOrganization: existing?.accountOrganization,
             loginMethod: existing?.loginMethod)

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -1,5 +1,4 @@
 import CodexBarCore
-import CryptoKit
 import Foundation
 
 struct TokenAccountUsageSnapshot: Identifiable {
@@ -45,41 +44,41 @@ struct CodexAccountUsageSnapshot: Identifiable {
 extension UsageStore {
     func activateCachedTokenAccountSnapshot(provider: UsageProvider, accountID: UUID) {
         guard self.settings.effectiveSelectedTokenAccount(for: provider)?.id == accountID else { return }
-        self.tokenAccountLiveStateProviders.insert(provider)
+        self.tokenAccountLiveStateProviders.insert(provider.instanceID)
         guard let account = self.uniqueTokenAccount(provider: provider, accountID: accountID),
-              let cached = self.accountSnapshots[provider]?.first(where: {
+              let cached = self.accountSnapshots[provider.instanceID]?.first(where: {
                   $0.account.id == accountID && $0.cacheKey == self.tokenAccountSnapshotCacheKey(
                       provider: provider,
                       account: account)
               })
         else {
-            self.accountSnapshots[provider]?.removeAll { $0.account.id == accountID }
-            self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
+            self.accountSnapshots[provider.instanceID]?.removeAll { $0.account.id == accountID }
+            self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider.instanceID)
             // Never show the previous account's usage under the newly selected account. Segmented layouts only
             // fetch the active account, so an uncached selection must render as refreshing until its fetch completes.
             self.clearTokenAccountLiveSnapshot(provider: provider)
             return
         }
 
-        self.knownLimitsAvailabilityByProvider[provider] = .resolve(
+        self.knownLimitsAvailabilityByProvider[provider.instanceID] = .resolve(
             provider: provider,
             snapshot: cached.snapshot,
             lastErrorDescription: cached.error)
 
         if let snapshot = cached.snapshot {
-            self.snapshots[provider] = snapshot
-            self.lastKnownResetSnapshots[provider] = snapshot
+            self.snapshots[provider.instanceID] = snapshot
+            self.lastKnownResetSnapshots[provider.instanceID] = snapshot
             self.installProviderDerivedTokenSnapshot(from: snapshot, for: provider)
         } else {
-            self.snapshots.removeValue(forKey: provider)
-            self.lastKnownResetSnapshots.removeValue(forKey: provider)
+            self.snapshots.removeValue(forKey: provider.instanceID)
+            self.lastKnownResetSnapshots.removeValue(forKey: provider.instanceID)
             self.resetProviderDerivedTokenSnapshot(for: provider)
         }
-        self.errors[provider] = cached.error
+        self.errors[provider.instanceID] = cached.error
         if let sourceLabel = cached.sourceLabel {
-            self.lastSourceLabels[provider] = sourceLabel
+            self.lastSourceLabels[provider.instanceID] = sourceLabel
         } else {
-            self.lastSourceLabels.removeValue(forKey: provider)
+            self.lastSourceLabels.removeValue(forKey: provider.instanceID)
         }
     }
 
@@ -96,21 +95,21 @@ extension UsageStore {
             error: nil,
             sourceLabel: sourceLabel,
             cacheKey: self.tokenAccountSnapshotCacheKey(provider: provider, account: account))
-        var snapshots = self.accountSnapshots[provider] ?? []
+        var snapshots = self.accountSnapshots[provider.instanceID] ?? []
         if let index = snapshots.firstIndex(where: { $0.account.id == account.id }) {
             snapshots[index] = cached
         } else {
             snapshots.append(cached)
         }
-        self.accountSnapshots[provider] = snapshots
+        self.accountSnapshots[provider.instanceID] = snapshots
     }
 
     func pruneTokenAccountSnapshots(provider: UsageProvider, accounts: [ProviderTokenAccount]) {
         let retained = self.validTokenAccountSnapshots(provider: provider, accounts: accounts)
         if retained.isEmpty {
-            self.accountSnapshots.removeValue(forKey: provider)
+            self.accountSnapshots.removeValue(forKey: provider.instanceID)
         } else {
-            self.accountSnapshots[provider] = retained
+            self.accountSnapshots[provider.instanceID] = retained
         }
     }
 
@@ -120,8 +119,8 @@ extension UsageStore {
     {
         self.pruneTokenAccountSnapshots(provider: provider, accounts: accounts)
         guard let selectedAccount = self.settings.effectiveSelectedTokenAccount(for: provider) else {
-            if self.tokenAccountLiveStateProviders.remove(provider) != nil {
-                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
+            if self.tokenAccountLiveStateProviders.remove(provider.instanceID) != nil {
+                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider.instanceID)
                 self.clearTokenAccountLiveSnapshot(provider: provider)
             }
             return
@@ -132,11 +131,11 @@ extension UsageStore {
     }
 
     private func clearTokenAccountLiveSnapshot(provider: UsageProvider) {
-        self.snapshots.removeValue(forKey: provider)
+        self.snapshots.removeValue(forKey: provider.instanceID)
         self.resetProviderDerivedTokenSnapshot(for: provider)
-        self.errors.removeValue(forKey: provider)
-        self.lastSourceLabels.removeValue(forKey: provider)
-        self.lastKnownResetSnapshots.removeValue(forKey: provider)
+        self.errors.removeValue(forKey: provider.instanceID)
+        self.lastSourceLabels.removeValue(forKey: provider.instanceID)
+        self.lastKnownResetSnapshots.removeValue(forKey: provider.instanceID)
     }
 
     func validTokenAccountSnapshots(
@@ -146,25 +145,10 @@ extension UsageStore {
         let accountsByID = Dictionary(grouping: accounts, by: \.id).compactMapValues { matches in
             matches.count == 1 ? matches[0] : nil
         }
-        return (self.accountSnapshots[provider] ?? []).filter { cached in
+        return (self.accountSnapshots[provider.instanceID] ?? []).filter { cached in
             guard let account = accountsByID[cached.account.id] else { return false }
             return cached.cacheKey == self.tokenAccountSnapshotCacheKey(provider: provider, account: account)
         }
-    }
-
-    func tokenAccountSnapshotCacheKey(provider: UsageProvider, account: ProviderTokenAccount) -> String {
-        var config = self.settings.configSnapshot.providerConfig(for: provider) ?? ProviderConfig(id: provider)
-        // Active selection and sibling accounts must not invalidate a valid per-account snapshot.
-        config.tokenAccounts = nil
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        var material = Data(provider.rawValue.utf8)
-        material.append((try? encoder.encode(config)) ?? Data())
-        material.append((try? encoder.encode(account)) ?? Data())
-        if Self.tokenCostRequiresProviderSnapshot(provider) {
-            material.append(Data(self.tokenSnapshotScopeSignature(for: provider).utf8))
-        }
-        return SHA256.hash(data: material).map { String(format: "%02x", $0) }.joined()
     }
 
     func uniqueTokenAccount(provider: UsageProvider, accountID: UUID) -> ProviderTokenAccount? {
@@ -588,7 +572,7 @@ extension UsageStore {
         let priorSnapshots = await MainActor.run {
             self.pruneTokenAccountSnapshots(provider: provider, accounts: accounts)
             self.activateCachedTokenAccountSnapshot(provider: provider, accountID: effectiveSelected.id)
-            return self.accountSnapshots[provider] ?? []
+            return self.accountSnapshots[provider.instanceID] ?? []
         }
         let priorByAccountID = Dictionary(uniqueKeysWithValues: priorSnapshots.map { ($0.account.id, $0) })
 
@@ -636,7 +620,7 @@ extension UsageStore {
             snapshots.allSatisfy { $0.snapshot == nil }
         if !shouldPreservePriorState {
             await MainActor.run {
-                self.accountSnapshots[provider] = snapshots
+                self.accountSnapshots[provider.instanceID] = snapshots
             }
         }
 
@@ -932,7 +916,7 @@ extension UsageStore {
             codexActiveSourceOverride: codexActiveSourceOverride)
         let fetcher = ProviderRegistry.makeFetcher(base: self.codexFetcher, provider: provider, env: env)
         let contextProvider = provider
-        let publicationGeneration = self.providerRefreshPublicationContexts[provider]?.generation
+        let publicationGeneration = self.providerRefreshPublicationContexts[provider.instanceID]?.generation
         let contextConfigRevision = self.settings.providerConfigRevision(for: provider)
         let originalAccountToken = account?.token
         let originalManualToken = provider == .stepfun ? self.settings.stepfunToken : nil
@@ -1005,7 +989,7 @@ extension UsageStore {
     {
         guard let generation else { return true }
         let currentConfigRevision = self.settings.providerConfigRevision(for: provider)
-        guard let publication = self.providerRefreshPublicationContexts[provider] else { return false }
+        guard let publication = self.providerRefreshPublicationContexts[provider.instanceID] else { return false }
         if publication.generation == generation {
             return publication.configRevision == currentConfigRevision
         }
@@ -1016,11 +1000,11 @@ extension UsageStore {
 
     private func advanceProviderRefreshConfigRevision(provider: UsageProvider, generation: UInt64?) {
         guard let generation,
-              var publication = self.providerRefreshPublicationContexts[provider],
+              var publication = self.providerRefreshPublicationContexts[provider.instanceID],
               publication.generation == generation
         else { return }
         publication.configRevision = self.settings.providerConfigRevision(for: provider)
-        self.providerRefreshPublicationContexts[provider] = publication
+        self.providerRefreshPublicationContexts[provider.instanceID] = publication
     }
 
     func sourceMode(for provider: UsageProvider) -> ProviderSourceMode {
@@ -1524,7 +1508,7 @@ extension UsageStore {
     {
         await MainActor.run {
             guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
-            self.lastFetchAttempts[provider] = outcome.attempts
+            self.lastFetchAttempts[provider.instanceID] = outcome.attempts
         }
         guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
         switch outcome.result {
@@ -1543,7 +1527,8 @@ extension UsageStore {
                     ? labeled.preservingDeepSeekPlatformProfiles(
                         from: self.presentationSnapshot(for: .deepseek))
                     : labeled
-                let backfilled = profileStable.backfillingResetTimes(from: self.lastKnownResetSnapshots[provider])
+                let backfilled = profileStable.backfillingResetTimes(
+                    from: self.lastKnownResetSnapshots[provider.instanceID])
                 let warningAccountDiscriminator = Self.warningTokenAccountDiscriminator(account)
                 self.handleQuotaWarningTransitions(
                     provider: provider,
@@ -1554,17 +1539,17 @@ extension UsageStore {
                     provider: provider,
                     snapshot: backfilled,
                     accountDiscriminatorOverride: provider == .claude ? warningAccountDiscriminator : nil)
-                self.lastKnownResetSnapshots[provider] = backfilled
-                self.snapshots[provider] = backfilled
-                self.widgetUsagePreservationBlockedProviders.remove(provider)
+                self.lastKnownResetSnapshots[provider.instanceID] = backfilled
+                self.snapshots[provider.instanceID] = backfilled
+                self.widgetUsagePreservationBlockedProviders.remove(provider.instanceID)
                 if provider == .deepseek {
                     self.clearDeepSeekProfileTransition()
                 }
                 self.publishProviderDerivedTokenSnapshot(from: backfilled, for: provider)
-                self.lastSourceLabels[provider] = result.sourceLabel
-                self.errors[provider] = nil
-                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
-                self.failureGates[provider]?.recordSuccess()
+                self.lastSourceLabels[provider.instanceID] = result.sourceLabel
+                self.errors[provider.instanceID] = nil
+                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider.instanceID)
+                self.failureGates[provider.instanceID]?.recordSuccess()
                 return backfilled
             }
             guard let backfilled else { return }
@@ -1586,35 +1571,35 @@ extension UsageStore {
                        account: currentAccount),
                    let fallback = fallbackAccountSnapshot.snapshot
                 {
-                    self.snapshots[provider] = fallback
-                    self.lastKnownResetSnapshots[provider] = fallback
-                    self.lastSourceLabels[provider] = "oauth"
+                    self.snapshots[provider.instanceID] = fallback
+                    self.lastKnownResetSnapshots[provider.instanceID] = fallback
+                    self.lastSourceLabels[provider.instanceID] = "oauth"
                     self.cacheTokenAccountSnapshot(
                         provider: provider,
                         account: currentAccount,
                         snapshot: fallback,
                         sourceLabel: "oauth")
-                    self.errors[provider] = nil
-                    self.failureGates[provider]?.reset()
+                    self.errors[provider.instanceID] = nil
+                    self.failureGates[provider.instanceID]?.reset()
                     return
                 }
-                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
+                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider.instanceID)
                 if provider == .deepseek {
                     self.markDeepSeekProfileTransitionUnavailable()
                 }
                 guard let message = self.tokenAccountErrorMessage(error) else {
-                    self.errors[provider] = nil
+                    self.errors[provider.instanceID] = nil
                     return
                 }
-                let hadPriorData = self.snapshots[provider] != nil || fallbackSnapshot != nil
-                let shouldSurface = self.failureGates[provider]?
+                let hadPriorData = self.snapshots[provider.instanceID] != nil || fallbackSnapshot != nil
+                let shouldSurface = self.failureGates[provider.instanceID]?
                     .shouldSurfaceError(onFailureWithPriorData: hadPriorData) ?? true
                 if shouldSurface {
-                    self.errors[provider] = message
-                    self.snapshots.removeValue(forKey: provider)
+                    self.errors[provider.instanceID] = message
+                    self.snapshots.removeValue(forKey: provider.instanceID)
                     self.clearProviderDerivedTokenSnapshot(for: provider)
                 } else {
-                    self.errors[provider] = nil
+                    self.errors[provider.instanceID] = nil
                 }
             }
         }

--- a/Sources/CodexBar/UsageStore+TokenCost.swift
+++ b/Sources/CodexBar/UsageStore+TokenCost.swift
@@ -29,11 +29,11 @@ extension UsageStore {
             return .proceed(nil)
         }
         guard let header = CookieHeaderNormalizer.normalize(self.settings.cursorCookieHeader) else {
-            self.lastTokenFetchAt.removeValue(forKey: provider)
-            self.lastTokenFetchScope.removeValue(forKey: provider)
+            self.lastTokenFetchAt.removeValue(forKey: provider.instanceID)
+            self.lastTokenFetchScope.removeValue(forKey: provider.instanceID)
             self.clearTokenSnapshot(for: provider)
-            self.tokenErrors[provider] = "Cursor cost requires a non-empty Manual cookie header."
-            self.tokenFailureGates[provider]?.reset()
+            self.tokenErrors[provider.instanceID] = "Cursor cost requires a non-empty Manual cookie header."
+            self.tokenFailureGates[provider.instanceID]?.reset()
             return .reject
         }
         return .proceed(header)
@@ -86,7 +86,7 @@ extension UsageStore {
     }
 
     func tokenSnapshot(for provider: UsageProvider) -> CostUsageTokenSnapshot? {
-        self.tokenSnapshots[provider]
+        self.tokenSnapshots[provider.instanceID]
     }
 
     func tokenSnapshotForCurrentProviderConfig(
@@ -103,7 +103,7 @@ extension UsageStore {
     func tokenSnapshotPublicationForCurrentProviderConfig(
         for provider: UsageProvider) -> CurrentProviderConfigTokenPublication?
     {
-        guard let publication = self.tokenSnapshotPublications[provider],
+        guard let publication = self.tokenSnapshotPublications[provider.instanceID],
               publication.providerConfigRevision == self.settings.providerConfigRevision(for: provider),
               publication.scopeSignature == self.tokenSnapshotScopeSignature(for: provider)
         else { return nil }
@@ -113,22 +113,22 @@ extension UsageStore {
     }
 
     func tokenSnapshotPublicationRevision(for provider: UsageProvider) -> UInt64 {
-        self.tokenSnapshotPublicationRevisions[provider] ?? 0
+        self.tokenSnapshotPublicationRevisions[provider.instanceID] ?? 0
     }
 
     func publishTokenSnapshot(_ snapshot: CostUsageTokenSnapshot, for provider: UsageProvider) {
-        self.tokenSnapshots[provider] = snapshot
+        self.tokenSnapshots[provider.instanceID] = snapshot
         self.publishTokenSnapshotState(snapshot, for: provider)
     }
 
     func publishConfirmedEmptyTokenSnapshot(for provider: UsageProvider) {
-        self.tokenSnapshots.removeValue(forKey: provider)
+        self.tokenSnapshots.removeValue(forKey: provider.instanceID)
         self.publishTokenSnapshotState(nil, for: provider)
     }
 
     private func publishTokenSnapshotState(_ snapshot: CostUsageTokenSnapshot?, for provider: UsageProvider) {
-        self.tokenSnapshotPublicationRevisions[provider, default: 0] &+= 1
-        self.tokenSnapshotPublications[provider] = TokenSnapshotPublication(
+        self.tokenSnapshotPublicationRevisions[provider.instanceID, default: 0] &+= 1
+        self.tokenSnapshotPublications[provider.instanceID] = TokenSnapshotPublication(
             snapshot: snapshot,
             publicationRevision: self.tokenSnapshotPublicationRevision(for: provider),
             providerConfigRevision: self.settings.providerConfigRevision(for: provider),
@@ -136,8 +136,8 @@ extension UsageStore {
     }
 
     func installCachedTokenSnapshot(_ snapshot: CostUsageTokenSnapshot, for provider: UsageProvider) {
-        self.tokenSnapshots[provider] = snapshot
-        self.tokenSnapshotPublications[provider] = TokenSnapshotPublication(
+        self.tokenSnapshots[provider.instanceID] = snapshot
+        self.tokenSnapshotPublications[provider.instanceID] = TokenSnapshotPublication(
             snapshot: snapshot,
             publicationRevision: self.tokenSnapshotPublicationRevision(for: provider),
             providerConfigRevision: self.settings.providerConfigRevision(for: provider),
@@ -145,8 +145,8 @@ extension UsageStore {
     }
 
     func clearTokenSnapshot(for provider: UsageProvider) {
-        self.tokenSnapshots.removeValue(forKey: provider)
-        self.tokenSnapshotPublications.removeValue(forKey: provider)
+        self.tokenSnapshots.removeValue(forKey: provider.instanceID)
+        self.tokenSnapshotPublications.removeValue(forKey: provider.instanceID)
     }
 
     func clearTokenSnapshots() {
@@ -161,8 +161,8 @@ extension UsageStore {
         } else {
             self.clearTokenSnapshot(for: provider)
         }
-        self.tokenErrors[provider] = nil
-        self.tokenFailureGates[provider]?.recordSuccess()
+        self.tokenErrors[provider.instanceID] = nil
+        self.tokenFailureGates[provider.instanceID]?.recordSuccess()
     }
 
     func publishProviderDerivedTokenSnapshot(from snapshot: UsageSnapshot, for provider: UsageProvider) {
@@ -172,15 +172,15 @@ extension UsageStore {
         } else {
             self.publishConfirmedEmptyTokenSnapshot(for: provider)
         }
-        self.tokenErrors[provider] = nil
-        self.tokenFailureGates[provider]?.recordSuccess()
+        self.tokenErrors[provider.instanceID] = nil
+        self.tokenFailureGates[provider.instanceID]?.recordSuccess()
     }
 
     func resetProviderDerivedTokenSnapshot(for provider: UsageProvider) {
         guard Self.tokenCostRequiresProviderSnapshot(provider) else { return }
         self.clearTokenSnapshot(for: provider)
-        self.tokenErrors[provider] = nil
-        self.tokenFailureGates[provider]?.reset()
+        self.tokenErrors[provider.instanceID] = nil
+        self.tokenFailureGates[provider.instanceID]?.reset()
     }
 
     func clearProviderDerivedTokenSnapshot(for provider: UsageProvider) {
@@ -189,11 +189,11 @@ extension UsageStore {
     }
 
     func tokenError(for provider: UsageProvider) -> String? {
-        self.tokenErrors[provider]
+        self.tokenErrors[provider.instanceID]
     }
 
     func tokenLastAttemptAt(for provider: UsageProvider) -> Date? {
-        self.lastTokenFetchAt[provider]
+        self.lastTokenFetchAt[provider.instanceID]
     }
 
     @discardableResult
@@ -265,11 +265,11 @@ extension UsageStore {
     }
 
     func isTokenRefreshInFlight(for provider: UsageProvider) -> Bool {
-        self.tokenRefreshInFlight.contains(provider)
+        self.tokenRefreshInFlight.contains(provider.instanceID)
     }
 
     func tokenCostRefreshIsActive(for provider: UsageProvider) -> Bool {
-        if self.tokenRefreshInFlight.contains(provider) {
+        if self.tokenRefreshInFlight.contains(provider.instanceID) {
             return true
         }
         return provider == .codex && self.codexCostCatchUpActivity?.phase == .indexing
@@ -354,8 +354,8 @@ extension UsageStore {
         costScopeSignature: String) -> Bool
     {
         guard self.tokenSnapshotPublicationForCurrentProviderConfig(for: provider) != nil,
-              let last = self.lastTokenFetchAt[provider],
-              self.lastTokenFetchScope[provider] == costScopeSignature
+              let last = self.lastTokenFetchAt[provider.instanceID],
+              self.lastTokenFetchScope[provider.instanceID] == costScopeSignature
         else {
             return false
         }

--- a/Sources/CodexBar/UsageStore+TokenRefreshSequence.swift
+++ b/Sources/CodexBar/UsageStore+TokenRefreshSequence.swift
@@ -4,8 +4,8 @@ import Foundation
 extension UsageStore {
     private enum TokenRefreshSequenceScope: Sendable {
         case all
-        case provider(UsageProvider)
-        case providers([UsageProvider])
+        case provider(ProviderInstanceID)
+        case providers([ProviderInstanceID])
     }
 
     func startTokenTimer() {
@@ -40,7 +40,7 @@ extension UsageStore {
         if force,
            self.tokenRefreshSequenceTask != nil,
            let activeProvider = self.tokenRefreshSequenceProvider,
-           activeProvider != provider
+           activeProvider != provider.instanceID
         {
             // A scoped user refresh can run beside unrelated scheduled work. The scheduled
             // sequence still owns the shared slot, so the timer cannot introduce a third pass.
@@ -48,7 +48,8 @@ extension UsageStore {
             self.scheduleMemoryPressureRelief()
             return
         }
-        guard let task = await self.serializedTokenRefreshTask(force: force, scope: .provider(provider)) else {
+        guard let task = await self.serializedTokenRefreshTask(force: force, scope: .provider(provider.instanceID))
+        else {
             return
         }
         await self.awaitTokenRefreshSequence(task)
@@ -75,7 +76,7 @@ extension UsageStore {
         force: Bool,
         scope: TokenRefreshSequenceScope) -> Task<Void, Never>
     {
-        let providers: [UsageProvider] = switch scope {
+        let providers: [ProviderInstanceID] = switch scope {
         case .all:
             self.enabledProvidersForBackgroundWork()
         case let .provider(provider):
@@ -114,7 +115,7 @@ extension UsageStore {
     }
 
     func requestTokenRefreshAfterStaleCompletion(for provider: UsageProvider) {
-        self.tokenRefreshRetryProviders.insert(provider)
+        self.tokenRefreshRetryProviders.insert(provider.instanceID)
         Task { @MainActor [weak self] in
             await Task.yield()
             self?.startPendingTokenRefreshRetryIfPossible()
@@ -138,13 +139,14 @@ extension UsageStore {
         return true
     }
 
-    private func refreshTokenUsageSequence(providers: [UsageProvider], force: Bool) async {
+    private func refreshTokenUsageSequence(providers: [ProviderInstanceID], force: Bool) async {
         defer { self.tokenRefreshSequenceProvider = nil }
-        for provider in providers {
+        for instanceID in providers {
             if Task.isCancelled {
                 break
             }
-            self.tokenRefreshSequenceProvider = provider
+            guard let provider = instanceID.firstPartyProvider else { continue }
+            self.tokenRefreshSequenceProvider = instanceID
             await self.refreshTokenUsage(provider, force: force)
             self.tokenRefreshSequenceProvider = nil
         }

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -58,13 +58,15 @@ extension UsageStore {
         let deviceID = self.settings.iCloudSyncDeviceID
         var payloads: [String: AccountSnapshotSyncPayload] = [:]
 
-        for (provider, usage) in self.snapshots {
+        for (instanceID, usage) in self.snapshots {
             let identity = usage.identity?.accountID ?? usage.identity?.accountEmail
             let label = usage.identity?.accountEmail
                 ?? usage.identity?.accountOrganization
-                ?? ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
+                ?? instanceID.firstPartyProvider
+                .map { ProviderDescriptorRegistry.descriptor(for: $0).metadata.displayName }
+                ?? instanceID.rawValue
             let payload = AccountSnapshotSyncPayload(
-                provider: provider,
+                provider: instanceID,
                 deviceID: deviceID,
                 accountIdentity: identity,
                 displayLabel: label,
@@ -95,7 +97,7 @@ extension UsageStore {
                 ?? usage.identity?.accountEmail
                 ?? "\(accountSnapshot.id.source):\(accountSnapshot.id.opaqueID)"
             let payload = AccountSnapshotSyncPayload(
-                provider: accountSnapshot.provider,
+                provider: accountSnapshot.provider.instanceID,
                 deviceID: deviceID,
                 accountIdentity: identity,
                 displayLabel: accountSnapshot.displayLabel,
@@ -113,10 +115,10 @@ extension UsageStore {
             identities.insert(AccountSnapshotSyncPayload.accountKey(for: identity))
         }
 
-        if let usage = self.snapshots[provider] {
+        if let usage = self.snapshots[provider.instanceID] {
             insert(usage.identity?.accountID ?? usage.identity?.accountEmail)
         }
-        for accountSnapshot in self.accountSnapshots[provider] ?? [] {
+        for accountSnapshot in self.accountSnapshots[provider.instanceID] ?? [] {
             insert(accountSnapshot.snapshot?.identity?.accountID)
             insert(accountSnapshot.snapshot?.identity?.accountEmail)
             insert(accountSnapshot.account.externalIdentifier)
@@ -157,7 +159,7 @@ extension UsageStore {
             self.makeWidgetEntry(
                 for: provider,
                 now: now,
-                previousEntry: previousSnapshot?.entries.first { $0.provider == provider })
+                previousEntry: previousSnapshot?.entries.first { $0.provider == provider.instanceID })
         }
         return WidgetSnapshot(
             entries: entries,
@@ -171,7 +173,7 @@ extension UsageStore {
         now: Date,
         previousEntry: WidgetSnapshot.ProviderEntry?) -> WidgetSnapshot.ProviderEntry?
     {
-        let snapshot = self.snapshots[provider]
+        let snapshot = self.snapshots[provider.instanceID]
         let storedTokenSnapshot = self.tokenSnapshotForCurrentProviderConfig(for: provider)?.snapshot
         let claudeQuotaOwnerKey: String? = if provider == .claude {
             self.claudeWidgetQuotaOwnerKey()
@@ -181,8 +183,10 @@ extension UsageStore {
         let preservedClaudeUsage: PreservedClaudeWidgetUsage? = if provider == .claude,
                                                                    snapshot == nil,
                                                                    !self.widgetUsagePreservationBlockedProviders
-                                                                       .contains(provider),
-                                                                       self.knownLimitsAvailabilityByProvider[provider]?
+                                                                       .contains(provider.instanceID),
+                                                                       self
+                                                                           .knownLimitsAvailabilityByProvider[provider
+                                                                               .instanceID]?
                                                                            .isUnavailable != true
         {
             Self.preservedClaudeWidgetUsage(

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -104,7 +104,7 @@ extension UsageStore {
 
     /// Returns the login method (plan type) for the specified provider, if available.
     private func loginMethod(for provider: UsageProvider) -> String? {
-        self.snapshots[provider]?.loginMethod(for: provider)
+        self.snapshots[provider.instanceID]?.loginMethod(for: provider)
     }
 
     /// Returns true if the Claude account appears to be a subscription (Max, Pro, Ultra, Team).
@@ -161,15 +161,15 @@ final class UsageStore {
         case dashboardWeb
     }
 
-    var snapshots: [UsageProvider: UsageSnapshot] = [:]
-    var errors: [UsageProvider: String] = [:]
-    var diagnostics: [UsageProvider: String] = [:]
+    var snapshots: [ProviderInstanceID: UsageSnapshot] = [:]
+    var errors: [ProviderInstanceID: String] = [:]
+    var diagnostics: [ProviderInstanceID: String] = [:]
     var geminiObservedConsumerTierDeprecation = false
-    var knownLimitsAvailabilityByProvider: [UsageProvider: UsageLimitsAvailability] = [:]
-    var lastSourceLabels: [UsageProvider: String] = [:]
-    var lastFetchAttempts: [UsageProvider: [ProviderFetchAttempt]] = [:]
-    var accountSnapshots: [UsageProvider: [TokenAccountUsageSnapshot]] = [:]
-    var tokenAccountLiveStateProviders: Set<UsageProvider> = []
+    var knownLimitsAvailabilityByProvider: [ProviderInstanceID: UsageLimitsAvailability] = [:]
+    var lastSourceLabels: [ProviderInstanceID: String] = [:]
+    var lastFetchAttempts: [ProviderInstanceID: [ProviderFetchAttempt]] = [:]
+    var accountSnapshots: [ProviderInstanceID: [TokenAccountUsageSnapshot]] = [:]
+    var tokenAccountLiveStateProviders: Set<ProviderInstanceID> = []
     var codexAccountSnapshots: [CodexAccountUsageSnapshot] = []
     var kiloScopeSnapshots: [KiloScopeSnapshot] = []
     var claudeSwapAccountSnapshots: [ProviderAccountUsageSnapshot] = []
@@ -179,11 +179,11 @@ final class UsageStore {
     var claudeSwapRevision: UInt64 = 0
     @ObservationIgnored var claudeSwapRefreshTask: Task<Void, Never>?
     @ObservationIgnored var claudeSwapTransientState = ClaudeSwapTransientState()
-    var tokenSnapshots: [UsageProvider: CostUsageTokenSnapshot] = [:]
-    var tokenSnapshotPublications: [UsageProvider: TokenSnapshotPublication] = [:]
-    var tokenSnapshotPublicationRevisions: [UsageProvider: UInt64] = [:]
-    var tokenErrors: [UsageProvider: String] = [:]
-    var tokenRefreshInFlight: Set<UsageProvider> = []
+    var tokenSnapshots: [ProviderInstanceID: CostUsageTokenSnapshot] = [:]
+    var tokenSnapshotPublications: [ProviderInstanceID: TokenSnapshotPublication] = [:]
+    var tokenSnapshotPublicationRevisions: [ProviderInstanceID: UInt64] = [:]
+    var tokenErrors: [ProviderInstanceID: String] = [:]
+    var tokenRefreshInFlight: Set<ProviderInstanceID> = []
     var codexCostCatchUpActivity: CodexCostCatchUpActivity?
     var spendDashboardCodexCostCatchUpActivity: CodexCostCatchUpActivity?
     var spendDashboardCodexCostCatchUpRevision: UInt64 = 0
@@ -194,19 +194,19 @@ final class UsageStore {
     var openAIDashboardRequiresLogin: Bool = false
     var openAIDashboardCookieImportStatus: String?
     var openAIDashboardCookieImportDebugLog: String?
-    var versions: [UsageProvider: String] = [:]
-    @ObservationIgnored var versionDetectionProviders: Set<UsageProvider> = []
+    var versions: [ProviderInstanceID: String] = [:]
+    @ObservationIgnored var versionDetectionProviders: Set<ProviderInstanceID> = []
     var isRefreshing = false
     var hasForcedRefreshEnrichmentInFlight = false
-    var refreshingProviders: Set<UsageProvider> = []
+    var refreshingProviders: Set<ProviderInstanceID> = []
     var debugForceAnimation = false
     var pathDebugInfo: PathDebugSnapshot = .empty
-    var statuses: [UsageProvider: ProviderStatus] = [:]
-    var statusComponents: [UsageProvider: [ProviderStatusComponent]] = [:]
-    var probeLogs: [UsageProvider: String] = [:]
+    var statuses: [ProviderInstanceID: ProviderStatus] = [:]
+    var statusComponents: [ProviderInstanceID: [ProviderStatusComponent]] = [:]
+    var probeLogs: [ProviderInstanceID: String] = [:]
     var historicalPaceRevision: Int = 0
     var planUtilizationHistoryRevision: Int = 0
-    var providerStorageFootprints: [UsageProvider: ProviderStorageFootprint] = [:]
+    var providerStorageFootprints: [ProviderInstanceID: ProviderStorageFootprint] = [:]
     @ObservationIgnored var lastCreditsSnapshot: CreditsSnapshot?
     @ObservationIgnored var lastCreditsSnapshotAccountKey: String?
     @ObservationIgnored var lastCreditsSource: CodexCreditsSource = .none
@@ -301,7 +301,7 @@ final class UsageStore {
     @ObservationIgnored var widgetSnapshotPersistTask: Task<Void, Never>?
     @ObservationIgnored var lastQueuedWidgetSnapshot: WidgetSnapshot?
     @ObservationIgnored let widgetSnapshotURL: URL?
-    @ObservationIgnored var widgetUsagePreservationBlockedProviders: Set<UsageProvider> = []
+    @ObservationIgnored var widgetUsagePreservationBlockedProviders: Set<ProviderInstanceID> = []
 
     @ObservationIgnored let codexFetcher: UsageFetcher
     @ObservationIgnored let claudeFetcher: any ClaudeUsageFetching
@@ -318,16 +318,18 @@ final class UsageStore {
     @ObservationIgnored let providerLogger = CodexBarLog.logger(LogCategories.providers)
     @ObservationIgnored let adaptiveRefreshLogger = CodexBarLog.logger(LogCategories.adaptiveRefresh)
     @ObservationIgnored var openAIWebDebugLines: [String] = []
-    @ObservationIgnored var failureGates: [UsageProvider: ConsecutiveFailureGate] = [:]
-    @ObservationIgnored var tokenFailureGates: [UsageProvider: ConsecutiveFailureGate] = [:]
+    @ObservationIgnored var failureGates: [ProviderInstanceID: ConsecutiveFailureGate] = [:]
+    @ObservationIgnored var tokenFailureGates: [ProviderInstanceID: ConsecutiveFailureGate] = [:]
     @ObservationIgnored var providerSpecs: [UsageProvider: ProviderSpec] = [:]
     @ObservationIgnored let providerMetadata: [UsageProvider: ProviderMetadata]
-    @ObservationIgnored var providerRuntimes: [UsageProvider: any ProviderRuntime] = [:]
-    @ObservationIgnored var providerRefreshCoordinator = ProviderRefreshCoordinator<UsageProvider>()
-    @ObservationIgnored var providerRefreshPublicationContexts: [UsageProvider: ProviderRefreshPublicationContext] = [:]
-    @ObservationIgnored var providerCleanupRevisions: [UsageProvider: UInt64] = [:]
-    @ObservationIgnored private var providerAvailabilityCache: [UsageProvider: ProviderAvailabilityCacheEntry] = [:]
-    @ObservationIgnored var accountInfoCache: [UsageProvider: AccountInfoCacheEntry] = [:]
+    @ObservationIgnored var providerRuntimes: [ProviderInstanceID: any ProviderRuntime] = [:]
+    @ObservationIgnored var providerRefreshCoordinator = ProviderRefreshCoordinator<ProviderInstanceID>()
+    @ObservationIgnored var providerRefreshPublicationContexts:
+        [ProviderInstanceID: ProviderRefreshPublicationContext] = [:]
+    @ObservationIgnored var providerCleanupRevisions: [ProviderInstanceID: UInt64] = [:]
+    @ObservationIgnored private var providerAvailabilityCache:
+        [ProviderInstanceID: ProviderAvailabilityCacheEntry] = [:]
+    @ObservationIgnored var accountInfoCache: [ProviderInstanceID: AccountInfoCacheEntry] = [:]
     @ObservationIgnored private var timerTask: Task<Void, Never>?
     /// In-memory only; resets on every launch.
     @ObservationIgnored private(set) var lastMenuOpenAt: Date?
@@ -338,8 +340,8 @@ final class UsageStore {
     @ObservationIgnored var tokenTimerTask: Task<Void, Never>?
     @ObservationIgnored var tokenRefreshSequenceTask: Task<Void, Never>?
     @ObservationIgnored var tokenRefreshSequenceToken: UUID?
-    @ObservationIgnored var tokenRefreshSequenceProvider: UsageProvider?
-    @ObservationIgnored var tokenRefreshRetryProviders: Set<UsageProvider> = []
+    @ObservationIgnored var tokenRefreshSequenceProvider: ProviderInstanceID?
+    @ObservationIgnored var tokenRefreshRetryProviders: Set<ProviderInstanceID> = []
     @ObservationIgnored var codexCostCatchUpTask: Task<Void, Never>?
     @ObservationIgnored var codexCostCatchUpToken: UUID?
     @ObservationIgnored var codexCostCatchUpScopeSignature: String?
@@ -384,9 +386,9 @@ final class UsageStore {
     @ObservationIgnored let codexAccountUsageSnapshotStore: (any CodexAccountUsageSnapshotStoring)?
     @ObservationIgnored var codexHistoricalDataset: CodexHistoricalDataset?
     @ObservationIgnored var codexHistoricalDatasetAccountKey: String?
-    @ObservationIgnored var lastKnownResetSnapshots: [UsageProvider: UsageSnapshot] = [:]
+    @ObservationIgnored var lastKnownResetSnapshots: [ProviderInstanceID: UsageSnapshot] = [:]
     @ObservationIgnored var deepseekProfileTransition: DeepSeekProfileTransition?
-    @ObservationIgnored var sessionQuotaTransitionStates: [UsageProvider: SessionQuotaTransitionState] = [:]
+    @ObservationIgnored var sessionQuotaTransitionStates: [ProviderInstanceID: SessionQuotaTransitionState] = [:]
     @ObservationIgnored var codexSessionQuotaBaselineRequirement: CodexSessionQuotaBaselineRequirement?
     var codexSessionQuotaBaselineRequired: Bool {
         self.codexSessionQuotaBaselineRequirement != nil
@@ -394,17 +396,17 @@ final class UsageStore {
 
     @ObservationIgnored var quotaWarningState: [QuotaWarningStateKey: QuotaWarningState] = [:]
     @ObservationIgnored let hookRateLimiter = HookRateLimiter()
-    @ObservationIgnored var providerStatusHadIssue: [UsageProvider: Bool] = [:]
+    @ObservationIgnored var providerStatusHadIssue: [ProviderInstanceID: Bool] = [:]
     /// Last observed usage fraction (0...1) per account and quota-warning lane, used
     /// to detect upward crossings of a quota_low hook rule's own threshold.
     @ObservationIgnored var quotaLowHookUsage: [QuotaWarningStateKey: Double] = [:]
     @ObservationIgnored var quotaLowHookConfigRevision: Int?
     @ObservationIgnored var predictivePaceWarningNotifiedKeys: Set<PredictivePaceWarningStateKey> = []
-    @ObservationIgnored var lastPermissionPromptNotificationAt: [UsageProvider: Date] = [:]
-    @ObservationIgnored var lastTokenFetchAt: [UsageProvider: Date] = [:]
-    @ObservationIgnored var lastTokenFetchScope: [UsageProvider: String] = [:]
-    @ObservationIgnored var planUtilizationHistory: [UsageProvider: PlanUtilizationHistoryBuckets] = [:]
-    @ObservationIgnored var sessionEquivalentBurnCache: [UsageProvider: SessionEquivalentBurnCacheEntry] = [:]
+    @ObservationIgnored var lastPermissionPromptNotificationAt: [ProviderInstanceID: Date] = [:]
+    @ObservationIgnored var lastTokenFetchAt: [ProviderInstanceID: Date] = [:]
+    @ObservationIgnored var lastTokenFetchScope: [ProviderInstanceID: String] = [:]
+    @ObservationIgnored var planUtilizationHistory: [ProviderInstanceID: PlanUtilizationHistoryBuckets] = [:]
+    @ObservationIgnored var sessionEquivalentBurnCache: [ProviderInstanceID: SessionEquivalentBurnCacheEntry] = [:]
     @ObservationIgnored var sessionEquivalentHistoryScanCount: Int = 0
 
     /// Background load task; cleared on deinit and on the cancel test seam.
@@ -482,10 +484,10 @@ final class UsageStore {
         self
             .failureGates = Dictionary(
                 uniqueKeysWithValues: UsageProvider.allCases
-                    .map { ($0, ConsecutiveFailureGate()) })
+                    .map { ($0.instanceID, ConsecutiveFailureGate()) })
         self.tokenFailureGates = Dictionary(
             uniqueKeysWithValues: UsageProvider.allCases
-                .map { ($0, ConsecutiveFailureGate()) })
+                .map { ($0.instanceID, ConsecutiveFailureGate()) })
         self.providerSpecs = registry.specs(
             settings: settings,
             metadata: self.providerMetadata,
@@ -494,7 +496,7 @@ final class UsageStore {
             browserDetection: browserDetection,
             environmentBase: environmentBase)
         self.providerRuntimes = Dictionary(uniqueKeysWithValues: ProviderCatalog.all.compactMap { implementation in
-            implementation.makeRuntime().map { (implementation.id, $0) }
+            implementation.makeRuntime().map { (implementation.id.instanceID, $0) }
         })
         self.startPlanUtilizationHistoryLoad(
             gate: planUtilizationHistoryLoadGateForTesting,
@@ -541,7 +543,7 @@ final class UsageStore {
         if enabled.count > 1 {
             return .combined
         }
-        if let provider = enabled.first {
+        if let provider = enabled.first?.firstPartyProvider {
             return self.style(for: provider)
         }
         return .codex
@@ -554,25 +556,23 @@ final class UsageStore {
         return false
     }
 
-    func enabledProviders() -> [UsageProvider] {
+    func enabledProviders() -> [ProviderInstanceID] {
         // Use cached enablement to avoid repeated UserDefaults lookups in animation ticks.
         let enabled = self.settings.enabledProvidersOrdered(metadataByProvider: self.providerMetadata)
         let now = Date()
-        return enabled.filter { self.isProviderAvailable($0, now: now) }
+        return enabled.filter { instanceID in
+            instanceID.firstPartyProvider.map { self.isProviderAvailable($0, now: now) } ?? false
+        }
     }
 
     /// Enabled providers without availability filtering. Used for display (switcher, merge-icons).
-    func enabledProvidersForDisplay() -> [UsageProvider] {
+    func enabledProvidersForDisplay() -> [ProviderInstanceID] {
         self.settings.enabledProvidersOrdered(metadataByProvider: self.providerMetadata)
     }
 
     /// Providers that should actually participate in background refresh/status/token work.
-    func enabledProvidersForBackgroundWork() -> [UsageProvider] {
+    func enabledProvidersForBackgroundWork() -> [ProviderInstanceID] {
         self.enabledProviders()
-    }
-
-    var statusChecksEnabled: Bool {
-        self.settings.statusChecksEnabled
     }
 
     func metadata(for provider: UsageProvider) -> ProviderMetadata {
@@ -583,12 +583,12 @@ final class UsageStore {
         self.metadata(for: .codex).browserCookieOrder ?? Browser.defaultImportOrder
     }
 
-    func snapshot(for provider: UsageProvider) -> UsageSnapshot? {
-        self.snapshots[provider]
+    func snapshot(for instanceID: ProviderInstanceID) -> UsageSnapshot? {
+        self.snapshots[instanceID]
     }
 
     func sourceLabel(for provider: UsageProvider) -> String {
-        var label = self.lastSourceLabels[provider] ?? ""
+        var label = self.lastSourceLabels[provider.instanceID] ?? ""
         if label.isEmpty {
             let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
             let modes = descriptor.fetchPlan.sourceModes
@@ -617,7 +617,7 @@ final class UsageStore {
     }
 
     func fetchAttempts(for provider: UsageProvider) -> [ProviderFetchAttempt] {
-        self.lastFetchAttempts[provider] ?? []
+        self.lastFetchAttempts[provider.instanceID] ?? []
     }
 
     func style(for provider: UsageProvider) -> IconStyle {
@@ -625,15 +625,16 @@ final class UsageStore {
     }
 
     func isStale(provider: UsageProvider) -> Bool {
-        self.errors[provider] != nil
+        self.errors[provider.instanceID] != nil
     }
 
     func knownLimitsAvailability(for provider: UsageProvider) -> UsageLimitsAvailability? {
-        self.knownLimitsAvailabilityByProvider[provider]
+        self.knownLimitsAvailabilityByProvider[provider.instanceID]
     }
 
     func hasSatisfiedUsageFetch(for provider: UsageProvider) -> Bool {
-        self.snapshot(for: provider) != nil || self.knownLimitsAvailability(for: provider)?.isUnavailable == true
+        self.snapshot(for: provider.instanceID) != nil ||
+            self.knownLimitsAvailability(for: provider)?.isUnavailable == true
     }
 
     func needsUsageRefreshRetry(for provider: UsageProvider) -> Bool {
@@ -656,7 +657,7 @@ final class UsageStore {
         guard provider != .codex else { return true }
 
         let configRevision = self.settings.configRevision
-        if let cached = self.providerAvailabilityCache[provider],
+        if let cached = self.providerAvailabilityCache[provider.instanceID],
            cached.isValid(now: now, configRevision: configRevision)
         {
             return cached.available
@@ -677,7 +678,7 @@ final class UsageStore {
         let available = ProviderCatalog.implementation(for: provider)?
             .isAvailable(context: context)
             ?? true
-        self.providerAvailabilityCache[provider] = ProviderAvailabilityCacheEntry(
+        self.providerAvailabilityCache[provider.instanceID] = ProviderAvailabilityCacheEntry(
             available: available,
             configRevision: configRevision,
             expiresAt: now.addingTimeInterval(self.providerAvailabilityCacheTTL))
@@ -740,17 +741,18 @@ final class UsageStore {
             self.clearUnavailableProviderState(
                 displayEnabledProviders: enabledProviderSet,
                 availableProviders: availableRefreshProviders)
-            self.scheduleStorageFootprintRefresh(for: displayEnabledProviders)
+            self.scheduleStorageFootprintRefresh(for: displayEnabledProviders.compactMap(\.firstPartyProvider))
 
             await withTaskGroup(of: Void.self) { group in
-                for provider in refreshProviders {
+                for instanceID in refreshProviders {
+                    guard let provider = instanceID.firstPartyProvider else { continue }
                     group.addTask {
                         await self.refreshProvider(
                             provider,
                             coalesceIfRefreshing: coalesceProviderRefreshesOverride ??
                                 (ProviderInteractionContext.current == .background))
                     }
-                    if availableRefreshProviders.contains(provider) {
+                    if availableRefreshProviders.contains(provider.instanceID) {
                         group.addTask { await self.refreshProviderStatus(provider) }
                     }
                 }
@@ -976,8 +978,8 @@ extension UsageStore {
             return url
         } catch {
             await MainActor.run {
-                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider)
-                self.errors[provider] = "Failed to save log: \(error.localizedDescription)"
+                self.knownLimitsAvailabilityByProvider.removeValue(forKey: provider.instanceID)
+                self.errors[provider.instanceID] = "Failed to save log: \(error.localizedDescription)"
             }
             return nil
         }
@@ -989,7 +991,7 @@ extension UsageStore {
 
     // swiftlint:disable:next function_body_length
     func debugLog(for provider: UsageProvider) async -> String {
-        if let cached = self.probeLogs[provider], !cached.isEmpty {
+        if let cached = self.probeLogs[provider.instanceID], !cached.isEmpty {
             return cached
         }
 
@@ -1158,7 +1160,7 @@ extension UsageStore {
                 await buildText()
             }
         }.value
-        self.probeLogs[provider] = text
+        self.probeLogs[provider.instanceID] = text
         return text
     }
 
@@ -1371,7 +1373,8 @@ extension UsageStore {
     func detectVersions() {
         let enabled = Set(self.settings.enabledProvidersOrdered(metadataByProvider: self.providerMetadata))
         self.versionDetectionProviders = enabled
-        let implementations = Self.versionDetectionImplementations(enabled: enabled)
+        let implementations = Self.versionDetectionImplementations(
+            enabled: Set(enabled.compactMap(\.firstPartyProvider)))
         let browserDetection = self.browserDetection
         Task { @MainActor [weak self] in
             let resolved = await Task.detached { () -> [UsageProvider: String] in
@@ -1392,7 +1395,7 @@ extension UsageStore {
                 }
                 return resolved
             }.value
-            self?.versions = resolved
+            self?.versions = Dictionary(uniqueKeysWithValues: resolved.map { ($0.key.instanceID, $0.value) })
         }
     }
 
@@ -1432,13 +1435,13 @@ extension UsageStore {
 
         if Self.tokenCostRequiresProviderSnapshot(provider) {
             if self.tokenSnapshotPublicationForCurrentProviderConfig(for: provider) != nil {
-                self.tokenErrors[provider] = nil
-                self.tokenFailureGates[provider]?.recordSuccess()
+                self.tokenErrors[provider.instanceID] = nil
+                self.tokenFailureGates[provider.instanceID]?.recordSuccess()
                 self.persistWidgetSnapshot(reason: "token-usage")
             } else {
                 self.clearTokenSnapshot(for: provider)
-                self.tokenErrors[provider] = nil
-                self.tokenFailureGates[provider]?.reset()
+                self.tokenErrors[provider.instanceID] = nil
+                self.tokenFailureGates[provider.instanceID]?.reset()
             }
             return
         }
@@ -1460,7 +1463,7 @@ extension UsageStore {
             return
         }
 
-        guard !self.tokenRefreshInFlight.contains(provider) else { return }
+        guard !self.tokenRefreshInFlight.contains(provider.instanceID) else { return }
 
         let now = Date()
         let historyDays = self.settings.costUsageHistoryDays
@@ -1480,16 +1483,16 @@ extension UsageStore {
         {
             return
         }
-        self.lastTokenFetchAt[provider] = now
-        self.lastTokenFetchScope[provider] = costScopeSignature
-        self.tokenRefreshInFlight.insert(provider)
-        defer { self.tokenRefreshInFlight.remove(provider) }
+        self.lastTokenFetchAt[provider.instanceID] = now
+        self.lastTokenFetchScope[provider.instanceID] = costScopeSignature
+        self.tokenRefreshInFlight.insert(provider.instanceID)
+        defer { self.tokenRefreshInFlight.remove(provider.instanceID) }
 
         if let override = self._test_tokenUsageRefreshOverride {
             await override(provider, force)
             if Task.isCancelled {
-                self.lastTokenFetchAt.removeValue(forKey: provider)
-                self.lastTokenFetchScope.removeValue(forKey: provider)
+                self.lastTokenFetchAt.removeValue(forKey: provider.instanceID)
+                self.lastTokenFetchScope.removeValue(forKey: provider.instanceID)
             }
             return
         }
@@ -1529,13 +1532,13 @@ extension UsageStore {
                 self.requestTokenRefreshAfterStaleCompletion(for: provider)
                 return
             }
-            self.lastTokenFetchScope[provider] = completedCostScopeSignature
+            self.lastTokenFetchScope[provider.instanceID] = completedCostScopeSignature
             self.startCodexCostCatchUpIfNeeded(afterRefreshing: provider)
 
             guard !snapshot.daily.isEmpty || snapshot.meteredCostUSD != nil else {
                 self.publishConfirmedEmptyTokenSnapshot(for: provider)
-                self.tokenErrors[provider] = Self.tokenCostNoDataMessage(for: provider)
-                self.tokenFailureGates[provider]?.recordSuccess()
+                self.tokenErrors[provider.instanceID] = Self.tokenCostNoDataMessage(for: provider)
+                self.tokenFailureGates[provider.instanceID]?.recordSuccess()
                 return
             }
             self.logTokenUsageSuccess(
@@ -1544,8 +1547,8 @@ extension UsageStore {
                 historyDays: historyDays,
                 startedAt: startedAt)
             self.publishTokenSnapshot(snapshot, for: provider)
-            self.tokenErrors[provider] = nil
-            self.tokenFailureGates[provider]?.recordSuccess()
+            self.tokenErrors[provider.instanceID] = nil
+            self.tokenFailureGates[provider.instanceID]?.recordSuccess()
             self.persistWidgetSnapshot(reason: "token-usage")
         } catch {
             guard self.tokenRefreshPublicationIsCurrent(
@@ -1580,14 +1583,14 @@ extension UsageStore {
                     attemptedAt: now,
                     costScopeSignature: costScopeSignature)
             }
-            let hadPriorData = self.tokenSnapshots[provider] != nil
-            let shouldSurface = self.tokenFailureGates[provider]?
+            let hadPriorData = self.tokenSnapshots[provider.instanceID] != nil
+            let shouldSurface = self.tokenFailureGates[provider.instanceID]?
                 .shouldSurfaceError(onFailureWithPriorData: hadPriorData) ?? true
             if shouldSurface {
-                self.tokenErrors[provider] = error.localizedDescription
+                self.tokenErrors[provider.instanceID] = error.localizedDescription
                 self.clearTokenSnapshot(for: provider)
             } else {
-                self.tokenErrors[provider] = nil
+                self.tokenErrors[provider.instanceID] = nil
             }
         }
     }
@@ -1598,10 +1601,10 @@ extension UsageStore {
             self.cancelSpendDashboardCodexCostCatchUp()
         }
         self.clearTokenSnapshot(for: provider)
-        self.tokenErrors[provider] = nil
-        self.tokenFailureGates[provider]?.reset()
-        self.lastTokenFetchAt.removeValue(forKey: provider)
-        self.lastTokenFetchScope.removeValue(forKey: provider)
+        self.tokenErrors[provider.instanceID] = nil
+        self.tokenFailureGates[provider.instanceID]?.reset()
+        self.lastTokenFetchAt.removeValue(forKey: provider.instanceID)
+        self.lastTokenFetchScope.removeValue(forKey: provider.instanceID)
     }
 
     private func logTokenUsageSuccess(
@@ -1628,13 +1631,13 @@ extension UsageStore {
         attemptedAt: Date,
         costScopeSignature: String)
     {
-        guard self.lastTokenFetchAt[provider] == attemptedAt,
-              self.lastTokenFetchScope[provider] == costScopeSignature
+        guard self.lastTokenFetchAt[provider.instanceID] == attemptedAt,
+              self.lastTokenFetchScope[provider.instanceID] == costScopeSignature
         else {
             return
         }
-        self.lastTokenFetchAt.removeValue(forKey: provider)
-        self.lastTokenFetchScope.removeValue(forKey: provider)
+        self.lastTokenFetchAt.removeValue(forKey: provider.instanceID)
+        self.lastTokenFetchScope.removeValue(forKey: provider.instanceID)
     }
 
     /// Fast failures may retry on the next scheduled pass instead of waiting out the fetch

--- a/Sources/CodexBar/UsageStoreSupport.swift
+++ b/Sources/CodexBar/UsageStoreSupport.swift
@@ -112,7 +112,7 @@ struct ConsecutiveFailureGate {
 #if DEBUG
 extension UsageStore {
     func _setSnapshotForTesting(_ snapshot: UsageSnapshot?, provider: UsageProvider) {
-        self.snapshots[provider] = snapshot?.scoped(to: provider)
+        self.snapshots[provider.instanceID] = snapshot?.scoped(to: provider)
     }
 
     func _setTokenSnapshotForTesting(_ snapshot: CostUsageTokenSnapshot?, provider: UsageProvider) {
@@ -124,18 +124,18 @@ extension UsageStore {
     }
 
     func _setTokenErrorForTesting(_ error: String?, provider: UsageProvider) {
-        self.tokenErrors[provider] = error
+        self.tokenErrors[provider.instanceID] = error
     }
 
     func _setErrorForTesting(_ error: String?, provider: UsageProvider) {
-        self.errors[provider] = error
+        self.errors[provider.instanceID] = error
     }
 
     func _setKnownLimitsAvailabilityForTesting(
         _ availability: UsageLimitsAvailability?,
         provider: UsageProvider)
     {
-        self.knownLimitsAvailabilityByProvider[provider] = availability
+        self.knownLimitsAvailabilityByProvider[provider.instanceID] = availability
     }
 
     func _setCodexHistoricalDatasetForTesting(_ dataset: CodexHistoricalDataset?, accountKey: String? = nil) {

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -185,7 +185,7 @@ extension CodexBarCLI {
 
         let result = ConfigSetAPIKeyResult(
             provider: provider.rawValue,
-            enabled: config.providerConfig(for: provider)?.enabled ?? false,
+            enabled: config.providerConfig(for: provider.instanceID)?.enabled ?? false,
             configPath: store.fileURL.path)
 
         switch output.format {
@@ -226,7 +226,7 @@ extension CodexBarCLI {
         accountOptions: ConfigAPIKeyAccountOptions? = nil) -> CodexBarConfig
     {
         var updated = config.normalized()
-        var providerConfig = updated.providerConfig(for: provider) ?? ProviderConfig(id: provider)
+        var providerConfig = updated.providerConfig(for: provider.instanceID) ?? ProviderConfig(id: provider.instanceID)
         if let accountOptions {
             let existing = providerConfig.tokenAccounts
             let accounts = existing?.accounts ?? []
@@ -309,7 +309,7 @@ extension CodexBarCLI {
         enabled: Bool) -> CodexBarConfig
     {
         var updated = config.normalized()
-        var providerConfig = updated.providerConfig(for: provider) ?? ProviderConfig(id: provider)
+        var providerConfig = updated.providerConfig(for: provider.instanceID) ?? ProviderConfig(id: provider.instanceID)
         providerConfig.enabled = enabled
         updated.setProviderConfig(providerConfig)
         return updated
@@ -318,7 +318,8 @@ extension CodexBarCLI {
     static func configProviderStatuses(_ config: CodexBarConfig) -> [ConfigProviderStatusResult] {
         let metadata = ProviderDescriptorRegistry.metadata
         return config.normalized().providers.map { providerConfig in
-            let meta = metadata[providerConfig.id]
+            let provider = providerConfig.id.firstPartyProvider
+            let meta = provider.flatMap { metadata[$0] }
             let defaultEnabled = meta?.defaultEnabled ?? false
             return ConfigProviderStatusResult(
                 provider: providerConfig.id.rawValue,

--- a/Sources/CodexBarCLI/CLICookieCommand.swift
+++ b/Sources/CodexBarCLI/CLICookieCommand.swift
@@ -255,7 +255,7 @@ extension CodexBarCLI {
         descriptor: ProviderDescriptor,
         config: CodexBarConfig) -> CookieRefreshResult?
     {
-        switch config.providerConfig(for: descriptor.id)?.cookieSource ?? .auto {
+        switch config.providerConfig(for: descriptor.id.instanceID)?.cookieSource ?? .auto {
         case .manual:
             CookieRefreshResult(
                 provider: descriptor.cli.name,

--- a/Sources/CodexBarCLI/CLIDashboardCommand.swift
+++ b/Sources/CodexBarCLI/CLIDashboardCommand.swift
@@ -41,7 +41,7 @@ struct DashboardSnapshotProducer: Sendable {
     {
         let selection = CodexBarCLI.providerSelection(
             rawOverride: nil,
-            enabled: config.enabledProviders())
+            enabled: config.enabledProviders().compactMap(\.firstPartyProvider))
         let usageOutput = try await self.collectUsage(selection.asList)
         let costPayloads = await self.collectCost(
             CodexBarCLI.costProviders(from: selection),

--- a/Sources/CodexBarCLI/CLIDiagnoseCommand.swift
+++ b/Sources/CodexBarCLI/CLIDiagnoseCommand.swift
@@ -27,7 +27,9 @@ extension CodexBarCLI {
             }
             providerSelection = parsed
         } else {
-            providerSelection = Self.providerSelection(rawOverride: nil, enabled: config.enabledProviders())
+            providerSelection = Self.providerSelection(
+                rawOverride: nil,
+                enabled: config.enabledProviders().compactMap(\.firstPartyProvider))
         }
 
         let providers = providerSelection.asList
@@ -152,7 +154,7 @@ extension CodexBarCLI {
             auth: Self.diagnosticAuthSummary(
                 provider: provider,
                 account: account,
-                config: tokenContext.config.providerConfig(for: provider),
+                config: tokenContext.config.providerConfig(for: provider.instanceID),
                 environment: env,
                 settings: settings),
             appVersion: Self.currentVersion()))

--- a/Sources/CodexBarCLI/CLIHelpers.swift
+++ b/Sources/CodexBarCLI/CLIHelpers.swift
@@ -12,7 +12,9 @@ import Foundation
 extension CodexBarCLI {
     static func decodeProvider(from values: ParsedValues, config: CodexBarConfig) -> ProviderSelection {
         let rawOverride = values.options["provider"]?.last
-        return Self.providerSelection(rawOverride: rawOverride, enabled: config.enabledProviders())
+        return Self.providerSelection(
+            rawOverride: rawOverride,
+            enabled: config.enabledProviders().compactMap(\.firstPartyProvider))
     }
 
     static func providerSelection(rawOverride: String?, enabled: [UsageProvider]) -> ProviderSelection {

--- a/Sources/CodexBarCLI/CLIHooksWatchCommand.swift
+++ b/Sources/CodexBarCLI/CLIHooksWatchCommand.swift
@@ -199,7 +199,7 @@ extension CodexBarCLI {
         config: CodexBarConfig) -> [HookQuotaLaneObservation]
     {
         let account = usage.accountEmail(for: provider)
-        let warnings = config.providerConfig(for: provider)?.quotaWarnings
+        let warnings = config.providerConfig(for: provider.instanceID)?.quotaWarnings
         let lanes: [(QuotaWarningWindow, RateWindow?)] = [
             (.session, usage.primary),
             (.weekly, usage.secondary),
@@ -348,7 +348,7 @@ extension CodexBarCLI {
         guard !enabled.isEmpty else {
             return .failure(CLIArgumentError("No providers are enabled."))
         }
-        return .success(enabled)
+        return .success(enabled.compactMap(\.firstPartyProvider))
     }
 }
 

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -1391,7 +1391,9 @@ extension CodexBarCLI {
         config: CodexBarConfig) throws -> ProviderSelection
     {
         guard let rawProvider, !rawProvider.isEmpty else {
-            return providerSelection(rawOverride: nil, enabled: config.enabledProviders())
+            return providerSelection(
+                rawOverride: nil,
+                enabled: config.enabledProviders().compactMap(\.firstPartyProvider))
         }
         guard let selection = ProviderSelection(argument: rawProvider) else {
             throw CLIServeArgumentError.invalidProvider(rawProvider)

--- a/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
+++ b/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
@@ -18,7 +18,7 @@ enum DashboardSnapshotBuilder {
         for cost in costPayloads {
             costByProvider[cost.provider] = cost
         }
-        let enabledProviders = Set(config.enabledProviders())
+        let enabledProviders = Set(config.enabledProviders().compactMap(\.firstPartyProvider))
         var sortKeys: [String: Int] = [:]
         for (index, provider) in config.orderedProviders().enumerated() where sortKeys[provider.rawValue] == nil {
             sortKeys[provider.rawValue] = index * 10
@@ -114,7 +114,7 @@ enum DashboardSnapshotBuilder {
     {
         guard mode != .none,
               let provider,
-              let identity = usage?.identity(for: provider)
+              let identity = usage?.identity(for: provider.instanceID)
         else {
             return nil
         }

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -56,8 +56,10 @@ struct TokenAccountCLIContext {
         self.accountsByProvider = switch resolutionScope {
         case .configuredAccounts:
             Dictionary(uniqueKeysWithValues: config.providers.compactMap { provider in
-                guard let accounts = provider.tokenAccounts else { return nil }
-                return (provider.id, accounts)
+                guard let firstPartyProvider = provider.id.firstPartyProvider,
+                      let accounts = provider.tokenAccounts
+                else { return nil }
+                return (firstPartyProvider, accounts)
             })
         case .ambientAccount:
             [:]
@@ -384,7 +386,7 @@ struct TokenAccountCLIContext {
 
         let store = CodexBarConfigStore()
         var config = try store.load() ?? .makeDefault()
-        var providerConfig = config.providerConfig(for: provider) ?? ProviderConfig(id: provider)
+        var providerConfig = config.providerConfig(for: provider.instanceID) ?? ProviderConfig(id: provider.instanceID)
         providerConfig.region = trimmed
         config.setProviderConfig(providerConfig)
         try store.save(config)
@@ -400,7 +402,7 @@ struct TokenAccountCLIContext {
 
         let store = CodexBarConfigStore()
         guard var config = try store.load() else { return }
-        guard var providerConfig = config.providerConfig(for: provider),
+        guard var providerConfig = config.providerConfig(for: provider.instanceID),
               let data = providerConfig.tokenAccounts,
               let index = data.accounts.firstIndex(where: { $0.id == accountID })
         else {
@@ -443,11 +445,11 @@ struct TokenAccountCLIContext {
     {
         let label = account.label.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !label.isEmpty else { return snapshot }
-        let existing = snapshot.identity(for: provider)
+        let existing = snapshot.identity(for: provider.instanceID)
         let email = existing?.accountEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedEmail = (email?.isEmpty ?? true) ? label : email
         let identity = ProviderIdentitySnapshot(
-            providerID: provider,
+            providerID: provider.instanceID,
             accountEmail: resolvedEmail,
             accountOrganization: existing?.accountOrganization,
             loginMethod: existing?.loginMethod)
@@ -497,7 +499,7 @@ struct TokenAccountCLIContext {
     }
 
     private func providerConfig(for provider: UsageProvider) -> ProviderConfig? {
-        self.config.providerConfig(for: provider)
+        self.config.providerConfig(for: provider.instanceID)
     }
 
     private func codexAccountReconciler(activeSource: CodexActiveSource? = nil) -> DefaultCodexAccountReconciler {

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -40,7 +40,7 @@ public struct CodexBarConfig: Codable, Sendable {
             let providerDecoder = try providersContainer.superDecoder()
             let providerContainer = try providerDecoder.container(keyedBy: ProviderCodingKeys.self)
             let rawID = try providerContainer.decode(String.self, forKey: .id)
-            guard UsageProvider(rawValue: rawID) != nil else {
+            guard let instanceID = ProviderInstanceID(rawValue: rawID), instanceID.firstPartyProvider != nil else {
                 Self.log.warning("Ignoring unknown provider in config", metadata: ["provider": rawID])
                 continue
             }
@@ -88,18 +88,18 @@ public struct CodexBarConfig: Codable, Sendable {
     public func normalized(
         metadata: [UsageProvider: ProviderMetadata] = ProviderDescriptorRegistry.metadata) -> CodexBarConfig
     {
-        var seen: Set<UsageProvider> = []
+        var seen: Set<ProviderInstanceID> = []
         var normalized: [ProviderConfig] = []
         normalized.reserveCapacity(max(self.providers.count, UsageProvider.allCases.count))
 
         for var provider in self.providers {
             guard !seen.contains(provider.id) else { continue }
             seen.insert(provider.id)
-            if provider.id == .deepseek {
+            if provider.id.firstPartyProvider == .deepseek {
                 provider.deepseekProfileID = provider.sanitizedDeepSeekProfileID
                 provider.deepseekProfileScope = provider.sanitizedDeepSeekProfileScope
             }
-            if provider.id == .moonshot,
+            if provider.id.firstPartyProvider == .moonshot,
                provider.sanitizedAPIKey != nil,
                provider.sanitizedAPIKeyRegion == nil
             {
@@ -108,7 +108,7 @@ public struct CodexBarConfig: Codable, Sendable {
             normalized.append(provider)
         }
 
-        for provider in UsageProvider.allCases where !seen.contains(provider) {
+        for provider in UsageProvider.allCases where !seen.contains(provider.instanceID) {
             normalized.append(Self.defaultProviderConfig(
                 provider,
                 metadata: metadata,
@@ -128,20 +128,21 @@ public struct CodexBarConfig: Codable, Sendable {
         return copy
     }
 
-    public func orderedProviders() -> [UsageProvider] {
+    public func orderedProviders() -> [ProviderInstanceID] {
         self.providers.map(\.id)
     }
 
     public func enabledProviders(
-        metadata: [UsageProvider: ProviderMetadata] = ProviderDescriptorRegistry.metadata) -> [UsageProvider]
+        metadata: [UsageProvider: ProviderMetadata] = ProviderDescriptorRegistry.metadata) -> [ProviderInstanceID]
     {
         self.providers.compactMap { config in
-            let enabled = config.enabled ?? metadata[config.id]?.defaultEnabled ?? false
+            let enabled = config.enabled ?? config.id.firstPartyProvider
+                .flatMap { metadata[$0]?.defaultEnabled } ?? false
             return enabled ? config.id : nil
         }
     }
 
-    public func providerConfig(for id: UsageProvider) -> ProviderConfig? {
+    public func providerConfig(for id: ProviderInstanceID) -> ProviderConfig? {
         self.providers.first(where: { $0.id == id })
     }
 
@@ -159,14 +160,14 @@ public struct CodexBarConfig: Codable, Sendable {
         alibabaTokenPlanRegion: AlibabaTokenPlanAPIRegion) -> ProviderConfig
     {
         ProviderConfig(
-            id: provider,
+            id: provider.instanceID,
             enabled: metadata[provider]?.defaultEnabled,
             region: provider == .alibabatokenplan ? alibabaTokenPlanRegion.rawValue : nil)
     }
 }
 
 public struct ProviderConfig: Codable, Sendable, Identifiable {
-    public let id: UsageProvider
+    public let id: ProviderInstanceID
     public var enabled: Bool?
     public var source: ProviderSourceMode?
     public var extrasEnabled: Bool?
@@ -195,7 +196,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var apiKeyRegion: String?
 
     public init(
-        id: UsageProvider,
+        id: ProviderInstanceID,
         enabled: Bool? = nil,
         source: ProviderSourceMode? = nil,
         extrasEnabled: Bool? = nil,

--- a/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
@@ -131,7 +131,15 @@ public enum CodexBarConfigValidator {
     }
 
     private static func validateProvider(_ entry: ProviderConfig, issues: inout [CodexBarConfigIssue]) {
-        let provider = entry.id
+        guard let provider = entry.id.firstPartyProvider else {
+            issues.append(CodexBarConfigIssue(
+                severity: .error,
+                provider: nil,
+                field: "id",
+                code: "unsupported_provider",
+                message: "Provider \(entry.id.rawValue) has no first-party implementation."))
+            return
+        }
         let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
         let supportedSources = descriptor.fetchPlan.sourceModes
         let supportsWeb = supportedSources.contains(.auto) || supportedSources.contains(.web)
@@ -256,15 +264,16 @@ public enum CodexBarConfigValidator {
     private static func validateSecretKey(_ entry: ProviderConfig, issues: inout [CodexBarConfigIssue]) {
         guard let secretKey = entry.secretKey,
               !secretKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              entry.id != .bedrock,
-              entry.id != .doubao
+              let provider = entry.id.firstPartyProvider,
+              provider != .bedrock,
+              provider != .doubao
         else {
             return
         }
 
         issues.append(CodexBarConfigIssue(
             severity: .warning,
-            provider: entry.id,
+            provider: provider,
             field: "secretKey",
             code: "secret_key_unused",
             message: "secretKey is set but only bedrock and doubao use secretKey."))
@@ -339,8 +348,9 @@ public enum CodexBarConfigValidator {
         }
         return entry.tokenAccounts?.accounts.contains(where: { account in
             let token = account.token.trimmingCharacters(in: .whitespacesAndNewlines)
-            return !token.isEmpty &&
-                TokenAccountSupportCatalog.envOverride(for: entry.id, token: token)?.isEmpty == false
+            guard let provider = entry.id.firstPartyProvider else { return false }
+            return !token.isEmpty && TokenAccountSupportCatalog.envOverride(for: provider, token: token)?
+                .isEmpty == false
         }) == true
     }
 
@@ -349,7 +359,7 @@ public enum CodexBarConfigValidator {
     }
 
     private static func validateRegion(_ entry: ProviderConfig, issues: inout [CodexBarConfigIssue]) {
-        let provider = entry.id
+        guard let provider = entry.id.firstPartyProvider else { return }
         guard let region = entry.region?.trimmingCharacters(in: .whitespacesAndNewlines),
               !region.isEmpty
         else {

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -919,7 +919,7 @@ public enum CookieHeaderCache {
     }
 
     private static func key(for provider: UsageProvider, scope: Scope?) -> KeychainCacheStore.Key {
-        KeychainCacheStore.Key.cookie(provider: provider, scopeIdentifier: scope?.keychainIdentifier)
+        KeychainCacheStore.Key.cookie(provider: provider.instanceID, scopeIdentifier: scope?.keychainIdentifier)
     }
 }
 

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -878,16 +878,16 @@ public enum KeychainCacheStore {
 }
 
 extension KeychainCacheStore.Key {
-    public static func cookie(provider: UsageProvider, scopeIdentifier: String? = nil) -> Self {
+    public static func cookie(provider instanceID: ProviderInstanceID, scopeIdentifier: String? = nil) -> Self {
         let identifier: String = if let scopeIdentifier, !scopeIdentifier.isEmpty {
-            "\(provider.rawValue).\(scopeIdentifier)"
+            "\(instanceID.rawValue).\(scopeIdentifier)"
         } else {
-            provider.rawValue
+            instanceID.rawValue
         }
         return Self(category: "cookie", identifier: identifier)
     }
 
-    public static func oauth(provider: UsageProvider) -> Self {
-        Self(category: "oauth", identifier: provider.rawValue)
+    public static func oauth(provider instanceID: ProviderInstanceID) -> Self {
+        Self(category: "oauth", identifier: instanceID.rawValue)
     }
 }

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -1,7 +1,11 @@
 public enum LogCategories {
-    public static func provider(_ provider: UsageProvider, scope: String? = nil) -> String {
-        let base = provider == .opencodego ? "opencode-go" : provider.rawValue
+    public static func providerInstance(_ instanceID: ProviderInstanceID, scope: String? = nil) -> String {
+        let base = instanceID.firstPartyProvider == .opencodego ? "opencode-go" : instanceID.rawValue
         return scope.map { "\(base)-\($0)" } ?? base
+    }
+
+    public static func provider(_ provider: UsageProvider, scope: String? = nil) -> String {
+        self.providerInstance(provider.instanceID, scope: scope)
     }
 
     public static let abacusCookie = Self.provider(.abacus, scope: "cookie")

--- a/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
@@ -57,7 +57,7 @@ public enum ProviderPluginCapability: String, Sendable {
 }
 
 public struct ProviderPluginManifest: @unchecked Sendable {
-    public let id: UsageProvider
+    public let id: ProviderInstanceID
     public let name: String
     public let endpoints: Set<ProviderPluginEndpoint>
     public let auth: ProviderPluginAuth?
@@ -75,7 +75,7 @@ public struct ProviderPluginManifest: @unchecked Sendable {
         }
 
         let rawID = try Self.requiredString(definition, property: "id")
-        guard let id = UsageProvider(rawValue: rawID) else {
+        guard let id = ProviderInstanceID(rawValue: rawID), id.firstPartyProvider != nil else {
             throw ProviderPluginError.invalidManifest(
                 "provider id '\(rawID)' must match an existing UsageProvider raw value")
         }

--- a/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
@@ -454,7 +454,7 @@ private final class ProviderPluginWorker: @unchecked Sendable {
         host.setObject(cacheSet, forKeyedSubscript: "cacheSet" as NSString)
 
         let log: @convention(block) (String) -> Void = { [manifest] message in
-            let logger = CodexBarLog.logger(LogCategories.provider(manifest.id, scope: "plugin"))
+            let logger = CodexBarLog.logger(LogCategories.providerInstance(manifest.id, scope: "plugin"))
             logger.debug("\(redactionValues.redact(message))")
         }
         host.setObject(log, forKeyedSubscript: "log" as NSString)
@@ -554,7 +554,12 @@ private final class ProviderPluginWorker: @unchecked Sendable {
                 return
             }
 
-            let provider = self.manifest.id
+            guard let provider = self.manifest.id.firstPartyProvider else {
+                self.reject(
+                    ProviderPluginJSValueBox(reject),
+                    error: ProviderPluginError.secretAccess("browser cookies require a first-party provider"))
+                return
+            }
             let worker = self
             let resolveBox = ProviderPluginJSValueBox(resolve)
             let rejectBox = ProviderPluginJSValueBox(reject)

--- a/Sources/CodexBarCore/Plugins/ProviderPluginSnapshotMapper.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginSnapshotMapper.swift
@@ -5,7 +5,7 @@ import Foundation
 enum ProviderPluginSnapshotMapper {
     private static let maximumStringBytes = 256
 
-    static func map(_ value: JSValue, provider: UsageProvider, now: Date = Date()) throws -> UsageSnapshot {
+    static func map(_ value: JSValue, provider: ProviderInstanceID, now: Date = Date()) throws -> UsageSnapshot {
         guard value.isObject, !value.isArray, !value.isNull else {
             throw ProviderPluginError.invalidSnapshot("fetchUsage must resolve to an object")
         }
@@ -207,7 +207,7 @@ enum ProviderPluginSnapshotMapper {
             updatedAt: now)
     }
 
-    private static func identity(_ root: JSValue, provider: UsageProvider) throws -> ProviderIdentitySnapshot? {
+    private static func identity(_ root: JSValue, provider: ProviderInstanceID) throws -> ProviderIdentitySnapshot? {
         guard let value = root.forProperty("identity"), !value.isUndefined, !value.isNull else { return nil }
         guard value.isObject, !value.isArray else {
             throw ProviderPluginError.invalidSnapshot("identity must be an object")

--- a/Sources/CodexBarCore/Plugins/ScriptFetchStrategy.swift
+++ b/Sources/CodexBarCore/Plugins/ScriptFetchStrategy.swift
@@ -101,7 +101,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
             throw ProviderPluginError.secretAccess("required provider secret is unavailable")
         }
         let runtime = try self.loadedRuntime()
-        guard runtime.manifest.id == self.provider else {
+        guard runtime.manifest.id == self.provider.instanceID else {
             throw ProviderPluginError.invalidManifest(
                 "bundled plugin id '\(runtime.manifest.id.rawValue)' does not match '\(self.provider.rawValue)'")
         }

--- a/Sources/CodexBarCore/ProviderIdentitySnapshot.swift
+++ b/Sources/CodexBarCore/ProviderIdentitySnapshot.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 public struct ProviderIdentitySnapshot: Codable, Sendable {
-    public let providerID: UsageProvider?
+    public let providerID: ProviderInstanceID?
     public let accountEmail: String?
     public let accountOrganization: String?
     public let loginMethod: String?
     public let accountID: String?
 
     public init(
-        providerID: UsageProvider?,
+        providerID: ProviderInstanceID?,
         accountEmail: String?,
         accountOrganization: String?,
         loginMethod: String?,
@@ -21,16 +21,20 @@ public struct ProviderIdentitySnapshot: Codable, Sendable {
         self.accountID = accountID
     }
 
-    public func scoped(to provider: UsageProvider) -> ProviderIdentitySnapshot {
-        if self.providerID == provider {
+    public func scoped(to instanceID: ProviderInstanceID) -> ProviderIdentitySnapshot {
+        if self.providerID == instanceID {
             return self
         }
         return ProviderIdentitySnapshot(
-            providerID: provider,
+            providerID: instanceID,
             accountEmail: self.accountEmail,
             accountOrganization: self.accountOrganization,
             loginMethod: self.loginMethod,
             accountID: self.accountID)
+    }
+
+    public func scoped(to provider: UsageProvider) -> ProviderIdentitySnapshot {
+        self.scoped(to: provider.instanceID)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexReconciledState.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexReconciledState.swift
@@ -61,7 +61,7 @@ public struct CodexReconciledState: Sendable {
         let resolvedEmail = accountEmail ?? snapshot.signedInEmail
         let resolvedPlan = accountPlan ?? snapshot.accountPlan
         let identity = ProviderIdentitySnapshot(
-            providerID: provider,
+            providerID: provider.instanceID,
             accountEmail: resolvedEmail,
             accountOrganization: nil,
             loginMethod: resolvedPlan)

--- a/Sources/CodexBarCore/Providers/ProviderInstanceID.swift
+++ b/Sources/CodexBarCore/Providers/ProviderInstanceID.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+public struct ProviderInstanceID: RawRepresentable, Hashable, Codable, Sendable, CustomStringConvertible {
+    public let rawValue: String
+
+    public var description: String {
+        self.rawValue
+    }
+
+    public init?(rawValue: String) {
+        guard Self.isValid(rawValue) else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(firstPartyProvider provider: UsageProvider) {
+        self.rawValue = provider.rawValue
+    }
+
+    public var firstPartyProvider: UsageProvider? {
+        UsageProvider(rawValue: self.rawValue)
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        guard let instanceID = Self(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Provider instance ID must contain 1-64 lowercase ASCII letters, digits, or hyphens")
+        }
+        self = instanceID
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+
+    private static func isValid(_ rawValue: String) -> Bool {
+        guard (1...64).contains(rawValue.utf8.count) else { return false }
+        return rawValue.utf8.allSatisfy { byte in
+            (UInt8(ascii: "a")...UInt8(ascii: "z")).contains(byte) ||
+                (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(byte) ||
+                byte == UInt8(ascii: "-")
+        }
+    }
+}
+
+extension UsageProvider {
+    public var instanceID: ProviderInstanceID {
+        ProviderInstanceID(firstPartyProvider: self)
+    }
+}
+
+// First-party spellings keep call sites concise while their values remain validated instance IDs.
+// swiftformat:disable sortDeclarations
+extension ProviderInstanceID {
+    public static let codex = UsageProvider.codex.instanceID
+    public static let openai = UsageProvider.openai.instanceID
+    public static let azureopenai = UsageProvider.azureopenai.instanceID
+    public static let claude = UsageProvider.claude.instanceID
+    public static let clinepass = UsageProvider.clinepass.instanceID
+    public static let cursor = UsageProvider.cursor.instanceID
+    public static let opencode = UsageProvider.opencode.instanceID
+    public static let opencodego = UsageProvider.opencodego.instanceID
+    public static let alibaba = UsageProvider.alibaba.instanceID
+    public static let alibabatokenplan = UsageProvider.alibabatokenplan.instanceID
+    public static let qwencloud = UsageProvider.qwencloud.instanceID
+    public static let factory = UsageProvider.factory.instanceID
+    public static let gemini = UsageProvider.gemini.instanceID
+    public static let antigravity = UsageProvider.antigravity.instanceID
+    public static let copilot = UsageProvider.copilot.instanceID
+    public static let devin = UsageProvider.devin.instanceID
+    public static let zai = UsageProvider.zai.instanceID
+    public static let minimax = UsageProvider.minimax.instanceID
+    public static let manus = UsageProvider.manus.instanceID
+    public static let kimi = UsageProvider.kimi.instanceID
+    public static let kilo = UsageProvider.kilo.instanceID
+    public static let kiro = UsageProvider.kiro.instanceID
+    public static let vertexai = UsageProvider.vertexai.instanceID
+    public static let augment = UsageProvider.augment.instanceID
+    public static let jetbrains = UsageProvider.jetbrains.instanceID
+    public static let moonshot = UsageProvider.moonshot.instanceID
+    public static let amp = UsageProvider.amp.instanceID
+    public static let t3chat = UsageProvider.t3chat.instanceID
+    public static let ollama = UsageProvider.ollama.instanceID
+    public static let synthetic = UsageProvider.synthetic.instanceID
+    public static let warp = UsageProvider.warp.instanceID
+    public static let openrouter = UsageProvider.openrouter.instanceID
+    public static let elevenlabs = UsageProvider.elevenlabs.instanceID
+    public static let windsurf = UsageProvider.windsurf.instanceID
+    public static let zed = UsageProvider.zed.instanceID
+    public static let perplexity = UsageProvider.perplexity.instanceID
+    public static let mimo = UsageProvider.mimo.instanceID
+    public static let doubao = UsageProvider.doubao.instanceID
+    public static let sakana = UsageProvider.sakana.instanceID
+    public static let abacus = UsageProvider.abacus.instanceID
+    public static let mistral = UsageProvider.mistral.instanceID
+    public static let deepseek = UsageProvider.deepseek.instanceID
+    public static let deepinfra = UsageProvider.deepinfra.instanceID
+    public static let codebuff = UsageProvider.codebuff.instanceID
+    public static let crof = UsageProvider.crof.instanceID
+    public static let venice = UsageProvider.venice.instanceID
+    public static let commandcode = UsageProvider.commandcode.instanceID
+    public static let qoder = UsageProvider.qoder.instanceID
+    public static let stepfun = UsageProvider.stepfun.instanceID
+    public static let bedrock = UsageProvider.bedrock.instanceID
+    public static let grok = UsageProvider.grok.instanceID
+    public static let groq = UsageProvider.groq.instanceID
+    public static let llmproxy = UsageProvider.llmproxy.instanceID
+    public static let litellm = UsageProvider.litellm.instanceID
+    public static let deepgram = UsageProvider.deepgram.instanceID
+    public static let poe = UsageProvider.poe.instanceID
+    public static let chutes = UsageProvider.chutes.instanceID
+    public static let neuralwatt = UsageProvider.neuralwatt.instanceID
+    public static let clawrouter = UsageProvider.clawrouter.instanceID
+    public static let longcat = UsageProvider.longcat.instanceID
+    public static let sub2api = UsageProvider.sub2api.instanceID
+    public static let wayfinder = UsageProvider.wayfinder.instanceID
+    public static let zenmux = UsageProvider.zenmux.instanceID
+    public static let aiand = UsageProvider.aiand.instanceID
+    public static let zoommate = UsageProvider.zoommate.instanceID
+    public static let xai = UsageProvider.xai.instanceID
+    public static let notion = UsageProvider.notion.instanceID
+}
+
+// swiftformat:enable sortDeclarations

--- a/Sources/CodexBarCore/Sync/SyncModels.swift
+++ b/Sources/CodexBarCore/Sync/SyncModels.swift
@@ -26,7 +26,7 @@ public enum ProviderIntentSecretField: String, CaseIterable, Sendable {
 /// representation in this type, so untrusted sync payloads cannot change them.
 public struct ProviderIntentPayload: Codable, Sendable {
     public let schemaVersion: Int
-    public let provider: UsageProvider
+    public let provider: ProviderInstanceID
     public var enabled: Bool?
     public var extrasEnabled: Bool?
     public var region: String?
@@ -65,9 +65,10 @@ public struct ProviderIntentPayload: Codable, Sendable {
         canEnable: (UsageProvider, ProviderConfig) -> Bool) throws -> ProviderConfig
     {
         precondition(local.id == self.provider)
+        guard let firstPartyProvider = self.provider.firstPartyProvider else { return local }
         var result = local
         if self.enabled == true {
-            if canEnable(self.provider, local) {
+            if canEnable(firstPartyProvider, local) {
                 result.enabled = true
             }
         } else {
@@ -126,8 +127,8 @@ public struct ProviderIntentPayload: Codable, Sendable {
         return fields
     }
 
-    public static func recordName(for provider: UsageProvider) -> String {
-        "intent-\(provider.rawValue)"
+    public static func recordName(for instanceID: ProviderInstanceID) -> String {
+        "intent-\(instanceID.rawValue)"
     }
 }
 
@@ -162,7 +163,7 @@ public struct DeviceSyncPayload: Codable, Sendable {
 
 public struct AccountSnapshotSyncPayload: Codable, Sendable {
     public let schemaVersion: Int
-    public let provider: UsageProvider
+    public let provider: ProviderInstanceID
     public let deviceID: String
     public let accountKey: String
     public let fetchedAt: Date
@@ -170,7 +171,7 @@ public struct AccountSnapshotSyncPayload: Codable, Sendable {
     public let usage: UsageSnapshot
 
     public init(
-        provider: UsageProvider,
+        provider: ProviderInstanceID,
         deviceID: String,
         accountIdentity: String?,
         displayLabel: String,
@@ -187,7 +188,7 @@ public struct AccountSnapshotSyncPayload: Codable, Sendable {
     }
 
     public init(
-        provider: UsageProvider,
+        provider: ProviderInstanceID,
         deviceID: String,
         accountKey: String,
         fetchedAt: Date,

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -432,8 +432,8 @@ public struct UsageSnapshot: Codable, Sendable {
         try container.encodeIfPresent(self.identity?.loginMethod, forKey: .loginMethod)
     }
 
-    public func identity(for provider: UsageProvider) -> ProviderIdentitySnapshot? {
-        guard let identity, identity.providerID == provider else { return nil }
+    public func identity(for instanceID: ProviderInstanceID) -> ProviderIdentitySnapshot? {
+        guard let identity, identity.providerID == instanceID else { return nil }
         return identity
     }
 
@@ -460,15 +460,15 @@ public struct UsageSnapshot: Codable, Sendable {
     }
 
     public func accountEmail(for provider: UsageProvider) -> String? {
-        self.identity(for: provider)?.accountEmail
+        self.identity(for: provider.instanceID)?.accountEmail
     }
 
     public func accountOrganization(for provider: UsageProvider) -> String? {
-        self.identity(for: provider)?.accountOrganization
+        self.identity(for: provider.instanceID)?.accountOrganization
     }
 
     public func loginMethod(for provider: UsageProvider) -> String? {
-        self.identity(for: provider)?.loginMethod
+        self.identity(for: provider.instanceID)?.loginMethod
     }
 
     public var hasRateLimitWindows: Bool {
@@ -689,7 +689,7 @@ public enum UsageLimitsAvailability: Equatable, Sendable {
 
         if provider == .doubao || provider == .antigravity {
             guard let snapshot,
-                  snapshot.identity(for: provider) != nil
+                  snapshot.identity(for: provider.instanceID) != nil
             else {
                 return .available
             }
@@ -699,7 +699,7 @@ public enum UsageLimitsAvailability: Equatable, Sendable {
         guard provider == .codex else { return .available }
 
         if let snapshot {
-            guard snapshot.identity(for: provider) != nil else { return .available }
+            guard snapshot.identity(for: provider.instanceID) != nil else { return .available }
             return snapshot.hasRateLimitWindows ? .available : .unavailable
         }
 

--- a/Sources/CodexBarCore/WidgetSnapshot.swift
+++ b/Sources/CodexBarCore/WidgetSnapshot.swift
@@ -16,7 +16,7 @@ public struct WidgetSnapshot: Codable, Sendable {
     }
 
     public struct ProviderEntry: Codable, Sendable {
-        public let provider: UsageProvider
+        public let provider: ProviderInstanceID
         public let updatedAt: Date
         public let primary: RateWindow?
         public let secondary: RateWindow?
@@ -28,6 +28,34 @@ public struct WidgetSnapshot: Codable, Sendable {
         public let dailyUsage: [DailyUsagePoint]
         public let providerCost: ProviderCostSnapshot?
         public let quotaOwnerKey: String?
+
+        public init(
+            instanceID: ProviderInstanceID,
+            updatedAt: Date,
+            primary: RateWindow?,
+            secondary: RateWindow?,
+            tertiary: RateWindow?,
+            usageRows: [WidgetUsageRowSnapshot]? = nil,
+            creditsRemaining: Double?,
+            codeReviewRemainingPercent: Double?,
+            tokenUsage: TokenUsageSummary?,
+            dailyUsage: [DailyUsagePoint],
+            providerCost: ProviderCostSnapshot? = nil,
+            quotaOwnerKey: String? = nil)
+        {
+            self.provider = instanceID
+            self.updatedAt = updatedAt
+            self.primary = primary
+            self.secondary = secondary
+            self.tertiary = tertiary
+            self.usageRows = usageRows
+            self.creditsRemaining = creditsRemaining
+            self.codeReviewRemainingPercent = codeReviewRemainingPercent
+            self.tokenUsage = tokenUsage
+            self.dailyUsage = dailyUsage
+            self.providerCost = providerCost
+            self.quotaOwnerKey = quotaOwnerKey
+        }
 
         public init(
             provider: UsageProvider,
@@ -43,18 +71,19 @@ public struct WidgetSnapshot: Codable, Sendable {
             providerCost: ProviderCostSnapshot? = nil,
             quotaOwnerKey: String? = nil)
         {
-            self.provider = provider
-            self.updatedAt = updatedAt
-            self.primary = primary
-            self.secondary = secondary
-            self.tertiary = tertiary
-            self.usageRows = usageRows
-            self.creditsRemaining = creditsRemaining
-            self.codeReviewRemainingPercent = codeReviewRemainingPercent
-            self.tokenUsage = tokenUsage
-            self.dailyUsage = dailyUsage
-            self.providerCost = providerCost
-            self.quotaOwnerKey = quotaOwnerKey
+            self.init(
+                instanceID: provider.instanceID,
+                updatedAt: updatedAt,
+                primary: primary,
+                secondary: secondary,
+                tertiary: tertiary,
+                usageRows: usageRows,
+                creditsRemaining: creditsRemaining,
+                codeReviewRemainingPercent: codeReviewRemainingPercent,
+                tokenUsage: tokenUsage,
+                dailyUsage: dailyUsage,
+                providerCost: providerCost,
+                quotaOwnerKey: quotaOwnerKey)
         }
     }
 
@@ -142,13 +171,13 @@ public struct WidgetSnapshot: Codable, Sendable {
     }
 
     public let entries: [ProviderEntry]
-    public let enabledProviders: [UsageProvider]
+    public let enabledProviders: [ProviderInstanceID]
     public let usageBarsShowUsed: Bool
     public let generatedAt: Date
 
     public init(
         entries: [ProviderEntry],
-        enabledProviders: [UsageProvider]? = nil,
+        enabledProviders: [ProviderInstanceID]? = nil,
         usageBarsShowUsed: Bool = false,
         generatedAt: Date)
     {
@@ -169,7 +198,7 @@ public struct WidgetSnapshot: Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.entries = try container.decode([ProviderEntry].self, forKey: .entries)
         self.generatedAt = try container.decode(Date.self, forKey: .generatedAt)
-        self.enabledProviders = try container.decodeIfPresent([UsageProvider].self, forKey: .enabledProviders)
+        self.enabledProviders = try container.decodeIfPresent([ProviderInstanceID].self, forKey: .enabledProviders)
             ?? self.entries.map(\.provider)
         self.usageBarsShowUsed = try container.decodeIfPresent(Bool.self, forKey: .usageBarsShowUsed) ?? false
     }
@@ -232,18 +261,25 @@ public enum WidgetSnapshotStore {
 public enum WidgetSelectionStore {
     private static let selectedProviderKey = "widgetSelectedProvider"
 
-    public static func loadSelectedProvider(bundleID: String? = Bundle.main.bundleIdentifier) -> UsageProvider? {
+    public static func loadSelectedProvider(bundleID: String? = Bundle.main.bundleIdentifier) -> ProviderInstanceID? {
         let defaults = self.sharedDefaults(bundleID: bundleID)
         guard let raw = defaults.string(forKey: self.selectedProviderKey) else { return nil }
-        return UsageProvider(rawValue: raw)
+        return ProviderInstanceID(rawValue: raw)
+    }
+
+    public static func saveSelectedProvider(
+        instanceID: ProviderInstanceID,
+        bundleID: String? = Bundle.main.bundleIdentifier)
+    {
+        let defaults = self.sharedDefaults(bundleID: bundleID)
+        defaults.set(instanceID.rawValue, forKey: self.selectedProviderKey)
     }
 
     public static func saveSelectedProvider(
         _ provider: UsageProvider,
         bundleID: String? = Bundle.main.bundleIdentifier)
     {
-        let defaults = self.sharedDefaults(bundleID: bundleID)
-        defaults.set(provider.rawValue, forKey: self.selectedProviderKey)
+        self.saveSelectedProvider(instanceID: provider.instanceID, bundleID: bundleID)
     }
 
     private static func sharedDefaults(bundleID: String?) -> UserDefaults {

--- a/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
+++ b/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
@@ -88,7 +88,7 @@ struct BurnDownState {
         selection: BurnWindowChoice,
         now: Date = Date())
     {
-        guard let entry = snapshot.entries.first(where: { $0.provider == provider }) else { return nil }
+        guard let entry = snapshot.entries.first(where: { $0.provider == provider.instanceID }) else { return nil }
         self.entry = entry
         self.selection = selection
         self.now = now
@@ -156,7 +156,7 @@ enum BurnDownRefreshSchedule {
         now: Date = Date()) -> Date
     {
         let fallback = now.addingTimeInterval(self.maximumInterval)
-        guard let entry = snapshot.entries.first(where: { $0.provider == provider }) else { return fallback }
+        guard let entry = snapshot.entries.first(where: { $0.provider == provider.instanceID }) else { return fallback }
         let nextReset = [entry.primary?.resetsAt, entry.secondary?.resetsAt]
             .compactMap(\.self)
             .filter { $0 > now }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -195,8 +195,8 @@ struct CodexBarSwitcherTimelineProvider: TimelineProvider {
         let snapshot = WidgetSnapshotStore.load() ?? WidgetPreviewData.emptySnapshot()
         let providers = self.availableProviders(from: snapshot)
         let stored = WidgetSelectionStore.loadSelectedProvider()
-        let selected = providers.first { $0 == stored } ?? providers.first ?? .codex
-        if selected != stored {
+        let selected = providers.first { $0.instanceID == stored } ?? providers.first ?? .codex
+        if selected.instanceID != stored {
             WidgetSelectionStore.saveSelectedProvider(selected)
         }
         return CodexBarSwitcherEntry(
@@ -212,8 +212,13 @@ struct CodexBarSwitcherTimelineProvider: TimelineProvider {
 
     static func supportedProviders(from snapshot: WidgetSnapshot) -> [UsageProvider] {
         let enabled = snapshot.enabledProviders
-        let providers = enabled.isEmpty ? snapshot.entries.map(\.provider) : enabled
-        let supported = providers.filter { ProviderChoice(provider: $0) != nil }
+        let instanceIDs = enabled.isEmpty ? snapshot.entries.map(\.provider) : enabled
+        let supported = instanceIDs.compactMap { instanceID -> UsageProvider? in
+            guard let provider = instanceID.firstPartyProvider, ProviderChoice(provider: provider) != nil else {
+                return nil
+            }
+            return provider
+        }
         return supported.isEmpty ? [.codex] : supported
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -11,7 +11,7 @@ struct CodexBarUsageWidgetView: View {
     let entry: CodexBarWidgetEntry
 
     var body: some View {
-        let providerEntry = self.entry.snapshot.entries.first { $0.provider == self.entry.provider }
+        let providerEntry = self.entry.snapshot.entries.first { $0.provider == self.entry.provider.instanceID }
         Group {
             if let providerEntry {
                 self.content(providerEntry: providerEntry)
@@ -54,7 +54,7 @@ struct CodexBarHistoryWidgetView: View {
     let entry: CodexBarWidgetEntry
 
     var body: some View {
-        let providerEntry = self.entry.snapshot.entries.first { $0.provider == self.entry.provider }
+        let providerEntry = self.entry.snapshot.entries.first { $0.provider == self.entry.provider.instanceID }
         Group {
             if let providerEntry {
                 HistoryView(entry: providerEntry, isLarge: self.family == .systemLarge)
@@ -83,7 +83,7 @@ struct CodexBarCompactWidgetView: View {
     let entry: CodexBarCompactEntry
 
     var body: some View {
-        let providerEntry = self.entry.snapshot.entries.first { $0.provider == self.entry.provider }
+        let providerEntry = self.entry.snapshot.entries.first { $0.provider == self.entry.provider.instanceID }
         Group {
             if let providerEntry {
                 CompactMetricView(entry: providerEntry, metric: self.entry.metric)
@@ -113,7 +113,7 @@ struct CodexBarSwitcherWidgetView: View {
     let entry: CodexBarSwitcherEntry
 
     var body: some View {
-        let providerEntry = self.entry.snapshot.entries.first { $0.provider == self.entry.provider }
+        let providerEntry = self.entry.snapshot.entries.first { $0.provider == self.entry.provider.instanceID }
         VStack(alignment: .leading, spacing: 10) {
             ProviderSwitcherRow(
                 providers: self.entry.availableProviders,
@@ -228,7 +228,7 @@ enum CompactMetricFormatter {
         }
     }
 
-    static func costMetricLabel(_ label: String, provider: UsageProvider) -> String {
+    static func costMetricLabel(_ label: String, provider: ProviderInstanceID) -> String {
         guard provider == .codex else { return "\(label) cost" }
         // Existing widget timelines may predate the estimate labels. Do not leave a bare
         // dollar value until the app next republishes it.
@@ -270,7 +270,7 @@ private struct ProviderSwitchChip: View {
     var body: some View {
         let label = self.compact ? self.shortLabel : self.longLabel
         let background = self.selected
-            ? WidgetColors.color(for: self.provider).opacity(0.2)
+            ? WidgetColors.color(for: self.provider.instanceID).opacity(0.2)
             : Color.primary.opacity(0.08)
 
         if let choice = ProviderChoice(provider: self.provider) {
@@ -631,7 +631,7 @@ struct WidgetUsageRow: Identifiable, Equatable {
                 provider: entry.provider,
                 now: now)
         } else {
-            let metadata = ProviderDefaults.metadata[entry.provider]
+            let metadata = entry.provider.firstPartyProvider.flatMap { ProviderDefaults.metadata[$0] }
             var defaultRows = [
                 WidgetUsageRow(
                     id: "primary",
@@ -685,7 +685,7 @@ struct WidgetUsageRow: Identifiable, Equatable {
     private static func applyingCodexWeeklyCap(
         _ rows: [WidgetUsageRow],
         snapshots: [WidgetSnapshot.WidgetUsageRowSnapshot],
-        provider: UsageProvider,
+        provider: ProviderInstanceID,
         now: Date) -> [WidgetUsageRow]
     {
         guard provider == .codex,
@@ -812,12 +812,13 @@ private struct HistoryView: View {
 }
 
 private struct HeaderView: View {
-    let provider: UsageProvider
+    let provider: ProviderInstanceID
     let updatedAt: Date
 
     var body: some View {
         HStack(alignment: .firstTextBaseline) {
-            Text(ProviderDefaults.metadata[self.provider]?.displayName ?? self.provider.rawValue.capitalized)
+            Text(self.provider.firstPartyProvider.flatMap { ProviderDefaults.metadata[$0]?.displayName }
+                ?? self.provider.rawValue.capitalized)
                 .font(.body)
                 .fontWeight(.semibold)
             Spacer()
@@ -931,8 +932,9 @@ enum UsageHistoryChartMode {
 
 enum WidgetColors {
     // swiftlint:disable:next cyclomatic_complexity
-    static func color(for provider: UsageProvider) -> Color {
-        switch provider {
+    static func color(for instanceID: ProviderInstanceID) -> Color {
+        guard let provider = instanceID.firstPartyProvider else { return .secondary }
+        return switch provider {
         case .codex:
             Color(red: 73 / 255, green: 163 / 255, blue: 176 / 255)
         case .openai:

--- a/Tests/CodexBarTests/CLIServeRawHTTPTests.swift
+++ b/Tests/CodexBarTests/CLIServeRawHTTPTests.swift
@@ -324,7 +324,7 @@ struct CLIServeRawHTTPTests {
         let store = testConfigStore(suiteName: "CLIServeRawHTTPTests-\(UUID().uuidString)")
         defer { try? store.deleteIfPresent() }
         try store.save(CodexBarConfig(providers: UsageProvider.allCases.map {
-            ProviderConfig(id: $0, enabled: false)
+            ProviderConfig(id: $0.instanceID, enabled: false)
         }))
         let runtime = ServeRuntime(
             configStore: store,
@@ -370,7 +370,7 @@ struct CLIServeRawHTTPTests {
         let store = testConfigStore(suiteName: "CLIServeRawHTTPTests-\(UUID().uuidString)")
         defer { try? store.deleteIfPresent() }
         try store.save(CodexBarConfig(providers: UsageProvider.allCases.map {
-            ProviderConfig(id: $0, enabled: false)
+            ProviderConfig(id: $0.instanceID, enabled: false)
         }))
         if let rawConfigJSON {
             try Data(rawConfigJSON.utf8).write(to: store.fileURL)

--- a/Tests/CodexBarTests/CodexSessionQuotaFalseRestoreTests.swift
+++ b/Tests/CodexBarTests/CodexSessionQuotaFalseRestoreTests.swift
@@ -1026,7 +1026,7 @@ extension CodexSessionQuotaFalseRestoreTests {
             secondary: nil,
             updatedAt: updatedAt,
             identity: ProviderIdentitySnapshot(
-                providerID: provider,
+                providerID: provider.instanceID,
                 accountEmail: email,
                 accountOrganization: nil,
                 loginMethod: "test"))

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -388,7 +388,10 @@ struct CookieHeaderCacheTests {
             #expect(loaded == nil)
             #expect(FileManager.default.fileExists(atPath: legacyURL.path) == true)
 
-            switch KeychainCacheStore.load(key: .cookie(provider: provider), as: CookieHeaderCache.Entry.self) {
+            switch KeychainCacheStore.load(
+                key: .cookie(provider: provider.instanceID),
+                as: CookieHeaderCache.Entry.self)
+            {
             case .missing:
                 #expect(true)
             case .found, .temporarilyUnavailable, .invalid:
@@ -407,7 +410,7 @@ struct CookieHeaderCacheTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         CookieHeaderCache.withLegacyBaseURLOverrideForTesting(legacyBase) {
             let provider: UsageProvider = .codex
-            let key = KeychainCacheStore.Key.cookie(provider: provider)
+            let key = KeychainCacheStore.Key.cookie(provider: provider.instanceID)
             KeychainCacheStore.store(key: key, entry: WrongEntry(value: "not-a-cookie-entry"))
 
             #expect(CookieHeaderCache.load(provider: provider) == nil)
@@ -438,7 +441,7 @@ struct CookieHeaderCacheTests {
                 cookieHeader: "auth=scoped",
                 sourceLabel: "Chrome")
             KeychainCacheStore.store(
-                key: .cookie(provider: provider, scopeIdentifier: "managed-store-unreadable"),
+                key: .cookie(provider: provider.instanceID, scopeIdentifier: "managed-store-unreadable"),
                 entry: WrongEntry(value: "invalid"))
             CookieHeaderCache.store(
                 CookieHeaderCache.Entry(
@@ -473,7 +476,7 @@ struct CookieHeaderCacheTests {
 
         // Remove the backing entry without going through CookieHeaderCache: the strict load
         // sees the change, the display path keeps serving the memoized snapshot.
-        KeychainCacheStore.clear(key: .cookie(provider: provider))
+        KeychainCacheStore.clear(key: .cookie(provider: provider.instanceID))
         #expect(CookieHeaderCache.load(provider: provider) == nil)
         #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=abc")
     }
@@ -489,12 +492,12 @@ struct CookieHeaderCacheTests {
         #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
 
         KeychainCacheStore.store(
-            key: .cookie(provider: provider),
+            key: .cookie(provider: provider.instanceID),
             entry: CookieHeaderCache.Entry(
                 cookieHeader: "auth=behind-the-back",
                 storedAt: Date(timeIntervalSince1970: 0),
                 sourceLabel: "Chrome"))
-        defer { KeychainCacheStore.clear(key: .cookie(provider: provider)) }
+        defer { KeychainCacheStore.clear(key: .cookie(provider: provider.instanceID)) }
         #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
     }
 
@@ -593,7 +596,7 @@ struct CookieHeaderCacheTests {
         try await CookieHeaderCache.withDisplayUnavailableRetryIntervalOverrideForTesting(0.05) {
             let provider: UsageProvider = .codex
             KeychainCacheStore.store(
-                key: .cookie(provider: provider),
+                key: .cookie(provider: provider.instanceID),
                 entry: CookieHeaderCache.Entry(
                     cookieHeader: "auth=available-after-retry",
                     storedAt: Date(timeIntervalSince1970: 0),
@@ -829,7 +832,7 @@ struct CookieHeaderCacheTests {
 
         let provider: UsageProvider = .codex
         KeychainCacheStore.store(
-            key: .cookie(provider: provider),
+            key: .cookie(provider: provider.instanceID),
             entry: CookieHeaderCache.Entry(
                 cookieHeader: "auth=secret",
                 storedAt: Date(timeIntervalSince1970: 0),
@@ -858,7 +861,7 @@ struct CookieHeaderCacheTests {
         try await CookieHeaderCache.withDisplayStalenessIntervalOverrideForTesting(0) {
             let provider: UsageProvider = .codex
             KeychainCacheStore.store(
-                key: .cookie(provider: provider),
+                key: .cookie(provider: provider.instanceID),
                 entry: CookieHeaderCache.Entry(
                     cookieHeader: "auth=old",
                     storedAt: Date(timeIntervalSince1970: 0),
@@ -866,7 +869,7 @@ struct CookieHeaderCacheTests {
             #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=old")
 
             KeychainCacheStore.store(
-                key: .cookie(provider: provider),
+                key: .cookie(provider: provider.instanceID),
                 entry: CookieHeaderCache.Entry(
                     cookieHeader: "auth=new",
                     storedAt: Date(timeIntervalSince1970: 1),

--- a/Tests/CodexBarTests/MenuCardRefreshTests.swift
+++ b/Tests/CodexBarTests/MenuCardRefreshTests.swift
@@ -45,7 +45,7 @@ struct MenuCardRefreshTests {
                 secondary: nil,
                 updatedAt: updatedAt,
                 identity: ProviderIdentitySnapshot(
-                    providerID: provider,
+                    providerID: provider.instanceID,
                     accountEmail: nil,
                     accountOrganization: nil,
                     loginMethod: "Pro"))

--- a/Tests/CodexBarTests/PredictivePaceWarningTests.swift
+++ b/Tests/CodexBarTests/PredictivePaceWarningTests.swift
@@ -692,7 +692,7 @@ struct PredictivePaceWarningTests {
                 resetDescription: nil),
             updatedAt: now,
             identity: ProviderIdentitySnapshot(
-                providerID: provider,
+                providerID: provider.instanceID,
                 accountEmail: accountEmail,
                 accountOrganization: nil,
                 loginMethod: nil))

--- a/Tests/CodexBarTests/ProviderInstanceIDTests.swift
+++ b/Tests/CodexBarTests/ProviderInstanceIDTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+struct ProviderInstanceIDTests {
+    @Test(arguments: ["a", "codex", "acme-gateway", String(repeating: "a", count: 64), "0-9"])
+    func `accepts IDs from the declared ASCII grammar`(_ rawValue: String) throws {
+        let instanceID = try #require(ProviderInstanceID(rawValue: rawValue))
+        #expect(instanceID.rawValue == rawValue)
+    }
+
+    @Test(arguments: [
+        "",
+        "UPPERCASE",
+        "under_score",
+        "contains space",
+        "café",
+        "slash/value",
+        String(repeating: "a", count: 65),
+    ])
+    func `rejects IDs outside the declared ASCII grammar`(_ rawValue: String) {
+        #expect(ProviderInstanceID(rawValue: rawValue) == nil)
+    }
+
+    @Test
+    func `codable representation is a validated bare string`() throws {
+        let instanceID = try #require(ProviderInstanceID(rawValue: "acme-gateway"))
+        let encoded = try JSONEncoder().encode(instanceID)
+
+        #expect(String(data: encoded, encoding: .utf8) == #""acme-gateway""#)
+        #expect(try JSONDecoder().decode(ProviderInstanceID.self, from: encoded) == instanceID)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(ProviderInstanceID.self, from: Data(#""Acme""#.utf8))
+        }
+    }
+
+    @Test
+    func `first party mapping preserves raw values and rejects dynamic IDs`() throws {
+        for provider in UsageProvider.allCases {
+            #expect(provider.instanceID.rawValue == provider.rawValue)
+            #expect(provider.instanceID.firstPartyProvider == provider)
+        }
+
+        let dynamicID = try #require(ProviderInstanceID(rawValue: "acme-gateway"))
+        #expect(dynamicID.firstPartyProvider == nil)
+    }
+
+    @Test
+    func `distinct instance IDs isolate runtime state`() throws {
+        let first = try #require(ProviderInstanceID(rawValue: "acme-primary"))
+        let second = try #require(ProviderInstanceID(rawValue: "acme-secondary"))
+        var snapshots: [ProviderInstanceID: String] = [:]
+        var errors: [ProviderInstanceID: String] = [:]
+
+        snapshots[first] = "first snapshot"
+        snapshots[second] = "second snapshot"
+        errors[first] = "first error"
+
+        #expect(snapshots[first] == "first snapshot")
+        #expect(snapshots[second] == "second snapshot")
+        #expect(errors[first] == "first error")
+        #expect(errors[second] == nil)
+    }
+
+    @Test
+    func `distinct dynamic instances persist isolated history files`() throws {
+        let first = try #require(ProviderInstanceID(rawValue: "acme-primary"))
+        let second = try #require(ProviderInstanceID(rawValue: "acme-secondary"))
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProviderInstanceIDTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let store = PlanUtilizationHistoryStore(directoryURL: directoryURL)
+        let capturedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        func buckets(_ percent: Double) -> PlanUtilizationHistoryBuckets {
+            PlanUtilizationHistoryBuckets(unscoped: [
+                PlanUtilizationSeriesHistory(
+                    name: .session,
+                    windowMinutes: 300,
+                    entries: [
+                        PlanUtilizationHistoryEntry(
+                            capturedAt: capturedAt,
+                            usedPercent: percent,
+                            resetsAt: nil),
+                    ]),
+            ])
+        }
+
+        store.save([first: buckets(20), second: buckets(80)])
+        let loaded = store.load()
+
+        #expect(loaded[first]?.unscoped.first?.entries.first?.usedPercent == 20)
+        #expect(loaded[second]?.unscoped.first?.entries.first?.usedPercent == 80)
+        #expect(try Set(FileManager.default.contentsOfDirectory(atPath: directoryURL.path)) == [
+            "acme-primary.json",
+            "acme-secondary.json",
+        ])
+    }
+}

--- a/Tests/CodexBarTests/ProviderInstanceIdentityCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ProviderInstanceIdentityCharacterizationTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCLI
+@testable import CodexBarCore
+
+struct ProviderInstanceIdentityCharacterizationTests {
+    @Test
+    func `config provider IDs and enablement encode as their existing bare strings`() throws {
+        let input = Data(#"{"version":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":false}]}"#
+            .utf8)
+        let config = try JSONDecoder().decode(CodexBarConfig.self, from: input)
+
+        #expect(config.orderedProviders() == [.claude, .codex])
+        #expect(config.enabledProviders() == [.claude])
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let encoded = try encoder.encode(config)
+        let encodedJSON = try #require(String(data: encoded, encoding: .utf8))
+        #expect(encodedJSON ==
+            #"{"providers":[{"enabled":true,"id":"claude"},{"enabled":false,"id":"codex"}],"version":1}"#)
+    }
+
+    @Test
+    func `history uses the provider raw value for its filename and leaves payload shape unchanged`() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProviderInstanceIdentityCharacterizationTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let history = PlanUtilizationSeriesHistory(
+            name: .session,
+            windowMinutes: 300,
+            entries: [
+                PlanUtilizationHistoryEntry(
+                    capturedAt: Date(timeIntervalSince1970: 0),
+                    usedPercent: 12,
+                    resetsAt: nil),
+            ])
+        let store = PlanUtilizationHistoryStore(directoryURL: directoryURL)
+        store.save([.claude: PlanUtilizationHistoryBuckets(unscoped: [history])])
+
+        let filenames = try FileManager.default.contentsOfDirectory(atPath: directoryURL.path)
+        #expect(filenames == ["claude.json"])
+        let data = try Data(contentsOf: directoryURL.appendingPathComponent("claude.json"))
+        let encodedJSON = try #require(String(data: data, encoding: .utf8))
+        let expectedJSON = #"{"accounts":{},"sessionEquivalentWindowPairIdentities":{},"unscoped":["# +
+            #"{"entries":[{"capturedAt":"1970-01-01T00:00:00Z","usedPercent":12}],"# +
+            #""name":"session","windowMinutes":300}],"version":1}"#
+        #expect(encodedJSON == expectedJSON)
+        #expect(store.load().keys.sorted(by: { $0.rawValue < $1.rawValue }) == [.claude])
+    }
+
+    @Test
+    func `provider config ordering remains the menu and status ordering contract`() {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .gemini, enabled: true),
+            ProviderConfig(id: .claude, enabled: false),
+            ProviderConfig(id: .codex, enabled: true),
+        ])
+
+        #expect(config.orderedProviders() == [.gemini, .claude, .codex])
+        #expect(config.enabledProviders() == [.gemini, .codex])
+    }
+
+    @MainActor
+    @Test
+    func `settings pane selection persists the provider prefixed raw value`() throws {
+        let suiteName = "ProviderInstanceIdentityCharacterizationTests-selection-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let selection = PreferencesSelection(userDefaults: defaults)
+        selection.pane = .provider(.claude)
+
+        #expect(defaults.string(forKey: PreferencesSelection.paneDefaultsKey) == "provider:claude")
+        #expect(PreferencesSelection(userDefaults: defaults).pane == .provider(.claude))
+    }
+
+    @Test
+    func `keychain cache accounts retain provider raw values`() {
+        #expect(KeychainCacheStore.Key.cookie(provider: .claude).account == "cookie.claude")
+        #expect(KeychainCacheStore.Key.cookie(provider: .claude, scopeIdentifier: "profile").account ==
+            "cookie.claude.profile")
+        #expect(KeychainCacheStore.Key.oauth(provider: .claude).account == "oauth.claude")
+    }
+
+    @Test
+    func `provider identity encodes its provider as the existing bare string`() throws {
+        let snapshot = ProviderIdentitySnapshot(
+            providerID: .claude,
+            accountEmail: "user@example.com",
+            accountOrganization: nil,
+            loginMethod: "oauth")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        let encoded = try encoder.encode(snapshot)
+        let encodedJSON = try #require(String(data: encoded, encoding: .utf8))
+
+        #expect(encodedJSON ==
+            #"{"accountEmail":"user@example.com","loginMethod":"oauth","providerID":"claude"}"#)
+    }
+
+    @Test
+    func `widget snapshot provider IDs retain their payload format and order`() throws {
+        let entries = [UsageProvider.claude, .codex].map { provider in
+            WidgetSnapshot.ProviderEntry(
+                provider: provider,
+                updatedAt: Date(timeIntervalSinceReferenceDate: 0),
+                primary: nil,
+                secondary: nil,
+                tertiary: nil,
+                creditsRemaining: nil,
+                codeReviewRemainingPercent: nil,
+                tokenUsage: nil,
+                dailyUsage: [])
+        }
+        let snapshot = WidgetSnapshot(
+            entries: entries,
+            enabledProviders: [.claude, .codex],
+            generatedAt: Date(timeIntervalSinceReferenceDate: 0))
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        let encoded = try encoder.encode(snapshot)
+        let encodedJSON = try #require(String(data: encoded, encoding: .utf8))
+        let expectedJSON = #"{"enabledProviders":["claude","codex"],"entries":["# +
+            #"{"dailyUsage":[],"provider":"claude","updatedAt":0},"# +
+            #"{"dailyUsage":[],"provider":"codex","updatedAt":0}],"# +
+            #""generatedAt":0,"usageBarsShowUsed":false}"#
+
+        #expect(encodedJSON == expectedJSON)
+    }
+
+    @Test
+    func `CLI provider payload keeps the provider raw string`() {
+        let payload = ProviderPayload(
+            provider: .claude,
+            account: nil,
+            version: nil,
+            source: "oauth",
+            status: nil,
+            usage: nil,
+            credits: nil,
+            antigravityPlanInfo: nil,
+            openaiDashboard: nil,
+            error: nil)
+
+        let expected = """
+        [
+          {
+            "provider" : "claude",
+            "source" : "oauth"
+          }
+        ]
+        """
+        #expect(CodexBarCLI.encodeJSON([payload], pretty: true) == expected)
+    }
+}

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -93,11 +93,11 @@ struct ProviderSettingsDescriptorTests {
                         provider: provider,
                         cookieHeader: "new-test-cookie",
                         sourceLabel: "Test new")
-                    fixture.store.snapshots[provider] = UsageSnapshot(
+                    fixture.store.snapshots[provider.instanceID] = UsageSnapshot(
                         primary: nil,
                         secondary: nil,
                         updatedAt: Date())
-                    fixture.store.lastSourceLabels[provider] = "web"
+                    fixture.store.lastSourceLabels[provider.instanceID] = "web"
                 }
                 defer { fixture.store._test_providerRefreshOverride = nil }
 
@@ -151,11 +151,11 @@ struct ProviderSettingsDescriptorTests {
                         provider: provider,
                         cookieHeader: "invalid-test-cookie",
                         sourceLabel: "Test invalid")
-                    fixture.store.snapshots[provider] = UsageSnapshot(
+                    fixture.store.snapshots[provider.instanceID] = UsageSnapshot(
                         primary: nil,
                         secondary: nil,
                         updatedAt: Date())
-                    fixture.store.lastSourceLabels[provider] = "local"
+                    fixture.store.lastSourceLabels[provider.instanceID] = "local"
                 }
                 defer { fixture.store._test_providerRefreshOverride = nil }
 
@@ -191,7 +191,7 @@ struct ProviderSettingsDescriptorTests {
                         provider: provider,
                         cookieHeader: "unvalidated-test-cookie",
                         sourceLabel: "Test unvalidated")
-                    fixture.store.snapshots.removeValue(forKey: provider)
+                    fixture.store.snapshots.removeValue(forKey: provider.instanceID)
                 }
                 defer { fixture.store._test_providerRefreshOverride = nil }
 

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -1600,7 +1600,7 @@ struct SettingsStoreTests {
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
 
-        #expect(store.orderedProviders() == UsageProvider.allCases)
+        #expect(store.orderedProviders() == UsageProvider.allCases.map(\.instanceID))
     }
 
     @Test
@@ -1625,7 +1625,7 @@ struct SettingsStoreTests {
 
         let legacyOrder: [UsageProvider] = [.gemini, .codex]
         let appendedProviders = UsageProvider.allCases.filter { !legacyOrder.contains($0) }
-        #expect(storeA.orderedProviders() == legacyOrder + appendedProviders)
+        #expect(storeA.orderedProviders() == (legacyOrder + appendedProviders).map(\.instanceID))
 
         // Move one provider; ensure it's persisted across instances.
         let antigravityIndex = try #require(storeA.orderedProviders().firstIndex(of: .antigravity))

--- a/Tests/CodexBarTests/ShareStatsTests.swift
+++ b/Tests/CodexBarTests/ShareStatsTests.swift
@@ -333,7 +333,7 @@ struct ShareStatsTests {
         accountOrganization: String? = nil) -> UsageSnapshot
     {
         let identity = ProviderIdentitySnapshot(
-            providerID: provider,
+            providerID: provider.instanceID,
             accountEmail: nil,
             accountOrganization: accountOrganization,
             loginMethod: rawName)

--- a/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
@@ -655,7 +655,7 @@ struct StatusItemAnimationSignatureTests {
         settings.setMergedOverviewProviderSelection(
             provider: .claude,
             isSelected: false,
-            activeProviders: store.enabledProvidersForDisplay())
+            activeProviders: store.enabledFirstPartyProvidersForDisplay())
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -709,7 +709,7 @@ struct StatusItemAnimationSignatureTests {
         settings.setMergedOverviewProviderSelection(
             provider: .claude,
             isSelected: false,
-            activeProviders: store.enabledProvidersForDisplay())
+            activeProviders: store.enabledFirstPartyProvidersForDisplay())
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -763,7 +763,7 @@ struct StatusItemAnimationSignatureTests {
             fetcher: fetcher,
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings)
-        let activeProviders = store.enabledProvidersForDisplay()
+        let activeProviders = store.enabledFirstPartyProvidersForDisplay()
         settings.setMergedOverviewProviderSelection(
             provider: .codex,
             isSelected: false,
@@ -781,7 +781,8 @@ struct StatusItemAnimationSignatureTests {
             statusBar: testStatusBar())
         defer { controller.releaseStatusItemsForTesting() }
 
-        #expect(settings.resolvedMergedOverviewProviders(activeProviders: store.enabledProvidersForDisplay()) == [])
+        #expect(settings.resolvedMergedOverviewProviders(
+            activeProviders: store.enabledFirstPartyProvidersForDisplay()) == [])
         #expect(controller.primaryProviderForUnifiedIcon() == .claude)
     }
 
@@ -827,11 +828,13 @@ struct StatusItemAnimationSignatureTests {
         store._setSnapshotForTesting(snapshot, provider: .claude)
 
         #expect(store.enabledProvidersForDisplay().prefix(3) == [.cursor, .codex, .claude])
-        #expect(settings.resolvedMergedOverviewProviders(activeProviders: store.enabledProvidersForDisplay()) == [
+        let expectedProviders: [UsageProvider] = [
             .cursor,
             .codex,
             .claude,
-        ])
+        ]
+        #expect(settings.resolvedMergedOverviewProviders(
+            activeProviders: store.enabledFirstPartyProvidersForDisplay()) == expectedProviders)
 
         controller.applyIcon(phase: nil)
 

--- a/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
@@ -742,7 +742,7 @@ struct StatusItemBalanceDisplayTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        settings.selectedMenuProvider = provider
+        settings.selectedMenuProvider = provider.instanceID
         settings.menuBarDisplayMode = .both
         settings.usageBarsShowUsed = true
 

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -124,7 +124,7 @@ struct StatusItemControllerSplitLifecycleTests {
         defer { controller.releaseStatusItemsForTesting() }
 
         let menus = try [UsageProvider.codex, .claude].map { provider in
-            try #require(controller.providerMenus[provider])
+            try #require(controller.providerMenus[provider.instanceID])
         }
         let keys = menus.map(ObjectIdentifier.init)
         for (menu, key) in zip(menus, keys) {

--- a/Tests/CodexBarTests/StatusItemExtraUsageMetricTests.swift
+++ b/Tests/CodexBarTests/StatusItemExtraUsageMetricTests.swift
@@ -244,7 +244,7 @@ struct StatusItemExtraUsageMetricTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        settings.selectedMenuProvider = provider
+        settings.selectedMenuProvider = provider.instanceID
         settings.menuBarDisplayMode = displayMode
         settings.resetTimesShowAbsolute = resetTimesShowAbsolute
         settings.usageBarsShowUsed = true

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -451,7 +451,7 @@ struct StatusItemIconObservationSignatureTests {
                 resetDescription: nil),
             updatedAt: updatedAt,
             identity: ProviderIdentitySnapshot(
-                providerID: provider,
+                providerID: provider.instanceID,
                 accountEmail: email,
                 accountOrganization: nil,
                 loginMethod: "plus"))

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -467,7 +467,7 @@ struct StatusMenuHostedSubmenuRefreshTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        settings.selectedMenuProvider = provider
+        settings.selectedMenuProvider = provider.instanceID
         settings.costUsageEnabled = true
         settings.providerStorageFootprintsEnabled = true
         Self.enableOnly(settings, provider: provider)

--- a/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
+++ b/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
@@ -73,7 +73,7 @@ extension StatusMenuTests {
         // Give every enabled provider a fresh, non-stale snapshot so the ONLY reason to refresh on
         // open is the new setting — not a stale/missing retry (which is the pre-existing behavior).
         let now = Date()
-        for provider in store.enabledProvidersForBackgroundWork() {
+        for provider in store.enabledFirstPartyProvidersForBackgroundWork() {
             store._setSnapshotForTesting(
                 UsageSnapshot(
                     primary: RateWindow(
@@ -110,7 +110,7 @@ extension StatusMenuTests {
         StatusItemController.setMenuOpenRefreshDelayForTesting(.zero)
         defer { StatusItemController.resetMenuOpenRefreshDelayForTesting() }
 
-        let expectedProviders = Set(store.enabledProvidersForBackgroundWork())
+        let expectedProviders = Set(store.enabledFirstPartyProvidersForBackgroundWork())
         let menu = controller.makeMenu(for: .claude)
         controller.menuWillOpen(menu)
         defer { controller.menuDidClose(menu) }
@@ -1496,7 +1496,7 @@ extension StatusMenuTests {
             secondary: nil,
             updatedAt: Date(),
             identity: ProviderIdentitySnapshot(
-                providerID: provider,
+                providerID: provider.instanceID,
                 accountEmail: email,
                 accountOrganization: nil,
                 loginMethod: "ChatGPT"))

--- a/Tests/CodexBarTests/StatusMenuMergedOverviewRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuMergedOverviewRefreshTests.swift
@@ -26,7 +26,7 @@ struct StatusMenuMergedOverviewRefreshTests {
         defer { controller.menuDidClose(menu) }
 
         let visibleProviders = settings.resolvedMergedOverviewProviders(
-            activeProviders: controller.store.enabledProvidersForDisplay())
+            activeProviders: controller.store.enabledFirstPartyProvidersForDisplay())
         #expect(!visibleProviders.contains(.opencode))
 
         controller.store.refreshingProviders.insert(.opencode)

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -439,7 +439,7 @@ struct StatusMenuPersistentRefreshTests {
         let controller = self.makeController(settings: settings)
         let now = Date()
         for provider in [UsageProvider.claude, .codex] {
-            controller.store.snapshots[provider] = UsageSnapshot(
+            controller.store.snapshots[provider.instanceID] = UsageSnapshot(
                 primary: RateWindow(
                     usedPercent: 21,
                     windowMinutes: 300,
@@ -449,9 +449,9 @@ struct StatusMenuPersistentRefreshTests {
                 updatedAt: now)
             let frozen = try #require(controller.menuCardModel(for: provider))
             controller.menuCardRefreshMonitor.beginManualRefresh(frozenModels: [provider: frozen])
-            controller.store.refreshingProviders.insert(provider)
+            controller.store.refreshingProviders.insert(provider.instanceID)
 
-            controller.store.snapshots[provider] = UsageSnapshot(
+            controller.store.snapshots[provider.instanceID] = UsageSnapshot(
                 primary: RateWindow(
                     usedPercent: 18,
                     windowMinutes: 300,
@@ -467,7 +467,7 @@ struct StatusMenuPersistentRefreshTests {
             #expect(inFlight.metrics.first?.percentLabel == "79% left")
 
             controller.menuCardRefreshMonitor.endManualRefresh()
-            controller.store.refreshingProviders.remove(provider)
+            controller.store.refreshingProviders.remove(provider.instanceID)
             let completed = controller.menuCardRefreshMonitor.model(for: provider, fallback: frozen)
             #expect(completed.metrics.first?.percentLabel == "82% left")
         }

--- a/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
+++ b/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
@@ -1178,7 +1178,7 @@ extension TokenAccountEnvironmentPrecedenceTests {
             usageDetails: [ZaiUsageDetail(modelCode: "glm-4", usage: 40)],
             nextResetTime: reset)
         let identity = ProviderIdentitySnapshot(
-            providerID: provider,
+            providerID: provider.instanceID,
             accountEmail: nil,
             accountOrganization: "Org",
             loginMethod: "Pro")

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -1310,7 +1310,7 @@ extension UsageStorePlanUtilizationTests {
             secondary: RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
             updatedAt: Date(),
             identity: ProviderIdentitySnapshot(
-                providerID: provider,
+                providerID: provider.instanceID,
                 accountEmail: email,
                 accountOrganization: nil,
                 loginMethod: "plus"))

--- a/docs/custom-provider-design.md
+++ b/docs/custom-provider-design.md
@@ -11,6 +11,8 @@ read_when:
 Status: accepted design boundary. This document defines a bounded MVP; it does not authorize runtime networking or
 implement the feature.
 
+Implementation status: slice 1, the `ProviderInstanceID` runtime identity seam, has landed.
+
 Issue: [#1735](https://github.com/steipete/CodexBar/issues/1735)
 
 ## Decision summary

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -13,6 +13,11 @@ parsing, and generic `UsageSnapshot` projection in one bundled JavaScript file. 
 system: IDs remain compile-time `UsageProvider` cases, scripts ship inside CodexBar, and the normal Swift path remains
 the default.
 
+Plugin manifests and their projected snapshots now carry a validated `ProviderInstanceID`. The prototype still maps
+that instance ID to an existing first-party `UsageProvider` before using browser-cookie brokerage or other bespoke
+provider paths; provider-specific snapshot payloads remain enum-typed, and the widget's `AppEnum` still lists only
+first-party cases. User-installed plugins without an enum case therefore remain out of scope for this prototype.
+
 ## Enable and test
 
 Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, Venice, Crof, OpenAI, z.ai, OpenRouter, Poe,


### PR DESCRIPTION
## Summary

This introduces `ProviderInstanceID` as the identity seam for a concrete provider instance. Runtime and persistence identity can now evolve independently from the compile-time `UsageProvider` kind, while first-party providers retain their existing kind projection.

This is the slice-1 identity work from the custom-provider design: establish the typed instance identifier, migrate existing identity-bearing surfaces, preserve first-party behavior, and leave plugin multiplicity and user-installed discovery for later slices.

The proof is deliberately characterization-first and remains two commits:

1. `test: characterize provider instance identity`
2. `feat: add provider instance identity seam`

## Migrated surfaces

- Core provider/runtime identity, plugin manifests and snapshots, fetch strategies, and logging
- Config validation/migration, settings/defaults, sync records, cookie/keychain caches, and widget snapshot persistence
- Usage state, refresh coordination, token/account caches, plan-utilization history, status, diagnostics, and storage tracking
- Menu/status-item routing, preferences/navigation, CLI projections, widgets, and share/dashboard projections

All existing first-party raw identifiers remain unchanged, so this produces zero persisted-byte change. Characterization coverage confirms the existing encodings and keys before the type migration, and no identity-bearing surface is blocked on `UsageProvider` after this slice.

This leaves a clean seam for user-installed plugins to provide distinct runtime/persistence instance identities next, without turning plugin instances into new compile-time enum cases.

## Verification

- `make check`
- `make build`
- `make test` — 811/811 selections passed
- structured Codex autoreview — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
