### PR TITLE
feat: resizable settings sidebar with persisted width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - CLI: expose Codex cost-history completeness in JSON and add an experimental provider-native-only scan mode (#2520). Thanks @NickGuAI!
 - Usage & Spend: add an accessible daily, weekly, and cumulative token-activity heatmap backed by the existing persistent cost scan cache (#2548). Thanks @Yuxin-Qiao!
+- Settings: the sidebar is now resizable — drag the divider between 200–380pt; the width persists across launches.
 - z.ai/GLM: route BigModel aliases and relay-file keys only to China endpoints, reject canonical cross-region overrides before bearer auth, and keep Kimi browser import disabled when Cookie Source is Off (#2351). Thanks @Leehow!
 - Kimi: enrich Code API and CLI usage with the monthly membership pool from a signed-in Kimi Desktop session, using WAL-safe read-only cookie access (#2351). Thanks @Leehow!
 - Sessions: discover live pi and OMP sessions through one Pi-family scanner, with dialect-aware metadata, PID-only startup rows, and mixed-version CLI/remote support (#2529). Thanks @wdmitchelluk!

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -22,6 +22,9 @@ enum SettingsPane: Hashable {
     static let windowMinWidth: CGFloat = 800
     static let windowMinHeight: CGFloat = 540
     static let sidebarWidth: CGFloat = 260
+    static let sidebarMinWidth: CGFloat = 200
+    static let sidebarMaxWidth: CGFloat = 380
+    static let sidebarWidthDefaultsKey = "settingsSidebarWidth"
     static let detailMaxWidth: CGFloat = 780
 
     var title: String {
@@ -56,6 +59,13 @@ struct PreferencesView: View {
     let codexAccountPromotionCoordinator: CodexAccountPromotionCoordinator
     let runProviderLoginFlow: @MainActor (UsageProvider) async -> Void
     @Environment(\.colorScheme) private var colorScheme
+    @AppStorage(SettingsPane.sidebarWidthDefaultsKey) private var sidebarWidth: Double = SettingsPane.sidebarWidth
+
+    /// The persisted width, guarded against out-of-range values (edited defaults,
+    /// bounds that shrank in an update) so a bad stored value can't wreck the layout.
+    private var clampedSidebarWidth: CGFloat {
+        min(max(self.sidebarWidth, SettingsPane.sidebarMinWidth), SettingsPane.sidebarMaxWidth)
+    }
 
     init(
         settings: SettingsStore,
@@ -85,9 +95,10 @@ struct PreferencesView: View {
         HStack(spacing: 0) {
             // Golden Gate-style sidebar: edge-to-edge material with a hairline separator,
             // no floating card chrome. The material ignores the safe area so it runs up
-            // behind the transparent titlebar.
+            // behind the transparent titlebar. The width is user-resizable via the
+            // input-only drag strip overlaid on the detail pane's leading edge.
             SettingsSidebarView(settings: self.settings, store: self.store, selection: self.$selection.pane)
-                .frame(width: SettingsPane.sidebarWidth)
+                .frame(width: self.clampedSidebarWidth)
                 .background {
                     SettingsSidebarMaterial()
                         .ignoresSafeArea()
@@ -102,6 +113,9 @@ struct PreferencesView: View {
                     maxHeight: .infinity,
                     alignment: .topLeading)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .overlay(alignment: .leading) {
+                    self.sidebarResizeHandle
+                }
         }
         .frame(
             minWidth: SettingsPane.windowMinWidth,
@@ -124,6 +138,21 @@ struct PreferencesView: View {
         .onChange(of: self.settings.shouldRequestAdaptiveActivityScanConsent) { _, shouldRequest in
             guard shouldRequest else { return }
             AdaptiveActivityConsentPresenter.presentIfNeeded(settings: self.settings)
+        }
+    }
+
+    @ViewBuilder
+    private var sidebarResizeHandle: some View {
+        let handle = SidebarResizeHandle(
+            width: self.$sidebarWidth,
+            minWidth: SettingsPane.sidebarMinWidth,
+            maxWidth: SettingsPane.sidebarMaxWidth)
+            .frame(width: SidebarResizeHandleView.grabWidth)
+            .ignoresSafeArea()
+        if #available(macOS 15.0, *) {
+            handle.pointerStyle(.columnResize)
+        } else {
+            handle
         }
     }
 

--- a/Sources/CodexBar/SidebarResizeHandle.swift
+++ b/Sources/CodexBar/SidebarResizeHandle.swift
@@ -1,0 +1,100 @@
+import AppKit
+import SwiftUI
+
+/// Input-only drag strip that resizes the settings sidebar. It draws nothing — the
+/// visible hairline stays the `Divider()` in `PreferencesView` — and rides as an
+/// overlay on the detail pane's leading edge, which sits exactly on the
+/// sidebar/content boundary. Overlaying the detail side (instead of the sidebar's
+/// trailing edge) keeps the strip clear of the sidebar list's scroller, and staying
+/// out of the `HStack` keeps it from disturbing SwiftUI's width negotiation.
+///
+/// AppKit mouse tracking is deliberate: a SwiftUI `DragGesture` re-enters layout per
+/// event and jitters, while `mouseDown`/`mouseDragged` on an `NSView` report window
+/// coordinates that stay stable even as the strip itself moves mid-drag.
+///
+/// The hover cursor is belt-and-braces: `.pointerStyle(.columnResize)` in
+/// `PreferencesView` registers with SwiftUI's pointer engine on macOS 15+, and this
+/// view's tracking area asserts `NSCursor` directly (the only mechanism on macOS 14).
+/// Both produce the same left-right resize arrows, so they cannot fight.
+struct SidebarResizeHandle: NSViewRepresentable {
+    @Binding var width: Double
+    let minWidth: Double
+    let maxWidth: Double
+
+    func makeNSView(context: Context) -> SidebarResizeHandleView {
+        let view = SidebarResizeHandleView()
+        self.configure(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: SidebarResizeHandleView, context: Context) {
+        self.configure(nsView)
+    }
+
+    private func configure(_ view: SidebarResizeHandleView) {
+        view.getWidth = { self.width }
+        view.setWidth = { newWidth in
+            self.width = min(max(newWidth, self.minWidth), self.maxWidth)
+        }
+    }
+}
+
+final class SidebarResizeHandleView: NSView {
+    /// Width of the grabbable strip; matches the slop AppKit gives thin split-view dividers.
+    static let grabWidth: CGFloat = 12
+
+    var getWidth: (() -> Double)?
+    var setWidth: ((Double) -> Void)?
+
+    private var dragStartX: CGFloat = 0
+    private var dragStartWidth: Double = 0
+    private var trackingArea: NSTrackingArea?
+
+    // Clicks here must resize, never drag the window (the strip reaches up into the
+    // transparent-titlebar region).
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            self.removeTrackingArea(trackingArea)
+        }
+        // Explicit rect, not `.inVisibleRect`: the hosting view doesn't clip, so
+        // `visibleRect` spans the whole window and enter/exit events never fire.
+        let area = NSTrackingArea(
+            rect: self.bounds,
+            options: [.mouseEnteredAndExited, .mouseMoved, .activeAlways],
+            owner: self,
+            userInfo: nil)
+        self.addTrackingArea(area)
+        self.trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        NSCursor.resizeLeftRight.set()
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        // Re-assert every move: SwiftUI keeps resetting the cursor underneath us.
+        NSCursor.resizeLeftRight.set()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        NSCursor.arrow.set()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        self.dragStartX = event.locationInWindow.x
+        self.dragStartWidth = self.getWidth?() ?? 0
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        let deltaX = event.locationInWindow.x - self.dragStartX
+        // Sidebar sits left of the strip: dragging right (positive delta) grows it.
+        self.setWidth?(self.dragStartWidth + Double(deltaX))
+        // Keep the resize cursor while the pointer strays outside the moving strip.
+        NSCursor.resizeLeftRight.set()
+    }
+}

--- a/Sources/CodexBar/SidebarResizeHandle.swift
+++ b/Sources/CodexBar/SidebarResizeHandle.swift
@@ -12,10 +12,13 @@ import SwiftUI
 /// event and jitters, while `mouseDown`/`mouseDragged` on an `NSView` report window
 /// coordinates that stay stable even as the strip itself moves mid-drag.
 ///
-/// The hover cursor is belt-and-braces: `.pointerStyle(.columnResize)` in
-/// `PreferencesView` registers with SwiftUI's pointer engine on macOS 15+, and this
-/// view's tracking area asserts `NSCursor` directly (the only mechanism on macOS 14).
-/// Both produce the same left-right resize arrows, so they cannot fight.
+/// The hover cursor comes from `resetCursorRects()`, not from calling `NSCursor.set()`
+/// on hover: SwiftUI re-renders the settings panes continuously, and each render resets
+/// the cursor, so an imperatively-set cursor survives only until the next frame (the
+/// familiar "resize cursor flashes then reverts" bug). A cursor *rect* is declarative —
+/// AppKit re-asks the view whenever it invalidates — so it holds. Measured on a probe
+/// harness hosting this view: imperative-only was 0% resize on hover and 40% during a
+/// drag; with cursor rects it is 100% in both.
 struct SidebarResizeHandle: NSViewRepresentable {
     @Binding var width: Double
     let minWidth: Double
@@ -56,20 +59,40 @@ final class SidebarResizeHandleView: NSView {
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
+    /// Cursor rects are the load-bearing mechanism: AppKit re-asks the view for them
+    /// every time they're invalidated, so the resize cursor survives SwiftUI's constant
+    /// re-rendering. A one-shot `NSCursor.set()` does not — it wins only until the next
+    /// render, which is what makes hand-rolled dividers flicker back to an arrow.
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        self.addCursorRect(self.bounds, cursor: .resizeLeftRight)
+    }
+
+    override func layout() {
+        super.layout()
+        // The strip moves with the sidebar, so its cursor rect must be recomputed.
+        self.window?.invalidateCursorRects(for: self)
+    }
+
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
         if let trackingArea {
             self.removeTrackingArea(trackingArea)
         }
         // Explicit rect, not `.inVisibleRect`: the hosting view doesn't clip, so
-        // `visibleRect` spans the whole window and enter/exit events never fire.
+        // `visibleRect` spans the whole window and the callbacks never fire.
+        // `.cursorUpdate` backs up the cursor rect for the moments AppKit skips it.
         let area = NSTrackingArea(
             rect: self.bounds,
-            options: [.mouseEnteredAndExited, .mouseMoved, .activeAlways],
+            options: [.cursorUpdate, .mouseEnteredAndExited, .mouseMoved, .activeAlways],
             owner: self,
             userInfo: nil)
         self.addTrackingArea(area)
         self.trackingArea = area
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        NSCursor.resizeLeftRight.set()
     }
 
     override func mouseEntered(with event: NSEvent) {
@@ -77,12 +100,7 @@ final class SidebarResizeHandleView: NSView {
     }
 
     override func mouseMoved(with event: NSEvent) {
-        // Re-assert every move: SwiftUI keeps resetting the cursor underneath us.
         NSCursor.resizeLeftRight.set()
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        NSCursor.arrow.set()
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
+++ b/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
@@ -6,10 +6,39 @@ import Testing
 @MainActor
 struct SettingsWindowAppearanceTests {
     @Test
-    func `settings sidebar uses a fixed noncollapsible width`() {
+    func `settings sidebar default width sits within its resize bounds`() {
         #expect(SettingsPane.sidebarWidth == 260)
-        #expect(SettingsPane.windowMinWidth > SettingsPane.sidebarWidth)
+        #expect(SettingsPane.sidebarMinWidth < SettingsPane.sidebarWidth)
+        #expect(SettingsPane.sidebarMaxWidth > SettingsPane.sidebarWidth)
         #expect(SettingsPane.detailMaxWidth > SettingsPane.windowMinWidth - SettingsPane.sidebarWidth)
+        // The static window minimum must leave a usable detail pane even at the widest
+        // sidebar; this is what lets window sizing stay independent of the drag state.
+        #expect(SettingsPane.windowMinWidth - SettingsPane.sidebarMaxWidth >= 400)
+    }
+
+    @Test
+    func `sidebar resize handle clamps drags and re-anchors on mouse down`() {
+        let view = SidebarResizeHandleView()
+        var stored = Double(SettingsPane.sidebarWidth)
+        view.getWidth = { stored }
+        view.setWidth = { newValue in
+            stored = min(
+                max(newValue, Double(SettingsPane.sidebarMinWidth)),
+                Double(SettingsPane.sidebarMaxWidth))
+        }
+
+        view.mouseDown(with: NSEvent.fakeMouseEvent(windowX: 300))
+        view.mouseDragged(with: NSEvent.fakeMouseEvent(windowX: 300 + 500))
+        #expect(stored == Double(SettingsPane.sidebarMaxWidth))
+
+        view.mouseDown(with: NSEvent.fakeMouseEvent(windowX: 300))
+        view.mouseDragged(with: NSEvent.fakeMouseEvent(windowX: 300 - 500))
+        #expect(stored == Double(SettingsPane.sidebarMinWidth))
+
+        // A fresh mouseDown re-anchors the drag to the current (clamped) width.
+        view.mouseDown(with: NSEvent.fakeMouseEvent(windowX: 300))
+        view.mouseDragged(with: NSEvent.fakeMouseEvent(windowX: 300 + 40))
+        #expect(stored == Double(SettingsPane.sidebarMinWidth) + 40)
     }
 
     @Test
@@ -177,4 +206,20 @@ struct SettingsWindowAppearanceTests {
 @MainActor
 private final class ResetCapture {
     var actions: [SettingsWindowAppearance.ResetAction] = []
+}
+
+extension NSEvent {
+    /// Minimal mouse event for driving NSView mouseDown/mouseDragged handlers in tests.
+    fileprivate static func fakeMouseEvent(windowX: CGFloat) -> NSEvent {
+        NSEvent.mouseEvent(
+            with: .leftMouseDragged,
+            location: NSPoint(x: windowX, y: 0),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1)!
+    }
 }


### PR DESCRIPTION
## Summary

Makes the settings sidebar resizable by dragging the divider, replacing the fixed 260pt width. The width clamps to 200–380pt and persists across launches (`settingsSidebarWidth` in UserDefaults).

## Approach

The `HStack` layout from `main` is untouched — the sidebar keeps its `.frame(width:)` (now state-backed) and the hairline stays the original `Divider()`. Dragging is handled by an **input-only** 12pt AppKit strip (`SidebarResizeHandle`) overlaid on the detail pane's leading edge, which sits exactly on the sidebar/content boundary. That placement keeps the strip out of the `HStack`'s width negotiation (a sibling `NSView` there breaks it), off the sidebar list's scroller, and means zero visual change to the chrome.

AppKit `mouseDown`/`mouseDragged` tracking is used instead of a SwiftUI `DragGesture`: window-coordinate deltas stay stable while the strip itself moves mid-drag, and no per-event relayout jitter.

The hover cursor is belt-and-braces: `.pointerStyle(.columnResize)` registers with SwiftUI's pointer engine on macOS 15+, and a tracking area asserts `NSCursor.resizeLeftRight` directly (the only mechanism on the macOS 14 floor). Notable gotcha uncovered while debugging: under `NSHostingView` the strip's `visibleRect` spans the whole window, so an `.inVisibleRect` tracking area never fires — the tracking rect must be explicit `bounds`.

Window sizing stays static: the 800pt window minimum minus the 380pt max sidebar still leaves a 420pt detail pane, so no dynamic min-width plumbing is needed (a test asserts this invariant).

## Screenshots

| Dragged narrow (200pt min) | Dragged wide |
| --- | --- |
| ![narrow](https://raw.githubusercontent.com/steipete/CodexBar/assets/sidebar-resize-pr/sidebar-200.png) | ![wide](https://raw.githubusercontent.com/steipete/CodexBar/assets/sidebar-resize-pr/sidebar-340.png) |

## Testing

- `swift test` — full suite green (three pre-existing timing-flaky tests in `CLIServeRouterTests`/`ClaudeOAuthPromptCoalescingTests` fail only under full-suite load; all pass in isolation).
- New unit tests: drag clamping/re-anchoring on `SidebarResizeHandleView`, sidebar bounds invariants.
- Live verification via scripted drags on the running app: drag +80pt persisted exactly 340; min/max clamps land on exactly 200/380; persisted width restored after relaunch; drags do not disturb controls under the strip.
