### PR TITLE
Report unreadable Claude OAuth refresh as terminal

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -28,6 +28,11 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         case cliUnavailable
         case attemptedSucceeded
         case attemptedFailed(String)
+        /// The Claude CLI can still refresh its own credentials, but CodexBar has no permitted way to observe the
+        /// result: production never reads the foreign Keychain item, and this profile has no credentials file to
+        /// fall back on. The touch still runs first, in case it writes that file; when it does not, report this
+        /// rather than a retryable failure so background polling can back off.
+        case unreadableAfterRefresh
     }
 
     private static let log = CodexBarLog.logger(LogCategories.claudeUsage)
@@ -71,7 +76,8 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             switch outcome {
             case .attemptedFailed, .skippedByCooldown, .skippedByPromptPolicy, .cliUnavailable:
                 return await self.attempt(now: now, timeout: timeout, environment: environment)
-            case .attemptedSucceeded:
+            case .attemptedSucceeded, .unreadableAfterRefresh:
+                // Retrying cannot make an unreadable refresh readable; reuse the joined verdict.
                 return outcome
             }
         case let .joinDifferentProfileThenRetry(id, task, state):
@@ -99,6 +105,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         let readStrategy: ClaudeOAuthKeychainReadStrategy
         let promptMode: ClaudeOAuthKeychainPromptMode
         let keychainAccessDisabled: Bool
+        let keychainReadAllowed: Bool
         let hasSelectedProfileOAuthCredentialsFile: Bool
         #if DEBUG
         let cliAvailableOverride: Bool?
@@ -147,6 +154,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             // from the user's stored preference, not the strategy-adjusted mode used by our own reads.
             promptMode: ClaudeOAuthKeychainPromptPreference.storedMode(),
             keychainAccessDisabled: KeychainAccessGate.isDisabled,
+            keychainReadAllowed: ClaudeOAuthCredentialsStore.keychainAccessAllowed,
             hasSelectedProfileOAuthCredentialsFile: ClaudeOAuthCredentialsStore
                 .hasSelectedProfileOAuthCredentialsFile(environment: environment),
             cliAvailableOverride: self.cliAvailableOverrideForTesting,
@@ -164,6 +172,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             // from the user's stored preference, not the strategy-adjusted mode used by our own reads.
             promptMode: ClaudeOAuthKeychainPromptPreference.storedMode(),
             keychainAccessDisabled: KeychainAccessGate.isDisabled,
+            keychainReadAllowed: ClaudeOAuthCredentialsStore.keychainAccessAllowed,
             hasSelectedProfileOAuthCredentialsFile: ClaudeOAuthCredentialsStore
                 .hasSelectedProfileOAuthCredentialsFile(environment: environment))
         #endif
@@ -279,11 +288,21 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             return .attemptedSucceeded
         }
 
+        // Re-check after the touch rather than reusing the pre-touch snapshot: on older Claude Code the touch can
+        // still create the credentials file, which is a readable source even though the Keychain item is not.
+        let unreadable = touchError == nil
+            && self.isRefreshResultUnreadable(configuration: configuration)
         self.recordAttempt(
             now: now,
-            cooldown: self.shortCooldownInterval,
+            // Nothing about this state changes until the user switches source or Claude Code writes a file again,
+            // so back off on the long interval instead of retrying every short cycle.
+            cooldown: unreadable ? self.defaultCooldownInterval : self.shortCooldownInterval,
             profileIdentifier: profileIdentifier,
             state: state)
+        if unreadable {
+            self.log.warning("Claude OAuth delegated refresh produced no readable credential source")
+            return .unreadableAfterRefresh
+        }
         if let touchError {
             let errorType = String(describing: type(of: touchError))
             self.log.warning(
@@ -486,6 +505,20 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         return ClaudeOAuthCredentialsStore.readRawClaudeKeychainPayloadViaSecurityCLIIfEnabled(
             interaction: interaction,
             readStrategy: readStrategy)
+    }
+
+    /// Whether a successful Claude CLI refresh would still be invisible to CodexBar.
+    ///
+    /// Production never reads `Claude Code-credentials` (see `ClaudeOAuthCredentialsStore.keychainAccessAllowed`),
+    /// so the only attributable source left is the profile's credentials file. Claude Code 2.1.x stops writing that
+    /// file, which leaves nothing for the post-touch reload to pick up.
+    private static func isRefreshResultUnreadable(configuration: AttemptConfiguration) -> Bool {
+        guard !configuration.keychainReadAllowed else { return false }
+        guard !configuration.hasSelectedProfileOAuthCredentialsFile else { return false }
+        // The captured value predates the touch, so ask again: on older Claude Code the touch itself can write the
+        // credentials file, and that is a source the post-touch reload can still use.
+        return !ClaudeOAuthCredentialsStore.hasSelectedProfileOAuthCredentialsFile(
+            environment: configuration.environment)
     }
 
     private static func mcpOAuthOnlyKeychainFailureIfPresent(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -304,6 +304,9 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             return AttemptResult(.attemptedSucceeded)
         }
 
+        // A touch *error* deliberately stays retryable even when nothing is readable: the error may be transient,
+        // and on older Claude Code a retried touch can still create the credentials file. Only the
+        // completes-cleanly-but-unobservable variant is provably terminal.
         let unreadable = touchError == nil
             && self.isRefreshResultUnreadable(configuration: configuration)
         self.recordAttempt(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -14,7 +14,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         var inFlightAttemptID: UInt64?
         var inFlightInteraction: ProviderInteraction?
         var inFlightProfileIdentifier: String?
-        var inFlightTask: Task<Outcome, Never>?
+        var inFlightTask: Task<AttemptResult, Never>?
         var nextAttemptID: UInt64 = 0
 
         init(persistsCooldown: Bool) {
@@ -28,11 +28,18 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         case cliUnavailable
         case attemptedSucceeded
         case attemptedFailed(String)
-        /// The Claude CLI can still refresh its own credentials, but CodexBar has no permitted way to observe the
-        /// result: production never reads the foreign Keychain item, and this profile has no credentials file to
-        /// fall back on. The touch still runs first, in case it writes that file; when it does not, report this
-        /// rather than a retryable failure so background polling can back off.
-        case unreadableAfterRefresh
+    }
+
+    /// `Outcome` ships in the `CodexBarCore` library product, so a new case would break downstream exhaustive
+    /// switches. The unreadable verdict rides alongside it instead of extending it.
+    struct AttemptResult: Sendable, Equatable {
+        let outcome: Outcome
+        let isUnreadableAfterRefresh: Bool
+
+        init(_ outcome: Outcome, isUnreadableAfterRefresh: Bool = false) {
+            self.outcome = outcome
+            self.isUnreadableAfterRefresh = isUnreadableAfterRefresh
+        }
     }
 
     private static let log = CodexBarLog.logger(LogCategories.claudeUsage)
@@ -49,8 +56,16 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         timeout: TimeInterval = 8,
         environment: [String: String] = ProcessInfo.processInfo.environment) async -> Outcome
     {
+        await self.attemptDetailed(now: now, timeout: timeout, environment: environment).outcome
+    }
+
+    static func attemptDetailed(
+        now: Date = Date(),
+        timeout: TimeInterval = 8,
+        environment: [String: String] = ProcessInfo.processInfo.environment) async -> AttemptResult
+    {
         if Task.isCancelled {
-            return .attemptedFailed("Cancelled.")
+            return AttemptResult(.attemptedFailed("Cancelled."))
         }
 
         let decision = self.inFlightDecision(
@@ -71,31 +86,32 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         case let .join(task):
             return await task.value
         case let .joinThenRetry(id, task, state):
-            let outcome = await task.value
+            let result = await task.value
             self.clearInFlightTaskIfStillCurrent(id: id, state: state)
-            switch outcome {
+            // Retrying cannot make an unreadable refresh readable, so reuse the joined verdict.
+            if result.isUnreadableAfterRefresh { return result }
+            switch result.outcome {
             case .attemptedFailed, .skippedByCooldown, .skippedByPromptPolicy, .cliUnavailable:
-                return await self.attempt(now: now, timeout: timeout, environment: environment)
-            case .attemptedSucceeded, .unreadableAfterRefresh:
-                // Retrying cannot make an unreadable refresh readable; reuse the joined verdict.
-                return outcome
+                return await self.attemptDetailed(now: now, timeout: timeout, environment: environment)
+            case .attemptedSucceeded:
+                return result
             }
         case let .joinDifferentProfileThenRetry(id, task, state):
             _ = await task.value
             self.clearInFlightTaskIfStillCurrent(id: id, state: state)
-            return await self.attempt(now: now, timeout: timeout, environment: environment)
+            return await self.attemptDetailed(now: now, timeout: timeout, environment: environment)
         case let .start(id, task, state):
-            let outcome = await task.value
+            let result = await task.value
             self.clearInFlightTaskIfStillCurrent(id: id, state: state)
-            return outcome
+            return result
         }
     }
 
     private enum InFlightDecision {
-        case join(Task<Outcome, Never>)
-        case joinThenRetry(UInt64, Task<Outcome, Never>, AttemptStateStorage)
-        case joinDifferentProfileThenRetry(UInt64, Task<Outcome, Never>, AttemptStateStorage)
-        case start(UInt64, Task<Outcome, Never>, AttemptStateStorage)
+        case join(Task<AttemptResult, Never>)
+        case joinThenRetry(UInt64, Task<AttemptResult, Never>, AttemptStateStorage)
+        case joinDifferentProfileThenRetry(UInt64, Task<AttemptResult, Never>, AttemptStateStorage)
+        case start(UInt64, Task<AttemptResult, Never>, AttemptStateStorage)
     }
 
     private struct AttemptConfiguration {
@@ -206,7 +222,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         now: Date,
         timeout: TimeInterval,
         configuration: AttemptConfiguration,
-        state: AttemptStateStorage) async -> Outcome
+        state: AttemptStateStorage) async -> AttemptResult
     {
         let profileIdentifier = configuration.profileIdentifier
 
@@ -217,12 +233,12 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
            configuration.keychainAccessDisabled || configuration.promptMode != .always
         {
             self.log.info("Claude OAuth delegated refresh skipped by Keychain prompt policy")
-            return .skippedByPromptPolicy
+            return AttemptResult(.skippedByPromptPolicy)
         }
 
         guard self.isClaudeCLIAvailable(environment: configuration.environment, configuration: configuration) else {
             self.log.info("Claude OAuth delegated refresh skipped: claude CLI unavailable")
-            return .cliUnavailable
+            return AttemptResult(.cliUnavailable)
         }
 
         // Atomically reserve an attempt under the lock so concurrent callers don't race past isInCooldown() and start
@@ -234,7 +250,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             state: state)
         else {
             self.log.debug("Claude OAuth delegated refresh skipped by cooldown")
-            return .skippedByCooldown
+            return AttemptResult(.skippedByCooldown)
         }
 
         if let mcpOAuthOnlyFailure = self.mcpOAuthOnlyKeychainFailureIfPresent(
@@ -252,7 +268,7 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             self.log.warning(
                 "Claude OAuth delegated refresh skipped: Claude keychain has MCP OAuth state only",
                 metadata: ["readStrategy": configuration.readStrategy.rawValue])
-            return .attemptedFailed(mcpOAuthOnlyFailure)
+            return AttemptResult(.attemptedFailed(mcpOAuthOnlyFailure))
         }
 
         let baseline = self.currentKeychainChangeObservationBaseline(
@@ -285,23 +301,21 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
                 profileIdentifier: profileIdentifier,
                 state: state)
             self.log.info("Claude OAuth delegated refresh touch succeeded")
-            return .attemptedSucceeded
+            return AttemptResult(.attemptedSucceeded)
         }
 
-        // Re-check after the touch rather than reusing the pre-touch snapshot: on older Claude Code the touch can
-        // still create the credentials file, which is a readable source even though the Keychain item is not.
         let unreadable = touchError == nil
             && self.isRefreshResultUnreadable(configuration: configuration)
         self.recordAttempt(
             now: now,
-            // Nothing about this state changes until the user switches source or Claude Code writes a file again,
-            // so back off on the long interval instead of retrying every short cycle.
             cooldown: unreadable ? self.defaultCooldownInterval : self.shortCooldownInterval,
             profileIdentifier: profileIdentifier,
             state: state)
         if unreadable {
             self.log.warning("Claude OAuth delegated refresh produced no readable credential source")
-            return .unreadableAfterRefresh
+            return AttemptResult(
+                .attemptedFailed("No readable Claude credential source after the Claude CLI touch."),
+                isUnreadableAfterRefresh: true)
         }
         if let touchError {
             let errorType = String(describing: type(of: touchError))
@@ -309,11 +323,11 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
                 "Claude OAuth delegated refresh touch failed",
                 metadata: ["errorType": errorType])
             self.log.debug("Claude OAuth delegated refresh touch error: \(touchError.localizedDescription)")
-            return .attemptedFailed(touchError.localizedDescription)
+            return AttemptResult(.attemptedFailed(touchError.localizedDescription))
         }
 
         self.log.warning("Claude OAuth delegated refresh touch did not update Claude keychain")
-        return .attemptedFailed("Claude keychain did not update after Claude CLI touch.")
+        return AttemptResult(.attemptedFailed("Claude keychain did not update after Claude CLI touch."))
     }
 
     public static func isInCooldown(
@@ -507,16 +521,10 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             readStrategy: readStrategy)
     }
 
-    /// Whether a successful Claude CLI refresh would still be invisible to CodexBar.
-    ///
-    /// Production never reads `Claude Code-credentials` (see `ClaudeOAuthCredentialsStore.keychainAccessAllowed`),
-    /// so the only attributable source left is the profile's credentials file. Claude Code 2.1.x stops writing that
-    /// file, which leaves nothing for the post-touch reload to pick up.
     private static func isRefreshResultUnreadable(configuration: AttemptConfiguration) -> Bool {
         guard !configuration.keychainReadAllowed else { return false }
         guard !configuration.hasSelectedProfileOAuthCredentialsFile else { return false }
-        // The captured value predates the touch, so ask again: on older Claude Code the touch itself can write the
-        // credentials file, and that is a source the post-touch reload can still use.
+        // Ask again: the captured value predates the touch, which on older Claude Code writes the file itself.
         return !ClaudeOAuthCredentialsStore.hasSelectedProfileOAuthCredentialsFile(
             environment: configuration.environment)
     }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher+DelegatedRefreshMessages.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher+DelegatedRefreshMessages.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// Presentation helpers for delegated Claude CLI refresh outcomes, split out to keep ClaudeUsageFetcher.swift
-/// within the file-length limit.
+/// Split out of `ClaudeUsageFetcher.swift` to keep that file within the file-length limit.
 extension ClaudeUsageFetcher {
     static func delegatedRefreshOutcomeLabel(
         _ outcome: ClaudeOAuthDelegatedRefreshCoordinator.Outcome) -> String
@@ -17,13 +16,11 @@ extension ClaudeUsageFetcher {
             "attemptedSucceeded"
         case .attemptedFailed:
             "attemptedFailed"
-        case .unreadableAfterRefresh:
-            "unreadableAfterRefresh"
         }
     }
 
     static func delegatedRefreshFailureMessage(
-        for outcome: ClaudeOAuthDelegatedRefreshCoordinator.Outcome,
+        for result: ClaudeOAuthDelegatedRefreshCoordinator.AttemptResult,
         retryError: Error) -> String
     {
         if let oauthError = retryError as? ClaudeOAuthFetchError,
@@ -32,7 +29,15 @@ extension ClaudeUsageFetcher {
             return oauthError.localizedDescription
         }
 
-        switch outcome {
+        if result.isUnreadableAfterRefresh {
+            // Not "run `claude login`, then retry": that refreshes Claude Code's own Keychain item, which this
+            // build never reads, so the same expired cache comes back.
+            return "Claude OAuth credentials expired and CodexBar cannot read them back. Claude Code owns the "
+                + "Keychain item and no credentials file is present for this profile, so refreshing will not "
+                + "restore usage. Switch Claude Usage source to Web/CLI."
+        }
+
+        switch result.outcome {
         case .skippedByCooldown:
             return "Claude OAuth token expired and delegated refresh is cooling down. "
                 + "Please retry shortly, or run `claude login`."
@@ -48,12 +53,6 @@ extension ClaudeUsageFetcher {
         case let .attemptedFailed(message):
             return "Claude OAuth token expired and delegated Claude CLI refresh failed: \(message). "
                 + "Run `claude login`, then retry."
-        case .unreadableAfterRefresh:
-            // Deliberately not "run `claude login`, then retry": Claude Code would refresh its own Keychain item,
-            // which CodexBar does not read, so the same expired cache would come back.
-            return "Claude OAuth credentials expired and CodexBar cannot read them back. Claude Code owns the "
-                + "Keychain item and no credentials file is present for this profile, so refreshing will not "
-                + "restore usage. Switch Claude Usage source to Web/CLI."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher+DelegatedRefreshMessages.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher+DelegatedRefreshMessages.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Presentation helpers for delegated Claude CLI refresh outcomes, split out to keep ClaudeUsageFetcher.swift
+/// within the file-length limit.
+extension ClaudeUsageFetcher {
+    static func delegatedRefreshOutcomeLabel(
+        _ outcome: ClaudeOAuthDelegatedRefreshCoordinator.Outcome) -> String
+    {
+        switch outcome {
+        case .skippedByCooldown:
+            "skippedByCooldown"
+        case .skippedByPromptPolicy:
+            "skippedByPromptPolicy"
+        case .cliUnavailable:
+            "cliUnavailable"
+        case .attemptedSucceeded:
+            "attemptedSucceeded"
+        case .attemptedFailed:
+            "attemptedFailed"
+        case .unreadableAfterRefresh:
+            "unreadableAfterRefresh"
+        }
+    }
+
+    static func delegatedRefreshFailureMessage(
+        for outcome: ClaudeOAuthDelegatedRefreshCoordinator.Outcome,
+        retryError: Error) -> String
+    {
+        if let oauthError = retryError as? ClaudeOAuthFetchError,
+           case .rateLimited = oauthError
+        {
+            return oauthError.localizedDescription
+        }
+
+        switch outcome {
+        case .skippedByCooldown:
+            return "Claude OAuth token expired and delegated refresh is cooling down. "
+                + "Please retry shortly, or run `claude login`."
+        case .skippedByPromptPolicy:
+            return "Claude OAuth token expired; background refresh is disabled by the Keychain prompt policy. "
+                + "Refresh CodexBar manually or run `claude login`."
+        case .cliUnavailable:
+            return "Claude OAuth token expired and Claude CLI is not available for delegated refresh. "
+                + "Install/configure `claude`, or run `claude login`."
+        case .attemptedSucceeded:
+            return "Claude OAuth token is still unavailable after delegated Claude CLI refresh. "
+                + "Run `claude login`, then retry."
+        case let .attemptedFailed(message):
+            return "Claude OAuth token expired and delegated Claude CLI refresh failed: \(message). "
+                + "Run `claude login`, then retry."
+        case .unreadableAfterRefresh:
+            // Deliberately not "run `claude login`, then retry": Claude Code would refresh its own Keychain item,
+            // which CodexBar does not read, so the same expired cache would come back.
+            return "Claude OAuth credentials expired and CodexBar cannot read them back. Claude Code owns the "
+                + "Keychain item and no credentials file is present for this profile, so refreshing will not "
+                + "restore usage. Switch Claude Usage source to Web/CLI."
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -420,7 +420,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                         throw ClaudeUsageError.oauthFailed(
                             "Claude OAuth token expired; delegated refresh is unavailable (outcome="
                                 + "\(ClaudeUsageFetcher.delegatedRefreshOutcomeLabel(delegatedOutcome))).")
-                    case .attemptedSucceeded, .attemptedFailed:
+                    case .attemptedSucceeded, .attemptedFailed, .unreadableAfterRefresh:
                         break
                     }
                 }
@@ -962,52 +962,6 @@ extension ClaudeUsageFetcher {
             now: now,
             timeout: timeout,
             environment: environment)
-    }
-
-    private static func delegatedRefreshOutcomeLabel(
-        _ outcome: ClaudeOAuthDelegatedRefreshCoordinator.Outcome) -> String
-    {
-        switch outcome {
-        case .skippedByCooldown:
-            "skippedByCooldown"
-        case .skippedByPromptPolicy:
-            "skippedByPromptPolicy"
-        case .cliUnavailable:
-            "cliUnavailable"
-        case .attemptedSucceeded:
-            "attemptedSucceeded"
-        case .attemptedFailed:
-            "attemptedFailed"
-        }
-    }
-
-    private static func delegatedRefreshFailureMessage(
-        for outcome: ClaudeOAuthDelegatedRefreshCoordinator.Outcome,
-        retryError: Error) -> String
-    {
-        if let oauthError = retryError as? ClaudeOAuthFetchError,
-           case .rateLimited = oauthError
-        {
-            return oauthError.localizedDescription
-        }
-
-        switch outcome {
-        case .skippedByCooldown:
-            return "Claude OAuth token expired and delegated refresh is cooling down. "
-                + "Please retry shortly, or run `claude login`."
-        case .skippedByPromptPolicy:
-            return "Claude OAuth token expired; background refresh is disabled by the Keychain prompt policy. "
-                + "Refresh CodexBar manually or run `claude login`."
-        case .cliUnavailable:
-            return "Claude OAuth token expired and Claude CLI is not available for delegated refresh. "
-                + "Install/configure `claude`, or run `claude login`."
-        case .attemptedSucceeded:
-            return "Claude OAuth token is still unavailable after delegated Claude CLI refresh. "
-                + "Run `claude login`, then retry."
-        case let .attemptedFailed(message):
-            return "Claude OAuth token expired and delegated Claude CLI refresh failed: \(message). "
-                + "Run `claude login`, then retry."
-        }
     }
 
     private static func delegatedRetryFailureMetadata(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -405,12 +405,14 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                 policy: delegatedPromptPolicy,
                 allowBackgroundDelegatedRefresh: self.fetcher.allowBackgroundDelegatedRefresh)
 
-            let delegatedOutcome = await ClaudeUsageFetcher.attemptDelegatedRefresh(
+            let delegatedResult = await ClaudeUsageFetcher.attemptDelegatedRefresh(
                 environment: self.fetcher.environment)
+            let delegatedOutcome = delegatedResult.outcome
             ClaudeUsageFetcher.log.info(
                 "Claude OAuth delegated refresh attempted",
                 metadata: [
                     "outcome": ClaudeUsageFetcher.delegatedRefreshOutcomeLabel(delegatedOutcome),
+                    "unreadableAfterRefresh": "\(delegatedResult.isUnreadableAfterRefresh)",
                 ])
 
             do {
@@ -420,7 +422,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                         throw ClaudeUsageError.oauthFailed(
                             "Claude OAuth token expired; delegated refresh is unavailable (outcome="
                                 + "\(ClaudeUsageFetcher.delegatedRefreshOutcomeLabel(delegatedOutcome))).")
-                    case .attemptedSucceeded, .attemptedFailed, .unreadableAfterRefresh:
+                    case .attemptedSucceeded, .attemptedFailed:
                         break
                     }
                 }
@@ -517,7 +519,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                         delegatedOutcome: delegatedOutcome))
                 throw ClaudeUsageError.oauthFailed(
                     ClaudeUsageFetcher.delegatedRefreshFailureMessage(
-                        for: delegatedOutcome,
+                        for: delegatedResult,
                         retryError: error))
             }
         }
@@ -951,14 +953,14 @@ extension ClaudeUsageFetcher {
         now: Date = Date(),
         timeout: TimeInterval = 15,
         environment: [String: String] = ProcessInfo.processInfo.environment)
-        async -> ClaudeOAuthDelegatedRefreshCoordinator.Outcome
+        async -> ClaudeOAuthDelegatedRefreshCoordinator.AttemptResult
     {
         #if DEBUG
         if let override = delegatedRefreshAttemptOverride {
-            return await override(now, timeout, environment)
+            return await .init(override(now, timeout, environment))
         }
         #endif
-        return await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+        return await ClaudeOAuthDelegatedRefreshCoordinator.attemptDetailed(
             now: now,
             timeout: timeout,
             environment: environment)

--- a/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshUnreadableResultTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshUnreadableResultTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+private final class UnreadableResultTouchCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        self.lock.lock()
+        self.value += 1
+        self.lock.unlock()
+    }
+
+    func count() -> Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.value
+    }
+}
+
+/// Regression coverage for #2634: the Claude CLI touch runs and completes, but the refreshed credential lands
+/// somewhere the current build never reads, so a retryable "keychain did not update" verdict is wrong.
+@Suite(.serialized)
+struct ClaudeOAuthDelegatedRefreshUnreadableResultTests {
+    private static let unchangedFingerprint = ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint(
+        modifiedAt: 1,
+        createdAt: 1,
+        persistentRefHash: "ref1")
+
+    private func makeCredentialsData(accessToken: String, expiresAt: Date) -> Data {
+        let millis = Int(expiresAt.timeIntervalSince1970 * 1000)
+        return Data("""
+        {
+          "claudeAiOauth": {
+            "accessToken": "\(accessToken)",
+            "expiresAt": \(millis),
+            "scopes": ["user:profile"]
+          }
+        }
+        """.utf8)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("codexbar-unreadable-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    /// Runs one attempt with the Claude Keychain unreadable and the credentials file pinned to `credentialsURL`.
+    private func attemptWithUnreadableKeychain(
+        credentialsURL: URL,
+        now: Date,
+        touchAuthPath: @escaping @Sendable (TimeInterval, [String: String]) async throws -> Void)
+        async throws -> ClaudeOAuthDelegatedRefreshCoordinator.Outcome
+    {
+        try await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(credentialsURL) {
+                try await KeychainAccessGate.withTaskOverrideForTesting(false) {
+                    try await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.always) {
+                        try await ClaudeOAuthDelegatedRefreshCoordinator.withIsolatedStateForTesting {
+                            ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting()
+                            defer { ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting() }
+                            return try await ClaudeOAuthDelegatedRefreshCoordinator
+                                .withKeychainFingerprintOverrideForTesting {
+                                    Self.unchangedFingerprint
+                                } operation: {
+                                    try await ClaudeOAuthDelegatedRefreshCoordinator
+                                        .withCLIAvailableOverrideForTesting(true) {
+                                            try await ClaudeOAuthDelegatedRefreshCoordinator
+                                                .withTouchAuthPathOverrideForTesting(touchAuthPath) {
+                                                    await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                                                        now: now,
+                                                        timeout: 0.1)
+                                                }
+                                        }
+                                }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    func `unreadable refresh result reports terminal outcome instead of retryable failure`() async throws {
+        let root = try self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let touches = UnreadableResultTouchCounter()
+        let outcome = try await self.attemptWithUnreadableKeychain(
+            credentialsURL: root.appendingPathComponent(".credentials.json"),
+            now: Date(timeIntervalSince1970: 70000),
+            // Succeeds, and deliberately leaves the fingerprint untouched: Claude Code already refreshed.
+            touchAuthPath: { _, _ in touches.increment() })
+
+        #expect(outcome == .unreadableAfterRefresh)
+        // The touch still runs: on older Claude Code it can create the credentials file we would then read.
+        #expect(touches.count() == 1)
+    }
+
+    @Test
+    func `unchanged fingerprint stays retryable when a credentials file is present`() async throws {
+        let root = try self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let credentialsURL = root.appendingPathComponent(".credentials.json")
+        try self.makeCredentialsData(
+            accessToken: "from-file",
+            expiresAt: Date(timeIntervalSinceNow: 3600))
+            .write(to: credentialsURL)
+
+        let outcome = try await self.attemptWithUnreadableKeychain(
+            credentialsURL: credentialsURL,
+            now: Date(timeIntervalSince1970: 71000),
+            touchAuthPath: { _, _ in })
+
+        guard case let .attemptedFailed(message) = outcome else {
+            Issue.record("Expected .attemptedFailed, got \(outcome)")
+            return
+        }
+        #expect(message.contains("did not update"))
+    }
+}

--- a/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshUnreadableResultTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshUnreadableResultTests.swift
@@ -19,8 +19,7 @@ private final class UnreadableResultTouchCounter: @unchecked Sendable {
     }
 }
 
-/// Regression coverage for #2634: the Claude CLI touch runs and completes, but the refreshed credential lands
-/// somewhere the current build never reads, so a retryable "keychain did not update" verdict is wrong.
+/// Regression coverage for #2634: the touch completes, but nothing this build reads holds the result.
 @Suite(.serialized)
 struct ClaudeOAuthDelegatedRefreshUnreadableResultTests {
     private static let unchangedFingerprint = ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint(
@@ -48,12 +47,11 @@ struct ClaudeOAuthDelegatedRefreshUnreadableResultTests {
         return root
     }
 
-    /// Runs one attempt with the Claude Keychain unreadable and the credentials file pinned to `credentialsURL`.
     private func attemptWithUnreadableKeychain(
         credentialsURL: URL,
         now: Date,
         touchAuthPath: @escaping @Sendable (TimeInterval, [String: String]) async throws -> Void)
-        async throws -> ClaudeOAuthDelegatedRefreshCoordinator.Outcome
+        async throws -> ClaudeOAuthDelegatedRefreshCoordinator.AttemptResult
     {
         try await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
             try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(credentialsURL) {
@@ -70,7 +68,7 @@ struct ClaudeOAuthDelegatedRefreshUnreadableResultTests {
                                         .withCLIAvailableOverrideForTesting(true) {
                                             try await ClaudeOAuthDelegatedRefreshCoordinator
                                                 .withTouchAuthPathOverrideForTesting(touchAuthPath) {
-                                                    await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                                                    await ClaudeOAuthDelegatedRefreshCoordinator.attemptDetailed(
                                                         now: now,
                                                         timeout: 0.1)
                                                 }
@@ -92,10 +90,10 @@ struct ClaudeOAuthDelegatedRefreshUnreadableResultTests {
         let outcome = try await self.attemptWithUnreadableKeychain(
             credentialsURL: root.appendingPathComponent(".credentials.json"),
             now: Date(timeIntervalSince1970: 70000),
-            // Succeeds, and deliberately leaves the fingerprint untouched: Claude Code already refreshed.
+            // Succeeds while leaving the fingerprint untouched: Claude Code already refreshed.
             touchAuthPath: { _, _ in touches.increment() })
 
-        #expect(outcome == .unreadableAfterRefresh)
+        #expect(outcome.isUnreadableAfterRefresh)
         // The touch still runs: on older Claude Code it can create the credentials file we would then read.
         #expect(touches.count() == 1)
     }
@@ -115,7 +113,8 @@ struct ClaudeOAuthDelegatedRefreshUnreadableResultTests {
             now: Date(timeIntervalSince1970: 71000),
             touchAuthPath: { _, _ in })
 
-        guard case let .attemptedFailed(message) = outcome else {
+        #expect(!outcome.isUnreadableAfterRefresh)
+        guard case let .attemptedFailed(message) = outcome.outcome else {
             Issue.record("Expected .attemptedFailed, got \(outcome)")
             return
         }

--- a/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshUnreadableResultTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshUnreadableResultTests.swift
@@ -99,6 +99,31 @@ struct ClaudeOAuthDelegatedRefreshUnreadableResultTests {
     }
 
     @Test
+    func `failed touch stays retryable even in the unreadable configuration`() async throws {
+        let root = try self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        struct TouchStubError: Error, LocalizedError {
+            var errorDescription: String? {
+                "SessionError: capture timed out"
+            }
+        }
+        let result = try await self.attemptWithUnreadableKeychain(
+            credentialsURL: root.appendingPathComponent(".credentials.json"),
+            now: Date(timeIntervalSince1970: 72000),
+            touchAuthPath: { _, _ in throw TouchStubError() })
+
+        // Deliberate: a touch *error* may be transient, and on older Claude Code a retried touch can still
+        // create the credentials file, so only the completes-cleanly-but-unobservable variant is terminal.
+        #expect(!result.isUnreadableAfterRefresh)
+        guard case let .attemptedFailed(message) = result.outcome else {
+            Issue.record("Expected .attemptedFailed, got \(result)")
+            return
+        }
+        #expect(message.contains("SessionError"))
+    }
+
+    @Test
     func `unchanged fingerprint stays retryable when a credentials file is present`() async throws {
         let root = try self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
Fixes part of #2634.

## Problem

When the delegated Claude CLI refresh completes cleanly but the Keychain fingerprint does not move, `performAttempt` reports `.attemptedFailed("Claude keychain did not update after Claude CLI touch.")`. On 0.47.0 that verdict is wrong in a specific and permanent way.

Success is defined as the fingerprint changing inside the touch window (`min(timeout, 2)`s, `delays = [0.2, 0.5, 0.8]`). If Claude Code already refreshed its own item on its own schedule, the CLI has nothing to do, the fingerprint does not move, and the attempt fails. Since `keychainAccessAllowed` is an unconditional `return false` in release, the refreshed credential is unreadable anyway — so on a profile with no `~/.claude/.credentials.json`, no amount of retrying can succeed.

The background path then printed `... delegated Claude CLI refresh failed: Claude keychain did not update after Claude CLI touch. Run 'claude login', then retry.` Both halves mislead: retrying cannot help, and `claude login` refreshes the Keychain item that CodexBar does not read.

## Change

The verdict is carried on an internal `AttemptResult` rather than a new `Outcome` case:

```swift
struct AttemptResult: Sendable, Equatable {
    let outcome: Outcome
    let isUnreadableAfterRefresh: Bool
}
```

`Outcome` ships in the `CodexBarCore` library product, so adding a case would break downstream exhaustive switches on source update. The public enum and `attempt(now:timeout:environment:)` are unchanged; the fetcher reads the detail through a new internal `attemptDetailed`. `git diff upstream/main` adds and removes no `public` line.

The state is detected after the touch, not before:

```swift
guard !configuration.keychainReadAllowed else { return false }
guard !configuration.hasSelectedProfileOAuthCredentialsFile else { return false }
return !ClaudeOAuthCredentialsStore.hasSelectedProfileOAuthCredentialsFile(
    environment: configuration.environment)
```

- The touch still runs. On older Claude Code it can create the credentials file, and the post-touch re-check picks that up.
- `keychainReadAllowed` is captured in `AttemptConfiguration` because `performAttempt` runs in a detached task, where task-local overrides do not apply.
- The attempt records the long cooldown instead of the short one, so background polling stops relaunching `claude` every 20s for a state that cannot change. User-initiated refresh still bypasses the cooldown.
- A joined attempt reuses the verdict rather than retrying; readability does not depend on interaction.

The message change is scoped to the background path. `shouldPreserveOwnerCLIHandoff` returns `true` only for `.userInitiated`, so an explicit Refresh still rethrows the typed `.refreshDelegatedToClaudeCLI` handoff and reaches the owner-CLI pipeline exactly as before. Only background refreshes fall through to the generic catch, and those are the ones that were printing "Run `claude login`, then retry" for a state where neither helps.

Two presentation helpers moved to `ClaudeUsageFetcher+DelegatedRefreshMessages.swift` to stay under the file-length limit; visibility widened from `private static` to `static`, no logic change.

## Scope and limits

- **This does not fix the `SessionError` path in the report.** When the touch itself errors, the outcome stays `.attemptedFailed` with the underlying error, on the short cooldown. Masking a real touch error behind a terminal verdict would hide the CLI-hang defect, which looks like a separate problem. Only the completes-but-unobservable variant is addressed here.
- **This does not restore usage.** It reports the state accurately and stops the retry churn. Actually recovering OAuth needs the credential-ownership decision, which is still open on the issue.
- The post-touch re-check runs inside the detached task, so under tests it reads `isolatedTestCredentialsURL` — a per-process random temp path that is never created — rather than an overridden URL. The captured pre-touch value is what the tests steer, and a stray file there would fail the assertion loudly rather than pass wrongly.

## On after-fix runtime output

I tried to capture it and could not; the obstacle is structural. `Scripts/package_app.sh` signs ad hoc, so a locally built bundle has a different code identity than the installed notarized one and cannot read CodexBar's own cached-credential Keychain item:

```
Keychain cache item is unusable by this executable
(oauth.claude.profile.22c64993…); treating as missing
```

It therefore starts with no cached credentials at all — a different state from the bug, which needs an *expired* cache. It never entered the OAuth path (zero delegated-refresh log lines) and fell through to the CLI scrape. The build holding the reproducing state is the notarized one, which lacks the patch; the build with the patch cannot reach the state. Closing that needs a Developer ID signed build.

The pre-fix side is live rather than fixture-based: on this setup the retained log holds no `touch succeeded` and no `touch failed`, only `touch did not update Claude keychain` → `attemptedFailed`, with the Keychain `mdat` sitting 31 minutes after the cached token's expiry.

Also worth stating: the changed message is background-only. `ClaudeProviderDescriptor` sets `allowBackgroundDelegatedRefresh: false`, `performAttempt` returns `.skippedByPromptPolicy` for background work unless the prompt policy is `always`, and `shouldPreserveOwnerCLIHandoff` keeps the existing handoff for `.userInitiated`. On the "only on user action" configuration from the linked issue the message path is unreachable by design, so no local capture would surface it either.

## Tests

`ClaudeOAuthDelegatedRefreshUnreadableResultTests`:

- unreadable Keychain + no credentials file + clean touch → `isUnreadableAfterRefresh`, and the touch is asserted to have run once
- same conditions with a credentials file present → plain `.attemptedFailed`, flag clear

Both use testing overrides and a temp credentials URL; no real Keychain access.

## Commands run

- `swift build` and `swift build -c release`
- `swift test --filter ClaudeOAuthDelegatedRefresh` — 27 tests, all green
- `make test` — full suite, 813 selections
- `./Scripts/lint.sh format` and `./Scripts/lint.sh` — 0 violations

Two pre-existing failures showed up on my machine during the full run; both reproduce identically on pristine `main`:

- `ProviderPluginExtensionParityTests` — `PerplexityUsageSnapshot.promoExpiryFormatter` never sets `locale`, so `MMM` resolves through `Locale.current` and renders `1월` on a Korean-locale host. Unrelated to this change, fixed separately in #2651.
- `ClaudeOAuthDelegatedRefreshProfileIsolationTests / legacy cooldown migrates only to the default credentials profile` — fails when run alongside sibling suites, passes in isolation, and does not reproduce on every run.
