### PR TITLE
feat: classified errors, deadlines, and overrides for JS plugins; cut over four more providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Copilot: decode the AI credits counter for token-billed seats and expose it in `codexbar diagnose`, so Business seats with zero-entitlement quotas are no longer blank at the data layer (#2613, refs #2593). Thanks @Yuxin-Qiao, and @KSEGIT for the discovery!
 
 ### Changed
-- Provider plugins: use the bundled JavaScript implementation by default for Crof, Venice, OpenRouter, ClawRouter, and Deepgram on macOS, with identical golden-tested output and the native fetchers retained only for the Linux CLI.
+- Provider plugins: use the bundled JavaScript implementation by default for Crof, Venice, OpenRouter, ClawRouter, Deepgram, and sub2api on macOS, with identical golden-tested output and the native fetchers retained only for the Linux CLI.
 - Settings: refresh the Plugins pane to match the other panes — labeled install and directory rows with a Show in Finder affordance, a tilde-abbreviated path, a properly sized empty state, and consistent section footers.
 - Settings: localize every Plugins pane control, status, approval prompt, and alert across all complete app locales.
 - **Breaking JSON change:** provider-specific usage payload keys are being removed from `codexbar usage --format json`, `serve /usage`, and synced snapshots in favor of the generic Codable `usage.details` sections. The app and text CLI now render those same declarative rows and charts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Copilot: decode the AI credits counter for token-billed seats and expose it in `codexbar diagnose`, so Business seats with zero-entitlement quotas are no longer blank at the data layer (#2613, refs #2593). Thanks @Yuxin-Qiao, and @KSEGIT for the discovery!
 
 ### Changed
-- Provider plugins: use the bundled JavaScript implementation by default for Crof, Venice, and OpenRouter on macOS, with identical golden-tested output and the native fetchers retained only for the Linux CLI.
+- Provider plugins: use the bundled JavaScript implementation by default for Crof, Venice, OpenRouter, and ClawRouter on macOS, with identical golden-tested output and the native fetchers retained only for the Linux CLI.
 - Settings: refresh the Plugins pane to match the other panes — labeled install and directory rows with a Show in Finder affordance, a tilde-abbreviated path, a properly sized empty state, and consistent section footers.
 - Settings: localize every Plugins pane control, status, approval prompt, and alert across all complete app locales.
 - **Breaking JSON change:** provider-specific usage payload keys are being removed from `codexbar usage --format json`, `serve /usage`, and synced snapshots in favor of the generic Codable `usage.details` sections. The app and text CLI now render those same declarative rows and charts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Copilot: decode the AI credits counter for token-billed seats and expose it in `codexbar diagnose`, so Business seats with zero-entitlement quotas are no longer blank at the data layer (#2613, refs #2593). Thanks @Yuxin-Qiao, and @KSEGIT for the discovery!
 
 ### Changed
-- Provider plugins: use the bundled JavaScript implementation by default for Crof and Venice on macOS, with identical golden-tested output and the native fetchers retained only for the Linux CLI.
+- Provider plugins: use the bundled JavaScript implementation by default for Crof, Venice, and OpenRouter on macOS, with identical golden-tested output and the native fetchers retained only for the Linux CLI.
 - Settings: refresh the Plugins pane to match the other panes — labeled install and directory rows with a Show in Finder affordance, a tilde-abbreviated path, a properly sized empty state, and consistent section footers.
 - Settings: localize every Plugins pane control, status, approval prompt, and alert across all complete app locales.
 - **Breaking JSON change:** provider-specific usage payload keys are being removed from `codexbar usage --format json`, `serve /usage`, and synced snapshots in favor of the generic Codable `usage.details` sections. The app and text CLI now render those same declarative rows and charts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Copilot: decode the AI credits counter for token-billed seats and expose it in `codexbar diagnose`, so Business seats with zero-entitlement quotas are no longer blank at the data layer (#2613, refs #2593). Thanks @Yuxin-Qiao, and @KSEGIT for the discovery!
 
 ### Changed
-- Provider plugins: use the bundled JavaScript implementation by default for Crof, Venice, OpenRouter, and ClawRouter on macOS, with identical golden-tested output and the native fetchers retained only for the Linux CLI.
+- Provider plugins: use the bundled JavaScript implementation by default for Crof, Venice, OpenRouter, ClawRouter, and Deepgram on macOS, with identical golden-tested output and the native fetchers retained only for the Linux CLI.
 - Settings: refresh the Plugins pane to match the other panes — labeled install and directory rows with a Show in Finder affordance, a tilde-abbreviated path, a properly sized empty state, and consistent section footers.
 - Settings: localize every Plugins pane control, status, approval prompt, and alert across all complete app locales.
 - **Breaking JSON change:** provider-specific usage payload keys are being removed from `codexbar usage --format json`, `serve /usage`, and synced snapshots in favor of the generic Codable `usage.details` sections. The app and text CLI now render those same declarative rows and charts.

--- a/Sources/CodexBar/Providers/OpenRouter/OpenRouterProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/OpenRouter/OpenRouterProviderImplementation.swift
@@ -14,6 +14,7 @@ struct OpenRouterProviderImplementation: ProviderImplementation {
     @MainActor
     func observeSettings(_ settings: SettingsStore) {
         _ = settings.openRouterAPIToken
+        _ = settings.openRouterAPIURL
     }
 
     @MainActor
@@ -41,6 +42,16 @@ struct OpenRouterProviderImplementation: ProviderImplementation {
                 kind: .secure,
                 placeholder: "sk-or-v1-...",
                 binding: context.stringBinding(\.openRouterAPIToken),
+                actions: [],
+                isVisible: nil,
+                onActivate: nil),
+            ProviderSettingsFieldDescriptor(
+                id: "openrouter-api-url",
+                title: "API URL",
+                subtitle: "Optional. Defaults to the hosted OpenRouter API.",
+                kind: .plain,
+                placeholder: "https://openrouter.ai/api/v1",
+                binding: context.stringBinding(\.openRouterAPIURL),
                 actions: [],
                 isVisible: nil,
                 onActivate: nil),

--- a/Sources/CodexBar/Providers/OpenRouter/OpenRouterSettingsStore.swift
+++ b/Sources/CodexBar/Providers/OpenRouter/OpenRouterSettingsStore.swift
@@ -11,4 +11,13 @@ extension SettingsStore {
             self.logSecretUpdate(provider: .openrouter, field: "apiKey", value: newValue)
         }
     }
+
+    var openRouterAPIURL: String {
+        get { self.configSnapshot.providerConfig(for: .openrouter)?.sanitizedEnterpriseHost ?? "" }
+        set {
+            self.updateProviderConfig(provider: .openrouter) { entry in
+                entry.enterpriseHost = self.normalizedConfigValue(newValue)
+            }
+        }
+    }
 }

--- a/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
@@ -35,6 +35,7 @@ public enum CodexBarConfigValidator {
         .kimi,
         .litellm,
         .llmproxy,
+        .openrouter,
         .sub2api,
         .wayfinder,
     ]

--- a/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
@@ -545,7 +545,14 @@ private final class ProviderPluginWorker: @unchecked Sendable {
         let responseSizeLimit = self.responseSizeLimit
         Task.detached {
             do {
-                let response = try await transport.response(for: request)
+                let responseTask = Task { try await transport.response(for: request) }
+                let response: ProviderHTTPResponse = switch await BoundedTaskJoin(sourceTask: responseTask)
+                    .value(joinGrace: .seconds(request.timeoutInterval))
+                {
+                case let .value(response): response
+                case let .failure(error): throw error
+                case .timedOut: throw URLError(.timedOut)
+                }
                 guard response.data.count <= responseSizeLimit else {
                     throw ProviderPluginError.http("response exceeded the \(responseSizeLimit)-byte limit")
                 }
@@ -647,7 +654,7 @@ private final class ProviderPluginWorker: @unchecked Sendable {
             throw ProviderPluginError.networkPolicy("HTTP method is not allowed")
         }
         request.httpMethod = method
-        request.timeoutInterval = 15
+        request.timeoutInterval = try Self.timeoutSeconds(options)
         if method == "POST" {
             guard let bodyJSON = options.forProperty("bodyJSON"), bodyJSON.isString else {
                 throw ProviderPluginError.http("POST JSON body is missing")
@@ -696,6 +703,22 @@ private final class ProviderPluginWorker: @unchecked Sendable {
             request.setValue(authValue, forHTTPHeaderField: auth.header)
         }
         return request
+    }
+
+    private static func timeoutSeconds(_ options: JSValue) throws -> TimeInterval {
+        guard options.isObject,
+              let value = options.forProperty("timeoutSeconds"),
+              !value.isUndefined,
+              !value.isNull
+        else { return 15 }
+        guard value.isNumber else {
+            throw ProviderPluginError.http("timeoutSeconds must be a number from 1 through 30")
+        }
+        let seconds = value.toDouble()
+        guard seconds.isFinite, (1...30).contains(seconds) else {
+            throw ProviderPluginError.http("timeoutSeconds must be a number from 1 through 30")
+        }
+        return seconds
     }
 
     private func allowedOrigin(for url: URL, settings: [String: String]) throws -> Bool {

--- a/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
@@ -164,6 +164,9 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
             case .script: return ProviderPluginError.script(message.removingPluginErrorPrefix)
             }
         }
+        if let classifiedError = error as? ProviderFetchClassifiedError {
+            return ProviderFetchClassifiedError(kind: classifiedError.kind, message: message)
+        }
         return ProviderPluginError.script(message)
     }
 }
@@ -405,7 +408,7 @@ private final class ProviderPluginWorker: @unchecked Sendable {
         let reject: @convention(block) (JSValue) -> Void = { [weak self] value in
             guard let self else { return }
             defer { self.retainedCallbacks[callbackID] = nil }
-            completion(.failure(ProviderPluginError.script(redactionValues.redact(self.message(from: value)))))
+            completion(.failure(self.failure(from: value, redactionValues: redactionValues)))
         }
         self.retainedCallbacks[callbackID] = [resolve, reject]
 
@@ -754,6 +757,23 @@ private final class ProviderPluginWorker: @unchecked Sendable {
             return message.toString()
         }
         return value.toString()
+    }
+
+    private func failure(
+        from value: JSValue,
+        redactionValues: ProviderPluginRedactionValues) -> Error
+    {
+        let message = redactionValues.redact(self.message(from: value))
+        let marker = "__CODEXBAR_FAILURE__:"
+        if message.hasPrefix(marker),
+           let separator = message[message.index(message.startIndex, offsetBy: marker.count)...].firstIndex(of: ":"),
+           let kind = ProviderFetchClassifiedError.Kind(
+               rawValue: String(message[message.index(message.startIndex, offsetBy: marker.count)..<separator]))
+        {
+            let body = String(message[message.index(after: separator)...])
+            return ProviderFetchClassifiedError(kind: kind, message: body)
+        }
+        return ProviderPluginError.script(message)
     }
 
     private static func exceptionMessage(_ context: JSContext) -> String? {

--- a/Sources/CodexBarCore/Plugins/ProviderPluginSnapshotMapper.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginSnapshotMapper.swift
@@ -19,6 +19,7 @@ enum ProviderPluginSnapshotMapper {
         let identity = try self.identity(value, provider: provider)
         let subscriptionRenewsAt = try self.optionalDate(value, property: "subscriptionRenewsAt")
         let subscriptionExpiresAt = try self.optionalDate(value, property: "subscriptionExpiresAt")
+        let dataConfidence = try self.dataConfidence(value)
 
         guard primary != nil || secondary != nil || tertiary != nil || !(extraRateWindows?.isEmpty ?? true)
             || providerCost != nil
@@ -37,7 +38,19 @@ enum ProviderPluginSnapshotMapper {
             subscriptionExpiresAt: subscriptionExpiresAt,
             subscriptionRenewsAt: subscriptionRenewsAt,
             updatedAt: now,
-            identity: identity)
+            identity: identity,
+            dataConfidence: dataConfidence)
+    }
+
+    private static func dataConfidence(_ root: JSValue) throws -> UsageDataConfidence {
+        guard let value = root.forProperty("dataConfidence"), !value.isUndefined, !value.isNull else {
+            return .unknown
+        }
+        guard value.isString, let confidence = UsageDataConfidence(rawValue: value.toString()) else {
+            throw ProviderPluginError.invalidSnapshot(
+                "dataConfidence must be 'exact', 'estimated', 'percentOnly', or 'unknown'")
+        }
+        return confidence
     }
 
     private static func details(_ root: JSValue) throws -> [ProviderDetailSection] {

--- a/Sources/CodexBarCore/Plugins/ScriptFetchStrategy.swift
+++ b/Sources/CodexBarCore/Plugins/ScriptFetchStrategy.swift
@@ -22,6 +22,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
     }
 
     public typealias ValuesResolver = @Sendable (ProviderFetchContext) -> Values?
+    public typealias ContextValidator = @Sendable (ProviderFetchContext) throws -> Void
     public typealias EnabledResolver = @Sendable ([String: String]) -> Bool
 
     public let id: String
@@ -32,6 +33,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
     private let sourceLabel: String
     private let secretKey: String?
     private let resolveValues: ValuesResolver
+    private let validateContext: ContextValidator
     private let isEnabled: EnabledResolver
     private let transport: any ProviderHTTPTransport
     private let timeout: TimeInterval
@@ -47,6 +49,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         kind: ProviderFetchKind = .apiToken,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
+        validateContext: @escaping ContextValidator = { _ in },
         resolveSecret: @escaping SecretResolver,
         isEnabled: @escaping EnabledResolver = { ProviderPluginPrototype.isEnabled(environment: $0) })
     {
@@ -58,6 +61,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         self.secretKey = secretKey
         self.transport = transport
         self.timeout = timeout
+        self.validateContext = validateContext
         self.resolveValues = { context in
             guard let secret = resolveSecret(context.env) else { return nil }
             return Values(secrets: [secretKey: secret])
@@ -74,6 +78,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         kind: ProviderFetchKind = .apiToken,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
+        validateContext: @escaping ContextValidator = { _ in },
         resolveValues: @escaping ValuesResolver,
         isEnabled: @escaping EnabledResolver = { ProviderPluginPrototype.isEnabled(environment: $0) })
     {
@@ -85,6 +90,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         self.secretKey = secretKey
         self.transport = transport
         self.timeout = timeout
+        self.validateContext = validateContext
         self.resolveValues = resolveValues
         self.isEnabled = isEnabled
     }
@@ -99,6 +105,7 @@ public final class ScriptFetchStrategy: ProviderFetchStrategy, @unchecked Sendab
         guard self.isEnabled(context.env) else {
             throw ProviderPluginError.load("JavaScript provider prototype is disabled")
         }
+        try self.validateContext(context)
         guard let values = self.resolveValues(context) else {
             throw ProviderPluginError.secretAccess("required provider secret is unavailable")
         }
@@ -165,6 +172,8 @@ extension ProviderFetchPlan {
     static func scriptPrototypeAPI(
         configuration: ScriptPrototypeAPIConfiguration,
         resolveToken: @escaping APITokenFetchStrategy.TokenResolver,
+        resolveSettings: @escaping @Sendable ([String: String]) -> [String: String] = { _ in [:] },
+        validateContext: @escaping ScriptFetchStrategy.ContextValidator = { _ in },
         missingCredentialsError: @escaping APITokenFetchStrategy.MissingCredentialsError,
         loadUsage: @escaping APITokenFetchStrategy.UsageLoader) -> ProviderFetchPlan
     {
@@ -187,7 +196,13 @@ extension ProviderFetchPlan {
                         provider: configuration.provider,
                         bundledPlugin: configuration.plugin,
                         secretKey: configuration.secretKey,
-                        resolveSecret: resolveToken),
+                        validateContext: validateContext,
+                        resolveValues: { context in
+                            guard let token = resolveToken(context.env) else { return nil }
+                            return ScriptFetchStrategy.Values(
+                                settings: resolveSettings(context.env),
+                                secrets: [configuration.secretKey: token])
+                        }),
                     swift,
                 ]
             }))

--- a/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
@@ -59,7 +59,20 @@ public enum ClawRouterProviderDescriptor {
                         provider: .clawrouter,
                         bundledPlugin: "clawrouter",
                         secretKey: ClawRouterSettingsReader.apiKeyEnvironmentKey,
-                        resolveSecret: { ProviderTokenResolver.clawRouterToken(environment: $0) }),
+                        validateContext: { context in
+                            try ClawRouterSettingsReader.validateEndpointOverride(environment: context.env)
+                        },
+                        resolveValues: { context in
+                            guard let token = ProviderTokenResolver.clawRouterToken(environment: context.env) else {
+                                return nil
+                            }
+                            return ScriptFetchStrategy.Values(
+                                settings: [
+                                    ClawRouterSettingsReader.baseURLEnvironmentKey:
+                                        ClawRouterSettingsReader.baseURL(environment: context.env).absoluteString,
+                                ],
+                                secrets: [ClawRouterSettingsReader.apiKeyEnvironmentKey: token])
+                        }),
                     swift,
                 ]
             }))

--- a/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
@@ -6,7 +6,7 @@ public enum ClawRouterProviderDescriptor {
         environmentKey: ClawRouterSettingsReader.apiKeyEnvironmentKey,
         additionalProjections: [.enterpriseHost(ClawRouterSettingsReader.baseURLEnvironmentKey)],
         resolve: ClawRouterSettingsReader.apiKey,
-        missingCredentialMessage: { _ in ClawRouterUsageError.missingCredentials.errorDescription })
+        missingCredentialMessage: { _ in ClawRouterSettingsReader.missingCredentialsMessage })
 
     static func makeDescriptor() -> ProviderDescriptor {
         ProviderDescriptor(
@@ -50,33 +50,31 @@ public enum ClawRouterProviderDescriptor {
         #if canImport(JavaScriptCore)
         ProviderFetchPlan(
             sourceModes: [.auto, .api],
-            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
-                let swift = ClawRouterAPIFetchStrategy()
-                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
-                return [
-                    ScriptFetchStrategy(
-                        id: "clawrouter.js",
-                        provider: .clawrouter,
-                        bundledPlugin: "clawrouter",
-                        secretKey: ClawRouterSettingsReader.apiKeyEnvironmentKey,
-                        validateContext: { context in
-                            try ClawRouterSettingsReader.validateEndpointOverride(environment: context.env)
-                        },
-                        resolveValues: { context in
-                            guard let token = ProviderTokenResolver.clawRouterToken(environment: context.env) else {
-                                return nil
-                            }
-                            return ScriptFetchStrategy.Values(
-                                settings: [
-                                    ClawRouterSettingsReader.baseURLEnvironmentKey:
-                                        ClawRouterSettingsReader.baseURL(environment: context.env).absoluteString,
-                                ],
-                                secrets: [ClawRouterSettingsReader.apiKeyEnvironmentKey: token])
-                        }),
-                    swift,
-                ]
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in
+                [ScriptFetchStrategy(
+                    id: "clawrouter.js",
+                    provider: .clawrouter,
+                    bundledPlugin: "clawrouter",
+                    secretKey: ClawRouterSettingsReader.apiKeyEnvironmentKey,
+                    sourceLabel: "api",
+                    validateContext: { context in
+                        try ClawRouterSettingsReader.validateEndpointOverride(environment: context.env)
+                    },
+                    resolveValues: { context in
+                        guard let token = self.credentials.resolveToken(environment: context.env)?.token else {
+                            return nil
+                        }
+                        return ScriptFetchStrategy.Values(
+                            settings: [
+                                ClawRouterSettingsReader.baseURLEnvironmentKey:
+                                    ClawRouterSettingsReader.baseURL(environment: context.env).absoluteString,
+                            ],
+                            secrets: [ClawRouterSettingsReader.apiKeyEnvironmentKey: token])
+                    },
+                    isEnabled: { _ in true })]
             }))
         #else
+        // Linux compatibility only. JavaScriptCore platforms use the bundled ClawRouter plugin above.
         ProviderFetchPlan(
             sourceModes: [.auto, .api],
             pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [ClawRouterAPIFetchStrategy()] }))
@@ -84,6 +82,7 @@ public enum ClawRouterProviderDescriptor {
     }
 }
 
+#if !canImport(JavaScriptCore)
 struct ClawRouterAPIFetchStrategy: ProviderFetchStrategy {
     let id = "clawrouter.api"
     let kind: ProviderFetchKind = .apiToken
@@ -107,3 +106,4 @@ struct ClawRouterAPIFetchStrategy: ProviderFetchStrategy {
         false
     }
 }
+#endif

--- a/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterSettingsReader.swift
@@ -15,6 +15,8 @@ public enum ClawRouterSettingsReader {
     public static let apiKeyEnvironmentKey = "CLAWROUTER_API_KEY"
     public static let baseURLEnvironmentKey = "CLAWROUTER_BASE_URL"
     public static let defaultBaseURL = URL(string: "https://clawrouter.openclaw.ai")!
+    public static let missingCredentialsMessage =
+        "Missing ClawRouter API key. Add one in Settings or set CLAWROUTER_API_KEY."
 
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?

--- a/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterUsageFetcher.swift
@@ -1,3 +1,5 @@
+// Linux compatibility only. JavaScriptCore platforms use the bundled ClawRouter plugin.
+#if !canImport(JavaScriptCore)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -297,3 +299,4 @@ public enum ClawRouterUsageFetcher {
             day: 1).date
     }
 }
+#endif

--- a/Sources/CodexBarCore/Providers/Deepgram/DeepgramProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Deepgram/DeepgramProviderDescriptor.swift
@@ -69,46 +69,49 @@ public enum DeepgramProviderDescriptor {
     }
 
     private static func fetchPlan() -> ProviderFetchPlan {
+        #if canImport(JavaScriptCore)
         ProviderFetchPlan(
             sourceModes: [.auto, .api],
-            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
-                let swift = DeepgramAPIFetchStrategy()
-                #if canImport(JavaScriptCore)
-                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
-                return [
-                    ScriptFetchStrategy(
-                        id: "deepgram.js",
-                        provider: .deepgram,
-                        bundledPlugin: "deepgram",
-                        secretKey: DeepgramSettingsReader.apiKeyEnvironmentKey,
-                        resolveValues: { context in
-                            guard let key = ProviderTokenResolver.deepgramResolution(
-                                type: .apiKey,
-                                environment: context.env)
-                            else { return nil }
-                            var settings: [String: String] = [:]
-                            if let project = ProviderTokenResolver.deepgramResolution(
-                                type: .projectID,
-                                environment: context.env)
-                            {
-                                settings[DeepgramSettingsReader.projectIDEnvironmentKey] = project
-                            }
-                            if let apiURL = context.env[DeepgramUsageFetcher.apiURLKey] {
-                                settings[DeepgramUsageFetcher.apiURLKey] = apiURL
-                            }
-                            return ScriptFetchStrategy.Values(
-                                settings: settings,
-                                secrets: [DeepgramSettingsReader.apiKeyEnvironmentKey: key])
-                        }),
-                    swift,
-                ]
-                #else
-                return [swift]
-                #endif
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in
+                [ScriptFetchStrategy(
+                    id: "deepgram.js",
+                    provider: .deepgram,
+                    bundledPlugin: "deepgram",
+                    secretKey: DeepgramSettingsReader.apiKeyEnvironmentKey,
+                    sourceLabel: "api",
+                    validateContext: { context in
+                        try DeepgramSettingsReader.validateEndpointOverride(environment: context.env)
+                    },
+                    resolveValues: { context in
+                        guard let key = self.credentials.resolveToken(
+                            environment: context.env)?.token
+                        else { return nil }
+                        var settings = [
+                            DeepgramSettingsReader.apiURLEnvironmentKey:
+                                DeepgramSettingsReader.apiURL(environment: context.env).absoluteString,
+                        ]
+                        if let project = self.credentials.resolveToken(
+                            kind: .projectID,
+                            environment: context.env)?.token
+                        {
+                            settings[DeepgramSettingsReader.projectIDEnvironmentKey] = project
+                        }
+                        return ScriptFetchStrategy.Values(
+                            settings: settings,
+                            secrets: [DeepgramSettingsReader.apiKeyEnvironmentKey: key])
+                    },
+                    isEnabled: { _ in true })]
             }))
+        #else
+        // Linux compatibility only. JavaScriptCore platforms use the bundled Deepgram plugin above.
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [DeepgramAPIFetchStrategy()] }))
+        #endif
     }
 }
 
+#if !canImport(JavaScriptCore)
 struct DeepgramAPIFetchStrategy: ProviderFetchStrategy {
     let id: String = "deepgram.api"
     let kind: ProviderFetchKind = .apiToken
@@ -148,15 +151,19 @@ struct DeepgramAPIFetchStrategy: ProviderFetchStrategy {
             environment: context.env)
     }
 }
+#endif
 
 /// Errors related to Deepgram settings
 public enum DeepgramSettingsError: LocalizedError, Sendable {
     case missingToken
+    case invalidEndpointOverride(String)
 
     public var errorDescription: String? {
         switch self {
         case .missingToken:
             "Deepgram API token not configured. Set DEEPGRAM_API_KEY environment variable or configure in Settings."
+        case let .invalidEndpointOverride(key):
+            "Deepgram endpoint override \(key) must use HTTPS or a bare host."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Deepgram/DeepgramSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Deepgram/DeepgramSettingsReader.swift
@@ -3,6 +3,8 @@ import Foundation
 public struct DeepgramSettingsReader: Sendable {
     public static let apiKeyEnvironmentKey = "DEEPGRAM_API_KEY"
     public static let projectIDEnvironmentKey = "DEEPGRAM_PROJECT_ID"
+    public static let apiURLEnvironmentKey = "DEEPGRAM_API_URL"
+    public static let defaultAPIURL = URL(string: "https://api.deepgram.com/v1")!
 
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
@@ -14,6 +16,22 @@ public struct DeepgramSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         self.cleaned(environment[self.projectIDEnvironmentKey])
+    }
+
+    public static func apiURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> URL
+    {
+        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return self.defaultAPIURL }
+        return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) ?? self.defaultAPIURL
+    }
+
+    public static func validateEndpointOverride(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
+        guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) != nil else {
+            throw DeepgramSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
+        }
     }
 
     private static func cleaned(_ raw: String?) -> String? {

--- a/Sources/CodexBarCore/Providers/Deepgram/DeepgramUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Deepgram/DeepgramUsageFetcher.swift
@@ -1,3 +1,5 @@
+// Linux compatibility only. JavaScriptCore platforms use the bundled Deepgram plugin.
+#if !canImport(JavaScriptCore)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -584,3 +586,4 @@ public struct DeepgramUsageFetcher: Sendable {
         }
     }
 }
+#endif

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterProviderDescriptor.swift
@@ -70,35 +70,39 @@ public enum OpenRouterProviderDescriptor {
 
     private static func fetchPlan() -> ProviderFetchPlan {
         #if canImport(JavaScriptCore)
-        .scriptPrototypeAPI(
-            configuration: .init(
-                provider: .openrouter,
-                plugin: "openrouter",
-                secretKey: OpenRouterSettingsReader.envKey,
-                strategyID: "openrouter.api"),
-            resolveToken: { ProviderTokenResolver.openRouterToken(environment: $0) },
-            resolveSettings: { environment in
-                var settings = [
-                    OpenRouterSettingsReader.apiURLEnvironmentKey:
-                        OpenRouterSettingsReader.apiURL(environment: environment).absoluteString,
-                    OpenRouterSettingsReader.clientTitleEnvironmentKey:
-                        OpenRouterSettingsReader.clientTitle(environment: environment),
-                ]
-                if let referer = OpenRouterSettingsReader.httpReferer(environment: environment) {
-                    settings[OpenRouterSettingsReader.httpRefererEnvironmentKey] = referer
-                }
-                return settings
-            },
-            validateContext: { context in
-                try OpenRouterSettingsReader.validateEndpointOverrides(environment: context.env)
-            },
-            missingCredentialsError: { OpenRouterSettingsError.missingToken },
-            loadUsage: { apiKey, context in
-                try await OpenRouterUsageFetcher.fetchUsage(
-                    apiKey: apiKey,
-                    environment: context.env).toUsageSnapshot()
-            })
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in
+                [ScriptFetchStrategy(
+                    id: "openrouter.js",
+                    provider: .openrouter,
+                    bundledPlugin: "openrouter",
+                    secretKey: OpenRouterSettingsReader.envKey,
+                    sourceLabel: "api",
+                    validateContext: { context in
+                        try OpenRouterSettingsReader.validateEndpointOverrides(environment: context.env)
+                    },
+                    resolveValues: { context in
+                        guard let token = self.credentials.resolveToken(environment: context.env)?.token else {
+                            return nil
+                        }
+                        var settings = [
+                            OpenRouterSettingsReader.apiURLEnvironmentKey:
+                                OpenRouterSettingsReader.apiURL(environment: context.env).absoluteString,
+                            OpenRouterSettingsReader.clientTitleEnvironmentKey:
+                                OpenRouterSettingsReader.clientTitle(environment: context.env),
+                        ]
+                        if let referer = OpenRouterSettingsReader.httpReferer(environment: context.env) {
+                            settings[OpenRouterSettingsReader.httpRefererEnvironmentKey] = referer
+                        }
+                        return ScriptFetchStrategy.Values(
+                            settings: settings,
+                            secrets: [OpenRouterSettingsReader.envKey: token])
+                    },
+                    isEnabled: { _ in true })]
+            }))
         #else
+        // Linux compatibility only. JavaScriptCore platforms use the bundled OpenRouter plugin above.
         .apiToken(
             strategyID: "openrouter.api",
             resolveToken: { ProviderTokenResolver.openRouterToken(environment: $0) },

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterProviderDescriptor.swift
@@ -4,6 +4,7 @@ public enum OpenRouterProviderDescriptor {
     public static let descriptor: ProviderDescriptor = Self.makeDescriptor()
     private static let credentials = ProviderCredentialAdapter.apiKey(
         environmentKey: OpenRouterSettingsReader.envKey,
+        additionalProjections: [.enterpriseHost(OpenRouterSettingsReader.apiURLEnvironmentKey)],
         resolve: OpenRouterSettingsReader.apiToken,
         tokenAccountSupport: TokenAccountSupport(
             title: "API keys",
@@ -12,6 +13,18 @@ public enum OpenRouterProviderDescriptor {
             injection: .environment(key: OpenRouterSettingsReader.envKey),
             requiresManualCookieSource: false,
             cookieName: nil),
+        configValidator: { config in
+            guard let raw = config.sanitizedEnterpriseHost,
+                  ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil
+            else { return [] }
+            return [CodexBarConfigIssue(
+                severity: .error,
+                provider: .openrouter,
+                field: "enterpriseHost",
+                code: "invalid_enterprise_host",
+                message: OpenRouterSettingsError.invalidEndpointOverride(
+                    OpenRouterSettingsReader.apiURLEnvironmentKey).errorDescription ?? "Invalid OpenRouter API URL.")]
+        },
         missingCredentialMessage: { _ in OpenRouterSettingsError.missingToken.errorDescription })
 
     static func makeDescriptor() -> ProviderDescriptor {
@@ -64,6 +77,21 @@ public enum OpenRouterProviderDescriptor {
                 secretKey: OpenRouterSettingsReader.envKey,
                 strategyID: "openrouter.api"),
             resolveToken: { ProviderTokenResolver.openRouterToken(environment: $0) },
+            resolveSettings: { environment in
+                var settings = [
+                    OpenRouterSettingsReader.apiURLEnvironmentKey:
+                        OpenRouterSettingsReader.apiURL(environment: environment).absoluteString,
+                    OpenRouterSettingsReader.clientTitleEnvironmentKey:
+                        OpenRouterSettingsReader.clientTitle(environment: environment),
+                ]
+                if let referer = OpenRouterSettingsReader.httpReferer(environment: environment) {
+                    settings[OpenRouterSettingsReader.httpRefererEnvironmentKey] = referer
+                }
+                return settings
+            },
+            validateContext: { context in
+                try OpenRouterSettingsReader.validateEndpointOverrides(environment: context.env)
+            },
             missingCredentialsError: { OpenRouterSettingsError.missingToken },
             loadUsage: { apiKey, context in
                 try await OpenRouterUsageFetcher.fetchUsage(

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
@@ -4,6 +4,10 @@ import Foundation
 public enum OpenRouterSettingsReader {
     /// Environment variable key for OpenRouter API token
     public static let envKey = "OPENROUTER_API_KEY"
+    public static let apiURLEnvironmentKey = "OPENROUTER_API_URL"
+    public static let httpRefererEnvironmentKey = "OPENROUTER_HTTP_REFERER"
+    public static let clientTitleEnvironmentKey = "OPENROUTER_X_TITLE"
+    public static let defaultClientTitle = "CodexBar"
 
     /// Returns the API token from environment if present and non-empty
     public static func apiToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
@@ -21,9 +25,17 @@ public enum OpenRouterSettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment["OPENROUTER_API_URL"]) else { return }
+        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
-        throw OpenRouterSettingsError.invalidEndpointOverride("OPENROUTER_API_URL")
+        throw OpenRouterSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
+    }
+
+    public static func httpReferer(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.cleaned(environment[self.httpRefererEnvironmentKey])
+    }
+
+    public static func clientTitle(environment: [String: String] = ProcessInfo.processInfo.environment) -> String {
+        self.cleaned(environment[self.clientTitleEnvironmentKey]) ?? self.defaultClientTitle
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -42,7 +54,7 @@ public enum OpenRouterSettingsReader {
     }
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
-        guard let raw = self.cleaned(environment["OPENROUTER_API_URL"]) else { return nil }
+        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
@@ -308,9 +308,6 @@ public struct OpenRouterUsageFetcher: Sendable {
     private static let maxErrorBodyLength = 240
     private static let maxDebugErrorBodyLength = 2000
     private static let debugFullErrorBodiesEnvKey = "CODEXBAR_DEBUG_OPENROUTER_ERROR_BODIES"
-    private static let httpRefererEnvKey = "OPENROUTER_HTTP_REFERER"
-    private static let clientTitleEnvKey = "OPENROUTER_X_TITLE"
-    private static let defaultClientTitle = "CodexBar"
 
     /// Fetches credits usage from OpenRouter using the provided API key
     public static func fetchUsage(
@@ -331,11 +328,10 @@ public struct OpenRouterUsageFetcher: Sendable {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = Self.creditsRequestTimeoutSeconds
-        if let referer = Self.sanitizedHeaderValue(environment[self.httpRefererEnvKey]) {
+        if let referer = OpenRouterSettingsReader.httpReferer(environment: environment) {
             request.setValue(referer, forHTTPHeaderField: "HTTP-Referer")
         }
-        let title = Self.sanitizedHeaderValue(environment[self.clientTitleEnvKey]) ?? Self.defaultClientTitle
-        request.setValue(title, forHTTPHeaderField: "X-Title")
+        request.setValue(OpenRouterSettingsReader.clientTitle(environment: environment), forHTTPHeaderField: "X-Title")
 
         let response = try await transport.response(for: request)
         let data = response.data
@@ -477,10 +473,6 @@ public struct OpenRouterUsageFetcher: Sendable {
 
     private static func debugFullErrorBodiesEnabled(environment: [String: String]) -> Bool {
         environment[self.debugFullErrorBodiesEnvKey] == "1"
-    }
-
-    private static func sanitizedHeaderValue(_ raw: String?) -> String? {
-        OpenRouterSettingsReader.cleaned(raw)
     }
 
     private static func sanitizedResponseBodySummary(_ data: Data) -> String {

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
@@ -1,3 +1,5 @@
+// Linux compatibility only. JavaScriptCore platforms use the bundled OpenRouter plugin.
+#if !canImport(JavaScriptCore)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -557,3 +559,4 @@ public enum OpenRouterUsageError: LocalizedError, Sendable {
         }
     }
 }
+#endif

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -176,8 +176,12 @@ public struct ProviderDiagnosticUsageSummary: Codable, Sendable {
         }
 
         var providerSpecificData: [String] = []
-        if snapshot.openAIAPIUsage != nil { providerSpecificData.append("openAIAPIUsage") }
-        if snapshot.mistralUsage != nil { providerSpecificData.append("mistralUsage") }
+        if snapshot.openAIAPIUsage != nil {
+            providerSpecificData.append("openAIAPIUsage")
+        }
+        if snapshot.mistralUsage != nil {
+            providerSpecificData.append("mistralUsage")
+        }
 
         self.updatedAt = snapshot.updatedAt
         self.dataConfidence = snapshot.dataConfidence.rawValue
@@ -336,6 +340,14 @@ public struct ProviderDiagnosticError: Codable, Sendable {
         if error is ProviderEndpointOverrideError {
             return "configuration"
         }
+        if let pluginError = error as? ProviderFetchClassifiedError {
+            return switch pluginError.kind {
+            case .authenticationExpired, .missingCredential, .permissionDenied: "auth"
+            case .rateLimited, .providerUnavailable, .apiFailure: "api"
+            case .parseFailure: "parse"
+            case .networkFailure: "network"
+            }
+        }
         if let minimaxError = error as? MiniMaxUsageError {
             switch minimaxError {
             case .networkError: return "network"
@@ -352,7 +364,9 @@ public struct ProviderDiagnosticError: Codable, Sendable {
             case .parseFailed: return "parse"
             }
         }
-        if error is MiniMaxSettingsError || error is MiniMaxAPISettingsError { return "auth" }
+        if error is MiniMaxSettingsError || error is MiniMaxAPISettingsError {
+            return "auth"
+        }
         return ProviderDiagnosticFetchAttempt.errorCategoryLabel(error.localizedDescription)
     }
 

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -199,6 +199,31 @@ public enum ProviderFetchError: LocalizedError, Sendable {
     }
 }
 
+public struct ProviderFetchClassifiedError: LocalizedError, Sendable, Equatable {
+    public enum Kind: String, Sendable, CaseIterable {
+        case authenticationExpired = "authentication-expired"
+        case missingCredential = "missing-credential"
+        case permissionDenied = "permission-denied"
+        case rateLimited = "rate-limited"
+        case providerUnavailable = "provider-unavailable"
+        case parseFailure = "parse-failure"
+        case networkFailure = "network-failure"
+        case apiFailure = "api-failure"
+    }
+
+    public let kind: Kind
+    public let message: String
+
+    public init(kind: Kind, message: String) {
+        self.kind = kind
+        self.message = message
+    }
+
+    public var errorDescription: String? {
+        self.message
+    }
+}
+
 public enum ProviderFetchKind: Sendable {
     case cli
     case web

--- a/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
@@ -27,8 +27,8 @@ public enum Sub2APIProviderDescriptor {
         },
         missingCredentialMessage: { environment in
             Sub2APISettingsReader.apiKey(environment: environment) == nil
-                ? Sub2APIUsageError.missingCredentials.errorDescription
-                : Sub2APIUsageError.missingBaseURL.errorDescription
+                ? Sub2APISettingsReader.missingCredentialsMessage
+                : Sub2APISettingsReader.missingBaseURLMessage
         })
 
     public static func primaryLabel(snapshot: UsageSnapshot) -> String? {
@@ -72,35 +72,36 @@ public enum Sub2APIProviderDescriptor {
             versionDetector: nil))
 
     private static func fetchPlan() -> ProviderFetchPlan {
+        #if canImport(JavaScriptCore)
         ProviderFetchPlan(
             sourceModes: [.auto, .api],
-            pipeline: ProviderFetchPipeline(resolveStrategies: { context in
-                let swift = Sub2APIAPIFetchStrategy()
-                #if canImport(JavaScriptCore)
-                guard ProviderPluginPrototype.isEnabled(environment: context.env) else { return [swift] }
-                return [
-                    ScriptFetchStrategy(
-                        id: "sub2api.js",
-                        provider: .sub2api,
-                        bundledPlugin: "sub2api",
-                        secretKey: Sub2APISettingsReader.apiKeyEnvironmentKey,
-                        resolveValues: { context in
-                            guard let key = Sub2APISettingsReader.apiKey(environment: context.env),
-                                  let baseURL = Sub2APISettingsReader.baseURL(environment: context.env)
-                            else { return nil }
-                            return ScriptFetchStrategy.Values(
-                                settings: [Sub2APISettingsReader.baseURLEnvironmentKey: baseURL.absoluteString],
-                                secrets: [Sub2APISettingsReader.apiKeyEnvironmentKey: key])
-                        }),
-                    swift,
-                ]
-                #else
-                return [swift]
-                #endif
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in
+                [ScriptFetchStrategy(
+                    id: "sub2api.js",
+                    provider: .sub2api,
+                    bundledPlugin: "sub2api",
+                    secretKey: Sub2APISettingsReader.apiKeyEnvironmentKey,
+                    sourceLabel: "api",
+                    resolveValues: { context in
+                        guard let key = self.credentials.resolveToken(environment: context.env)?.token,
+                              let baseURL = Sub2APISettingsReader.baseURL(environment: context.env)
+                        else { return nil }
+                        return ScriptFetchStrategy.Values(
+                            settings: [Sub2APISettingsReader.baseURLEnvironmentKey: baseURL.absoluteString],
+                            secrets: [Sub2APISettingsReader.apiKeyEnvironmentKey: key])
+                    },
+                    isEnabled: { _ in true })]
             }))
+        #else
+        // Linux compatibility only. JavaScriptCore platforms use the bundled sub2api plugin above.
+        ProviderFetchPlan(
+            sourceModes: [.auto, .api],
+            pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [Sub2APIAPIFetchStrategy()] }))
+        #endif
     }
 }
 
+#if !canImport(JavaScriptCore)
 struct Sub2APIAPIFetchStrategy: ProviderFetchStrategy {
     let id = "sub2api.api"
     let kind: ProviderFetchKind = .apiToken
@@ -125,3 +126,4 @@ struct Sub2APIAPIFetchStrategy: ProviderFetchStrategy {
         false
     }
 }
+#endif

--- a/Sources/CodexBarCore/Providers/Sub2API/Sub2APISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Sub2API/Sub2APISettingsReader.swift
@@ -11,6 +11,10 @@ public enum Sub2APISettingsError: LocalizedError, Equatable, Sendable {
 public enum Sub2APISettingsReader {
     public static let apiKeyEnvironmentKey = "SUB2API_API_KEY"
     public static let baseURLEnvironmentKey = "SUB2API_BASE_URL"
+    public static let missingCredentialsMessage =
+        "Missing sub2api API key. Add a group API key in Settings or set SUB2API_API_KEY."
+    public static let missingBaseURLMessage =
+        "Missing or invalid sub2api base URL. Add one in Settings or set SUB2API_BASE_URL."
 
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?

--- a/Sources/CodexBarCore/Providers/Sub2API/Sub2APIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Sub2API/Sub2APIUsageFetcher.swift
@@ -1,3 +1,5 @@
+// Linux compatibility only. JavaScriptCore platforms use the bundled sub2api plugin.
+#if !canImport(JavaScriptCore)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -415,3 +417,4 @@ public struct Sub2APIUsageFetcher: Sendable {
         return fractional.date(from: raw) ?? ISO8601DateFormatter().date(from: raw)
     }
 }
+#endif

--- a/Sources/CodexBarCore/Resources/Plugins/clawrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/clawrouter.js
@@ -1,17 +1,22 @@
 defineProvider({
   id: "clawrouter",
   name: "ClawRouter",
-  endpoints: ["https://clawrouter.openclaw.ai"],
+  endpoints: ["https://clawrouter.openclaw.ai", { setting: "CLAWROUTER_BASE_URL", policy: "https" }],
   auth: { type: "bearer", secret: "CLAWROUTER_API_KEY" },
-  settings: [{
-    key: "CLAWROUTER_API_KEY",
-    title: "API key",
-    subtitle: "ClawRouter policy key used for the usage ledger.",
-    type: "secure",
-  }],
+  settings: [
+    {
+      key: "CLAWROUTER_API_KEY",
+      title: "API key",
+      subtitle: "ClawRouter policy key used for the usage ledger.",
+      type: "secure",
+    },
+    { key: "CLAWROUTER_BASE_URL", title: "Base URL", type: "plain" },
+  ],
 
   async fetchUsage(ctx) {
-    const response = await ctx.http.getJSON("https://clawrouter.openclaw.ai/v1/usage");
+    let base = (ctx.settings.get("CLAWROUTER_BASE_URL") || "https://clawrouter.openclaw.ai").replace(/\/+$/, "");
+    if (!/\/v1$/.test(base)) base += "/v1";
+    const response = await ctx.http.getJSON(`${base}/usage`);
     if (response.status === 401 || response.status === 403) {
       throw new Error("ClawRouter rejected the API key");
     }

--- a/Sources/CodexBarCore/Resources/Plugins/clawrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/clawrouter.js
@@ -16,21 +16,32 @@ defineProvider({
   async fetchUsage(ctx) {
     let base = (ctx.settings.get("CLAWROUTER_BASE_URL") || "https://clawrouter.openclaw.ai").replace(/\/+$/, "");
     if (!/\/v1$/.test(base)) base += "/v1";
-    const response = await ctx.http.getJSON(`${base}/usage`);
+    const response = await ctx.http.get(`${base}/usage`);
     if (response.status === 401 || response.status === 403) {
-      throw new Error("ClawRouter rejected the API key");
+      throw ctx.fail.authenticationExpired("ClawRouter rejected the API key. Check the key and its policy status.");
+    }
+    if (response.status === 429) throw ctx.fail.rateLimited("ClawRouter API returned HTTP 429.");
+    if (response.status >= 500) {
+      throw ctx.fail.providerUnavailable(`ClawRouter API returned HTTP ${response.status}.`);
     }
     if (response.status < 200 || response.status >= 300) {
-      throw new Error(`ClawRouter API error: HTTP ${response.status}`);
+      throw ctx.fail.apiFailure(`ClawRouter API returned HTTP ${response.status}.`);
     }
-    const payload = response.json;
+    let payload;
+    try {
+      payload = JSON.parse(response.bodyText);
+    } catch (_) {
+      throw ctx.fail.parseFailure("Could not parse ClawRouter usage: response was not valid JSON");
+    }
     if (!payload || typeof payload !== "object" || Array.isArray(payload) ||
         !payload.budget || !payload.usage || !payload.usage.summary || !Array.isArray(payload.usage.providers)) {
-      throw new Error("Failed to parse ClawRouter usage response");
+      throw ctx.fail.parseFailure("Could not parse ClawRouter usage: response shape is invalid");
     }
 
     function integer(value, field) {
-      if (!Number.isInteger(value)) throw new Error(`ClawRouter ${field} must be an integer`);
+      if (!Number.isInteger(value)) {
+        throw ctx.fail.parseFailure(`Could not parse ClawRouter usage: ${field} must be an integer`);
+      }
       return value;
     }
     function micros(value, field, optional) {
@@ -49,7 +60,7 @@ defineProvider({
 
     const budget = payload.budget;
     if (typeof budget.configured !== "boolean" || typeof budget.ledger !== "string") {
-      throw new Error("Failed to parse ClawRouter budget");
+      throw ctx.fail.parseFailure("Could not parse ClawRouter usage: budget is invalid");
     }
     const limit = micros(budget.limitMicros, "budget.limitMicros", true);
     const spent = micros(budget.spentMicros, "budget.spentMicros", true);
@@ -65,7 +76,9 @@ defineProvider({
     const actualCost = micros(summary.actualCostMicros, "summary.actualCostMicros", false);
 
     const providers = payload.usage.providers.map(item => {
-      if (!item || typeof item.provider !== "string") throw new Error("ClawRouter provider name must be a string");
+      if (!item || typeof item.provider !== "string") {
+        throw ctx.fail.parseFailure("Could not parse ClawRouter usage: provider name must be a string");
+      }
       return {
         provider: item.provider.trim() || "Unknown",
         requests: integer(item.requestCount, "provider.requestCount"),
@@ -77,6 +90,7 @@ defineProvider({
     }).sort((a, b) => b.cost - a.cost || b.requests - a.requests || a.provider.localeCompare(b.provider));
 
     const result = {
+      dataConfidence: "exact",
       identity: {
         organization: `${providers.length} routed providers`,
         loginMethod: budget.configured ? "Managed monthly budget" : "Unmetered",
@@ -93,8 +107,10 @@ defineProvider({
     };
 
     if (spent !== null && limit !== null) {
-      result.primary = { usedPercent: ctx.pct(spent, limit) };
-      if (resetsAt) result.primary.resetsAt = resetsAt;
+      if (limit > 0) {
+        result.primary = { usedPercent: ctx.pct(spent, limit) };
+        if (resetsAt) result.primary.resetsAt = resetsAt;
+      }
       result.cost = { used: spent, limit, currency: "USD", period: "This month" };
       if (resetsAt) result.cost.resetsAt = resetsAt;
       result.details[0].rows.push({

--- a/Sources/CodexBarCore/Resources/Plugins/deepgram.js
+++ b/Sources/CodexBarCore/Resources/Plugins/deepgram.js
@@ -9,54 +9,136 @@ defineProvider({
     { key: "DEEPGRAM_API_URL", title: "API URL", type: "plain" },
   ],
   async fetchUsage(ctx) {
-    const base = (ctx.settings.get("DEEPGRAM_API_URL") || "https://api.deepgram.com/v1").replace(/\/$/, "");
+    const base = (ctx.settings.get("DEEPGRAM_API_URL") || "https://api.deepgram.com/v1").replace(/\/+$/, "");
+
+    function classifyStatus(status) {
+      if (status === 401) return ctx.fail.authenticationExpired("Deepgram API key is invalid or expired.");
+      if (status === 403) {
+        return ctx.fail.permissionDenied(
+          "Deepgram rejected access: The API key may not have access to the project or the Management API. HTTP 403");
+      }
+      if (status === 429) return ctx.fail.rateLimited("Deepgram API error: HTTP 429");
+      if (status >= 500) return ctx.fail.providerUnavailable(`Deepgram API error: HTTP ${status}`);
+      return ctx.fail.apiFailure(`Deepgram API error: HTTP ${status}`);
+    }
+
+    async function getJSON(url) {
+      let response;
+      try {
+        response = await ctx.http.get(url);
+      } catch (error) {
+        throw ctx.fail.networkFailure(`Deepgram network error: ${error && error.message || error}`);
+      }
+      if (response.status !== 200) throw classifyStatus(response.status);
+      try {
+        return JSON.parse(response.bodyText);
+      } catch (_) {
+        throw ctx.fail.parseFailure("Deepgram parse error: response was not valid JSON");
+      }
+    }
+
+    function optionalNumber(value, field, integer) {
+      if (value === null || value === undefined) return 0;
+      if (typeof value !== "number" || !Number.isFinite(value) || (integer && !Number.isInteger(value))) {
+        throw ctx.fail.parseFailure(`Deepgram parse error: ${field} has an invalid number`);
+      }
+      return value;
+    }
+
+    function optionalString(value, field) {
+      if (value === null || value === undefined) return null;
+      if (typeof value !== "string") {
+        throw ctx.fail.parseFailure(`Deepgram parse error: ${field} must be a string`);
+      }
+      return value;
+    }
+
+    function usagePayload(payload) {
+      if (!payload || typeof payload !== "object" || Array.isArray(payload) || !Array.isArray(payload.results)) {
+        throw ctx.fail.parseFailure("Deepgram parse error: usage results must be an array");
+      }
+      const result = {
+        start: optionalString(payload.start, "start"),
+        end: optionalString(payload.end, "end"),
+        hours: 0,
+        totalHours: 0,
+        agentHours: 0,
+        tokensIn: 0,
+        tokensOut: 0,
+        tts: 0,
+        requests: 0,
+      };
+      if (payload.resolution !== null && payload.resolution !== undefined) {
+        if (!payload.resolution || typeof payload.resolution !== "object" || Array.isArray(payload.resolution)) {
+          throw ctx.fail.parseFailure("Deepgram parse error: resolution must be an object");
+        }
+        optionalString(payload.resolution.units, "resolution.units");
+        optionalNumber(payload.resolution.amount, "resolution.amount", true);
+      }
+      for (const row of payload.results) {
+        if (!row || typeof row !== "object" || Array.isArray(row)) {
+          throw ctx.fail.parseFailure("Deepgram parse error: usage result must be an object");
+        }
+        result.hours += optionalNumber(row.hours, "hours", false);
+        result.totalHours += optionalNumber(row.total_hours, "total_hours", false);
+        result.agentHours += optionalNumber(row.agent_hours, "agent_hours", false);
+        result.tokensIn += optionalNumber(row.tokens_in, "tokens_in", true);
+        result.tokensOut += optionalNumber(row.tokens_out, "tokens_out", true);
+        result.tts += optionalNumber(row.tts_characters, "tts_characters", true);
+        result.requests += optionalNumber(row.requests, "requests", true);
+      }
+      return result;
+    }
+
     const configuredProject = ctx.settings.get("DEEPGRAM_PROJECT_ID");
     let projects;
     if (configuredProject) {
-      projects = [{ project_id: configuredProject }];
+      projects = [{ project_id: configuredProject, name: null }];
     } else {
-      const response = await ctx.http.getJSON(`${base}/projects`);
-      if (response.status !== 200 || !response.json || !Array.isArray(response.json.projects)) {
-        throw new Error(`Deepgram projects API error: HTTP ${response.status}`);
+      const payload = await getJSON(`${base}/projects`);
+      if (!payload || typeof payload !== "object" || !Array.isArray(payload.projects)) {
+        throw ctx.fail.parseFailure("Deepgram parse error: projects must be an array");
       }
-      projects = response.json.projects;
+      projects = payload.projects.map((project, index) => {
+        if (!project || typeof project !== "object" || typeof project.project_id !== "string") {
+          throw ctx.fail.parseFailure(`Deepgram parse error: projects[${index}].project_id must be a string`);
+        }
+        const name = optionalString(project.name, `projects[${index}].name`);
+        return { project_id: project.project_id, name };
+      });
     }
-    if (!projects.length) throw new Error("Deepgram returned no projects");
+    if (!projects.length) {
+      throw ctx.fail.apiFailure("Deepgram project ID is invalid or no projects were returned for this API key.");
+    }
 
     const totals = { hours: 0, totalHours: 0, agentHours: 0, tokensIn: 0, tokensOut: 0, tts: 0, requests: 0 };
     let start = null;
     let end = null;
     for (const project of projects) {
-      const response = await ctx.http.getJSON(
-        `${base}/projects/${encodeURIComponent(project.project_id)}/usage/breakdown`);
-      if (response.status !== 200 || !response.json || !Array.isArray(response.json.results)) {
-        throw new Error(`Deepgram usage API error: HTTP ${response.status}`);
-      }
-      start = !start || (response.json.start && response.json.start < start) ? response.json.start : start;
-      end = !end || (response.json.end && response.json.end > end) ? response.json.end : end;
-      for (const row of response.json.results) {
-        totals.hours += Number(row.hours || 0);
-        totals.totalHours += Number(row.total_hours || 0);
-        totals.agentHours += Number(row.agent_hours || 0);
-        totals.tokensIn += Number(row.tokens_in || 0);
-        totals.tokensOut += Number(row.tokens_out || 0);
-        totals.tts += Number(row.tts_characters || 0);
-        totals.requests += Number(row.requests || 0);
-      }
+      const payload = usagePayload(await getJSON(
+        `${base}/projects/${encodeURIComponent(project.project_id)}/usage/breakdown`));
+      if (payload.start && (!start || payload.start < start)) start = payload.start;
+      if (payload.end && (!end || payload.end > end)) end = payload.end;
+      for (const field of Object.keys(totals)) totals[field] += payload[field];
     }
-    const number = value => new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value);
-    const rows = [{ label: "Requests", value: new Intl.NumberFormat("en-US").format(totals.requests) }];
+
+    const decimal = value => new Intl.NumberFormat("en-US", {
+      minimumFractionDigits: value === Math.floor(value) ? 0 : 1,
+      maximumFractionDigits: 1,
+    }).format(value);
+    const integer = value => new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
+    const rows = [{ label: "Requests", value: integer(totals.requests) }];
     if (totals.hours || totals.totalHours) rows.push({
       label: "Audio",
-      value: `${number(totals.hours)} hours`,
-      secondaryValue: `${number(totals.totalHours)} billable hours`,
+      value: `${decimal(totals.hours)} hours`,
+      secondaryValue: `${decimal(totals.totalHours)} billable hours`,
     });
-    if (totals.agentHours) rows.push({ label: "Agent hours", value: number(totals.agentHours) });
+    if (totals.agentHours) rows.push({ label: "Agent hours", value: decimal(totals.agentHours) });
     if (totals.tokensIn || totals.tokensOut) rows.push({
       label: "Tokens",
-      value: new Intl.NumberFormat("en-US").format(totals.tokensIn + totals.tokensOut),
+      value: integer(totals.tokensIn + totals.tokensOut),
     });
-    if (totals.tts) rows.push({ label: "TTS characters", value: new Intl.NumberFormat("en-US").format(totals.tts) });
+    if (totals.tts) rows.push({ label: "TTS characters", value: integer(totals.tts) });
     if (start && end) rows.push({ label: "Period", value: `${start} to ${end}` });
     const loginMethod = projects.length > 1
       ? `${projects.length} projects`

--- a/Sources/CodexBarCore/Resources/Plugins/openrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/openrouter.js
@@ -1,18 +1,27 @@
 defineProvider({
   id: "openrouter",
   name: "OpenRouter",
-  endpoints: ["https://openrouter.ai"],
+  endpoints: ["https://openrouter.ai", { setting: "OPENROUTER_API_URL", policy: "https" }],
   auth: { type: "bearer", secret: "OPENROUTER_API_KEY" },
-  settings: [{
-    key: "OPENROUTER_API_KEY",
-    title: "API key",
-    subtitle: "OpenRouter API key used for credits and key quota.",
-    type: "secure",
-  }],
+  settings: [
+    {
+      key: "OPENROUTER_API_KEY",
+      title: "API key",
+      subtitle: "OpenRouter API key used for credits and key quota.",
+      type: "secure",
+    },
+    { key: "OPENROUTER_API_URL", title: "API URL", type: "plain" },
+    { key: "OPENROUTER_HTTP_REFERER", title: "HTTP referer", type: "plain" },
+    { key: "OPENROUTER_X_TITLE", title: "Client title", type: "plain" },
+  ],
 
   async fetchUsage(ctx) {
-    const creditsResponse = await ctx.http.getJSON("https://openrouter.ai/api/v1/credits", {
-      headers: { "X-Title": "CodexBar" },
+    const base = (ctx.settings.get("OPENROUTER_API_URL") || "https://openrouter.ai/api/v1").replace(/\/+$/, "");
+    const headers = { "X-Title": ctx.settings.get("OPENROUTER_X_TITLE") || "CodexBar" };
+    const referer = ctx.settings.get("OPENROUTER_HTTP_REFERER");
+    if (referer) headers["HTTP-Referer"] = referer;
+    const creditsResponse = await ctx.http.getJSON(`${base}/credits`, {
+      headers,
     });
     if (creditsResponse.status !== 200) {
       throw new Error(`OpenRouter API error: HTTP ${creditsResponse.status}`);
@@ -35,7 +44,7 @@ defineProvider({
     const balance = Math.max(0, totalCredits - totalUsage);
     let keyData = null;
     try {
-      const keyResponse = await ctx.http.getJSON("https://openrouter.ai/api/v1/key");
+      const keyResponse = await ctx.http.getJSON(`${base}/key`);
       if (keyResponse.status === 200 && keyResponse.json &&
           keyResponse.json.data && typeof keyResponse.json.data === "object") {
         keyData = keyResponse.json.data;

--- a/Sources/CodexBarCore/Resources/Plugins/openrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/openrouter.js
@@ -16,27 +16,31 @@ defineProvider({
   ],
 
   async fetchUsage(ctx) {
+    function finite(value, field, optional) {
+      if (optional && (value === null || value === undefined)) return null;
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        throw ctx.fail.parseFailure(`Failed to parse OpenRouter response: ${field} must be a finite number`);
+      }
+      return value;
+    }
+
     const base = (ctx.settings.get("OPENROUTER_API_URL") || "https://openrouter.ai/api/v1").replace(/\/+$/, "");
     const headers = { "X-Title": ctx.settings.get("OPENROUTER_X_TITLE") || "CodexBar" };
     const referer = ctx.settings.get("OPENROUTER_HTTP_REFERER");
     if (referer) headers["HTTP-Referer"] = referer;
-    const creditsResponse = await ctx.http.getJSON(`${base}/credits`, {
-      headers,
-    });
+    const creditsResponse = await ctx.http.get(`${base}/credits`, { headers });
     if (creditsResponse.status !== 200) {
-      throw new Error(`OpenRouter API error: HTTP ${creditsResponse.status}`);
+      throw ctx.fail.apiFailure(`OpenRouter API error: HTTP ${creditsResponse.status}`);
     }
-    const credits = creditsResponse.json && creditsResponse.json.data;
+    let creditsPayload;
+    try {
+      creditsPayload = JSON.parse(creditsResponse.bodyText);
+    } catch (_) {
+      throw ctx.fail.parseFailure("Failed to parse OpenRouter response: response was not valid JSON");
+    }
+    const credits = creditsPayload && creditsPayload.data;
     if (!credits || typeof credits !== "object" || Array.isArray(credits)) {
-      throw new Error("Failed to parse OpenRouter credits: data must be an object");
-    }
-
-    function finite(value, field, optional) {
-      if (optional && (value === null || value === undefined)) return null;
-      if (typeof value !== "number" || !Number.isFinite(value)) {
-        throw new Error(`Failed to parse OpenRouter response: ${field} must be a finite number`);
-      }
-      return value;
+      throw ctx.fail.parseFailure("Failed to parse OpenRouter credits: data must be an object");
     }
 
     const totalCredits = finite(credits.total_credits, "total_credits", false);
@@ -44,10 +48,23 @@ defineProvider({
     const balance = Math.max(0, totalCredits - totalUsage);
     let keyData = null;
     try {
-      const keyResponse = await ctx.http.getJSON(`${base}/key`);
-      if (keyResponse.status === 200 && keyResponse.json &&
-          keyResponse.json.data && typeof keyResponse.json.data === "object") {
-        keyData = keyResponse.json.data;
+      const keyResponse = await ctx.http.get(`${base}/key`, { timeoutSeconds: 1 });
+      const keyPayload = keyResponse.status === 200 ? JSON.parse(keyResponse.bodyText) : null;
+      if (keyPayload && keyPayload.data && typeof keyPayload.data === "object" &&
+          !Array.isArray(keyPayload.data)) {
+        const candidate = keyPayload.data;
+        for (const field of [
+          "limit", "limit_remaining", "usage", "usage_daily", "usage_weekly", "usage_monthly",
+        ]) finite(candidate[field], `key.${field}`, true);
+        if (candidate.limit_reset !== null && candidate.limit_reset !== undefined &&
+            typeof candidate.limit_reset !== "string") throw new TypeError("key.limit_reset must be a string");
+        if (candidate.rate_limit !== null && candidate.rate_limit !== undefined &&
+            (!candidate.rate_limit || typeof candidate.rate_limit !== "object" ||
+             !Number.isInteger(candidate.rate_limit.requests) ||
+             typeof candidate.rate_limit.interval !== "string")) {
+          throw new TypeError("key.rate_limit is invalid");
+        }
+        keyData = candidate;
       }
     } catch (_) {}
 

--- a/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
+++ b/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
@@ -36,6 +36,21 @@
     },
   });
 
+  const failureKinds = Object.freeze({
+    authenticationExpired: "authentication-expired",
+    missingCredential: "missing-credential",
+    permissionDenied: "permission-denied",
+    rateLimited: "rate-limited",
+    providerUnavailable: "provider-unavailable",
+    parseFailure: "parse-failure",
+    networkFailure: "network-failure",
+    apiFailure: "api-failure",
+  });
+  const classifiedFailure = kind => message =>
+    new Error(`__CODEXBAR_FAILURE__:${kind}:${String(message)}`);
+  ctx.fail = Object.freeze(Object.fromEntries(
+    Object.entries(failureKinds).map(([name, kind]) => [name, classifiedFailure(kind)])));
+
   ctx.browser = Object.freeze({
     cookieHeader(domain) {
       return new Promise((resolve, reject) => host.cookieHeader(String(domain), resolve, reject));

--- a/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
+++ b/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
@@ -23,6 +23,7 @@
       }
       const hostOptions = { bodyJSON };
       if (opts.headers !== undefined) hostOptions.headers = opts.headers;
+      if (opts.timeoutSeconds !== undefined) hostOptions.timeoutSeconds = opts.timeoutSeconds;
       return new Promise((resolve, reject) => host.http(String(url), hostOptions, "POST", true, resolve, reject));
     },
   });

--- a/Sources/CodexBarCore/Resources/Plugins/sub2api.js
+++ b/Sources/CodexBarCore/Resources/Plugins/sub2api.js
@@ -8,55 +8,208 @@ defineProvider({
     { key: "SUB2API_BASE_URL", title: "Base URL", type: "plain" },
   ],
   async fetchUsage(ctx) {
-    let base = ctx.settings.get("SUB2API_BASE_URL").replace(/\/$/, "");
+    let base = ctx.settings.get("SUB2API_BASE_URL").replace(/\/+$/, "");
     if (!/\/v1(?:\/usage)?$/.test(base)) base += "/v1";
     if (!/\/usage$/.test(base)) base += "/usage";
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
-    const response = await ctx.http.getJSON(`${base}?days=30&timezone=${encodeURIComponent(timezone)}`);
-    if (response.status < 200 || response.status >= 300) throw new Error(`sub2api API error: HTTP ${response.status}`);
-    const data = response.json || {};
-    if (data.isValid === false) throw new Error("sub2api credentials are invalid");
-    const unit = data.unit || (data.quota && data.quota.unit) || "USD";
-    const amount = (used, limit, valueUnit = "USD") => `${valueUnit.toUpperCase() === "USD" ? `$${Number(used).toFixed(2)}` : `${Number(used).toFixed(2)} ${valueUnit}`} / ${valueUnit.toUpperCase() === "USD" ? `$${Number(limit).toFixed(2)}` : `${Number(limit).toFixed(2)} ${valueUnit}`}`;
-    const window = (used, limit, minutes, valueUnit = "USD") => limit > 0 ? ({
-      usedPercent: ctx.pct(used, limit), windowMinutes: minutes,
+    let response;
+    try {
+      response = await ctx.http.get(`${base}?days=30&timezone=${encodeURIComponent(timezone)}`, {
+        timeoutSeconds: 15,
+      });
+    } catch (error) {
+      throw ctx.fail.networkFailure(`sub2api network error: ${error && error.message || error}`);
+    }
+    if (response.status === 401 || response.status === 403) {
+      throw ctx.fail.authenticationExpired(
+        "sub2api rejected the API key. Check that the key is active and assigned to a group.");
+    }
+    if (response.status === 429) throw ctx.fail.rateLimited("sub2api API returned HTTP 429.");
+    if (response.status >= 500) {
+      throw ctx.fail.providerUnavailable(`sub2api API returned HTTP ${response.status}.`);
+    }
+    if (response.status < 200 || response.status >= 300) {
+      throw ctx.fail.apiFailure(`sub2api API returned HTTP ${response.status}.`);
+    }
+
+    let data;
+    try {
+      data = JSON.parse(response.bodyText);
+    } catch (_) {
+      throw ctx.fail.parseFailure("Could not parse sub2api usage: response was not valid JSON");
+    }
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      throw ctx.fail.parseFailure("Could not parse sub2api usage: response must be an object");
+    }
+
+    function optional(value, field, type) {
+      if (value === null || value === undefined) return null;
+      if (typeof value !== type || (type === "number" && !Number.isFinite(value))) {
+        throw ctx.fail.parseFailure(`Could not parse sub2api usage: ${field} has an invalid type`);
+      }
+      return value;
+    }
+    function requiredNumber(value, field) {
+      const number = optional(value, field, "number");
+      if (number === null) throw ctx.fail.parseFailure(`Could not parse sub2api usage: ${field} is required`);
+      return number;
+    }
+    function requiredString(value, field) {
+      const string = optional(value, field, "string");
+      if (string === null || !string) {
+        throw ctx.fail.parseFailure(`Could not parse sub2api usage: ${field} is required`);
+      }
+      return string;
+    }
+    function parseDate(value, field) {
+      const text = optional(value, field, "string");
+      if (text === null) return undefined;
+      try { return ctx.date.iso(text); } catch (_) {
+        throw ctx.fail.parseFailure(`Could not parse sub2api usage: ${field} is not a valid date`);
+      }
+    }
+
+    const mode = optional(data.mode, "mode", "string") || "unknown";
+    const isValid = optional(data.isValid, "isValid", "boolean");
+    const status = optional(data.status, "status", "string");
+    const planName = optional(data.planName, "planName", "string");
+    optional(data.remaining, "remaining", "number");
+    const balance = optional(data.balance, "balance", "number");
+    const rootUnit = optional(data.unit, "unit", "string");
+    if (isValid === false) {
+      throw ctx.fail.authenticationExpired(
+        "sub2api rejected the API key. Check that the key is active and assigned to a group.");
+    }
+
+    let quota = null;
+    if (data.quota !== null && data.quota !== undefined) {
+      if (!data.quota || typeof data.quota !== "object" || Array.isArray(data.quota)) {
+        throw ctx.fail.parseFailure("Could not parse sub2api usage: quota must be an object");
+      }
+      quota = {
+        limit: requiredNumber(data.quota.limit, "quota.limit"),
+        used: requiredNumber(data.quota.used, "quota.used"),
+        remaining: requiredNumber(data.quota.remaining, "quota.remaining"),
+        unit: optional(data.quota.unit, "quota.unit", "string"),
+      };
+    }
+    const unit = rootUnit || quota && quota.unit || "USD";
+
+    let subscription = null;
+    if (data.subscription !== null && data.subscription !== undefined) {
+      if (!data.subscription || typeof data.subscription !== "object" || Array.isArray(data.subscription)) {
+        throw ctx.fail.parseFailure("Could not parse sub2api usage: subscription must be an object");
+      }
+      subscription = {
+        dailyUsage: optional(data.subscription.daily_usage_usd, "subscription.daily_usage_usd", "number") || 0,
+        weeklyUsage: optional(data.subscription.weekly_usage_usd, "subscription.weekly_usage_usd", "number") || 0,
+        monthlyUsage: optional(data.subscription.monthly_usage_usd, "subscription.monthly_usage_usd", "number") || 0,
+        dailyLimit: optional(data.subscription.daily_limit_usd, "subscription.daily_limit_usd", "number"),
+        weeklyLimit: optional(data.subscription.weekly_limit_usd, "subscription.weekly_limit_usd", "number"),
+        monthlyLimit: optional(data.subscription.monthly_limit_usd, "subscription.monthly_limit_usd", "number"),
+        expiresAt: parseDate(data.subscription.expires_at, "subscription.expires_at"),
+      };
+    }
+
+    const money = (value, valueUnit = "USD") => valueUnit.toUpperCase() === "USD"
+      ? `$${new Intl.NumberFormat("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(value)}`
+      : `${Number(value).toFixed(2)} ${valueUnit}`;
+    const amount = (used, limit, valueUnit = "USD") =>
+      `${money(used, valueUnit)} / ${money(limit, valueUnit)}`;
+    const window = (used, limit, minutes, valueUnit = "USD") => limit !== null && limit > 0 ? ({
+      usedPercent: ctx.pct(used, limit),
+      windowMinutes: minutes,
       resetDescription: amount(used, limit, valueUnit),
     }) : null;
     let primary = null;
     let secondary = null;
     let tertiary = null;
-    if (data.subscription) {
-      primary = window(data.subscription.daily_usage_usd || 0, data.subscription.daily_limit_usd, 1440);
-      secondary = window(data.subscription.weekly_usage_usd || 0, data.subscription.weekly_limit_usd, 10080);
-      tertiary = window(data.subscription.monthly_usage_usd || 0, data.subscription.monthly_limit_usd, 43200);
-    } else if (data.quota) {
-      primary = window(data.quota.used, data.quota.limit, null, data.quota.unit || unit);
+    if (subscription) {
+      primary = window(subscription.dailyUsage, subscription.dailyLimit, 1440);
+      secondary = window(subscription.weeklyUsage, subscription.weeklyLimit, 10080);
+      tertiary = window(subscription.monthlyUsage, subscription.monthlyLimit, 43200);
+    } else if (quota) {
+      primary = window(quota.used, quota.limit, null, quota.unit || unit);
       if (primary) delete primary.windowMinutes;
+    }
+
+    let rateLimits = data.rate_limits;
+    if (rateLimits === null || rateLimits === undefined) rateLimits = [];
+    if (!Array.isArray(rateLimits)) {
+      throw ctx.fail.parseFailure("Could not parse sub2api usage: rate_limits must be an array");
     }
     const minuteMap = { "5h": 300, "1d": 1440, "7d": 10080 };
     const titleMap = { "5h": "5 hour limit", "1d": "Daily limit", "7d": "7 day limit" };
-    const extraWindows = (data.rate_limits || []).map(rate => ({
-      id: rate.window,
-      title: titleMap[rate.window.toLowerCase()] || `${rate.window} limit`,
-      window: {
-        usedPercent: ctx.pct(rate.used, rate.limit),
-        windowMinutes: minuteMap[rate.window.toLowerCase()],
-        resetsAt: rate.reset_at ? ctx.date.iso(rate.reset_at) : undefined,
-        resetDescription: amount(rate.used, rate.limit),
-      },
-    }));
-    const rows = [];
-    if (data.balance !== undefined && data.balance !== null) rows.push({ label: "Balance", value: amount(data.balance, data.balance, unit).split(" / ")[0] });
-    for (const [title, totals] of [["Today", data.usage && data.usage.today], ["All time", data.usage && data.usage.total]]) {
-      if (!totals) continue;
-      rows.push({ label: `${title} requests`, value: new Intl.NumberFormat("en-US").format(totals.requests || 0) });
-      rows.push({ label: `${title} tokens`, value: new Intl.NumberFormat("en-US").format(totals.total_tokens || 0), secondaryValue: `$${Number(totals.actual_cost || 0).toFixed(2)}` });
+    const extraWindows = rateLimits.map((rate, index) => {
+      if (!rate || typeof rate !== "object" || Array.isArray(rate)) {
+        throw ctx.fail.parseFailure(`Could not parse sub2api usage: rate_limits[${index}] must be an object`);
+      }
+      const rateWindow = requiredString(rate.window, `rate_limits[${index}].window`);
+      const limit = requiredNumber(rate.limit, `rate_limits[${index}].limit`);
+      const used = requiredNumber(rate.used, `rate_limits[${index}].used`);
+      requiredNumber(rate.remaining, `rate_limits[${index}].remaining`);
+      return {
+        id: rateWindow,
+        title: titleMap[rateWindow.toLowerCase()] || `${rateWindow} limit`,
+        window: {
+          usedPercent: ctx.pct(used, limit),
+          windowMinutes: minuteMap[rateWindow.toLowerCase()],
+          resetsAt: parseDate(rate.reset_at, `rate_limits[${index}].reset_at`),
+          resetDescription: amount(used, limit),
+        },
+      };
+    });
+
+    function totals(value, field) {
+      if (value === null || value === undefined) return null;
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw ctx.fail.parseFailure(`Could not parse sub2api usage: ${field} must be an object`);
+      }
+      const requests = optional(value.requests, `${field}.requests`, "number") || 0;
+      const tokens = optional(value.total_tokens, `${field}.total_tokens`, "number") || 0;
+      if (!Number.isInteger(requests) || !Number.isInteger(tokens)) {
+        throw ctx.fail.parseFailure(`Could not parse sub2api usage: ${field} counts must be integers`);
+      }
+      return {
+        requests,
+        tokens,
+        cost: optional(value.actual_cost, `${field}.actual_cost`, "number") || 0,
+      };
     }
+    let usage = data.usage;
+    if (usage === null || usage === undefined) usage = {};
+    if (!usage || typeof usage !== "object" || Array.isArray(usage)) {
+      throw ctx.fail.parseFailure("Could not parse sub2api usage: usage must be an object");
+    }
+    const rows = [];
+    if (balance !== null) {
+      rows.push({ label: "Balance", value: money(balance, unit) });
+    }
+    for (const [title, value] of [
+      ["Today", totals(usage.today, "usage.today")],
+      ["All time", totals(usage.total, "usage.total")],
+    ]) {
+      if (!value) continue;
+      rows.push({ label: `${title} requests`, value: new Intl.NumberFormat("en-US").format(value.requests) });
+      rows.push({
+        label: `${title} tokens`,
+        value: new Intl.NumberFormat("en-US").format(value.tokens),
+        secondaryValue: money(value.cost),
+      });
+    }
+    const expiresAt = subscription && subscription.expiresAt || parseDate(data.expires_at, "expires_at");
     return {
-      primary, secondary, tertiary, extraWindows,
-      subscriptionExpiresAt: (data.subscription && data.subscription.expires_at) || data.expires_at,
-      identity: { organization: data.planName, loginMethod: data.planName },
+      primary,
+      secondary,
+      tertiary,
+      extraWindows,
+      subscriptionExpiresAt: expiresAt,
+      identity: { organization: planName, loginMethod: planName },
       details: rows.length ? [{ title: "Usage summary", rows }] : undefined,
+      dataConfidence: "exact",
     };
   },
 });

--- a/Tests/CodexBarTests/CLIOutputTests.swift
+++ b/Tests/CodexBarTests/CLIOutputTests.swift
@@ -37,21 +37,26 @@ struct CLIOutputTests {
 
     @Test
     func `text renderer includes deepgram usage metrics`() {
-        let deepgram = DeepgramUsageSnapshot(
-            projectID: "project-123",
-            start: "2026-05-10",
-            end: "2026-05-17",
-            hours: 12.5,
-            totalHours: 14,
-            agentHours: 1.25,
-            tokensIn: 100,
-            tokensOut: 50,
-            ttsCharacters: 1200,
-            requests: 42,
-            updatedAt: Date(timeIntervalSince1970: 0))
+        let deepgram = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            details: [.makeSection(title: "Usage summary", rows: [
+                .makeRow(label: "Requests", value: "42"),
+                .makeRow(label: "Audio", value: "12.5 hours", secondaryValue: "14 billable hours"),
+                .makeRow(label: "Agent hours", value: "1.2"),
+                .makeRow(label: "Tokens", value: "150"),
+                .makeRow(label: "TTS characters", value: "1,200"),
+                .makeRow(label: "Period", value: "2026-05-10 to 2026-05-17"),
+            ])],
+            updatedAt: Date(timeIntervalSince1970: 0),
+            identity: ProviderIdentitySnapshot(
+                providerID: .deepgram,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Project: project-123"))
         let text = CLIRenderer.renderText(
             provider: .deepgram,
-            snapshot: deepgram.toUsageSnapshot(),
+            snapshot: deepgram,
             credits: nil,
             context: RenderContext(
                 header: "Deepgram (api)",

--- a/Tests/CodexBarTests/ClawRouterUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/ClawRouterUsageFetcherTests.swift
@@ -1,24 +1,15 @@
+#if canImport(JavaScriptCore)
 import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
 @testable import CodexBarCLI
 
-struct ClawRouterUsageFetcherTests {
+struct ClawRouterPluginGoldenTests {
     @Test
-    func `parses monthly budget and provider agnostic usage`() throws {
-        let parsed = try ClawRouterUsageFetcher._parseSnapshotForTesting(
-            Data(Self.budgetedResponse.utf8),
-            updatedAt: Date(timeIntervalSince1970: 1))
+    func `monthly budget fixture matches the production golden`() async throws {
+        let snapshot = try await Self.fetch(body: Self.budgetedResponse, now: Date(timeIntervalSince1970: 1))
 
-        #expect(parsed.budgetLimitUSD == 25)
-        #expect(parsed.budgetSpentUSD == 0.006)
-        #expect(parsed.budgetRemainingUSD == 24.994)
-        #expect(parsed.requestCount == 6)
-        #expect(parsed.totalTokens == 54191)
-        #expect(parsed.providers.map(\.provider) == ["openai", "anthropic"])
-
-        let snapshot = parsed.toUsageSnapshot()
         #expect(snapshot.identity?.providerID == .clawrouter)
         #expect(snapshot.primary?.usedPercent == 0.024)
         #expect(snapshot.secondary == nil)
@@ -26,7 +17,6 @@ struct ClawRouterUsageFetcherTests {
         #expect(snapshot.providerCost?.limit == 25)
         #expect(snapshot.details.last?.rows.map(\.label) == ["openai", "anthropic"])
         #expect(snapshot.dataConfidence == .exact)
-
         let reset = try #require(snapshot.primary?.resetsAt)
         let expected = try #require(DateComponents(
             calendar: Calendar(identifier: .gregorian),
@@ -38,51 +28,69 @@ struct ClawRouterUsageFetcherTests {
     }
 
     @Test
-    func `supports unmetered policies and arbitrary providers`() throws {
-        let parsed = try ClawRouterUsageFetcher._parseSnapshotForTesting(
-            Data(Self.unmeteredResponse.utf8),
-            updatedAt: Date(timeIntervalSince1970: 1))
-        let snapshot = parsed.toUsageSnapshot()
+    func `unmetered fixture keeps arbitrary providers and spend`() async throws {
+        let snapshot = try await Self.fetch(body: Self.unmeteredResponse)
 
-        #expect(!parsed.budgetConfigured)
-        #expect(parsed.providers.map(\.provider) == ["replicate", "tavily"])
         #expect(snapshot.primary == nil)
         #expect(snapshot.identity?.loginMethod == "Unmetered")
         #expect(snapshot.providerCost?.used == 1.25)
         #expect(snapshot.providerCost?.limit == 0)
+        #expect(snapshot.details.last?.rows.map(\.label) == ["replicate", "tavily"])
     }
 
-    @Test
-    func `usage URL accepts root and versioned base URLs`() throws {
-        #expect(
-            try ClawRouterUsageFetcher._usageURLForTesting(
-                baseURL: #require(URL(string: "https://router.example.com"))).absoluteString ==
-                "https://router.example.com/v1/usage")
-        #expect(
-            try ClawRouterUsageFetcher._usageURLForTesting(
-                baseURL: #require(URL(string: "https://router.example.com/v1"))).absoluteString ==
-                "https://router.example.com/v1/usage")
+    @Test(arguments: [false, true])
+    func `root and versioned base URLs reach the same usage path`(versioned: Bool) async throws {
+        let recorder = ClawRouterRequestRecorder()
+        let runtime = try ProviderPluginRuntime(
+            bundledPlugin: "clawrouter",
+            transport: Self.transport(body: Self.budgetedResponse, recorder: recorder))
+        let base = versioned ? "https://router.example.com/v1" : "https://router.example.com"
+
+        _ = try await runtime.fetchUsage(
+            settings: [ClawRouterSettingsReader.baseURLEnvironmentKey: base],
+            secrets: [ClawRouterSettingsReader.apiKeyEnvironmentKey: "smoke-key"])
+
+        let request = try #require(await recorder.requests.first)
+        #expect(request.url?.absoluteString == "https://router.example.com/v1/usage")
+        #expect(request.httpMethod == "GET")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer smoke-key")
     }
 
-    @Test
-    func `fetch sends bearer key and maps authorization failure`() async throws {
-        let transport = ProviderHTTPTransportStub { request in
-            #expect(request.url?.absoluteString == "https://router.example.com/v1/usage")
-            #expect(request.httpMethod == "GET")
-            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer smoke-key")
-            let response = try #require(HTTPURLResponse(
-                url: request.url!,
-                statusCode: 401,
-                httpVersion: nil,
-                headerFields: nil))
-            return (Data(), response)
+    @Test(arguments: [
+        (401, ProviderFetchClassifiedError.Kind.authenticationExpired),
+        (403, .authenticationExpired),
+        (429, .rateLimited),
+        (500, .providerUnavailable),
+        (400, .apiFailure),
+    ])
+    func `HTTP failures preserve classified surface`(
+        status: Int,
+        kind: ProviderFetchClassifiedError.Kind) async throws
+    {
+        do {
+            _ = try await Self.fetch(body: "not-json", status: status)
+            Issue.record("Expected classified failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == kind)
+            if status == 401 || status == 403 {
+                #expect(error.message == "ClawRouter rejected the API key. Check the key and its policy status.")
+            } else {
+                #expect(error.message == "ClawRouter API returned HTTP \(status).")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
+    }
 
-        await #expect(throws: ClawRouterUsageError.invalidCredentials) {
-            _ = try await ClawRouterUsageFetcher.fetchUsage(
-                apiKey: "smoke-key",
-                baseURL: #require(URL(string: "https://router.example.com")),
-                transport: transport)
+    @Test(arguments: ["not-json", #"{"budget":{}}"#])
+    func `malformed responses are classified parse failures`(body: String) async throws {
+        do {
+            _ = try await Self.fetch(body: body)
+            Issue.record("Expected parse failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == .parseFailure)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
     }
 
@@ -125,24 +133,19 @@ struct ClawRouterUsageFetcherTests {
     }
 
     @Test
-    func `usage snapshot preserves ClawRouter detail when cached`() throws {
-        let parsed = try ClawRouterUsageFetcher._parseSnapshotForTesting(
-            Data(Self.budgetedResponse.utf8),
-            updatedAt: Date(timeIntervalSince1970: 1))
-        let encoded = try JSONEncoder().encode(parsed.toUsageSnapshot())
+    func `usage snapshot preserves ClawRouter detail when cached`() async throws {
+        let snapshot = try await Self.fetch(body: Self.budgetedResponse, now: Date(timeIntervalSince1970: 1))
+        let encoded = try JSONEncoder().encode(snapshot)
         let decoded = try JSONDecoder().decode(UsageSnapshot.self, from: encoded)
 
-        #expect(decoded.details == parsed.toUsageSnapshot().details)
+        #expect(decoded.details == snapshot.details)
         #expect(decoded.identity?.providerID == .clawrouter)
     }
 
     @Test
-    func `text CLI renders budgeted spend and routed usage`() throws {
-        let parsed = try ClawRouterUsageFetcher._parseSnapshotForTesting(
-            Data(Self.budgetedResponse.utf8),
-            updatedAt: Date(timeIntervalSince1970: 1))
-
-        let output = Self.renderText(parsed.toUsageSnapshot())
+    func `text CLI renders budgeted spend and routed usage`() async throws {
+        let snapshot = try await Self.fetch(body: Self.budgetedResponse, now: Date(timeIntervalSince1970: 1))
+        let output = Self.renderText(snapshot)
 
         #expect(output.contains("Requests: 6 · 5 succeeded · 1 failed"))
         #expect(output.contains("Tokens: 54191 · 50000 input · 4191 output"))
@@ -152,16 +155,13 @@ struct ClawRouterUsageFetcherTests {
     }
 
     @Test
-    func `text CLI renders unmetered and zero spend without a zero limit`() throws {
-        let unmetered = try ClawRouterUsageFetcher._parseSnapshotForTesting(
-            Data(Self.unmeteredResponse.utf8),
-            updatedAt: Date(timeIntervalSince1970: 1))
-        let zeroSpend = try ClawRouterUsageFetcher._parseSnapshotForTesting(
-            Data(Self.unmeteredResponse.replacingOccurrences(of: "1250000", with: "0").utf8),
-            updatedAt: Date(timeIntervalSince1970: 1))
+    func `text CLI renders unmetered and zero spend without a zero limit`() async throws {
+        let unmetered = try await Self.fetch(body: Self.unmeteredResponse)
+        let zeroSpend = try await Self.fetch(
+            body: Self.unmeteredResponse.replacingOccurrences(of: "1250000", with: "0"))
 
-        let unmeteredOutput = Self.renderText(unmetered.toUsageSnapshot())
-        let zeroSpendOutput = Self.renderText(zeroSpend.toUsageSnapshot())
+        let unmeteredOutput = Self.renderText(unmetered)
+        let zeroSpendOutput = Self.renderText(zeroSpend)
 
         #expect(unmeteredOutput.contains("Actual cost: $1.250000"))
         #expect(unmeteredOutput.contains("Requests: 3 · 3 succeeded · 0 failed"))
@@ -169,6 +169,38 @@ struct ClawRouterUsageFetcherTests {
         #expect(zeroSpendOutput.contains("Actual cost: $0.000000"))
         #expect(zeroSpendOutput.contains("Requests: 3 · 3 succeeded · 0 failed"))
         #expect(!zeroSpendOutput.contains(" / 0.0"))
+    }
+
+    private static func fetch(
+        body: String,
+        status: Int = 200,
+        now: Date = Date(timeIntervalSince1970: 1)) async throws -> UsageSnapshot
+    {
+        let runtime = try ProviderPluginRuntime(
+            bundledPlugin: "clawrouter",
+            transport: Self.transport(body: body, status: status))
+        return try await runtime.fetchUsage(
+            settings: [ClawRouterSettingsReader.baseURLEnvironmentKey: "https://clawrouter.openclaw.ai"],
+            secrets: [ClawRouterSettingsReader.apiKeyEnvironmentKey: "fixture-key"],
+            now: now)
+    }
+
+    private static func transport(
+        body: String,
+        status: Int = 200,
+        recorder: ClawRouterRequestRecorder? = nil) -> ProviderHTTPTransportHandler
+    {
+        ProviderHTTPTransportHandler { request in
+            if let recorder {
+                await recorder.append(request)
+            }
+            let response = try #require(HTTPURLResponse(
+                url: request.url!,
+                statusCode: status,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]))
+            return (Data(body.utf8), response)
+        }
     }
 
     private static func renderText(_ snapshot: UsageSnapshot) -> String {
@@ -273,3 +305,12 @@ struct ClawRouterUsageFetcherTests {
     }
     """
 }
+
+private actor ClawRouterRequestRecorder {
+    private(set) var requests: [URLRequest] = []
+
+    func append(_ request: URLRequest) {
+        self.requests.append(request)
+    }
+}
+#endif

--- a/Tests/CodexBarTests/ConfigValidationTests.swift
+++ b/Tests/CodexBarTests/ConfigValidationTests.swift
@@ -284,6 +284,19 @@ struct ConfigValidationTests {
     }
 
     @Test
+    func `allows OpenRouter endpoint`() {
+        var config = CodexBarConfig.makeDefault()
+        config.setProviderConfig(ProviderConfig(
+            id: .openrouter,
+            apiKey: "fixture",
+            enterpriseHost: "https://router.example.com/api/v1"))
+        let issues = CodexBarConfigValidator.validate(config)
+
+        #expect(!issues.contains(where: { $0.provider == .openrouter && $0.code == "enterprise_host_unused" }))
+        #expect(!issues.contains(where: { $0.provider == .openrouter && $0.code == "invalid_enterprise_host" }))
+    }
+
+    @Test
     func `unsupported enterprise host warning lists every supported provider`() throws {
         var config = CodexBarConfig.makeDefault()
         config.setProviderConfig(ProviderConfig(id: .gemini, enterpriseHost: "https://example.com"))
@@ -292,8 +305,8 @@ struct ConfigValidationTests {
         }))
 
         #expect(issue.message ==
-            "enterpriseHost is set but only azureopenai, clawrouter, copilot, kimi, litellm, llmproxy, sub2api, and " +
-            "wayfinder " +
+            "enterpriseHost is set but only azureopenai, clawrouter, copilot, kimi, litellm, llmproxy, openrouter, " +
+            "sub2api, and wayfinder " +
             "support enterpriseHost.")
     }
 

--- a/Tests/CodexBarTests/DeepgramProviderTests.swift
+++ b/Tests/CodexBarTests/DeepgramProviderTests.swift
@@ -1,3 +1,4 @@
+#if canImport(JavaScriptCore)
 import Foundation
 import SwiftUI
 import Testing
@@ -21,7 +22,6 @@ struct DeepgramProviderTests {
             fetcher: UsageFetcher(environment: [:]),
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings)
-
         let context = ProviderSettingsContext(
             provider: .deepgram,
             settings: settings,
@@ -43,33 +43,25 @@ struct DeepgramProviderTests {
             requestConfirmation: { _ in },
             runLoginFlow: {})
 
-        let implementation = DeepgramProviderImplementation()
-        let fields = implementation.settingsFields(context: context)
-
+        let fields = DeepgramProviderImplementation().settingsFields(context: context)
         let apiField = try #require(fields.first(where: { $0.id == "deepgram-api-key" }))
         let projectField = try #require(fields.first(where: { $0.id == "deepgram-project-id" }))
 
         #expect(apiField.kind == .secure)
         #expect(projectField.kind == .plain)
-
-        // Verify bindings update the SettingsStore
         apiField.binding.wrappedValue = "dg_test_token"
         #expect(settings.deepgramAPIKey == "dg_test_token")
-
         projectField.binding.wrappedValue = "proj-1234"
         #expect(settings.deepgramProjectID == "proj-1234")
     }
 
     @Test
-    nonisolated func `parses usage breakdown response into visible usage notes`() throws {
+    nonisolated func `usage breakdown fixture matches visible detail golden`() async throws {
         let body = #"""
         {
           "start": "2025-01-16",
           "end": "2025-01-23",
-          "resolution": {
-            "units": "day",
-            "amount": 1
-          },
+          "resolution": { "units": "day", "amount": 1 },
           "results": [
             {
               "hours": 1619.7242069444444,
@@ -79,40 +71,23 @@ struct DeepgramProviderTests {
               "tokens_out": 340,
               "tts_characters": 9158866,
               "requests": 373381,
-              "grouping": {
-                "start": "2025-01-16",
-                "end": "2025-01-16",
-                "endpoint": "listen"
-              }
+              "grouping": { "start": "2025-01-16", "end": "2025-01-16", "endpoint": "listen" }
             },
             {
               "hours": 2.25,
               "total_hours": 3.5,
               "requests": 19,
-              "grouping": {
-                "start": "2025-01-17",
-                "end": "2025-01-17",
-                "endpoint": "speak"
-              }
+              "grouping": { "start": "2025-01-17", "end": "2025-01-17", "endpoint": "speak" }
             }
           ]
         }
         """#
 
-        let updatedAt = Date(timeIntervalSince1970: 123)
-        let snapshot = try DeepgramUsageFetcher._parseSnapshotForTesting(
-            Data(body.utf8),
+        let usage = try await Self.fetch(
             projectID: "project-123",
-            updatedAt: updatedAt)
-        let usage = snapshot.toUsageSnapshot()
+            transport: Self.transport { _ in body },
+            now: Date(timeIntervalSince1970: 123))
 
-        #expect(snapshot.requests == 373_400)
-        #expect(snapshot.hours == 1621.9742069444444)
-        #expect(snapshot.totalHours == 1625.2395791666668)
-        #expect(snapshot.agentHours == 41.33564388888889)
-        #expect(snapshot.tokensIn == 1200)
-        #expect(snapshot.tokensOut == 340)
-        #expect(snapshot.ttsCharacters == 9_158_866)
         #expect(usage.detailRow(label: "Requests")?.value == "373,400")
         #expect(usage.loginMethod(for: .deepgram) == "Project: project-123")
         #expect(usage.detailRow(label: "Audio")?.value == "1,622.0 hours")
@@ -124,129 +99,148 @@ struct DeepgramProviderTests {
     }
 
     @Test
-    nonisolated func `fetch usage calls breakdown endpoint with token auth`() async throws {
-        let transport = ProviderHTTPTransportStub { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            #expect(url.path == "/v1/projects/project-123/usage/breakdown")
-            let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-            #expect(components?.queryItems?.contains(URLQueryItem(name: "start", value: "2025-01-16")) == true)
-            #expect(components?.queryItems?.contains(URLQueryItem(name: "end", value: "2025-01-23")) == true)
-            #expect(request.value(forHTTPHeaderField: "Authorization") == "Token dg-test")
-            #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
-            #expect(request.timeoutInterval == 15)
-
-            let body = #"""
-            {
-              "start": "2025-01-16",
-              "end": "2025-01-23",
-              "resolution": {
-                "units": "day",
-                "amount": 1
-              },
-              "results": [
-                {
-                  "hours": 1.5,
-                  "total_hours": 2,
-                  "requests": 7
-                }
-              ]
-            }
-            """#
-            return Self.makeResponse(url: url, body: body)
+    nonisolated func `fetch uses normalized override and token authorization`() async throws {
+        let recorder = DeepgramRequestRecorder()
+        let body = #"""
+        {
+          "start": "2025-01-16",
+          "end": "2025-01-23",
+          "resolution": { "units": "day", "amount": 1 },
+          "results": [{ "hours": 1.5, "total_hours": 2, "requests": 7 }]
         }
+        """#
+        let transport = Self.transport(recorder: recorder) { _ in body }
 
-        let usage = try await DeepgramUsageFetcher.fetchUsage(
-            apiKey: " dg-test ",
-            projectID: " project-123 ",
-            query: DeepgramUsageQuery(start: "2025-01-16", end: "2025-01-23"),
-            environment: ["DEEPGRAM_API_URL": "https://deepgram.test/v1"],
+        let usage = try await Self.fetch(
+            projectID: "project-123",
+            apiURL: "https://deepgram.test/v1",
             transport: transport)
 
-        #expect(usage.projectID == "project-123")
-        #expect(usage.requests == 7)
-        #expect(usage.hours == 1.5)
-        #expect(usage.totalHours == 2)
-
-        let requests = await transport.requests()
-        #expect(requests.count == 1)
+        let request = try #require(await recorder.requests.first)
+        #expect(request.url?.path == "/v1/projects/project-123/usage/breakdown")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Token dg-test")
+        #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+        #expect(request.timeoutInterval == 15)
+        #expect(usage.detailRow(label: "Requests")?.value == "7")
+        #expect(usage.detailRow(label: "Audio")?.value == "1.5 hours")
     }
 
     @Test
-    nonisolated func `fetch usage discovers projects when project id is omitted`() async throws {
-        let transport = ProviderHTTPTransportStub { request in
-            let url = try #require(request.url)
-            #expect(request.value(forHTTPHeaderField: "Authorization") == "Token dg-test")
-
-            switch url.path {
+    nonisolated func `project discovery aggregates every project`() async throws {
+        let recorder = DeepgramRequestRecorder()
+        let transport = Self.transport(recorder: recorder) { request in
+            switch request.url?.path {
             case "/v1/projects":
-                return Self.makeResponse(url: url, body: #"""
-                {
-                  "projects": [
-                    { "project_id": "project-a", "name": "Alpha" },
-                    { "project_id": "project-b", "name": "Beta" }
-                  ]
-                }
-                """#)
-
+                #"{"projects":[{"project_id":"project-a","name":"Alpha"},{"project_id":"project-b","name":"Beta"}]}"#
             case "/v1/projects/project-a/usage/breakdown":
-                return Self.makeResponse(url: url, body: #"""
-                {
-                  "start": "2025-01-16",
-                  "end": "2025-01-23",
-                  "results": [
-                    { "hours": 1, "total_hours": 2, "requests": 3 }
-                  ]
-                }
-                """#)
-
+                #"{"start":"2025-01-16","end":"2025-01-23","results":[{"hours":1,"total_hours":2,"requests":3}]}"#
             case "/v1/projects/project-b/usage/breakdown":
-                return Self.makeResponse(url: url, body: #"""
-                {
-                  "start": "2025-01-17",
-                  "end": "2025-01-24",
-                  "results": [
-                    { "hours": 4, "total_hours": 5, "requests": 6 }
-                  ]
-                }
-                """#)
-
+                #"{"start":"2025-01-17","end":"2025-01-24","results":[{"hours":4,"total_hours":5,"requests":6}]}"#
             default:
                 throw URLError(.badURL)
             }
         }
 
-        let usage = try await DeepgramUsageFetcher.fetchUsage(
-            apiKey: "dg-test",
-            environment: ["DEEPGRAM_API_URL": "https://deepgram.test/v1"],
-            transport: transport)
+        let usage = try await Self.fetch(apiURL: "https://deepgram.test/v1", transport: transport)
 
-        #expect(usage.projectID == "all")
-        #expect(usage.projectCount == 2)
-        #expect(usage.requests == 9)
-        #expect(usage.hours == 5)
-        #expect(usage.totalHours == 7)
-        #expect(usage.start == "2025-01-16")
-        #expect(usage.end == "2025-01-24")
-        #expect(usage.toUsageSnapshot().loginMethod(for: .deepgram) == "2 projects")
-
-        let requests = await transport.requests()
-        #expect(requests.map { $0.url?.path } == [
+        #expect(usage.detailRow(label: "Requests")?.value == "9")
+        #expect(usage.detailRow(label: "Audio")?.value == "5 hours")
+        #expect(usage.detailRow(label: "Audio")?.secondaryValue == "7 billable hours")
+        #expect(usage.detailRow(label: "Period")?.value == "2025-01-16 to 2025-01-24")
+        #expect(usage.loginMethod(for: .deepgram) == "2 projects")
+        #expect(await recorder.requests.map { $0.url?.path } == [
             "/v1/projects",
             "/v1/projects/project-a/usage/breakdown",
             "/v1/projects/project-b/usage/breakdown",
         ])
     }
 
-    private nonisolated static func makeResponse(
-        url: URL,
-        body: String,
-        statusCode: Int = 200) -> (Data, URLResponse)
+    @Test(arguments: [
+        (401, ProviderFetchClassifiedError.Kind.authenticationExpired),
+        (403, .permissionDenied),
+        (429, .rateLimited),
+        (500, .providerUnavailable),
+        (400, .apiFailure),
+    ])
+    nonisolated func `HTTP failures preserve classified surface`(
+        status: Int,
+        kind: ProviderFetchClassifiedError.Kind) async throws
     {
-        let response = HTTPURLResponse(
-            url: url,
-            statusCode: statusCode,
-            httpVersion: "HTTP/1.1",
-            headerFields: ["Content-Type": "application/json"])!
-        return (Data(body.utf8), response)
+        let transport = ProviderHTTPTransportHandler { request in
+            let response = try #require(HTTPURLResponse(
+                url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil))
+            return (Data("not-json".utf8), response)
+        }
+
+        do {
+            _ = try await Self.fetch(projectID: "project-123", transport: transport)
+            Issue.record("Expected classified failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == kind)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    nonisolated func `network and parse failures retain their classifications`() async throws {
+        do {
+            _ = try await Self.fetch(
+                projectID: "project-123",
+                transport: ProviderHTTPTransportHandler { _ in throw URLError(.notConnectedToInternet) })
+            Issue.record("Expected network failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == .networkFailure)
+        }
+
+        do {
+            _ = try await Self.fetch(projectID: "project-123", transport: Self.transport { _ in "not-json" })
+            Issue.record("Expected parse failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == .parseFailure)
+        }
+    }
+
+    private nonisolated static func fetch(
+        projectID: String? = nil,
+        apiURL: String = "https://api.deepgram.com/v1",
+        transport: ProviderHTTPTransportHandler,
+        now: Date = Date()) async throws -> UsageSnapshot
+    {
+        var settings = [DeepgramSettingsReader.apiURLEnvironmentKey: apiURL]
+        if let projectID {
+            settings[DeepgramSettingsReader.projectIDEnvironmentKey] = projectID
+        }
+        let runtime = try ProviderPluginRuntime(bundledPlugin: "deepgram", transport: transport)
+        return try await runtime.fetchUsage(
+            settings: settings,
+            secrets: [DeepgramSettingsReader.apiKeyEnvironmentKey: "dg-test"],
+            now: now)
+    }
+
+    private nonisolated static func transport(
+        recorder: DeepgramRequestRecorder? = nil,
+        body: @escaping @Sendable (URLRequest) throws -> String) -> ProviderHTTPTransportHandler
+    {
+        ProviderHTTPTransportHandler { request in
+            if let recorder {
+                await recorder.append(request)
+            }
+            let response = try #require(HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]))
+            return try (Data(body(request).utf8), response)
+        }
     }
 }
+
+private actor DeepgramRequestRecorder {
+    private(set) var requests: [URLRequest] = []
+
+    func append(_ request: URLRequest) {
+        self.requests.append(request)
+    }
+}
+#endif

--- a/Tests/CodexBarTests/OpenRouterTestSnapshots.swift
+++ b/Tests/CodexBarTests/OpenRouterTestSnapshots.swift
@@ -1,0 +1,147 @@
+#if canImport(JavaScriptCore)
+import Foundation
+@testable import CodexBarCore
+
+/// Test-only fixture projection for UI tests. Production JavaScriptCore builds use openrouter.js.
+struct OpenRouterRateLimit: Sendable {
+    let requests: Int
+    let interval: String
+}
+
+struct OpenRouterUsageSnapshot: Sendable {
+    let totalCredits: Double
+    let totalUsage: Double
+    let balance: Double
+    let usedPercent: Double
+    let keyDataFetched: Bool
+    let keyLimit: Double?
+    let keyLimitRemaining: Double?
+    let keyLimitReset: String?
+    let keyUsage: Double?
+    let keyUsageDaily: Double?
+    let keyUsageWeekly: Double?
+    let keyUsageMonthly: Double?
+    let rateLimit: OpenRouterRateLimit?
+    let updatedAt: Date
+
+    init(
+        totalCredits: Double,
+        totalUsage: Double,
+        balance: Double,
+        usedPercent: Double,
+        keyDataFetched: Bool = false,
+        keyLimit: Double? = nil,
+        keyLimitRemaining: Double? = nil,
+        keyLimitReset: String? = nil,
+        keyUsage: Double? = nil,
+        keyUsageDaily: Double? = nil,
+        keyUsageWeekly: Double? = nil,
+        keyUsageMonthly: Double? = nil,
+        rateLimit: OpenRouterRateLimit?,
+        updatedAt: Date)
+    {
+        self.totalCredits = totalCredits
+        self.totalUsage = totalUsage
+        self.balance = balance
+        self.usedPercent = usedPercent
+        self.keyDataFetched = keyDataFetched || keyLimit != nil || keyLimitRemaining != nil || keyUsage != nil ||
+            keyUsageDaily != nil || keyUsageWeekly != nil || keyUsageMonthly != nil
+        self.keyLimit = keyLimit
+        self.keyLimitRemaining = keyLimitRemaining
+        self.keyLimitReset = keyLimitReset
+        self.keyUsage = keyUsage
+        self.keyUsageDaily = keyUsageDaily
+        self.keyUsageWeekly = keyUsageWeekly
+        self.keyUsageMonthly = keyUsageMonthly
+        self.rateLimit = rateLimit
+        self.updatedAt = updatedAt
+    }
+
+    func toUsageSnapshot() -> UsageSnapshot {
+        let keyUsed = self.keyUsed
+        let primary: RateWindow? = if let keyLimit, keyLimit > 0, let keyUsed, keyUsed >= 0 {
+            RateWindow(
+                usedPercent: min(100, max(0, keyUsed / keyLimit * 100)),
+                windowMinutes: nil,
+                resetsAt: nil,
+                resetDescription: nil)
+        } else {
+            nil
+        }
+        let currency = { (value: Double) in UsageFormatter.usdString(value) }
+        var details: [ProviderDetailSection] = [.makeSection(title: "Credits", rows: [
+            .makeRow(label: "Remaining", value: currency(self.balance)),
+            .makeRow(label: "Used", value: currency(self.totalUsage)),
+            .makeRow(label: "Total added", value: currency(self.totalCredits)),
+        ])]
+        if self.keyDataFetched {
+            var rows: [ProviderDetailSection.Row] = []
+            if let keyLimit, keyLimit > 0 {
+                rows.append(.makeRow(label: "API key budget", value: currency(keyLimit)))
+                if let keyUsed {
+                    rows.append(.makeRow(
+                        label: "API key remaining",
+                        value: currency(max(0, keyLimit - keyUsed))))
+                }
+                if let keyUsage {
+                    rows.append(.makeRow(label: "API key used", value: currency(keyUsage)))
+                }
+            } else {
+                rows.append(.makeRow(label: "API key budget", value: "No limit configured"))
+            }
+            if let reset = self.keyLimitReset?.trimmingCharacters(in: .whitespacesAndNewlines), !reset.isEmpty {
+                rows.append(.makeRow(label: "Reset window", value: reset))
+            }
+            let periods = [
+                ("Today", self.keyUsageDaily),
+                ("This week", self.keyUsageWeekly),
+                ("This month", self.keyUsageMonthly),
+            ]
+            for (label, value) in periods {
+                if let value {
+                    rows.append(.makeRow(label: label, value: currency(value)))
+                }
+            }
+            if let rateLimit {
+                rows.append(.makeRow(
+                    label: "Rate limit",
+                    value: "\(rateLimit.requests) requests / \(rateLimit.interval)"))
+            }
+            let points = periods.compactMap { label, value in value.map { (label, $0) } }
+            details.append(.makeSection(
+                title: "API key",
+                rows: rows,
+                chart: points.isEmpty ? nil : .makeChart(title: "Key spend", unit: "USD", points: points)))
+        } else {
+            details.append(.makeSection(title: "API key", rows: [
+                .makeRow(label: "API key budget", value: "Unavailable right now"),
+            ]))
+        }
+        return UsageSnapshot(
+            primary: primary,
+            secondary: nil,
+            tertiary: nil,
+            providerCost: nil,
+            details: details,
+            updatedAt: self.updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: .openrouter,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Balance: \(currency(self.balance))"))
+    }
+
+    private var keyUsed: Double? {
+        guard self.keyDataFetched, let keyLimit, keyLimit > 0 else { return nil }
+        if let keyLimitRemaining, keyLimitRemaining.isFinite {
+            return keyLimit - min(keyLimit, max(0, keyLimitRemaining))
+        }
+        return switch self.keyLimitReset?.lowercased() {
+        case "daily": self.keyUsageDaily ?? self.keyUsage
+        case "weekly": self.keyUsageWeekly ?? self.keyUsage
+        case "monthly": self.keyUsageMonthly ?? self.keyUsage
+        default: self.keyUsage
+        }
+    }
+}
+#endif

--- a/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
+++ b/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
@@ -33,7 +33,9 @@ struct OpenRouterPluginGoldenTests {
 
     @Test
     func `credits error is classified without response body details`() async throws {
-        let body = #"{"error":"bad token sk-or-v1-abc123","token":"secret-token","authorization":"Bearer sk-or-v1-xyz789"}"#
+        let body = #"""
+        {"error":"bad token sk-or-v1-abc123","token":"secret-token","authorization":"Bearer sk-or-v1-xyz789"}
+        """#
 
         do {
             _ = try await Self.fetch(creditsBody: body, creditsStatus: 401)

--- a/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
+++ b/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
@@ -1,471 +1,271 @@
+#if canImport(JavaScriptCore)
 import Foundation
 import Testing
 @testable import CodexBarCore
 
-@Suite(.serialized)
-struct OpenRouterUsageStatsTests {
+struct OpenRouterPluginGoldenTests {
     @Test
-    func `to usage snapshot uses key quota for primary window`() {
-        let snapshot = OpenRouterUsageSnapshot(
-            totalCredits: 50,
-            totalUsage: 45.3895596325,
-            balance: 4.6104403675,
-            usedPercent: 90.779119265,
-            keyLimit: 20,
-            keyUsage: 5,
-            rateLimit: nil,
-            updatedAt: Date(timeIntervalSince1970: 1_739_841_600))
+    func `key quota fixture matches the production golden`() async throws {
+        let snapshot = try await Self.fetch(keyBody: #"{"data":{"limit":20,"usage":5}}"#)
 
-        let usage = snapshot.toUsageSnapshot()
-
-        #expect(usage.primary?.usedPercent == 25)
-        #expect(usage.primary?.resetsAt == nil)
-        #expect(usage.primary?.resetDescription == nil)
-        #expect(usage.detailRow(label: "API key budget")?.value == "$20.00")
-        #expect(usage.detailRow(label: "API key remaining")?.value == "$15.00")
+        #expect(snapshot.primary?.usedPercent == 25)
+        #expect(snapshot.primary?.resetsAt == nil)
+        #expect(snapshot.primary?.resetDescription == nil)
+        #expect(snapshot.detailRow(label: "API key budget")?.value == "$20.00")
+        #expect(snapshot.detailRow(label: "API key remaining")?.value == "$15.00")
     }
 
     @Test
-    func `to usage snapshot without valid key limit omits primary window`() {
-        let snapshot = OpenRouterUsageSnapshot(
-            totalCredits: 50,
-            totalUsage: 45.3895596325,
-            balance: 4.6104403675,
-            usedPercent: 90.779119265,
-            keyLimit: nil,
-            keyUsage: nil,
-            rateLimit: nil,
-            updatedAt: Date(timeIntervalSince1970: 1_739_841_600))
+    func `missing key limit omits primary and marks no limit`() async throws {
+        let snapshot = try await Self.fetch(keyBody: #"{"data":{}}"#)
 
-        let usage = snapshot.toUsageSnapshot()
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.detailRow(label: "API key budget")?.value == "No limit configured")
+    }
+
+    @Test
+    func `unavailable key enrichment omits primary and marks unavailable`() async throws {
+        let snapshot = try await Self.fetch(keyBody: "{}", keyStatus: 500)
+
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.detailRow(label: "API key budget")?.value == "Unavailable right now")
+    }
+
+    @Test
+    func `credits error is classified without response body details`() async throws {
+        let body = #"{"error":"bad token sk-or-v1-abc123","token":"secret-token","authorization":"Bearer sk-or-v1-xyz789"}"#
+
+        do {
+            _ = try await Self.fetch(creditsBody: body, creditsStatus: 401)
+            Issue.record("Expected API failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == .apiFailure)
+            #expect(error.message == "OpenRouter API error: HTTP 401")
+            #expect(!error.localizedDescription.contains("secret-token"))
+            #expect(!error.localizedDescription.contains("sk-or-v1-abc123"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func `requests preserve credits headers and one second enrichment deadline`() async throws {
+        let requests = OpenRouterRequestRecorder()
+        let transport = Self.transport(requests: requests, keyBody: #"""
+        {"data":{
+          "limit":20,
+          "usage":0.5,
+          "usage_daily":0.12,
+          "usage_weekly":0.74,
+          "usage_monthly":4.56,
+          "rate_limit":{"requests":120,"interval":"10s"}
+        }}
+        """#)
+        let runtime = try ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
+
+        let usage = try await runtime.fetchUsage(
+            settings: [
+                OpenRouterSettingsReader.apiURLEnvironmentKey: "https://openrouter.test/api/v1",
+                OpenRouterSettingsReader.httpRefererEnvironmentKey: "https://codexbar.example",
+                OpenRouterSettingsReader.clientTitleEnvironmentKey: "CodexBar QA",
+            ],
+            secrets: [OpenRouterSettingsReader.envKey: "sk-or-v1-test"])
+
+        let recorded = await requests.requests
+        #expect(recorded.count == 2)
+        #expect(recorded[0].timeoutInterval == 15)
+        #expect(recorded[0].value(forHTTPHeaderField: "HTTP-Referer") == "https://codexbar.example")
+        #expect(recorded[0].value(forHTTPHeaderField: "X-Title") == "CodexBar QA")
+        #expect(recorded[1].timeoutInterval == 1)
+        #expect(recorded[1].value(forHTTPHeaderField: "HTTP-Referer") == nil)
+        #expect(recorded[1].value(forHTTPHeaderField: "X-Title") == nil)
+        #expect(usage.detailRow(label: "Today")?.value == "$0.12")
+        #expect(usage.detailRow(label: "This week")?.value == "$0.74")
+        #expect(usage.detailRow(label: "This month")?.value == "$4.56")
+        #expect(usage.detailRow(label: "Rate limit")?.value == "120 requests / 10s")
+    }
+
+    @Test
+    func `server remaining drives monthly quota golden`() async throws {
+        let usage = try await Self.fetch(keyBody: #"""
+        {"data":{
+          "limit":500,
+          "limit_remaining":454.542594979,
+          "limit_reset":"monthly",
+          "usage":433.286754736,
+          "usage_daily":3.404645509,
+          "usage_weekly":3.404645509,
+          "usage_monthly":45.457405021
+        }}
+        """#)
+
+        #expect(abs((usage.primary?.usedPercent ?? -1) - 9.0914810042) < 1e-9)
+        #expect(usage.detailRow(label: "API key remaining")?.value == "$454.54")
+        #expect(usage.detailRow(label: "Reset window")?.value == "monthly")
+    }
+
+    @Test
+    func `missing remaining falls back to reset window usage`() async throws {
+        let usage = try await Self.fetch(keyBody: #"""
+        {"data":{
+          "limit":500,
+          "limit_reset":"monthly",
+          "usage":433.286754736,
+          "usage_monthly":45.457405021
+        }}
+        """#)
+
+        #expect(abs((usage.primary?.usedPercent ?? -1) - 9.0914810042) < 1e-9)
+        #expect(usage.detailRow(label: "API key remaining")?.value == "$454.54")
+    }
+
+    @Test
+    func `reset window works without cumulative usage`() async throws {
+        let usage = try await Self.fetch(keyBody: #"""
+        {"data":{
+          "limit":500,
+          "limit_reset":"monthly",
+          "usage_monthly":45.457405021
+        }}
+        """#)
+
+        #expect(abs((usage.primary?.usedPercent ?? -1) - 9.0914810042) < 1e-9)
+        #expect(usage.detailRow(label: "API key remaining")?.value == "$454.54")
+    }
+
+    @Test
+    func `negative server remaining is exhausted quota`() async throws {
+        let usage = try await Self.fetch(keyBody: #"""
+        {"data":{
+          "limit":500,
+          "limit_remaining":-5,
+          "limit_reset":"monthly",
+          "usage":433.286754736,
+          "usage_monthly":45.457405021
+        }}
+        """#)
+
+        #expect(usage.primary?.usedPercent == 100)
+        #expect(usage.detailRow(label: "API key remaining")?.value == "$0.00")
+    }
+
+    @Test
+    func `malformed key enrichment degrades to unavailable`() async throws {
+        let usage = try await Self.fetch(keyBody: #"{"data":{"limit":"twenty"}}"#)
 
         #expect(usage.primary == nil)
         #expect(usage.detailRow(label: "API key budget")?.value == "Unavailable right now")
     }
 
     @Test
-    func `to usage snapshot when no limit configured omits primary and marks no limit`() {
-        let snapshot = OpenRouterUsageSnapshot(
-            totalCredits: 50,
-            totalUsage: 45.3895596325,
-            balance: 4.6104403675,
-            usedPercent: 90.779119265,
-            keyDataFetched: true,
-            keyLimit: nil,
-            keyUsage: nil,
-            rateLimit: nil,
-            updatedAt: Date(timeIntervalSince1970: 1_739_841_600))
-
-        let usage = snapshot.toUsageSnapshot()
-
-        #expect(usage.primary == nil)
-        #expect(usage.detailRow(label: "API key budget")?.value == "No limit configured")
-    }
-
-    @Test
-    func `sanitizers redact sensitive token shapes`() {
-        let body = """
-        {"error":"bad token sk-or-v1-abc123","token":"secret-token","authorization":"Bearer sk-or-v1-xyz789"}
-        """
-
-        let summary = OpenRouterUsageFetcher._sanitizedResponseBodySummaryForTesting(body)
-        let debugBody = OpenRouterUsageFetcher._redactedDebugResponseBodyForTesting(body)
-
-        #expect(summary.contains("sk-or-v1-[REDACTED]"))
-        #expect(summary.contains("\"token\":\"[REDACTED]\""))
-        #expect(!summary.contains("secret-token"))
-        #expect(!summary.contains("sk-or-v1-abc123"))
-
-        #expect(debugBody?.contains("sk-or-v1-[REDACTED]") == true)
-        #expect(debugBody?.contains("\"token\":\"[REDACTED]\"") == true)
-        #expect(debugBody?.contains("secret-token") == false)
-        #expect(debugBody?.contains("sk-or-v1-xyz789") == false)
-    }
-
-    @Test
-    func `non200 fetch throws generic HTTP error without body details`() async throws {
-        let registered = URLProtocol.registerClass(OpenRouterStubURLProtocol.self)
-        defer {
-            if registered {
-                URLProtocol.unregisterClass(OpenRouterStubURLProtocol.self)
-            }
-            OpenRouterStubURLProtocol.handler = nil
-        }
-
-        OpenRouterStubURLProtocol.handler = { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            let body = #"{"error":"invalid sk-or-v1-super-secret","token":"dont-leak-me"}"#
-            return Self.makeResponse(url: url, body: body, statusCode: 401)
-        }
-
+    func `credits parse failure is classified`() async throws {
         do {
-            _ = try await OpenRouterUsageFetcher.fetchUsage(
-                apiKey: "sk-or-v1-test",
-                environment: ["OPENROUTER_API_URL": "https://openrouter.test/api/v1"])
-            Issue.record("Expected OpenRouterUsageError.apiError")
-        } catch let error as OpenRouterUsageError {
-            guard case let .apiError(message) = error else {
-                Issue.record("Expected apiError, got: \(error)")
-                return
-            }
-            #expect(message == "HTTP 401")
-            #expect(!message.contains("dont-leak-me"))
-            #expect(!message.contains("sk-or-v1-super-secret"))
+            _ = try await Self.fetch(creditsBody: #"{"data":{"total_credits":"many","total_usage":40}}"#)
+            Issue.record("Expected parse failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == .parseFailure)
+            #expect(error.message.contains("total_credits"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
     }
 
     @Test
-    func `fetch usage sets credits timeout and client headers`() async throws {
-        let registered = URLProtocol.registerClass(OpenRouterStubURLProtocol.self)
-        defer {
-            if registered {
-                URLProtocol.unregisterClass(OpenRouterStubURLProtocol.self)
-            }
-            OpenRouterStubURLProtocol.handler = nil
+    func `invalid credits JSON is classified as parse failure`() async throws {
+        do {
+            _ = try await Self.fetch(creditsBody: "not-json")
+            Issue.record("Expected parse failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == .parseFailure)
+            #expect(error.message == "Failed to parse OpenRouter response: response was not valid JSON")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
-
-        OpenRouterStubURLProtocol.handler = { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            switch url.path {
-            case "/api/v1/credits":
-                #expect(request.timeoutInterval == 15)
-                #expect(request.value(forHTTPHeaderField: "HTTP-Referer") == "https://codexbar.example")
-                #expect(request.value(forHTTPHeaderField: "X-Title") == "CodexBar QA")
-                let body = #"{"data":{"total_credits":100,"total_usage":40}}"#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            case "/api/v1/key":
-                let body = #"""
-                {"data":{
-                  "limit":20,
-                  "usage":0.5,
-                  "usage_daily":0.12,
-                  "usage_weekly":0.74,
-                  "usage_monthly":4.56,
-                  "rate_limit":{"requests":120,"interval":"10s"}
-                }}
-                """#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            default:
-                return Self.makeResponse(url: url, body: "{}", statusCode: 404)
-            }
-        }
-
-        let usage = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "sk-or-v1-test",
-            environment: [
-                "OPENROUTER_API_URL": "https://openrouter.test/api/v1",
-                "OPENROUTER_HTTP_REFERER": " https://codexbar.example ",
-                "OPENROUTER_X_TITLE": "CodexBar QA",
-            ])
-
-        #expect(usage.totalCredits == 100)
-        #expect(usage.totalUsage == 40)
-        #expect(usage.keyDataFetched)
-        #expect(usage.keyLimit == 20)
-        #expect(usage.keyUsage == 0.5)
-        #expect(usage.keyUsageDaily == 0.12)
-        #expect(usage.keyUsageWeekly == 0.74)
-        #expect(usage.keyUsageMonthly == 4.56)
-        #expect(usage.keyRemaining == 19.5)
-        #expect(usage.keyUsedPercent == 2.5)
-        #expect(usage.keyQuotaStatus == .available)
     }
 
     @Test
-    func `fetch usage prefers server remaining for monthly key quota`() async throws {
-        let registered = URLProtocol.registerClass(OpenRouterStubURLProtocol.self)
-        defer {
-            if registered {
-                URLProtocol.unregisterClass(OpenRouterStubURLProtocol.self)
-            }
-            OpenRouterStubURLProtocol.handler = nil
-        }
-
-        OpenRouterStubURLProtocol.handler = { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            switch url.path {
-            case "/api/v1/credits":
-                let body = #"{"data":{"total_credits":100,"total_usage":40}}"#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            case "/api/v1/key":
-                let body = #"""
-                {"data":{
-                  "limit":500,
-                  "limit_remaining":454.542594979,
-                  "limit_reset":"monthly",
-                  "usage":433.286754736,
-                  "usage_daily":3.404645509,
-                  "usage_weekly":3.404645509,
-                  "usage_monthly":45.457405021
-                }}
-                """#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            default:
-                return Self.makeResponse(url: url, body: "{}", statusCode: 404)
-            }
-        }
-
-        let usage = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "sk-or-v1-test",
-            environment: ["OPENROUTER_API_URL": "https://openrouter.test/api/v1"])
-
-        #expect(usage.keyLimitRemaining == 454.542594979)
-        #expect(usage.keyLimitReset == "monthly")
-        #expect(usage.keyRemaining == 454.542594979)
-        #expect(abs((usage.keyUsedPercent ?? -1) - 9.0914810042) < 1e-9)
-        #expect(usage.keyQuotaStatus == .available)
-    }
-
-    @Test
-    func `fetch usage without remaining falls back to reset window usage`() async throws {
-        let registered = URLProtocol.registerClass(OpenRouterStubURLProtocol.self)
-        defer {
-            if registered {
-                URLProtocol.unregisterClass(OpenRouterStubURLProtocol.self)
-            }
-            OpenRouterStubURLProtocol.handler = nil
-        }
-
-        OpenRouterStubURLProtocol.handler = { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            switch url.path {
-            case "/api/v1/credits":
-                let body = #"{"data":{"total_credits":100,"total_usage":40}}"#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            case "/api/v1/key":
-                let body = #"""
-                {"data":{
-                  "limit":500,
-                  "limit_reset":"monthly",
-                  "usage":433.286754736,
-                  "usage_monthly":45.457405021
-                }}
-                """#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            default:
-                return Self.makeResponse(url: url, body: "{}", statusCode: 404)
-            }
-        }
-
-        let usage = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "sk-or-v1-test",
-            environment: ["OPENROUTER_API_URL": "https://openrouter.test/api/v1"])
-
-        #expect(usage.keyLimitRemaining == nil)
-        #expect(usage.keyLimitReset == "monthly")
-        #expect(abs((usage.keyRemaining ?? -1) - 454.542594979) < 1e-9)
-        #expect(abs((usage.keyUsedPercent ?? -1) - 9.0914810042) < 1e-9)
-        #expect(usage.keyQuotaStatus == .available)
-    }
-
-    @Test
-    func `fetch usage without cumulative usage falls back to reset window usage`() async throws {
-        let registered = URLProtocol.registerClass(OpenRouterStubURLProtocol.self)
-        defer {
-            if registered {
-                URLProtocol.unregisterClass(OpenRouterStubURLProtocol.self)
-            }
-            OpenRouterStubURLProtocol.handler = nil
-        }
-
-        OpenRouterStubURLProtocol.handler = { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            switch url.path {
-            case "/api/v1/credits":
-                let body = #"{"data":{"total_credits":100,"total_usage":40}}"#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            case "/api/v1/key":
-                let body = #"""
-                {"data":{
-                  "limit":500,
-                  "limit_reset":"monthly",
-                  "usage_monthly":45.457405021
-                }}
-                """#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            default:
-                return Self.makeResponse(url: url, body: "{}", statusCode: 404)
-            }
-        }
-
-        let usage = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "sk-or-v1-test",
-            environment: ["OPENROUTER_API_URL": "https://openrouter.test/api/v1"])
-
-        #expect(usage.keyLimitRemaining == nil)
-        #expect(usage.keyLimitReset == "monthly")
-        #expect(abs((usage.keyRemaining ?? -1) - 454.542594979) < 1e-9)
-        #expect(abs((usage.keyUsedPercent ?? -1) - 9.0914810042) < 1e-9)
-        #expect(usage.keyQuotaStatus == .available)
-    }
-
-    @Test
-    func `fetch usage treats negative server remaining as exhausted quota`() async throws {
-        let registered = URLProtocol.registerClass(OpenRouterStubURLProtocol.self)
-        defer {
-            if registered {
-                URLProtocol.unregisterClass(OpenRouterStubURLProtocol.self)
-            }
-            OpenRouterStubURLProtocol.handler = nil
-        }
-
-        OpenRouterStubURLProtocol.handler = { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            switch url.path {
-            case "/api/v1/credits":
-                let body = #"{"data":{"total_credits":100,"total_usage":40}}"#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            case "/api/v1/key":
-                let body = #"""
-                {"data":{
-                  "limit":500,
-                  "limit_remaining":-5,
-                  "limit_reset":"monthly",
-                  "usage":433.286754736,
-                  "usage_monthly":45.457405021
-                }}
-                """#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            default:
-                return Self.makeResponse(url: url, body: "{}", statusCode: 404)
-            }
-        }
-
-        let usage = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "sk-or-v1-test",
-            environment: ["OPENROUTER_API_URL": "https://openrouter.test/api/v1"])
-
-        #expect(usage.keyLimitRemaining == -5)
-        #expect(usage.keyRemaining == 0)
-        #expect(usage.keyUsedPercent == 100)
-        #expect(usage.keyQuotaStatus == .available)
-    }
-
-    @Test
-    func `fetch usage when key endpoint fails marks quota unavailable`() async throws {
-        let registered = URLProtocol.registerClass(OpenRouterStubURLProtocol.self)
-        defer {
-            if registered {
-                URLProtocol.unregisterClass(OpenRouterStubURLProtocol.self)
-            }
-            OpenRouterStubURLProtocol.handler = nil
-        }
-
-        OpenRouterStubURLProtocol.handler = { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            switch url.path {
-            case "/api/v1/credits":
-                let body = #"{"data":{"total_credits":100,"total_usage":40}}"#
-                return Self.makeResponse(url: url, body: body, statusCode: 200)
-            case "/api/v1/key":
-                return Self.makeResponse(url: url, body: "{}", statusCode: 500)
-            default:
-                return Self.makeResponse(url: url, body: "{}", statusCode: 404)
-            }
-        }
-
-        let usage = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "sk-or-v1-test",
-            environment: ["OPENROUTER_API_URL": "https://openrouter.test/api/v1"])
-
-        #expect(!usage.keyDataFetched)
-        #expect(usage.keyQuotaStatus == .unavailable)
-    }
-
-    @Test
-    func `key enrichment timeout does not wait for operation that ignores cancellation`() async throws {
-        let startedAt = ContinuousClock.now
-
-        let fetched = try await OpenRouterUsageFetcher._boundedKeyFetchForTesting(
-            timeout: .milliseconds(20))
-        {
-            await withCheckedContinuation { continuation in
-                DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
-                    continuation.resume()
+    func `key enrichment deadline does not block credits result`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            if request.url?.path.hasSuffix("/key") == true {
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 1.5) {
+                        continuation.resume()
+                    }
                 }
             }
+            return try Self.response(
+                request,
+                body: request.url?.path.hasSuffix("/key") == true
+                    ? #"{"data":{"limit":20,"usage":5}}"#
+                    : Self.defaultCreditsBody)
         }
+        let runtime = try ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
+        let startedAt = ContinuousClock.now
 
-        let elapsed = startedAt.duration(to: .now)
-        #expect(!fetched)
-        #expect(elapsed < .milliseconds(300))
+        let usage = try await runtime.fetchUsage(secrets: [OpenRouterSettingsReader.envKey: "fixture-key"])
 
-        try await Task.sleep(for: .milliseconds(550))
+        #expect(ContinuousClock.now - startedAt < .seconds(1.4))
+        #expect(usage.primary == nil)
+        #expect(usage.detailRow(label: "API key budget")?.value == "Unavailable right now")
+        try await Task.sleep(for: .milliseconds(600))
     }
 
-    @Test
-    func `usage snapshot round trip persists open router usage metadata`() throws {
-        let openRouter = OpenRouterUsageSnapshot(
-            totalCredits: 50,
-            totalUsage: 45.3895596325,
-            balance: 4.6104403675,
-            usedPercent: 90.779119265,
-            keyDataFetched: true,
-            keyLimit: nil,
-            keyLimitRemaining: 454.542594979,
-            keyLimitReset: "monthly",
-            keyUsage: nil,
-            keyUsageDaily: 0.12,
-            keyUsageWeekly: 0.74,
-            keyUsageMonthly: 4.56,
-            rateLimit: nil,
-            updatedAt: Date(timeIntervalSince1970: 1_739_841_600))
-        let snapshot = openRouter.toUsageSnapshot()
+    private static let defaultCreditsBody = #"{"data":{"total_credits":100,"total_usage":40}}"#
 
-        let encoder = JSONEncoder()
-        let data = try encoder.encode(snapshot)
-        let decoded = try JSONDecoder().decode(UsageSnapshot.self, from: data)
-
-        #expect(decoded.detailRow(label: "API key budget")?.value == "No limit configured")
-        #expect(decoded.detailRow(label: "Reset window")?.value == "monthly")
-        #expect(decoded.detailRow(label: "Today")?.value == "$0.12")
-        #expect(decoded.detailRow(label: "This week")?.value == "$0.74")
-        #expect(decoded.detailRow(label: "This month")?.value == "$4.56")
-    }
-
-    private static func makeResponse(
-        url: URL,
-        body: String,
-        statusCode: Int = 200) -> (HTTPURLResponse, Data)
+    private static func fetch(
+        creditsBody: String = Self.defaultCreditsBody,
+        creditsStatus: Int = 200,
+        keyBody: String = #"{"data":{"limit":20,"usage":5}}"#,
+        keyStatus: Int = 200) async throws -> UsageSnapshot
     {
-        let response = HTTPURLResponse(
-            url: url,
+        let runtime = try ProviderPluginRuntime(
+            bundledPlugin: "openrouter",
+            transport: Self.transport(
+                creditsBody: creditsBody,
+                creditsStatus: creditsStatus,
+                keyBody: keyBody,
+                keyStatus: keyStatus))
+        return try await runtime.fetchUsage(secrets: [OpenRouterSettingsReader.envKey: "fixture-key"])
+    }
+
+    private static func transport(
+        requests: OpenRouterRequestRecorder? = nil,
+        creditsBody: String = Self.defaultCreditsBody,
+        creditsStatus: Int = 200,
+        keyBody: String,
+        keyStatus: Int = 200) -> ProviderHTTPTransportHandler
+    {
+        ProviderHTTPTransportHandler { request in
+            if let requests {
+                await requests.append(request)
+            }
+            let isKey = request.url?.path.hasSuffix("/key") == true
+            return try Self.response(
+                request,
+                body: isKey ? keyBody : creditsBody,
+                statusCode: isKey ? keyStatus : creditsStatus)
+        }
+    }
+
+    private static func response(
+        _ request: URLRequest,
+        body: String,
+        statusCode: Int = 200) throws -> (Data, URLResponse)
+    {
+        let response = try #require(HTTPURLResponse(
+            url: request.url!,
             statusCode: statusCode,
             httpVersion: "HTTP/1.1",
-            headerFields: ["Content-Type": "application/json"])!
-        return (response, Data(body.utf8))
+            headerFields: ["Content-Type": "application/json"]))
+        return (Data(body.utf8), response)
     }
 }
 
-final class OpenRouterStubURLProtocol: URLProtocol {
-    private static let _handlerBox = LockIsolated<((URLRequest) throws -> (HTTPURLResponse, Data))?>(nil)
-    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
-        get { Self._handlerBox.value }
-        set { Self._handlerBox.setValue(newValue) }
-    }
+private actor OpenRouterRequestRecorder {
+    private(set) var requests: [URLRequest] = []
 
-    override static func canInit(with request: URLRequest) -> Bool {
-        request.url?.host == "openrouter.test"
+    func append(_ request: URLRequest) {
+        self.requests.append(request)
     }
-
-    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        guard let handler = Self.handler else {
-            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        do {
-            let (response, data) = try handler(self.request)
-            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            self.client?.urlProtocol(self, didLoad: data)
-            self.client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            self.client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
 }
+#endif

--- a/Tests/CodexBarTests/ProviderCredentialCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ProviderCredentialCharacterizationTests.swift
@@ -147,7 +147,6 @@ struct ProviderCredentialCharacterizationTests {
             (.llmproxy, "LLM_PROXY_API_KEY", "LLM_PROXY_BASE_URL"),
             (.litellm, "LITELLM_API_KEY", "LITELLM_BASE_URL"),
             (.clawrouter, "CLAWROUTER_API_KEY", "CLAWROUTER_BASE_URL"),
-            (.openrouter, "OPENROUTER_API_KEY", "OPENROUTER_API_URL"),
             (.sub2api, "SUB2API_API_KEY", "SUB2API_BASE_URL"),
         ]
         for (provider, keyName, endpointName) in endpointFixtures {
@@ -156,18 +155,6 @@ struct ProviderCredentialCharacterizationTests {
                 provider: provider,
                 config: ProviderConfig(id: provider.instanceID, apiKey: "key", enterpriseHost: "https://api.example"))
             #expect(environment == [keyName: "key", endpointName: "https://api.example"])
-        }
-        for (provider, endpointName) in [
-            (UsageProvider.openrouter, OpenRouterSettingsReader.apiURLEnvironmentKey),
-            (.clawrouter, ClawRouterSettingsReader.baseURLEnvironmentKey),
-        ] {
-            let environment = ProviderConfigEnvironment.applyProviderConfigOverrides(
-                base: [endpointName: "https://environment.example"],
-                provider: provider,
-                config: ProviderConfig(
-                    id: provider.instanceID,
-                    enterpriseHost: "https://config.example"))
-            #expect(environment[endpointName] == "https://config.example")
         }
 
         let wayfinder = ProviderConfigEnvironment.applyProviderConfigOverrides(
@@ -329,12 +316,6 @@ struct ProviderCredentialCharacterizationTests {
         #expect(!Self.issueCodes(for: ProviderConfig(
             id: .sub2api,
             enterpriseHost: "https://api.example")).contains("invalid_enterprise_host"))
-        #expect(Self.issueCodes(for: ProviderConfig(
-            id: .openrouter,
-            enterpriseHost: "http://api.example")).contains("invalid_enterprise_host"))
-        #expect(!Self.issueCodes(for: ProviderConfig(
-            id: .openrouter,
-            enterpriseHost: "api.example/v1")).contains("invalid_enterprise_host"))
 
         let incompleteTeam = ProviderTokenAccount(
             id: UUID(),

--- a/Tests/CodexBarTests/ProviderCredentialCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ProviderCredentialCharacterizationTests.swift
@@ -147,6 +147,7 @@ struct ProviderCredentialCharacterizationTests {
             (.llmproxy, "LLM_PROXY_API_KEY", "LLM_PROXY_BASE_URL"),
             (.litellm, "LITELLM_API_KEY", "LITELLM_BASE_URL"),
             (.clawrouter, "CLAWROUTER_API_KEY", "CLAWROUTER_BASE_URL"),
+            (.openrouter, "OPENROUTER_API_KEY", "OPENROUTER_API_URL"),
             (.sub2api, "SUB2API_API_KEY", "SUB2API_BASE_URL"),
         ]
         for (provider, keyName, endpointName) in endpointFixtures {
@@ -155,6 +156,18 @@ struct ProviderCredentialCharacterizationTests {
                 provider: provider,
                 config: ProviderConfig(id: provider.instanceID, apiKey: "key", enterpriseHost: "https://api.example"))
             #expect(environment == [keyName: "key", endpointName: "https://api.example"])
+        }
+        for (provider, endpointName) in [
+            (UsageProvider.openrouter, OpenRouterSettingsReader.apiURLEnvironmentKey),
+            (.clawrouter, ClawRouterSettingsReader.baseURLEnvironmentKey),
+        ] {
+            let environment = ProviderConfigEnvironment.applyProviderConfigOverrides(
+                base: [endpointName: "https://environment.example"],
+                provider: provider,
+                config: ProviderConfig(
+                    id: provider.instanceID,
+                    enterpriseHost: "https://config.example"))
+            #expect(environment[endpointName] == "https://config.example")
         }
 
         let wayfinder = ProviderConfigEnvironment.applyProviderConfigOverrides(
@@ -316,6 +329,12 @@ struct ProviderCredentialCharacterizationTests {
         #expect(!Self.issueCodes(for: ProviderConfig(
             id: .sub2api,
             enterpriseHost: "https://api.example")).contains("invalid_enterprise_host"))
+        #expect(Self.issueCodes(for: ProviderConfig(
+            id: .openrouter,
+            enterpriseHost: "http://api.example")).contains("invalid_enterprise_host"))
+        #expect(!Self.issueCodes(for: ProviderConfig(
+            id: .openrouter,
+            enterpriseHost: "api.example/v1")).contains("invalid_enterprise_host"))
 
         let incompleteTeam = ProviderTokenAccount(
             id: UUID(),

--- a/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
+++ b/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
@@ -322,6 +322,25 @@ struct ProviderDiagnosticExportTests {
         #expect(diagParse.category == "parse")
     }
 
+    @Test(arguments: [
+        (ProviderFetchClassifiedError.Kind.authenticationExpired, "auth"),
+        (.missingCredential, "auth"),
+        (.permissionDenied, "auth"),
+        (.rateLimited, "api"),
+        (.providerUnavailable, "api"),
+        (.apiFailure, "api"),
+        (.parseFailure, "parse"),
+        (.networkFailure, "network"),
+    ])
+    func `diagnostic error maps classified plugin failures`(kind: ProviderFetchClassifiedError.Kind, category: String) {
+        let error = ProviderFetchClassifiedError(kind: kind, message: "fixture detail")
+
+        let diagnostic = ProviderDiagnosticError(from: error, authConfigured: true)
+
+        #expect(diagnostic.category == category)
+        #expect(!diagnostic.safeDescription.contains("fixture detail"))
+    }
+
     @Test
     func `diagnostic error maps Alibaba invalid endpoint override to configuration`() {
         let error = ProviderEndpointOverrideError.alibabaCodingPlan("ALIBABA_CODING_PLAN_QUOTA_URL")

--- a/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
+++ b/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
@@ -82,15 +82,6 @@ struct ProviderEndpointOverrideSecurityTests {
         let insecureURL = "http://attacker.test/v1"
 
         do {
-            _ = try await OpenRouterUsageFetcher.fetchUsage(
-                apiKey: "openrouter-test",
-                environment: ["OPENROUTER_API_URL": insecureURL])
-            Issue.record("Expected OpenRouterSettingsError.invalidEndpointOverride")
-        } catch {
-            #expect(error as? OpenRouterSettingsError == .invalidEndpointOverride("OPENROUTER_API_URL"))
-        }
-
-        do {
             _ = try await CodebuffUsageFetcher.fetchUsage(
                 apiKey: "codebuff-test",
                 environment: ["CODEBUFF_API_URL": insecureURL])

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -158,6 +158,28 @@ struct ProviderPluginDetailsParityTests {
         #expect(recorded[1].value(forHTTPHeaderField: "X-Title") == nil)
     }
 
+    @Test
+    func `OpenRouter credential adapter projects and validates configured origin`() throws {
+        let endpointKey = OpenRouterSettingsReader.apiURLEnvironmentKey
+        let configured = ProviderConfigEnvironment.applyProviderConfigOverrides(
+            base: [endpointKey: "https://environment.example"],
+            provider: .openrouter,
+            config: ProviderConfig(
+                id: .openrouter,
+                apiKey: "config-key",
+                enterpriseHost: "https://config.example/v1"))
+
+        #expect(configured[OpenRouterSettingsReader.envKey] == "config-key")
+        #expect(configured[endpointKey] == "https://config.example/v1")
+        let credentials = try #require(ProviderDescriptorRegistry.descriptor(for: .openrouter).credentials)
+        #expect(credentials.validateConfig(ProviderConfig(
+            id: .openrouter,
+            enterpriseHost: "http://api.example")).contains { $0.code == "invalid_enterprise_host" })
+        #expect(credentials.validateConfig(ProviderConfig(
+            id: .openrouter,
+            enterpriseHost: "api.example/v1")).isEmpty)
+    }
+
     @Test(arguments: [false, true])
     func `ClawRouter cut-over honors default and overridden requests`(overridden: Bool) async throws {
         let baseURL = try #require(URL(string: overridden

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -130,6 +130,79 @@ struct ProviderPluginDetailsParityTests {
         ])
     }
 
+    @Test(arguments: [false, true])
+    func `OpenRouter default and overridden requests match Swift`(overridden: Bool) async throws {
+        let environment: [String: String] = overridden ? [
+            OpenRouterSettingsReader.apiURLEnvironmentKey: "https://router.example.test/gateway/v1",
+            OpenRouterSettingsReader.httpRefererEnvironmentKey: " https://codexbar.example ",
+            OpenRouterSettingsReader.clientTitleEnvironmentKey: "CodexBar QA",
+        ] : [:]
+        let settings: [String: String] = [
+            OpenRouterSettingsReader.apiURLEnvironmentKey:
+                OpenRouterSettingsReader.apiURL(environment: environment).absoluteString,
+            OpenRouterSettingsReader.clientTitleEnvironmentKey:
+                OpenRouterSettingsReader.clientTitle(environment: environment),
+            OpenRouterSettingsReader.httpRefererEnvironmentKey:
+                OpenRouterSettingsReader.httpReferer(environment: environment) ?? "",
+        ]
+        let requests = PluginRequestRecorder()
+        let transport = Self.recordingTransport(requests) { request in
+            request.url?.path.hasSuffix("/key") == true ? Self.openRouterKey : Self.openRouterCredits
+        }
+
+        _ = try await OpenRouterUsageFetcher.fetchUsage(
+            apiKey: "fixture-key",
+            environment: environment,
+            transport: transport)
+        _ = try await ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport).fetchUsage(
+            settings: settings,
+            secrets: [OpenRouterSettingsReader.envKey: "fixture-key"])
+
+        let recorded = await requests.requests
+        #expect(recorded.count == 4)
+        #expect(recorded[0].url == recorded[2].url)
+        #expect(recorded[1].url == recorded[3].url)
+        #expect(recorded[0].url?.absoluteString == (overridden
+                ? "https://router.example.test/gateway/v1/credits"
+                : "https://openrouter.ai/api/v1/credits"))
+        #expect(recorded[1].url?.absoluteString == (overridden
+                ? "https://router.example.test/gateway/v1/key"
+                : "https://openrouter.ai/api/v1/key"))
+        #expect(recorded[0].value(forHTTPHeaderField: "X-Title") == (overridden ? "CodexBar QA" : "CodexBar"))
+        #expect(recorded[0].value(forHTTPHeaderField: "HTTP-Referer") ==
+            (overridden ? "https://codexbar.example" : nil))
+        #expect(recorded[0].value(forHTTPHeaderField: "X-Title") ==
+            recorded[2].value(forHTTPHeaderField: "X-Title"))
+        #expect(recorded[0].value(forHTTPHeaderField: "HTTP-Referer") ==
+            recorded[2].value(forHTTPHeaderField: "HTTP-Referer"))
+        #expect(recorded[1].value(forHTTPHeaderField: "X-Title") == nil)
+        #expect(recorded[3].value(forHTTPHeaderField: "X-Title") == nil)
+    }
+
+    @Test(arguments: [false, true])
+    func `ClawRouter default and overridden requests match Swift`(overridden: Bool) async throws {
+        let baseURL = try #require(URL(string: overridden
+                ? "https://router.example.test/gateway/v1"
+                : "https://clawrouter.openclaw.ai"))
+        let requests = PluginRequestRecorder()
+        let transport = Self.recordingTransport(requests) { _ in Self.clawRouter }
+
+        _ = try await ClawRouterUsageFetcher.fetchUsage(
+            apiKey: "fixture-key",
+            baseURL: baseURL,
+            transport: transport)
+        _ = try await ProviderPluginRuntime(bundledPlugin: "clawrouter", transport: transport).fetchUsage(
+            settings: [ClawRouterSettingsReader.baseURLEnvironmentKey: baseURL.absoluteString],
+            secrets: [ClawRouterSettingsReader.apiKeyEnvironmentKey: "fixture-key"])
+
+        let recorded = await requests.requests
+        #expect(recorded.count == 2)
+        #expect(recorded[0].url == recorded[1].url)
+        #expect(recorded[0].url?.absoluteString == (overridden
+                ? "https://router.example.test/gateway/v1/usage"
+                : "https://clawrouter.openclaw.ai/v1/usage"))
+    }
+
     @Test
     func `Poe fixture has Swift core parity and stable details`() async throws {
         let transport = Self.transport { request in
@@ -273,6 +346,21 @@ struct ProviderPluginDetailsParityTests {
         ProviderHTTPTransportHandler { request in
             #expect(request.httpMethod == "GET")
             #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer fixture-key")
+            let response = try #require(HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]))
+            return try (Data(body(request).utf8), response)
+        }
+    }
+
+    private static func recordingTransport(
+        _ recorder: PluginRequestRecorder,
+        body: @escaping @Sendable (URLRequest) throws -> String) -> ProviderHTTPTransportHandler
+    {
+        ProviderHTTPTransportHandler { request in
+            await recorder.append(request)
             let response = try #require(HTTPURLResponse(
                 url: request.url!,
                 statusCode: 200,
@@ -427,6 +515,14 @@ private struct FixtureClaudeFetcher: ClaudeUsageFetching {
 
     func detectVersion() -> String? {
         nil
+    }
+}
+
+private actor PluginRequestRecorder {
+    private(set) var requests: [URLRequest] = []
+
+    func append(_ request: URLRequest) {
+        self.requests.append(request)
     }
 }
 #endif

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -9,7 +9,6 @@ struct ProviderPluginDetailsParityTests {
         let fixtures: [(UsageProvider, [String], [String])] = [
             (.openai, ["openai.api.balance"], ["openai.js", "openai.api.balance"]),
             (.zai, ["zai.api"], ["zai.js", "zai.api"]),
-            (.openrouter, ["openrouter.api"], ["openrouter.js", "openrouter.api"]),
             (.poe, ["poe.api"], ["poe.js", "poe.api"]),
             (.clawrouter, ["clawrouter.api"], ["clawrouter.js", "clawrouter.api"]),
         ]
@@ -51,7 +50,7 @@ struct ProviderPluginDetailsParityTests {
     }
 
     @Test
-    func `OpenRouter fixture has Swift core parity and stable details`() async throws {
+    func `OpenRouter fixture matches stable cut-over details`() async throws {
         let transport = Self.transport { request in
             switch request.url?.path {
             case "/api/v1/credits": Self.openRouterCredits
@@ -60,15 +59,11 @@ struct ProviderPluginDetailsParityTests {
             }
         }
         let now = Date(timeIntervalSince1970: 1_785_686_400)
-        let swift = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "fixture-key",
-            environment: [:],
-            transport: transport).toUsageSnapshot()
         let script = try await ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
             .fetchUsage(secrets: ["OPENROUTER_API_KEY": "fixture-key"], now: now)
 
-        Self.expectCoreParity(swift, script)
-        #expect(swift.details == script.details)
+        #expect(script.primary?.usedPercent == 25)
+        #expect(script.identity?.loginMethod == "Balance: $60.00")
         #expect(try script.details == [
             Self.section("Credits", rows: [
                 Self.row("Remaining", "$60.00"),
@@ -131,7 +126,7 @@ struct ProviderPluginDetailsParityTests {
     }
 
     @Test(arguments: [false, true])
-    func `OpenRouter default and overridden requests match Swift`(overridden: Bool) async throws {
+    func `OpenRouter cut-over honors default and overridden requests`(overridden: Bool) async throws {
         let environment: [String: String] = overridden ? [
             OpenRouterSettingsReader.apiURLEnvironmentKey: "https://router.example.test/gateway/v1",
             OpenRouterSettingsReader.httpRefererEnvironmentKey: " https://codexbar.example ",
@@ -150,18 +145,12 @@ struct ProviderPluginDetailsParityTests {
             request.url?.path.hasSuffix("/key") == true ? Self.openRouterKey : Self.openRouterCredits
         }
 
-        _ = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "fixture-key",
-            environment: environment,
-            transport: transport)
         _ = try await ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport).fetchUsage(
             settings: settings,
             secrets: [OpenRouterSettingsReader.envKey: "fixture-key"])
 
         let recorded = await requests.requests
-        #expect(recorded.count == 4)
-        #expect(recorded[0].url == recorded[2].url)
-        #expect(recorded[1].url == recorded[3].url)
+        #expect(recorded.count == 2)
         #expect(recorded[0].url?.absoluteString == (overridden
                 ? "https://router.example.test/gateway/v1/credits"
                 : "https://openrouter.ai/api/v1/credits"))
@@ -171,12 +160,7 @@ struct ProviderPluginDetailsParityTests {
         #expect(recorded[0].value(forHTTPHeaderField: "X-Title") == (overridden ? "CodexBar QA" : "CodexBar"))
         #expect(recorded[0].value(forHTTPHeaderField: "HTTP-Referer") ==
             (overridden ? "https://codexbar.example" : nil))
-        #expect(recorded[0].value(forHTTPHeaderField: "X-Title") ==
-            recorded[2].value(forHTTPHeaderField: "X-Title"))
-        #expect(recorded[0].value(forHTTPHeaderField: "HTTP-Referer") ==
-            recorded[2].value(forHTTPHeaderField: "HTTP-Referer"))
         #expect(recorded[1].value(forHTTPHeaderField: "X-Title") == nil)
-        #expect(recorded[3].value(forHTTPHeaderField: "X-Title") == nil)
     }
 
     @Test(arguments: [false, true])

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -10,7 +10,6 @@ struct ProviderPluginDetailsParityTests {
             (.openai, ["openai.api.balance"], ["openai.js", "openai.api.balance"]),
             (.zai, ["zai.api"], ["zai.js", "zai.api"]),
             (.poe, ["poe.api"], ["poe.js", "poe.api"]),
-            (.clawrouter, ["clawrouter.api"], ["clawrouter.js", "clawrouter.api"]),
         ]
 
         for (provider, defaultIDs, enabledIDs) in fixtures {
@@ -89,22 +88,18 @@ struct ProviderPluginDetailsParityTests {
     }
 
     @Test
-    func `ClawRouter fixture has Swift core parity and stable details`() async throws {
+    func `ClawRouter fixture matches stable cut-over details`() async throws {
         let transport = Self.transport { request in
             guard request.url?.path == "/v1/usage" else { throw FixtureError.unexpectedURL(request.url) }
             return Self.clawRouter
         }
         let now = Date(timeIntervalSince1970: 1_785_686_400)
-        let swift = try await ClawRouterUsageFetcher.fetchUsage(
-            apiKey: "fixture-key",
-            baseURL: #require(URL(string: "https://clawrouter.openclaw.ai")),
-            transport: transport,
-            updatedAt: now).toUsageSnapshot()
         let script = try await ProviderPluginRuntime(bundledPlugin: "clawrouter", transport: transport)
             .fetchUsage(secrets: ["CLAWROUTER_API_KEY": "fixture-key"], now: now)
 
-        Self.expectCoreParity(swift, script)
-        #expect(swift.details == script.details)
+        #expect(script.primary?.usedPercent == 0.024)
+        #expect(script.providerCost?.used == 0.006)
+        #expect(script.providerCost?.limit == 25)
         #expect(try script.details == [
             Self.section("Usage", rows: [
                 Self.row("Requests", "6", "5 succeeded · 1 failed"),
@@ -164,24 +159,19 @@ struct ProviderPluginDetailsParityTests {
     }
 
     @Test(arguments: [false, true])
-    func `ClawRouter default and overridden requests match Swift`(overridden: Bool) async throws {
+    func `ClawRouter cut-over honors default and overridden requests`(overridden: Bool) async throws {
         let baseURL = try #require(URL(string: overridden
                 ? "https://router.example.test/gateway/v1"
                 : "https://clawrouter.openclaw.ai"))
         let requests = PluginRequestRecorder()
         let transport = Self.recordingTransport(requests) { _ in Self.clawRouter }
 
-        _ = try await ClawRouterUsageFetcher.fetchUsage(
-            apiKey: "fixture-key",
-            baseURL: baseURL,
-            transport: transport)
         _ = try await ProviderPluginRuntime(bundledPlugin: "clawrouter", transport: transport).fetchUsage(
             settings: [ClawRouterSettingsReader.baseURLEnvironmentKey: baseURL.absoluteString],
             secrets: [ClawRouterSettingsReader.apiKeyEnvironmentKey: "fixture-key"])
 
         let recorded = await requests.requests
-        #expect(recorded.count == 2)
-        #expect(recorded[0].url == recorded[1].url)
+        #expect(recorded.count == 1)
         #expect(recorded[0].url?.absoluteString == (overridden
                 ? "https://router.example.test/gateway/v1/usage"
                 : "https://clawrouter.openclaw.ai/v1/usage"))

--- a/Tests/CodexBarTests/ProviderPluginExtensionParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginExtensionParityTests.swift
@@ -59,7 +59,7 @@ struct ProviderPluginExtensionParityTests {
     }
 
     @Test
-    func `Deepgram plugin matches generic Swift projection and details golden`() async throws {
+    func `Deepgram plugin matches the cut-over details golden`() async throws {
         let transport = Self.transport { request in
             switch request.url?.path {
             case "/v1/projects":
@@ -70,14 +70,11 @@ struct ProviderPluginExtensionParityTests {
                 throw URLError(.badURL)
             }
         }
-        let swift = try await DeepgramUsageFetcher.fetchUsage(apiKey: "fixture-key", transport: transport)
-            .toUsageSnapshot()
         let script = try await ProviderPluginRuntime(bundledPlugin: "deepgram", transport: transport)
             .fetchUsage(secrets: ["DEEPGRAM_API_KEY": "fixture-key"])
 
-        #expect(script.primary == swift.primary)
-        #expect(script.identity?.loginMethod == swift.identity?.loginMethod)
-        #expect(script.details == swift.details)
+        #expect(script.primary == nil)
+        #expect(script.identity?.loginMethod == "Project: Alpha")
         #expect(try script.details == [ProviderDetailSection(
             title: "Usage summary",
             rows: [

--- a/Tests/CodexBarTests/ProviderPluginExtensionParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginExtensionParityTests.swift
@@ -86,24 +86,22 @@ struct ProviderPluginExtensionParityTests {
     }
 
     @Test
-    func `sub2api plugin matches generic Swift projection and details golden`() async throws {
+    func `sub2api plugin matches the cut-over details golden`() async throws {
         let fixture = #"{"mode":"quota_limited","isValid":true,"planName":"Team","quota":{"limit":100,"used":25,"remaining":75,"unit":"USD"},"usage":{"today":{"requests":4,"total_tokens":1200,"actual_cost":1.25}}}"#
         let transport = Self.transport { _ in fixture }
         let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let swift = try Sub2APIUsageFetcher._parseSnapshotForTesting(Data(fixture.utf8), updatedAt: now)
-            .toUsageSnapshot()
         let script = try await ProviderPluginRuntime(bundledPlugin: "sub2api", transport: transport)
             .fetchUsage(
                 settings: ["SUB2API_BASE_URL": "http://127.0.0.1:8787"],
                 secrets: ["SUB2API_API_KEY": "fixture-key"],
                 now: now)
 
-        #expect(script.primary == swift.primary)
-        #expect(script.secondary == swift.secondary)
-        #expect(script.tertiary == swift.tertiary)
-        #expect(script.identity?.accountOrganization == swift.identity?.accountOrganization)
-        #expect(script.identity?.loginMethod == swift.identity?.loginMethod)
-        #expect(script.details == swift.details)
+        #expect(script.primary?.usedPercent == 25)
+        #expect(script.secondary == nil)
+        #expect(script.tertiary == nil)
+        #expect(script.identity?.accountOrganization == "Team")
+        #expect(script.identity?.loginMethod == "Team")
+        #expect(script.dataConfidence == .exact)
         #expect(try script.details == [ProviderDetailSection(
             title: "Usage summary",
             rows: [

--- a/Tests/CodexBarTests/ProviderPluginParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginParityTests.swift
@@ -29,6 +29,7 @@ struct ProviderPluginParityTests {
             (.venice, "VENICE_API_KEY"),
             (.openrouter, "OPENROUTER_API_KEY"),
             (.clawrouter, "CLAWROUTER_API_KEY"),
+            (.deepgram, "DEEPGRAM_API_KEY"),
         ] {
             let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
             let context = Self.context(environment: [key: "fixture-key"])
@@ -44,7 +45,7 @@ struct ProviderPluginParityTests {
         }
     }
 
-    @Test(arguments: [UsageProvider.openrouter, .clawrouter])
+    @Test(arguments: [UsageProvider.openrouter, .clawrouter, .deepgram])
     func `override preflight preserves provider validation errors`(provider: UsageProvider) async throws {
         let environment: [String: String] = switch provider {
         case .openrouter: [
@@ -55,6 +56,11 @@ struct ProviderPluginParityTests {
         case .clawrouter: [
                 ClawRouterSettingsReader.apiKeyEnvironmentKey: "fixture-key",
                 ClawRouterSettingsReader.baseURLEnvironmentKey: "http://router.example.test",
+                ProviderPluginPrototype.environmentKey: "1",
+            ]
+        case .deepgram: [
+                DeepgramSettingsReader.apiKeyEnvironmentKey: "fixture-key",
+                DeepgramSettingsReader.apiURLEnvironmentKey: "http://router.example.test",
                 ProviderPluginPrototype.environmentKey: "1",
             ]
         default: [:]
@@ -72,6 +78,13 @@ struct ProviderPluginParityTests {
         } catch let error as ClawRouterSettingsError {
             #expect(provider == .clawrouter)
             #expect(error == .invalidEndpointOverride(ClawRouterSettingsReader.baseURLEnvironmentKey))
+        } catch let error as DeepgramSettingsError {
+            #expect(provider == .deepgram)
+            guard case let .invalidEndpointOverride(key) = error else {
+                Issue.record("Unexpected Deepgram settings error: \(error)")
+                return
+            }
+            #expect(key == DeepgramSettingsReader.apiURLEnvironmentKey)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }

--- a/Tests/CodexBarTests/ProviderPluginParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginParityTests.swift
@@ -30,17 +30,20 @@ struct ProviderPluginParityTests {
             (.openrouter, "OPENROUTER_API_KEY"),
             (.clawrouter, "CLAWROUTER_API_KEY"),
             (.deepgram, "DEEPGRAM_API_KEY"),
+            (.sub2api, "SUB2API_API_KEY"),
         ] {
             let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
-            let context = Self.context(environment: [key: "fixture-key"])
+            var environment = [key: "fixture-key"]
+            if provider == .sub2api {
+                environment[Sub2APISettingsReader.baseURLEnvironmentKey] = "https://api.example.com"
+            }
+            let context = Self.context(environment: environment)
             let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(context)
 
             #expect(strategies.map(\.id) == ["\(provider.rawValue).js"])
             #expect(await strategies[0].isAvailable(context))
-            let flagged = await descriptor.fetchPlan.pipeline.resolveStrategies(Self.context(environment: [
-                key: "fixture-key",
-                ProviderPluginPrototype.environmentKey: "1",
-            ]))
+            environment[ProviderPluginPrototype.environmentKey] = "1"
+            let flagged = await descriptor.fetchPlan.pipeline.resolveStrategies(Self.context(environment: environment))
             #expect(flagged.map(\.id) == ["\(provider.rawValue).js"])
         }
     }

--- a/Tests/CodexBarTests/ProviderPluginParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginParityTests.swift
@@ -51,17 +51,20 @@ struct ProviderPluginParityTests {
     @Test(arguments: [UsageProvider.openrouter, .clawrouter, .deepgram])
     func `override preflight preserves provider validation errors`(provider: UsageProvider) async throws {
         let environment: [String: String] = switch provider {
-        case .openrouter: [
+        case .openrouter:
+            [
                 OpenRouterSettingsReader.envKey: "fixture-key",
                 OpenRouterSettingsReader.apiURLEnvironmentKey: "http://router.example.test",
                 ProviderPluginPrototype.environmentKey: "1",
             ]
-        case .clawrouter: [
+        case .clawrouter:
+            [
                 ClawRouterSettingsReader.apiKeyEnvironmentKey: "fixture-key",
                 ClawRouterSettingsReader.baseURLEnvironmentKey: "http://router.example.test",
                 ProviderPluginPrototype.environmentKey: "1",
             ]
-        case .deepgram: [
+        case .deepgram:
+            [
                 DeepgramSettingsReader.apiKeyEnvironmentKey: "fixture-key",
                 DeepgramSettingsReader.apiURLEnvironmentKey: "http://router.example.test",
                 ProviderPluginPrototype.environmentKey: "1",

--- a/Tests/CodexBarTests/ProviderPluginParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginParityTests.swift
@@ -28,6 +28,7 @@ struct ProviderPluginParityTests {
             (UsageProvider.crof, "CROF_API_KEY"),
             (.venice, "VENICE_API_KEY"),
             (.openrouter, "OPENROUTER_API_KEY"),
+            (.clawrouter, "CLAWROUTER_API_KEY"),
         ] {
             let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
             let context = Self.context(environment: [key: "fixture-key"])

--- a/Tests/CodexBarTests/ProviderPluginParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginParityTests.swift
@@ -24,7 +24,11 @@ struct ProviderPluginParityTests {
 
     @Test
     func `cut-over providers use only JS without the prototype flag`() async {
-        for (provider, key) in [(UsageProvider.crof, "CROF_API_KEY"), (.venice, "VENICE_API_KEY")] {
+        for (provider, key) in [
+            (UsageProvider.crof, "CROF_API_KEY"),
+            (.venice, "VENICE_API_KEY"),
+            (.openrouter, "OPENROUTER_API_KEY"),
+        ] {
             let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
             let context = Self.context(environment: [key: "fixture-key"])
             let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(context)
@@ -176,7 +180,7 @@ struct ProviderPluginParityTests {
     }
 
     @Test
-    func `OpenRouter monthly limit fixture has Swift and JS snapshot parity`() async throws {
+    func `OpenRouter monthly limit fixture matches the cut-over golden`() async throws {
         let creditsBody = #"{"data":{"total_credits":100,"total_usage":40}}"#
         let keyBody = #"""
         {"data":{
@@ -203,22 +207,18 @@ struct ProviderPluginParityTests {
         }
         let now = Date()
 
-        let swift = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "fixture-key",
-            environment: ["OPENROUTER_API_URL": "https://openrouter.test/api/v1"],
-            transport: transport).toUsageSnapshot()
         let runtime = try ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
         let script = try await runtime.fetchUsage(
             secrets: ["OPENROUTER_API_KEY": "fixture-key"],
             now: now)
 
-        #expect(swift.primary?.usedPercent == 9.0914810042)
         #expect(script.primary?.usedPercent == 9.0914810042)
-        Self.expectCoreParity(swift, script)
+        #expect(script.identity?.providerID == .openrouter)
+        #expect(script.identity?.loginMethod == "Balance: $60.00")
     }
 
     @Test
-    func `OpenRouter remaining above limit fixture has Swift and JS snapshot parity`() async throws {
+    func `OpenRouter remaining above limit fixture matches the cut-over golden`() async throws {
         let creditsBody = #"{"data":{"total_credits":100,"total_usage":40}}"#
         let keyBody = #"""
         {"data":{
@@ -242,10 +242,6 @@ struct ProviderPluginParityTests {
         }
         let now = Date()
 
-        let swift = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "fixture-key",
-            environment: ["OPENROUTER_API_URL": "https://openrouter.test/api/v1"],
-            transport: transport).toUsageSnapshot()
         let runtime = try ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
         let script = try await runtime.fetchUsage(
             secrets: ["OPENROUTER_API_KEY": "fixture-key"],
@@ -253,13 +249,12 @@ struct ProviderPluginParityTests {
 
         // Server remaining above the configured limit clamps to a full quota (0% used)
         // in both implementations instead of suppressing the meter.
-        #expect(swift.primary?.usedPercent == 0)
         #expect(script.primary?.usedPercent == 0)
-        Self.expectCoreParity(swift, script)
+        #expect(script.detailRow(label: "API key remaining")?.value == "$500.00")
     }
 
     @Test
-    func `OpenRouter reset window fallback without cumulative usage has Swift and JS parity`() async throws {
+    func `OpenRouter reset window fallback without cumulative usage matches the cut-over golden`() async throws {
         let creditsBody = #"{"data":{"total_credits":100,"total_usage":40}}"#
         let keyBody = #"""
         {"data":{
@@ -282,10 +277,6 @@ struct ProviderPluginParityTests {
         }
         let now = Date()
 
-        let swift = try await OpenRouterUsageFetcher.fetchUsage(
-            apiKey: "fixture-key",
-            environment: ["OPENROUTER_API_URL": "https://openrouter.test/api/v1"],
-            transport: transport).toUsageSnapshot()
         let runtime = try ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
         let script = try await runtime.fetchUsage(
             secrets: ["OPENROUTER_API_KEY": "fixture-key"],
@@ -293,9 +284,8 @@ struct ProviderPluginParityTests {
 
         // Without cumulative usage, the reset-window fallback still renders the meter
         // in both implementations.
-        #expect(swift.primary?.usedPercent == 9.0914810042)
         #expect(script.primary?.usedPercent == 9.0914810042)
-        Self.expectCoreParity(swift, script)
+        #expect(script.detailRow(label: "API key remaining")?.value == "$454.54")
     }
 
     private static func transport(body: String) -> ProviderHTTPTransportHandler {

--- a/Tests/CodexBarTests/ProviderPluginParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginParityTests.swift
@@ -39,6 +39,39 @@ struct ProviderPluginParityTests {
         }
     }
 
+    @Test(arguments: [UsageProvider.openrouter, .clawrouter])
+    func `override preflight preserves provider validation errors`(provider: UsageProvider) async throws {
+        let environment: [String: String] = switch provider {
+        case .openrouter: [
+                OpenRouterSettingsReader.envKey: "fixture-key",
+                OpenRouterSettingsReader.apiURLEnvironmentKey: "http://router.example.test",
+                ProviderPluginPrototype.environmentKey: "1",
+            ]
+        case .clawrouter: [
+                ClawRouterSettingsReader.apiKeyEnvironmentKey: "fixture-key",
+                ClawRouterSettingsReader.baseURLEnvironmentKey: "http://router.example.test",
+                ProviderPluginPrototype.environmentKey: "1",
+            ]
+        default: [:]
+        }
+        let context = Self.context(environment: environment)
+        let strategy = try #require(await ProviderDescriptorRegistry.descriptor(for: provider)
+            .fetchPlan.pipeline.resolveStrategies(context).first)
+
+        do {
+            _ = try await strategy.fetch(context)
+            Issue.record("Expected invalid endpoint override")
+        } catch let error as OpenRouterSettingsError {
+            #expect(provider == .openrouter)
+            #expect(error == .invalidEndpointOverride(OpenRouterSettingsReader.apiURLEnvironmentKey))
+        } catch let error as ClawRouterSettingsError {
+            #expect(provider == .clawrouter)
+            #expect(error == .invalidEndpointOverride(ClawRouterSettingsReader.baseURLEnvironmentKey))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
     @Test
     func `Synthetic fixture has Swift and JS snapshot parity`() async throws {
         let body = """

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -52,6 +52,65 @@ struct ProviderPluginRuntimeTests {
     }
 
     @Test
+    func `HTTP request deadline defaults to fifteen seconds and accepts bounded override`() async throws {
+        let requests = RequestRecorder()
+        let runtime = try ProviderPluginRuntime(
+            source: Self.plugin(fetchBody: """
+            await ctx.http.getJSON("https://api.example.test/default");
+            const response = await ctx.http.getJSON("https://api.example.test/override", { timeoutSeconds: 7.5 });
+            return { primary: { usedPercent: response.json.used } };
+            """),
+            transport: Self.transport(recorder: requests, body: #"{"used":11}"#))
+
+        let snapshot = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret-value"])
+
+        #expect(snapshot.primary?.usedPercent == 11)
+        let recorded = await requests.all
+        #expect(recorded.map(\.timeoutInterval) == [15, 7.5])
+    }
+
+    @Test(arguments: ["0", "0.5", "31", #""slow""#])
+    func `HTTP request deadline rejects values outside one through thirty seconds`(value: String) async throws {
+        let requests = RequestRecorder()
+        let runtime = try ProviderPluginRuntime(
+            source: Self.plugin(fetchBody: """
+            await ctx.http.getJSON("https://api.example.test/usage", { timeoutSeconds: \(value) });
+            return { primary: { usedPercent: 1 } };
+            """),
+            transport: Self.transport(recorder: requests))
+
+        await #expect(throws: ProviderPluginError.self) {
+            _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret-value"])
+        }
+        #expect(await requests.isEmpty)
+    }
+
+    @Test
+    func `HTTP request deadline cancels a transport that exceeds it`() async throws {
+        let runtime = try ProviderPluginRuntime(
+            source: Self.plugin(fetchBody: """
+            await ctx.http.getJSON("https://api.example.test/slow", { timeoutSeconds: 1 });
+            return { primary: { usedPercent: 1 } };
+            """),
+            transport: ProviderHTTPTransportHandler { request in
+                try await Task.sleep(for: .seconds(5))
+                let response = try #require(HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]))
+                return (Data(#"{"used":1}"#.utf8), response)
+            })
+        let startedAt = ContinuousClock.now
+
+        await #expect(throws: ProviderPluginError.self) {
+            _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret-value"])
+        }
+
+        #expect(ContinuousClock.now - startedAt < .seconds(2))
+    }
+
+    @Test
     func `settings split enforces kind and only secrets are redacted`() async throws {
         let runtime = try ProviderPluginRuntime(source: Self.plugin(
             settings: """
@@ -462,6 +521,10 @@ private actor RequestRecorder {
 
     var first: URLRequest? {
         self.requests.first
+    }
+
+    var all: [URLRequest] {
+        self.requests
     }
 
     func append(_ request: URLRequest) {

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -315,6 +315,33 @@ struct ProviderPluginRuntimeTests {
         }
     }
 
+    @Test(arguments: [
+        ("exact", UsageDataConfidence.exact),
+        ("estimated", .estimated),
+        ("percentOnly", .percentOnly),
+        ("unknown", .unknown),
+    ])
+    func `data confidence maps validated values`(rawValue: String, expected: UsageDataConfidence) async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
+        return { primary: { usedPercent: 1 }, dataConfidence: "\(rawValue)" };
+        """))
+
+        let snapshot = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret"])
+
+        #expect(snapshot.dataConfidence == expected)
+    }
+
+    @Test(arguments: [#""certain""#, "42"])
+    func `invalid data confidence fails the snapshot`(value: String) async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
+        return { primary: { usedPercent: 1 }, dataConfidence: \(value) };
+        """))
+
+        await #expect(throws: ProviderPluginError.self) {
+            _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret"])
+        }
+    }
+
     @Test
     func `details map strictly and trim display strings`() async throws {
         let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -323,6 +323,49 @@ struct ProviderPluginRuntimeTests {
         }
     }
 
+    @Test(arguments: ProviderFetchClassifiedError.Kind.allCases)
+    func `classified failures preserve kind and message`(kind: ProviderFetchClassifiedError.Kind) async throws {
+        let apiName = switch kind {
+        case .authenticationExpired: "authenticationExpired"
+        case .missingCredential: "missingCredential"
+        case .permissionDenied: "permissionDenied"
+        case .rateLimited: "rateLimited"
+        case .providerUnavailable: "providerUnavailable"
+        case .parseFailure: "parseFailure"
+        case .networkFailure: "networkFailure"
+        case .apiFailure: "apiFailure"
+        }
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
+        throw ctx.fail.\(apiName)("classified fixture");
+        """))
+
+        do {
+            _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret"])
+            Issue.record("Expected classified failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == kind)
+            #expect(error.message == "classified fixture")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func `unclassified failures retain generic script mapping`() async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
+        throw new Error("ordinary fixture");
+        """))
+
+        do {
+            _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret"])
+            Issue.record("Expected script failure")
+        } catch let error as ProviderPluginError {
+            #expect(error == .script("ordinary fixture"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
     @Test
     func `script errors redact known secrets`() async throws {
         let secret = "super-secret-fixture-value"

--- a/Tests/CodexBarTests/Sub2APIMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/Sub2APIMenuCardModelTests.swift
@@ -1,3 +1,4 @@
+#if canImport(JavaScriptCore)
 import CodexBarCore
 import Foundation
 import Testing
@@ -5,7 +6,7 @@ import Testing
 
 struct Sub2APIMenuCardModelTests {
     @Test
-    func `subscription amounts share the percentage row`() throws {
+    func `subscription amounts share the percentage row`() async throws {
         let now = Date(timeIntervalSince1970: 1_720_440_000)
         let json = """
         {
@@ -20,9 +21,7 @@ struct Sub2APIMenuCardModelTests {
           }
         }
         """
-        let snapshot = try Sub2APIUsageFetcher._parseSnapshotForTesting(
-            Data(json.utf8),
-            updatedAt: now).toUsageSnapshot()
+        let snapshot = try await Self.snapshot(json, now: now)
         let metadata = try #require(ProviderDefaults.metadata[.sub2api])
 
         let model = UsageMenuCardView.Model.make(.init(
@@ -59,7 +58,7 @@ struct Sub2APIMenuCardModelTests {
     }
 
     @Test
-    func `plan balance and per key totals render without overloading identity`() throws {
+    func `plan balance and per key totals render without overloading identity`() async throws {
         let now = Date(timeIntervalSince1970: 1_720_440_000)
         let json = """
         {
@@ -73,9 +72,7 @@ struct Sub2APIMenuCardModelTests {
           }
         }
         """
-        let snapshot = try Sub2APIUsageFetcher._parseSnapshotForTesting(
-            Data(json.utf8),
-            updatedAt: now).toUsageSnapshot()
+        let snapshot = try await Self.snapshot(json, now: now)
         let metadata = try #require(ProviderDefaults.metadata[.sub2api])
 
         let model = UsageMenuCardView.Model.make(.init(
@@ -106,7 +103,7 @@ struct Sub2APIMenuCardModelTests {
     }
 
     @Test
-    func `extra window amount renders as detail instead of reset`() throws {
+    func `extra window amount renders as detail instead of reset`() async throws {
         let now = Date(timeIntervalSince1970: 1_720_440_000)
         let json = """
         {
@@ -121,9 +118,7 @@ struct Sub2APIMenuCardModelTests {
           ]
         }
         """
-        let snapshot = try Sub2APIUsageFetcher._parseSnapshotForTesting(
-            Data(json.utf8),
-            updatedAt: now).toUsageSnapshot()
+        let snapshot = try await Self.snapshot(json, now: now)
         let metadata = try #require(ProviderDefaults.metadata[.sub2api])
 
         let model = UsageMenuCardView.Model.make(.init(
@@ -150,4 +145,20 @@ struct Sub2APIMenuCardModelTests {
         #expect(weekly.resetText == nil)
         #expect(weekly.detailText == "$40.00 / $200.00")
     }
+
+    private static func snapshot(_ body: String, now: Date) async throws -> UsageSnapshot {
+        let runtime = try ProviderPluginRuntime(
+            bundledPlugin: "sub2api",
+            transport: ProviderHTTPTransportHandler { request in
+                let response = try #require(HTTPURLResponse(
+                    url: request.url!, statusCode: 200, httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]))
+                return (Data(body.utf8), response)
+            })
+        return try await runtime.fetchUsage(
+            settings: [Sub2APISettingsReader.baseURLEnvironmentKey: "https://api.example.com"],
+            secrets: [Sub2APISettingsReader.apiKeyEnvironmentKey: "fixture-key"],
+            now: now)
+    }
 }
+#endif

--- a/Tests/CodexBarTests/Sub2APIMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/Sub2APIMenuCardModelTests.swift
@@ -151,7 +151,9 @@ struct Sub2APIMenuCardModelTests {
             bundledPlugin: "sub2api",
             transport: ProviderHTTPTransportHandler { request in
                 let response = try #require(HTTPURLResponse(
-                    url: request.url!, statusCode: 200, httpVersion: nil,
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
                     headerFields: ["Content-Type": "application/json"]))
                 return (Data(body.utf8), response)
             })

--- a/Tests/CodexBarTests/Sub2APIPluginGoldenTests.swift
+++ b/Tests/CodexBarTests/Sub2APIPluginGoldenTests.swift
@@ -1,0 +1,173 @@
+#if canImport(JavaScriptCore)
+import CodexBarCore
+import Foundation
+import Testing
+
+struct Sub2APIPluginGoldenTests {
+    @Test
+    func `quota limited fixture matches the production golden`() async throws {
+        let snapshot = try await Self.fetch("""
+        {
+          "mode": "quota_limited",
+          "isValid": true,
+          "status": "active",
+          "remaining": 75,
+          "unit": "USD",
+          "quota": { "limit": 100, "used": 25, "remaining": 75, "unit": "USD" },
+          "rate_limits": [
+            { "window": "5h", "limit": 20, "used": 5, "remaining": 15,
+              "reset_at": "2026-07-11T12:30:00Z" },
+            { "window": "7d", "limit": 200, "used": 40, "remaining": 160 }
+          ],
+          "expires_at": "2026-08-01T00:00:00Z",
+          "usage": {
+            "today": { "requests": 4, "total_tokens": 1200, "actual_cost": 1.25 },
+            "total": { "requests": 40, "total_tokens": 12000, "actual_cost": 25 }
+          }
+        }
+        """)
+
+        #expect(snapshot.identity?.providerID == .sub2api)
+        #expect(snapshot.primary?.usedPercent == 25)
+        #expect(snapshot.extraRateWindows?.count == 2)
+        #expect(snapshot.extraRateWindows?.first?.window.windowMinutes == 300)
+        #expect(snapshot.detailRow(label: "Today requests")?.value == "4")
+        #expect(snapshot.detailRow(label: "Today tokens")?.value == "1,200")
+        #expect(snapshot.detailRow(label: "Today tokens")?.secondaryValue == "$1.25")
+        #expect(snapshot.detailRow(label: "All time requests")?.value == "40")
+        #expect(snapshot.subscriptionExpiresAt != nil)
+        #expect(snapshot.dataConfidence == .exact)
+    }
+
+    @Test
+    func `subscription windows remain authoritative and grouped`() async throws {
+        let snapshot = try await Self.fetch("""
+        {
+          "mode": "unrestricted",
+          "planName": "Claude Team",
+          "subscription": {
+            "daily_usage_usd": 120.23,
+            "weekly_usage_usd": 229.20,
+            "monthly_usage_usd": 1296.23,
+            "daily_limit_usd": 120,
+            "weekly_limit_usd": 700,
+            "monthly_limit_usd": 2800,
+            "expires_at": "2026-08-15T00:00:00.123Z"
+          },
+          "daily_usage": [{ "date": "2026-07-05", "actual_cost": 229.20 }]
+        }
+        """)
+
+        #expect(snapshot.primary?.usedPercent == 100)
+        #expect(snapshot.secondary?.usedPercent == 229.20 / 700 * 100)
+        #expect(snapshot.tertiary?.usedPercent == 1296.23 / 2800 * 100)
+        #expect(snapshot.primary?.resetDescription == "$120.23 / $120.00")
+        #expect(snapshot.tertiary?.resetDescription == "$1,296.23 / $2,800.00")
+        #expect(snapshot.identity?.loginMethod == "Claude Team")
+    }
+
+    @Test(arguments: [
+        "https://api.example.com",
+        "https://api.example.com/v1",
+        "https://api.example.com/v1/usage",
+    ])
+    func `request shape and hard deadline match the native golden`(baseURL: String) async throws {
+        let recorder = Sub2APIRequestRecorder()
+        _ = try await Self.fetch(
+            #"{"mode":"unrestricted","isValid":true,"balance":5}"#,
+            baseURL: baseURL,
+            recorder: recorder)
+
+        let request = try #require(await recorder.requests.first)
+        #expect(request.url?.path == "/v1/usage")
+        let queryItems = try URLComponents(url: #require(request.url), resolvingAgainstBaseURL: false)?.queryItems ?? []
+        #expect(queryItems.contains(URLQueryItem(name: "days", value: "30")))
+        #expect(queryItems.contains(URLQueryItem(name: "timezone", value: TimeZone.current.identifier)))
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer fixture-key")
+        #expect(request.timeoutInterval == 15)
+    }
+
+    @Test(arguments: [
+        (401, ProviderFetchClassifiedError.Kind.authenticationExpired),
+        (403, .authenticationExpired),
+        (429, .rateLimited),
+        (500, .providerUnavailable),
+        (400, .apiFailure),
+    ])
+    func `HTTP failures preserve classified surface`(
+        status: Int,
+        kind: ProviderFetchClassifiedError.Kind) async throws
+    {
+        do {
+            _ = try await Self.fetch("not-json", status: status)
+            Issue.record("Expected classified failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == kind)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func `invalid key parse and network failures keep classifications`() async throws {
+        await Self.expectFailure(.authenticationExpired) {
+            try await Self.fetch(#"{"mode":"unrestricted","isValid":false}"#)
+        }
+        await Self.expectFailure(.parseFailure) {
+            try await Self.fetch(#"{"quota":{"limit":"many"}}"#)
+        }
+        let runtime = try ProviderPluginRuntime(
+            bundledPlugin: "sub2api",
+            transport: ProviderHTTPTransportHandler { _ in throw URLError(.notConnectedToInternet) })
+        await Self.expectFailure(.networkFailure) {
+            try await runtime.fetchUsage(
+                settings: [Sub2APISettingsReader.baseURLEnvironmentKey: "https://api.example.com"],
+                secrets: [Sub2APISettingsReader.apiKeyEnvironmentKey: "fixture-key"])
+        }
+    }
+
+    private static func expectFailure(
+        _ kind: ProviderFetchClassifiedError.Kind,
+        operation: () async throws -> UsageSnapshot) async
+    {
+        do {
+            _ = try await operation()
+            Issue.record("Expected \(kind.rawValue) failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == kind)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    private static func fetch(
+        _ body: String,
+        status: Int = 200,
+        baseURL: String = "https://api.example.com",
+        recorder: Sub2APIRequestRecorder? = nil) async throws -> UsageSnapshot
+    {
+        let runtime = try ProviderPluginRuntime(
+            bundledPlugin: "sub2api",
+            transport: ProviderHTTPTransportHandler { request in
+                if let recorder {
+                    await recorder.append(request)
+                }
+                let response = try #require(HTTPURLResponse(
+                    url: request.url!, statusCode: status, httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]))
+                return (Data(body.utf8), response)
+            })
+        return try await runtime.fetchUsage(
+            settings: [Sub2APISettingsReader.baseURLEnvironmentKey: baseURL],
+            secrets: [Sub2APISettingsReader.apiKeyEnvironmentKey: "fixture-key"])
+    }
+}
+
+private actor Sub2APIRequestRecorder {
+    private(set) var requests: [URLRequest] = []
+
+    func append(_ request: URLRequest) {
+        self.requests.append(request)
+    }
+}
+#endif

--- a/Tests/CodexBarTests/Sub2APIPluginGoldenTests.swift
+++ b/Tests/CodexBarTests/Sub2APIPluginGoldenTests.swift
@@ -153,7 +153,9 @@ struct Sub2APIPluginGoldenTests {
                     await recorder.append(request)
                 }
                 let response = try #require(HTTPURLResponse(
-                    url: request.url!, statusCode: status, httpVersion: nil,
+                    url: request.url!,
+                    statusCode: status,
+                    httpVersion: nil,
                     headerFields: ["Content-Type": "application/json"]))
                 return (Data(body.utf8), response)
             })

--- a/Tests/CodexBarTests/Sub2APIUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/Sub2APIUsageFetcherTests.swift
@@ -1,3 +1,4 @@
+#if !canImport(JavaScriptCore)
 import CodexBarCore
 import Foundation
 import Testing
@@ -341,3 +342,4 @@ struct Sub2APIUsageFetcherTests {
             hour: 12)))
     }
 }
+#endif

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -544,10 +544,10 @@ extension UsageStoreCoverageTests {
         }
 
         let store = Self.makeUsageStore(settings: settings)
-        #expect(store.unavailableMessage(for: .sub2api) == Sub2APIUsageError.missingCredentials.errorDescription)
+        #expect(store.unavailableMessage(for: .sub2api) == Sub2APISettingsReader.missingCredentialsMessage)
 
         settings.sub2APIAPIKey = "group-key"
-        #expect(store.unavailableMessage(for: .sub2api) == Sub2APIUsageError.missingBaseURL.errorDescription)
+        #expect(store.unavailableMessage(for: .sub2api) == Sub2APISettingsReader.missingBaseURLMessage)
     }
 
     @Test

--- a/TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift
+++ b/TestsLinux/ProviderEndpointOverrideSecurityLinuxTests.swift
@@ -15,6 +15,7 @@ struct ProviderEndpointOverrideSecurityLinuxTests {
         #expect(MiMoWebFetchStrategy.shouldFallbackToLocal(error: MiMoSettingsError.invalidCookie) == true)
     }
 
+    #if !canImport(JavaScriptCore)
     @Test
     func deepgramRejectsInsecureOverrideBeforeSendingToken() async {
         let transport = FailingTransport()
@@ -30,6 +31,7 @@ struct ProviderEndpointOverrideSecurityLinuxTests {
             Issue.record("Expected DeepgramUsageError.invalidEndpointOverride, got \(error)")
         }
     }
+    #endif
 
     @Test
     func zaiRejectsInsecureQuotaOverrideBeforeSendingToken() async {
@@ -111,9 +113,11 @@ struct ProviderEndpointOverrideSecurityLinuxTests {
 
     @Test
     func affectedProviderOverridesAcceptHTTPSAndBareHosts() throws {
+        #if !canImport(JavaScriptCore)
         try DeepgramUsageFetcher.validateEndpointOverrides(environment: [
             DeepgramUsageFetcher.apiURLKey: "deepgram-proxy.test/v1",
         ])
+        #endif
         try ZaiSettingsReader
             .validateEndpointOverrides(environment: [ZaiSettingsReader.quotaURLKey: "https://zai-proxy.test/quota"])
         try ZaiSettingsReader.validateEndpointOverrides(environment: [ZaiSettingsReader.apiHostKey: "localhost:9443"])

--- a/docs/plugin-conversion-matrix.md
+++ b/docs/plugin-conversion-matrix.md
@@ -26,8 +26,8 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 
 | Status | Count |
 |---|---:|
-| `cut-over` | 3 |
-| `converted` | 12 |
+| `cut-over` | 4 |
+| `converted` | 11 |
 | `convertible-now` | 8 |
 | `needs-cookie-import` | 19 |
 | `needs-files/subprocess/oauth-broker` | 15 |
@@ -96,7 +96,7 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 | poe | `converted` | Yes | Converted: fixed-origin bearer GET balance/history pagination with daily points and model/type summaries. |
 | chutes | `convertible-now` | No | Verified bearer GET fan-out on the canonical origin; dynamic quota lanes map to named windows. |
 | neuralwatt | `convertible-now` | No | Verified canonical bearer GET; quota lanes and prepaid cost/energy project generically. |
-| clawrouter | `converted` | Yes | Cutover stopped: the plugin supports only the canonical origin, while native production accepts a validated `CLAWROUTER_BASE_URL`. |
+| clawrouter | `cut-over` | Yes | Cut over on JavaScriptCore: validated configured origins, classified failures, exact confidence, budget/ledger details, and provider charts match native behavior; the native fetch core is Linux-only. |
 | longcat | `needs-cookie-import` | No | Skipped: browser-cookie retry needs domain/path-aware cookie selection across multiple imported sessions; the generic broker currently returns one flattened header. |
 | sub2api | `converted` | Yes | Cutover stopped: the plugin does not preserve the native total-request deadline and 401/403 invalid-credential classification. |
 | wayfinder | `needs-pty/webview/native` | No | The local unauthenticated HTTP gateway, metrics text, and routing/savings model violate HTTPS-only generic scope. |

--- a/docs/plugin-conversion-matrix.md
+++ b/docs/plugin-conversion-matrix.md
@@ -26,8 +26,8 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 
 | Status | Count |
 |---|---:|
-| `cut-over` | 4 |
-| `converted` | 11 |
+| `cut-over` | 5 |
+| `converted` | 10 |
 | `convertible-now` | 8 |
 | `needs-cookie-import` | 19 |
 | `needs-files/subprocess/oauth-broker` | 15 |
@@ -92,7 +92,7 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 | groq | `needs-cookie-import` | No | Skipped: Stytch session exchange and console history remain a multi-step auth flow. |
 | llmproxy | `needs-pty/webview/native` | No | Its origin is user-selected and may be private HTTP, conflicting with the manifest's fixed HTTPS origins. |
 | litellm | `needs-pty/webview/native` | No | Its required user-selected proxy origin and optional private HTTP cannot be declared by a bundled static manifest. |
-| deepgram | `converted` | Yes | Cutover stopped: the plugin does not preserve native 400/401/403, network, and parse error classification. |
+| deepgram | `cut-over` | Yes | Cut over on JavaScriptCore: project discovery, aggregation, configured origins, numeric validation, and classified auth/permission/rate/network/API/parse failures match native behavior; the native fetch core is Linux-only. |
 | poe | `converted` | Yes | Converted: fixed-origin bearer GET balance/history pagination with daily points and model/type summaries. |
 | chutes | `convertible-now` | No | Verified bearer GET fan-out on the canonical origin; dynamic quota lanes map to named windows. |
 | neuralwatt | `convertible-now` | No | Verified canonical bearer GET; quota lanes and prepaid cost/energy project generically. |

--- a/docs/plugin-conversion-matrix.md
+++ b/docs/plugin-conversion-matrix.md
@@ -26,8 +26,8 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 
 | Status | Count |
 |---|---:|
-| `cut-over` | 2 |
-| `converted` | 13 |
+| `cut-over` | 3 |
+| `converted` | 12 |
 | `convertible-now` | 8 |
 | `needs-cookie-import` | 19 |
 | `needs-files/subprocess/oauth-broker` | 15 |
@@ -69,7 +69,7 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 | ollama | `needs-cookie-import` | No | Skipped: hosted parity requires HTML bootstrap/state extraction plus API-key fallback arbitration. |
 | synthetic | `converted` | Yes | Converted: fixed-origin bearer GET with generic windows, cost, dates, and identity. |
 | warp | `needs-pty/webview/native` | No | Warp sends a POST GraphQL operation, which the GET-only HTTP broker cannot express. |
-| openrouter | `converted` | Yes | Cutover stopped: the plugin lacks the endpoint/referer/title overrides and one-second best-effort key-enrichment deadline of the native path. |
+| openrouter | `cut-over` | Yes | Cut over on JavaScriptCore: endpoint and client-header overrides plus one-second best-effort key enrichment match native behavior; the native fetch core is Linux-only. |
 | elevenlabs | `convertible-now` | No | Verified `xi-api-key` GET; heterogeneous character/minute quotas map to named generic windows. |
 | windsurf | `needs-files/subprocess/oauth-broker` | No | Chromium localStorage, IDE databases, and binary protobuf decoding supply the current session. |
 | zed | `needs-files/subprocess/oauth-broker` | No | Zed server settings and a named Keychain credential must be read locally. |

--- a/docs/plugin-conversion-matrix.md
+++ b/docs/plugin-conversion-matrix.md
@@ -26,8 +26,8 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 
 | Status | Count |
 |---|---:|
-| `cut-over` | 5 |
-| `converted` | 10 |
+| `cut-over` | 6 |
+| `converted` | 9 |
 | `convertible-now` | 8 |
 | `needs-cookie-import` | 19 |
 | `needs-files/subprocess/oauth-broker` | 15 |
@@ -98,7 +98,7 @@ that remain cheap to convert. Remaining buckets name the next blocker after this
 | neuralwatt | `convertible-now` | No | Verified canonical bearer GET; quota lanes and prepaid cost/energy project generically. |
 | clawrouter | `cut-over` | Yes | Cut over on JavaScriptCore: validated configured origins, classified failures, exact confidence, budget/ledger details, and provider charts match native behavior; the native fetch core is Linux-only. |
 | longcat | `needs-cookie-import` | No | Skipped: browser-cookie retry needs domain/path-aware cookie selection across multiple imported sessions; the generic broker currently returns one flattened header. |
-| sub2api | `converted` | Yes | Cutover stopped: the plugin does not preserve the native total-request deadline and 401/403 invalid-credential classification. |
+| sub2api | `cut-over` | Yes | Cut over on JavaScriptCore: configured HTTPS/loopback origins, a hard 15-second request deadline, strict parsing, exact confidence, and classified failures match native behavior; the native fetch core is Linux-only. |
 | wayfinder | `needs-pty/webview/native` | No | The local unauthenticated HTTP gateway, metrics text, and routing/savings model violate HTTPS-only generic scope. |
 | zenmux | `convertible-now` | No | Verified fixed-origin bearer GET pair; subscription and optional PAYG balance map generically. |
 | aiand | `convertible-now` | No | Verified fixed-origin bearer GET pagination; 30-day spend maps to generic cost. |

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -93,8 +93,9 @@ built-ins, but no browser or Node host environment. Tests assert that `fetch`, `
 - `await ctx.http.get(url, opts?)` performs a GET and returns `{status, headers, bodyText}`.
 - `await ctx.http.postJSON(url, {body, headers?})` performs a POST and returns `{status, headers, json}`. `body` must be
   JSON-serializable. The serialized body is passed directly to the broker and is never logged.
-- `opts.headers` may contain string header values. Requests have a 15-second timeout, responses are capped at 5 MiB,
-  and transport uses `ProviderHTTPClient`, including its same-origin HTTPS redirect policy.
+- `opts.headers` may contain string header values. `opts.timeoutSeconds` sets a hard deadline from 1 through 30 seconds
+  (default 15), responses are capped at 5 MiB, and transport uses `ProviderHTTPClient`, including its same-origin HTTPS
+  redirect policy.
 - `ctx.settings.get(key)` reads only a declared `plain` setting; `ctx.settings.getSecret(key)` reads only a declared
   `secure` setting. Kind mismatches and undeclared keys throw. Only secure values are tracked for redaction.
 - `ctx.fail` creates typed host failures for authentication, missing credentials, permission, rate limiting, provider

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -13,9 +13,9 @@ This document describes the bundled first-party conversion prototype. User-insta
 
 This prototype proves that an existing first-party `UsageProvider` can define its manifest, HTTP requests, response
 parsing, and generic `UsageSnapshot` projection in one bundled JavaScript file. It is deliberately not a user-plugin
-system: IDs remain compile-time `UsageProvider` cases and scripts ship inside CodexBar. Crof, Venice, OpenRouter, and
-ClawRouter have cut over
-to the bundled script on JavaScriptCore platforms; their native fetch cores remain compiled only for the Linux CLI.
+system: IDs remain compile-time `UsageProvider` cases and scripts ship inside CodexBar. Crof, Venice, OpenRouter,
+ClawRouter, and Deepgram have cut over to the bundled script on JavaScriptCore platforms; their native fetch cores
+remain compiled only for the Linux CLI.
 
 Plugin manifests and their projected snapshots now carry a validated `ProviderInstanceID`. The prototype still maps
 that instance ID to an existing first-party `UsageProvider` before using browser-cookie brokerage or other bespoke
@@ -24,13 +24,13 @@ case therefore remain out of scope for this prototype.
 
 ## Enable and test
 
-Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, OpenAI, z.ai, Poe,
-Deepgram, sub2api, xAI, Manus, Perplexity, T3 Chat, and Qoder then prepend a script strategy to their existing pipeline.
+Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, OpenAI, z.ai, Poe, sub2api, xAI, Manus,
+Perplexity, T3 Chat, and Qoder then prepend a script strategy to their existing pipeline.
 A missing required secret or disabled cookie source leaves the script
 strategy unavailable and permits the Swift strategy to run; a loaded script that fails does not fall back, so parity
 defects stay visible. Without the variable, the resolver returns the original Swift strategy only and does not load
-JavaScriptCore or a plugin resource for those providers. Crof, Venice, OpenRouter, and ClawRouter always resolve only their script strategy on
-JavaScriptCore platforms; `CODEXBAR_JS_PROVIDERS` does not affect them.
+JavaScriptCore or a plugin resource for those providers. Crof, Venice, OpenRouter, ClawRouter, and Deepgram always
+resolve only their script strategy on JavaScriptCore platforms; `CODEXBAR_JS_PROVIDERS` does not affect them.
 
 Run the focused proof with:
 

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -14,8 +14,8 @@ This document describes the bundled first-party conversion prototype. User-insta
 This prototype proves that an existing first-party `UsageProvider` can define its manifest, HTTP requests, response
 parsing, and generic `UsageSnapshot` projection in one bundled JavaScript file. It is deliberately not a user-plugin
 system: IDs remain compile-time `UsageProvider` cases and scripts ship inside CodexBar. Crof, Venice, OpenRouter,
-ClawRouter, and Deepgram have cut over to the bundled script on JavaScriptCore platforms; their native fetch cores
-remain compiled only for the Linux CLI.
+ClawRouter, Deepgram, and sub2api have cut over to the bundled script on JavaScriptCore platforms; their native fetch
+cores remain compiled only for the Linux CLI.
 
 Plugin manifests and their projected snapshots now carry a validated `ProviderInstanceID`. The prototype still maps
 that instance ID to an existing first-party `UsageProvider` before using browser-cookie brokerage or other bespoke
@@ -24,13 +24,13 @@ case therefore remain out of scope for this prototype.
 
 ## Enable and test
 
-Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, OpenAI, z.ai, Poe, sub2api, xAI, Manus,
+Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, OpenAI, z.ai, Poe, xAI, Manus,
 Perplexity, T3 Chat, and Qoder then prepend a script strategy to their existing pipeline.
 A missing required secret or disabled cookie source leaves the script
 strategy unavailable and permits the Swift strategy to run; a loaded script that fails does not fall back, so parity
 defects stay visible. Without the variable, the resolver returns the original Swift strategy only and does not load
-JavaScriptCore or a plugin resource for those providers. Crof, Venice, OpenRouter, ClawRouter, and Deepgram always
-resolve only their script strategy on JavaScriptCore platforms; `CODEXBAR_JS_PROVIDERS` does not affect them.
+JavaScriptCore or a plugin resource for those providers. Crof, Venice, OpenRouter, ClawRouter, Deepgram, and sub2api
+always resolve only their script strategy on JavaScriptCore platforms; `CODEXBAR_JS_PROVIDERS` does not affect them.
 
 Run the focused proof with:
 

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -97,6 +97,9 @@ built-ins, but no browser or Node host environment. Tests assert that `fetch`, `
   and transport uses `ProviderHTTPClient`, including its same-origin HTTPS redirect policy.
 - `ctx.settings.get(key)` reads only a declared `plain` setting; `ctx.settings.getSecret(key)` reads only a declared
   `secure` setting. Kind mismatches and undeclared keys throw. Only secure values are tracked for redaction.
+- `ctx.fail` creates typed host failures for authentication, missing credentials, permission, rate limiting, provider
+  availability, parsing, network, and API errors. Plugins throw the returned error; ordinary exceptions retain the
+  generic script-error mapping.
 - `await ctx.browser.cookieHeader(domain)` returns a Cookie header only for a declared domain and only when the
   `browser-cookies` capability is present. The broker honors the provider's auto/manual/off setting, cache, and browser
   priority order. Cookie headers and individual cookie values are secret-equivalent and redacted at the bridge.

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -13,7 +13,8 @@ This document describes the bundled first-party conversion prototype. User-insta
 
 This prototype proves that an existing first-party `UsageProvider` can define its manifest, HTTP requests, response
 parsing, and generic `UsageSnapshot` projection in one bundled JavaScript file. It is deliberately not a user-plugin
-system: IDs remain compile-time `UsageProvider` cases and scripts ship inside CodexBar. Crof, Venice, and OpenRouter have cut over
+system: IDs remain compile-time `UsageProvider` cases and scripts ship inside CodexBar. Crof, Venice, OpenRouter, and
+ClawRouter have cut over
 to the bundled script on JavaScriptCore platforms; their native fetch cores remain compiled only for the Linux CLI.
 
 Plugin manifests and their projected snapshots now carry a validated `ProviderInstanceID`. The prototype still maps
@@ -23,12 +24,12 @@ case therefore remain out of scope for this prototype.
 
 ## Enable and test
 
-Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, OpenAI, z.ai, Poe, ClawRouter,
+Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, OpenAI, z.ai, Poe,
 Deepgram, sub2api, xAI, Manus, Perplexity, T3 Chat, and Qoder then prepend a script strategy to their existing pipeline.
 A missing required secret or disabled cookie source leaves the script
 strategy unavailable and permits the Swift strategy to run; a loaded script that fails does not fall back, so parity
 defects stay visible. Without the variable, the resolver returns the original Swift strategy only and does not load
-JavaScriptCore or a plugin resource for those providers. Crof, Venice, and OpenRouter always resolve only their script strategy on
+JavaScriptCore or a plugin resource for those providers. Crof, Venice, OpenRouter, and ClawRouter always resolve only their script strategy on
 JavaScriptCore platforms; `CODEXBAR_JS_PROVIDERS` does not affect them.
 
 Run the focused proof with:

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -128,7 +128,8 @@ be positive integers.
 `nextRegenAmount`, and `balance` are optional. A missing limit maps to zero. `identity` accepts bounded, trimmed `email`,
 `organization`, `loginMethod`, and `accountID` strings; Swift always scopes it to the manifest provider ID.
 `subscriptionRenewsAt` and `subscriptionExpiresAt` accept a JavaScript `Date` or ISO-8601 string. Missing optionals are
-fine, while a present value of the wrong type fails the entire fetch with its property path.
+fine. `dataConfidence` accepts `exact`, `estimated`, `percentOnly`, or `unknown` and defaults to `unknown`; a present
+value of the wrong type fails the entire fetch with its property path.
 
 ### Declarative details
 

--- a/docs/plugin-prototype.md
+++ b/docs/plugin-prototype.md
@@ -13,7 +13,7 @@ This document describes the bundled first-party conversion prototype. User-insta
 
 This prototype proves that an existing first-party `UsageProvider` can define its manifest, HTTP requests, response
 parsing, and generic `UsageSnapshot` projection in one bundled JavaScript file. It is deliberately not a user-plugin
-system: IDs remain compile-time `UsageProvider` cases and scripts ship inside CodexBar. Crof and Venice have cut over
+system: IDs remain compile-time `UsageProvider` cases and scripts ship inside CodexBar. Crof, Venice, and OpenRouter have cut over
 to the bundled script on JavaScriptCore platforms; their native fetch cores remain compiled only for the Linux CLI.
 
 Plugin manifests and their projected snapshots now carry a validated `ProviderInstanceID`. The prototype still maps
@@ -23,12 +23,12 @@ case therefore remain out of scope for this prototype.
 
 ## Enable and test
 
-Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, OpenAI, z.ai, OpenRouter, Poe, ClawRouter,
+Set `CODEXBAR_JS_PROVIDERS=1` in CodexBar's environment. Synthetic, OpenAI, z.ai, Poe, ClawRouter,
 Deepgram, sub2api, xAI, Manus, Perplexity, T3 Chat, and Qoder then prepend a script strategy to their existing pipeline.
 A missing required secret or disabled cookie source leaves the script
 strategy unavailable and permits the Swift strategy to run; a loaded script that fails does not fall back, so parity
 defects stay visible. Without the variable, the resolver returns the original Swift strategy only and does not load
-JavaScriptCore or a plugin resource for those providers. Crof and Venice always resolve only their script strategy on
+JavaScriptCore or a plugin resource for those providers. Crof, Venice, and OpenRouter always resolve only their script strategy on
 JavaScriptCore platforms; `CODEXBAR_JS_PROVIDERS` does not affect them.
 
 Run the focused proof with:
@@ -39,9 +39,9 @@ swift test --filter ProviderPluginParityTests
 swift test --filter ProviderPluginDetailsParityTests
 ```
 
-The parity suites send the same canned responses through an injected `ProviderHTTPTransport` to both implementations
-and compare core windows, percentages, reset dates, cost, subscription dates, and identity fields. Details-provider
-fixtures additionally characterize the complete declarative section output.
+The parity suites send canned responses through an injected `ProviderHTTPTransport`. Flag-gated providers compare the
+Swift and JavaScript implementations, while cut-over providers use JavaScript goldens for windows, percentages, reset
+dates, cost, subscription dates, identity, and complete declarative detail output.
 
 ## Manifest
 
@@ -175,7 +175,7 @@ cannot interrupt the abandoned JavaScriptCore thread, which may remain alive unt
 runtime needs a public interrupt API or a killable helper-process boundary before accepting untrusted scripts.
 
 The same watchdog is production-default for first-party cut-over providers. It is part of the shared runtime, not the
-prototype flag, so Crof and Venice retain timeout and fresh-context recovery without `CODEXBAR_JS_PROVIDERS`.
+prototype flag, so cut-over providers retain timeout and fresh-context recovery without `CODEXBAR_JS_PROVIDERS`.
 
 ## Current limitations
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -87,7 +87,8 @@ example, `acme-usage` and `API_KEY` use `CODEXBAR_PLUGIN_ACME_USAGE_API_KEY`.
 - `await ctx.http.getJSON(url, opts?)` performs GET and returns `{status, headers, json}`.
 - `await ctx.http.get(url, opts?)` performs GET and returns `{status, headers, bodyText}`.
 - `await ctx.http.postJSON(url, {body, headers?})` performs JSON POST. `body` must be JSON-serializable.
-- `opts.headers` accepts string values. Plugins cannot replace their declared auth header.
+- `opts.headers` accepts string values. Plugins cannot replace their declared auth header. `opts.timeoutSeconds` sets a
+  hard request deadline from 1 through 30 seconds; the default is 15 seconds.
 - `ctx.settings.get(key)` reads a declared `plain` setting.
 - `ctx.settings.getSecret(key)` reads a declared `secure` setting. Missing values return `null`; kind mismatches and
   undeclared keys throw.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -128,6 +128,7 @@ return {
   cost: { used: 8.5, limit: 20, currency: "USD", period: "This month", balance: 11.5 },
   identity: { email: "user@example.com", organization: "Acme", loginMethod: "API key", accountID: "123" },
   subscriptionRenewsAt: "2026-09-01T00:00:00Z",
+  dataConfidence: "exact", // exact | estimated | percentOnly | unknown
   details: [{
     title: "Usage summary",
     rows: [{ label: "Requests", value: "1,240", secondaryValue: "Last 30 days" }],
@@ -143,7 +144,7 @@ return {
 
 Percentages must be finite and are clamped to 0–100. Window minutes are positive integers. Cost requires finite `used`
 and a three-letter uppercase currency. Dates are JavaScript `Date` values or ISO-8601 strings. Snapshot identity is
-always scoped to the manifest's instance ID. Details allow at most 8 sections, 24 rows per section, 120 chart points,
+always scoped to the manifest's instance ID. Data confidence defaults to `unknown`. Details allow at most 8 sections, 24 rows per section, 120 chart points,
 and 120 characters per detail string. Wrong types and limit violations fail the whole fetch instead of truncating it.
 
 ## TypeScript

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -91,6 +91,9 @@ example, `acme-usage` and `API_KEY` use `CODEXBAR_PLUGIN_ACME_USAGE_API_KEY`.
 - `ctx.settings.get(key)` reads a declared `plain` setting.
 - `ctx.settings.getSecret(key)` reads a declared `secure` setting. Missing values return `null`; kind mismatches and
   undeclared keys throw.
+- `ctx.fail` creates classified errors for `authenticationExpired`, `missingCredential`, `permissionDenied`,
+  `rateLimited`, `providerUnavailable`, `parseFailure`, `networkFailure`, and `apiFailure`. Throw the returned error,
+  for example `throw ctx.fail.rateLimited("Provider rate limit reached")`; ordinary errors retain generic mapping.
 - `await ctx.browser.cookieHeader(domain)` returns a cookie header only with the `browser-cookies` capability and for a
   declared domain. The app imports from Chrome only. Cookie values are secret-equivalent and redacted.
 - `ctx.html.metaContent(html, name)` returns the first matching quoted meta value or `null`.


### PR DESCRIPTION
## Summary

This wave closes the three host-API gaps that blocked the next JavaScript provider cutovers, then makes the bundled scripts the only JavaScriptCore implementation for OpenRouter, ClawRouter, Deepgram, and sub2api. The existing Swift fetch cores remain available only when JavaScriptCore is unavailable, preserving the Linux CLI without retaining a second macOS implementation.

## Host API capabilities

- Classified failures: `ctx.fail` now maps authentication, missing-credential, permission, rate-limit, availability, parse, network, and API failures back to typed host errors. `classified failures preserve kind and message` covers every kind, while `unclassified failures retain generic script mapping` preserves the ordinary script-error path.
- Hard request deadlines: `opts.timeoutSeconds` accepts a bounded 1–30 second deadline with a 15-second default and cancels transport work when the deadline expires. Coverage is `HTTP request deadline defaults to fifteen seconds and accepts bounded override`, `HTTP request deadline rejects values outside one through thirty seconds`, and `HTTP request deadline cancels a transport that exceeds it`.
- Provider request overrides: script strategies can project provider-owned plain settings and validate the full fetch context before JavaScript runs, so validated endpoint and client-header overrides retain the native contracts. Coverage is `OpenRouter cut-over honors default and overridden requests`, `ClawRouter cut-over honors default and overridden requests`, and `override preflight preserves provider validation errors`.

JavaScriptCore does not preserve a custom `Error` subclass or its Swift-facing metadata reliably across a promise rejection. `ctx.fail` therefore throws an ordinary `Error` carrying a reserved marker; the Swift bridge decodes only recognized marker/kind pairs after redaction. Ordinary JavaScript errors continue through the generic mapping, so this workaround does not broaden the bridge contract.

## Provider cutovers

- OpenRouter preserves endpoint/referer/title overrides, credit formatting, and a one-second best-effort key-enrichment deadline. Its goldens include `key quota fixture matches the production golden`, `requests preserve credits headers and one second enrichment deadline`, `credits error is classified without response body details`, and the parse-classification cases.
- ClawRouter preserves validated configured origins, exact confidence, budget/ledger details, and chart output. Its goldens include `monthly budget fixture matches the production golden`, `HTTP failures preserve classified surface`, and `malformed responses are classified parse failures`.
- Deepgram preserves project discovery and aggregation, configured origins, numeric validation, and native auth/permission/rate/network/API/parse classifications. Its goldens include `usage breakdown fixture matches visible detail golden`, `HTTP failures preserve classified surface`, and `network and parse failures retain their classifications`.
- sub2api preserves HTTPS and loopback origins, the hard 15-second total-request deadline, strict parsing, exact confidence, grouped subscription windows, and classified failures. Its goldens include `request shape and hard deadline match the native golden`, `HTTP failures preserve classified surface`, and `invalid key parse and network failures keep classifications`.

The four native fetch cores total 1,873 Swift lines and are now gated out of JavaScriptCore builds while remaining compiled for Linux.

## Remaining converted providers

The flag-gated conversion remainder is now Synthetic, OpenAI, z.ai, Poe, xAI, Manus, Perplexity, T3 Chat, and Qoder. The conversion matrix is mutually exclusive at 6 cut over and 9 converted.

## Gates

- `make check` — passed; zero formatting changes and zero SwiftLint violations
- `make build` — passed
- `make test` — passed 818/818 selections in 69/69 groups, with zero retries
- `swift build --target CodexBarLinuxTests` — passed
- structured Codex autoreview against `origin/main` — clean, no accepted/actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
