### PR TITLE
Fix infinite Overview flicker from agent-session rescan feedback loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Codex: define Fast cost as estimated API Fast USD, resolve it models.dev-first with model-specific API ratios, and refresh GPT-5.6 Terra/Luna fallback rates (refs #2175). Thanks @iam-brain!
 
 ### Fixed
+- Overview: stop the infinite menu flicker when hovering between provider chart submenus with Agent Sessions enabled — no-op session rescans no longer invalidate menus, submenu hovers no longer trigger rescans, and session updates defer tracked-parent rebuilds like other data refreshes (#2652). Thanks @qazi0!
 - Command Code: parse and display 5-hour and weekly rolling limits alongside monthly credits and reset times (#2466). Thanks @derekszen!
 - OpenCode Go: include Zen balance in CLI usage reads without waiting beyond five seconds (#2583). Thanks @Yuxin-Qiao!
 - Usage & Spend: keep validated Codex totals visible while the local scanner catches up, with refresh indicators in the dashboard and menu cost rows (#2397). Thanks @hhh2210!

--- a/Sources/CodexBar/AgentSessionsStore.swift
+++ b/Sources/CodexBar/AgentSessionsStore.swift
@@ -181,8 +181,17 @@ final class AgentSessionsStore {
     }
 
     func applyLocalScanResult(_ sessions: [AgentSession], updatedAt: Date = Date()) {
-        self.latestLocalActivityAt = Self.latestActivityAt(in: sessions)
-        self.localSessions = self.settings.agentSessionsEnabled ? sessions : []
+        let latestActivityAt = Self.latestActivityAt(in: sessions)
+        let effectiveSessions = self.settings.agentSessionsEnabled ? sessions : []
+        // Rescans that reproduce the current content must not publish: `onUpdate` invalidates
+        // menus, and a redundant invalidation landing while the user hovers an Overview row's
+        // chart submenu fed the open/close rebuild flicker loop in #2652.
+        if latestActivityAt == self.latestLocalActivityAt, effectiveSessions == self.localSessions {
+            self.lastUpdatedAt = updatedAt
+            return
+        }
+        self.latestLocalActivityAt = latestActivityAt
+        self.localSessions = effectiveSessions
         self.lastUpdatedAt = updatedAt
         self.onUpdate?()
     }
@@ -196,7 +205,7 @@ final class AgentSessionsStore {
             let results = await self.remoteFetcher.fetch(hosts: hosts)
             let outcome = self.remoteRefreshGate.finish(generation: generation)
             guard !Task.isCancelled, self.settings.agentSessionsEnabled else { return }
-            if outcome.shouldPublish {
+            if outcome.shouldPublish, results != self.remoteHosts {
                 self.remoteHosts = results
                 self.lastUpdatedAt = Date()
                 self.onUpdate?()

--- a/Sources/CodexBar/StatusItemController+AgentSessions.swift
+++ b/Sources/CodexBar/StatusItemController+AgentSessions.swift
@@ -2,6 +2,8 @@ import AppKit
 
 extension StatusItemController {
     func wireAgentSessionUpdates() {
+        // `onUpdate` only fires when the session content actually changed (the store dedupes
+        // no-op rescans); an unconditional per-scan invalidation was half of the #2652 loop.
         self.agentSessions.onUpdate = { [weak self] in
             guard let self else { return }
             if let latestActivityAt = self.agentSessions.latestLocalActivityAt {
@@ -10,7 +12,14 @@ extension StatusItemController {
                 self.store.clearCodingActivityObservation()
             }
             if self.settings.agentSessionsEnabled {
-                self.invalidateMenus(refreshOpenMenus: true)
+                // Match the store-observation path (`handleObservedStoreMenuChange`): mark menus
+                // stale but never rebuild a tracked parent in place. Rebuilding the Overview
+                // parent mid-hover replaces the hovered row and force-closes its hosted chart
+                // submenu, which is the other half of the #2652 flicker loop.
+                self.invalidateMenus(
+                    refreshOpenMenus: true,
+                    deferOpenParentMenuRebuild: true,
+                    allowStaleContentDuringDataRefresh: true)
             }
         }
     }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -64,9 +64,16 @@ extension StatusItemController {
     }
 
     func menuWillOpen(_ menu: NSMenu) {
-        // Records interaction and may bring an adaptive timer forward; never refreshes synchronously.
-        self.store.noteMenuOpened()
-        self.agentSessions.refreshOnMenuOpen()
+        if menu.supermenu == nil {
+            // Records interaction and may bring an adaptive timer forward; never refreshes
+            // synchronously. Root opens only: hover-opening a hosted chart submenu must not kick
+            // off an agent-session rescan — the scan completion invalidates the tracked parent
+            // while its submenu is open, and on the Overview tab the resulting structural parent
+            // rebuild force-closes the hovered submenu. Each reopen then triggered another rescan,
+            // producing an infinite open/close/rebuild flicker loop (#2652).
+            self.store.noteMenuOpened()
+            self.agentSessions.refreshOnMenuOpen()
+        }
 
         let trace = self.beginMenuOperationTrace("menuWillOpen", breadcrumb: "menuWillOpen")
         defer { self.endMenuOperationTrace(trace, menu: menu, provider: self.menuProvider(for: menu)) }

--- a/Tests/CodexBarTests/AgentSessionMenuInvalidationTests.swift
+++ b/Tests/CodexBarTests/AgentSessionMenuInvalidationTests.swift
@@ -1,0 +1,135 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+/// Characterizes the menu-invalidation behavior of agent-session rescans (#2652).
+///
+/// The Overview flicker loop needed two ingredients: every rescan unconditionally invalidated
+/// menus (even with byte-identical results), and the agent-session path rebuilt a tracked parent
+/// menu in place instead of deferring like the store-observation path. On the Overview tab the
+/// in-place rebuild is structural, so it replaced the hovered row and force-closed its hosted
+/// chart submenu; the reopen triggered another rescan, closing the loop.
+extension StatusMenuTests {
+    private func makeSession(
+        id: String = "session-1",
+        lastActivityAt: Date? = Date(timeIntervalSince1970: 1_700_000_000)) -> AgentSession
+    {
+        AgentSession(
+            id: id,
+            provider: .claude,
+            source: .cli,
+            state: .active,
+            pid: 1234,
+            cwd: "/tmp/project",
+            projectName: "project",
+            startedAt: Date(timeIntervalSince1970: 1_699_999_000),
+            lastActivityAt: lastActivityAt,
+            transcriptPath: nil,
+            host: "local")
+    }
+
+    @Test
+    func `agent session rescan with unchanged sessions does not invalidate menus`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.agentSessionsEnabled = true
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        controller.openMenus[ObjectIdentifier(menu)] = menu
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let sessions = [self.makeSession()]
+        let scanTime = Date(timeIntervalSince1970: 1_700_000_100)
+        controller.agentSessions.applyLocalScanResult(sessions, updatedAt: scanTime)
+        let versionAfterFirstScan = controller.menuContentVersion
+
+        // A rescan that reproduces the exact same session list must be a menu no-op; every open
+        // of a hovered chart submenu used to trigger such a rescan and re-dirty the parent.
+        controller.agentSessions.applyLocalScanResult(sessions, updatedAt: scanTime.addingTimeInterval(30))
+        #expect(controller.menuContentVersion == versionAfterFirstScan)
+
+        // Changed session content still invalidates.
+        controller.agentSessions.applyLocalScanResult(
+            [self.makeSession(lastActivityAt: scanTime.addingTimeInterval(60))],
+            updatedAt: scanTime.addingTimeInterval(60))
+        #expect(controller.menuContentVersion != versionAfterFirstScan)
+    }
+
+    @Test
+    func `agent session change defers parent rebuild while hosted submenu is open`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.agentSessionsEnabled = true
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let menuKey = ObjectIdentifier(menu)
+        controller.openMenus[menuKey] = menu
+
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.costHistoryChartID,
+            provider: .claude)
+        let submenuKey = ObjectIdentifier(submenu)
+        controller.openMenus[submenuKey] = submenu
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let openedVersion = controller.menuVersions[menuKey]
+        var parentRebuildCount = 0
+        controller._test_openMenuRebuildObserver = { rebuilt in
+            if rebuilt === menu {
+                parentRebuildCount += 1
+            }
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        // Session data changes while the user hovers an Overview row's chart submenu.
+        controller.agentSessions.applyLocalScanResult([self.makeSession()])
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+
+        // The tracked parent must stay attached (stale) instead of being structurally rebuilt in
+        // place, which would force-close the hovered submenu and feed the #2652 flicker loop.
+        #expect(parentRebuildCount == 0)
+        #expect(controller.menuVersions[menuKey] == openedVersion)
+        #expect(controller.parentMenuRebuildsDeferredDuringTracking.contains(menuKey))
+
+        // Once the hovered submenu closes, the deferred rebuild lands exactly once.
+        controller.menuDidClose(submenu)
+        for _ in 0..<20 where parentRebuildCount == 0 {
+            await Task.yield()
+        }
+        #expect(controller.openMenus[submenuKey] == nil)
+        #expect(parentRebuildCount == 1)
+        #expect(controller.menuVersions[menuKey] == controller.menuContentVersion)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the infinite Overview flicker reported in #2652: hovering the Codex chart submenu and then the Claude section on the Overview tab locked the popup into an endless open/close/rebuild cycle.

## Root cause — a three-legged feedback loop

1. `menuWillOpen` fired `agentSessions.refreshOnMenuOpen()` for **every** menu open, including hover-opened hosted chart submenus — each hover started a local session rescan.
2. Every rescan completion invalidated menus **unconditionally** (even for byte-identical results) with `deferOpenParentMenuRebuild: false` — the lone outlier from the signature-gated, deferred store-observation path. Hovering the Codex chart primed the parent menu dirty.
3. Moving to the Claude row closed the Codex submenu, triggering the deferred parent rebuild — and on Overview, `populateMenu` cannot smart-update, so the rebuild is structural: the hovered Claude row and its cost-history submenu are replaced, force-closing/reopening the submenu under the cursor. Each reopen fires another rescan → loop.

This also explains the report's specifics: it needs Agent Sessions **and** Cost Summary enabled (the latter is what gives the Claude row a hosted submenu), and it's Overview-only (smart update is disabled there).

## Fix (each change breaks one leg)

- `AgentSessionsStore`: skip `onUpdate` when rescan results are content-identical (dedupe at the source).
- `StatusItemController+Menu`: only root menu opens trigger `noteMenuOpened()`/`refreshOnMenuOpen()`; hover-opened submenus no longer start rescans.
- `StatusItemController+AgentSessions`: session updates now invalidate with `deferOpenParentMenuRebuild: true, allowStaleContentDuringDataRefresh: true`, matching the house pattern — a tracked parent is never structurally rebuilt mid-hover.

## Testing

- New `AgentSessionMenuInvalidationTests` (controller/menu-session seam, per repo guidance): *unchanged rescan does not invalidate menus* and *session change defers parent rebuild while hosted submenu is open* — **both fail with the fix stashed and pass with it applied**.
- `StatusMenuTests` (167) pass; adjacent AgentSession/AdaptiveRefresh/HostedSubmenu/MenuOpenRefresh suites (118) pass (one pre-existing wall-clock perf flake under parallel load only).
- `swift build` clean, `make check` 0 violations. Codex autoreview (gpt-5.6-sol, high): clean, no findings.

Live confirmation on a dual-account machine follows on this PR. Thanks @qazi0 for the precise report!

Fixes #2652.
