### PR TITLE
test: accept GMT/UTC alias in sub2api timezone golden

### DIFF
--- a/Tests/CodexBarTests/Sub2APIPluginGoldenTests.swift
+++ b/Tests/CodexBarTests/Sub2APIPluginGoldenTests.swift
@@ -86,7 +86,7 @@ struct Sub2APIPluginGoldenTests {
         // same zone, so accept either alias instead of the exact identifier.
         let sentTimezone = try #require(queryItems.first { $0.name == "timezone" }?.value)
         let currentIdentifier = TimeZone.current.identifier
-        let zeroOffsetAliases: Set<String> = ["GMT", "UTC", "Etc/UTC", "Etc/GMT"]
+        let zeroOffsetAliases: Set = ["GMT", "UTC", "Etc/UTC", "Etc/GMT"]
         #expect(
             sentTimezone == currentIdentifier
                 || (zeroOffsetAliases.contains(sentTimezone) && zeroOffsetAliases.contains(currentIdentifier)))

--- a/Tests/CodexBarTests/Sub2APIPluginGoldenTests.swift
+++ b/Tests/CodexBarTests/Sub2APIPluginGoldenTests.swift
@@ -82,7 +82,14 @@ struct Sub2APIPluginGoldenTests {
         #expect(request.url?.path == "/v1/usage")
         let queryItems = try URLComponents(url: #require(request.url), resolvingAgainstBaseURL: false)?.queryItems ?? []
         #expect(queryItems.contains(URLQueryItem(name: "days", value: "30")))
-        #expect(queryItems.contains(URLQueryItem(name: "timezone", value: TimeZone.current.identifier)))
+        // Foundation says "GMT" where JS Intl says "UTC" on UTC-configured machines; both are the
+        // same zone, so accept either alias instead of the exact identifier.
+        let sentTimezone = try #require(queryItems.first { $0.name == "timezone" }?.value)
+        let currentIdentifier = TimeZone.current.identifier
+        let zeroOffsetAliases: Set<String> = ["GMT", "UTC", "Etc/UTC", "Etc/GMT"]
+        #expect(
+            sentTimezone == currentIdentifier
+                || (zeroOffsetAliases.contains(sentTimezone) && zeroOffsetAliases.contains(currentIdentifier)))
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer fixture-key")
         #expect(request.timeoutInterval == 15)
     }


### PR DESCRIPTION
Unbreaks main CI on UTC-configured runners after #2678.

The sub2api JS plugin sends the user's real timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone`; Foundation's `TimeZone.current.identifier` reports `GMT` where Intl reports `UTC` on UTC-configured machines. The golden asserted the exact Foundation identifier, so it failed only on such machines (CI), while real-world request behavior is identical on both paths. The assertion now accepts the zero-offset aliases and still pins the exact identifier everywhere else. Proven under TZ=UTC, America/Los_Angeles, and Asia/Tokyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
