### PR TITLE
Pin Perplexity promo expiry formatter to en_US_POSIX

### DIFF
--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityUsageSnapshot.swift
@@ -59,7 +59,10 @@ public struct PerplexityUsageSnapshot: Sendable {
         return "Max"
     }
 
-    private static let promoExpiryFormatter: DateFormatter = {
+    /// Pinned to POSIX English so `MMM` cannot resolve through `Locale.current`: the surrounding label is
+    /// hardcoded English and the bundled plugin formats the same value with `toLocaleDateString("en-US", …)`.
+    /// Internal rather than private so a test can assert the pin survives.
+    static let promoExpiryFormatter: DateFormatter = {
         let fmt = DateFormatter()
         fmt.locale = Locale(identifier: "en_US_POSIX")
         fmt.dateFormat = "MMM d"

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityUsageSnapshot.swift
@@ -61,6 +61,7 @@ public struct PerplexityUsageSnapshot: Sendable {
 
     private static let promoExpiryFormatter: DateFormatter = {
         let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
         fmt.dateFormat = "MMM d"
         return fmt
     }()

--- a/Tests/CodexBarTests/PerplexityPromoExpiryLocaleTests.swift
+++ b/Tests/CodexBarTests/PerplexityPromoExpiryLocaleTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+/// The promo expiry label is hardcoded English (`"… bonus · exp. …"`) and the bundled Perplexity plugin formats
+/// the same value with `toLocaleDateString("en-US", …)`. If the formatter loses its explicit locale it silently
+/// falls back to `Locale.current`, which only diverges on non-English hosts — so parity coverage alone passes
+/// before and after the regression on an English runner. These assertions hold on every host.
+struct PerplexityPromoExpiryLocaleTests {
+    @Test
+    func `promo expiry formatter stays pinned to POSIX English`() {
+        #expect(PerplexityUsageSnapshot.promoExpiryFormatter.locale.identifier == "en_US_POSIX")
+    }
+
+    @Test
+    func `promo expiry renders an English month regardless of host locale`() {
+        // 2026-01-01T00:00:00Z, rendered in the formatter's own time zone.
+        let expiry = Date(timeIntervalSince1970: 1_767_225_600)
+        let rendered = PerplexityUsageSnapshot.promoExpiryFormatter.string(from: expiry)
+
+        #expect(rendered.hasPrefix("Jan"))
+        // Guards the specific regression: a `Locale.current` fallback emits digits plus a localized month
+        // marker (for example `1월`) instead of an ASCII month abbreviation.
+        let isASCIIOnly = rendered.unicodeScalars.allSatisfy(\.isASCII)
+        #expect(isASCIIOnly)
+    }
+}

--- a/Tests/CodexBarTests/PerplexityPromoExpiryLocaleTests.swift
+++ b/Tests/CodexBarTests/PerplexityPromoExpiryLocaleTests.swift
@@ -14,8 +14,9 @@ struct PerplexityPromoExpiryLocaleTests {
 
     @Test
     func `promo expiry renders an English month regardless of host locale`() {
-        // 2026-01-01T00:00:00Z, rendered in the formatter's own time zone.
-        let expiry = Date(timeIntervalSince1970: 1_767_225_600)
+        // 2026-01-15T12:00:00Z. The formatter keeps the host time zone, so this sits far enough from both
+        // month boundaries to stay in January from UTC-12 through UTC+14.
+        let expiry = Date(timeIntervalSince1970: 1_768_478_400)
         let rendered = PerplexityUsageSnapshot.promoExpiryFormatter.string(from: expiry)
 
         #expect(rendered.hasPrefix("Jan"))


### PR DESCRIPTION
`PerplexityUsageSnapshot.promoExpiryFormatter` builds a `DateFormatter` with `dateFormat = "MMM d"` but never sets `locale`, so `MMM` resolves through `Locale.current`. On a non-English system the month renders in the user's language while the rest of the string is hardcoded English, and the JS plugin path keeps emitting English — so the two projections disagree.

On a `ko_KR` machine, `ProviderPluginExtensionParityTests / Perplexity cookie plugin matches Swift generic projection` fails on `main`:

```
script.secondary   resetDescription: "0/300 bonus · exp. Jan 1"
swift.secondary    resetDescription: "0/300 bonus · exp. 1월 1"
```

The surrounding text (`bonus`, `exp.`) is not localized, so a translated month is not the intent here.

Every other `DateFormatter` under `Sources/CodexBarCore/Providers/` already pins `en_US_POSIX`, including the two that use the same `MMM` pattern — `CursorStatusProbe.swift:741` and `ClaudeUsageFetcher.swift:1259`. This one was the remaining omission. Same fix shape as #868 ("pin RelativeDateTimeFormatter to en_US to stop mixed-locale labels").

## Deterministic coverage

Addresses the review finding that parity coverage alone cannot catch this: it only diverges on a non-English host, so an English runner stays green before and after the regression.

`PerplexityPromoExpiryLocaleTests` asserts two things that hold on every host:

- the formatter keeps `en_US_POSIX`, so deleting the assignment fails immediately
- the rendered month starts with `Jan` and is ASCII-only, which a `Locale.current` fallback cannot satisfy on a localized host

The fixture is `2026-01-15T12:00:00Z`, not a month boundary: the formatter deliberately keeps the host time zone, so a midnight-UTC instant would render as `Dec 31` west of UTC and fail the assertion even with a correct locale pin. Mid-January stays in January from UTC-12 through UTC+14. Verified by running the suite under `TZ=Pacific/Midway` as well as the local `Asia/Seoul`.

`promoExpiryFormatter` changed from `private static` to `static` for this. It stays internal — `CodexBarCore`'s public surface is unchanged (`git diff upstream/main` shows no `public` line added or removed).

## On live proof

I cannot produce runtime output from a real Perplexity account, and I do not think it is obtainable for this label. `promoExpiration` is only non-nil when the API returns a `credit_grants` entry with `type == "promotional"` and an `expires_at` timestamp:

```swift
self.promoExpiration = promotional
    .compactMap { $0.expiresAtTs.map { Date(timeIntervalSince1970: $0) } }
    .min()
```

Without such a grant the ` · exp. …` suffix is never appended, so the affected string does not render at all. I only have a free Perplexity account, which carries no promotional grant, so no live capture from my setup could exercise this path either way.

What I can attest to is real rather than synthetic: my machine runs `ko_KR`, and the parity test genuinely fails on `main` and passes with this patch there. The added assertions then make that reproducible on any locale.

## Commands run

- `swift test --filter "PerplexityPromoExpiryLocaleTests|ProviderPluginExtensionParityTests"` — 9 tests, green; parity red before the fix on this host
- `./Scripts/lint.sh format` and `./Scripts/lint.sh` — 0 violations
