### PR TITLE
test: deflake refresh coalescing cleanup

### DIFF
--- a/Tests/CodexBarTests/RequiredRefreshCoalescingTests.swift
+++ b/Tests/CodexBarTests/RequiredRefreshCoalescingTests.swift
@@ -476,15 +476,13 @@ extension CodexBackgroundRefreshCoalescingTests {
         #expect(await tokenGate.waitUntilStarted(count: 1))
         #expect(await creditsGate.waitUntilStartedWithin(count: 1))
 
+        let tokenRefreshTask = try #require(store.tokenRefreshSequenceTask)
         await tokenGate.resumeNext()
-        for _ in 0..<100 where store.tokenRefreshSequenceTask != nil {
-            await Task.yield()
-        }
+        await tokenRefreshTask.value
         #expect(store.tokenRefreshSequenceTask == nil)
         #expect(store.hasForcedRefreshEnrichmentInFlight)
 
         store.scheduleTokenRefreshForTesting()
-        try await Task.sleep(for: .milliseconds(100))
         #expect(store.tokenRefreshSequenceTask == nil)
         #expect(await tokenGate.recordedCalls().count == 1)
 


### PR DESCRIPTION
## Summary

- replace bounded `Task.yield()` polling with an await on the token refresh sequence task that owns cleanup
- remove the post-scheduling sleep because the timer exclusion guard and task-slot publication are synchronous on `MainActor`
- keep production refresh behavior unchanged

## Why

The sharded suite intermittently observed `tokenRefreshSequenceTask` before its owner reached the final cleanup statement. A fixed number of scheduler yields is not a completion guarantee under load. Awaiting the captured owner task establishes the exact synchronization boundary the assertion needs.

## Tests

- focused test: 1,000 repetitions, all passed
- `swift test --filter CodexBackgroundRefreshCoalescingTests`: 23 tests passed
- `make check`: passed; SwiftFormat clean and SwiftLint reported 0 violations
- `make test`: 817 selections in 69 groups passed with 0 retries and 0 failures
- Codex autoreview: clean, no accepted/actionable findings
