### PR TITLE
fix: bound widget-snapshot file I/O with timeout and circuit breaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Codex: define Fast cost as estimated API Fast USD, resolve it models.dev-first with model-specific API ratios, and refresh GPT-5.6 Terra/Luna fallback rates (refs #2175). Thanks @iam-brain!
 
 ### Fixed
+- Widgets: bound widget-snapshot file I/O with a defensive timeout and skip further container access once it wedges, so a blocked macOS 26 app-group open() can no longer beachball the app or hang the widget (#2267 follow-up).
 - Command Code: parse and display 5-hour and weekly rolling limits alongside monthly credits and reset times (#2466). Thanks @derekszen!
 - OpenCode Go: include Zen balance in CLI usage reads without waiting beyond five seconds (#2583). Thanks @Yuxin-Qiao!
 - Usage & Spend: keep validated Codex totals visible while the local scanner catches up, with refresh indicators in the dashboard and menu cost rows (#2397). Thanks @hhh2210!

--- a/Sources/CodexBarCore/WidgetSnapshot.swift
+++ b/Sources/CodexBarCore/WidgetSnapshot.swift
@@ -213,28 +213,130 @@ public struct WidgetSnapshot: Codable, Sendable {
 }
 
 public enum WidgetSnapshotStore {
-    private static let filename = AppGroupSupport.widgetSnapshotFilename
+    @usableFromInline
+    static let defaultLoadTimeout: TimeInterval = 2.0
 
-    public static func load(bundleID: String? = Bundle.main.bundleIdentifier) -> WidgetSnapshot? {
-        self.load(from: self.snapshotURL(bundleID: bundleID))
+    @usableFromInline
+    static let defaultSaveTimeout: TimeInterval = 10.0
+
+    private static let filename = AppGroupSupport.widgetSnapshotFilename
+    private static let boundedIOExecutionLock = NSLock()
+    private static let boundedIOStateLock = NSLock()
+    private nonisolated(unsafe) static var boundedIOCircuitBreakerTripped = false
+    private static let log = CodexBarLog.logger("widget-snapshot")
+
+    /// Access is synchronized by `lock`, so detached worker threads can safely publish a result.
+    private final class BoundedResultBox<Value: Sendable>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: Value?
+
+        func set(_ value: Value?) {
+            self.lock.lock()
+            self.value = value
+            self.lock.unlock()
+        }
+
+        func get() -> Value? {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.value
+        }
     }
 
-    public static func load(from url: URL) -> WidgetSnapshot? {
-        guard let data = try? Data(contentsOf: url) else { return nil }
+    public static func load(bundleID: String? = Bundle.main.bundleIdentifier) -> WidgetSnapshot? {
+        guard !self.isBoundedIOCircuitBreakerTripped() else { return nil }
+        return self.load(from: self.snapshotURL(bundleID: bundleID))
+    }
+
+    public static func load(
+        from url: URL,
+        timeout: TimeInterval = WidgetSnapshotStore.defaultLoadTimeout) -> WidgetSnapshot?
+    {
+        guard let data: Data = self.performBounded(label: "load", timeout: timeout, operation: {
+            try? Data(contentsOf: url)
+        }) else { return nil }
         return try? self.decoder.decode(WidgetSnapshot.self, from: data)
     }
 
     public static func save(_ snapshot: WidgetSnapshot, bundleID: String? = Bundle.main.bundleIdentifier) {
+        guard !self.isBoundedIOCircuitBreakerTripped() else { return }
         self.save(snapshot, to: self.snapshotURL(bundleID: bundleID))
     }
 
-    public static func save(_ snapshot: WidgetSnapshot, to url: URL) {
-        do {
-            let data = try self.encoder.encode(snapshot)
-            try data.write(to: url, options: [.atomic])
-        } catch {
-            return
+    public static func save(
+        _ snapshot: WidgetSnapshot,
+        to url: URL,
+        timeout: TimeInterval = WidgetSnapshotStore.defaultSaveTimeout)
+    {
+        guard !self.isBoundedIOCircuitBreakerTripped(),
+              let data = try? self.encoder.encode(snapshot)
+        else { return }
+
+        _ = self.performBounded(label: "save", timeout: timeout) {
+            do {
+                try data.write(to: url, options: [.atomic])
+                return true
+            } catch {
+                return nil
+            }
         }
+    }
+
+    static func _test_performBounded<T: Sendable>(
+        timeout: TimeInterval,
+        operation: @escaping @Sendable () -> T?) -> T?
+    {
+        self.performBounded(label: "test", timeout: timeout, operation: operation)
+    }
+
+    static func _test_resetBoundedIOState() {
+        self.boundedIOStateLock.lock()
+        self.boundedIOCircuitBreakerTripped = false
+        self.boundedIOStateLock.unlock()
+    }
+
+    private static func performBounded<T: Sendable>(
+        label: String,
+        timeout: TimeInterval,
+        operation: @escaping @Sendable () -> T?) -> T?
+    {
+        guard !self.isBoundedIOCircuitBreakerTripped() else { return nil }
+        self.boundedIOExecutionLock.lock()
+        defer { self.boundedIOExecutionLock.unlock() }
+        guard !self.isBoundedIOCircuitBreakerTripped() else { return nil }
+
+        let result = BoundedResultBox<T>()
+        let completion = DispatchSemaphore(value: 0)
+        let thread = Thread {
+            result.set(operation())
+            completion.signal()
+        }
+        thread.name = "CodexBar.widget-snapshot.\(label)"
+        thread.start()
+
+        guard completion.wait(timeout: .now() + timeout) == .success else {
+            self.tripBoundedIOCircuitBreaker(label: label, timeout: timeout)
+            return nil
+        }
+        return result.get()
+    }
+
+    private static func isBoundedIOCircuitBreakerTripped() -> Bool {
+        self.boundedIOStateLock.lock()
+        defer { self.boundedIOStateLock.unlock() }
+        return self.boundedIOCircuitBreakerTripped
+    }
+
+    private static func tripBoundedIOCircuitBreaker(label: String, timeout: TimeInterval) {
+        self.boundedIOStateLock.lock()
+        let didTrip = !self.boundedIOCircuitBreakerTripped
+        self.boundedIOCircuitBreakerTripped = true
+        self.boundedIOStateLock.unlock()
+
+        guard didTrip else { return }
+        self.log.warning(
+            "Widget snapshot I/O timed out; disabling container access for this process",
+            metadata: ["operation": label, "timeoutSeconds": String(timeout)])
     }
 
     private static func snapshotURL(bundleID: String?) -> URL {

--- a/Tests/CodexBarTests/WidgetSnapshotBoundedIOTests.swift
+++ b/Tests/CodexBarTests/WidgetSnapshotBoundedIOTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct WidgetSnapshotBoundedIOTests {
+    @Test
+    func `snapshot roundtrip completes through bounded file IO`() throws {
+        WidgetSnapshotStore._test_resetBoundedIOState()
+        defer { WidgetSnapshotStore._test_resetBoundedIOState() }
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("snapshot.json")
+        let snapshot = Self.snapshot()
+
+        WidgetSnapshotStore.save(snapshot, to: url, timeout: 2.0)
+        let loaded = WidgetSnapshotStore.load(from: url, timeout: 2.0)
+
+        #expect(loaded?.entries.isEmpty == true)
+        #expect(loaded?.enabledProviders == [.codex])
+        #expect(loaded?.usageBarsShowUsed == true)
+        #expect(loaded?.generatedAt == snapshot.generatedAt)
+    }
+
+    @Test
+    func `bounded operation timeout returns nil and trips the circuit breaker`() {
+        WidgetSnapshotStore._test_resetBoundedIOState()
+        defer { WidgetSnapshotStore._test_resetBoundedIOState() }
+        let counter = LockedCounter()
+
+        let result: Int? = WidgetSnapshotStore._test_performBounded(timeout: 0.1) {
+            Thread.sleep(forTimeInterval: 1.0)
+            return 1
+        }
+        let afterTimeout: Int? = WidgetSnapshotStore._test_performBounded(timeout: 1.0) {
+            counter.increment()
+            return 2
+        }
+
+        #expect(result == nil)
+        #expect(afterTimeout == nil)
+        #expect(counter.value == 0)
+    }
+
+    @Test
+    func `tripped circuit breaker skips later loads saves and operations immediately`() throws {
+        WidgetSnapshotStore._test_resetBoundedIOState()
+        defer { WidgetSnapshotStore._test_resetBoundedIOState() }
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let existingURL = directory.appendingPathComponent("existing.json")
+        let skippedSaveURL = directory.appendingPathComponent("skipped.json")
+        let snapshot = Self.snapshot()
+        WidgetSnapshotStore.save(snapshot, to: existingURL, timeout: 2.0)
+        let counter = LockedCounter()
+
+        let timedOut: Int? = WidgetSnapshotStore._test_performBounded(timeout: 0.1) {
+            Thread.sleep(forTimeInterval: 1.0)
+            return 1
+        }
+        let start = Date()
+        let skipped: Int? = WidgetSnapshotStore._test_performBounded(timeout: 1.0) {
+            counter.increment()
+            return 2
+        }
+        let loaded = WidgetSnapshotStore.load(from: existingURL, timeout: 1.0)
+        WidgetSnapshotStore.save(snapshot, to: skippedSaveURL, timeout: 1.0)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(timedOut == nil)
+        #expect(skipped == nil)
+        #expect(counter.value == 0)
+        #expect(loaded == nil)
+        #expect(!FileManager.default.fileExists(atPath: skippedSaveURL.path))
+        #expect(elapsed < 0.25)
+    }
+
+    @Test
+    func `reset seam restores bounded operations`() {
+        WidgetSnapshotStore._test_resetBoundedIOState()
+        defer { WidgetSnapshotStore._test_resetBoundedIOState() }
+
+        let timedOut: Int? = WidgetSnapshotStore._test_performBounded(timeout: 0.1) {
+            Thread.sleep(forTimeInterval: 1.0)
+            return 1
+        }
+        let blocked: Int? = WidgetSnapshotStore._test_performBounded(timeout: 1.0) { 2 }
+        WidgetSnapshotStore._test_resetBoundedIOState()
+        let restored: Int? = WidgetSnapshotStore._test_performBounded(timeout: 1.0) { 3 }
+
+        #expect(timedOut == nil)
+        #expect(blocked == nil)
+        #expect(restored == 3)
+    }
+
+    private static func snapshot() -> WidgetSnapshot {
+        WidgetSnapshot(
+            entries: [],
+            enabledProviders: [.codex],
+            usageBarsShowUsed: true,
+            generatedAt: Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WidgetSnapshotBoundedIOTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.count
+    }
+
+    func increment() {
+        self.lock.lock()
+        self.count += 1
+        self.lock.unlock()
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2656 / #2599: on some macOS 26 hosts, opening the widget-snapshot file in the app-group container can block forever (app-data/TCC or container wedge — we sampled a real never-returning `open()`). #2656 walled that off from test runs; this PR protects the app and widget themselves.

## Fix

All `WidgetSnapshotStore` file I/O now runs through a bounded runner: the blocking call executes on a detached thread (not the shared dispatch pool, so a wedged call cannot poison it) with a semaphore deadline — 2 s for loads, 10 s for saves. The first timeout logs a warning and trips a process-wide one-way circuit breaker; every subsequent load/save short-circuits immediately. A global execution lock serializes bounded calls, capping leaked threads at one per process.

Net effect on a wedged host: at most one bounded stall per process instead of an indefinite main-thread beachball (`UsageStore.persistWidgetSnapshot` does a synchronous first-load on the main actor) or a permanently stalled widget timeline. The widget extension's `load()` call sites are covered with no call-site changes.

## Proof

- New `WidgetSnapshotBoundedIOTests` (4): roundtrip through bounded I/O; timeout returns nil, trips breaker, and the next operation never executes; tripped breaker skips load/save immediately (elapsed-time asserted); reset seam restores behavior.
- `WidgetSnapshotTestIsolationTests`, `CodexAccountPromotionServiceTests`, `AdaptiveRefreshHeuristicsTests` — 39/39 across the four suites.
- `make check` clean.

Refs #2267.
