### PR TITLE
refactor: refresh Plugins pane visuals to match sibling settings panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Provider plugins: install local JavaScript or TypeScript providers with manifest-driven settings and generic menu cards, approval-bound network/cookie access, and sandboxed Sucrase transpilation.
 
 ### Changed
+- Settings: refresh the Plugins pane to match the other panes — labeled install and directory rows with a Show in Finder affordance, a tilde-abbreviated path, a properly sized empty state, and consistent section footers.
 - Menu: move each usage window's used percentage and reset time into its title row, with all pace detail on one line (#2182). Thanks @jack24254029!
 - Codex: define Fast cost as estimated API Fast USD, resolve it models.dev-first with model-specific API ratios, and refresh GPT-5.6 Terra/Luna fallback rates (refs #2175). Thanks @iam-brain!
 

--- a/Sources/CodexBar/PreferencesPluginsPane.swift
+++ b/Sources/CodexBar/PreferencesPluginsPane.swift
@@ -16,26 +16,44 @@ struct PluginsPane: View {
     var body: some View {
         Form {
             Section {
-                HStack {
-                    Button("Install…") { self.choosePlugin() }
-                    Button("Refresh") { self.refresh() }
-                    Spacer()
-                    Text(UserProviderPluginLoader.defaultProvidersDirectory.path)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
+                LabeledContent {
+                    Button(L("Install…")) { self.choosePlugin() }
+                } label: {
+                    SettingsRowLabel(
+                        L("Install plugin"),
+                        subtitle: L("Copies a JavaScript or TypeScript file into the plugins directory."))
+                }
+
+                LabeledContent {
+                    HStack(spacing: 8) {
+                        Button(L("Refresh")) { self.refresh() }
+                        Button(L("Show in Finder")) { self.revealPluginsDirectory() }
+                    }
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(L("Plugins directory"))
+                        Text(Self.pluginsDirectoryDisplayPath)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
                 }
             } header: {
-                Text("Provider Plugins")
+                Text(L("Provider Plugins"))
             } footer: {
-                Text("Plugins are local JavaScript or TypeScript files. Network and cookie access require approval.")
+                SettingsSectionFooter(
+                    L("Plugins are local JavaScript or TypeScript files. Network and cookie access require approval."))
             }
 
             if self.results.isEmpty {
-                ContentUnavailableView(
-                    "No Plugins Installed",
-                    systemImage: "puzzlepiece.extension",
-                    description: Text("Drop one .js or .ts file into the plugins directory, or choose Install…."))
+                Section {
+                    ContentUnavailableView {
+                        Label(L("No Plugins Installed"), systemImage: "puzzlepiece.extension")
+                    } description: {
+                        Text(L("Drop a .js or .ts file into the plugins directory, or choose Install…"))
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 180)
+                }
             }
 
             ForEach(self.results, id: \.fileURL) { result in
@@ -47,6 +65,9 @@ struct PluginsPane: View {
             }
         }
         .formStyle(.grouped)
+        .toggleStyle(.switch)
+        .scrollContentBackground(.hidden)
+        .background(FocusResigningBackground())
         .onAppear { self.refresh() }
         .sheet(item: self.$pendingApproval) { pending in
             PluginApprovalSheet(
@@ -57,7 +78,7 @@ struct PluginsPane: View {
                 })
         }
         .alert(
-            "Delete Plugin?",
+            L("Delete Plugin?"),
             isPresented: Binding(
                 get: { self.pendingDelete != nil },
                 set: {
@@ -66,15 +87,16 @@ struct PluginsPane: View {
                     }
                 }),
             actions: {
-                Button("Delete", role: .destructive) { self.completeDelete() }
-                Button("Cancel", role: .cancel) { self.pendingDelete = nil }
+                Button(L("Delete"), role: .destructive) { self.completeDelete() }
+                Button(L("Cancel"), role: .cancel) { self.pendingDelete = nil }
             },
             message: {
-                Text(
-                    "This removes the plugin file, transpile cache, approval, saved settings and secrets, and history.")
+                Text(L(
+                    "This removes the plugin file, transpile cache, approval, " +
+                        "saved settings and secrets, and history."))
             })
         .alert(
-            "Plugin Error",
+            L("Plugin Error"),
             isPresented: Binding(
                 get: { self.operationError != nil },
                 set: {
@@ -82,7 +104,7 @@ struct PluginsPane: View {
                         self.operationError = nil
                     }
                 }),
-            actions: { Button("OK") { self.operationError = nil } },
+            actions: { Button(L("OK")) { self.operationError = nil } },
             message: { Text(self.operationError ?? "") })
     }
 
@@ -91,27 +113,31 @@ struct PluginsPane: View {
             settings: self.settings.pluginConfig(plugin.manifest.id)?.pluginSettings ?? [:])
         let approved = binding.map(self.store.pluginApprovalStore.isApproved) == true
         let status = if !self.settings.isPluginEnabled(plugin.manifest.id) {
-            "Disabled"
+            L("Disabled")
         } else if approved {
-            "Active"
+            L("Active")
         } else {
-            "Needs approval"
+            L("Needs approval")
         }
 
         return Section {
-            LabeledContent("File") {
-                Text(plugin.fileURL.path).textSelection(.enabled)
+            Toggle(L("Enabled"), isOn: self.enabledBinding(plugin.manifest.id))
+            LabeledContent(L("Status"), value: status)
+            LabeledContent(L("File")) {
+                Text(Self.displayPath(plugin.fileURL)).textSelection(.enabled)
             }
-            LabeledContent("Status", value: status)
-            LabeledContent("Origins", value: binding?.origins.joined(separator: ", ") ?? "Configure endpoint settings")
             LabeledContent(
-                "Capabilities",
+                L("Origins"),
+                value: binding?.origins.joined(separator: ", ") ?? L("Configure endpoint settings"))
+            LabeledContent(
+                L("Capabilities"),
                 value: plugin.manifest.capabilities.map(\.rawValue).sorted().joined(separator: ", ")
-                    .nilIfEmpty ?? "Network")
+                    .nilIfEmpty ?? L("Network"))
             if !plugin.manifest.cookieDomains.isEmpty {
-                LabeledContent("Cookie domains", value: plugin.manifest.cookieDomains.sorted().joined(separator: ", "))
+                LabeledContent(
+                    L("Cookie domains"),
+                    value: plugin.manifest.cookieDomains.sorted().joined(separator: ", "))
             }
-            Toggle("Enabled", isOn: self.enabledBinding(plugin.manifest.id))
             ForEach(plugin.manifest.settings, id: \.key) { setting in
                 if setting.kind == .secure {
                     SecureField(setting.title, text: self.settingBinding(plugin.manifest.id, setting: setting))
@@ -123,17 +149,21 @@ struct PluginsPane: View {
                 }
             }
             if let error = self.store.errors[plugin.manifest.id] {
-                Text(error).foregroundStyle(.red).textSelection(.enabled)
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             HStack {
                 if !approved {
-                    Button("Approve…") { self.requestApproval(plugin: plugin, sourceURL: nil) }
+                    Button(L("Approve…")) { self.requestApproval(plugin: plugin, sourceURL: nil) }
                 }
-                Button("Refresh") {
+                Button(L("Refresh")) {
                     Task { await self.store.refreshUserPlugin(plugin.manifest.id) }
                 }
                 Spacer()
-                Button("Delete…", role: .destructive) {
+                Button(L("Delete…"), role: .destructive) {
                     self.pendingDelete = PluginDeleteRequest(fileURL: plugin.fileURL, plugin: plugin)
                 }
             }
@@ -144,20 +174,36 @@ struct PluginsPane: View {
 
     private func invalidPluginSection(_ result: UserProviderPluginLoadResult) -> some View {
         Section {
-            LabeledContent("File") { Text(result.fileURL.path).textSelection(.enabled) }
-            LabeledContent("Status", value: "Error")
-            Text(result.error ?? "Unknown validation error")
+            LabeledContent(L("File")) { Text(Self.displayPath(result.fileURL)).textSelection(.enabled) }
+            LabeledContent(L("Status"), value: L("Error"))
+            Label(result.error ?? L("Unknown validation error"), systemImage: "exclamationmark.triangle.fill")
+                .font(.callout)
                 .foregroundStyle(.red)
                 .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
             HStack {
                 Spacer()
-                Button("Delete…", role: .destructive) {
+                Button(L("Delete…"), role: .destructive) {
                     self.pendingDelete = PluginDeleteRequest(fileURL: result.fileURL, plugin: nil)
                 }
             }
         } header: {
             Label(result.fileURL.deletingPathExtension().lastPathComponent, systemImage: "exclamationmark.triangle")
         }
+    }
+
+    private static var pluginsDirectoryDisplayPath: String {
+        displayPath(UserProviderPluginLoader.defaultProvidersDirectory)
+    }
+
+    private static func displayPath(_ url: URL) -> String {
+        (url.path as NSString).abbreviatingWithTildeInPath
+    }
+
+    private func revealPluginsDirectory() {
+        let directory = UserProviderPluginLoader.defaultProvidersDirectory
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        NSWorkspace.shared.open(directory)
     }
 
     private func refresh() {
@@ -305,7 +351,7 @@ private struct PluginApprovalSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text(self.pending.sourceURL == nil ? "Approve Plugin" : "Install and Approve Plugin")
+            Text(self.pending.sourceURL == nil ? L("Approve Plugin") : L("Install and Approve Plugin"))
                 .font(.title2.bold())
             Text(self.pending.plugin.manifest.name)
             ForEach(self.pending.plugin.manifest.settings.filter { $0.kind == .plain }, id: \.key) { setting in
@@ -314,34 +360,34 @@ private struct PluginApprovalSheet: View {
                     set: { self.settings[setting.key] = $0 }))
             }
             if let binding = self.binding {
-                GroupBox("Network authority") {
+                GroupBox(L("Network authority")) {
                     VStack(alignment: .leading, spacing: 6) {
                         ForEach(binding.origins, id: \.self) { Text($0).textSelection(.enabled) }
-                        Text("Auth: \(binding.authMode)")
-                        Text(
-                            "Capabilities: " +
-                                (binding.capabilities.joined(separator: ", ").nilIfEmpty ?? "network"))
-                        Text("Secrets: \(binding.secretNames.joined(separator: ", ").nilIfEmpty ?? "none")")
+                        Text(L("Auth: %@", binding.authMode))
+                        Text(L(
+                            "Capabilities: %@",
+                            binding.capabilities.joined(separator: ", ").nilIfEmpty ?? L("network")))
+                        Text(L("Secrets: %@", binding.secretNames.joined(separator: ", ").nilIfEmpty ?? L("none")))
                         if !binding.cookieDomains.isEmpty {
-                            Text("Cookie domains: \(binding.cookieDomains.joined(separator: ", "))")
+                            Text(L("Cookie domains: %@", binding.cookieDomains.joined(separator: ", ")))
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 ForEach(binding.typedConfirmationOrigins, id: \.self) { origin in
-                    TextField("Type \(origin) to confirm", text: Binding(
+                    TextField(L("Type %@ to confirm", origin), text: Binding(
                         get: { self.confirmations[origin] ?? "" },
                         set: { self.confirmations[origin] = $0 }))
                 }
             } else {
-                Text("Enter every endpoint setting to review the exact network origins.")
+                Text(L("Enter every endpoint setting to review the exact network origins."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
             HStack {
                 Spacer()
-                Button("Cancel", role: .cancel, action: self.onCancel)
-                Button(self.pending.sourceURL == nil ? "Approve" : "Install") {
+                Button(L("Cancel"), role: .cancel, action: self.onCancel)
+                Button(self.pending.sourceURL == nil ? L("Approve") : L("Install")) {
                     self.onApprove(self.confirmations, self.settings)
                 }
                 .keyboardShortcut(.defaultAction)


### PR DESCRIPTION
## Summary

Visual refresh of Settings → Plugins so it matches the design language of the other settings panes (General, Advanced, Hooks, iCloud Sync).

### What changed

- **Header section** now uses the sibling panes' `LabeledContent` row pattern instead of a loose button row:
  - "Install plugin" row with a `SettingsRowLabel` subtitle and a trailing `Install…` button.
  - "Plugins directory" row showing the path tilde-abbreviated (`~/.config/codexbar/providers`) as a subtle selectable caption, with `Refresh` and a new `Show in Finder` affordance (creates the directory if missing, then opens it).
- **Footer** switched from bare `Text` (which macOS renders trailing-aligned at body size) to the shared `SettingsSectionFooter`, matching Advanced/General/iCloud Sync.
- **Empty state** now lives inside a `Section` card with the `Label` + description `ContentUnavailableView` form and a bounded `minHeight` (same pattern as the Spend dashboard), so it no longer balloons to fill the pane. Fixed the `Install….` four-dot ellipsis typo and reworded to "Drop a .js or .ts file…".
- **Installed plugin sections**: `Enabled` toggle moved to the top and rendered as a switch (pane-level `.toggleStyle(.switch)` like General/Advanced), file paths tilde-abbreviated, errors shown as a red warning `Label` instead of bare red text.
- **Pane chrome**: added `.scrollContentBackground(.hidden)` and `FocusResigningBackground()` to match the other panes in the Golden Gate settings window.
- All user-facing strings in the pane (including the approval sheet and alerts) are now wrapped in `L(...)`, matching sibling panes. The keys fall back to their English text; adding them to the 23 locale catalogs is left as a follow-up because the app-locale lint gate requires full parity across all complete locales, which would balloon this PR.

### Proof

- `swift build` clean (Xcode-beta toolchain).
- `./Scripts/lint.sh lint` clean (SwiftFormat, SwiftLint, app locale checks).
- `swift test --skip-build --filter "UserProviderPluginTests|LocalizationBundleTests"` — 14 tests, all pass.
- Codex autoreview (`--mode local`, gpt-5.6-sol, high): clean, no accepted findings.

Screenshots follow in a separate pass (another session currently owns the running app instance).
