### PR TITLE
refactor: namespace provider-specific config fields into provider folders

### DIFF
--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -54,7 +54,9 @@ public struct CodexBarConfig: Codable, Sendable {
 
     /// User plugins exist only where JavaScriptCore does; other platforms drop their config entries.
     private static func isKnownProviderInstance(_ instanceID: ProviderInstanceID) -> Bool {
-        if instanceID.firstPartyProvider != nil { return true }
+        if instanceID.firstPartyProvider != nil {
+            return true
+        }
         #if canImport(JavaScriptCore)
         return UserProviderPluginRegistry.plugin(for: instanceID) != nil
         #else
@@ -107,15 +109,8 @@ public struct CodexBarConfig: Codable, Sendable {
         for var provider in self.providers {
             guard !seen.contains(provider.id) else { continue }
             seen.insert(provider.id)
-            if provider.id.firstPartyProvider == .deepseek {
-                provider.deepseekProfileID = provider.sanitizedDeepSeekProfileID
-                provider.deepseekProfileScope = provider.sanitizedDeepSeekProfileScope
-            }
-            if provider.id.firstPartyProvider == .moonshot,
-               provider.sanitizedAPIKey != nil,
-               provider.sanitizedAPIKeyRegion == nil
-            {
-                provider.apiKeyRegion = provider.sanitizedRegion ?? MoonshotRegion.international.rawValue
+            if let firstPartyProvider = provider.id.firstPartyProvider {
+                ProviderDescriptorRegistry.descriptor(for: firstPartyProvider).normalizeConfig(&provider)
             }
             normalized.append(provider)
         }
@@ -191,24 +186,11 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var workspaceID: String?
     public var enterpriseHost: String?
     public var tokenAccounts: ProviderTokenAccountData?
-    public var claudeSwapEnabled: Bool?
-    public var claudeSwapShowSingleAccount: Bool?
-    public var claudeSwapExecutablePath: String?
-    public var codexActiveSource: CodexActiveSource?
-    public var codexProfileHomePaths: [String]?
-    public var antigravityPrioritizeExhaustedQuotas: Bool?
     public var quotaWarnings: QuotaWarningConfig?
-    public var kiloKnownOrganizations: [KiloOrganization]?
-    public var kiloEnabledOrganizationIDs: [String]?
-    public var awsProfile: String?
-    public var awsAuthMode: String?
-    public var deepseekProfileID: String?
-    public var deepseekProfileScope: String?
-    /// Region that owns `apiKey`. Region-routed providers use this to keep credentials host-scoped.
-    public var apiKeyRegion: String?
     /// Arbitrary user-plugin values stay scoped to the provider instance. Secure values are redacted from config dumps.
     public var pluginSettings: [String: String]?
     public var pluginSecrets: [String: String]?
+    var extensionValues: [String: ProviderConfigExtensionValue]
 
     public init(
         id: ProviderInstanceID,
@@ -223,20 +205,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         workspaceID: String? = nil,
         enterpriseHost: String? = nil,
         tokenAccounts: ProviderTokenAccountData? = nil,
-        claudeSwapEnabled: Bool? = nil,
-        claudeSwapShowSingleAccount: Bool? = nil,
-        claudeSwapExecutablePath: String? = nil,
-        codexActiveSource: CodexActiveSource? = nil,
-        codexProfileHomePaths: [String]? = nil,
-        antigravityPrioritizeExhaustedQuotas: Bool? = nil,
         quotaWarnings: QuotaWarningConfig? = nil,
-        kiloKnownOrganizations: [KiloOrganization]? = nil,
-        kiloEnabledOrganizationIDs: [String]? = nil,
-        awsProfile: String? = nil,
-        awsAuthMode: String? = nil,
-        deepseekProfileID: String? = nil,
-        deepseekProfileScope: String? = nil,
-        apiKeyRegion: String? = nil,
         pluginSettings: [String: String]? = nil,
         pluginSecrets: [String: String]? = nil)
     {
@@ -252,22 +221,10 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.workspaceID = workspaceID
         self.enterpriseHost = enterpriseHost
         self.tokenAccounts = tokenAccounts
-        self.claudeSwapEnabled = claudeSwapEnabled
-        self.claudeSwapShowSingleAccount = claudeSwapShowSingleAccount
-        self.claudeSwapExecutablePath = claudeSwapExecutablePath
-        self.codexActiveSource = codexActiveSource
-        self.codexProfileHomePaths = codexProfileHomePaths
-        self.antigravityPrioritizeExhaustedQuotas = antigravityPrioritizeExhaustedQuotas
         self.quotaWarnings = quotaWarnings
-        self.kiloKnownOrganizations = kiloKnownOrganizations
-        self.kiloEnabledOrganizationIDs = kiloEnabledOrganizationIDs
-        self.awsProfile = awsProfile
-        self.awsAuthMode = awsAuthMode
-        self.deepseekProfileID = deepseekProfileID
-        self.deepseekProfileScope = deepseekProfileScope
-        self.apiKeyRegion = apiKeyRegion
         self.pluginSettings = pluginSettings
         self.pluginSecrets = pluginSecrets
+        self.extensionValues = [:]
     }
 
     public var sanitizedAPIKey: String? {
@@ -286,36 +243,12 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         Self.clean(self.region)
     }
 
-    public var sanitizedAPIKeyRegion: String? {
-        Self.clean(self.apiKeyRegion)
-    }
-
     public var sanitizedWorkspaceID: String? {
         Self.clean(self.workspaceID)
     }
 
     public var sanitizedEnterpriseHost: String? {
         Self.clean(self.enterpriseHost)
-    }
-
-    public var sanitizedClaudeSwapExecutablePath: String? {
-        Self.clean(self.claudeSwapExecutablePath)
-    }
-
-    public var sanitizedAWSProfile: String? {
-        Self.clean(self.awsProfile)
-    }
-
-    public var sanitizedAWSAuthMode: String? {
-        Self.clean(self.awsAuthMode)
-    }
-
-    public var sanitizedDeepSeekProfileID: String? {
-        Self.clean(self.deepseekProfileID).map(DeepSeekSettingsReader.canonicalProfileID)
-    }
-
-    public var sanitizedDeepSeekProfileScope: String? {
-        Self.clean(self.deepseekProfileScope)
     }
 
     public func sanitizedForDump() -> ProviderConfig {
@@ -338,7 +271,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         return copy
     }
 
-    private static func clean(_ raw: String?) -> String? {
+    static func clean(_ raw: String?) -> String? {
         guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
             return nil
         }

--- a/Sources/CodexBarCore/Config/ProviderConfigCoding.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigCoding.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+extension ProviderConfig {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case enabled
+        case source
+        case extrasEnabled
+        case apiKey
+        case secretKey
+        case cookieHeader
+        case cookieSource
+        case region
+        case workspaceID
+        case enterpriseHost
+        case tokenAccounts
+        case quotaWarnings
+        case pluginSettings
+        case pluginSecrets
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: ProviderConfigCodingKey.self)
+        self.id = try container.decode(ProviderInstanceID.self, forKey: .init(CodingKeys.id.rawValue))
+        self.enabled = try container.decodeIfPresent(Bool.self, forKey: .init(CodingKeys.enabled.rawValue))
+        self.source = try container.decodeIfPresent(ProviderSourceMode.self, forKey: .init(CodingKeys.source.rawValue))
+        self.extrasEnabled = try container.decodeIfPresent(Bool.self, forKey: .init(CodingKeys.extrasEnabled.rawValue))
+        self.apiKey = try container.decodeIfPresent(String.self, forKey: .init(CodingKeys.apiKey.rawValue))
+        self.secretKey = try container.decodeIfPresent(String.self, forKey: .init(CodingKeys.secretKey.rawValue))
+        self.cookieHeader = try container.decodeIfPresent(String.self, forKey: .init(CodingKeys.cookieHeader.rawValue))
+        self.cookieSource = try container.decodeIfPresent(
+            ProviderCookieSource.self,
+            forKey: .init(CodingKeys.cookieSource.rawValue))
+        self.region = try container.decodeIfPresent(String.self, forKey: .init(CodingKeys.region.rawValue))
+        self.workspaceID = try container.decodeIfPresent(String.self, forKey: .init(CodingKeys.workspaceID.rawValue))
+        self.enterpriseHost = try container.decodeIfPresent(
+            String.self,
+            forKey: .init(CodingKeys.enterpriseHost.rawValue))
+        self.tokenAccounts = try container.decodeIfPresent(
+            ProviderTokenAccountData.self,
+            forKey: .init(CodingKeys.tokenAccounts.rawValue))
+        self.quotaWarnings = try container.decodeIfPresent(
+            QuotaWarningConfig.self,
+            forKey: .init(CodingKeys.quotaWarnings.rawValue))
+        self.pluginSettings = try container.decodeIfPresent(
+            [String: String].self,
+            forKey: .init(CodingKeys.pluginSettings.rawValue))
+        self.pluginSecrets = try container.decodeIfPresent(
+            [String: String].self,
+            forKey: .init(CodingKeys.pluginSecrets.rawValue))
+
+        let genericKeys = Set(CodingKeys.allCases.map(\.rawValue))
+        self.extensionValues = try container.allKeys.reduce(into: [:]) { values, key in
+            guard !genericKeys.contains(key.stringValue), try !container.decodeNil(forKey: key) else { return }
+            values[key.stringValue] = try container.decode(ProviderConfigExtensionValue.self, forKey: key)
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: ProviderConfigCodingKey.self)
+        try container.encode(self.id, forKey: .init(CodingKeys.id.rawValue))
+        try container.encodeIfPresent(self.enabled, forKey: .init(CodingKeys.enabled.rawValue))
+        try container.encodeIfPresent(self.source, forKey: .init(CodingKeys.source.rawValue))
+        try container.encodeIfPresent(self.extrasEnabled, forKey: .init(CodingKeys.extrasEnabled.rawValue))
+        try container.encodeIfPresent(self.apiKey, forKey: .init(CodingKeys.apiKey.rawValue))
+        try container.encodeIfPresent(self.secretKey, forKey: .init(CodingKeys.secretKey.rawValue))
+        try container.encodeIfPresent(self.cookieHeader, forKey: .init(CodingKeys.cookieHeader.rawValue))
+        try container.encodeIfPresent(self.cookieSource, forKey: .init(CodingKeys.cookieSource.rawValue))
+        try container.encodeIfPresent(self.region, forKey: .init(CodingKeys.region.rawValue))
+        try container.encodeIfPresent(self.workspaceID, forKey: .init(CodingKeys.workspaceID.rawValue))
+        try container.encodeIfPresent(self.enterpriseHost, forKey: .init(CodingKeys.enterpriseHost.rawValue))
+        try container.encodeIfPresent(self.tokenAccounts, forKey: .init(CodingKeys.tokenAccounts.rawValue))
+        try container.encodeIfPresent(self.quotaWarnings, forKey: .init(CodingKeys.quotaWarnings.rawValue))
+        try container.encodeIfPresent(self.pluginSettings, forKey: .init(CodingKeys.pluginSettings.rawValue))
+        try container.encodeIfPresent(self.pluginSecrets, forKey: .init(CodingKeys.pluginSecrets.rawValue))
+        for (key, value) in self.extensionValues {
+            try container.encode(value, forKey: .init(key))
+        }
+    }
+
+    func extensionValue<Value: Codable>(_ type: Value.Type = Value.self, forKey key: String) -> Value? {
+        guard let value = self.extensionValues[key],
+              let data = try? JSONEncoder().encode(value)
+        else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    mutating func setExtensionValue(_ value: (some Codable)?, forKey key: String) {
+        precondition(
+            !CodingKeys.allCases.map(\.rawValue).contains(key),
+            "Provider extension key collides with a generic key")
+        guard let value else {
+            self.extensionValues[key] = nil
+            return
+        }
+        guard let data = try? JSONEncoder().encode(value),
+              let encoded = try? JSONDecoder().decode(ProviderConfigExtensionValue.self, from: data)
+        else {
+            assertionFailure("Provider config extension value must be JSON encodable")
+            return
+        }
+        self.extensionValues[key] = encoded
+    }
+}
+
+private struct ProviderConfigCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int? = nil
+
+    init(_ stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(stringValue: String) {
+        self.init(stringValue)
+    }
+
+    init?(intValue: Int) {
+        nil
+    }
+}
+
+enum ProviderConfigExtensionValue: Codable, Sendable {
+    case bool(Bool)
+    case integer(Int64)
+    case number(Double)
+    case string(String)
+    case array([Self])
+    case object([String: Self])
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int64.self) {
+            self = .integer(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([Self].self) {
+            self = .array(value)
+        } else {
+            self = try .object(container.decode([String: Self].self))
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .bool(value): try container.encode(value)
+        case let .integer(value): try container.encode(value)
+        case let .number(value): try container.encode(value)
+        case let .string(value): try container.encode(value)
+        case let .array(value): try container.encode(value)
+        case let .object(value): try container.encode(value)
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderConfig.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension ProviderConfig {
+    public var antigravityPrioritizeExhaustedQuotas: Bool? {
+        get { self.extensionValue(forKey: "antigravityPrioritizeExhaustedQuotas") }
+        set { self.setExtensionValue(newValue, forKey: "antigravityPrioritizeExhaustedQuotas") }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderConfig.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension ProviderConfig {
+    public var awsProfile: String? {
+        get { self.extensionValue(forKey: "awsProfile") }
+        set { self.setExtensionValue(newValue, forKey: "awsProfile") }
+    }
+
+    public var awsAuthMode: String? {
+        get { self.extensionValue(forKey: "awsAuthMode") }
+        set { self.setExtensionValue(newValue, forKey: "awsAuthMode") }
+    }
+
+    public var sanitizedAWSProfile: String? {
+        Self.clean(self.awsProfile)
+    }
+
+    public var sanitizedAWSAuthMode: String? {
+        Self.clean(self.awsAuthMode)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderConfig.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+extension ProviderConfig {
+    public var claudeSwapEnabled: Bool? {
+        get { self.extensionValue(forKey: "claudeSwapEnabled") }
+        set { self.setExtensionValue(newValue, forKey: "claudeSwapEnabled") }
+    }
+
+    public var claudeSwapShowSingleAccount: Bool? {
+        get { self.extensionValue(forKey: "claudeSwapShowSingleAccount") }
+        set { self.setExtensionValue(newValue, forKey: "claudeSwapShowSingleAccount") }
+    }
+
+    public var claudeSwapExecutablePath: String? {
+        get { self.extensionValue(forKey: "claudeSwapExecutablePath") }
+        set { self.setExtensionValue(newValue, forKey: "claudeSwapExecutablePath") }
+    }
+
+    public var sanitizedClaudeSwapExecutablePath: String? {
+        Self.clean(self.claudeSwapExecutablePath)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderConfig.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension ProviderConfig {
+    public var codexActiveSource: CodexActiveSource? {
+        get { self.extensionValue(forKey: "codexActiveSource") }
+        set { self.setExtensionValue(newValue, forKey: "codexActiveSource") }
+    }
+
+    public var codexProfileHomePaths: [String]? {
+        get { self.extensionValue(forKey: "codexProfileHomePaths") }
+        set { self.setExtensionValue(newValue, forKey: "codexProfileHomePaths") }
+    }
+}

--- a/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekProviderConfig.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension ProviderConfig {
+    public var deepseekProfileID: String? {
+        get { self.extensionValue(forKey: "deepseekProfileID") }
+        set { self.setExtensionValue(newValue, forKey: "deepseekProfileID") }
+    }
+
+    public var deepseekProfileScope: String? {
+        get { self.extensionValue(forKey: "deepseekProfileScope") }
+        set { self.setExtensionValue(newValue, forKey: "deepseekProfileScope") }
+    }
+
+    public var sanitizedDeepSeekProfileID: String? {
+        Self.clean(self.deepseekProfileID).map(DeepSeekSettingsReader.canonicalProfileID)
+    }
+
+    public var sanitizedDeepSeekProfileScope: String? {
+        Self.clean(self.deepseekProfileScope)
+    }
+}

--- a/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekProviderDescriptor.swift
@@ -80,7 +80,11 @@ public enum DeepSeekProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "deepseek",
                 aliases: ["deep-seek", "ds"],
-                versionDetector: nil))
+                versionDetector: nil),
+            configNormalizer: { config in
+                config.deepseekProfileID = config.sanitizedDeepSeekProfileID
+                config.deepseekProfileScope = config.sanitizedDeepSeekProfileScope
+            })
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Kilo/KiloProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloProviderConfig.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension ProviderConfig {
+    public var kiloKnownOrganizations: [KiloOrganization]? {
+        get { self.extensionValue(forKey: "kiloKnownOrganizations") }
+        set { self.setExtensionValue(newValue, forKey: "kiloKnownOrganizations") }
+    }
+
+    public var kiloEnabledOrganizationIDs: [String]? {
+        get { self.extensionValue(forKey: "kiloEnabledOrganizationIDs") }
+        set { self.setExtensionValue(newValue, forKey: "kiloEnabledOrganizationIDs") }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderConfig.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension ProviderConfig {
+    /// Region that owns `apiKey`; keeping it separate prevents credentials from crossing Moonshot hosts.
+    public var apiKeyRegion: String? {
+        get { self.extensionValue(forKey: "apiKeyRegion") }
+        set { self.setExtensionValue(newValue, forKey: "apiKeyRegion") }
+    }
+
+    public var sanitizedAPIKeyRegion: String? {
+        Self.clean(self.apiKeyRegion)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift
@@ -44,7 +44,11 @@ public enum MoonshotProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "moonshot",
                 aliases: [],
-                versionDetector: nil))
+                versionDetector: nil),
+            configNormalizer: { config in
+                guard config.sanitizedAPIKey != nil, config.sanitizedAPIKeyRegion == nil else { return }
+                config.apiKeyRegion = config.sanitizedRegion ?? MoonshotRegion.international.rawValue
+            })
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -109,6 +109,7 @@ public struct ProviderDescriptor: Sendable {
     public let settingsSection: ProviderSettingsSectionRegistration
     public let fetchPlan: ProviderFetchPlan
     public let cli: ProviderCLIConfig
+    private let configNormalizer: @Sendable (inout ProviderConfig) -> Void
 
     public init(
         id: UsageProvider,
@@ -118,7 +119,8 @@ public struct ProviderDescriptor: Sendable {
         tokenCost: ProviderTokenCostConfig,
         pace: ProviderPaceCapability = .unsupported,
         fetchPlan: ProviderFetchPlan,
-        cli: ProviderCLIConfig)
+        cli: ProviderCLIConfig,
+        configNormalizer: @escaping @Sendable (inout ProviderConfig) -> Void = { _ in })
     {
         self.id = id
         self.settingsSection = settingsSection ?? .empty(for: id.instanceID)
@@ -128,6 +130,7 @@ public struct ProviderDescriptor: Sendable {
         self.pace = pace
         self.fetchPlan = fetchPlan
         self.cli = cli
+        self.configNormalizer = configNormalizer
     }
 
     public func fetchOutcome(context: ProviderFetchContext) async -> ProviderFetchOutcome {
@@ -137,6 +140,10 @@ public struct ProviderDescriptor: Sendable {
     public func fetch(context: ProviderFetchContext) async throws -> ProviderFetchResult {
         let outcome = await self.fetchOutcome(context: context)
         return try outcome.result.get()
+    }
+
+    public func normalizeConfig(_ config: inout ProviderConfig) {
+        self.configNormalizer(&config)
     }
 }
 

--- a/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
+++ b/Tests/CodexBarTests/CLICardsClaudeSwapTests.swift
@@ -66,7 +66,8 @@ struct CLICardsClaudeSwapTests {
     @Test
     func `configured executable path strips surrounding quotes`() {
         for rawPath in ["  \"/tmp/cswap\"  ", "  '/tmp/cswap'  "] {
-            let config = ProviderConfig(id: .claude, claudeSwapExecutablePath: rawPath)
+            var config = ProviderConfig(id: .claude)
+            config.claudeSwapExecutablePath = rawPath
             #expect(CLIClaudeSwapCards.executablePath(from: config) == "/tmp/cswap")
         }
         #expect(CLIClaudeSwapCards.executablePath(from: nil).isEmpty)
@@ -78,7 +79,8 @@ struct CLICardsClaudeSwapTests {
         let legacy = try JSONDecoder().decode(ProviderConfig.self, from: legacyData)
         #expect(legacy.claudeSwapShowSingleAccount != true)
 
-        let enabled = ProviderConfig(id: .claude, claudeSwapShowSingleAccount: true)
+        var enabled = ProviderConfig(id: .claude)
+        enabled.claudeSwapShowSingleAccount = true
         let encoded = try JSONEncoder().encode(enabled)
         let decoded = try JSONDecoder().decode(ProviderConfig.self, from: encoded)
         #expect(decoded.claudeSwapShowSingleAccount == true)

--- a/Tests/CodexBarTests/CodexActiveSourceConfigTests.swift
+++ b/Tests/CodexBarTests/CodexActiveSourceConfigTests.swift
@@ -74,9 +74,7 @@ struct CodexActiveSourceConfigTests {
     func `provider config encodes live system active source with expected schema`() throws {
         let config = CodexBarConfig(
             providers: [
-                ProviderConfig(
-                    id: .codex,
-                    codexActiveSource: .liveSystem),
+                codexProviderConfig(activeSource: .liveSystem),
             ])
 
         let data = try JSONEncoder().encode(config)
@@ -95,9 +93,7 @@ struct CodexActiveSourceConfigTests {
         let accountID = UUID()
         let config = CodexBarConfig(
             providers: [
-                ProviderConfig(
-                    id: .codex,
-                    codexActiveSource: .managedAccount(id: accountID)),
+                codexProviderConfig(activeSource: .managedAccount(id: accountID)),
             ])
 
         let data = try JSONEncoder().encode(config)
@@ -115,10 +111,9 @@ struct CodexActiveSourceConfigTests {
     func `provider config encodes profile home source in downgrade readable envelope`() throws {
         let config = CodexBarConfig(
             providers: [
-                ProviderConfig(
-                    id: .codex,
-                    codexActiveSource: .profileHome(path: "/Users/test/.codex-work"),
-                    codexProfileHomePaths: ["/Users/test/.codex-work"]),
+                codexProviderConfig(
+                    activeSource: .profileHome(path: "/Users/test/.codex-work"),
+                    profileHomePaths: ["/Users/test/.codex-work"]),
             ])
 
         let data = try JSONEncoder().encode(config)
@@ -140,9 +135,7 @@ struct CodexActiveSourceConfigTests {
     func `provider config round trips live system active source`() throws {
         let config = CodexBarConfig(
             providers: [
-                ProviderConfig(
-                    id: .codex,
-                    codexActiveSource: .liveSystem),
+                codexProviderConfig(activeSource: .liveSystem),
             ])
 
         let data = try JSONEncoder().encode(config)
@@ -156,9 +149,7 @@ struct CodexActiveSourceConfigTests {
         let accountID = UUID()
         let config = CodexBarConfig(
             providers: [
-                ProviderConfig(
-                    id: .codex,
-                    codexActiveSource: .managedAccount(id: accountID)),
+                codexProviderConfig(activeSource: .managedAccount(id: accountID)),
             ])
 
         let data = try JSONEncoder().encode(config)
@@ -171,10 +162,9 @@ struct CodexActiveSourceConfigTests {
     func `provider config round trips profile home active source`() throws {
         let config = CodexBarConfig(
             providers: [
-                ProviderConfig(
-                    id: .codex,
-                    codexActiveSource: .profileHome(path: "/Users/test/.codex-work"),
-                    codexProfileHomePaths: ["/Users/test/.codex-work"]),
+                codexProviderConfig(
+                    activeSource: .profileHome(path: "/Users/test/.codex-work"),
+                    profileHomePaths: ["/Users/test/.codex-work"]),
             ])
 
         let data = try JSONEncoder().encode(config)
@@ -206,6 +196,16 @@ struct CodexActiveSourceConfigTests {
 
         #expect(decoded == .liveSystem)
     }
+}
+
+private func codexProviderConfig(
+    activeSource: CodexActiveSource,
+    profileHomePaths: [String]? = nil) -> ProviderConfig
+{
+    var config = ProviderConfig(id: .codex)
+    config.codexActiveSource = activeSource
+    config.codexProfileHomePaths = profileHomePaths
+    return config
 }
 
 private struct ReleasedCodexBarConfig: Decodable {

--- a/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
+++ b/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
@@ -168,13 +168,11 @@ struct CodexProfileHomeAccountTests {
         #expect(settings.cachedCodexAccountReconciliationSnapshot != nil)
         #expect(settings.cachedCodexAccountMenuProjection != nil)
 
+        var externalProviderConfig = ProviderConfig(id: .codex)
+        externalProviderConfig.codexActiveSource = .profileHome(path: profileHome.path)
+        externalProviderConfig.codexProfileHomePaths = []
         settings.applyExternalConfig(
-            CodexBarConfig(providers: [
-                ProviderConfig(
-                    id: .codex,
-                    codexActiveSource: .profileHome(path: profileHome.path),
-                    codexProfileHomePaths: []),
-            ]),
+            CodexBarConfig(providers: [externalProviderConfig]),
             reason: "profile-removed")
 
         #expect(settings.cachedCodexAccountReconciliationSnapshot == nil)

--- a/Tests/CodexBarTests/Fixtures/Config/provider-specific-full.json
+++ b/Tests/CodexBarTests/Fixtures/Config/provider-specific-full.json
@@ -1,0 +1,61 @@
+{
+  "providers" : [
+    {
+      "claudeSwapEnabled" : true,
+      "claudeSwapExecutablePath" : "\/opt\/homebrew\/bin\/claude-swap",
+      "claudeSwapShowSingleAccount" : false,
+      "enabled" : true,
+      "id" : "claude"
+    },
+    {
+      "codexActiveSource" : {
+        "homePath" : "\/Users\/fixture\/.codex-work",
+        "kind" : "liveSystem"
+      },
+      "codexProfileHomePaths" : [
+        "\/Users\/fixture\/.codex-work",
+        "\/tmp\/codex-profile"
+      ],
+      "id" : "codex"
+    },
+    {
+      "antigravityPrioritizeExhaustedQuotas" : true,
+      "id" : "antigravity"
+    },
+    {
+      "id" : "kilo",
+      "kiloEnabledOrganizationIDs" : [
+        "org_alpha"
+      ],
+      "kiloKnownOrganizations" : [
+        {
+          "id" : "org_alpha",
+          "name" : "Alpha",
+          "role" : "owner"
+        },
+        {
+          "id" : "org_beta",
+          "name" : "Beta"
+        }
+      ]
+    },
+    {
+      "awsAuthMode" : "profile",
+      "awsProfile" : "fixture-work",
+      "id" : "bedrock",
+      "region" : "us-west-2"
+    },
+    {
+      "deepseekProfileID" : "chrome:Profile 2",
+      "deepseekProfileScope" : "fixture@example.com",
+      "id" : "deepseek"
+    },
+    {
+      "apiKey" : "fixture-moonshot-key",
+      "apiKeyRegion" : "china",
+      "id" : "moonshot",
+      "region" : "china"
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/CodexBarTests/Fixtures/Config/provider-specific-sparse.json
+++ b/Tests/CodexBarTests/Fixtures/Config/provider-specific-sparse.json
@@ -1,0 +1,48 @@
+{
+  "providers" : [
+    {
+      "claudeSwapEnabled" : false,
+      "claudeSwapExecutablePath" : "",
+      "claudeSwapShowSingleAccount" : true,
+      "id" : "claude"
+    },
+    {
+      "codexActiveSource" : {
+        "accountID" : "00000000-0000-0000-0000-000000000042",
+        "kind" : "managedAccount"
+      },
+      "codexProfileHomePaths" : [
+
+      ],
+      "id" : "codex"
+    },
+    {
+      "antigravityPrioritizeExhaustedQuotas" : false,
+      "id" : "antigravity"
+    },
+    {
+      "id" : "kilo",
+      "kiloEnabledOrganizationIDs" : [
+
+      ],
+      "kiloKnownOrganizations" : [
+
+      ]
+    },
+    {
+      "awsAuthMode" : "keys",
+      "awsProfile" : "",
+      "id" : "bedrock"
+    },
+    {
+      "deepseekProfileID" : "",
+      "deepseekProfileScope" : "",
+      "id" : "deepseek"
+    },
+    {
+      "apiKeyRegion" : "international",
+      "id" : "moonshot"
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/CodexBarTests/ProviderConfigByteStabilityTests.swift
+++ b/Tests/CodexBarTests/ProviderConfigByteStabilityTests.swift
@@ -1,0 +1,25 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct ProviderConfigByteStabilityTests {
+    @Test(arguments: [
+        "provider-specific-full",
+        "provider-specific-sparse",
+    ])
+    func `current provider config fixtures re-encode byte for byte`(fixtureName: String) throws {
+        let fixtureURL = try #require(Bundle.module.url(
+            forResource: fixtureName,
+            withExtension: "json",
+            subdirectory: "Fixtures/Config"))
+        let fixtureData = try Data(contentsOf: fixtureURL)
+        let config = try JSONDecoder().decode(CodexBarConfig.self, from: fixtureData)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encoded = try encoder.encode(config)
+
+        // Text fixtures keep the repository-standard final newline; JSONEncoder intentionally does not emit one.
+        #expect(Data(fixtureData.dropLast()) == encoded)
+    }
+}

--- a/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
+++ b/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
@@ -4,11 +4,11 @@ import Testing
 struct ProviderConfigEnvironmentTests {
     @Test
     func `projects Moonshot key with its bound region`() {
-        let config = ProviderConfig(
+        var config = ProviderConfig(
             id: .moonshot,
             apiKey: "china-token",
-            region: MoonshotRegion.china.rawValue,
-            apiKeyRegion: MoonshotRegion.china.rawValue)
+            region: MoonshotRegion.china.rawValue)
+        config.apiKeyRegion = MoonshotRegion.china.rawValue
         let env = ProviderConfigEnvironment.applyAPIKeyOverride(
             base: ["MOONSHOT_API_KEY": "international-token"],
             provider: .moonshot,
@@ -302,10 +302,10 @@ struct ProviderConfigEnvironmentTests {
 
     @Test
     func `applies API key override for moonshot`() {
-        let config = ProviderConfig(
+        var config = ProviderConfig(
             id: .moonshot,
-            apiKey: "moon-token",
-            apiKeyRegion: MoonshotRegion.international.rawValue)
+            apiKey: "moon-token")
+        config.apiKeyRegion = MoonshotRegion.international.rawValue
         let env = ProviderConfigEnvironment.applyAPIKeyOverride(
             base: [:],
             provider: .moonshot,
@@ -516,13 +516,13 @@ struct ProviderConfigEnvironmentTests {
 
     @Test
     func `bedrock profile mode projects AWS_PROFILE without saved static keys`() {
-        let config = ProviderConfig(
+        var config = ProviderConfig(
             id: .bedrock,
             apiKey: "AKIATEST",
             secretKey: "secret",
-            region: "eu-west-1",
-            awsProfile: "work",
-            awsAuthMode: "profile")
+            region: "eu-west-1")
+        config.awsProfile = "work"
+        config.awsAuthMode = "profile"
         let env = ProviderConfigEnvironment.applyAPIKeyOverride(
             base: [:],
             provider: .bedrock,
@@ -565,7 +565,9 @@ struct ProviderConfigEnvironmentTests {
 
     @Test
     func `bedrock profile mode preserves inherited static credentials for environment source profiles`() {
-        let config = ProviderConfig(id: .bedrock, awsProfile: "work", awsAuthMode: "profile")
+        var config = ProviderConfig(id: .bedrock)
+        config.awsProfile = "work"
+        config.awsAuthMode = "profile"
         let env = ProviderConfigEnvironment.applyAPIKeyOverride(
             base: [
                 BedrockSettingsReader.accessKeyIDKey: "AKIAINHERITED",
@@ -602,12 +604,12 @@ struct ProviderConfigEnvironmentTests {
 
     @Test
     func `bedrock keys mode still projects static credentials`() {
-        let config = ProviderConfig(
+        var config = ProviderConfig(
             id: .bedrock,
             apiKey: "AKIATEST",
             secretKey: "secret",
-            region: "us-west-2",
-            awsAuthMode: "keys")
+            region: "us-west-2")
+        config.awsAuthMode = "keys"
         let env = ProviderConfigEnvironment.applyAPIKeyOverride(
             base: [:],
             provider: .bedrock,
@@ -636,12 +638,12 @@ struct ProviderConfigEnvironmentTests {
 
     @Test
     func `projects the legacy DeepSeek Platform token and stable profile identifier`() {
-        let config = ProviderConfig(
+        var config = ProviderConfig(
             id: .deepseek,
             apiKey: "legacy-api-key",
-            cookieHeader: "browser-platform-token",
-            deepseekProfileID: "/profiles/Profile 2",
-            deepseekProfileScope: "account-id")
+            cookieHeader: "browser-platform-token")
+        config.deepseekProfileID = "/profiles/Profile 2"
+        config.deepseekProfileScope = "account-id"
         let env = ProviderConfigEnvironment.applyProviderConfigOverrides(
             base: [:],
             provider: .deepseek,
@@ -655,13 +657,10 @@ struct ProviderConfigEnvironmentTests {
 
     @Test
     func `normalization preserves a legacy DeepSeek browser token and canonicalizes the profile path`() throws {
-        let config = CodexBarConfig(providers: [
-            ProviderConfig(
-                id: .deepseek,
-                cookieHeader: "browser-platform-token",
-                deepseekProfileID: "/profiles/Profile 2",
-                deepseekProfileScope: " account-id "),
-        ]).normalized()
+        var providerConfig = ProviderConfig(id: .deepseek, cookieHeader: "browser-platform-token")
+        providerConfig.deepseekProfileID = "/profiles/Profile 2"
+        providerConfig.deepseekProfileScope = " account-id "
+        let config = CodexBarConfig(providers: [providerConfig]).normalized()
         let deepseek = try #require(config.providerConfig(for: .deepseek))
 
         #expect(deepseek.cookieHeader == "browser-platform-token")

--- a/Tests/CodexBarTests/SyncModelTests.swift
+++ b/Tests/CodexBarTests/SyncModelTests.swift
@@ -12,7 +12,7 @@ struct SyncModelTests {
             token: "account-secret",
             addedAt: 1,
             lastUsed: nil)
-        let local = ProviderConfig(
+        var local = ProviderConfig(
             id: .codex,
             enabled: true,
             source: .cli,
@@ -23,12 +23,12 @@ struct SyncModelTests {
             cookieSource: .manual,
             region: "us",
             workspaceID: "workspace",
-            tokenAccounts: .init(version: 1, accounts: [account], activeIndex: 0),
-            claudeSwapExecutablePath: "/machine/bin/cswap",
-            codexActiveSource: .managedAccount(id: UUID()),
-            codexProfileHomePaths: ["/machine/codex"],
-            awsProfile: "machine-profile",
-            awsAuthMode: "machine-auth")
+            tokenAccounts: .init(version: 1, accounts: [account], activeIndex: 0))
+        local.claudeSwapExecutablePath = "/machine/bin/cswap"
+        local.codexActiveSource = .managedAccount(id: UUID())
+        local.codexProfileHomePaths = ["/machine/codex"]
+        local.awsProfile = "machine-profile"
+        local.awsAuthMode = "machine-auth"
 
         let payload = ProviderIntentPayload(config: local)
         let encoded = try CanonicalSyncJSON.string(payload)
@@ -43,17 +43,17 @@ struct SyncModelTests {
         #expect(secrets["cookieHeader"] == "session=secret")
         #expect(secrets["tokenAccounts"]?.contains("account-secret") == true)
 
-        let baseline = ProviderConfig(
+        var baseline = ProviderConfig(
             id: .codex,
             enabled: false,
             source: .web,
             apiKey: "local-api",
-            cookieSource: .off,
-            claudeSwapExecutablePath: "/local/cswap",
-            codexActiveSource: .liveSystem,
-            codexProfileHomePaths: ["/local/home"],
-            awsProfile: "local-profile",
-            awsAuthMode: "local-auth")
+            cookieSource: .off)
+        baseline.claudeSwapExecutablePath = "/local/cswap"
+        baseline.codexActiveSource = .liveSystem
+        baseline.codexProfileHomePaths = ["/local/home"]
+        baseline.awsProfile = "local-profile"
+        baseline.awsAuthMode = "local-auth"
         let applied = try decoded.applying(to: baseline, secretFields: secrets) { _, _ in true }
 
         #expect(applied.enabled == true)

--- a/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
+++ b/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
@@ -626,12 +626,10 @@ struct TokenAccountEnvironmentPrecedenceTests {
                 lastAuthenticatedAt: nil),
         ])
         try FileManagedCodexAccountStore(fileURL: storeURL).storeAccounts(accounts)
-        let config = CodexBarConfig(providers: [
-            ProviderConfig(
-                id: .codex,
-                codexActiveSource: .managedAccount(id: secondID),
-                codexProfileHomePaths: [profileHome.path]),
-        ])
+        var providerConfig = ProviderConfig(id: .codex)
+        providerConfig.codexActiveSource = .managedAccount(id: secondID)
+        providerConfig.codexProfileHomePaths = [profileHome.path]
+        let config = CodexBarConfig(providers: [providerConfig])
         let context = try TokenAccountCLIContext(
             selection: TokenAccountCLISelection(label: nil, index: nil, allAccounts: true),
             config: config,
@@ -705,12 +703,10 @@ struct TokenAccountEnvironmentPrecedenceTests {
         defer { try? FileManager.default.removeItem(at: root) }
         try FileManager.default.createDirectory(at: ambientHome, withIntermediateDirectories: true)
 
-        let config = CodexBarConfig(providers: [
-            ProviderConfig(
-                id: .codex,
-                codexActiveSource: .profileHome(path: "relative-codex-home"),
-                codexProfileHomePaths: ["relative-codex-home"]),
-        ])
+        var providerConfig = ProviderConfig(id: .codex)
+        providerConfig.codexActiveSource = .profileHome(path: "relative-codex-home")
+        providerConfig.codexProfileHomePaths = ["relative-codex-home"]
+        let config = CodexBarConfig(providers: [providerConfig])
         let context = try TokenAccountCLIContext(
             selection: TokenAccountCLISelection(label: nil, index: nil, allAccounts: false),
             config: config,

--- a/TestsLinux/CLICardsClaudeSwapTests.swift
+++ b/TestsLinux/CLICardsClaudeSwapTests.swift
@@ -66,7 +66,8 @@ struct CLICardsClaudeSwapTests {
     @Test
     func `configured executable path strips surrounding quotes`() {
         for rawPath in ["  \"/tmp/cswap\"  ", "  '/tmp/cswap'  "] {
-            let config = ProviderConfig(id: .claude, claudeSwapExecutablePath: rawPath)
+            var config = ProviderConfig(id: .claude)
+            config.claudeSwapExecutablePath = rawPath
             #expect(CLIClaudeSwapCards.executablePath(from: config) == "/tmp/cswap")
         }
         #expect(CLIClaudeSwapCards.executablePath(from: nil).isEmpty)
@@ -78,7 +79,8 @@ struct CLICardsClaudeSwapTests {
         let legacy = try JSONDecoder().decode(ProviderConfig.self, from: legacyData)
         #expect(legacy.claudeSwapShowSingleAccount != true)
 
-        let enabled = ProviderConfig(id: .claude, claudeSwapShowSingleAccount: true)
+        var enabled = ProviderConfig(id: .claude)
+        enabled.claudeSwapShowSingleAccount = true
         let encoded = try JSONEncoder().encode(enabled)
         let decoded = try JSONDecoder().decode(ProviderConfig.self, from: encoded)
         #expect(decoded.claudeSwapShowSingleAccount == true)


### PR DESCRIPTION
## Summary

Moves the 13 provider-specific fields leaked into the central `ProviderConfig` (claude-swap trio, Codex source/profile paths, Antigravity quota ordering, Kilo organizations, Bedrock AWS profile/auth, DeepSeek profile pair, Moonshot region) into typed per-provider config extensions living in each provider's folder. `ProviderConfig` drops from 28 stored fields / 173 LOC to 15 generic fields + one internal extension bag / 111 LOC. Future provider-specific config fields require only a typed extension in the provider folder — no central edits.

**Persisted `config.json` bytes are contractually unchanged**: characterization commit `729e68108` (landed BEFORE the refactor commit) adds full and sparse real-schema fixtures with exact re-encoding tests; both remain byte-identical through the new coding path.

## Proof

- Byte-stability suite green (fixtures committed pre-refactor; diff structure is the proof)
- Full suite 814/814 (68 groups), zero retries; make check 0 violations; build clean
- Structured autoreview (branch vs origin/main): clean, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
