### PR TITLE
Fix ETXTBSY race in claude-swap CLI card test

### DIFF
--- a/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
+++ b/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
@@ -373,14 +373,7 @@ struct CLICardsClaudeSwapTests {
         ]}
         JSON
         """
-        // Executing a file this process just wrote races with every other test
-        // that spawns a child: the fork inherits the still-open write descriptor
-        // and execve fails with ETXTBSY. Write the body as data instead, and
-        // execute the checked-in trampoline that reads it.
-        try Data(script.utf8).write(to: executable.appendingPathExtension("sh"))
-        try FileManager.default.createSymbolicLink(
-            at: executable,
-            withDestinationURL: Self.execTrampoline())
+        try FakeExecutable.install(script, at: executable)
 
         let output = await CLIClaudeSwapCards.fetch(
             eligible: true,
@@ -423,19 +416,5 @@ struct CLICardsClaudeSwapTests {
         #expect(output.cards == ambient.cards)
         #expect(output.cardFailures.last?.accountLabel == "claude-swap")
         #expect(output.exitCode != .success)
-    }
-
-    private static func execTrampoline() throws -> URL {
-        var directory = URL(filePath: #filePath).deletingLastPathComponent()
-        for _ in 0..<12 {
-            let candidate = directory.appending(path: "Tests/CodexBarTests/Fixtures/Scripts/exec-trampoline.sh")
-            if FileManager.default.fileExists(atPath: candidate.path(percentEncoded: false)) {
-                return candidate
-            }
-            directory.deleteLastPathComponent()
-        }
-        throw NSError(domain: "CLICardsClaudeSwapTests", code: 1, userInfo: [
-            NSLocalizedDescriptionKey: "Could not locate exec-trampoline.sh from \(#filePath)",
-        ])
     }
 }

--- a/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
+++ b/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
@@ -373,8 +373,14 @@ struct CLICardsClaudeSwapTests {
         ]}
         JSON
         """
-        try Data(script.utf8).write(to: executable)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        // Executing a file this process just wrote races with every other test
+        // that spawns a child: the fork inherits the still-open write descriptor
+        // and execve fails with ETXTBSY. Write the body as data instead, and
+        // execute the checked-in trampoline that reads it.
+        try Data(script.utf8).write(to: executable.appendingPathExtension("sh"))
+        try FileManager.default.createSymbolicLink(
+            at: executable,
+            withDestinationURL: Self.execTrampoline())
 
         let output = await CLIClaudeSwapCards.fetch(
             eligible: true,
@@ -417,5 +423,19 @@ struct CLICardsClaudeSwapTests {
         #expect(output.cards == ambient.cards)
         #expect(output.cardFailures.last?.accountLabel == "claude-swap")
         #expect(output.exitCode != .success)
+    }
+
+    private static func execTrampoline() throws -> URL {
+        var directory = URL(filePath: #filePath).deletingLastPathComponent()
+        for _ in 0..<12 {
+            let candidate = directory.appending(path: "Tests/CodexBarTests/Fixtures/Scripts/exec-trampoline.sh")
+            if FileManager.default.fileExists(atPath: candidate.path(percentEncoded: false)) {
+                return candidate
+            }
+            directory.deleteLastPathComponent()
+        }
+        throw NSError(domain: "CLICardsClaudeSwapTests", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Could not locate exec-trampoline.sh from \(#filePath)",
+        ])
     }
 }

--- a/Tests/CodexBarTests/FakeExecutableSupport.swift
+++ b/Tests/CodexBarTests/FakeExecutableSupport.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Installs a fake CLI on disk for tests that need to launch one.
+///
+/// Executing a file the test process just wrote races with every other test that
+/// spawns a child: the fork inherits the still-open write descriptor and execve
+/// fails with `ETXTBSY`. Swift Testing runs the suite concurrently inside one
+/// process, so that window is wide, and Linux Foundation has no
+/// `POSIX_SPAWN_CLOEXEC_DEFAULT` to close it.
+///
+/// Writing the body as data and executing a checked-in trampoline keeps execve
+/// away from every file this process wrote.
+enum FakeExecutable {
+    /// Writes `body` beside `url` and links `url` to the checked-in trampoline.
+    static func install(_ body: String, at url: URL) throws {
+        try Data(body.utf8).write(to: url.appendingPathExtension("sh"))
+        try FileManager.default.createSymbolicLink(at: url, withDestinationURL: self.trampoline())
+    }
+
+    private static func trampoline() throws -> URL {
+        var directory = URL(filePath: #filePath).deletingLastPathComponent()
+        for _ in 0..<12 {
+            let candidate = directory.appending(path: "Tests/CodexBarTests/Fixtures/Scripts/exec-trampoline.sh")
+            if FileManager.default.fileExists(atPath: candidate.path(percentEncoded: false)) {
+                return candidate
+            }
+            directory.deleteLastPathComponent()
+        }
+        throw NSError(domain: "FakeExecutable", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Could not locate exec-trampoline.sh from \(#filePath)",
+        ])
+    }
+}

--- a/Tests/CodexBarTests/Fixtures/Scripts/exec-trampoline.sh
+++ b/Tests/CodexBarTests/Fixtures/Scripts/exec-trampoline.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Execution target for tests that need a fake CLI on disk.
+#
+# Tests symlink this file into a temporary directory and write the real script
+# body beside the symlink as "<name>.sh". Only this checked-in file is ever
+# handed to execve, so a fork in a concurrently running test cannot inherit a
+# write descriptor on the target and fail the launch with ETXTBSY.
+#
+# "$0" is the symlink path the caller executed, not this file, on both Linux
+# and macOS. That is what lets "$0.sh" resolve per test.
+exec /bin/sh "$0.sh" "$@"

--- a/TestsLinux/AntigravityCLIStrategyLinuxTests.swift
+++ b/TestsLinux/AntigravityCLIStrategyLinuxTests.swift
@@ -8,10 +8,7 @@ struct AntigravityCLIStrategyLinuxTests {
     func `cli local strategy is available with HTTP fallback`() async throws {
         let binaryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-antigravity-\(UUID().uuidString)")
-        try Data("#!/bin/sh\n".utf8).write(to: binaryURL)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755],
-            ofItemAtPath: binaryURL.path)
+        try FakeExecutable.install("#!/bin/sh\n", at: binaryURL)
         defer { try? FileManager.default.removeItem(at: binaryURL) }
 
         let context = ProviderFetchContext(

--- a/TestsLinux/CLICardsClaudeSwapTests.swift
+++ b/TestsLinux/CLICardsClaudeSwapTests.swift
@@ -372,8 +372,7 @@ struct CLICardsClaudeSwapTests {
         ]}
         JSON
         """
-        try Data(script.utf8).write(to: executable)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        try FakeExecutable.install(script, at: executable)
 
         let output = await CLIClaudeSwapCards.fetch(
             eligible: true,

--- a/TestsLinux/FakeExecutableSupport.swift
+++ b/TestsLinux/FakeExecutableSupport.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Installs a fake CLI on disk for tests that need to launch one.
+///
+/// Executing a file the test process just wrote races with every other test that
+/// spawns a child: the fork inherits the still-open write descriptor and execve
+/// fails with `ETXTBSY`. Swift Testing runs the suite concurrently inside one
+/// process, so that window is wide, and Linux Foundation has no
+/// `POSIX_SPAWN_CLOEXEC_DEFAULT` to close it.
+///
+/// Writing the body as data and executing a checked-in trampoline keeps execve
+/// away from every file this process wrote.
+enum FakeExecutable {
+    /// Writes `body` beside `url` and links `url` to the checked-in trampoline.
+    static func install(_ body: String, at url: URL) throws {
+        try Data(body.utf8).write(to: url.appendingPathExtension("sh"))
+        try FileManager.default.createSymbolicLink(at: url, withDestinationURL: self.trampoline())
+    }
+
+    private static func trampoline() throws -> URL {
+        var directory = URL(filePath: #filePath).deletingLastPathComponent()
+        for _ in 0..<12 {
+            let candidate = directory.appending(path: "Tests/CodexBarTests/Fixtures/Scripts/exec-trampoline.sh")
+            if FileManager.default.fileExists(atPath: candidate.path(percentEncoded: false)) {
+                return candidate
+            }
+            directory.deleteLastPathComponent()
+        }
+        throw NSError(domain: "FakeExecutable", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Could not locate exec-trampoline.sh from \(#filePath)",
+        ])
+    }
+}

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -230,8 +230,7 @@ struct PlatformGatingTests {
           printf '%s\\n' '{"loggedIn":\(loggedInJSON)}'
         fi
         """
-        try Data(script.utf8).write(to: binaryURL)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
+        try FakeExecutable.install(script, at: binaryURL)
         return binaryURL
     }
 


### PR DESCRIPTION
## Summary

Fixes a flaky `linux-arm64` failure in `CLICardsClaudeSwapTests`. The test wrote a
shell script, set mode `0755`, and executed it immediately. Under
`swift test --parallel` that races with every other test that spawns a child
process, and `execve` fails with `ETXTBSY`.

Tests now write the script body as data and execute a checked-in trampoline that
reads it, so `execve` only ever touches a file no test process has written.

## Root cause

Swift Testing runs the suite concurrently inside one process, so all tests share
one file descriptor table. The sequence:

1. `Data.write(to:)` opens a write descriptor on the new script.
2. Another test calls `Process.run()` and forks. The child inherits that
   descriptor, because Linux Foundation has no `POSIX_SPAWN_CLOEXEC_DEFAULT`.
3. The test executes the script. `execve` returns `ETXTBSY`, because the inode is
   still open for writing in the child.

Foundation flattens the errno and reports `NSCocoaErrorDomain error 256`, which is
why the original CI failure named no cause.

macOS never hits this. Darwin's Foundation spawns with
`POSIX_SPAWN_CLOEXEC_DEFAULT`, so children do not inherit the descriptor.

## Scope

`CodexBarLinuxTests` (`TestsLinux`) is the target the Linux job compiles;
`CodexBarTests` is macOS-only (`Package.swift:190-204`). Three sites in
`TestsLinux` used the racing pattern, and all three ran in the failing job:

- `CLICardsClaudeSwapTests.swift`, the test that actually flaked
- `PlatformGatingTests.swift`, which executes a fake `claude` CLI
- `AntigravityCLIStrategyLinuxTests.swift`

The mirrored `Tests/CodexBarTests/CLICardsClaudeSwapTests.swift` is updated too, so
the two trees stay in step. The remaining write-then-execute sites under
`Tests/CodexBarTests` are macOS-only and cannot hit this race.

The suites supplying the racing forks are `ShellCommandSessionLinuxTests`,
`ProcessPipeCaptureLinuxTests`, `CostUsageScanExecutorLinuxTests`, and
`HookDispatchTests`.

## Verification

Reproduced and measured in `swift:6.3.3-noble` on arm64, matching the CI runner. A
standalone harness ran the same shape: `Data.write(to:)` for the writer,
`Foundation.Process` for the forkers, and `posix_spawn` for the launch so the
errno stays visible.

| shape | attempts | `ETXTBSY` |
| --- | --- | --- |
| write, chmod, exec (current) | 600 | 112 |
| trampoline (this PR) | 600 | 0 |

Also run:

- `swift test --parallel` on Linux arm64 in Docker: 355 tests in 53 suites passed.
- `swift test --filter CLICardsClaudeSwapTests` on macOS: 26 tests passed.
- `make check`: 0 violations in 1756 files.

## Notes

The script heredocs are unchanged, so each test still shows what its fake CLI
does. `$0` inside a shebang script is the path handed to `execve`, that is the
symlink, on both Linux and macOS. That is verified on both platforms and is what
lets `"$0.sh"` resolve per test.

Found while running CI for #2640, a docs-only change that had no way to cause it.
Failing job:
https://github.com/steipete/CodexBar/actions/runs/30885238832/job/91914882363
