### PR TITLE
refactor: unify CLI onto descriptor-owned provider capabilities

### DIFF
--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -15,21 +15,19 @@ extension UsageStore {
     private nonisolated static let claudeOAuthPlanUtilizationAccountKeyPrefix = "__claude_oauth__:"
 
     func supportsPlanUtilizationHistory(for provider: UsageProvider) -> Bool {
-        switch provider {
-        case .codex, .claude, .antigravity, .opencodego:
-            true
-        default:
-            if self.planUtilizationHistory[provider.instanceID]?.isEmpty == false {
-                true
-            } else if self.settings.historicalTrackingEnabled, let snapshot = self.snapshots[provider.instanceID] {
-                !self.planUtilizationSeriesSamples(
-                    provider: provider,
-                    snapshot: snapshot,
-                    capturedAt: snapshot.updatedAt).isEmpty
-            } else {
-                false
-            }
+        if ProviderDescriptorRegistry.descriptor(for: provider).history.alwaysTracksPlanUtilization {
+            return true
         }
+        if self.planUtilizationHistory[provider.instanceID]?.isEmpty == false {
+            return true
+        }
+        guard self.settings.historicalTrackingEnabled, let snapshot = self.snapshots[provider.instanceID] else {
+            return false
+        }
+        return !self.planUtilizationSeriesSamples(
+            provider: provider,
+            snapshot: snapshot,
+            capturedAt: snapshot.updatedAt).isEmpty
     }
 
     private nonisolated static let planUtilizationMinSampleIntervalSeconds: TimeInterval = 60 * 60
@@ -339,12 +337,8 @@ extension UsageStore {
     }
 
     private func shouldRecordPlanUtilizationHistory(for provider: UsageProvider) -> Bool {
-        switch provider {
-        case .codex, .claude, .antigravity, .opencodego:
-            true
-        default:
+        ProviderDescriptorRegistry.descriptor(for: provider).history.alwaysTracksPlanUtilization ||
             self.settings.historicalTrackingEnabled
-        }
     }
 
     private nonisolated static func updatedPlanUtilizationHistories(
@@ -575,6 +569,7 @@ extension UsageStore {
             }
         }
 
+        // Provider-specific by design: payload shapes project different semantic lanes into history series.
         switch provider {
         case .codex:
             let projection = self.codexConsumerProjection(

--- a/Sources/CodexBarCLI/CLIDiagnoseCommand.swift
+++ b/Sources/CodexBarCLI/CLIDiagnoseCommand.swift
@@ -174,17 +174,6 @@ extension CodexBarCLI {
             environment: environment,
             settings: settings)
     }
-
-    static func resolveMiniMaxAuthMode(
-        environment: [String: String],
-        settings: ProviderSettingsSnapshot?) -> MiniMaxAuthMode
-    {
-        let apiToken = ProviderTokenResolver.minimaxToken(environment: environment)
-        let envCookieHeader = ProviderTokenResolver.minimaxCookie(environment: environment)
-        let settingsCookieHeader = CookieHeaderNormalizer.normalize(settings?.minimax?.manualCookieHeader)
-        let cookieHeader = envCookieHeader ?? settingsCookieHeader
-        return MiniMaxAuthMode.resolve(apiToken: apiToken, cookieHeader: cookieHeader)
-    }
 }
 
 #if DEBUG
@@ -202,13 +191,6 @@ extension CodexBarCLI {
             config: config,
             environment: environment,
             settings: settings)
-    }
-
-    static func _resolveMiniMaxAuthModeForTesting(
-        environment: [String: String],
-        settings: ProviderSettingsSnapshot?) -> MiniMaxAuthMode
-    {
-        self.resolveMiniMaxAuthMode(environment: environment, settings: settings)
     }
 }
 #endif

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -16,8 +16,10 @@ enum CLIRenderer {
         context: RenderContext,
         now: Date = Date()) -> String
     {
-        let meta = ProviderDescriptorRegistry.descriptor(for: provider).metadata
-        let labels = self.rateWindowLabels(provider: provider, metadata: meta, snapshot: snapshot)
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
+        let labels = descriptor.presentation.rateWindowLabels(
+            metadata: descriptor.metadata,
+            snapshot: snapshot)
         var lines: [String] = []
         lines.append(self.headerLine(context.header, useColor: context.useColor))
         self.appendPrimaryLines(
@@ -41,19 +43,14 @@ enum CLIRenderer {
             context: context,
             now: now,
             lines: &lines)
-        self.appendZaiExtraRateWindows(
+        self.appendExtraRateWindows(
             provider: provider,
             snapshot: snapshot,
             context: context,
             now: now,
             lines: &lines)
         self.appendProviderDetails(snapshot.details, useColor: context.useColor, lines: &lines)
-        self.appendDevinOverageBalanceLine(
-            provider: provider,
-            snapshot: snapshot,
-            useColor: context.useColor,
-            lines: &lines)
-        self.appendClaudeExtraUsageBalanceLine(
+        self.appendPresentationCostLines(
             provider: provider,
             snapshot: snapshot,
             useColor: context.useColor,
@@ -92,8 +89,10 @@ enum CLIRenderer {
         includeIdentity: Bool,
         now: Date = Date()) -> [String]
     {
-        let meta = ProviderDescriptorRegistry.descriptor(for: provider).metadata
-        let labels = self.rateWindowLabels(provider: provider, metadata: meta, snapshot: snapshot)
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
+        let labels = descriptor.presentation.rateWindowLabels(
+            metadata: descriptor.metadata,
+            snapshot: snapshot)
         var lines: [String] = []
         self.appendPrimaryLines(
             provider: provider,
@@ -116,19 +115,14 @@ enum CLIRenderer {
             context: context,
             now: now,
             lines: &lines)
-        self.appendZaiExtraRateWindows(
+        self.appendExtraRateWindows(
             provider: provider,
             snapshot: snapshot,
             context: context,
             now: now,
             lines: &lines)
         self.appendProviderDetails(snapshot.details, useColor: context.useColor, lines: &lines)
-        self.appendDevinOverageBalanceLine(
-            provider: provider,
-            snapshot: snapshot,
-            useColor: context.useColor,
-            lines: &lines)
-        self.appendClaudeExtraUsageBalanceLine(
+        self.appendPresentationCostLines(
             provider: provider,
             snapshot: snapshot,
             useColor: context.useColor,
@@ -162,26 +156,10 @@ enum CLIRenderer {
     }
 
     static func planBadgeText(provider: UsageProvider, snapshot: UsageSnapshot) -> String? {
-        if provider == .mimo, let balance = snapshot.detailRow(label: "Balance")?.value {
-            return balance
-        }
-        if provider == .kilo {
-            let kiloLogin = self.kiloLoginParts(snapshot: snapshot)
-            if let pass = kiloLogin.pass {
-                return UsageFormatter.cleanPlanName(pass)
-            }
-            return nil
-        }
-        guard let plan = snapshot.loginMethod(for: provider),
-              !plan.isEmpty,
-              provider != .mimo || !plan.localizedCaseInsensitiveContains("balance:")
-        else {
-            return nil
-        }
-        if provider == .codex {
-            return CodexPlanFormatting.displayName(plan) ?? plan
-        }
-        return self.nonCodexPlanDisplay(provider: provider, plan: plan)
+        ProviderDescriptorRegistry.descriptor(for: provider)
+            .presentation
+            .identity(provider: provider, snapshot: snapshot)
+            .badge
     }
 
     static func colorizeAccentBold(_ text: String) -> String {
@@ -423,8 +401,10 @@ enum CLIRenderer {
         resetStyle: ResetTimeDisplayStyle,
         now: Date = Date()) -> [CLICardMetric]
     {
-        let meta = ProviderDescriptorRegistry.descriptor(for: provider).metadata
-        let labels = self.rateWindowLabels(provider: provider, metadata: meta, snapshot: snapshot)
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
+        let labels = descriptor.presentation.rateWindowLabels(
+            metadata: descriptor.metadata,
+            snapshot: snapshot)
         var metrics: [CLICardMetric] = []
         if let primary = snapshot.primary, !primary.isSyntheticPlaceholder {
             metrics.append(self.makeCardMetric(
@@ -450,15 +430,13 @@ enum CLIRenderer {
                 resetStyle: resetStyle,
                 now: now))
         }
-        if provider == .zai {
-            for extra in snapshot.extraRateWindows ?? [] where extra.id == "zai-mcp" {
-                metrics.append(self.makeCardMetric(
-                    provider: provider,
-                    label: extra.title,
-                    window: extra.window,
-                    resetStyle: resetStyle,
-                    now: now))
-            }
+        for extra in descriptor.presentation.extraRateWindows(snapshot: snapshot) {
+            metrics.append(self.makeCardMetric(
+                provider: provider,
+                label: extra.title,
+                window: extra.window,
+                resetStyle: resetStyle,
+                now: now))
         }
         return metrics
     }
@@ -472,13 +450,17 @@ enum CLIRenderer {
         now: Date = Date()) -> [String]
     {
         var lines: [String] = []
+        // Provider-specific by design: codexResetCredits is a behavioral Codex payload, not presentation metadata.
         if provider == .codex, let resetCredits = snapshot.codexResetCredits {
             let inventory = resetCredits.availableInventory(at: now)
             let value = inventory.count == 1 ? "1 available" : "\(inventory.count) available"
             lines.append(self.labelValueLine("Limit Reset Credits", value: value, useColor: useColor))
         }
-        if provider == .codex, let credits {
-            let remaining = credits.codexCreditLimit?.remaining ?? credits.remaining
+        if let credits,
+           let remaining = ProviderDescriptorRegistry.descriptor(for: provider)
+               .presentation
+               .creditRemaining(credits)
+        {
             lines.append(self.labelValueLine(
                 "Credits",
                 value: UsageFormatter.creditsString(from: remaining),
@@ -501,24 +483,19 @@ enum CLIRenderer {
     {
         var lines: [String] = []
         if snapshot.primary == nil {
+            let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
             self.appendPrimaryLines(
                 provider: provider,
                 snapshot: snapshot,
-                labels: self.rateWindowLabels(
-                    provider: provider,
-                    metadata: ProviderDescriptorRegistry.descriptor(for: provider).metadata,
+                labels: descriptor.presentation.rateWindowLabels(
+                    metadata: descriptor.metadata,
                     snapshot: snapshot),
                 context: context,
                 now: now,
                 lines: &lines)
         }
         self.appendProviderDetails(snapshot.details, useColor: context.useColor, lines: &lines)
-        self.appendDevinOverageBalanceLine(
-            provider: provider,
-            snapshot: snapshot,
-            useColor: context.useColor,
-            lines: &lines)
-        self.appendClaudeExtraUsageBalanceLine(
+        self.appendPresentationCostLines(
             provider: provider,
             snapshot: snapshot,
             useColor: context.useColor,
@@ -528,11 +505,11 @@ enum CLIRenderer {
             snapshot: snapshot,
             useColor: context.useColor,
             lines: &lines)
-        if provider == .kilo {
-            let kiloLogin = self.kiloLoginParts(snapshot: snapshot)
-            for detail in kiloLogin.details {
-                lines.append(self.labelValueLine("Activity", value: detail, useColor: context.useColor))
-            }
+        let identity = ProviderDescriptorRegistry.descriptor(for: provider)
+            .presentation
+            .identity(provider: provider, snapshot: snapshot)
+        for detail in identity.details {
+            lines.append(self.labelValueLine(detail.label, value: detail.value, useColor: context.useColor))
         }
         return lines
     }
@@ -579,7 +556,7 @@ enum CLIRenderer {
             self.pacePayload(
                 provider: provider,
                 window: $0,
-                kind: self.paceKind(provider: provider, fallback: .session),
+                slot: .primary,
                 weeklyWorkDays: weeklyWorkDays,
                 now: now)
         }
@@ -587,7 +564,7 @@ enum CLIRenderer {
             self.pacePayload(
                 provider: provider,
                 window: $0,
-                kind: self.paceKind(provider: provider, fallback: .weekly),
+                slot: .secondary,
                 weeklyWorkDays: weeklyWorkDays,
                 now: now)
         }
@@ -595,7 +572,7 @@ enum CLIRenderer {
             self.pacePayload(
                 provider: provider,
                 window: $0,
-                kind: self.paceKind(provider: provider, fallback: .weekly),
+                slot: .tertiary,
                 weeklyWorkDays: weeklyWorkDays,
                 now: now)
         }
@@ -617,7 +594,7 @@ enum CLIRenderer {
     private static func appendPrimaryLines(
         provider: UsageProvider,
         snapshot: UsageSnapshot,
-        labels: RateWindowLabels,
+        labels: ProviderRateWindowLabels,
         context: RenderContext,
         now: Date,
         lines: inout [String])
@@ -627,22 +604,15 @@ enum CLIRenderer {
                 provider: provider,
                 title: labels.primary,
                 window: primary,
-                paceKind: self.paceKind(provider: provider, fallback: .session),
+                paceSlot: .primary,
                 context: context,
                 now: now,
                 lines: &lines)
             return
         }
 
-        guard
-            provider != .clawrouter,
-            let cost = snapshot.providerCost,
-            !(provider == .devin && cost.period == "Extra usage balance"),
-            !(provider == .claude && cost.used == 0 && cost.limit == 0 && cost.balance != nil),
-            // xAI's providerCost carries the prepaid balance, not a spend/limit
-            // pair; the dedicated balance line renders it instead.
-            !(provider == .xai && cost.period == "Prepaid credits")
-        else { return }
+        let presentation = ProviderDescriptorRegistry.descriptor(for: provider).presentation.cost(snapshot: snapshot)
+        guard presentation.showsGenericFallback, let cost = snapshot.providerCost else { return }
         // Fallback to cost/quota display if no primary rate window.
         let label = cost.currencyCode == "Quota" ? "Quota" : "Cost"
         let value = "\(String(format: "%.1f", cost.used)) / \(String(format: "%.1f", cost.limit))"
@@ -653,7 +623,7 @@ enum CLIRenderer {
     private static func appendSecondaryLines(
         provider: UsageProvider,
         snapshot: UsageSnapshot,
-        labels: RateWindowLabels,
+        labels: ProviderRateWindowLabels,
         context: RenderContext,
         now: Date,
         lines: inout [String])
@@ -663,7 +633,7 @@ enum CLIRenderer {
             provider: provider,
             title: labels.secondary,
             window: weekly,
-            paceKind: self.paceKind(provider: provider, fallback: .weekly),
+            paceSlot: .secondary,
             context: context,
             now: now,
             lines: &lines)
@@ -694,39 +664,24 @@ enum CLIRenderer {
         }
     }
 
-    private static func appendDevinOverageBalanceLine(
+    private static func appendPresentationCostLines(
         provider: UsageProvider,
         snapshot: UsageSnapshot,
         useColor: Bool,
         lines: inout [String])
     {
-        guard provider == .devin,
-              let cost = snapshot.providerCost,
-              cost.period == "Extra usage balance"
-        else { return }
-        let balance = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
-        lines.append(self.labelValueLine("Extra usage", value: balance, useColor: useColor))
-    }
-
-    private static func appendClaudeExtraUsageBalanceLine(
-        provider: UsageProvider,
-        snapshot: UsageSnapshot,
-        useColor: Bool,
-        lines: inout [String])
-    {
-        guard provider == .claude,
-              let cost = snapshot.providerCost,
-              let balance = cost.balance
-        else { return }
-        let value = UsageFormatter.currencyString(balance, currencyCode: cost.currencyCode)
-        lines.append(self.labelValueLine("Extra usage balance", value: value, useColor: useColor))
+        let presentation = ProviderDescriptorRegistry.descriptor(for: provider).presentation.cost(snapshot: snapshot)
+        for balance in presentation.balances {
+            let value = UsageFormatter.currencyString(balance.amount, currencyCode: balance.currencyCode)
+            lines.append(self.labelValueLine(balance.label, value: value, useColor: useColor))
+        }
     }
 
     // swiftlint:disable:next function_parameter_count
     private static func appendTertiaryLines(
         provider: UsageProvider,
         snapshot: UsageSnapshot,
-        labels: RateWindowLabels,
+        labels: ProviderRateWindowLabels,
         context: RenderContext,
         now: Date,
         lines: inout [String])
@@ -736,7 +691,7 @@ enum CLIRenderer {
         if let pace = self.paceLine(
             provider: provider,
             window: tertiary,
-            kind: self.paceKind(provider: provider, fallback: .weekly),
+            slot: .tertiary,
             weeklyWorkDays: context.weeklyWorkDays,
             useColor: context.useColor,
             now: now)
@@ -748,62 +703,22 @@ enum CLIRenderer {
         }
     }
 
-    private static func appendZaiExtraRateWindows(
+    private static func appendExtraRateWindows(
         provider: UsageProvider,
         snapshot: UsageSnapshot,
         context: RenderContext,
         now: Date,
         lines: inout [String])
     {
-        guard provider == .zai else { return }
-        for extra in snapshot.extraRateWindows ?? [] where extra.id == "zai-mcp" {
+        let extras = ProviderDescriptorRegistry.descriptor(for: provider)
+            .presentation
+            .extraRateWindows(snapshot: snapshot)
+        for extra in extras {
             lines.append(self.rateLine(title: extra.title, window: extra.window, useColor: context.useColor))
             if let reset = self.resetLine(for: extra.window, style: context.resetStyle, now: now) {
                 lines.append(self.subtleLine(reset, useColor: context.useColor))
             }
         }
-    }
-
-    private struct RateWindowLabels {
-        let primary: String
-        let secondary: String
-        let tertiary: String
-        let showsTertiary: Bool
-    }
-
-    private static func rateWindowLabels(
-        provider: UsageProvider,
-        metadata: ProviderMetadata,
-        snapshot: UsageSnapshot) -> RateWindowLabels
-    {
-        if provider == .factory, snapshot.tertiary != nil {
-            return RateWindowLabels(
-                primary: "5-hour",
-                secondary: "Weekly",
-                tertiary: "Monthly",
-                showsTertiary: true)
-        }
-        let primaryLabel = if provider == .grok {
-            GrokProviderDescriptor.primaryLabel(window: snapshot.primary) ?? metadata.sessionLabel
-        } else if provider == .crof {
-            CrofProviderDescriptor.primaryLabel(snapshot: snapshot)
-        } else if provider == .sub2api {
-            Sub2APIProviderDescriptor.primaryLabel(snapshot: snapshot) ?? metadata.sessionLabel
-        } else if provider == .amp {
-            AmpProviderDescriptor.primaryLabel(snapshot: snapshot) ?? metadata.sessionLabel
-        } else {
-            metadata.sessionLabel
-        }
-        let secondaryLabel = if provider == .amp {
-            AmpProviderDescriptor.secondaryLabel(snapshot: snapshot) ?? metadata.weeklyLabel
-        } else {
-            metadata.weeklyLabel
-        }
-        return RateWindowLabels(
-            primary: primaryLabel,
-            secondary: secondaryLabel,
-            tertiary: metadata.opusLabel ?? "Sonnet",
-            showsTertiary: metadata.supportsOpus)
     }
 
     private static func appendCreditsLine(
@@ -812,8 +727,11 @@ enum CLIRenderer {
         useColor: Bool,
         lines: inout [String])
     {
-        guard provider == .codex, let credits else { return }
-        let remaining = credits.codexCreditLimit?.remaining ?? credits.remaining
+        guard let credits,
+              let remaining = ProviderDescriptorRegistry.descriptor(for: provider)
+                  .presentation
+                  .creditRemaining(credits)
+        else { return }
         lines.append(self.labelValueLine(
             "Credits",
             value: UsageFormatter.creditsString(from: remaining),
@@ -827,6 +745,7 @@ enum CLIRenderer {
         useColor: Bool,
         lines: inout [String])
     {
+        // Provider-specific by design: codexResetCredits is a behavioral Codex payload, not presentation metadata.
         guard provider == .codex, let resetCredits = snapshot.codexResetCredits else { return }
         let inventory = resetCredits.availableInventory(at: now)
         let value = if inventory.count == 1 {
@@ -863,30 +782,14 @@ enum CLIRenderer {
             lines.append(self.labelValueLine("Account", value: email, useColor: context.useColor))
         }
 
-        if provider == .kilo {
-            let kiloLogin = self.kiloLoginParts(snapshot: snapshot)
-            if let pass = kiloLogin.pass {
-                let cleaned = UsageFormatter.cleanPlanName(pass)
-                lines.append(self.labelValueLine("Plan", value: cleaned, useColor: context.useColor))
-            }
-            for detail in kiloLogin.details {
-                lines.append(self.labelValueLine("Activity", value: detail, useColor: context.useColor))
-            }
-        } else if let plan = snapshot.loginMethod(for: provider),
-                  !plan.isEmpty,
-                  provider != .mimo || !plan.localizedCaseInsensitiveContains("balance:")
-        {
-            let displayPlan = if provider == .codex {
-                CodexPlanFormatting.displayName(plan) ?? plan
-            } else if provider == .claude,
-                      plan.hasPrefix("Claude "),
-                      ClaudePlan.fromCompatibilityLoginMethod(plan) != nil
-            {
-                plan
-            } else {
-                self.nonCodexPlanDisplay(provider: provider, plan: plan)
-            }
-            lines.append(self.labelValueLine("Plan", value: displayPlan, useColor: context.useColor))
+        let identity = ProviderDescriptorRegistry.descriptor(for: provider)
+            .presentation
+            .identity(provider: provider, snapshot: snapshot)
+        if let plan = identity.plan {
+            lines.append(self.labelValueLine("Plan", value: plan, useColor: context.useColor))
+        }
+        for detail in identity.details {
+            lines.append(self.labelValueLine(detail.label, value: detail.value, useColor: context.useColor))
         }
 
         for note in context.notes {
@@ -896,34 +799,24 @@ enum CLIRenderer {
         }
     }
 
-    private static func nonCodexPlanDisplay(provider: UsageProvider, plan: String) -> String {
-        // cleanPlanName preserves acronyms ("Management API"); `.capitalized`
-        // would mangle them into "Management Api".
-        if provider == .gemini || provider == .mimo || provider == .xai {
-            return UsageFormatter.cleanPlanName(plan)
-        }
-        return plan.capitalized
-    }
-
     // swiftlint:disable:next function_parameter_count
     private static func appendRateWindowLines(
         provider: UsageProvider,
         title: String,
         window: RateWindow,
-        paceKind: PaceKind?,
+        paceSlot: ProviderPaceSlot,
         context: RenderContext,
         now: Date,
         lines: inout [String])
     {
         lines.append(self.rateLine(title: title, window: window, useColor: context.useColor))
-        if let paceKind,
-           let pace = self.paceLine(
-               provider: provider,
-               window: window,
-               kind: paceKind,
-               weeklyWorkDays: context.weeklyWorkDays,
-               useColor: context.useColor,
-               now: now)
+        if let pace = self.paceLine(
+            provider: provider,
+            window: window,
+            slot: paceSlot,
+            weeklyWorkDays: context.weeklyWorkDays,
+            useColor: context.useColor,
+            now: now)
         {
             lines.append(pace)
         }
@@ -987,29 +880,6 @@ enum CLIRenderer {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private static func kiloLoginParts(snapshot: UsageSnapshot) -> (pass: String?, details: [String]) {
-        guard let loginMethod = snapshot.loginMethod(for: .kilo) else {
-            return (nil, [])
-        }
-        let parts = loginMethod
-            .components(separatedBy: "·")
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        guard !parts.isEmpty else {
-            return (nil, [])
-        }
-        let first = parts[0]
-        if self.isKiloActivitySegment(first) {
-            return (nil, parts)
-        }
-        return (first, Array(parts.dropFirst()))
-    }
-
-    private static func isKiloActivitySegment(_ text: String) -> Bool {
-        let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return normalized.hasPrefix("auto top-up:")
-    }
-
     private static func headerLine(_ header: String, useColor: Bool) -> String {
         let decorated = "== \(header) =="
         guard useColor else { return decorated }
@@ -1046,80 +916,24 @@ enum CLIRenderer {
     /// so the baseline matches the menu bar when the setting is configured. Descriptor-backed reset windows
     /// also use .weekly wording. Codex historical refinement is not applied, so it can still differ from the
     /// menu for Codex accounts.
-    private enum PaceKind {
-        case session
-        case weekly
-
-        var defaultWindowMinutes: Int {
-            switch self {
-            case .session: 300
-            case .weekly: 10080
-            }
-        }
-
-        func supportsStandardPace(provider: UsageProvider) -> Bool {
-            switch self {
-            case .session:
-                provider == .codex || provider == .claude || provider == .ollama || provider == .kimi ||
-                    provider == .notion
-            case .weekly:
-                provider == .codex || provider == .claude || provider == .opencode || provider == .ollama ||
-                    provider == .kimi
-            }
-        }
-    }
-
     private struct PaceComputation {
         let pace: UsagePace
-        let kind: PaceKind
-    }
-
-    private static func paceKind(provider: UsageProvider, fallback: PaceKind) -> PaceKind {
-        guard provider == .kimi else { return fallback }
-        // Kimi stores weekly in primary and its rate limit in secondary, opposite the legacy CLI slot convention.
-        switch fallback {
-        case .session:
-            return .weekly
-        case .weekly:
-            return .session
-        }
+        let kind: ProviderPaceKind
     }
 
     private static func computePace(
         provider: UsageProvider,
         window: RateWindow,
-        kind: PaceKind,
+        slot: ProviderPaceSlot,
         weeklyWorkDays: Int? = nil,
         now: Date) -> PaceComputation?
     {
         let capability = ProviderDescriptorRegistry.descriptor(for: provider).pace
-        let paceWindow: RateWindow
-        let resolvedKind: PaceKind
-        if capability.supportsResetWindowPace(window: window, now: now) {
-            paceWindow = capability.resolvedResetWindowForPace(window)
-            resolvedKind = .weekly
+        guard let resolvedKind = capability.resolvedKind(slot: slot, window: window, now: now) else { return nil }
+        let paceWindow: RateWindow = if capability.supportsResetWindowPace(window: window, now: now) {
+            capability.resolvedResetWindowForPace(window)
         } else {
-            guard kind.supportsStandardPace(provider: provider) else { return nil }
-            paceWindow = window
-            resolvedKind = kind
-        }
-        if provider == .kimi {
-            let supportsWindow = switch resolvedKind {
-            case .session:
-                paceWindow.windowMinutes == KimiProviderDescriptor.sessionWindowMinutes
-            case .weekly:
-                capability.supportsResetWindowPace(window: paceWindow, now: now)
-            }
-            guard supportsWindow else { return nil }
-        }
-        // Only pace a real session window here; Claude w/o 5-hour data falls a 7-day window into primary.
-        // Notion's rolling allowance is a 6-hour window, so it needs the wider ceiling to match the card.
-        let sessionCeilingMinutes = provider == .notion ? NotionProviderDescriptor.rollingWindowMaxMinutes : 300
-        if case .session = resolvedKind, let minutes = paceWindow.windowMinutes, minutes > sessionCeilingMinutes {
-            return nil
-        }
-        if provider == .ollama, paceWindow.windowMinutes == nil {
-            return nil
+            window
         }
         guard paceWindow.remainingPercent > 0 else { return nil }
         // workDays applies only to the weekly (10 080-min) window; UsagePace.weekly ignores it for other durations.
@@ -1136,7 +950,7 @@ enum CLIRenderer {
     private static func paceSummary(
         provider: UsageProvider,
         for pace: UsagePace,
-        kind: PaceKind,
+        kind: ProviderPaceKind,
         now: Date) -> String
     {
         let expected = Int(pace.expectedUsedPercent.rounded())
@@ -1152,7 +966,7 @@ enum CLIRenderer {
     private static func paceLine(
         provider: UsageProvider,
         window: RateWindow,
-        kind: PaceKind,
+        slot: ProviderPaceSlot,
         weeklyWorkDays: Int? = nil,
         useColor: Bool,
         now: Date) -> String?
@@ -1160,7 +974,7 @@ enum CLIRenderer {
         guard let computation = self.computePace(
             provider: provider,
             window: window,
-            kind: kind,
+            slot: slot,
             weeklyWorkDays: weeklyWorkDays,
             now: now) else { return nil }
         let label = self.label("Pace", useColor: useColor)
@@ -1175,14 +989,14 @@ enum CLIRenderer {
     private static func pacePayload(
         provider: UsageProvider,
         window: RateWindow,
-        kind: PaceKind,
+        slot: ProviderPaceSlot,
         weeklyWorkDays: Int? = nil,
         now: Date) -> PacePayload?
     {
         guard let computation = self.computePace(
             provider: provider,
             window: window,
-            kind: kind,
+            slot: slot,
             weeklyWorkDays: weeklyWorkDays,
             now: now) else { return nil }
         return PacePayload(
@@ -1226,7 +1040,7 @@ enum CLIRenderer {
     private static func paceRightLabel(
         provider: UsageProvider,
         for pace: UsagePace,
-        kind: PaceKind,
+        kind: ProviderPaceKind,
         now: Date) -> String?
     {
         if pace.willLastToReset {
@@ -1243,7 +1057,9 @@ enum CLIRenderer {
     }
 
     private static func combinedLastsLabel(for pace: UsagePace, provider: UsageProvider) -> String {
-        guard provider == .codex else { return "Lasts until reset" }
+        guard ProviderDescriptorRegistry.descriptor(for: provider).pace.showsHeadroomHint else {
+            return "Lasts until reset"
+        }
         guard let speedLabel = speedHintLabel(for: pace) else {
             return "Lasts until reset"
         }

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -730,9 +730,9 @@ extension CodexBarCLI {
         environment: [String: String]? = nil,
         settings: ProviderSettingsSnapshot? = nil) -> Bool
     {
-        if self.webSupportExempt(
-            sourceMode,
-            provider: provider,
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
+        if descriptor.cli.isBrowserSupportExempt(
+            sourceMode: sourceMode,
             environment: environment,
             settings: settings)
         {
@@ -742,113 +742,9 @@ extension CodexBarCLI {
         case .web:
             true
         case .auto:
-            ProviderDescriptorRegistry.descriptor(for: provider).fetchPlan.sourceModes.contains(.web)
+            descriptor.fetchPlan.sourceModes.contains(.web)
         case .cli, .oauth, .api:
             false
-        }
-    }
-
-    /// Providers that can satisfy a source mode without the macOS-only web/browser path.
-    private static func webSupportExempt(
-        _ sourceMode: ProviderSourceMode,
-        provider: UsageProvider,
-        environment: [String: String]?,
-        settings: ProviderSettingsSnapshot?) -> Bool
-    {
-        if provider == .grok || provider == .amp {
-            return true
-        }
-        if sourceMode == .auto, provider == .codex || provider == .claude {
-            // Claude's cross-platform planner skips its unavailable web step and falls back to the CLI.
-            return true
-        }
-        if self.cookieSourceExempt(sourceMode, provider: provider, settings: settings) {
-            return true
-        }
-        return self.credentialExempt(
-            sourceMode,
-            provider: provider,
-            environment: environment,
-            settings: settings)
-    }
-
-    /// Exemptions granted by a manual cookie header instead of browser auto-import.
-    private static func cookieSourceExempt(
-        _ sourceMode: ProviderSourceMode,
-        provider: UsageProvider,
-        settings: ProviderSettingsSnapshot?) -> Bool
-    {
-        switch provider {
-        case .opencodego:
-            return sourceMode == .auto || settings?.opencodego?.cookieSource == .manual
-        case .commandcode:
-            return settings?.commandcode?.cookieSource == .manual
-        case .alibabatokenplan:
-            // The Alibaba/Qwen Token Plan fetch is plain URLSession + cookies; only browser
-            // cookie auto-import needs macOS, so a manual cookie header works off macOS too.
-            return settings?.alibabaTokenPlan?.cookieSource == .manual
-        case .qoder:
-            return settings?.qoder?.cookieSource == .manual
-        case .cursor:
-            #if os(Linux)
-            // Linux uses Cursor app auth and manual cookies; browser import remains macOS-only.
-            return settings?.cursor?.cookieSource != .off
-            #else
-            return false
-            #endif
-        default:
-            return false
-        }
-    }
-
-    /// Exemptions granted by an already-configured credential (token, API key, or local cache).
-    private static func credentialExempt(
-        _ sourceMode: ProviderSourceMode,
-        provider: UsageProvider,
-        environment: [String: String]?,
-        settings: ProviderSettingsSnapshot?) -> Bool
-    {
-        switch provider {
-        case .sakana:
-            guard sourceMode == .auto || sourceMode == .web else { return false }
-            return environment.map { SakanaSettingsReader.cookieHeader(environment: $0) != nil } == true
-        case .qwencloud:
-            guard sourceMode == .auto || sourceMode == .web,
-                  settings?.qwenCloud?.cookieSource != .off else { return false }
-            let hasEnvironmentCookie = environment.map {
-                QwenCloudSettingsReader.cookieHeader(environment: $0) != nil
-            } == true
-            let hasManualCookie = settings?.qwenCloud?.cookieSource == .manual &&
-                CookieHeaderNormalizer.normalize(settings?.qwenCloud?.manualCookieHeader) != nil
-            return hasEnvironmentCookie || hasManualCookie
-        case .ollama:
-            guard sourceMode == .auto else { return false }
-            let hasEnvironmentToken = environment.map {
-                ProviderTokenResolver.ollamaToken(environment: $0) != nil
-            } == true
-            return settings?.ollama?.cookieSource == .off || hasEnvironmentToken
-        case .kimi:
-            guard sourceMode == .auto else { return false }
-            return environment.map { environment in
-                ProviderTokenResolver.kimiAPIToken(environment: environment) != nil ||
-                    KimiSettingsReader.hasKimiCodeCredential(environment: environment)
-            } == true
-        case .factory:
-            // Linux Auto/legacy-cli can use FACTORY_API_KEY without browser cookies.
-            guard sourceMode == .auto || sourceMode == .cli else { return false }
-            return environment.map { FactorySettingsReader.apiKey(environment: $0) != nil } == true
-        case .minimax:
-            // The MiniMax API fetch is plain HTTPS + Bearer auth, so a configured key works off
-            // macOS. Standard `sk-api-` keys are the exception: Auto resolves them to the Coding
-            // Plan web strategy, which still needs the macOS-only web path.
-            guard sourceMode == .auto, let environment else { return false }
-            guard MiniMaxAPISettingsReader.apiToken(environment: environment) != nil else { return false }
-            return MiniMaxAPISettingsReader.apiKeyKind(environment: environment) != .standard
-        case .mimo:
-            guard sourceMode == .auto, let environment else { return false }
-            return MiMoLocalUsageFallback.cacheExists(environment: environment)
-        default:
-            return false
         }
     }
 }

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -135,6 +135,7 @@ extension CodexBarCLI {
                     output: output,
                     kind: .args)
             }
+            // Provider-specific by design: Codex exposes reconciled accounts beyond config token accounts.
             let supportsAllCodexAccounts = providerList[0] == .codex
                 && tokenSelection.allAccounts
                 && tokenSelection.label == nil
@@ -240,6 +241,7 @@ extension CodexBarCLI {
         tokenSelection: TokenAccountCLISelection) -> String?
     {
         guard enabled else { return nil }
+        // Provider-specific by design: this hidden verifier recreates Claude's owner-CLI lifecycle only.
         guard providers == [.claude], sourceMode == .auto else {
             return "--app-auto-verifier requires --provider claude --source auto."
         }
@@ -255,6 +257,7 @@ extension CodexBarCLI {
         tokenContext: TokenAccountCLIContext,
         command: UsageCommandContext) async -> UsageCommandOutput
     {
+        // Provider-specific by design: Codex can enumerate reconciled live, managed, and profile-home accounts.
         if provider == .codex, command.includeAllCodexAccounts {
             var output = UsageCommandOutput()
             let accounts = tokenContext.visibleCodexAccounts().visibleAccounts
@@ -404,6 +407,7 @@ extension CodexBarCLI {
                         resetStyle: input.command.resetStyle,
                         weeklyWorkDays: input.command.weeklyWorkDays,
                         notes: input.notes))
+                // Provider-specific by design: OpenAI dashboard payloads are behavioral Codex fetch results.
                 if let dashboard = input.dashboard, input.provider == .codex, input.effectiveSourceMode.usesWeb {
                     text += "\n" + Self.renderOpenAIWebDashboardText(dashboard)
                 }
@@ -511,6 +515,7 @@ extension CodexBarCLI {
             }
 
             var dashboard = result.dashboard
+            // Provider-specific by design: JSON preserves Codex's optional behavioral dashboard payload.
             if dashboard == nil, command.format == .json, provider == .codex {
                 dashboard = Self.loadOpenAIDashboardIfAvailable(
                     usage: usage,
@@ -586,6 +591,7 @@ extension CodexBarCLI {
         let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
         guard descriptor.cli.versionDetector != nil else { return false }
         guard result.strategyKind != .webDashboard else { return false }
+        // Provider-specific by design: Claude OAuth is in-process and has no CLI version to report.
         return !(provider == .claude && result.strategyKind == .oauth)
     }
 
@@ -613,6 +619,7 @@ extension CodexBarCLI {
         jsonOnly: Bool,
         persistsCLISessions: Bool) -> Bool
     {
+        // Provider-specific by design: --antigravity-plan-debug interrogates its persistent helper session.
         provider == .antigravity
             && planDebugEnabled
             && !jsonOnly
@@ -634,6 +641,7 @@ extension CodexBarCLI {
         provider: UsageProvider,
         command: UsageCommandContext) async -> AntigravityPlanInfoSummary?
     {
+        // Provider-specific by design: --antigravity-plan-debug requests its plan-only diagnostic.
         guard command.antigravityPlanDebug,
               provider == .antigravity,
               !command.jsonOnly
@@ -651,6 +659,7 @@ extension CodexBarCLI {
         provider: UsageProvider,
         command: UsageCommandContext) async
     {
+        // Provider-specific by design: --augment-debug emits Augment's explicit diagnostic dump.
         guard command.augmentDebug, provider == .augment else { return }
         #if os(macOS)
         let dump = await AugmentStatusProbe.latestDumps()

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -122,6 +122,7 @@ struct TokenAccountCLIContext {
         codexActiveSourceOverride: CodexActiveSource? = nil) ->
         ProviderSettingsSnapshot.CodexProviderSettings
     {
+        // Provider-specific by design: Codex settings include reconciliation state and profile-home selection.
         let config = self.providerConfig(for: .codex)
         let reconciliationSnapshot = self.codexAccountReconciler(
             activeSource: codexActiveSourceOverride).loadSnapshot()

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -104,6 +104,7 @@ struct TokenAccountCLIContext {
         codexActiveSourceOverride: CodexActiveSource? = nil) -> ProviderSettingsSnapshot?
     {
         let config = self.providerConfig(for: provider)
+        // Provider-specific by design: managed Codex profiles require live reconciliation state that is not config.
         if provider == .codex {
             return ProviderSettingsSnapshot.make(codex: self.makeCodexSettingsSnapshot(
                 account: account,
@@ -125,10 +126,12 @@ struct TokenAccountCLIContext {
         let reconciliationSnapshot = self.codexAccountReconciler(
             activeSource: codexActiveSourceOverride).loadSnapshot()
         let resolvedActiveSource = CodexActiveSourceResolver.resolve(from: reconciliationSnapshot)
+        let cookieSettings = ProviderCredentialSettingsContext(config: config, account: account)
+            .cookieSettings(for: .codex)
         return CodexProviderSettingsBuilder.make(input: CodexProviderSettingsBuilderInput(
             usageDataSource: .auto,
-            cookieSource: self.cookieSource(provider: .codex, account: account, config: config),
-            manualCookieHeader: self.manualCookieHeader(provider: .codex, account: account, config: config),
+            cookieSource: cookieSettings.cookieSource,
+            manualCookieHeader: cookieSettings.manualCookieHeader,
             reconciliationSnapshot: reconciliationSnapshot,
             resolvedActiveSource: resolvedActiveSource))
     }
@@ -145,6 +148,7 @@ struct TokenAccountCLIContext {
             provider: provider,
             config: providerConfig,
             selectedAccount: account)
+        // Provider-specific by design: managed Codex accounts select a distinct filesystem home, not a credential.
         if provider == .codex,
            let codexHomePath = self.codexHomePath(for: codexActiveSourceOverride)
         {
@@ -163,21 +167,8 @@ struct TokenAccountCLIContext {
 
     func manualTokenUpdater() -> ProviderFetchContext.ProviderManualTokenUpdater {
         { provider, token in
-            try? Self.updateStoredManualToken(provider: provider, token: token)
+            try? ProviderDescriptorRegistry.descriptor(for: provider).credentials?.persistManualToken(token)
         }
-    }
-
-    private static func updateStoredManualToken(provider: UsageProvider, token: String) throws {
-        guard provider == .stepfun else { return }
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-
-        let store = CodexBarConfigStore()
-        var config = try store.load() ?? .makeDefault()
-        var providerConfig = config.providerConfig(for: provider.instanceID) ?? ProviderConfig(id: provider.instanceID)
-        providerConfig.region = trimmed
-        config.setProviderConfig(providerConfig)
-        try store.save(config)
     }
 
     private static func updateStoredTokenAccount(
@@ -218,11 +209,13 @@ struct TokenAccountCLIContext {
     }
 
     func fetcher(base: UsageFetcher, provider: UsageProvider, env: [String: String]) -> UsageFetcher {
+        // Provider-specific by design: UsageFetcher owns Codex filesystem scopes and must be rebuilt with CODEX_HOME.
         guard provider == .codex else { return base }
         return UsageFetcher(environment: env)
     }
 
     func visibleCodexAccounts() -> CodexVisibleAccountProjection {
+        // Provider-specific by design: only Codex exposes reconciled live, managed, and profile-home accounts.
         self.codexAccountReconciler().loadVisibleAccounts()
     }
 
@@ -245,6 +238,7 @@ struct TokenAccountCLIContext {
     }
 
     func applyCodexVisibleAccountLabel(_ snapshot: UsageSnapshot, account: CodexVisibleAccount) -> UsageSnapshot {
+        // Provider-specific by design: reconciled Codex accounts carry workspace labels outside token-account config.
         let existing = snapshot.identity(for: .codex)
         let identity = ProviderIdentitySnapshot(
             providerID: .codex,
@@ -259,26 +253,9 @@ struct TokenAccountCLIContext {
         provider: UsageProvider,
         account: ProviderTokenAccount?) -> ProviderSourceMode
     {
-        guard provider == .claude else {
-            return base
-        }
         let config = self.providerConfig(for: provider)
-        let routing = self.claudeCredentialRouting(account: account, config: config)
-
-        guard account != nil else { return base }
-
-        // Selected-account credentials are authoritative regardless of the global source. Claude CLI usage is
-        // ambient to the active local profile and must never be labeled as a configured token account.
-        switch routing {
-        case .adminAPIKey:
-            return .api
-        case .oauth:
-            return .oauth
-        case .webCookie:
-            return .web
-        case .none:
-            return base
-        }
+        return ProviderDescriptorRegistry.descriptor(for: provider).credentials?
+            .selectedAccountSourceMode(base: base, account: account, config: config) ?? base
     }
 
     func preferredSourceMode(for provider: UsageProvider) -> ProviderSourceMode {
@@ -291,6 +268,7 @@ struct TokenAccountCLIContext {
     }
 
     private func codexAccountReconciler(activeSource: CodexActiveSource? = nil) -> DefaultCodexAccountReconciler {
+        // Provider-specific by design: this reconciles Codex profile homes with its managed-account store.
         let storeLoader: @Sendable () throws -> ManagedCodexAccountSet = if let managedCodexAccountStoreURL {
             {
                 try FileManagedCodexAccountStore(fileURL: managedCodexAccountStoreURL).loadAccounts()
@@ -311,6 +289,7 @@ struct TokenAccountCLIContext {
     }
 
     private func codexHomePath(for activeSourceOverride: CodexActiveSource?) -> String? {
+        // Provider-specific by design: Codex profile selection changes the local data root for the whole fetcher.
         let activeSource: CodexActiveSource = if let activeSourceOverride {
             activeSourceOverride
         } else {
@@ -335,53 +314,5 @@ struct TokenAccountCLIContext {
                 CodexHomeScope.normalizedHomePath($0) == normalizedPath
             } ? normalizedPath : nil
         }
-    }
-
-    private func manualCookieHeader(
-        provider: UsageProvider,
-        account: ProviderTokenAccount?,
-        config: ProviderConfig?) -> String?
-    {
-        self.cookieSettings(provider: provider, account: account, config: config).manualCookieHeader
-    }
-
-    private func cookieSource(
-        provider: UsageProvider,
-        account: ProviderTokenAccount?,
-        config: ProviderConfig?) -> ProviderCookieSource
-    {
-        self.cookieSettings(provider: provider, account: account, config: config).cookieSource
-    }
-
-    private func cookieSettings(
-        provider: UsageProvider,
-        account: ProviderTokenAccount?,
-        config: ProviderConfig?,
-        configuredHeader: String? = nil) -> ProviderSettingsSnapshot.CookieProviderSettings
-    {
-        let configuredSource: ProviderCookieSource = if let override = config?.cookieSource {
-            override
-        } else if provider == .stepfun, config?.sanitizedRegion != nil {
-            .manual
-        } else if config?.sanitizedCookieHeader != nil {
-            .manual
-        } else {
-            .auto
-        }
-        return ProviderCookieSettingsResolver.resolve(
-            provider: provider,
-            configuredSource: configuredSource,
-            configuredHeader: configuredHeader ?? config?.sanitizedCookieHeader,
-            selectedAccount: account)
-    }
-
-    private func claudeCredentialRouting(
-        account: ProviderTokenAccount?,
-        config: ProviderConfig?) -> ClaudeCredentialRouting
-    {
-        let manualCookieHeader = account == nil ? config?.sanitizedCookieHeader : nil
-        return ClaudeCredentialRouting.resolve(
-            tokenAccountToken: account?.token,
-            manualCookieHeader: manualCookieHeader)
     }
 }

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanProviderDescriptor.swift
@@ -100,7 +100,11 @@ public enum AlibabaTokenPlanProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "alibaba-token-plan",
                 aliases: ["alibaba-token", "bailian-token-plan"],
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { _, _, settings in
+                    // Manual cookies use plain URLSession; only browser import is platform-bound.
+                    settings?.alibabaTokenPlan?.cookieSource == .manual
+                }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -43,6 +43,13 @@ public enum AmpProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Amp cost summary is not supported." }),
             pace: .calendarMonthResetWindow,
+            presentation: ProviderUsagePresentation(rateWindowLabeler: { metadata, snapshot, _ in
+                ProviderRateWindowLabels(
+                    primary: Self.primaryLabel(snapshot: snapshot) ?? metadata.sessionLabel,
+                    secondary: Self.secondaryLabel(snapshot: snapshot) ?? metadata.weeklyLabel,
+                    tertiary: metadata.opusLabel ?? "Sonnet",
+                    showsTertiary: metadata.supportsOpus)
+            }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web, .cli],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -55,7 +55,8 @@ public enum AmpProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "amp",
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { _, _, _ in true }))
     }
 
     public static func primaryLabel(snapshot: UsageSnapshot) -> String? {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -51,6 +51,7 @@ public enum AntigravityProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Antigravity cost summary is not supported." }),
+            history: .alwaysTracked,
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .cli, .oauth],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -130,6 +130,7 @@ public enum ClaudeProviderDescriptor {
                 primary: .session(maximumMinutes: 300),
                 secondary: .weekly,
                 tertiary: .weekly),
+            history: .alwaysTracked,
             presentation: ProviderUsagePresentation(
                 identityPresenter: { provider, snapshot in
                     guard let plan = snapshot.loginMethod(for: provider), !plan.isEmpty else {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -155,7 +155,8 @@ public enum ClaudeProviderDescriptor {
                 binaryLocator: { BinaryLocator.resolveClaudeBinary() },
                 versionDetector: { browserDetection in
                     ClaudeUsageFetcher(browserDetection: browserDetection).detectVersion()
-                }))
+                },
+                browserSupportExemption: { sourceMode, _, _ in sourceMode == .auto }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -117,6 +117,36 @@ public enum ClaudeProviderDescriptor {
                 noDataMessage: self.noDataMessage,
                 menuHintLines: [.estimate],
                 supportsTokenSnapshot: true),
+            pace: ProviderPaceCapability(
+                primary: .session(maximumMinutes: 300),
+                secondary: .weekly,
+                tertiary: .weekly),
+            presentation: ProviderUsagePresentation(
+                identityPresenter: { provider, snapshot in
+                    guard let plan = snapshot.loginMethod(for: provider), !plan.isEmpty else {
+                        return ProviderIdentityPresentation(badge: nil, plan: nil)
+                    }
+                    let display = if plan.hasPrefix("Claude "),
+                                     ClaudePlan.fromCompatibilityLoginMethod(plan) != nil
+                    {
+                        plan
+                    } else {
+                        plan.capitalized
+                    }
+                    return ProviderIdentityPresentation(badge: display, plan: display)
+                },
+                costPresenter: { snapshot in
+                    guard let cost = snapshot.providerCost else { return ProviderCostPresentation() }
+                    let balances = cost.balance.map {
+                        [ProviderCostPresentation.Balance(
+                            label: "Extra usage balance",
+                            amount: $0,
+                            currencyCode: cost.currencyCode)]
+                    } ?? []
+                    return ProviderCostPresentation(
+                        showsGenericFallback: !(cost.used == 0 && cost.limit == 0 && cost.balance != nil),
+                        balances: balances)
+                }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web, .cli, .oauth],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -36,6 +36,15 @@ public enum ClaudeProviderDescriptor {
             }),
         authDetector: { environment, _ in
             ClaudeAdminAPISettingsReader.apiKey(environment: environment) == nil ? [] : ["api"]
+        },
+        selectedAccountSourceModeResolver: { base, account, _ in
+            guard let account else { return base }
+            return switch ClaudeCredentialRouting.resolve(tokenAccountToken: account.token, manualCookieHeader: nil) {
+            case .adminAPIKey: .api
+            case .oauth: .oauth
+            case .webCookie: .web
+            case .none: base
+            }
         })
 
     static func makeDescriptor() -> ProviderDescriptor {

--- a/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
@@ -40,6 +40,9 @@ public enum ClawRouterProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "ClawRouter spend is reported by its usage API." }),
+            presentation: ProviderUsagePresentation(costPresenter: { _ in
+                ProviderCostPresentation(showsGenericFallback: false)
+            }),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "clawrouter",

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -70,6 +70,7 @@ public enum CodexProviderDescriptor {
                 primary: .session(maximumMinutes: 300),
                 secondary: .weekly,
                 showsHeadroomHint: true),
+            history: .alwaysTracked,
             presentation: ProviderUsagePresentation(
                 identityPresenter: { provider, snapshot in
                     guard let plan = snapshot.loginMethod(for: provider), !plan.isEmpty else {

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -66,6 +66,19 @@ public enum CodexProviderDescriptor {
                 noDataMessage: self.noDataMessage,
                 menuHintLines: [.localized("codex_api_estimate_hint")],
                 supportsTokenSnapshot: true),
+            pace: ProviderPaceCapability(
+                primary: .session(maximumMinutes: 300),
+                secondary: .weekly,
+                showsHeadroomHint: true),
+            presentation: ProviderUsagePresentation(
+                identityPresenter: { provider, snapshot in
+                    guard let plan = snapshot.loginMethod(for: provider), !plan.isEmpty else {
+                        return ProviderIdentityPresentation(badge: nil, plan: nil)
+                    }
+                    let display = CodexPlanFormatting.displayName(plan) ?? plan
+                    return ProviderIdentityPresentation(badge: display, plan: display)
+                },
+                creditResolver: { $0.codexCreditLimit?.remaining ?? $0.remaining }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web, .cli, .oauth],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -85,7 +85,8 @@ public enum CodexProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "codex",
                 binaryLocator: { BinaryLocator.resolveCodexBinary() },
-                versionDetector: { _ in ProviderVersionDetector.codexVersion() }))
+                versionDetector: { _ in ProviderVersionDetector.codexVersion() },
+                browserSupportExemption: { sourceMode, _, _ in sourceMode == .auto }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
@@ -50,7 +50,10 @@ public enum CommandCodeProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "commandcode",
                 aliases: ["command-code"],
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { _, _, settings in
+                    settings?.commandcode?.cookieSource == .manual
+                }))
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Crof/CrofProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Crof/CrofProviderDescriptor.swift
@@ -45,6 +45,13 @@ public enum CrofProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Crof cost summary is not available via API." }),
+            presentation: ProviderUsagePresentation(rateWindowLabeler: { metadata, snapshot, _ in
+                ProviderRateWindowLabels(
+                    primary: Self.primaryLabel(snapshot: snapshot),
+                    secondary: metadata.weeklyLabel,
+                    tertiary: metadata.opusLabel ?? "Sonnet",
+                    showsTertiary: metadata.supportsOpus)
+            }),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "crof",

--- a/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
@@ -73,7 +73,15 @@ public enum CursorProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [CursorStatusFetchStrategy()] })),
             cli: ProviderCLIConfig(
                 name: "cursor",
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { _, _, settings in
+                    #if os(Linux)
+                    // Linux uses Cursor app auth and manual cookies; browser import remains macOS-only.
+                    settings?.cursor?.cookieSource != .off
+                    #else
+                    false
+                    #endif
+                }))
     }
 
     private static var supportsTokenSnapshot: Bool {

--- a/Sources/CodexBarCore/Providers/Devin/DevinProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinProviderDescriptor.swift
@@ -54,6 +54,17 @@ public enum DevinProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Devin cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(costPresenter: { snapshot in
+                guard let cost = snapshot.providerCost, cost.period == "Extra usage balance" else {
+                    return ProviderCostPresentation()
+                }
+                return ProviderCostPresentation(
+                    showsGenericFallback: false,
+                    balances: [ProviderCostPresentation.Balance(
+                        label: "Extra usage",
+                        amount: cost.used,
+                        currencyCode: cost.currencyCode)])
+            }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [DevinWebFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Factory/FactoryProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryProviderDescriptor.swift
@@ -71,7 +71,11 @@ public enum FactoryProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "factory",
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { sourceMode, environment, _ in
+                    guard sourceMode == .auto || sourceMode == .cli else { return false }
+                    return environment.map { FactorySettingsReader.apiKey(environment: $0) != nil } == true
+                }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Factory/FactoryProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryProviderDescriptor.swift
@@ -50,6 +50,20 @@ public enum FactoryProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Droid cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(rateWindowLabeler: { metadata, snapshot, _ in
+                guard snapshot.tertiary != nil else {
+                    return ProviderRateWindowLabels(
+                        primary: metadata.sessionLabel,
+                        secondary: metadata.weeklyLabel,
+                        tertiary: metadata.opusLabel ?? "Sonnet",
+                        showsTertiary: metadata.supportsOpus)
+                }
+                return ProviderRateWindowLabels(
+                    primary: "5-hour",
+                    secondary: "Weekly",
+                    tertiary: "Monthly",
+                    showsTertiary: true)
+            }),
             fetchPlan: ProviderFetchPlan(
                 // `.cli` remains as an Auto compatibility alias for persisted configs from older builds
                 // that advertised `[.auto, .cli]` while only implementing the web strategy.

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiProviderDescriptor.swift
@@ -44,6 +44,13 @@ public enum GeminiProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Gemini cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(identityPresenter: { provider, snapshot in
+                guard let plan = snapshot.loginMethod(for: provider), !plan.isEmpty else {
+                    return ProviderIdentityPresentation(badge: nil, plan: nil)
+                }
+                let display = UsageFormatter.cleanPlanName(plan)
+                return ProviderIdentityPresentation(badge: display, plan: display)
+            }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [GeminiStatusFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -71,7 +71,8 @@ public enum GrokProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "grok",
-                versionDetector: { _ in GrokStatusProbe.detectVersion() }))
+                versionDetector: { _ in GrokStatusProbe.detectVersion() },
+                browserSupportExemption: { _, _, _ in true }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -59,6 +59,13 @@ public enum GrokProviderDescriptor {
                     && timeUntilReset > 0
                     && timeUntilReset <= TimeInterval(windowMinutes) * 60
             }),
+            presentation: ProviderUsagePresentation(rateWindowLabeler: { metadata, snapshot, now in
+                ProviderRateWindowLabels(
+                    primary: Self.primaryLabel(window: snapshot.primary, now: now) ?? metadata.sessionLabel,
+                    secondary: metadata.weeklyLabel,
+                    tertiary: metadata.opusLabel ?? "Sonnet",
+                    showsTertiary: metadata.supportsOpus)
+            }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .cli, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
@@ -61,6 +61,25 @@ public enum KiloProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Kilo cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(identityPresenter: { provider, snapshot in
+                guard let loginMethod = snapshot.loginMethod(for: provider) else {
+                    return ProviderIdentityPresentation(badge: nil, plan: nil)
+                }
+                let parts = loginMethod
+                    .components(separatedBy: "·")
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                guard let first = parts.first else {
+                    return ProviderIdentityPresentation(badge: nil, plan: nil)
+                }
+                let firstIsActivity = first.lowercased().hasPrefix("auto top-up:")
+                let plan = firstIsActivity ? nil : UsageFormatter.cleanPlanName(first)
+                let activity = firstIsActivity ? parts : Array(parts.dropFirst())
+                return ProviderIdentityPresentation(
+                    badge: plan,
+                    plan: plan,
+                    details: activity.map { ProviderIdentityPresentation.Detail(label: "Activity", value: $0) })
+            }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .cli],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -67,7 +67,10 @@ public enum KimiProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Kimi Code cost summary is not supported." }),
             pace: ProviderPaceCapability(
-                resetWindowPace: .windowDuration(minutes: self.weeklyWindowMinutes)),
+                resetWindowPace: .windowDuration(minutes: self.weeklyWindowMinutes),
+                primary: .exact(kind: .weekly, minutes: self.weeklyWindowMinutes),
+                secondary: .exact(kind: .session, minutes: self.sessionWindowMinutes),
+                tertiary: .exact(kind: .session, minutes: self.sessionWindowMinutes)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -77,7 +77,14 @@ public enum KimiProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "kimi",
                 aliases: ["kimi-ai"],
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { sourceMode, environment, _ in
+                    guard sourceMode == .auto else { return false }
+                    return environment.map { environment in
+                        ProviderTokenResolver.kimiAPIToken(environment: environment) != nil ||
+                            KimiSettingsReader.hasKimiCodeCredential(environment: environment)
+                    } == true
+                }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
@@ -49,6 +49,17 @@ public enum MiMoProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Xiaomi MiMo cost summary is not supported." }),
             pace: .calendarMonthResetWindow,
+            presentation: ProviderUsagePresentation(identityPresenter: { provider, snapshot in
+                let balance = snapshot.detailRow(label: "Balance")?.value
+                guard let plan = snapshot.loginMethod(for: provider),
+                      !plan.isEmpty,
+                      !plan.localizedCaseInsensitiveContains("balance:")
+                else {
+                    return ProviderIdentityPresentation(badge: balance, plan: nil)
+                }
+                let display = UsageFormatter.cleanPlanName(plan)
+                return ProviderIdentityPresentation(badge: balance ?? display, plan: display)
+            }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { context in

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
@@ -71,7 +71,11 @@ public enum MiMoProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "mimo",
                 aliases: ["xiaomi-mimo"],
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { sourceMode, environment, _ in
+                    guard sourceMode == .auto, let environment else { return false }
+                    return MiMoLocalUsageFallback.cacheExists(environment: environment)
+                }))
     }
 }
 

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
@@ -98,7 +98,13 @@ public enum MiniMaxProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "minimax",
                 aliases: ["mini-max"],
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { sourceMode, environment, _ in
+                    // Standard sk-api keys select the Coding Plan web strategy; other tokens use HTTPS directly.
+                    guard sourceMode == .auto, let environment,
+                          MiniMaxAPISettingsReader.apiToken(environment: environment) != nil else { return false }
+                    return MiniMaxAPISettingsReader.apiKeyKind(environment: environment) != .standard
+                }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Notion/NotionProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Notion/NotionProviderDescriptor.swift
@@ -71,7 +71,11 @@ public enum NotionProviderDescriptor {
                 noDataMessage: { "Notion AI cost summary is not supported." }),
             // The billing-period window renews on a calendar cycle, so pace has to measure the real
             // month ending at the reset rather than the 30-day sentinel the snapshot carries.
-            pace: .calendarMonthResetWindow,
+            pace: ProviderPaceCapability(
+                resetWindowPace: .windowDuration(minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
+                inferredMonthlyDuration: .windowDuration(
+                    minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
+                primary: .session(maximumMinutes: self.rollingWindowMaxMinutes)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [NotionWebFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -52,6 +52,9 @@ public enum OllamaProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Ollama cost summary is not supported." }),
+            pace: ProviderPaceCapability(
+                primary: .session(maximumMinutes: 300, requiresDuration: true),
+                secondary: .weeklyWithDuration),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -60,7 +60,14 @@ public enum OllamaProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "ollama",
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { sourceMode, environment, settings in
+                    guard sourceMode == .auto else { return false }
+                    let hasEnvironmentToken = environment.map {
+                        ProviderTokenResolver.ollamaToken(environment: $0) != nil
+                    } == true
+                    return settings?.ollama?.cookieSource == .off || hasEnvironmentToken
+                }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
@@ -68,6 +68,7 @@ public enum OpenCodeProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "OpenCode cost summary is not supported." }),
+            pace: ProviderPaceCapability(secondary: .weekly),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [OpenCodeUsageFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -65,7 +65,10 @@ public enum OpenCodeGoProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "opencodego",
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { sourceMode, _, settings in
+                    sourceMode == .auto || settings?.opencodego?.cookieSource == .manual
+                }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -60,6 +60,7 @@ public enum OpenCodeGoProviderDescriptor {
                     "No OpenCode Go local usage history found in ~/.local/share/opencode/opencode.db."
                 }),
             pace: .calendarMonthResetWindow,
+            history: .alwaysTracked,
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/ProviderCLIConfig.swift
+++ b/Sources/CodexBarCore/Providers/ProviderCLIConfig.swift
@@ -1,20 +1,36 @@
 import Foundation
 
 public struct ProviderCLIConfig: Sendable {
+    public typealias BrowserSupportExemption = @Sendable (
+        _ sourceMode: ProviderSourceMode,
+        _ environment: [String: String]?,
+        _ settings: ProviderSettingsSnapshot?) -> Bool
+
     public let name: String
     public let aliases: [String]
     public let binaryLocator: (@Sendable () -> String?)?
     public let versionDetector: (@Sendable (BrowserDetection) -> String?)?
+    private let browserSupportExemption: BrowserSupportExemption
 
     public init(
         name: String,
         aliases: [String] = [],
         binaryLocator: (@Sendable () -> String?)? = nil,
-        versionDetector: (@Sendable (BrowserDetection) -> String?)?)
+        versionDetector: (@Sendable (BrowserDetection) -> String?)?,
+        browserSupportExemption: @escaping BrowserSupportExemption = { _, _, _ in false })
     {
         self.name = name
         self.aliases = aliases
         self.binaryLocator = binaryLocator
         self.versionDetector = versionDetector
+        self.browserSupportExemption = browserSupportExemption
+    }
+
+    public func isBrowserSupportExempt(
+        sourceMode: ProviderSourceMode,
+        environment: [String: String]?,
+        settings: ProviderSettingsSnapshot?) -> Bool
+    {
+        self.browserSupportExemption(sourceMode, environment, settings)
     }
 }

--- a/Sources/CodexBarCore/Providers/ProviderCredentialAdapter.swift
+++ b/Sources/CodexBarCore/Providers/ProviderCredentialAdapter.swift
@@ -89,6 +89,11 @@ public struct ProviderCredentialAdapter: Sendable {
     public typealias AccountEnvironmentOverride = @Sendable (
         _ environment: inout [String: String],
         _ account: ProviderTokenAccount) -> Void
+    public typealias SelectedAccountSourceModeResolver = @Sendable (
+        _ base: ProviderSourceMode,
+        _ account: ProviderTokenAccount?,
+        _ config: ProviderConfig?) -> ProviderSourceMode
+    public typealias ManualTokenPersister = @Sendable (_ token: String) throws -> Void
 
     public let supportsAPIKeyOverride: Bool
     public let usesRegion: Bool
@@ -102,6 +107,8 @@ public struct ProviderCredentialAdapter: Sendable {
     private let configValidator: ConfigValidator
     private let missingCredentialMessage: MissingCredentialMessage?
     private let accountEnvironmentOverride: AccountEnvironmentOverride
+    private let selectedAccountSourceModeResolver: SelectedAccountSourceModeResolver
+    private let manualTokenPersister: ManualTokenPersister?
 
     public init(
         supportsAPIKeyOverride: Bool = false,
@@ -115,7 +122,9 @@ public struct ProviderCredentialAdapter: Sendable {
         diagnosticSummary: DiagnosticSummary? = nil,
         configValidator: @escaping ConfigValidator = { _ in [] },
         missingCredentialMessage: MissingCredentialMessage? = nil,
-        accountEnvironmentOverride: @escaping AccountEnvironmentOverride = { _, _ in })
+        accountEnvironmentOverride: @escaping AccountEnvironmentOverride = { _, _ in },
+        selectedAccountSourceModeResolver: @escaping SelectedAccountSourceModeResolver = { base, _, _ in base },
+        manualTokenPersister: ManualTokenPersister? = nil)
     {
         self.supportsAPIKeyOverride = supportsAPIKeyOverride
         self.usesRegion = usesRegion
@@ -129,6 +138,8 @@ public struct ProviderCredentialAdapter: Sendable {
         self.configValidator = configValidator
         self.missingCredentialMessage = missingCredentialMessage
         self.accountEnvironmentOverride = accountEnvironmentOverride
+        self.selectedAccountSourceModeResolver = selectedAccountSourceModeResolver
+        self.manualTokenPersister = manualTokenPersister
     }
 
     public func applyConfig(base: [String: String], config: ProviderConfig?) -> [String: String] {
@@ -186,6 +197,18 @@ public struct ProviderCredentialAdapter: Sendable {
         account: ProviderTokenAccount)
     {
         self.accountEnvironmentOverride(&environment, account)
+    }
+
+    public func selectedAccountSourceMode(
+        base: ProviderSourceMode,
+        account: ProviderTokenAccount?,
+        config: ProviderConfig?) -> ProviderSourceMode
+    {
+        self.selectedAccountSourceModeResolver(base, account, config)
+    }
+
+    public func persistManualToken(_ token: String) throws {
+        try self.manualTokenPersister?(token)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -65,6 +65,53 @@ public enum ProviderPaceDurationRule: Sendable {
     }
 }
 
+public enum ProviderPaceKind: Sendable {
+    case session
+    case weekly
+
+    public var defaultWindowMinutes: Int {
+        switch self {
+        case .session: 300
+        case .weekly: 10080
+        }
+    }
+}
+
+public enum ProviderPaceSlot: Sendable {
+    case primary
+    case secondary
+    case tertiary
+}
+
+public struct ProviderStandardPaceLane: Sendable {
+    public let kind: ProviderPaceKind
+    public let windowRule: ProviderPaceWindowRule
+
+    public init(kind: ProviderPaceKind, windowRule: ProviderPaceWindowRule) {
+        self.kind = kind
+        self.windowRule = windowRule
+    }
+
+    public static func session(maximumMinutes: Int, requiresDuration: Bool = false) -> Self {
+        Self(kind: .session, windowRule: .custom { window, _ in
+            guard let minutes = window.windowMinutes else { return !requiresDuration }
+            return minutes <= maximumMinutes
+        })
+    }
+
+    public static var weekly: Self {
+        Self(kind: .weekly, windowRule: .custom { _, _ in true })
+    }
+
+    public static var weeklyWithDuration: Self {
+        Self(kind: .weekly, windowRule: .windowDurationPresent)
+    }
+
+    public static func exact(kind: ProviderPaceKind, minutes: Int) -> Self {
+        Self(kind: kind, windowRule: .windowDuration(minutes: minutes))
+    }
+}
+
 public struct ProviderPaceCapability: Sendable {
     public static let monthlyWindowSentinelMinutes = 30 * 24 * 60
     public static let unsupported = ProviderPaceCapability()
@@ -74,13 +121,25 @@ public struct ProviderPaceCapability: Sendable {
 
     public let resetWindowPace: ProviderPaceWindowRule
     public let inferredMonthlyDuration: ProviderPaceDurationRule
+    public let primary: ProviderStandardPaceLane?
+    public let secondary: ProviderStandardPaceLane?
+    public let tertiary: ProviderStandardPaceLane?
+    public let showsHeadroomHint: Bool
 
     public init(
         resetWindowPace: ProviderPaceWindowRule = .unsupported,
-        inferredMonthlyDuration: ProviderPaceDurationRule = .unsupported)
+        inferredMonthlyDuration: ProviderPaceDurationRule = .unsupported,
+        primary: ProviderStandardPaceLane? = nil,
+        secondary: ProviderStandardPaceLane? = nil,
+        tertiary: ProviderStandardPaceLane? = nil,
+        showsHeadroomHint: Bool = false)
     {
         self.resetWindowPace = resetWindowPace
         self.inferredMonthlyDuration = inferredMonthlyDuration
+        self.primary = primary
+        self.secondary = secondary
+        self.tertiary = tertiary
+        self.showsHeadroomHint = showsHeadroomHint
     }
 
     public func supportsResetWindowPace(window: RateWindow, now: Date) -> Bool {
@@ -105,6 +164,19 @@ public struct ProviderPaceCapability: Sendable {
             isSyntheticPlaceholder: window.isSyntheticPlaceholder)
     }
 
+    public func resolvedKind(slot: ProviderPaceSlot, window: RateWindow, now: Date) -> ProviderPaceKind? {
+        if self.supportsResetWindowPace(window: window, now: now) {
+            return .weekly
+        }
+        let lane = switch slot {
+        case .primary: self.primary
+        case .secondary: self.secondary
+        case .tertiary: self.tertiary
+        }
+        guard let lane, lane.windowRule.matches(window: window, now: now) else { return nil }
+        return lane.kind
+    }
+
     private static func inferredMonthlyWindowMinutes(endingAt resetsAt: Date) -> Int? {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? calendar.timeZone
@@ -121,6 +193,7 @@ public struct ProviderDescriptor: Sendable {
     public let branding: ProviderBranding
     public let tokenCost: ProviderTokenCostConfig
     public let pace: ProviderPaceCapability
+    public let presentation: ProviderUsagePresentation
     public let settingsSection: ProviderSettingsSectionRegistration
     public let credentials: ProviderCredentialAdapter?
     public let fetchPlan: ProviderFetchPlan
@@ -135,6 +208,7 @@ public struct ProviderDescriptor: Sendable {
         branding: ProviderBranding,
         tokenCost: ProviderTokenCostConfig,
         pace: ProviderPaceCapability = .unsupported,
+        presentation: ProviderUsagePresentation = ProviderUsagePresentation(),
         fetchPlan: ProviderFetchPlan,
         cli: ProviderCLIConfig,
         configNormalizer: @escaping @Sendable (inout ProviderConfig) -> Void = { _ in })
@@ -145,6 +219,7 @@ public struct ProviderDescriptor: Sendable {
         self.branding = branding
         self.tokenCost = tokenCost
         self.pace = pace
+        self.presentation = presentation
         self.credentials = credentials
         self.fetchPlan = fetchPlan
         self.cli = cli

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -25,6 +25,17 @@ public struct ProviderTokenCostConfig: Sendable {
     }
 }
 
+public struct ProviderHistoryCapability: Sendable, Equatable {
+    public static let optIn = ProviderHistoryCapability(alwaysTracksPlanUtilization: false)
+    public static let alwaysTracked = ProviderHistoryCapability(alwaysTracksPlanUtilization: true)
+
+    public let alwaysTracksPlanUtilization: Bool
+
+    public init(alwaysTracksPlanUtilization: Bool) {
+        self.alwaysTracksPlanUtilization = alwaysTracksPlanUtilization
+    }
+}
+
 public enum ProviderPaceWindowRule: Sendable {
     case unsupported
     case resetDatePresent
@@ -193,6 +204,7 @@ public struct ProviderDescriptor: Sendable {
     public let branding: ProviderBranding
     public let tokenCost: ProviderTokenCostConfig
     public let pace: ProviderPaceCapability
+    public let history: ProviderHistoryCapability
     public let presentation: ProviderUsagePresentation
     public let settingsSection: ProviderSettingsSectionRegistration
     public let credentials: ProviderCredentialAdapter?
@@ -208,6 +220,7 @@ public struct ProviderDescriptor: Sendable {
         branding: ProviderBranding,
         tokenCost: ProviderTokenCostConfig,
         pace: ProviderPaceCapability = .unsupported,
+        history: ProviderHistoryCapability = .optIn,
         presentation: ProviderUsagePresentation = ProviderUsagePresentation(),
         fetchPlan: ProviderFetchPlan,
         cli: ProviderCLIConfig,
@@ -219,6 +232,7 @@ public struct ProviderDescriptor: Sendable {
         self.branding = branding
         self.tokenCost = tokenCost
         self.pace = pace
+        self.history = history
         self.presentation = presentation
         self.credentials = credentials
         self.fetchPlan = fetchPlan

--- a/Sources/CodexBarCore/Providers/ProviderUsagePresentation.swift
+++ b/Sources/CodexBarCore/Providers/ProviderUsagePresentation.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+public struct ProviderRateWindowLabels: Sendable, Equatable {
+    public let primary: String
+    public let secondary: String
+    public let tertiary: String
+    public let showsTertiary: Bool
+
+    public init(primary: String, secondary: String, tertiary: String, showsTertiary: Bool) {
+        self.primary = primary
+        self.secondary = secondary
+        self.tertiary = tertiary
+        self.showsTertiary = showsTertiary
+    }
+}
+
+public struct ProviderIdentityPresentation: Sendable, Equatable {
+    public struct Detail: Sendable, Equatable {
+        public let label: String
+        public let value: String
+
+        public init(label: String, value: String) {
+            self.label = label
+            self.value = value
+        }
+    }
+
+    public let badge: String?
+    public let plan: String?
+    public let details: [Detail]
+
+    public init(badge: String?, plan: String?, details: [Detail] = []) {
+        self.badge = badge
+        self.plan = plan
+        self.details = details
+    }
+}
+
+public struct ProviderCostPresentation: Sendable, Equatable {
+    public struct Balance: Sendable, Equatable {
+        public let label: String
+        public let amount: Double
+        public let currencyCode: String
+
+        public init(label: String, amount: Double, currencyCode: String) {
+            self.label = label
+            self.amount = amount
+            self.currencyCode = currencyCode
+        }
+    }
+
+    public let showsGenericFallback: Bool
+    public let balances: [Balance]
+
+    public init(showsGenericFallback: Bool = true, balances: [Balance] = []) {
+        self.showsGenericFallback = showsGenericFallback
+        self.balances = balances
+    }
+}
+
+public struct ProviderUsagePresentation: Sendable {
+    public typealias RateWindowLabeler = @Sendable (
+        _ metadata: ProviderMetadata,
+        _ snapshot: UsageSnapshot,
+        _ now: Date) -> ProviderRateWindowLabels
+    public typealias IdentityPresenter = @Sendable (
+        _ provider: UsageProvider,
+        _ snapshot: UsageSnapshot) -> ProviderIdentityPresentation
+    public typealias CostPresenter = @Sendable (_ snapshot: UsageSnapshot) -> ProviderCostPresentation
+    public typealias ExtraRateWindowSelector = @Sendable (_ snapshot: UsageSnapshot) -> [NamedRateWindow]
+    public typealias CreditResolver = @Sendable (_ credits: CreditsSnapshot) -> Double?
+
+    private let rateWindowLabeler: RateWindowLabeler?
+    private let identityPresenter: IdentityPresenter?
+    private let costPresenter: CostPresenter
+    private let extraRateWindowSelector: ExtraRateWindowSelector
+    private let creditResolver: CreditResolver?
+
+    public init(
+        rateWindowLabeler: RateWindowLabeler? = nil,
+        identityPresenter: IdentityPresenter? = nil,
+        costPresenter: @escaping CostPresenter = { _ in ProviderCostPresentation() },
+        extraRateWindowSelector: @escaping ExtraRateWindowSelector = { _ in [] },
+        creditResolver: CreditResolver? = nil)
+    {
+        self.rateWindowLabeler = rateWindowLabeler
+        self.identityPresenter = identityPresenter
+        self.costPresenter = costPresenter
+        self.extraRateWindowSelector = extraRateWindowSelector
+        self.creditResolver = creditResolver
+    }
+
+    public func rateWindowLabels(
+        metadata: ProviderMetadata,
+        snapshot: UsageSnapshot,
+        now: Date = .now) -> ProviderRateWindowLabels
+    {
+        self.rateWindowLabeler?(metadata, snapshot, now) ?? ProviderRateWindowLabels(
+            primary: metadata.sessionLabel,
+            secondary: metadata.weeklyLabel,
+            tertiary: metadata.opusLabel ?? "Sonnet",
+            showsTertiary: metadata.supportsOpus)
+    }
+
+    public func identity(provider: UsageProvider, snapshot: UsageSnapshot) -> ProviderIdentityPresentation {
+        if let identityPresenter {
+            return identityPresenter(provider, snapshot)
+        }
+        guard let plan = snapshot.loginMethod(for: provider), !plan.isEmpty else {
+            return ProviderIdentityPresentation(badge: nil, plan: nil)
+        }
+        let display = plan.capitalized
+        return ProviderIdentityPresentation(badge: display, plan: display)
+    }
+
+    public func cost(snapshot: UsageSnapshot) -> ProviderCostPresentation {
+        self.costPresenter(snapshot)
+    }
+
+    public func extraRateWindows(snapshot: UsageSnapshot) -> [NamedRateWindow] {
+        self.extraRateWindowSelector(snapshot)
+    }
+
+    public func creditRemaining(_ credits: CreditsSnapshot) -> Double? {
+        self.creditResolver?(credits)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift
@@ -62,7 +62,10 @@ public enum QoderProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "qoder",
                 aliases: [],
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { _, _, settings in
+                    settings?.qoder?.cookieSource == .manual
+                }))
     }
 
     private static func fetchPlan() -> ProviderFetchPlan {

--- a/Sources/CodexBarCore/Providers/QwenCloud/QwenCloudProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/QwenCloud/QwenCloudProviderDescriptor.swift
@@ -58,7 +58,17 @@ public enum QwenCloudProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "qwen-cloud",
                 aliases: ["qwencloud", "qwen", "qwen-token-plan"],
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { sourceMode, environment, settings in
+                    guard sourceMode == .auto || sourceMode == .web,
+                          settings?.qwenCloud?.cookieSource != .off else { return false }
+                    let hasEnvironmentCookie = environment.map {
+                        QwenCloudSettingsReader.cookieHeader(environment: $0) != nil
+                    } == true
+                    let hasManualCookie = settings?.qwenCloud?.cookieSource == .manual &&
+                        CookieHeaderNormalizer.normalize(settings?.qwenCloud?.manualCookieHeader) != nil
+                    return hasEnvironmentCookie || hasManualCookie
+                }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Sakana/SakanaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Sakana/SakanaProviderDescriptor.swift
@@ -57,7 +57,11 @@ public enum SakanaProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "sakana",
                 aliases: ["sakana-ai"],
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { sourceMode, environment, _ in
+                    guard sourceMode == .auto || sourceMode == .web else { return false }
+                    return environment.map { SakanaSettingsReader.cookieHeader(environment: $0) != nil } == true
+                }))
     }
 }
 

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunProviderDescriptor.swift
@@ -18,7 +18,21 @@ public enum StepFunProviderDescriptor {
             cookieName: nil),
         authDetector: { environment, _ in
             StepFunSettingsReader.token(environment: environment) == nil ? [] : ["api"]
-        })
+        },
+        manualTokenPersister: { try Self.persistManualToken($0) })
+
+    private static func persistManualToken(_ token: String) throws {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let store = CodexBarConfigStore()
+        var config = try store.load() ?? .makeDefault()
+        var providerConfig = config.providerConfig(for: UsageProvider.stepfun.instanceID)
+            ?? ProviderConfig(id: UsageProvider.stepfun.instanceID)
+        providerConfig.region = trimmed
+        config.setProviderConfig(providerConfig)
+        try store.save(config)
+    }
 
     static func makeDescriptor() -> ProviderDescriptor {
         ProviderDescriptor(

--- a/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
@@ -70,6 +70,13 @@ public enum Sub2APIProviderDescriptor {
         tokenCost: ProviderTokenCostConfig(
             supportsTokenCost: false,
             noDataMessage: { "sub2api spend is reported by its usage API." }),
+        presentation: ProviderUsagePresentation(rateWindowLabeler: { metadata, snapshot, _ in
+            ProviderRateWindowLabels(
+                primary: Self.primaryLabel(snapshot: snapshot) ?? metadata.sessionLabel,
+                secondary: metadata.weeklyLabel,
+                tertiary: metadata.opusLabel ?? "Sonnet",
+                showsTertiary: metadata.supportsOpus)
+        }),
         fetchPlan: Self.fetchPlan(),
         cli: ProviderCLIConfig(
             name: "sub2api",

--- a/Sources/CodexBarCore/Providers/XAI/XAIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/XAI/XAIProviderDescriptor.swift
@@ -40,6 +40,18 @@ public enum XAIProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "xAI spend history comes from the Management API billing endpoints." }),
+            presentation: ProviderUsagePresentation(
+                identityPresenter: { provider, snapshot in
+                    guard let plan = snapshot.loginMethod(for: provider), !plan.isEmpty else {
+                        return ProviderIdentityPresentation(badge: nil, plan: nil)
+                    }
+                    let display = UsageFormatter.cleanPlanName(plan)
+                    return ProviderIdentityPresentation(badge: display, plan: display)
+                },
+                costPresenter: { snapshot in
+                    let showsFallback = snapshot.providerCost?.period != "Prepaid credits"
+                    return ProviderCostPresentation(showsGenericFallback: showsFallback)
+                }),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "xai",

--- a/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
@@ -91,6 +91,9 @@ public enum ZaiProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "z.ai cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(extraRateWindowSelector: { snapshot in
+                (snapshot.extraRateWindows ?? []).filter { $0.id == "zai-mcp" }
+            }),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "zai",

--- a/Tests/CodexBarTests/CLIDiagnoseCommandTests.swift
+++ b/Tests/CodexBarTests/CLIDiagnoseCommandTests.swift
@@ -41,22 +41,30 @@ struct CLIDiagnoseCommandTests {
     func `diagnose auth mode uses settings-backed MiniMax manual cookie when env token is absent`() {
         let settings = self.makeSettingsWithMiniMaxCookie("Cookie: session_id=demo-cookie")
 
-        let authMode = CodexBarCLI._resolveMiniMaxAuthModeForTesting(
+        let summary = CodexBarCLI._diagnosticAuthSummaryForTesting(
+            provider: .minimax,
+            account: nil,
+            config: nil,
             environment: [:],
             settings: settings)
 
-        #expect(authMode == .cookie)
+        #expect(summary.configured)
+        #expect(summary.modes == ["cookie"])
     }
 
     @Test
     func `diagnose auth mode keeps apiToken precedence over settings cookie`() {
         let settings = self.makeSettingsWithMiniMaxCookie("Cookie: session_id=demo-cookie")
 
-        let authMode = CodexBarCLI._resolveMiniMaxAuthModeForTesting(
+        let summary = CodexBarCLI._diagnosticAuthSummaryForTesting(
+            provider: .minimax,
+            account: nil,
+            config: nil,
             environment: [MiniMaxAPISettingsReader.apiTokenKey: "sk-api-demo-token"],
             settings: settings)
 
-        #expect(authMode == .apiToken)
+        #expect(summary.configured)
+        #expect(summary.modes == ["apiToken"])
     }
 
     @Test

--- a/Tests/CodexBarTests/CLIUnificationGoldenTests.swift
+++ b/Tests/CodexBarTests/CLIUnificationGoldenTests.swift
@@ -1,0 +1,541 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBarCLI
+
+struct CLIUnificationGoldenTests {
+    private static let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test
+    func `affected provider text output golden`() {
+        let output = Self.textFixtures.map { fixture in
+            CLIRenderer.renderText(
+                provider: fixture.provider,
+                snapshot: fixture.snapshot,
+                credits: nil,
+                context: RenderContext(
+                    header: fixture.provider.rawValue,
+                    status: nil,
+                    useColor: false,
+                    resetStyle: .countdown),
+                now: Self.now)
+        }.joined(separator: "\n---\n")
+
+        let expected = """
+        == factory ==
+        5-hour: 90% left [==========--]
+        Weekly: 80% left [=========---]
+        Monthly: 70% left [========----]
+        ---
+        == grok ==
+        Credits: 89% left [==========--]
+        ---
+        == crof ==
+        Credits: 88% left [==========--]
+        ---
+        == sub2api ==
+        Daily quota: 87% left [==========--]
+        Weekly quota: 86% left [==========--]
+        ---
+        == amp ==
+        Other usage: 85% left [==========--]
+        Orb usage: 84% left [==========--]
+        ---
+        == kilo ==
+        Credits: 83% left [=========---]
+        Renews after top-up
+        Plan: Kilo Pass
+        Activity: Auto top-up: enabled
+        ---
+        == qoder ==
+        Credits: 82% left [=========---]
+        500 weighted tokens
+        ---
+        == clawrouter ==
+        ---
+        == devin ==
+        Extra usage: $25.00
+        ---
+        == claude ==
+        Extra usage balance: $40.00
+        ---
+        == xai ==
+        ---
+        == codex ==
+        Session: 95% left [===========-]
+        Pace: 15% in reserve | Expected 20% used | Lasts until reset
+        Resets in 4h
+        Weekly: 75% left [=========---]
+        Pace: 4% in reserve | Expected 29% used | Lasts until reset
+        Resets in 5d
+        ---
+        == claude ==
+        Session: 60% left [=======-----]
+        Pace: 20% in deficit | Expected 20% used | Projected empty in 1h 30m
+        Resets in 4h
+        Weekly: 50% left [======------]
+        Pace: 21% in deficit | Expected 29% used | Runs out in 2d
+        Resets in 5d
+        ---
+        == opencode ==
+        Weekly: 70% left [========----]
+        Pace: On pace | Expected 29% used | Runs out in 4d 16h
+        Resets in 5d
+        ---
+        == ollama ==
+        Session: 90% left [==========--]
+        Resets in 4h
+        Weekly: 80% left [=========---]
+        Pace: 9% in reserve | Expected 29% used | Lasts until reset
+        Resets in 5d
+        ---
+        == kimi ==
+        Weekly: 70% left [========----]
+        Pace: 13% in reserve | Expected 43% used | Lasts until reset
+        Resets in 4d
+        Rate Limit: 90% left [==========--]
+        Pace: 10% in reserve | Expected 20% used | Lasts until reset
+        Resets in 4h
+        ---
+        == notion ==
+        Rolling: 80% left [=========---]
+        Pace: 3% in deficit | Expected 17% used | Projected empty in 4h
+        Resets in 5h
+        """
+        #expect(output == expected)
+    }
+
+    @Test
+    func `affected provider cards output golden`() {
+        let output = Self.cardFixtures.map { fixture in
+            let card = CLICardsRenderer.makeCard(CLICardBuildInput(
+                provider: fixture.provider,
+                snapshot: fixture.snapshot,
+                credits: nil,
+                source: "fixture",
+                status: nil,
+                notes: [],
+                useColor: false,
+                resetStyle: .countdown,
+                weeklyWorkDays: nil,
+                now: Self.now))
+            return CLICardsRenderer.render(
+                cards: [card],
+                failures: [],
+                terminalWidth: 42,
+                useColor: false)
+        }.joined(separator: "\n---\n")
+
+        let expected = """
+        ╭────────────────────────────────────────╮
+        │ Droid [fixture]                        │
+        │ ────────────────────────────────────── │
+        │ 5-hour                        90% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━     ] │
+        │                                        │
+        │ Weekly                        80% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━        ] │
+        │                                        │
+        │ Monthly                       70% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━            ] │
+        ╰────────────────────────────────────────╯
+        ---
+        ╭────────────────────────────────────────╮
+        │ Grok [fixture]                         │
+        │ ────────────────────────────────────── │
+        │ Credits                       89% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━     ] │
+        ╰────────────────────────────────────────╯
+        ---
+        ╭────────────────────────────────────────╮
+        │ Crof [fixture]                         │
+        │ ────────────────────────────────────── │
+        │ Credits                       88% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━      ] │
+        ╰────────────────────────────────────────╯
+        ---
+        ╭────────────────────────────────────────╮
+        │ sub2api [fixture]                      │
+        │ ────────────────────────────────────── │
+        │ Daily quota                   87% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━      ] │
+        │                                        │
+        │ Weekly quota                  86% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━      ] │
+        ╰────────────────────────────────────────╯
+        ---
+        ╭────────────────────────────────────────╮
+        │ Amp [fixture]                          │
+        │ ────────────────────────────────────── │
+        │ Other usage                   85% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━       ] │
+        │                                        │
+        │ Orb usage                     84% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━       ] │
+        ╰────────────────────────────────────────╯
+        ---
+        ╭────────────────────────────────────────╮
+        │ Kilo [fixture]          PLAN Kilo Pass │
+        │ ────────────────────────────────────── │
+        │ Credits                       83% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━       ] │
+        │ Renews after top-up                    │
+        │ Activity:         Auto top-up: enabled │
+        ╰────────────────────────────────────────╯
+        ---
+        ╭────────────────────────────────────────╮
+        │ Qoder [fixture]                        │
+        │ ────────────────────────────────────── │
+        │ Credits                       82% left │
+        │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━        ] │
+        │ 500 weighted tokens                    │
+        ╰────────────────────────────────────────╯
+        """
+        #expect(output == expected)
+    }
+
+    @Test
+    func `affected provider JSON output golden`() throws {
+        let payloads = Self.paceFixtures.map { fixture in
+            ProviderPayload(
+                provider: fixture.provider,
+                account: nil,
+                version: nil,
+                source: "fixture",
+                status: nil,
+                usage: fixture.snapshot,
+                credits: nil,
+                antigravityPlanInfo: nil,
+                openaiDashboard: nil,
+                error: nil,
+                pace: CLIRenderer.providerPacePayload(
+                    provider: fixture.provider,
+                    snapshot: fixture.snapshot,
+                    now: Self.now))
+        }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(payloads)
+        let output = try #require(String(data: data, encoding: .utf8))
+
+        let expected = """
+        [
+          {
+            "pace" : {
+              "primary" : {
+                "deltaPercent" : -15,
+                "expectedUsedPercent" : 20,
+                "stage" : "farBehind",
+                "summary" : "15% in reserve | Expected 20% used | Lasts until reset",
+                "willLastToReset" : true
+              },
+              "secondary" : {
+                "deltaPercent" : -4,
+                "expectedUsedPercent" : 29,
+                "stage" : "slightlyBehind",
+                "summary" : "4% in reserve | Expected 29% used | Lasts until reset",
+                "willLastToReset" : true
+              }
+            },
+            "provider" : "codex",
+            "source" : "fixture",
+            "usage" : {
+              "primary" : {
+                "resetsAt" : 1700014400,
+                "usedPercent" : 5,
+                "windowMinutes" : 300
+              },
+              "secondary" : {
+                "resetsAt" : 1700432000,
+                "usedPercent" : 25,
+                "windowMinutes" : 10080
+              },
+              "tertiary" : null,
+              "updatedAt" : 1700000000
+            }
+          },
+          {
+            "pace" : {
+              "primary" : {
+                "deltaPercent" : 20,
+                "etaSeconds" : 5400,
+                "expectedUsedPercent" : 20,
+                "stage" : "farAhead",
+                "summary" : "20% in deficit | Expected 20% used | Projected empty in 1h 30m",
+                "willLastToReset" : false
+              },
+              "secondary" : {
+                "deltaPercent" : 21,
+                "etaSeconds" : 172800,
+                "expectedUsedPercent" : 29,
+                "stage" : "farAhead",
+                "summary" : "21% in deficit | Expected 29% used | Runs out in 2d",
+                "willLastToReset" : false
+              }
+            },
+            "provider" : "claude",
+            "source" : "fixture",
+            "usage" : {
+              "primary" : {
+                "resetsAt" : 1700014400,
+                "usedPercent" : 40,
+                "windowMinutes" : 300
+              },
+              "secondary" : {
+                "resetsAt" : 1700432000,
+                "usedPercent" : 50,
+                "windowMinutes" : 10080
+              },
+              "tertiary" : null,
+              "updatedAt" : 1700000000
+            }
+          },
+          {
+            "pace" : {
+              "secondary" : {
+                "deltaPercent" : 1,
+                "etaSeconds" : 403200,
+                "expectedUsedPercent" : 29,
+                "stage" : "onTrack",
+                "summary" : "On pace | Expected 29% used | Runs out in 4d 16h",
+                "willLastToReset" : false
+              }
+            },
+            "provider" : "opencode",
+            "source" : "fixture",
+            "usage" : {
+              "primary" : null,
+              "secondary" : {
+                "resetsAt" : 1700432000,
+                "usedPercent" : 30,
+                "windowMinutes" : 10080
+              },
+              "tertiary" : null,
+              "updatedAt" : 1700000000
+            }
+          },
+          {
+            "pace" : {
+              "secondary" : {
+                "deltaPercent" : -9,
+                "expectedUsedPercent" : 29,
+                "stage" : "behind",
+                "summary" : "9% in reserve | Expected 29% used | Lasts until reset",
+                "willLastToReset" : true
+              }
+            },
+            "provider" : "ollama",
+            "source" : "fixture",
+            "usage" : {
+              "primary" : {
+                "resetsAt" : 1700014400,
+                "usedPercent" : 10
+              },
+              "secondary" : {
+                "resetsAt" : 1700432000,
+                "usedPercent" : 20,
+                "windowMinutes" : 10080
+              },
+              "tertiary" : null,
+              "updatedAt" : 1700000000
+            }
+          },
+          {
+            "pace" : {
+              "primary" : {
+                "deltaPercent" : -13,
+                "expectedUsedPercent" : 43,
+                "stage" : "farBehind",
+                "summary" : "13% in reserve | Expected 43% used | Lasts until reset",
+                "willLastToReset" : true
+              },
+              "secondary" : {
+                "deltaPercent" : -10,
+                "expectedUsedPercent" : 20,
+                "stage" : "behind",
+                "summary" : "10% in reserve | Expected 20% used | Lasts until reset",
+                "willLastToReset" : true
+              }
+            },
+            "provider" : "kimi",
+            "source" : "fixture",
+            "usage" : {
+              "primary" : {
+                "resetsAt" : 1700345600,
+                "usedPercent" : 30,
+                "windowMinutes" : 10080
+              },
+              "secondary" : {
+                "resetsAt" : 1700014400,
+                "usedPercent" : 10,
+                "windowMinutes" : 300
+              },
+              "tertiary" : null,
+              "updatedAt" : 1700000000
+            }
+          },
+          {
+            "pace" : {
+              "primary" : {
+                "deltaPercent" : 3,
+                "etaSeconds" : 14400,
+                "expectedUsedPercent" : 17,
+                "stage" : "slightlyAhead",
+                "summary" : "3% in deficit | Expected 17% used | Projected empty in 4h",
+                "willLastToReset" : false
+              }
+            },
+            "provider" : "notion",
+            "source" : "fixture",
+            "usage" : {
+              "primary" : {
+                "resetsAt" : 1700018000,
+                "usedPercent" : 20,
+                "windowMinutes" : 360
+              },
+              "secondary" : null,
+              "tertiary" : null,
+              "updatedAt" : 1700000000
+            }
+          }
+        ]
+        """
+        #expect(output == expected)
+    }
+
+    private struct Fixture {
+        let provider: UsageProvider
+        let snapshot: UsageSnapshot
+    }
+
+    private static var textFixtures: [Fixture] {
+        [
+            Fixture(provider: .factory, snapshot: snapshot(
+                primary: window(used: 10, minutes: 300),
+                secondary: window(used: 20, minutes: 10080),
+                tertiary: window(used: 30, minutes: 43200))),
+            Fixture(provider: .grok, snapshot: snapshot(
+                primary: window(used: 11, minutes: 120))),
+            Fixture(provider: .crof, snapshot: snapshot(
+                primary: window(used: 12, minutes: nil))),
+            Fixture(provider: .sub2api, snapshot: snapshot(
+                primary: window(used: 13, minutes: 1440),
+                secondary: window(used: 14, minutes: 10080))),
+            Fixture(provider: .amp, snapshot: snapshot(
+                primary: window(used: 15, minutes: 43200),
+                secondary: window(used: 16, minutes: 43200))),
+            Fixture(provider: .kilo, snapshot: snapshot(
+                primary: RateWindow(
+                    usedPercent: 17,
+                    windowMinutes: nil,
+                    resetsAt: nil,
+                    resetDescription: "Renews after top-up"),
+                loginMethod: "Kilo Pass · Auto top-up: enabled")),
+            Fixture(provider: .qoder, snapshot: snapshot(
+                primary: RateWindow(
+                    usedPercent: 18,
+                    windowMinutes: nil,
+                    resetsAt: nil,
+                    resetDescription: "500 weighted tokens"))),
+            Fixture(provider: .clawrouter, snapshot: costSnapshot(
+                used: 1,
+                limit: 10,
+                period: "Monthly")),
+            Fixture(provider: .devin, snapshot: costSnapshot(
+                used: 25,
+                limit: 0,
+                period: "Extra usage balance")),
+            Fixture(provider: .claude, snapshot: costSnapshot(
+                used: 0,
+                limit: 0,
+                period: "Extra usage",
+                balance: 40)),
+            Fixture(provider: .xai, snapshot: costSnapshot(
+                used: 30,
+                limit: 0,
+                period: "Prepaid credits")),
+        ] + paceFixtures
+    }
+
+    private static var cardFixtures: [Fixture] {
+        Array(textFixtures.prefix(7))
+    }
+
+    private static var paceFixtures: [Fixture] {
+        [
+            Fixture(provider: .codex, snapshot: snapshot(
+                primary: window(used: 5, minutes: 300, resetAfter: 4 * 60 * 60),
+                secondary: window(used: 25, minutes: 10080, resetAfter: 5 * 24 * 60 * 60))),
+            Fixture(provider: .claude, snapshot: snapshot(
+                primary: window(used: 40, minutes: 300, resetAfter: 4 * 60 * 60),
+                secondary: window(used: 50, minutes: 10080, resetAfter: 5 * 24 * 60 * 60))),
+            Fixture(provider: .opencode, snapshot: snapshot(
+                secondary: window(used: 30, minutes: 10080, resetAfter: 5 * 24 * 60 * 60))),
+            Fixture(provider: .ollama, snapshot: snapshot(
+                primary: window(used: 10, minutes: nil, resetAfter: 4 * 60 * 60),
+                secondary: window(used: 20, minutes: 10080, resetAfter: 5 * 24 * 60 * 60))),
+            Fixture(provider: .kimi, snapshot: snapshot(
+                primary: window(
+                    used: 30,
+                    minutes: KimiProviderDescriptor.weeklyWindowMinutes,
+                    resetAfter: 4 * 24 * 60 * 60),
+                secondary: window(
+                    used: 10,
+                    minutes: KimiProviderDescriptor.sessionWindowMinutes,
+                    resetAfter: 4 * 60 * 60))),
+            Fixture(provider: .notion, snapshot: snapshot(
+                primary: window(
+                    used: 20,
+                    minutes: NotionProviderDescriptor.rollingWindowMaxMinutes,
+                    resetAfter: 5 * 60 * 60))),
+        ]
+    }
+
+    private static func window(used: Double, minutes: Int?, resetAfter: TimeInterval? = nil) -> RateWindow {
+        RateWindow(
+            usedPercent: used,
+            windowMinutes: minutes,
+            resetsAt: resetAfter.map { Self.now.addingTimeInterval($0) },
+            resetDescription: nil)
+    }
+
+    private static func snapshot(
+        primary: RateWindow? = nil,
+        secondary: RateWindow? = nil,
+        tertiary: RateWindow? = nil,
+        loginMethod: String? = nil) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: primary,
+            secondary: secondary,
+            tertiary: tertiary,
+            updatedAt: self.now,
+            identity: loginMethod.map {
+                ProviderIdentitySnapshot(
+                    providerID: .kilo,
+                    accountEmail: nil,
+                    accountOrganization: nil,
+                    loginMethod: $0)
+            })
+    }
+
+    private static func costSnapshot(
+        used: Double,
+        limit: Double,
+        period: String,
+        balance: Double? = nil) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: used,
+                limit: limit,
+                currencyCode: "USD",
+                period: period,
+                balance: balance,
+                updatedAt: self.now),
+            updatedAt: self.now)
+    }
+}

--- a/Tests/CodexBarTests/CLIUnificationGoldenTests.swift
+++ b/Tests/CodexBarTests/CLIUnificationGoldenTests.swift
@@ -194,6 +194,7 @@ struct CLIUnificationGoldenTests {
         #expect(output == expected)
     }
 
+    // swiftlint:disable:next function_body_length
     @Test
     func `affected provider JSON output golden`() throws {
         let payloads = Self.paceFixtures.map { fixture in

--- a/Tests/CodexBarTests/CLIUnificationGoldenTests.swift
+++ b/Tests/CodexBarTests/CLIUnificationGoldenTests.swift
@@ -194,7 +194,7 @@ struct CLIUnificationGoldenTests {
         #expect(output == expected)
     }
 
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable function_body_length
     @Test
     func `affected provider JSON output golden`() throws {
         let payloads = Self.paceFixtures.map { fixture in
@@ -404,6 +404,8 @@ struct CLIUnificationGoldenTests {
         """
         #expect(output == expected)
     }
+
+    // swiftlint:enable function_body_length
 
     private struct Fixture {
         let provider: UsageProvider

--- a/Tests/CodexBarTests/ProviderHistoryCapabilityTests.swift
+++ b/Tests/CodexBarTests/ProviderHistoryCapabilityTests.swift
@@ -1,0 +1,13 @@
+import CodexBarCore
+import Testing
+
+struct ProviderHistoryCapabilityTests {
+    @Test
+    func `always tracked plan utilization providers are descriptor owned`() {
+        let alwaysTracked = Set(ProviderDescriptorRegistry.all.compactMap { descriptor in
+            descriptor.history.alwaysTracksPlanUtilization ? descriptor.id : nil
+        })
+
+        #expect(alwaysTracked == [.codex, .claude, .antigravity, .opencodego])
+    }
+}


### PR DESCRIPTION
## Summary

Unify CLI rendering, source availability, credential resolution, and history policy onto descriptor-owned provider capabilities. This removes duplicated provider policy from `CodexBarCLI` while keeping the intentionally provider-specific boundaries explicit.

## Diff shape

| Target | Added | Deleted | Net |
| --- | ---: | ---: | ---: |
| `CodexBar` | 14 | 19 | -5 |
| `CodexBarCLI` | 129 | 494 | -365 |
| `CodexBarCore` | 533 | 22 | +511 |
| `CodexBarTests` | 569 | 4 | +565 |

The provider-mention audit moved from **93 → 23 raw mentions** and **92 → 0 unjustified mentions**. The 23 remaining mentions are the 22 justified references at explicit provider-owned boundaries plus the existing Kilo help URL.

Those justified boundaries are:

- Codex reset-credit rendering
- managed Codex profile boundaries
- the plan-projection switch

## Characterization-first proof

Commit `cb0b36ec2` lands before the refactor and freezes 30 golden outputs: 17 text cases, 7 card cases, and 6 JSON/pace cases. The descriptor-ownership refactor follows those characterization tests, preserving the existing CLI contract while moving policy to its proper owner.

Local landing gates on exact head `75989453d`:

- `make test`: 820/820 selections green in 69/69 groups, with zero retries or failures
- `make check`: all portable checks, SwiftFormat, and strict SwiftLint green; 0 violations
- autoreview: clean, no accepted/actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
