### PR TITLE
docs: Symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,6 @@
 - Swift concurrency: treat sibling `async let` tasks as a review red flag when one child is required and another is optional/best-effort. Prefer sequential awaits or a drained `withThrowingTaskGroup` that surfaces required failures and explicitly contains optional failures; crash stacks mentioning `swift_task_dealloc` or `asyncLet_finish_after_task_completion` should trigger an audit of nearby `async let` usage.
 - Prefer modern SwiftUI/Observation macros: use `@Observable` models with `@State` ownership and `@Bindable` in views; avoid `ObservableObject`, `@ObservedObject`, and `@StateObject`.
 - Favor modern macOS 15+ APIs over legacy/deprecated counterparts when refactoring (Observation, new display link APIs, updated menu item styling, etc.).
-- Keep provider data siloed: when rendering usage or account info for a provider (Claude vs Codex), never display identity/plan fields sourced from a different provider.***
+- Keep provider data siloed: when rendering usage or account info for a provider (Claude vs Codex), never display identity/plan fields sourced from a different provider.
 - Claude CLI status line is custom + user-configurable; never rely on it for usage parsing by default. A user-enabled, opt-in statusLine JSON feed is permitted as an explicit data source (owner ruling, #2733): it must be off by default, clearly labeled as sourced from the user's own statusLine config, and fail soft when the format drifts.
 - Cookie imports: default Chrome-only when possible to avoid other browser prompts; override via browser list when needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+./AGENTS.md

--- a/Scripts/ci_macos_test_gate.sh
+++ b/Scripts/ci_macos_test_gate.sh
@@ -41,7 +41,7 @@ classify_path() {
   path_count=$((path_count + 1))
 
   case "$path" in
-    AGENTS.md|docs/configuration.md)
+    AGENTS.md|CLAUDE.md|docs/configuration.md)
       require_macos_tests "$path" "changes contributor or runtime configuration contracts"
       ;;
     *.md)

--- a/Scripts/test_ci_path_gate.sh
+++ b/Scripts/test_ci_path_gate.sh
@@ -57,6 +57,9 @@ assert_gate true rename-from-configuration-doc $'R100\tdocs/configuration.md\tdo
 assert_gate true agents-contract $'M\tAGENTS.md'
 assert_gate true rename-to-agents-contract $'R100\tdocs/old.md\tAGENTS.md'
 assert_gate true rename-from-agents-contract $'R100\tAGENTS.md\tdocs/new.md'
+assert_gate true claude-contract $'M\tCLAUDE.md'
+assert_gate true rename-to-claude-contract $'R100\tdocs/old.md\tCLAUDE.md'
+assert_gate true rename-from-claude-contract $'R100\tCLAUDE.md\tdocs/new.md'
 assert_gate true source $'M\tSources/CodexBar/App.swift'
 assert_gate false docs-site $'M\tdocs/index.html' $'M\tdocs/site.css' $'M\tdocs/site.js' \
   $'M\tdocs/site-locales.mjs' $'M\tdocs/social.html' $'M\tdocs/social.png' \


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md -> AGENTS.md` as a symlink so Claude Code picks up the same repository guidelines already documented for agents.
- Avoids maintaining two copies of build/test/coding-style guidance that would drift out of sync.
- Fix hanging `***` spotted in `AGENTS.md`.

## Test plan

- Update local repo to commit in PR to "create" symlink.
  - Tested OK.
- Start a `claude` session.
  - Tested OK.
- Invoke `/context` and **confirm** we see `CLAUDE.md` in context.
  - Tested OK - `CLAUDE.md: 2.4k tokens`.

<img width="278" height="27" alt="image" src="https://github.com/user-attachments/assets/58d9ace2-5cde-420f-942b-b2dc6683843d" />
