### PR TITLE
Fix Antigravity agy cold-start quota readiness wait

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -396,7 +396,8 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
                 try await self.fetchBySpawning(
                     binary: binary,
                     idleWindow: idleWindow,
-                    resetAfterFetch: resetAfterFetch)
+                    resetAfterFetch: resetAfterFetch,
+                    expectedAccountEmail: expectedAccountEmail)
             })
     }
 
@@ -448,17 +449,23 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     private func fetchBySpawning(
         binary: String,
         idleWindow: TimeInterval?,
-        resetAfterFetch: Bool) async throws -> ProviderFetchResult
+        resetAfterFetch: Bool,
+        expectedAccountEmail: String?) async throws -> ProviderFetchResult
     {
         let session = AntigravityCLISession.shared
         let pid = try await session.beginProbe(binary: binary, idleWindow: idleWindow)
-        let deadline = Date().addingTimeInterval(5.0)
+        // Fresh `agy` processes take a few seconds to complete macOS keyring
+        // authentication, then more time before quota endpoints answer. A 5s
+        // window reliably missed that cold-start window in live tests, so keep
+        // the readiness deadline long enough for a cold spawn.
+        let deadline = Date().addingTimeInterval(15.0)
         let snap: AntigravityStatusSnapshot
         let usage: UsageSnapshot
         do {
             snap = try await Self.waitForSnapshot(
                 pid: pid,
                 deadline: deadline,
+                expectedAccountEmail: expectedAccountEmail,
                 dependencies: SnapshotWaitDependencies(
                     pollIntervalNanoseconds: 200_000_000,
                     listeningPorts: { pid, timeout in
@@ -500,6 +507,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     static func waitForSnapshot(
         pid: pid_t,
         deadline: Date,
+        expectedAccountEmail: String? = nil,
         dependencies: SnapshotWaitDependencies) async throws -> AntigravityStatusSnapshot
     {
         var lastFetchError: Error?
@@ -534,7 +542,24 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
                 }
                 if let readySnapshot {
                     try await Self.checkAuthenticationPrompt(dependencies)
-                    return readySnapshot
+                    if AntigravitySelectedAccountGuard.matches(
+                        snapshotAccountEmail: readySnapshot.accountEmail,
+                        expectedAccountEmail: expectedAccountEmail)
+                    {
+                        return readySnapshot
+                    }
+                    // Fresh `agy` processes can answer quota endpoints before the
+                    // signed-in account email is available; keep polling so the
+                    // account guard does not reject the cold-start snapshot.
+                    lastFetchError = AntigravityStatusProbeError.accountMismatch(
+                        expected: expectedAccountEmail,
+                        found: readySnapshot.accountEmail)
+                    Self.log.debug(
+                        "Antigravity CLI HTTPS snapshot account not ready yet",
+                        metadata: [
+                            "pid": "\(pid)",
+                            "ports": ports.map(String.init).joined(separator: ","),
+                        ])
                 }
             }
 

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -488,6 +488,51 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
+    func `cli HTTPS keeps waiting while snapshot account is not ready yet`() async throws {
+        let fetchAttempts = AntigravityCLICounter()
+
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 123,
+            deadline: Date().addingTimeInterval(5),
+            expectedAccountEmail: "user@example.com",
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, _ in [50080] },
+                drainOutput: { Data() },
+                fetchSnapshot: { _ in
+                    if fetchAttempts.increment() == 1 {
+                        return AntigravityStatusSnapshot(
+                            modelQuotas: [
+                                AntigravityModelQuota(
+                                    label: "Claude Sonnet",
+                                    modelId: "claude-sonnet",
+                                    remainingFraction: 0.5,
+                                    resetTime: nil,
+                                    resetDescription: nil),
+                            ],
+                            accountEmail: nil,
+                            accountPlan: "Pro",
+                            source: .local)
+                    }
+                    return AntigravityStatusSnapshot(
+                        modelQuotas: [
+                            AntigravityModelQuota(
+                                label: "Claude Sonnet",
+                                modelId: "claude-sonnet",
+                                remainingFraction: 0.5,
+                                resetTime: nil,
+                                resetDescription: nil),
+                        ],
+                        accountEmail: "user@example.com",
+                        accountPlan: "Pro",
+                        source: .local)
+                }))
+
+        #expect(fetchAttempts.value == 2)
+        #expect(snapshot.accountEmail == "user@example.com")
+    }
+
+    @Test
     func `cli HTTPS drains output before ports appear`() async throws {
         let portPolls = AntigravityCLICounter()
         let drainAttempts = AntigravityCLICounter()


### PR DESCRIPTION
## Summary
- Wait up to 15s (was 5s) for a freshly spawned `agy` CLI HTTPS session to become quota-ready. Live tests showed a new `agy` needs ~3s for macOS keyring auth, then more time before quota endpoints answer; the 5s window reliably missed it.
- While waiting, keep polling when a parseable snapshot has no matching account email yet: fresh `agy` processes can answer quota endpoints before the signed-in userInfo email is available, and the selected-account guard would otherwise reject the cold-start snapshot.
- Add a focused test: `cli HTTPS keeps waiting while snapshot account is not ready yet`.

## Reproduction environment
- macOS arm64, Swift 6.3.3 toolchain
- `agy` 1.1.10 installed via `brew install --cask antigravity-cli` (`/opt/homebrew/bin/agy`)
- Antigravity.app closed for the whole run (no `language_server` process)
- Base: `7ace3d0b1`; all reproduction commands were one-shot CLI fetches: `swift run CodexBarCLI usage --provider antigravity --verbose`

## Before: cold start fails inside the 5s window
Fresh `agy` spawn at T+0s. Every probe in the window returns transient init errors:
```
T+1s  HTTP 500 {"code":"internal","message":"internal: failed to get load code assist
      response: error getting token source: You are not logged into Antigravity."}
T+2s  same error repeated; second listening port only TLS errors
T+5s  CLI gives up: "Antigravity CLI session stopping (one-shot CLI fetch)"
```
agy's own log shows keyring auth completes only at ~T+3.6s:
```
I0805 12:09:06.981  auth.go:137] ChainedAuth: authenticated via keyring (effective: keyring)
I0805 12:09:06.981  server_oauth.go:194] OAuth: authenticated successfully as <redacted>
```
Result: strategy chain falls through to OAuth, which returns only an all-100% availability row with no reset times (the known "availability-style fallback" payload).

## After: cold start succeeds with full quota
```
2026-08-05T12:17:04+0800 ... Antigravity CLI session started (binary=agy)
2026-08-05T12:17:07+0800 ... == Antigravity (cli) ==
Gemini Models: 2% left [------------]   Resets tomorrow, 11:52 AM
Claude and GPT: 100% left [============] Resets 5:17 PM
Account: <redacted>
Plan: <redacted>
```
Data returned ~3s after spawn, before the 15s deadline, straight from the `agy` CLI HTTPS source (no OAuth fallback).

## Parity check: cli source == app source
Same machine, same account; JSON payloads from `--format json` compared programmatically:
| Field | app source | cli source | Match |
| --- | --- | --- | --- |
| Gemini weekly usedPercent | 97.8170183 | 97.8170183 | identical |
| Gemini weekly resetsAt | 2026-08-06T03:52:58Z | 2026-08-06T03:52:58Z | identical |
| Claude+GPT weekly usedPercent | 0 | 0 | identical |
| account identity (email, plan) | <redacted> | same | identical |
| 5h + Claude/GPT weekly resetsAt | T | T + run gap | fetch-time-relative only |

Only fetch-time-relative reset timestamps shift by the seconds between the two runs; all fixed-schedule values and all usage fractions are byte-identical.

## Test
- `swift test --filter 'AntigravityCLIHTTPSFetchStrategyTests|AntigravityWarmAgyReuseTests|AntigravityCLISessionTests'` - 98 tests passed
- `make check` - 0 violations, 0 serious

## CI
All checks green on this PR: swift-test-macos (2 shards), build-linux-cli (arm64/x64/musl), lint, lint-build-test, changes, GitGuardian Security Checks.
