### PR TITLE
refactor: make JS plugins the macOS implementation for Crof and Venice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Copilot: decode the AI credits counter for token-billed seats and expose it in `codexbar diagnose`, so Business seats with zero-entitlement quotas are no longer blank at the data layer (#2613, refs #2593). Thanks @Yuxin-Qiao, and @KSEGIT for the discovery!
 
 ### Changed
+- Provider plugins: use the bundled JavaScript implementation by default for Crof and Venice on macOS, with identical golden-tested output and the native fetchers retained only for the Linux CLI.
 - Settings: refresh the Plugins pane to match the other panes — labeled install and directory rows with a Show in Finder affordance, a tilde-abbreviated path, a properly sized empty state, and consistent section footers.
 - Settings: localize every Plugins pane control, status, approval prompt, and alert across all complete app locales.
 - **Breaking JSON change:** provider-specific usage payload keys are being removed from `codexbar usage --format json`, `serve /usage`, and synced snapshots in favor of the generic Codable `usage.details` sections. The app and text CLI now render those same declarative rows and charts.

--- a/Sources/CodexBarCore/Plugins/ScriptFetchStrategy.swift
+++ b/Sources/CodexBarCore/Plugins/ScriptFetchStrategy.swift
@@ -29,6 +29,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
 
     private let provider: UsageProvider
     private let bundledPlugin: String
+    private let sourceLabel: String
     private let secretKey: String?
     private let resolveValues: ValuesResolver
     private let isEnabled: EnabledResolver
@@ -42,6 +43,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         provider: UsageProvider,
         bundledPlugin: String,
         secretKey: String,
+        sourceLabel: String = "js",
         kind: ProviderFetchKind = .apiToken,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
@@ -51,6 +53,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         self.id = id
         self.provider = provider
         self.bundledPlugin = bundledPlugin
+        self.sourceLabel = sourceLabel
         self.kind = kind
         self.secretKey = secretKey
         self.transport = transport
@@ -67,6 +70,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         provider: UsageProvider,
         bundledPlugin: String,
         secretKey: String? = nil,
+        sourceLabel: String = "js",
         kind: ProviderFetchKind = .apiToken,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
@@ -76,6 +80,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         self.id = id
         self.provider = provider
         self.bundledPlugin = bundledPlugin
+        self.sourceLabel = sourceLabel
         self.kind = kind
         self.secretKey = secretKey
         self.transport = transport
@@ -109,7 +114,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
             settings: values.settings,
             secrets: values.secrets,
             cookieResolver: ProviderPluginCookieBroker.resolver(context: context))
-        return self.makeResult(usage: usage, sourceLabel: "js")
+        return self.makeResult(usage: usage, sourceLabel: self.sourceLabel)
     }
 
     public func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Crof/CrofProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Crof/CrofProviderDescriptor.swift
@@ -52,18 +52,22 @@ public enum CrofProviderDescriptor {
 
     private static func fetchPlan() -> ProviderFetchPlan {
         #if canImport(JavaScriptCore)
-        .scriptPrototypeAPI(
-            configuration: .init(
-                provider: .crof,
-                plugin: "crof",
-                secretKey: CrofSettingsReader.apiKeyEnvironmentKeys[0],
-                strategyID: "crof.api"),
-            resolveToken: { ProviderTokenResolver.crofToken(environment: $0) },
-            missingCredentialsError: { CrofUsageError.missingCredentials },
-            loadUsage: { apiKey, _ in
-                try await CrofUsageFetcher.fetchUsage(apiKey: apiKey).toUsageSnapshot()
-            })
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in
+                [ScriptFetchStrategy(
+                    id: "crof.js",
+                    provider: .crof,
+                    bundledPlugin: "crof",
+                    secretKey: CrofSettingsReader.apiKeyEnvironmentKeys[0],
+                    sourceLabel: "api",
+                    resolveSecret: { environment in
+                        self.credentials.resolveToken(environment: environment)?.token
+                    },
+                    isEnabled: { _ in true })]
+            }))
         #else
+        // Linux compatibility only. JavaScriptCore platforms use the bundled plugin above.
         .apiToken(
             strategyID: "crof.api",
             resolveToken: { ProviderTokenResolver.crofToken(environment: $0) },

--- a/Sources/CodexBarCore/Providers/Crof/CrofUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Crof/CrofUsageFetcher.swift
@@ -1,3 +1,5 @@
+// Linux compatibility only. JavaScriptCore platforms use the bundled Crof plugin.
+#if !canImport(JavaScriptCore)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -87,3 +89,4 @@ public enum CrofUsageFetcher {
             updatedAt: Date())
     }
 }
+#endif

--- a/Sources/CodexBarCore/Providers/Crof/CrofUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Crof/CrofUsageSnapshot.swift
@@ -1,3 +1,5 @@
+// Linux compatibility only. JavaScriptCore platforms use the bundled Crof plugin.
+#if !canImport(JavaScriptCore)
 import Foundation
 
 public struct CrofUsageSnapshot: Sendable {
@@ -86,3 +88,4 @@ public struct CrofUsageSnapshot: Sendable {
             : startOfDay
     }
 }
+#endif

--- a/Sources/CodexBarCore/Providers/Venice/VeniceProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceProviderDescriptor.swift
@@ -57,18 +57,22 @@ public enum VeniceProviderDescriptor {
 
     private static func fetchPlan() -> ProviderFetchPlan {
         #if canImport(JavaScriptCore)
-        .scriptPrototypeAPI(
-            configuration: .init(
-                provider: .venice,
-                plugin: "venice",
-                secretKey: VeniceSettingsReader.apiKeyEnvironmentKey,
-                strategyID: "venice.api"),
-            resolveToken: { ProviderTokenResolver.veniceToken(environment: $0) },
-            missingCredentialsError: { VeniceUsageError.missingCredentials },
-            loadUsage: { apiKey, _ in
-                try await VeniceUsageFetcher.fetchUsage(apiKey: apiKey).toUsageSnapshot()
-            })
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in
+                [ScriptFetchStrategy(
+                    id: "venice.js",
+                    provider: .venice,
+                    bundledPlugin: "venice",
+                    secretKey: VeniceSettingsReader.apiKeyEnvironmentKey,
+                    sourceLabel: "api",
+                    resolveSecret: { environment in
+                        self.credentials.resolveToken(environment: environment)?.token
+                    },
+                    isEnabled: { _ in true })]
+            }))
         #else
+        // Linux compatibility only. JavaScriptCore platforms use the bundled plugin above.
         .apiToken(
             strategyID: "venice.api",
             resolveToken: { ProviderTokenResolver.veniceToken(environment: $0) },

--- a/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
@@ -1,3 +1,5 @@
+// Linux compatibility only. JavaScriptCore platforms use the bundled Venice plugin.
+#if !canImport(JavaScriptCore)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -237,3 +239,4 @@ extension KeyedDecodingContainer {
             debugDescription: "Expected a number or numeric string for \(key.stringValue)")
     }
 }
+#endif

--- a/Tests/CodexBarTests/CLISnapshotTests.swift
+++ b/Tests/CodexBarTests/CLISnapshotTests.swift
@@ -349,9 +349,7 @@ struct CLISnapshotTests {
     @Test
     func `renders crof dollar balance as detail not reset`() {
         let meta = ProviderDescriptorRegistry.descriptor(for: .crof).metadata
-        let snap = CrofUsageSnapshot(
-            credits: 9.9999,
-            updatedAt: Date(timeIntervalSince1970: 0)).toUsageSnapshot()
+        let snap = CrofTestSnapshots.credits(9.9999, updatedAt: Date(timeIntervalSince1970: 0))
 
         let output = CLIRenderer.renderText(
             provider: .crof,
@@ -371,11 +369,11 @@ struct CLISnapshotTests {
 
     @Test
     func `renders crof request quota when returned`() {
-        let snap = CrofUsageSnapshot(
+        let snap = CrofTestSnapshots.requestQuota(
             credits: 9.9999,
-            requestsPlan: 1000,
-            usableRequests: 998,
-            updatedAt: Date(timeIntervalSince1970: 0)).toUsageSnapshot()
+            plan: 1000,
+            remaining: 998,
+            updatedAt: Date(timeIntervalSince1970: 0))
 
         let output = CLIRenderer.renderText(
             provider: .crof,

--- a/Tests/CodexBarTests/CrofMenuCardTests.swift
+++ b/Tests/CodexBarTests/CrofMenuCardTests.swift
@@ -8,9 +8,7 @@ struct CrofMenuCardTests {
     func `model shows credit balance without request quota`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.crof])
-        let snapshot = CrofUsageSnapshot(
-            credits: 10,
-            updatedAt: now).toUsageSnapshot()
+        let snapshot = CrofTestSnapshots.credits(10, updatedAt: now)
 
         let model = UsageMenuCardView.Model.make(.init(
             provider: .crof,
@@ -44,11 +42,11 @@ struct CrofMenuCardTests {
     func `model keeps request quota rows when the API returns them`() throws {
         let now = Date()
         let metadata = try #require(ProviderDefaults.metadata[.crof])
-        let snapshot = CrofUsageSnapshot(
+        let snapshot = CrofTestSnapshots.requestQuota(
             credits: 10,
-            requestsPlan: 1000,
-            usableRequests: 998,
-            updatedAt: now).toUsageSnapshot()
+            plan: 1000,
+            remaining: 998,
+            updatedAt: now)
 
         let model = UsageMenuCardView.Model.make(.init(
             provider: .crof,

--- a/Tests/CodexBarTests/CrofUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CrofUsageFetcherTests.swift
@@ -1,16 +1,11 @@
+#if canImport(JavaScriptCore)
 import Foundation
 import Testing
 @testable import CodexBarCore
 
-@Suite(.serialized)
-struct CrofUsageFetcherTests {
+struct CrofPluginGoldenTests {
     @Test
-    func `usage URL points at public usage API`() {
-        #expect(CrofUsageFetcher.usageURL.absoluteString == "https://crof.ai/usage_api/")
-    }
-
-    @Test
-    func `usage response parses credits with null request quota fields`() throws {
+    func `credits-only fixture matches the production golden`() async throws {
         let json = """
         {
           "credits":9.0441,
@@ -26,99 +21,72 @@ struct CrofUsageFetcherTests {
           }
         }
         """
+        let snapshot = try await Self.fetch(json)
 
-        let snapshot = try CrofUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-
-        #expect(snapshot.credits == 9.0441)
-        #expect(snapshot.requestsPlan == nil)
-        #expect(snapshot.usableRequests == nil)
+        #expect(snapshot.primary == RateWindow(
+            usedPercent: 0,
+            windowMinutes: nil,
+            resetsAt: nil,
+            resetDescription: "$9.04"))
+        #expect(snapshot.secondary == nil)
+        #expect(snapshot.identity?.providerID == .crof)
+        #expect(snapshot.identity?.loginMethod == "API key")
     }
 
     @Test
-    func `usage response preserves request quota fields when present`() throws {
+    func `request-quota fixture matches the production golden`() async throws {
         let json = """
         {"credits":10.0,"requests_plan":1000,"usable_requests":998}
         """
+        let now = Date(timeIntervalSince1970: 1_777_800_000)
+        let fetchStartedAt = Date()
+        let snapshot = try await Self.fetch(json, now: now)
 
-        let snapshot = try CrofUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-
-        #expect(snapshot.credits == 10)
-        #expect(snapshot.requestsPlan == 1000)
-        #expect(snapshot.usableRequests == 998)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Chicago"))
+        let reset = try #require(calendar.date(
+            byAdding: .day,
+            value: 1,
+            to: calendar.startOfDay(for: fetchStartedAt)))
+        #expect(snapshot.primary == RateWindow(
+            usedPercent: 1,
+            windowMinutes: 1440,
+            resetsAt: reset,
+            resetDescription: "998 requests left"))
+        #expect(snapshot.secondary == RateWindow(
+            usedPercent: 0,
+            windowMinutes: nil,
+            resetsAt: nil,
+            resetDescription: "$10.00"))
     }
 
     @Test
-    func `usage snapshot maps credit balance as primary window`() {
-        let snapshot = CrofUsageSnapshot(
-            credits: 10,
-            updatedAt: Date(timeIntervalSince1970: 1_777_800_000))
+    func `credit balance formatting and depletion match the production goldens`() async throws {
+        let funded = try await Self.fetch(#"{"credits":9.9999,"requests_plan":null,"usable_requests":null}"#)
+        let depleted = try await Self.fetch(#"{"credits":0,"requests_plan":null,"usable_requests":null}"#)
 
-        let usage = snapshot.toUsageSnapshot()
-
-        #expect(usage.primary?.usedPercent == 0)
-        #expect(usage.primary?.windowMinutes == nil)
-        #expect(usage.primary?.resetsAt == nil)
-        #expect(usage.primary?.resetDescription == "$10.00")
-        #expect(usage.secondary == nil)
-        #expect(usage.identity?.providerID == .crof)
-        #expect(usage.identity?.loginMethod == "API key")
+        #expect(funded.primary?.usedPercent == 0)
+        #expect(funded.primary?.resetDescription == "$9.99")
+        #expect(depleted.primary?.usedPercent == 100)
+        #expect(depleted.primary?.resetDescription == "$0.00")
     }
 
     @Test
-    func `usage snapshot prefers request quota when present`() {
-        let snapshot = CrofUsageSnapshot(
-            credits: 10,
-            requestsPlan: 1000,
-            usableRequests: 998,
-            updatedAt: Date(timeIntervalSince1970: 1_777_800_000))
-
-        let usage = snapshot.toUsageSnapshot()
-
-        #expect(usage.primary?.usedPercent == 1)
-        #expect(usage.primary?.windowMinutes == 1440)
-        #expect(usage.primary?.resetsAt != nil)
-        #expect(usage.primary?.resetDescription == "998 requests left")
-        #expect(usage.secondary?.usedPercent == 0)
-        #expect(usage.secondary?.resetDescription == "$10.00")
-    }
-
-    @Test
-    func `usage snapshot floors credit balance to cents`() {
-        let snapshot = CrofUsageSnapshot(credits: 9.9999)
-
-        #expect(snapshot.toUsageSnapshot().primary?.resetDescription == "$9.99")
-    }
-
-    @Test
-    func `usage snapshot treats zero credits as exhausted`() {
-        let snapshot = CrofUsageSnapshot(credits: 0)
-
-        #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 100)
-        #expect(snapshot.toUsageSnapshot().primary?.resetDescription == "$0.00")
-    }
-
-    @Test
-    func `fetch sends bearer token`() async throws {
-        defer {
-            CrofStubURLProtocol.handler = nil
-            CrofStubURLProtocol.requests = []
-        }
-        CrofStubURLProtocol.requests = []
-        CrofStubURLProtocol.handler = { request in
-            guard let url = request.url else { throw URLError(.badURL) }
+    func `plugin request uses the public endpoint and bearer token`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            #expect(request.url?.absoluteString == "https://crof.ai/usage_api/")
+            #expect(request.httpMethod == "GET")
             #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer crof-test")
             #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
-            return try Self.makeResponse(
-                url: url,
+            return try Self.response(
+                request: request,
                 body: #"{"credits":9.0441,"requests_plan":null,"usable_requests":null,"usage":{}}"#)
         }
+        let runtime = try ProviderPluginRuntime(bundledPlugin: "crof", transport: transport)
 
-        let snapshot = try await CrofUsageFetcher.fetchUsage(apiKey: "crof-test", session: Self.makeSession())
+        let snapshot = try await runtime.fetchUsage(secrets: ["CROF_API_KEY": "crof-test"])
 
-        #expect(snapshot.credits == 9.0441)
-        #expect(snapshot.requestsPlan == nil)
-        #expect(snapshot.usableRequests == nil)
-        #expect(CrofStubURLProtocol.requests.map(\.url?.absoluteString) == ["https://crof.ai/usage_api/"])
+        #expect(snapshot.primary?.resetDescription == "$9.04")
     }
 
     @Test
@@ -132,115 +100,86 @@ struct CrofUsageFetcherTests {
     }
 
     @Test
-    func `settings reader uses CROF_API_KEY`() {
-        let token = CrofSettingsReader.apiKey(environment: [
-            CrofSettingsReader.apiKeyEnvironmentKeys[0]: "  crof-token  ",
-        ])
-
-        #expect(token == "crof-token")
-    }
-
-    @Test
-    func `token resolver uses crof environment token`() {
-        let env = [CrofSettingsReader.apiKeyEnvironmentKeys[0]: "crof-token"]
-        let resolution = ProviderTokenResolver.crofResolution(environment: env)
-
-        #expect(resolution?.token == "crof-token")
-        #expect(resolution?.source == .environment)
-    }
-
-    @Test
-    func `config API key override feeds crof environment`() {
-        let config = ProviderConfig(id: .crof, apiKey: "config-token")
-        let env = ProviderConfigEnvironment.applyAPIKeyOverride(
-            base: [:],
-            provider: .crof,
-            config: config)
-
-        #expect(env[CrofSettingsReader.apiKeyEnvironmentKeys[0]] == "config-token")
-        #expect(ProviderTokenResolver.crofToken(environment: env) == "config-token")
-    }
-
-    @Test
-    func `config API key leaves existing crof environment token alone`() {
+    func `settings and credential adapter preserve Crof precedence`() {
         let key = CrofSettingsReader.apiKeyEnvironmentKeys[0]
+        #expect(CrofSettingsReader.apiKey(environment: [key: "  crof-token  "]) == "crof-token")
+        #expect(ProviderTokenResolver.crofResolution(environment: [key: "crof-token"])?.token == "crof-token")
+
         let config = ProviderConfig(id: .crof, apiKey: "config-token")
-        let env = ProviderConfigEnvironment.applyAPIKeyOverride(
+        let configured = ProviderConfigEnvironment.applyAPIKeyOverride(base: [:], provider: .crof, config: config)
+        #expect(configured[key] == "config-token")
+        let overridden = ProviderConfigEnvironment.applyAPIKeyOverride(
             base: [key: "env-token"],
             provider: .crof,
             config: config)
-
-        #expect(env[key] == "env-token")
-        #expect(ProviderTokenResolver.crofToken(environment: env) == "env-token")
+        #expect(overridden[key] == "env-token")
     }
 
-    @Test
-    func `missing credentials fetch call throws missing credentials`() async {
-        do {
-            _ = try await CrofUsageFetcher.fetchUsage(apiKey: "   ")
-            Issue.record("Expected missingCredentials error")
-        } catch let error as CrofUsageError {
-            #expect(error == .missingCredentials)
-        } catch {
-            Issue.record("Unexpected error: \(error)")
-        }
-    }
-
-    private static func makeSession() -> URLSession {
-        let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [CrofStubURLProtocol.self]
-        return URLSession(configuration: config)
-    }
-
-    private static func makeResponse(
-        url: URL,
-        body: String,
-        statusCode: Int = 200) throws -> (HTTPURLResponse, Data)
+    private static func fetch(
+        _ body: String,
+        now: Date = Date(timeIntervalSince1970: 1_800_000_000)) async throws -> UsageSnapshot
     {
-        guard let response = HTTPURLResponse(
+        let runtime = try ProviderPluginRuntime(
+            bundledPlugin: "crof",
+            transport: ProviderHTTPTransportHandler { request in
+                try Self.response(request: request, body: body)
+            })
+        return try await runtime.fetchUsage(secrets: ["CROF_API_KEY": "fixture-key"], now: now)
+    }
+
+    private static func response(request: URLRequest, body: String) throws -> (Data, URLResponse) {
+        let url = try #require(request.url)
+        let response = try #require(HTTPURLResponse(
             url: url,
-            statusCode: statusCode,
+            statusCode: 200,
             httpVersion: nil,
-            headerFields: ["Content-Type": "application/json"])
-        else {
-            throw URLError(.badServerResponse)
-        }
-        return (response, Data(body.utf8))
+            headerFields: ["Content-Type": "application/json"]))
+        return (Data(body.utf8), response)
     }
 }
 
-final class CrofStubURLProtocol: URLProtocol {
-    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
-    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
-        get { Self._handlerBox.value }
-        set { Self._handlerBox.setValue(newValue) }
+enum CrofTestSnapshots {
+    static func credits(_ amount: Double, updatedAt: Date = Date()) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: amount > 0 ? 0 : 100,
+                windowMinutes: nil,
+                resetsAt: nil,
+                resetDescription: String(format: "$%.2f", floor(max(0, amount) * 100) / 100)),
+            secondary: nil,
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: .crof,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "API key"))
     }
 
-    nonisolated(unsafe) static var requests: [URLRequest] = []
-
-    override static func canInit(with request: URLRequest) -> Bool {
-        request.url?.host == "crof.ai"
+    static func requestQuota(
+        credits: Double,
+        plan: Double,
+        remaining: Double,
+        updatedAt: Date = Date()) -> UsageSnapshot
+    {
+        let clamped = max(0, min(plan, remaining))
+        let remainingPercent = plan > 0 ? floor(clamped / plan * 100) : 0
+        return UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 100 - remainingPercent,
+                windowMinutes: 1440,
+                resetsAt: updatedAt.addingTimeInterval(86400),
+                resetDescription: "\(Int(max(0, remaining))) requests left"),
+            secondary: self.credits(credits, updatedAt: updatedAt).primary,
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: .crof,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "API key"))
     }
-
-    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        Self.requests.append(self.request)
-        guard let handler = Self.handler else {
-            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        do {
-            let (response, data) = try handler(self.request)
-            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            self.client?.urlProtocol(self, didLoad: data)
-            self.client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            self.client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
 }
+#endif

--- a/Tests/CodexBarTests/ProviderPluginParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginParityTests.swift
@@ -23,6 +23,23 @@ struct ProviderPluginParityTests {
     }
 
     @Test
+    func `cut-over providers use only JS without the prototype flag`() async {
+        for (provider, key) in [(UsageProvider.crof, "CROF_API_KEY"), (.venice, "VENICE_API_KEY")] {
+            let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
+            let context = Self.context(environment: [key: "fixture-key"])
+            let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(context)
+
+            #expect(strategies.map(\.id) == ["\(provider.rawValue).js"])
+            #expect(await strategies[0].isAvailable(context))
+            let flagged = await descriptor.fetchPlan.pipeline.resolveStrategies(Self.context(environment: [
+                key: "fixture-key",
+                ProviderPluginPrototype.environmentKey: "1",
+            ]))
+            #expect(flagged.map(\.id) == ["\(provider.rawValue).js"])
+        }
+    }
+
+    @Test
     func `Synthetic fixture has Swift and JS snapshot parity`() async throws {
         let body = """
         {
@@ -64,7 +81,7 @@ struct ProviderPluginParityTests {
     }
 
     @Test
-    func `Venice fixture has Swift and JS snapshot parity`() async throws {
+    func `Venice fixture matches the cut-over golden`() async throws {
         let body = """
         {
           "canConsume": true,
@@ -76,28 +93,53 @@ struct ProviderPluginParityTests {
         let transport = Self.transport(body: body)
         let now = Date(timeIntervalSince1970: 1_775_000_000)
 
-        let swift = try await VeniceUsageFetcher.fetchUsage(
-            apiKey: "fixture-key",
-            transport: transport).toUsageSnapshot()
         let runtime = try ProviderPluginRuntime(bundledPlugin: "venice", transport: transport)
         let script = try await runtime.fetchUsage(secrets: ["VENICE_API_KEY": "fixture-key"], now: now)
 
-        Self.expectCoreParity(swift, script)
+        #expect(script.primary == RateWindow(
+            usedPercent: 50,
+            windowMinutes: nil,
+            resetsAt: nil,
+            resetDescription: "DIEM 50.00 / 100.00 epoch allocation"))
+        #expect(script.secondary == nil)
+        #expect(script.tertiary == nil)
+        #expect(script.providerCost == nil)
+        #expect(script.identity?.providerID == .venice)
+        #expect(script.identity?.accountEmail == nil)
+        #expect(script.identity?.accountOrganization == nil)
+        #expect(script.identity?.loginMethod == nil)
     }
 
     @Test
-    func `Crof fixture has Swift and JS snapshot parity`() async throws {
+    func `Crof fixture matches the cut-over golden`() async throws {
         let body = #"{"credits":9.9999,"requests_plan":1000,"usable_requests":998}"#
         let transport = Self.transport(body: body)
-        let now = Date()
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fetchStartedAt = Date()
 
-        let swift = try await CrofUsageFetcher.fetchUsage(
-            apiKey: "fixture-key",
-            session: transport).toUsageSnapshot()
         let runtime = try ProviderPluginRuntime(bundledPlugin: "crof", transport: transport)
         let script = try await runtime.fetchUsage(secrets: ["CROF_API_KEY": "fixture-key"], now: now)
 
-        Self.expectCoreParity(swift, script)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Chicago"))
+        let reset = try #require(calendar.date(
+            byAdding: .day,
+            value: 1,
+            to: calendar.startOfDay(for: fetchStartedAt)))
+        #expect(script.primary == RateWindow(
+            usedPercent: 1,
+            windowMinutes: 1440,
+            resetsAt: reset,
+            resetDescription: "998 requests left"))
+        #expect(script.secondary == RateWindow(
+            usedPercent: 0,
+            windowMinutes: nil,
+            resetsAt: nil,
+            resetDescription: "$9.99"))
+        #expect(script.tertiary == nil)
+        #expect(script.providerCost == nil)
+        #expect(script.identity?.providerID == .crof)
+        #expect(script.identity?.loginMethod == "API key")
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -936,9 +936,9 @@ struct CrofQuotaNotificationTests {
             settings: settings,
             sessionQuotaNotifier: notifier)
 
-        let funded = CrofUsageSnapshot(credits: 9.0441, updatedAt: Date()).toUsageSnapshot()
-        let depleted = CrofUsageSnapshot(credits: 0, updatedAt: Date()).toUsageSnapshot()
-        let toppedUp = CrofUsageSnapshot(credits: 5, updatedAt: Date()).toUsageSnapshot()
+        let funded = CrofTestSnapshots.credits(9.0441)
+        let depleted = CrofTestSnapshots.credits(0)
+        let toppedUp = CrofTestSnapshots.credits(5)
 
         #expect(funded.secondary == nil)
         #expect(funded.primary?.windowMinutes == nil)

--- a/Tests/CodexBarTests/VeniceUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/VeniceUsageFetcherTests.swift
@@ -1,297 +1,240 @@
+#if canImport(JavaScriptCore)
 import Foundation
 import Testing
 @testable import CodexBarCore
 
-struct VeniceUsageFetcherTests {
+struct VenicePluginGoldenTests {
     @Test
-    func `parses DIEM balance response`() throws {
-        let json = """
+    func `DIEM balance fixture matches the production golden`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "DIEM",
-          "balances": {
-            "diem": 90.50,
-            "usd": null
-          },
+          "balances": { "diem": 90.50, "usd": null },
           "diemEpochAllocation": 100.0
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        #expect(snapshot.canConsume == true)
-        #expect(snapshot.consumptionCurrency == "DIEM")
-        #expect(snapshot.diemBalance == 90.50)
-        #expect(snapshot.usdBalance == nil)
-        #expect(snapshot.diemEpochAllocation == 100.0)
+        """)
+        #expect(snapshot.primary?.usedPercent == 9.5)
+        #expect(snapshot.primary?.resetDescription == "DIEM 90.50 / 100.00 epoch allocation")
     }
 
     @Test
-    func `parses USD balance response`() throws {
-        let json = """
+    func `USD balance fixture matches the production golden`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "USD",
-          "balances": {
-            "diem": null,
-            "usd": 25.75
-          },
+          "balances": { "diem": null, "usd": 25.75 },
           "diemEpochAllocation": null
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        #expect(snapshot.canConsume == true)
-        #expect(snapshot.consumptionCurrency == "USD")
-        #expect(snapshot.diemBalance == nil)
-        #expect(snapshot.usdBalance == 25.75)
-        #expect(snapshot.diemEpochAllocation == nil)
+        """)
+        #expect(snapshot.primary?.usedPercent == 0)
+        #expect(snapshot.primary?.resetDescription == "$25.75 USD remaining")
     }
 
     @Test
-    func `parses string-encoded balances and allocation`() throws {
-        let json = """
+    func `string-encoded balances and allocation match the production golden`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "DIEM",
-          "balances": {
-            "diem": "90.50",
-            "usd": "25.75"
-          },
+          "balances": { "diem": "90.50", "usd": "25.75" },
           "diemEpochAllocation": "100.0"
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        #expect(snapshot.diemBalance == 90.50)
-        #expect(snapshot.usdBalance == 25.75)
-        #expect(snapshot.diemEpochAllocation == 100.0)
+        """)
+        #expect(snapshot.primary?.usedPercent == 9.5)
+        #expect(snapshot.primary?.resetDescription == "DIEM 90.50 / 100.00 epoch allocation")
     }
 
     @Test
-    func `parses both DIEM and USD present`() throws {
-        let json = """
+    func `bundled credits prefer DIEM allocation when both balances are present`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "BUNDLED_CREDITS",
-          "balances": {
-            "diem": 50.0,
-            "usd": 10.0
-          },
+          "balances": { "diem": 50.0, "usd": 10.0 },
           "diemEpochAllocation": 100.0
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        #expect(snapshot.diemBalance == 50.0)
-        #expect(snapshot.usdBalance == 10.0)
+        """)
+        #expect(snapshot.primary?.usedPercent == 50)
+        #expect(snapshot.primary?.resetDescription == "DIEM 50.00 / 100.00 epoch allocation")
     }
 
     @Test
-    func `uses DIEM allocation progress for bundled credits currency`() throws {
-        let json = """
-        {
-          "canConsume": true,
-          "consumptionCurrency": "BUNDLED_CREDITS",
-          "balances": {
-            "diem": 50.0,
-            "usd": 10.0
-          },
-          "diemEpochAllocation": 100.0
-        }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.resetDescription?.contains("DIEM 50.00 / 100.00") == true)
-        #expect(usage.primary?.usedPercent == 50.0)
-    }
-
-    @Test
-    func `uses USD display when consumptionCurrency is USD and both balances exist`() throws {
-        let json = """
+    func `USD currency wins when both balances are present`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "USD",
-          "balances": {
-            "diem": 50.0,
-            "usd": 12.34
-          },
+          "balances": { "diem": 50.0, "usd": 12.34 },
           "diemEpochAllocation": 100.0
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.resetDescription == "$12.34 USD remaining")
-        #expect(usage.primary?.usedPercent == 0)
+        """)
+        #expect(snapshot.primary?.usedPercent == 0)
+        #expect(snapshot.primary?.resetDescription == "$12.34 USD remaining")
     }
 
     @Test
-    func `handles canConsume=false`() throws {
-        let json = """
+    func `non-consumable fixture is exhausted`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": false,
           "consumptionCurrency": "USD",
-          "balances": {
-            "diem": null,
-            "usd": 100.0
-          },
+          "balances": { "diem": null, "usd": 100.0 },
           "diemEpochAllocation": null
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.usedPercent == 100)
-        #expect(usage.primary?.resetDescription == "Balance unavailable for API calls")
+        """)
+        #expect(snapshot.primary?.usedPercent == 100)
+        #expect(snapshot.primary?.resetDescription == "Balance unavailable for API calls")
     }
 
     @Test
-    func `displays DIEM with epoch allocation`() throws {
-        let json = """
+    func `DIEM allocation progress matches the production golden`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "DIEM",
-          "balances": {
-            "diem": 75.0,
-            "usd": null
-          },
+          "balances": { "diem": 75.0, "usd": null },
           "diemEpochAllocation": 100.0
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.resetDescription?.contains("DIEM 75.00 / 100.00") == true)
-        #expect(usage.primary?.usedPercent == 25.0)
+        """)
+        #expect(snapshot.primary?.usedPercent == 25)
+        #expect(snapshot.primary?.resetDescription == "DIEM 75.00 / 100.00 epoch allocation")
     }
 
     @Test
-    func `displays DIEM without allocation`() throws {
-        let json = """
+    func `DIEM without allocation matches the production golden`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "DIEM",
-          "balances": {
-            "diem": 50.0,
-            "usd": null
-          },
+          "balances": { "diem": 50.0, "usd": null },
           "diemEpochAllocation": null
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.resetDescription?.contains("DIEM 50.00 remaining") == true)
-        #expect(usage.primary?.usedPercent == 0)
+        """)
+        #expect(snapshot.primary?.usedPercent == 0)
+        #expect(snapshot.primary?.resetDescription == "DIEM 50.00 remaining")
     }
 
     @Test
-    func `displays USD balance`() throws {
-        let json = """
+    func `USD-only balance matches the production golden`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "USD",
-          "balances": {
-            "diem": null,
-            "usd": 15.50
-          },
+          "balances": { "diem": null, "usd": 15.50 },
           "diemEpochAllocation": null
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.resetDescription?.contains("$15.50") == true)
-        #expect(usage.primary?.usedPercent == 0)
+        """)
+        #expect(snapshot.primary?.usedPercent == 0)
+        #expect(snapshot.primary?.resetDescription == "$15.50 USD remaining")
     }
 
     @Test
-    func `handles zero balances`() throws {
-        let json = """
+    func `zero balances match the exhausted golden`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "USD",
-          "balances": {
-            "diem": 0.0,
-            "usd": 0.0
-          },
+          "balances": { "diem": 0.0, "usd": 0.0 },
           "diemEpochAllocation": null
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.resetDescription == "No Venice API balance available")
-        #expect(usage.primary?.usedPercent == 100)
+        """)
+        #expect(snapshot.primary?.usedPercent == 100)
+        #expect(snapshot.primary?.resetDescription == "No Venice API balance available")
     }
 
     @Test
-    func `handles null balances with canConsume=true`() throws {
-        let json = """
+    func `null balances match the exhausted golden`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": null,
-          "balances": {
-            "diem": null,
-            "usd": null
-          },
+          "balances": { "diem": null, "usd": null },
           "diemEpochAllocation": null
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.resetDescription == "No Venice API balance available")
-        #expect(usage.primary?.usedPercent == 100)
+        """)
+        #expect(snapshot.primary?.usedPercent == 100)
+        #expect(snapshot.primary?.resetDescription == "No Venice API balance available")
     }
 
     @Test
-    func `identity uses venice provider ID`() throws {
-        let json = """
+    func `identity stays scoped to Venice`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "DIEM",
-          "balances": {
-            "diem": 90.0,
-            "usd": null
-          },
+          "balances": { "diem": 90.0, "usd": null },
           "diemEpochAllocation": 100.0
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        let usage = snapshot.toUsageSnapshot()
-        #expect(usage.identity?.providerID == .venice)
-        #expect(usage.identity?.accountEmail == nil)
-        #expect(usage.identity?.accountOrganization == nil)
+        """)
+        #expect(snapshot.identity?.providerID == .venice)
+        #expect(snapshot.identity?.accountEmail == nil)
+        #expect(snapshot.identity?.accountOrganization == nil)
+        #expect(snapshot.identity?.loginMethod == nil)
     }
 
-    @Test
-    func `throws on malformed JSON`() {
-        let json = "[{ \"canConsume\": true }]"
-        #expect {
-            _ = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        } throws: { error in
-            guard case VeniceUsageError.parseFailed = error else { return false }
-            return true
+    @Test(arguments: [#"[{ "canConsume": true }]"#, "{ invalid json }"])
+    func `malformed fixtures fail the JS contract`(_ body: String) async throws {
+        let runtime = try ProviderPluginRuntime(
+            bundledPlugin: "venice",
+            transport: Self.transport(body: body))
+        await #expect(throws: ProviderPluginError.self) {
+            _ = try await runtime.fetchUsage(secrets: ["VENICE_API_KEY": "fixture-key"])
         }
     }
 
     @Test
-    func `throws on invalid JSON`() {
-        let json = "{ invalid json }"
-        #expect {
-            _ = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        } throws: { error in
-            guard case VeniceUsageError.parseFailed = error else { return false }
-            return true
-        }
-    }
-
-    @Test
-    func `clamps used percent to 0-100 range`() throws {
-        // Negative used percent should be clamped to 0
-        let json = """
+    func `used percentage clamps to zero`() async throws {
+        let snapshot = try await Self.fetch("""
         {
           "canConsume": true,
           "consumptionCurrency": "DIEM",
-          "balances": {
-            "diem": 150.0,
-            "usd": null
-          },
+          "balances": { "diem": 150.0, "usd": null },
           "diemEpochAllocation": 100.0
         }
-        """
-        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
-        let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.usedPercent == 0)
+        """)
+        #expect(snapshot.primary?.usedPercent == 0)
+        #expect(snapshot.primary?.resetDescription == "DIEM 150.00 / 100.00 epoch allocation")
+    }
+
+    @Test
+    func `plugin request uses the billing endpoint and bearer token`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            #expect(request.url?.absoluteString == "https://api.venice.ai/api/v1/billing/balance")
+            #expect(request.httpMethod == "GET")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer venice-test")
+            #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+            return try Self.response(request: request, body: """
+            {"canConsume":true,"consumptionCurrency":"USD","balances":{"diem":null,"usd":1},"diemEpochAllocation":null}
+            """)
+        }
+        let runtime = try ProviderPluginRuntime(bundledPlugin: "venice", transport: transport)
+        let snapshot = try await runtime.fetchUsage(secrets: ["VENICE_API_KEY": "venice-test"])
+        #expect(snapshot.primary?.resetDescription == "$1.00 USD remaining")
+    }
+
+    private static func fetch(_ body: String) async throws -> UsageSnapshot {
+        let runtime = try ProviderPluginRuntime(
+            bundledPlugin: "venice",
+            transport: Self.transport(body: body))
+        return try await runtime.fetchUsage(secrets: ["VENICE_API_KEY": "fixture-key"])
+    }
+
+    private static func transport(body: String) -> ProviderHTTPTransportHandler {
+        ProviderHTTPTransportHandler { request in
+            try Self.response(request: request, body: body)
+        }
+    }
+
+    private static func response(request: URLRequest, body: String) throws -> (Data, URLResponse) {
+        let url = try #require(request.url)
+        let response = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]))
+        return (Data(body.utf8), response)
     }
 }
+#endif

--- a/TestsLinux/CrofCreditsOnlyLinuxTests.swift
+++ b/TestsLinux/CrofCreditsOnlyLinuxTests.swift
@@ -1,3 +1,4 @@
+#if !canImport(JavaScriptCore)
 import Foundation
 import Testing
 @testable import CodexBarCore
@@ -61,3 +62,4 @@ struct CrofCreditsOnlyLinuxTests {
         #expect(CrofProviderDescriptor.primaryLabel(snapshot: usage) != "Credits")
     }
 }
+#endif

--- a/docs/crof.md
+++ b/docs/crof.md
@@ -37,6 +37,7 @@ and displays the returned dollar credit balance plus request quota fields when a
 
 ## Related files
 
-- `Sources/CodexBarCore/Providers/Crof/`
+- `Sources/CodexBarCore/Resources/Plugins/crof.js` (macOS implementation)
+- `Sources/CodexBarCore/Providers/Crof/` (descriptor/settings plus Linux compatibility fetcher)
 - `Sources/CodexBar/Providers/Crof/`
-- `Tests/CodexBarTests/CrofUsageFetcherTests.swift`
+- `Tests/CodexBarTests/CrofUsageFetcherTests.swift` (JavaScript goldens)

--- a/docs/plugin-conversion-matrix.md
+++ b/docs/plugin-conversion-matrix.md
@@ -17,7 +17,8 @@ is inherently a user-chosen origin (LLM Proxy and LiteLLM) do not qualify. The c
 current Swift request methods and snapshot projections; Azure OpenAI, StepFun, and Warp were removed from the audit's
 earlier “fully expressible” baseline because their current implementations issue POST requests.
 
-`converted` means the bundled JavaScript conversion is present behind `CODEXBAR_JS_PROVIDERS=1`. The Converted column
+`converted` means the bundled JavaScript conversion is present behind `CODEXBAR_JS_PROVIDERS=1`. `cut-over` means the
+bundled script is the only JavaScriptCore implementation, with any retained native core serving Linux only. The Converted column
 makes implementation state explicit and the totals are mutually exclusive: `convertible-now` counts only providers
 that remain cheap to convert. Remaining buckets name the next blocker after this host-extension slice.
 
@@ -25,7 +26,8 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 
 | Status | Count |
 |---|---:|
-| `converted` | 15 |
+| `cut-over` | 2 |
+| `converted` | 13 |
 | `convertible-now` | 8 |
 | `needs-cookie-import` | 19 |
 | `needs-files/subprocess/oauth-broker` | 15 |
@@ -67,7 +69,7 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 | ollama | `needs-cookie-import` | No | Skipped: hosted parity requires HTML bootstrap/state extraction plus API-key fallback arbitration. |
 | synthetic | `converted` | Yes | Converted: fixed-origin bearer GET with generic windows, cost, dates, and identity. |
 | warp | `needs-pty/webview/native` | No | Warp sends a POST GraphQL operation, which the GET-only HTTP broker cannot express. |
-| openrouter | `converted` | Yes | Converted: bearer GET credits plus best-effort key budget, period spend, rate-limit rows, and a spend chart. |
+| openrouter | `converted` | Yes | Cutover stopped: the plugin lacks the endpoint/referer/title overrides and one-second best-effort key-enrichment deadline of the native path. |
 | elevenlabs | `convertible-now` | No | Verified `xi-api-key` GET; heterogeneous character/minute quotas map to named generic windows. |
 | windsurf | `needs-files/subprocess/oauth-broker` | No | Chromium localStorage, IDE databases, and binary protobuf decoding supply the current session. |
 | zed | `needs-files/subprocess/oauth-broker` | No | Zed server settings and a named Keychain credential must be read locally. |
@@ -80,8 +82,8 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 | deepseek | `needs-files/subprocess/oauth-broker` | No | Platform auth/profile selection reads Chromium localStorage, and the result has a bespoke history model. |
 | deepinfra | `convertible-now` | No | Verified fixed-origin bearer GET pair; spend limit and balance project into generic cost/windows. |
 | codebuff | `needs-files/subprocess/oauth-broker` | No | Full credential parity reads a local Manicode credential file; environment-key mode is partial. |
-| crof | `converted` | Yes | Converted: fixed-origin bearer GET with exact credit formatting and America/Chicago daily reset. |
-| venice | `converted` | Yes | Converted: fixed-origin bearer GET with DIEM/USD allocation projection. |
+| crof | `cut-over` | Yes | Cut over on JavaScriptCore: fixed-origin bearer GET with exact credit formatting and America/Chicago daily reset; native fetch code is Linux-only. |
+| venice | `cut-over` | Yes | Cut over on JavaScriptCore: fixed-origin bearer GET with DIEM/USD allocation projection; native fetch code is Linux-only. |
 | commandcode | `needs-cookie-import` | No | Skipped: live subscription/depletion flags lack reconstructable fixtures within the per-provider cap. |
 | qoder | `converted` | Yes | Converted: declared global/China cookie domains, browser headers, and merged generic quota window. |
 | stepfun | `needs-files/subprocess/oauth-broker` | No | Device registration, password login, refresh, quota, and plan operations are POST-based token-broker work. |
@@ -90,13 +92,13 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 | groq | `needs-cookie-import` | No | Skipped: Stytch session exchange and console history remain a multi-step auth flow. |
 | llmproxy | `needs-pty/webview/native` | No | Its origin is user-selected and may be private HTTP, conflicting with the manifest's fixed HTTPS origins. |
 | litellm | `needs-pty/webview/native` | No | Its required user-selected proxy origin and optional private HTTP cannot be declared by a bundled static manifest. |
-| deepgram | `converted` | Yes | Converted: bounded `Token` authorization scheme plus project discovery and usage details. |
+| deepgram | `converted` | Yes | Cutover stopped: the plugin does not preserve native 400/401/403, network, and parse error classification. |
 | poe | `converted` | Yes | Converted: fixed-origin bearer GET balance/history pagination with daily points and model/type summaries. |
 | chutes | `convertible-now` | No | Verified bearer GET fan-out on the canonical origin; dynamic quota lanes map to named windows. |
 | neuralwatt | `convertible-now` | No | Verified canonical bearer GET; quota lanes and prepaid cost/energy project generically. |
-| clawrouter | `converted` | Yes | Converted for the canonical origin: monthly budget, ledger, request/token totals, routed-provider rows, and cost chart. |
+| clawrouter | `converted` | Yes | Cutover stopped: the plugin supports only the canonical origin, while native production accepts a validated `CLAWROUTER_BASE_URL`. |
 | longcat | `needs-cookie-import` | No | Skipped: browser-cookie retry needs domain/path-aware cookie selection across multiple imported sessions; the generic broker currently returns one flattened header. |
-| sub2api | `converted` | Yes | Converted: settings-derived HTTPS or loopback-HTTP origin with quota and usage details. |
+| sub2api | `converted` | Yes | Cutover stopped: the plugin does not preserve the native total-request deadline and 401/403 invalid-credential classification. |
 | wayfinder | `needs-pty/webview/native` | No | The local unauthenticated HTTP gateway, metrics text, and routing/savings model violate HTTPS-only generic scope. |
 | zenmux | `convertible-now` | No | Verified fixed-origin bearer GET pair; subscription and optional PAYG balance map generically. |
 | aiand | `convertible-now` | No | Verified fixed-origin bearer GET pagination; 30-day spend maps to generic cost. |

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -13,8 +13,8 @@ This document describes the bundled first-party conversion prototype. User-insta
 
 This prototype proves that an existing first-party `UsageProvider` can define its manifest, HTTP requests, response
 parsing, and generic `UsageSnapshot` projection in one bundled JavaScript file. It is deliberately not a user-plugin
-system: IDs remain compile-time `UsageProvider` cases, scripts ship inside CodexBar, and the normal Swift path remains
-the default.
+system: IDs remain compile-time `UsageProvider` cases and scripts ship inside CodexBar. Crof and Venice have cut over
+to the bundled script on JavaScriptCore platforms; their native fetch cores remain compiled only for the Linux CLI.
 
 Plugin manifests and their projected snapshots now carry a validated `ProviderInstanceID`. The prototype still maps
 that instance ID to an existing first-party `UsageProvider` before using browser-cookie brokerage or other bespoke
@@ -23,12 +23,13 @@ case therefore remain out of scope for this prototype.
 
 ## Enable and test
 
-Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, Venice, Crof, OpenAI, z.ai, OpenRouter, Poe,
-ClawRouter, Deepgram, sub2api, xAI, Manus, Perplexity, T3 Chat, and Qoder then prepend a script strategy to their
-existing pipeline. A missing required secret or disabled cookie source leaves the script
+Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, OpenAI, z.ai, OpenRouter, Poe, ClawRouter,
+Deepgram, sub2api, xAI, Manus, Perplexity, T3 Chat, and Qoder then prepend a script strategy to their existing pipeline.
+A missing required secret or disabled cookie source leaves the script
 strategy unavailable and permits the Swift strategy to run; a loaded script that fails does not fall back, so parity
 defects stay visible. Without the variable, the resolver returns the original Swift strategy only and does not load
-JavaScriptCore or a plugin resource.
+JavaScriptCore or a plugin resource for those providers. Crof and Venice always resolve only their script strategy on
+JavaScriptCore platforms; `CODEXBAR_JS_PROVIDERS` does not affect them.
 
 Run the focused proof with:
 
@@ -169,9 +170,12 @@ new context on a fresh executor, which the hung-script recovery test proves. Thi
 cannot interrupt the abandoned JavaScriptCore thread, which may remain alive until process exit. A production plugin
 runtime needs a public interrupt API or a killable helper-process boundary before accepting untrusted scripts.
 
+The same watchdog is production-default for first-party cut-over providers. It is part of the shared runtime, not the
+prototype flag, so Crof and Venice retain timeout and fresh-context recovery without `CODEXBAR_JS_PROVIDERS`.
+
 ## Current limitations
 
-The bundled-conversion flag is macOS-only and compiled out when JavaScriptCore is unavailable. It supports bundled
+The remaining bundled-conversion flag is macOS-only and compiled out when JavaScriptCore is unavailable. It supports bundled
 first-party IDs and the generic snapshot and declarative details only: no provider-specific Swift payloads,
 OAuth/refresh broker, local files or databases, subprocesses,
 arbitrary/form POST bodies, PTY, WebView, binary/protobuf responses, private-network HTTP, or unvalidated dynamic

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -107,6 +107,10 @@ User-plugin requests run in an ephemeral session with no ambient cookies, creden
 rejected, the timeout is 15 seconds, `Accept-Encoding: identity` is sent, compressed and non-2xx responses fail, and
 response bytes are capped at 1 MiB. Request URLs must match a declared, approved origin.
 
+Bundled first-party providers that have cut over to JavaScript use the shared runtime's 20-second hung-script watchdog.
+A timeout fails that refresh and discards the poisoned worker so the next refresh starts with a fresh context; this is
+production-default and does not depend on `CODEXBAR_JS_PROVIDERS`.
+
 ## Snapshot result
 
 Return at least one rate window, cost object, or detail section:
@@ -178,4 +182,3 @@ surfaces (status feeds, token accounts, OAuth, browser automation, storage probe
 specific payloads). Rendering is limited to generic snapshots and declarative details. There are no remote catalogs,
 downloaded plugins/assets, custom SVGs, imports, arbitrary local I/O, or compatibility fallback from an unknown ID to a
 built-in provider.
-


### PR DESCRIPTION
## Summary

This cutover makes the bundled JavaScript plugins the only fetch implementation selected for Crof and Venice on JavaScriptCore platforms. Their fetch plans are now JS-only on macOS, independent of `CODEXBAR_JS_PROVIDERS`; the Swift fetch cores remain solely as documented Linux compatibility and 416 lines of native implementation are excluded from macOS builds.

The cutover carries forward the parity-suite proof as exact golden snapshots for both providers. Crof retains its credit formatting, request-quota projection, and America/Chicago daily reset semantics; Venice retains its DIEM/USD allocation projection. The provider descriptors also assert the JS-only strategy shape on JavaScriptCore platforms while Linux continues to build the native compatibility targets.

The shared 20-second hung-script watchdog is production-default for these first-party cut-over providers. A timeout fails the current refresh and discards the poisoned worker so the next refresh receives a fresh JavaScriptCore context; it does not depend on the prototype flag.

## Deferred to the next slice

Four converted providers deliberately remain behind `CODEXBAR_JS_PROVIDERS` until their named host-API gaps are closed:

- OpenRouter: endpoint and header overrides plus the one-second best-effort enrichment deadline.
- ClawRouter: validated custom base URL support.
- Deepgram: native-equivalent 400/401/403, network, and parse error classification.
- sub2api: the total-request deadline plus 401/403 invalid-credential classification.

## Gates

- `make check` — passed; no formatting changes and zero SwiftLint violations
- `make build` — passed
- `make test` — passed 818/818 selections in 69/69 groups, with zero retries
- `swift build --target CodexBarLinuxTests` — passed
- structured Codex autoreview against `origin/main` — clean, no accepted/actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
