### PR TITLE
test: deflake Kimi grace-budget timing

### DIFF
--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -851,6 +851,8 @@ struct KimiUsageResponseParsingTests {
           ]
         }
         """
+        // Keep the cancellation-ignoring request slower than the scaled wall-clock guard.
+        let subscriptionDelaySeconds = 0.5 * TestTimingBudget.slowdownFactor
         let transport = ProviderHTTPTransportHandler { request in
             let url = try #require(request.url)
             let response = try #require(HTTPURLResponse(
@@ -867,7 +869,7 @@ struct KimiUsageResponseParsingTests {
             }
 
             return await withCheckedContinuation { continuation in
-                DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                DispatchQueue.global().asyncAfter(deadline: .now() + subscriptionDelaySeconds) {
                     continuation.resume(returning: (Data("{}".utf8), response))
                 }
             }
@@ -885,10 +887,12 @@ struct KimiUsageResponseParsingTests {
         #expect(usage.primary?.windowMinutes == KimiProviderDescriptor.weeklyWindowMinutes)
         #expect(usage.secondary?.usedPercent == 25)
         #expect(usage.extraRateWindows == nil)
-        #expect(elapsed < .milliseconds(250), "Subscription enrichment outlived its total budget: \(elapsed)")
+        #expect(
+            elapsed < TestTimingBudget.scaled(.milliseconds(250)),
+            "Subscription enrichment outlived its total budget: \(elapsed)")
 
         // Drain the deliberately cancellation-ignoring test request before the test exits.
-        try await Task.sleep(for: .milliseconds(550))
+        try await Task.sleep(for: TestTimingBudget.scaled(.milliseconds(550)))
     }
 
     @Test


### PR DESCRIPTION
## Problem

The Kimi test `subscription grace is a total budget for existing usage windows` used a fixed 250 ms wall-clock guard. On the loaded macOS runner in [CI run 30857240975](https://github.com/steipete/CodexBar/actions/runs/30857240975), it exceeded that bound by 3.5 ms even though the total grace-budget behavior was correct.

## Change

- Route the wall-clock guard through the `TestTimingBudget` loaded-runner scaling helper introduced by #2509.
- Scale the deliberately cancellation-ignoring subscription delay and its drain by the same factor, preserving the 500 ms slow-enrichment versus 250 ms guard relationship. A regression that waits for the optional enrichment still fails under CI scaling.
- No `TestsLinux` twin exists for this macOS Kimi provider test.

## Proof

- `swift test --filter KimiProviderTests` — 70 tests passed.
- `CI=1 swift test --skip-build --filter KimiProviderTests` — 70 tests passed; exercises the loaded-runner path.
- `make check` — passed with 0 SwiftFormat changes and 0 SwiftLint violations.
- `make test` — all 812 selections passed across 68 groups with no retries.
- Codex autoreview (`gpt-5.6-sol`, high) — clean, no accepted/actionable findings.
