### PR TITLE
Sync widget package resolution

### DIFF
--- a/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "6d8d9c11f3ca7164fa11aa5527a4ccb309a9175ecce14ff97c0f0eadf641afd1",
+  "originHash" : "ad67f0d4398bb4a21360148bef34796420ed4bd49ea9337ed53c6dc99e5a96bd",
   "pins" : [
     {
       "identity" : "commander",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/Commander",
       "state" : {
-        "revision" : "b9fb00564aa3229deeb48090801fec2c185951f4",
-        "version" : "0.2.3"
+        "revision" : "ae2ce746b386ff94b26648cfe5625cfa8d02639b",
+        "version" : "0.2.2"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
-        "version" : "2.9.4"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/SweetCookieKit",
       "state" : {
-        "revision" : "228c7927e03b85b25b41da23a44c4f5308519796",
-        "version" : "0.5.1"
+        "revision" : "d5ea6d92298779ec0c3ddf7d3d99da186a305e14",
+        "version" : "0.5.2"
       }
     },
     {
@@ -49,7 +49,7 @@
     {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
+      "location" : "https://github.com/apple/swift-crypto",
       "state" : {
         "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
         "version" : "3.15.1"
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
-        "version" : "1.14.0"
+        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
+        "version" : "1.13.2"
       }
     },
     {


### PR DESCRIPTION
## Summary

Synchronizes the WidgetExtension lockfile with the root `Package.resolved`.

## Root cause

The widget is a local Swift package dependency. Its separate Xcode lockfile pinned a different dependency graph than the root package, so the standard packaging script correctly failed with automatic package resolution disabled.

## Validation

- `xcodebuild -resolvePackageDependencies -project WidgetExtension/CodexBarWidgetExtension.xcodeproj -scheme CodexBarWidgetExtension -derivedDataPath .build/xcode-widget-extension-release -skipPackageUpdates -disableAutomaticPackageResolution -skipMacroValidation -skipPackagePluginValidation`
- `git diff --check`

The resolver accepted the synchronized graph using cached packages; no dependency update was performed.

### Resolver transcript (exact PR head)

Run with the App Store Xcode toolchain on `efaeadf73b2bd8c23fd41187169299eaf9f4134e`:

```text
Resolve Package Graph

Resolved source packages:
  swift-crypto @ 3.15.1
  Commander @ 0.2.2
  swift-asn1 @ 1.7.1
  Vortex @ ef53920
  SweetCookieKit @ 0.5.2
  Sparkle @ 2.9.3
  KeyboardShortcuts @ 2.4.0
  swift-log @ 1.13.2
  CodexBar @ local

resolved source packages: swift-crypto, Commander, swift-asn1, Vortex,
SweetCookieKit, Sparkle, KeyboardShortcuts, swift-log, CodexBar
```

This was run with both `-skipPackageUpdates` and
`-disableAutomaticPackageResolution`, so it verifies the committed lockfile
rather than permitting Xcode to repair it during the build.

### CI note

The failed `lint-build-test` belongs to the earlier **draft** run. Its log
states: `macOS Swift tests are required but deferred; aggregate CI remains
incomplete`. After the PR was marked ready for review, the new run passed
`changes` and `lint` and started both required `swift-test-macos` shards.
That failure is therefore workflow draft-gating, not a resolver or lockfile
failure.
