### PR TITLE
test: keep widget-snapshot container I/O out of test runs

### DIFF
--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -7,26 +7,23 @@ import WidgetKit
 extension UsageStore {
     /// Tests must never touch the real app-group container: the widget-snapshot
     /// `open()` can block forever behind macOS 26 app-data (TCC) gating, hanging
-    /// the whole suite. Only a test that installs `_test_widgetSnapshotSaveOverride`
-    /// opts into snapshot persistence; its container load is already stubbed out.
-    static func shouldPersistWidgetSnapshot(isRunningTests: Bool, hasSaveOverride: Bool) -> Bool {
-        !isRunningTests || hasSaveOverride
+    /// the whole suite. A test opts into persistence with an in-memory save
+    /// override (its container load is stubbed out) or an injected snapshot URL
+    /// that redirects all I/O to a test-owned file.
+    static func shouldPersistWidgetSnapshot(
+        isRunningTests: Bool,
+        hasSaveOverride: Bool,
+        hasInjectedSnapshotURL: Bool) -> Bool
+    {
+        !isRunningTests || hasSaveOverride || hasInjectedSnapshotURL
     }
 
     func persistWidgetSnapshot(reason: String) {
         guard Self.shouldPersistWidgetSnapshot(
             isRunningTests: SettingsStore.isRunningTests,
-            hasSaveOverride: self._test_widgetSnapshotSaveOverride != nil)
+            hasSaveOverride: self._test_widgetSnapshotSaveOverride != nil,
+            hasInjectedSnapshotURL: self.widgetSnapshotURL != nil)
         else { return }
-
-        #if DEBUG
-        // Unsigned test processes must not cross into the real app-group container. Snapshot tests
-        // opt in with an in-memory save override or an injected file URL.
-        guard !SettingsStore.isRunningTests ||
-            self._test_widgetSnapshotSaveOverride != nil ||
-            self.widgetSnapshotURL != nil
-        else { return }
-        #endif
         // A fresh process has token-cost data before a user-authorized Claude OAuth refresh can run.
         // Keep the last queued snapshot in memory so back-to-back writes cannot race the on-disk cache.
         let previousSnapshot = self.lastQueuedWidgetSnapshot ?? {

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -5,7 +5,20 @@ import WidgetKit
 #endif
 
 extension UsageStore {
+    /// Tests must never touch the real app-group container: the widget-snapshot
+    /// `open()` can block forever behind macOS 26 app-data (TCC) gating, hanging
+    /// the whole suite. Only a test that installs `_test_widgetSnapshotSaveOverride`
+    /// opts into snapshot persistence; its container load is already stubbed out.
+    static func shouldPersistWidgetSnapshot(isRunningTests: Bool, hasSaveOverride: Bool) -> Bool {
+        !isRunningTests || hasSaveOverride
+    }
+
     func persistWidgetSnapshot(reason: String) {
+        guard Self.shouldPersistWidgetSnapshot(
+            isRunningTests: SettingsStore.isRunningTests,
+            hasSaveOverride: self._test_widgetSnapshotSaveOverride != nil)
+        else { return }
+
         #if DEBUG
         // Unsigned test processes must not cross into the real app-group container. Snapshot tests
         // opt in with an in-memory save override or an injected file URL.

--- a/Tests/CodexBarTests/WidgetSnapshotTestIsolationTests.swift
+++ b/Tests/CodexBarTests/WidgetSnapshotTestIsolationTests.swift
@@ -1,0 +1,56 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+/// `WidgetSnapshotStore.load()` opens a file in the real app-group container. On
+/// macOS 26 that `open()` can block forever behind app-data (TCC) gating, so a
+/// test that reaches `persistWidgetSnapshot` without stubbing the save path hangs
+/// the whole suite. These tests pin the gate that keeps container I/O out of tests.
+@MainActor
+struct WidgetSnapshotTestIsolationTests {
+    @Test
+    func `persistence gate only opens for tests that install a save override`() {
+        #expect(!UsageStore.shouldPersistWidgetSnapshot(isRunningTests: true, hasSaveOverride: false))
+        #expect(UsageStore.shouldPersistWidgetSnapshot(isRunningTests: true, hasSaveOverride: true))
+        #expect(UsageStore.shouldPersistWidgetSnapshot(isRunningTests: false, hasSaveOverride: false))
+        #expect(UsageStore.shouldPersistWidgetSnapshot(isRunningTests: false, hasSaveOverride: true))
+    }
+
+    @Test
+    func `persist without a save override queues no widget snapshot work`() {
+        let settings = testSettingsStore(suiteName: "WidgetSnapshotTestIsolationTests-no-override")
+        settings.providerDetectionCompleted = true
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
+
+        store.persistWidgetSnapshot(reason: "test-no-override")
+
+        #expect(store.widgetSnapshotPersistTask == nil)
+        #expect(store.lastQueuedWidgetSnapshot == nil)
+    }
+
+    @Test
+    func `persist with a save override routes the snapshot through the override`() async {
+        let settings = testSettingsStore(suiteName: "WidgetSnapshotTestIsolationTests-override")
+        settings.providerDetectionCompleted = true
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
+        var saved: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { saved.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        store.persistWidgetSnapshot(reason: "test-override")
+        await store.widgetSnapshotPersistTask?.value
+
+        #expect(saved.count == 1)
+    }
+}

--- a/Tests/CodexBarTests/WidgetSnapshotTestIsolationTests.swift
+++ b/Tests/CodexBarTests/WidgetSnapshotTestIsolationTests.swift
@@ -6,29 +6,28 @@ import Testing
 /// `WidgetSnapshotStore.load()` opens a file in the real app-group container. On
 /// macOS 26 that `open()` can block forever behind app-data (TCC) gating, so a
 /// test that reaches `persistWidgetSnapshot` without stubbing the save path hangs
-/// the whole suite. These tests pin the gate that keeps container I/O out of tests.
+/// the whole suite. These tests pin the gate that keeps container I/O out of tests:
+/// persistence runs only for tests that opt in via the in-memory save override or
+/// an injected snapshot URL.
 @MainActor
 struct WidgetSnapshotTestIsolationTests {
     @Test
-    func `persistence gate only opens for tests that install a save override`() {
-        #expect(!UsageStore.shouldPersistWidgetSnapshot(isRunningTests: true, hasSaveOverride: false))
-        #expect(UsageStore.shouldPersistWidgetSnapshot(isRunningTests: true, hasSaveOverride: true))
-        #expect(UsageStore.shouldPersistWidgetSnapshot(isRunningTests: false, hasSaveOverride: false))
-        #expect(UsageStore.shouldPersistWidgetSnapshot(isRunningTests: false, hasSaveOverride: true))
+    func `persistence gate only opens for tests that opt in via override or injected URL`() {
+        #expect(!UsageStore.shouldPersistWidgetSnapshot(
+            isRunningTests: true, hasSaveOverride: false, hasInjectedSnapshotURL: false))
+        #expect(UsageStore.shouldPersistWidgetSnapshot(
+            isRunningTests: true, hasSaveOverride: true, hasInjectedSnapshotURL: false))
+        #expect(UsageStore.shouldPersistWidgetSnapshot(
+            isRunningTests: true, hasSaveOverride: false, hasInjectedSnapshotURL: true))
+        #expect(UsageStore.shouldPersistWidgetSnapshot(
+            isRunningTests: false, hasSaveOverride: false, hasInjectedSnapshotURL: false))
     }
 
     @Test
-    func `persist without a save override queues no widget snapshot work`() {
-        let settings = testSettingsStore(suiteName: "WidgetSnapshotTestIsolationTests-no-override")
-        settings.providerDetectionCompleted = true
-        let store = UsageStore(
-            fetcher: UsageFetcher(environment: [:]),
-            browserDetection: BrowserDetection(cacheTTL: 0),
-            settings: settings,
-            startupBehavior: .testing,
-            environmentBase: [:])
+    func `persist without any opt-in queues no widget snapshot work`() {
+        let store = Self.makeStore(suite: "no-opt-in")
 
-        store.persistWidgetSnapshot(reason: "test-no-override")
+        store.persistWidgetSnapshot(reason: "test-no-opt-in")
 
         #expect(store.widgetSnapshotPersistTask == nil)
         #expect(store.lastQueuedWidgetSnapshot == nil)
@@ -36,14 +35,7 @@ struct WidgetSnapshotTestIsolationTests {
 
     @Test
     func `persist with a save override routes the snapshot through the override`() async {
-        let settings = testSettingsStore(suiteName: "WidgetSnapshotTestIsolationTests-override")
-        settings.providerDetectionCompleted = true
-        let store = UsageStore(
-            fetcher: UsageFetcher(environment: [:]),
-            browserDetection: BrowserDetection(cacheTTL: 0),
-            settings: settings,
-            startupBehavior: .testing,
-            environmentBase: [:])
+        let store = Self.makeStore(suite: "override")
         var saved: [WidgetSnapshot] = []
         store._test_widgetSnapshotSaveOverride = { saved.append($0) }
         defer { store._test_widgetSnapshotSaveOverride = nil }
@@ -52,5 +44,30 @@ struct WidgetSnapshotTestIsolationTests {
         await store.widgetSnapshotPersistTask?.value
 
         #expect(saved.count == 1)
+    }
+
+    @Test
+    func `persist with an injected snapshot URL writes to that file`() async {
+        let snapshotURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WidgetSnapshotTestIsolationTests-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: snapshotURL) }
+        let store = Self.makeStore(suite: "injected-url", widgetSnapshotURL: snapshotURL)
+
+        store.persistWidgetSnapshot(reason: "test-injected-url")
+        await store.widgetSnapshotPersistTask?.value
+
+        #expect(WidgetSnapshotStore.load(from: snapshotURL) != nil)
+    }
+
+    private static func makeStore(suite: String, widgetSnapshotURL: URL? = nil) -> UsageStore {
+        let settings = testSettingsStore(suiteName: "WidgetSnapshotTestIsolationTests-\(suite)")
+        settings.providerDetectionCompleted = true
+        return UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:],
+            widgetSnapshotURL: widgetSnapshotURL)
     }
 }


### PR DESCRIPTION
## Summary

`AdaptiveRefreshHeuristicsTests` (and any suite that reaches `persistWidgetSnapshot` without a save override) can hang forever on macOS 26 hosts. Sampled stack: `UsageStore.persistWidgetSnapshot` → `WidgetSnapshotStore.load()` → `Data(contentsOf:)` → an `open()` on the real app-group container file that never returns (app-data/TCC gating on the host). Reproduced identically in two worktrees, so it is host state, not branch state.

## Fix

Tests must never do app-group container I/O. `persistWidgetSnapshot` now gates on a pure decision — `UsageStore.shouldPersistWidgetSnapshot(isRunningTests:hasSaveOverride:)` — so under tests it only proceeds when the test explicitly installs `_test_widgetSnapshotSaveOverride` (whose container *load* was already stubbed out in DEBUG). Test runs now touch the container on neither the read nor the write side; production behavior is unchanged.

## Proof

- On the exact machine that hung: `swift test --filter AdaptiveRefreshHeuristicsTests` went from an indefinite hang to 10/10 in ~3 s.
- `swift test --filter CodexAccountScopedRefreshTests` (109 tests, heavy user of the override seam) stays green.
- New `WidgetSnapshotTestIsolationTests` (3 tests): the gate truth table, no-override persists nothing, override receives the snapshot.
- `make check` clean.

Test-infrastructure only; no changelog entry.
