### PR TITLE
Retain partial Codex model rows

### DIFF
--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -194,12 +194,17 @@ struct SpendDashboardModel: Equatable, Sendable {
                 calendar: calendar)
         }
         let providers = Self.providerRows(summaries)
-        let completeModelSummaries = summaries.filter { summary in
+        let modelSummaries = summaries.filter { summary in
             guard summary.totalCost != nil else { return false }
-            return Self.modelSummary(summaries: [summary]).completeness == .complete
+            let summaryModelHistory = Self.modelSummary(summaries: [summary])
+            return summaryModelHistory.completeness == .complete ||
+                Self.canRetainPartialCodexModelHistory(summary)
         }
-        let modelSummary = Self.modelSummary(summaries: completeModelSummaries)
-        let modelHistoryCompleteness = completeModelSummaries.count == summaries.count
+        // A Codex session can have valid total cost without a model on every day. Keep its
+        // directly attributed rows, but the UI marks the aggregate partial and removes ranking.
+        let modelSummary = Self.modelSummary(summaries: modelSummaries)
+        let modelHistoryCompleteness = modelSummaries.count == summaries.count &&
+            modelSummary.completeness == .complete
             ? ModelHistoryCompleteness.complete
             : ModelHistoryCompleteness.incomplete
         let dailyPoints = Self.dailyPoints(summaries: summaries)
@@ -269,6 +274,15 @@ struct SpendDashboardModel: Equatable, Sendable {
             coveredInterval: coveredInterval,
             coveredDayCount: coveredDayCount,
             hasInvalidCostHistory: invalidCostHistory)
+    }
+
+    private static func canRetainPartialCodexModelHistory(_ summary: InputSummary) -> Bool {
+        guard summary.input.provider == .codex else { return false }
+        return summary.entries.allSatisfy { windowEntry in
+            let entry = windowEntry.entry
+            return Self.hasCompleteModelCostCoverage(entry) ||
+                (entry.modelBreakdowns?.isEmpty != false && Self.validCost(entry.costUSD) != nil)
+        }
     }
 
     private static func providerRows(_ summaries: [InputSummary]) -> [ProviderRow] {

--- a/Tests/CodexBarTests/SpendDashboardModelTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardModelTests.swift
@@ -270,6 +270,30 @@ struct SpendDashboardModelTests {
     }
 
     @Test
+    func `partially attributed Codex history retains its priced model rows`() throws {
+        let codex = SpendDashboardModel.ProviderInput(
+            provider: .codex,
+            displayName: "Codex",
+            snapshot: Self.snapshot(
+                currency: "USD",
+                entries: [
+                    Self.entry(day: "2026-07-15", cost: 2, model: "gpt-5.2-codex"),
+                    Self.entry(day: "2026-07-16", cost: 3, model: nil),
+                ]))
+        let group = try #require(SpendDashboardModel.build(
+            inputs: [codex],
+            requestedDays: 7,
+            now: Self.now,
+            calendar: Self.calendar).groups.first)
+
+        #expect(group.totalCost == 5)
+        #expect(group.modelHistoryCompleteness == .incomplete)
+        #expect(group.models.map(\.modelName) == ["gpt-5.2-codex"])
+        #expect(group.models.map(\.totalCost) == [2])
+        #expect(spendDashboardModelHistoryPresentation(group) == .partial)
+    }
+
+    @Test
     func `only uncovered source reports model breakdown unavailable`() throws {
         let uncovered = SpendDashboardModel.ProviderInput(
             provider: .claude,


### PR DESCRIPTION
## Summary

Retains trustworthy Codex model rows in Usage & Spend when other days have valid total cost but no model attribution.

## Root cause

The dashboard treated a Codex source as all-or-nothing: a single model-less day hid every fully priced model row from that same source. Codex logs legitimately contain model-less events, so this made the Models panel appear unavailable despite usable attribution.

## Behavior

- Keeps directly attributed Codex rows when the remaining days are valid but model-less.
- Marks the aggregate as partial and removes ranking, avoiding a false claim of complete attribution.
- Continues to fail closed for malformed, invalid, and partially priced model histories.

## Proof

- `swift test --filter SpendDashboardModelTests` — 29/29 passed.
- `make check` — passed.
- `make test` — 809 selections across 68 groups passed.
- `git diff --check` — passed.

Runtime screenshot proof will be added against this exact head.
