### PR TITLE
refactor: move usage presentation policy into provider descriptors

### DIFF
--- a/Sources/CodexBar/IconRemainingResolver.swift
+++ b/Sources/CodexBar/IconRemainingResolver.swift
@@ -3,67 +3,6 @@ import Foundation
 
 enum IconRemainingResolver {
     private static let visibleZeroPercent = 0.0001
-    private static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
-    // Antigravity quota summaries expose exact 5-hour session and weekly buckets for the compact icon.
-    private static let sessionWindowMinutes = 5 * 60
-    private static let weeklyWindowMinutes = 7 * 24 * 60
-
-    private static func codexProjection(snapshot: UsageSnapshot, now: Date) -> CodexConsumerProjection {
-        CodexConsumerProjection.make(
-            surface: .menuBar,
-            context: CodexConsumerProjection.Context(
-                snapshot: snapshot,
-                rawUsageError: nil,
-                liveCredits: nil,
-                rawCreditsError: nil,
-                liveDashboard: nil,
-                rawDashboardError: nil,
-                dashboardAttachmentAuthorized: false,
-                dashboardRequiresLogin: false,
-                now: now))
-    }
-
-    private static func codexVisibleWindows(snapshot: UsageSnapshot, now: Date) -> [RateWindow] {
-        let projection = self.codexProjection(snapshot: snapshot, now: now)
-        return projection.visibleRateLanes.compactMap { projection.menuBarSelectableRateWindow(for: $0) }
-    }
-
-    private static func antigravityQuotaSummaryWindows(
-        snapshot: UsageSnapshot)
-        -> (primary: RateWindow?, secondary: RateWindow?)?
-    {
-        let quotaSummaryWindows = snapshot.extraRateWindows?
-            .filter {
-                $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix)
-            } ?? []
-        guard !quotaSummaryWindows.isEmpty else { return nil }
-
-        return self.antigravityQuotaSummaryPair(in: quotaSummaryWindows.filter(\.usageKnown))
-    }
-
-    private static func antigravityQuotaSummaryPair(
-        in windows: [NamedRateWindow])
-        -> (primary: RateWindow?, secondary: RateWindow?)?
-    {
-        let session = self.mostConstrainedWindow(in: windows, windowMinutes: Self.sessionWindowMinutes)
-        let weekly = self.mostConstrainedWindow(in: windows, windowMinutes: Self.weeklyWindowMinutes)
-        guard session != nil || weekly != nil else { return nil }
-        return (primary: session, secondary: weekly)
-    }
-
-    /// Returns the highest-usage window for an exact Antigravity compact-icon cadence.
-    private static func mostConstrainedWindow(in windows: [NamedRateWindow], windowMinutes: Int) -> RateWindow? {
-        windows
-            .filter { $0.window.windowMinutes == windowMinutes }
-            .max { lhs, rhs in
-                if lhs.window.usedPercent != rhs.window.usedPercent {
-                    return lhs.window.usedPercent < rhs.window.usedPercent
-                }
-                // max(by:) keeps the right-hand element when this returns true; use `>` so the smallest id wins ties.
-                return lhs.id > rhs.id
-            }?
-            .window
-    }
 
     static func resolvedWindows(
         snapshot: UsageSnapshot,
@@ -72,34 +11,15 @@ enum IconRemainingResolver {
         now: Date = Date())
         -> (primary: RateWindow?, secondary: RateWindow?)
     {
-        if style == .perplexity {
-            let windows = snapshot.orderedPerplexityDisplayWindows()
-            return (
-                primary: windows.first,
-                secondary: windows.dropFirst().first)
+        guard let provider = UsageProvider(rawValue: style.rawValue) else {
+            return (primary: snapshot.primary, secondary: snapshot.secondary)
         }
-        if style == .antigravity {
-            // Only current quota-summary buckets define the fixed session/weekly icon lanes.
-            return self.antigravityQuotaSummaryWindows(snapshot: snapshot)
-                ?? (primary: nil, secondary: nil)
-        }
-        if style == .codex {
-            let windows = self.codexVisibleWindows(snapshot: snapshot, now: now)
-            return (
-                primary: windows.first,
-                secondary: windows.dropFirst().first)
-        }
-        if style == .copilot,
-           let secondaryOverrideWindowID,
-           let extraWindow = snapshot.extraRateWindows?.first(where: { $0.id == secondaryOverrideWindowID })?.window
-        {
-            return (
-                primary: snapshot.primary,
-                secondary: extraWindow)
-        }
-        return (
-            primary: snapshot.primary,
-            secondary: snapshot.secondary)
+        let windows = ProviderDescriptorRegistry.descriptor(for: provider).presentation.iconWindows(
+            context: ProviderIconWindowContext(
+                snapshot: snapshot,
+                secondaryOverrideWindowID: secondaryOverrideWindowID,
+                now: now))
+        return (primary: windows.primary, secondary: windows.secondary)
     }
 
     static func resolvedRemaining(
@@ -138,7 +58,13 @@ enum IconRemainingResolver {
             secondary: showUsed ? windows.secondary?.usedPercent : windows.secondary?.remainingPercent)
         // Provider style chooses the usage lanes; rendering style controls renderer-specific layout sentinels.
         // Merged icons still resolve Warp's lanes, but render as `.combined` and must keep the real percentage.
-        if showUsed, style == .warp, (renderingStyle ?? style) == .warp, let secondary = windows.secondary {
+        let presentation = UsageProvider(rawValue: style.rawValue)
+            .map { ProviderDescriptorRegistry.descriptor(for: $0).presentation }
+        if showUsed,
+           presentation?.treatsExhaustedSecondaryIconWindowAsMissing == true,
+           (renderingStyle ?? style) == style,
+           let secondary = windows.secondary
+        {
             if secondary.remainingPercent <= 0 {
                 // Preserve Warp's exhausted/no-bonus layout even though used percent is 100.
                 percents.secondary = 0

--- a/Sources/CodexBar/IconRenderer.swift
+++ b/Sources/CodexBar/IconRenderer.swift
@@ -636,8 +636,12 @@ enum IconRenderer {
                     }
                 }
 
+                let providerPresentation = UsageProvider(rawValue: style.rawValue)
+                    .map { ProviderDescriptorRegistry.descriptor(for: $0).presentation }
+                let usesMissingSecondaryLayout =
+                    providerPresentation?.treatsExhaustedSecondaryIconWindowAsMissing == true
                 let effectiveWeeklyRemaining: Double? = {
-                    if style == .warp, let weeklyRemaining, weeklyRemaining <= 0 {
+                    if usesMissingSecondaryLayout, let weeklyRemaining, weeklyRemaining <= 0 {
                         return nil
                     }
                     return weeklyRemaining
@@ -655,15 +659,16 @@ enum IconRenderer {
                 let creditsBottomRectPx = RectPx(x: barXPx, y: 4, w: barWidthPx, h: 6)
 
                 // Warp special case: when no bonus or bonus exhausted, show "top monthly, bottom dimmed"
-                let warpNoBonus = style == .warp && !weeklyAvailable
+                let missingSecondary = usesMissingSecondaryLayout && !weeklyAvailable
 
                 // "Hide critters" renders plain meter bars: suppress all face/decoration twists.
-                let twistFace = !hideCritters && style == .codex
-                let twistNotches = !hideCritters && style == .claude
-                let twistGemini = !hideCritters && (style == .gemini || style == .antigravity)
-                let twistAntigravity = !hideCritters && style == .antigravity
-                let twistFactory = !hideCritters && style == .factory
-                let twistWarp = !hideCritters && style == .warp
+                let decorations = hideCritters ? ProviderIconDecorations() : providerPresentation?.iconDecorations ?? []
+                let twistFace = decorations.contains(.face)
+                let twistNotches = decorations.contains(.notches)
+                let twistGemini = decorations.contains(.gemini)
+                let twistAntigravity = decorations.contains(.antigravity)
+                let twistFactory = decorations.contains(.factory)
+                let twistWarp = decorations.contains(.warp)
 
                 if weeklyAvailable {
                     // Normal: top=primary, bottom=secondary (bonus/weekly).
@@ -678,8 +683,8 @@ enum IconRenderer {
                         addWarpTwist: twistWarp,
                         blink: blink)
                     drawBar(rectPx: bottomRectPx, remaining: bottomValue)
-                } else if !hasWeekly || warpNoBonus {
-                    if style == .warp {
+                } else if !hasWeekly || missingSecondary {
+                    if usesMissingSecondaryLayout {
                         // Warp: no bonus or bonus exhausted -> top=monthly credits, bottom=dimmed track
                         drawBar(
                             rectPx: topRectPx,

--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -37,46 +37,20 @@ struct InlineUsageDashboardModel: Equatable {
 
 extension UsageMenuCardView.Model {
     static func apiProviderUsageNotes(input: Input) -> [String]? {
-        if input.provider == .openai,
-           let usage = input.snapshot?.openAIAPIUsage
+        let menuCard = ProviderDescriptorRegistry.descriptor(for: input.provider).presentation.menuCard
+        switch menuCard.usageNotes(context: ProviderUsageNotesContext(
+            snapshot: input.snapshot,
+            isRefreshing: input.isRefreshing,
+            tokenCostInlineDashboardEnabled: input.tokenCostInlineDashboardEnabled,
+            showOptionalUsage: input.showOptionalCreditsAndExtraUsage))
         {
+        case let .openAIAPI(usage):
             return self.openAIAPIUsageNotes(usage)
-        }
-
-        if input.provider == .deepseek {
-            if input.isRefreshing {
-                return []
-            }
-            if input.snapshot?.primary == nil {
-                if input.snapshot?.deepseekDetailedUsageState == .webSessionRequired {
-                    return [L("Sign in to DeepSeek Platform in Chrome for detailed usage.")]
-                }
-                if input.snapshot?.deepseekDetailedUsageState == .profileSelectionRequired {
-                    return [L("Select a DeepSeek Chrome profile in Settings.")]
-                }
-            }
-            guard input.tokenCostInlineDashboardEnabled,
-                  input.showOptionalCreditsAndExtraUsage
-            else { return nil }
-            guard input.snapshot?.details.isEmpty == false else {
-                if input.snapshot?.deepseekDetailedUsageState == .webSessionRequired {
-                    return [L("Sign in to DeepSeek Platform in Chrome for detailed usage.")]
-                }
-                if input.snapshot?.deepseekDetailedUsageState == .profileSelectionRequired {
-                    return [L("Select a DeepSeek Chrome profile in Settings.")]
-                }
-                return [L("Detailed usage unavailable.")]
-            }
+        case let .localized(keys):
+            return keys.map { L($0) }
+        case .unhandled:
             return nil
         }
-
-        if input.provider == .ollama,
-           input.snapshot?.identity?.loginMethod == "API key"
-        {
-            return [L("API key verified. Cloud quotas need browser cookies. Sign in to Ollama.")]
-        }
-
-        return nil
     }
 
     static func openAIAPIUsageNotes(_ usage: OpenAIAPIUsageSnapshot) -> [String] {
@@ -118,7 +92,8 @@ extension UsageMenuCardView.Model {
     }
 
     private static func resolveInlineUsageDashboard(input: Input) -> InlineUsageDashboardModel? {
-        if self.usesProviderCostHistoryAsPrimaryDashboard(input.provider),
+        let menuCard = ProviderDescriptorRegistry.descriptor(for: input.provider).presentation.menuCard
+        if menuCard.usesProviderCostHistoryAsPrimaryDashboard,
            let tokenSnapshot = primaryCostHistorySnapshot(input: input),
            !tokenSnapshot.daily.isEmpty
         {
@@ -128,7 +103,7 @@ extension UsageMenuCardView.Model {
                 comparisonPeriodsEnabled: input.costComparisonPeriodsEnabled,
                 preferredCurrencyCode: input.preferredCurrencyCode)
         }
-        if [.codex, .claude, .vertexai, .bedrock, .cursor, .opencodego].contains(input.provider),
+        if menuCard.supportsInlineTokenCostDashboard,
            input.tokenCostInlineDashboardEnabled,
            let tokenSnapshot = input.tokenSnapshot,
            !tokenSnapshot.daily.isEmpty || tokenSnapshot.meteredCostUSD != nil
@@ -143,24 +118,14 @@ extension UsageMenuCardView.Model {
     }
 
     static func usesProviderCostHistoryAsPrimaryDashboard(_ provider: UsageProvider) -> Bool {
-        provider == .openai || provider == .mistral
+        ProviderDescriptorRegistry.descriptor(for: provider).presentation.menuCard
+            .usesProviderCostHistoryAsPrimaryDashboard
     }
 
     static func primaryCostHistorySnapshot(input: Input) -> CostUsageTokenSnapshot? {
-        switch input.provider {
-        case .openai:
-            if let projected = input.snapshot?.openAIAPIUsage?.toCostUsageTokenSnapshot() {
-                return projected
-            }
-            return input.snapshot == nil ? input.tokenSnapshot : nil
-        case .mistral:
-            if let projected = input.snapshot?.mistralUsage?.toCostUsageTokenSnapshot() {
-                return projected
-            }
-            return input.snapshot == nil ? input.tokenSnapshot : nil
-        default:
-            return input.tokenSnapshot
-        }
+        ProviderDescriptorRegistry.descriptor(for: input.provider).presentation.menuCard.primaryCostHistory(
+            snapshot: input.snapshot,
+            tokenSnapshot: input.tokenSnapshot)
     }
 
     private static func costHistoryInlineDashboard(

--- a/Sources/CodexBar/MenuBarLayout.swift
+++ b/Sources/CodexBar/MenuBarLayout.swift
@@ -33,23 +33,9 @@ enum MenuBarLayoutSemanticWindowResolver {
         -> (session: RateWindow?, weekly: RateWindow?)
     {
         guard let snapshot else { return (nil, nil) }
-        let candidates = [
-            snapshot.primary,
-            snapshot.secondary,
-            snapshot.tertiary,
-        ] + (snapshot.extraRateWindows ?? []).map(\.window)
-        let usable = candidates.compactMap { window -> RateWindow? in
-            guard let window, !window.isSyntheticPlaceholder else { return nil }
-            return window
-        }
-        let session = usable.first { window in
-            guard let minutes = window.windowMinutes else { return false }
-            return (60...(12 * 60)).contains(minutes)
-        }
-        let cadenceWeekly = usable.first { $0.windowMinutes == 7 * 24 * 60 }
-        let kimiWeekly = snapshot.primary.flatMap { $0.isSyntheticPlaceholder ? nil : $0 }
-        let weekly = provider == .kimi ? kimiWeekly ?? cadenceWeekly : cadenceWeekly
-        return (session, weekly)
+        let windows = ProviderDescriptorRegistry.descriptor(for: provider).presentation
+            .semanticWindows(snapshot: snapshot)
+        return (windows.session, windows.weekly)
     }
 
     /// The active model-scoped weekly carve-out (e.g. Claude's `claude-weekly-scoped-fable`
@@ -263,11 +249,20 @@ extension MenuBarLayout {
     {
         switch preference {
         case .primary:
-            provider == .kimi ? .weekly : .session
+            self.percentWindow(
+                ProviderDescriptorRegistry.descriptor(for: provider ?? .codex).presentation.primarySemanticWindow)
         case .secondary:
-            provider == .kimi ? .session : .weekly
+            self.percentWindow(
+                ProviderDescriptorRegistry.descriptor(for: provider ?? .codex).presentation.secondarySemanticWindow)
         case .automatic, .primaryAndSecondary, .tertiary, .extraUsage, .average, .monthlyPlan:
             .automatic
+        }
+    }
+
+    private static func percentWindow(_ window: ProviderSemanticWindow) -> PercentWindow {
+        switch window {
+        case .session: .session
+        case .weekly: .weekly
         }
     }
 }

--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -2,12 +2,6 @@ import CodexBarCore
 import Foundation
 
 enum MenuBarMetricWindowResolver {
-    private enum Lane {
-        case primary
-        case secondary
-        case tertiary
-    }
-
     static func rateWindow(
         preference: MenuBarMetricPreference,
         provider: UsageProvider,
@@ -18,83 +12,64 @@ enum MenuBarMetricWindowResolver {
         -> RateWindow?
     {
         guard let snapshot else { return nil }
+        let presentation = ProviderDescriptorRegistry.descriptor(for: provider).presentation
+        let metric = Self.providerMetric(preference)
+        switch presentation.menuBarWindow(context: ProviderMenuBarWindowContext(
+            metric: metric,
+            snapshot: snapshot,
+            supportsAverage: supportsAverage,
+            prioritizesExhaustedQuotas: antigravityPrioritizeExhaustedQuotas,
+            now: now))
+        {
+        case let .resolved(window):
+            return window
+        case .unhandled:
+            break
+        }
         switch preference {
         case .monthlyPlan:
-            return snapshot.extraRateWindows?.first { $0.id == "mistral-monthly-plan" }?.window
+            return nil
         case .extraUsage:
             return Self.extraUsageWindow(snapshot: snapshot)
         case .tertiary:
             return Self.requestedWindow(
                 provider: provider,
                 snapshot: snapshot,
-                lanes: Self.tertiaryOrder(for: provider))
+                lanes: presentation.requestedMenuBarLaneOrder(for: .tertiary))
         case .primary:
             return Self.requestedWindow(
                 provider: provider,
                 snapshot: snapshot,
-                lanes: Self.primaryOrder(for: provider))
+                lanes: presentation.requestedMenuBarLaneOrder(for: .primary))
         case .secondary:
             return Self.requestedWindow(
                 provider: provider,
                 snapshot: snapshot,
-                lanes: Self.secondaryOrder(for: provider))
+                lanes: presentation.requestedMenuBarLaneOrder(for: .secondary))
         case .primaryAndSecondary:
             // Claude accounts that only expose an enterprise/extra-usage spend limit have no real
             // session/weekly lanes; surface the spend limit (as `.automatic` does) instead of an empty
             // or 0% placeholder lane.
-            if provider == .claude, let spendLimit = Self.claudeSpendLimitWindow(snapshot: snapshot) {
-                return spendLimit
-            }
             return Self.mostConstrainedWindow(
                 primary: snapshot.primary,
                 secondary: snapshot.secondary,
                 tertiary: nil)
         case .average:
-            return Self.averageWindow(provider: provider, snapshot: snapshot, supportsAverage: supportsAverage)
+            return Self.averageWindow(snapshot: snapshot, supportsAverage: supportsAverage)
         case .automatic:
             return Self.automaticWindow(
-                provider: provider,
+                presentation: presentation,
                 snapshot: snapshot,
-                antigravityPrioritizeExhaustedQuotas: antigravityPrioritizeExhaustedQuotas,
                 now: now)
         }
     }
 
     static func automaticSelectionPrioritizesExhaustedWindow(for provider: UsageProvider) -> Bool {
-        switch provider {
-        case .antigravity, .perplexity, .zai, .copilot, .cursor, .minimax, .claude, .codex:
-            false
-        default:
-            true
-        }
-    }
-
-    private static func tertiaryOrder(for provider: UsageProvider) -> [Lane] {
-        if provider == .perplexity || provider == .cursor || provider == .antigravity {
-            return [.tertiary, .secondary, .primary]
-        }
-        return [.primary, .secondary]
-    }
-
-    private static func primaryOrder(for provider: UsageProvider) -> [Lane] {
-        if provider == .perplexity || provider == .antigravity {
-            return [.primary, .secondary, .tertiary]
-        }
-        return [.primary, .secondary]
-    }
-
-    private static func secondaryOrder(for provider: UsageProvider) -> [Lane] {
-        if provider == .antigravity {
-            return [.secondary, .primary, .tertiary]
-        }
-        if provider == .perplexity {
-            return [.secondary, .tertiary, .primary]
-        }
-        return [.secondary, .primary]
+        ProviderDescriptorRegistry.descriptor(for: provider).presentation
+            .automaticSelectionPrioritizesExhaustedWindow
     }
 
     private static func averageWindow(
-        provider: UsageProvider,
         snapshot: UsageSnapshot,
         supportsAverage: Bool)
         -> RateWindow?
@@ -103,9 +78,6 @@ enum MenuBarMetricWindowResolver {
               let primary = snapshot.primary,
               let secondary = snapshot.secondary
         else {
-            if provider == .antigravity {
-                return self.window(in: snapshot, following: [.primary, .secondary, .tertiary])
-            }
             return snapshot.primary ?? snapshot.secondary
         }
 
@@ -114,69 +86,14 @@ enum MenuBarMetricWindowResolver {
     }
 
     private static func automaticWindow(
-        provider: UsageProvider,
+        presentation: ProviderUsagePresentation,
         snapshot: UsageSnapshot,
-        antigravityPrioritizeExhaustedQuotas: Bool,
         now: Date)
         -> RateWindow?
     {
-        if provider == .antigravity {
-            if antigravityPrioritizeExhaustedQuotas,
-               let window = antigravityQuotaSummaryRankingWindow(snapshot: snapshot, now: now)
-            {
-                return window
-            }
-            if let window = mostConstrainedAntigravityQuotaSummaryWindow(snapshot: snapshot) {
-                return window
-            }
-            return self.mostConstrainedWindow(
-                primary: snapshot.primary,
-                secondary: snapshot.secondary,
-                tertiary: snapshot.tertiary)
-                ?? self.mostConstrainedAntigravityLegacyExtraWindow(snapshot: snapshot)
-        }
-        if provider == .perplexity {
-            return snapshot.automaticPerplexityWindow()
-        }
-        if provider == .zai {
-            return self.mostConstrainedWindow(
-                primary: snapshot.primary,
-                secondary: snapshot.secondary,
-                tertiary: nil)
-        }
-        if provider == .factory || provider == .kimi || provider == .litellm {
-            if let exhausted = exhaustedWindow(
-                primary: snapshot.primary,
-                secondary: snapshot.secondary,
-                tertiary: nil)
-            {
-                return exhausted
-            }
-            return snapshot.secondary ?? snapshot.primary
-        }
-        if provider == .copilot,
-           let primary = snapshot.primary,
-           let secondary = snapshot.secondary
-        {
-            return primary.usedPercent >= secondary.usedPercent ? primary : secondary
-        }
-        if provider == .cursor {
-            return Self.mostConstrainedCursorWindow(
-                total: snapshot.primary,
-                auto: snapshot.secondary,
-                api: snapshot.tertiary)
-        }
-        if provider == .minimax {
-            return Self.mostConstrainedWindow(
-                primary: snapshot.primary,
-                secondary: snapshot.secondary,
-                tertiary: snapshot.tertiary)
-        }
-        if provider == .claude, let spendLimit = Self.claudeSpendLimitWindow(snapshot: snapshot) {
-            return spendLimit
-        }
-        if Self.automaticSelectionPrioritizesExhaustedWindow(for: provider),
-           let exhausted = Self.exhaustedWindow(
+        _ = now
+        if presentation.automaticSelectionPrioritizesExhaustedWindow,
+           let exhausted = exhaustedWindow(
                primary: snapshot.primary,
                secondary: snapshot.secondary,
                tertiary: snapshot.tertiary)
@@ -186,49 +103,33 @@ enum MenuBarMetricWindowResolver {
         return snapshot.primary ?? snapshot.secondary
     }
 
-    private static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
-    private static let antigravityCompactFallbackWindowIDPrefix = "antigravity-compact-fallback-"
-
-    private static func mostConstrainedAntigravityQuotaSummaryWindow(snapshot: UsageSnapshot) -> RateWindow? {
-        let windows = snapshot.extraRateWindows?
-            .filter { $0.usageKnown && $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix) }
-            .map(\.window) ?? []
-        guard !windows.isEmpty else { return nil }
-
-        let usableWindows = windows.filter { $0.usedPercent < 100 }
-        if let maxUsable = usableWindows.max(by: { $0.usedPercent < $1.usedPercent }) {
-            return maxUsable
+    private static func providerMetric(_ preference: MenuBarMetricPreference) -> ProviderMenuBarMetric {
+        switch preference {
+        case .automatic: .automatic
+        case .primary: .primary
+        case .secondary: .secondary
+        case .primaryAndSecondary: .primaryAndSecondary
+        case .tertiary: .tertiary
+        case .extraUsage: .extraUsage
+        case .average: .average
+        case .monthlyPlan: .monthlyPlan
         }
-        return windows.max(by: { $0.usedPercent < $1.usedPercent })
     }
 
+    private static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
     /// Picks the binding supported quota-summary lane for the exhausted-first opt-in.
     static func antigravityQuotaSummaryRankingWindow(
         snapshot: UsageSnapshot,
         now: Date)
         -> RateWindow?
     {
-        let candidates = Self.antigravityQuotaSummaryRows(snapshot: snapshot)
-            .filter {
-                $0.usageKnown &&
-                    $0.window.usedPercent.isFinite &&
-                    Self.isSupportedAntigravityQuotaCadence($0.window.windowMinutes)
-            }
-        return candidates.max { lhs, rhs in
-            if lhs.window.usedPercent != rhs.window.usedPercent {
-                return lhs.window.usedPercent < rhs.window.usedPercent
-            }
-
-            let lhsFutureReset = lhs.window.resetsAt.flatMap { $0 > now ? $0 : nil }
-            let rhsFutureReset = rhs.window.resetsAt.flatMap { $0 > now ? $0 : nil }
-            if (lhsFutureReset != nil) != (rhsFutureReset != nil) {
-                return lhsFutureReset == nil
-            }
-            if let lhsFutureReset, let rhsFutureReset, lhsFutureReset != rhsFutureReset {
-                return lhsFutureReset > rhsFutureReset
-            }
-            return lhs.id < rhs.id
-        }?.window
+        self.rateWindow(
+            preference: .automatic,
+            provider: .antigravity,
+            snapshot: snapshot,
+            supportsAverage: false,
+            antigravityPrioritizeExhaustedQuotas: true,
+            now: now)
     }
 
     /// True only when every fully understood quota family has an exhausted binding lane.
@@ -300,50 +201,12 @@ enum MenuBarMetricWindowResolver {
         return family
     }
 
-    private static func mostConstrainedAntigravityLegacyExtraWindow(snapshot: UsageSnapshot) -> RateWindow? {
-        let windows = snapshot.extraRateWindows?
-            .filter {
-                $0.usageKnown && $0.id.hasPrefix(Self.antigravityCompactFallbackWindowIDPrefix)
-            }
-            .map(\.window) ?? []
-        guard !windows.isEmpty else { return nil }
-
-        let usableWindows = windows.filter { $0.usedPercent < 100 }
-        if let maxUsable = usableWindows.max(by: { $0.usedPercent < $1.usedPercent }) {
-            return maxUsable
-        }
-        return windows.max(by: { $0.usedPercent < $1.usedPercent })
-    }
-
     private static func requestedWindow(
-        provider: UsageProvider,
+        provider _: UsageProvider,
         snapshot: UsageSnapshot,
-        lanes: [Lane]) -> RateWindow?
+        lanes: [ProviderUsageLane]) -> RateWindow?
     {
-        self.window(in: snapshot, following: lanes)
-            ?? (provider == .antigravity
-                ? self.mostConstrainedAntigravityLegacyExtraWindow(snapshot: snapshot)
-                : nil)
-    }
-
-    private static func window(in snapshot: UsageSnapshot, following lanes: [Lane]) -> RateWindow? {
-        for lane in lanes {
-            if let window = self.window(in: snapshot, lane: lane) {
-                return window
-            }
-        }
-        return nil
-    }
-
-    private static func window(in snapshot: UsageSnapshot, lane: Lane) -> RateWindow? {
-        switch lane {
-        case .primary:
-            snapshot.primary
-        case .secondary:
-            snapshot.secondary
-        case .tertiary:
-            snapshot.tertiary
-        }
+        ProviderUsagePresentation.window(in: snapshot, following: lanes)
     }
 
     private static func mostConstrainedWindow(
@@ -368,48 +231,24 @@ enum MenuBarMetricWindowResolver {
             .first { $0.usedPercent >= 100 }
     }
 
-    private static func mostConstrainedCursorWindow(
-        total: RateWindow?,
-        auto: RateWindow?,
-        api: RateWindow?)
-        -> RateWindow?
-    {
-        if let total, total.usedPercent >= 100 {
-            return total
-        }
-
-        let subquotaWindows = [auto, api].compactMap(\.self)
-        let usableSubquotaWindows = subquotaWindows.filter { $0.usedPercent < 100 }
-        if !subquotaWindows.isEmpty, usableSubquotaWindows.isEmpty {
-            return subquotaWindows.max(by: { $0.usedPercent < $1.usedPercent })
-        }
-
-        return ([total].compactMap(\.self) + usableSubquotaWindows)
-            .max(by: { $0.usedPercent < $1.usedPercent })
-    }
-
     /// The Claude spend-limit window when the account only exposes an enterprise/extra-usage spend limit
     /// and has no real session/weekly quota lanes (`primary` nil, a `.spendLimit` window, or an explicitly
     /// marked placeholder). Lets the automatic and combined metrics surface the spend limit instead of an empty
     /// or 0% placeholder lane. Returns nil for accounts that expose genuine quota lanes.
     static func claudeSpendLimitWindow(snapshot: UsageSnapshot) -> RateWindow? {
-        guard self.shouldUseClaudeSpendLimit(providerCost: snapshot.providerCost, snapshot: snapshot) else {
+        let presentation = ProviderDescriptorRegistry.descriptor(for: .claude).presentation
+        switch presentation.menuBarWindow(context: ProviderMenuBarWindowContext(
+            metric: .automatic,
+            snapshot: snapshot,
+            supportsAverage: false,
+            prioritizesExhaustedQuotas: false,
+            now: .now))
+        {
+        case let .resolved(window):
+            return window
+        case .unhandled:
             return nil
         }
-        return self.extraUsageWindow(snapshot: snapshot)
-    }
-
-    private static func shouldUseClaudeSpendLimit(
-        providerCost: ProviderCostSnapshot?,
-        snapshot: UsageSnapshot)
-        -> Bool
-    {
-        guard providerCost?.limit ?? 0 > 0,
-              snapshot.secondary == nil,
-              snapshot.tertiary == nil
-        else { return false }
-        guard let primary = snapshot.primary else { return true }
-        return primary.isSyntheticPlaceholder
     }
 
     private static func extraUsageWindow(snapshot: UsageSnapshot?) -> RateWindow? {

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -111,10 +111,11 @@ extension UsageMenuCardView.Model {
         preferredCurrencyCode: String = "auto") -> String?
     {
         guard metadata.supportsCredits else { return nil }
-        if metadata.id == .codex, credits == nil, error == nil {
-            return nil
-        }
-        if metadata.id == .amp, snapshot != nil {
+        let visibility = ProviderDescriptorRegistry.descriptor(for: metadata.id).presentation.menuCard.creditsVisibility
+        if visibility == .hidden ||
+            (visibility == .requiresValueOrError && credits == nil && error == nil) ||
+            (visibility == .hiddenWhenUsageSnapshotPresent && snapshot != nil)
+        {
             return nil
         }
         if let credits {

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -24,21 +24,23 @@ extension UsageMenuCardView.Model {
         input: Input,
         primary: RateWindow)
     {
-        if input.provider == .openrouter, let detail = self.trimmedResetDescription(primary) {
+        let policy = ProviderDescriptorRegistry.descriptor(for: input.provider).presentation.menuCard
+        guard let detail = self.trimmedResetDescription(primary) else { return }
+        switch policy.primaryDescriptionPlacement {
+        case .reset:
             presentation.resetText = detail
-        }
-        if [.copilot, .zenmux].contains(input.provider),
-           let detail = Self.trimmedResetDescription(primary)
-        {
+        case .detailLeft:
             presentation.detailLeft = detail
-        }
-        guard input.provider == .crof,
-              let detail = Self.trimmedResetDescription(primary)
-        else { return }
-        if input.snapshot?.secondary != nil {
-            presentation.detailRight = detail
-        } else {
+        case .detail:
             presentation.detailText = detail
+        case .detailBySecondaryPresence:
+            if input.snapshot?.secondary != nil {
+                presentation.detailRight = detail
+            } else {
+                presentation.detailText = detail
+            }
+        case .standard:
+            break
         }
     }
 
@@ -47,29 +49,29 @@ extension UsageMenuCardView.Model {
         input: Input,
         primary: RateWindow)
     {
-        if [.warp, .kilo, .mimo, .deepseek, .deepinfra, .qoder, .mistral, .neuralwatt, .litellm, .chutes]
-            .contains(input.provider),
-            let detail = nonEmptyResetDescription(primary)
+        let policy = ProviderDescriptorRegistry.descriptor(for: input.provider).presentation.menuCard
+        if policy.showsPrimaryBalanceDescription,
+           let detail = nonEmptyResetDescription(primary)
         {
             presentation.detailText = detail
         }
-        if let balance = Self.poeBalanceDetailText(input: input) {
-            presentation.detailText = balance
-        }
-        if input.provider == .kiro,
-           let remaining = input.snapshot?.detailRow(label: "Credits left")?.value,
-           let total = input.snapshot?.detailRow(label: "Credits total")?.value,
-           total != "0"
-        {
-            presentation.detailLeft = String(format: L("%@ of %@ credits left"), remaining, total)
-        }
-        if input.provider == .alibaba || input.provider == .alibabatokenplan || input.provider == .manus,
-           let detail = Self.nonEmptyResetDescription(primary)
-        {
-            presentation.detailText = detail
-            if input.provider == .manus {
-                presentation.resetText = nil
+        switch policy.primaryDetailKind {
+        case .poeBalance:
+            if let balance = Self.poeBalanceDetailText(input: input) {
+                presentation.detailText = balance
             }
+        case .kiroCredits:
+            if let remaining = input.snapshot?.detailRow(label: "Credits left")?.value,
+               let total = input.snapshot?.detailRow(label: "Credits total")?.value,
+               total != "0"
+            {
+                presentation.detailLeft = String(format: L("%@ of %@ credits left"), remaining, total)
+            }
+        case .none, .requestQuota:
+            break
+        }
+        if policy.clearsPrimaryReset {
+            presentation.resetText = nil
         }
     }
 
@@ -78,16 +80,14 @@ extension UsageMenuCardView.Model {
         input: Input,
         primary: RateWindow)
     {
-        if input.provider == .sub2api {
+        let policy = ProviderDescriptorRegistry.descriptor(for: input.provider).presentation.menuCard
+        if policy.usesRawPrimaryResetDescription {
             presentation.resetText = primary.resetDescription
         }
-        if [.warp, .kilo, .mimo, .deepseek, .deepinfra, .qoder, .mistral, .neuralwatt, .litellm, .zenmux, .chutes]
-            .contains(input.provider),
-            primary.resetsAt == nil
-        {
+        if policy.hidesPrimaryResetWithoutDate, primary.resetsAt == nil {
             presentation.resetText = nil
         }
-        if input.provider == .crof, input.snapshot?.secondary == nil {
+        if policy.hidesPrimaryResetWithoutSecondary, input.snapshot?.secondary == nil {
             presentation.resetText = nil
         }
     }
@@ -97,6 +97,7 @@ extension UsageMenuCardView.Model {
         input: Input,
         primary: RateWindow)
     {
+        let policy = ProviderDescriptorRegistry.descriptor(for: input.provider).presentation.menuCard
         if let paceDetail = sessionPaceDetail(
             provider: input.provider,
             window: primary,
@@ -105,7 +106,7 @@ extension UsageMenuCardView.Model {
         {
             self.apply(paceDetail, to: &presentation)
         }
-        if input.provider == .abacus {
+        if policy.usesAbacusPace {
             if let detail = Self.nonEmptyResetDescription(primary) {
                 presentation.detailText = detail
             }
@@ -125,7 +126,7 @@ extension UsageMenuCardView.Model {
         } else if let paceDetail = Self.resetWindowPaceDetail(
             window: primary,
             input: input,
-            pace: input.provider == .kimi ? input.weeklyPace : nil)
+            pace: policy.resetWindowUsesWeeklyPace ? input.weeklyPace : nil)
         {
             Self.apply(paceDetail, to: &presentation)
         }
@@ -136,11 +137,14 @@ extension UsageMenuCardView.Model {
         input: Input,
         primary: RateWindow)
     {
+        let policy = ProviderDescriptorRegistry.descriptor(for: input.provider).presentation.menuCard
         // Legacy request-based Cursor plans surface the raw used/limit quota on its own line.
-        if input.provider == .cursor, let quota = input.snapshot?.detailRow(label: "Request quota")?.value {
+        if case .requestQuota = policy.primaryDetailKind,
+           let quota = input.snapshot?.detailRow(label: "Request quota")?.value
+        {
             presentation.detailText = "\(L("Request quota")): \(quota)"
         }
-        if input.provider == .synthetic,
+        if policy.usesSyntheticRollingRegen,
            let regen = Self.syntheticRollingRegenDetail(
                window: primary,
                now: input.now,
@@ -149,9 +153,7 @@ extension UsageMenuCardView.Model {
             presentation.resetText = regen.resetText
             Self.apply(regen.pace, to: &presentation)
         }
-        let usesBalanceStatusText = input.provider == .deepseek || input.provider == .deepinfra ||
-            (input.provider == .crof && input.snapshot?.secondary == nil)
-        if usesBalanceStatusText {
+        if policy.movesPrimaryDetailToStatus(snapshot: input.snapshot) {
             presentation.statusText = presentation.detailText
             presentation.detailText = nil
         }

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -911,7 +911,8 @@ extension UsageMenuCardView.Model {
         let openAIAPIUsage = input.snapshot?.openAIAPIUsage
         let inlineUsageDashboard = Self.inlineUsageDashboard(input: input)
         let usageNotes = Self.usageNotes(input: input)
-        let rawCreditsText: String? = if input.provider == .openrouter ||
+        let menuCard = ProviderDescriptorRegistry.descriptor(for: input.provider).presentation.menuCard
+        let rawCreditsText: String? = if !menuCard.showsCreditsSection ||
             !input.showOptionalCreditsAndExtraUsage
         {
             nil
@@ -927,18 +928,11 @@ extension UsageMenuCardView.Model {
         let creditsProgressPercent = Self.creditsProgressPercent(credits: input.credits)
         let creditsScaleText = Self.creditsScaleText(credits: input.credits)
         let codexCreditLimitDetail = Self.codexCreditLimitDetail(credits: input.credits, now: input.now)
-        let isClaudeAdminAPI = input.provider == .claude &&
-            input.snapshot?.loginMethod(for: .claude) == "Admin API"
-        let isRequiredOpenCodeZenBalance = Self.isRequiredOpenCodeZenBalance(input.snapshot)
-        let hidesOptionalProviderCost = ((input.provider == .claude && !isClaudeAdminAPI) ||
-            input.provider == .cursor ||
-            input.provider == .factory ||
-            input.provider == .devin ||
-            (input.provider == .opencodego && !isRequiredOpenCodeZenBalance)) &&
-            !input.showOptionalCreditsAndExtraUsage
-        let providerCost: ProviderCostSection? = if hidesOptionalProviderCost ||
-            (input.provider == .openai && openAIAPIUsage != nil)
-        {
+        let isClaudeAdminAPI = input.snapshot?.loginMethod(for: input.provider) == "Admin API"
+        let showsProviderCost = menuCard.showsProviderCost(context: ProviderCostVisibilityContext(
+            snapshot: input.snapshot,
+            showOptionalUsage: input.showOptionalCreditsAndExtraUsage))
+        let providerCost: ProviderCostSection? = if !showsProviderCost {
             nil
         } else {
             Self.providerCostSection(

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -237,13 +237,10 @@ struct MenuDescriptor {
         if let snap = store.snapshot(for: provider.instanceID) {
             let resetStyle = settings.resetTimeDisplayStyle
             let labels = Self.rateWindowLabels(provider: provider, metadata: meta, snapshot: snap)
-            let crofShowsCreditsOnly = provider == .crof && snap.secondary == nil
+            let presentation = ProviderDescriptorRegistry.descriptor(for: provider).presentation
             if let primary = snap.primary {
                 let primaryDetail = primary.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
-                let primaryDescriptionIsDetail = provider == .warp || provider == .kilo || provider == .abacus ||
-                    provider == .deepseek || provider == .deepinfra || provider == .neuralwatt ||
-                    provider == .azureopenai || provider == .mimo || provider == .qoder || provider == .sub2api ||
-                    crofShowsCreditsOnly || provider == .chutes
+                let primaryDescriptionIsDetail = presentation.menu.usesPrimaryDescriptionAsDetail(snapshot: snap)
                 let primaryWindow = if primaryDescriptionIsDetail {
                     // Some providers use resetDescription for non-reset detail
                     // (e.g., "Unlimited", "X/Y credits"). Avoid rendering it as a "Resets ..." line.
@@ -267,14 +264,14 @@ struct MenuDescriptor {
                 {
                     entries.append(.text(primaryDetail, .secondary))
                 }
-                if provider == .crof,
+                if presentation.menu.duplicatesPrimaryDetailWhenResetDatePresent,
                    primary.resetsAt != nil,
                    let primaryDetail,
                    !primaryDetail.isEmpty
                 {
                     entries.append(.text(primaryDetail, .secondary))
                 }
-                if provider == .abacus,
+                if presentation.menu.showsPrimaryWeeklyPace,
                    let pace = store.weeklyPace(provider: provider, window: primary)
                 {
                     let paceSummary = UsagePaceText.weeklySummary(provider: provider, pace: pace)
@@ -286,15 +283,16 @@ struct MenuDescriptor {
             }
             if let weekly = snap.secondary {
                 let weeklyResetOverride: String? = {
-                    guard provider == .warp || provider == .kilo || provider == .perplexity || provider == .crof ||
-                        provider == .sub2api || provider == .chutes
-                    else { return nil }
                     let detail = weekly.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
                     guard let detail, !detail.isEmpty else { return nil }
-                    if [.kilo, .chutes].contains(provider), weekly.resetsAt != nil {
+                    switch presentation.menu.secondaryDescriptionMode {
+                    case .standard:
                         return nil
+                    case .resetOverride:
+                        return detail
+                    case .detailWhenResetDatePresent:
+                        return weekly.resetsAt == nil ? detail : nil
                     }
-                    return detail
                 }()
                 Self.appendRateWindow(
                     entries: &entries,
@@ -303,7 +301,7 @@ struct MenuDescriptor {
                     resetStyle: resetStyle,
                     showUsed: settings.usageBarsShowUsed,
                     resetOverride: weeklyResetOverride)
-                if [.kilo, .chutes].contains(provider),
+                if presentation.menu.secondaryDescriptionMode == .detailWhenResetDatePresent,
                    weekly.resetsAt != nil,
                    let detail = weekly.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines),
                    !detail.isEmpty
@@ -317,7 +315,7 @@ struct MenuDescriptor {
             }
             if labels.showsTertiary, let opus = snap.tertiary {
                 // Perplexity purchased credits don't reset; show the balance as plain text.
-                let opusResetOverride: String? = provider == .perplexity || provider == .sub2api
+                let opusResetOverride: String? = presentation.menu.tertiaryDescriptionOverridesReset
                     ? opus.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
                     : nil
                 Self.appendRateWindow(
@@ -328,15 +326,13 @@ struct MenuDescriptor {
                     showUsed: settings.usageBarsShowUsed,
                     resetOverride: opusResetOverride)
             }
-            if provider == .zai {
-                for extra in snap.extraRateWindows ?? [] where extra.id == "zai-mcp" {
-                    Self.appendRateWindow(
-                        entries: &entries,
-                        title: extra.title,
-                        window: extra.window,
-                        resetStyle: resetStyle,
-                        showUsed: settings.usageBarsShowUsed)
-                }
+            for extra in presentation.extraRateWindows(snapshot: snap) {
+                Self.appendRateWindow(
+                    entries: &entries,
+                    title: extra.title,
+                    window: extra.window,
+                    resetStyle: resetStyle,
+                    showUsed: settings.usageBarsShowUsed)
             }
 
             Self.appendProviderUsageSummaries(

--- a/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
@@ -238,13 +238,11 @@ struct PlanUtilizationHistoryChartMenuView: View {
         provider: UsageProvider,
         history: PlanUtilizationSeriesHistory) -> PlanUtilizationSeriesName
     {
-        if provider == .codex,
-           history.windowMinutes == CodexConsumerProjection.monthlyWindowMinutes,
-           history.name == .session || history.name == .weekly
-        {
-            return .monthly
-        }
-        return history.name
+        let presentation = ProviderDescriptorRegistry.descriptor(for: provider).presentation
+        let normalized = presentation.normalizePlanUtilizationSeries(
+            self.providerSeries(history.name),
+            windowMinutes: history.windowMinutes)
+        return self.historySeries(normalized)
     }
 
     nonisolated static func mergedEntries(
@@ -262,30 +260,32 @@ struct PlanUtilizationHistoryChartMenuView: View {
     {
         guard let snapshot else { return nil }
 
-        var names: Set<PlanUtilizationSeriesName> = []
-        switch provider {
-        case .codex:
-            names = CodexConsumerProjection.planUtilizationSeriesNames(snapshot: snapshot)
-        case .claude:
-            if snapshot.primary != nil { names.insert(.session) }
-            if snapshot.secondary != nil { names.insert(.weekly) }
-            if snapshot.tertiary != nil,
-               ProviderDescriptorRegistry.metadata[provider]?.supportsOpus == true
-            {
-                names.insert(.opus)
-            }
-        case .opencodego:
-            if snapshot.primary != nil { names.insert(.session) }
-            if snapshot.secondary != nil { names.insert(.weekly) }
-            if snapshot.tertiary != nil { names.insert(.monthly) }
-        default:
-            let windows = [snapshot.primary, snapshot.secondary, snapshot.tertiary].compactMap(\.self)
-                + (snapshot.extraRateWindows?.filter(\.usageKnown).map(\.window) ?? [])
-            guard windows.contains(where: { $0.windowMinutes == 7 * 24 * 60 }) else { return nil }
-            names.insert(.weekly)
-        }
+        return ProviderDescriptorRegistry.descriptor(for: provider).presentation
+            .planUtilizationSeries(snapshot: snapshot)
+            .map { Set($0.map(self.historySeries)) }
+    }
 
-        return names
+    private nonisolated static func providerSeries(
+        _ series: PlanUtilizationSeriesName) -> ProviderPlanUtilizationSeries
+    {
+        switch series {
+        case .session: .session
+        case .weekly: .weekly
+        case .opus: .tertiary
+        case .monthly: .monthly
+        default: .weekly
+        }
+    }
+
+    private nonisolated static func historySeries(
+        _ series: ProviderPlanUtilizationSeries) -> PlanUtilizationSeriesName
+    {
+        switch series {
+        case .session: .session
+        case .weekly: .weekly
+        case .tertiary: .opus
+        case .monthly: .monthly
+        }
     }
 
     private nonisolated static func makeModel(
@@ -798,14 +798,18 @@ struct PlanUtilizationHistoryChartMenuView: View {
         geo: GeometryProxy)
     {
         guard let location else {
-            if self.selectedPointID != nil { self.selectedPointID = nil }
+            if self.selectedPointID != nil {
+                self.selectedPointID = nil
+            }
             return
         }
 
         guard let plotAnchor = proxy.plotFrame else { return }
         let plotFrame = geo[plotAnchor]
         guard plotFrame.contains(location) else {
-            if self.selectedPointID != nil { self.selectedPointID = nil }
+            if self.selectedPointID != nil {
+                self.selectedPointID = nil
+            }
             return
         }
 

--- a/Sources/CodexBar/UsagePaceText.swift
+++ b/Sources/CodexBar/UsagePaceText.swift
@@ -118,7 +118,8 @@ enum UsagePaceText {
     }
 
     private static func combinedLastsLabel(for pace: UsagePace, provider: UsageProvider) -> String {
-        guard provider == .codex else { return L("Lasts until reset") }
+        let paceCapability = ProviderDescriptorRegistry.descriptor(for: provider).pace
+        guard paceCapability.showsHeadroomHint else { return L("Lasts until reset") }
         guard let speedLabel = self.speedHintLabel(for: pace) else {
             return L("Lasts until reset")
         }
@@ -152,34 +153,8 @@ enum UsagePaceText {
     }
 
     static func sessionPace(provider: UsageProvider, window: RateWindow, now: Date) -> UsagePace? {
-        guard provider == .codex || provider == .claude || provider == .ollama || provider == .antigravity ||
-            provider == .kimi || provider == .notion
-        else { return nil }
-        // Suppress session pace only for windows that classify into a longer lane (weekly/monthly).
-        // Unknown durations fall back to the session lane and keep their existing pace behavior.
-        if provider == .codex, let minutes = window.windowMinutes,
-           minutes == CodexConsumerProjection.weeklyWindowMinutes ||
-           minutes == CodexConsumerProjection.monthlyWindowMinutes
-        {
-            return nil
-        }
-        if provider == .ollama, window.windowMinutes == nil {
-            return nil
-        }
-        if provider == .antigravity, let windowMinutes = window.windowMinutes, windowMinutes != 300 {
-            return nil
-        }
-        if provider == .kimi, window.windowMinutes != KimiProviderDescriptor.sessionWindowMinutes {
-            return nil
-        }
-        if provider == .notion {
-            // Notion parses its rolling length from an API token (`6h`), so the shape is not guaranteed.
-            // Only a real rolling allowance may be paced here; anything longer is a billing period and
-            // belongs on the descriptor's reset-window pace instead.
-            guard let minutes = window.windowMinutes,
-                  minutes <= NotionProviderDescriptor.rollingWindowMaxMinutes
-            else { return nil }
-        }
+        let paceCapability = ProviderDescriptorRegistry.descriptor(for: provider).pace
+        guard paceCapability.supportsSessionPace(window: window, now: now) else { return nil }
         guard window.remainingPercent > 0 else { return nil }
         guard let pace = UsagePace.weekly(window: window, now: now, defaultWindowMinutes: 300) else { return nil }
         guard pace.expectedUsedPercent >= 3 else { return nil }

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
@@ -52,6 +52,11 @@ public enum AbacusProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Abacus AI cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(
+                menuCard: ProviderMenuCardPresentation(usesAbacusPace: true),
+                menu: ProviderMenuDescriptorPresentation(
+                    primaryDescriptionIsDetail: { _ in true },
+                    showsPrimaryWeeklyPace: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanProviderDescriptor.swift
@@ -84,6 +84,8 @@ public enum AlibabaCodingPlanProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Alibaba Coding Plan cost summary is not supported." }),
             pace: .calendarMonthResetWindow,
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                showsPrimaryBalanceDescription: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanProviderDescriptor.swift
@@ -94,6 +94,8 @@ public enum AlibabaTokenPlanProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Alibaba Token Plan cost summary is not supported." }),
             pace: .calendarMonthResetWindow,
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                showsPrimaryBalanceDescription: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -43,13 +43,15 @@ public enum AmpProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Amp cost summary is not supported." }),
             pace: .calendarMonthResetWindow,
-            presentation: ProviderUsagePresentation(rateWindowLabeler: { metadata, snapshot, _ in
-                ProviderRateWindowLabels(
-                    primary: Self.primaryLabel(snapshot: snapshot) ?? metadata.sessionLabel,
-                    secondary: Self.secondaryLabel(snapshot: snapshot) ?? metadata.weeklyLabel,
-                    tertiary: metadata.opusLabel ?? "Sonnet",
-                    showsTertiary: metadata.supportsOpus)
-            }),
+            presentation: ProviderUsagePresentation(
+                rateWindowLabeler: { metadata, snapshot, _ in
+                    ProviderRateWindowLabels(
+                        primary: Self.primaryLabel(snapshot: snapshot) ?? metadata.sessionLabel,
+                        secondary: Self.secondaryLabel(snapshot: snapshot) ?? metadata.weeklyLabel,
+                        tertiary: metadata.opusLabel ?? "Sonnet",
+                        showsTertiary: metadata.supportsOpus)
+                },
+                menuCard: ProviderMenuCardPresentation(creditsVisibility: .hiddenWhenUsageSnapshotPresent)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web, .cli],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -51,13 +51,125 @@ public enum AntigravityProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Antigravity cost summary is not supported." }),
+            pace: ProviderPaceCapability(
+                sessionPaceWindowRule: .custom { window, _ in
+                    window.windowMinutes == nil || window.windowMinutes == 300
+                }),
             history: .alwaysTracked,
+            presentation: ProviderUsagePresentation(
+                iconWindowResolver: self.iconWindows,
+                iconDecorations: [.gemini, .antigravity],
+                requestedMenuBarLaneOrders: [
+                    .primary: [.primary, .secondary, .tertiary],
+                    .secondary: [.secondary, .primary, .tertiary],
+                    .tertiary: [.tertiary, .secondary, .primary],
+                ],
+                automaticSelectionPrioritizesExhaustedWindow: false,
+                menuBarWindowResolver: self.menuBarWindow,
+                widgetRowLimitResolver: { rows, family in
+                    guard rows?.contains(where: { $0.id.hasPrefix(Self.quotaSummaryPrefix) }) == true else {
+                        return nil
+                    }
+                    return family == .small ? 2 : 3
+                }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .cli, .oauth],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "antigravity",
                 versionDetector: nil))
+    }
+
+    private static let quotaSummaryPrefix = "antigravity-quota-summary-"
+    private static let compactFallbackPrefix = "antigravity-compact-fallback-"
+
+    private static func iconWindows(context: ProviderIconWindowContext) -> ProviderUsageWindowPair {
+        let windows = (context.snapshot.extraRateWindows ?? [])
+            .filter { $0.usageKnown && $0.id.hasPrefix(self.quotaSummaryPrefix) }
+        guard !windows.isEmpty else { return ProviderUsageWindowPair(primary: nil, secondary: nil) }
+        return ProviderUsageWindowPair(
+            primary: self.mostConstrained(windows: windows, minutes: 300),
+            secondary: self.mostConstrained(windows: windows, minutes: 7 * 24 * 60))
+    }
+
+    private static func mostConstrained(windows: [NamedRateWindow], minutes: Int) -> RateWindow? {
+        windows
+            .filter { $0.window.windowMinutes == minutes }
+            .max { lhs, rhs in
+                if lhs.window.usedPercent != rhs.window.usedPercent {
+                    return lhs.window.usedPercent < rhs.window.usedPercent
+                }
+                return lhs.id > rhs.id
+            }?
+            .window
+    }
+
+    private static func menuBarWindow(
+        context: ProviderMenuBarWindowContext) -> ProviderMenuBarWindowResolution
+    {
+        switch context.metric {
+        case .primary, .secondary, .tertiary:
+            let order = self.descriptor.presentation.requestedMenuBarLaneOrder(for: context.metric)
+            return .resolved(
+                ProviderUsagePresentation.window(in: context.snapshot, following: order)
+                    ?? self.mostConstrainedExtraWindow(
+                        snapshot: context.snapshot,
+                        prefix: self.compactFallbackPrefix))
+        case .average where !context.supportsAverage:
+            return .resolved(ProviderUsagePresentation.window(
+                in: context.snapshot,
+                following: [.primary, .secondary, .tertiary]))
+        case .automatic:
+            if context.prioritizesExhaustedQuotas,
+               let ranked = self.rankedQuotaSummaryWindow(snapshot: context.snapshot, now: context.now)
+            {
+                return .resolved(ranked)
+            }
+            return .resolved(
+                self.mostConstrainedExtraWindow(snapshot: context.snapshot, prefix: self.quotaSummaryPrefix)
+                    ?? ProviderUsagePresentation.mostConstrained(
+                        context.snapshot.primary,
+                        context.snapshot.secondary,
+                        context.snapshot.tertiary)
+                    ?? self.mostConstrainedExtraWindow(
+                        snapshot: context.snapshot,
+                        prefix: self.compactFallbackPrefix))
+        default:
+            return .unhandled
+        }
+    }
+
+    private static func mostConstrainedExtraWindow(snapshot: UsageSnapshot, prefix: String) -> RateWindow? {
+        let windows = (snapshot.extraRateWindows ?? [])
+            .filter { $0.usageKnown && $0.id.hasPrefix(prefix) }
+            .map(\.window)
+        let usable = windows.filter { $0.usedPercent < 100 }
+        return (usable.isEmpty ? windows : usable).max(by: { $0.usedPercent < $1.usedPercent })
+    }
+
+    private static func rankedQuotaSummaryWindow(snapshot: UsageSnapshot, now: Date) -> RateWindow? {
+        (snapshot.extraRateWindows ?? [])
+            .filter {
+                $0.usageKnown &&
+                    $0.id.hasPrefix(self.quotaSummaryPrefix) &&
+                    $0.window.usedPercent.isFinite &&
+                    [300, 7 * 24 * 60].contains($0.window.windowMinutes)
+            }
+            .max { lhs, rhs in
+                if lhs.window.usedPercent != rhs.window.usedPercent {
+                    return lhs.window.usedPercent < rhs.window.usedPercent
+                }
+                let lhsReset = lhs.window.resetsAt.flatMap { $0 > now ? $0 : nil }
+                let rhsReset = rhs.window.resetsAt.flatMap { $0 > now ? $0 : nil }
+                if (lhsReset == nil) != (rhsReset == nil) {
+                    return lhsReset == nil
+                }
+                if let lhsReset, let rhsReset, lhsReset != rhsReset {
+                    return lhsReset > rhsReset
+                }
+                return lhs.id < rhs.id
+            }?
+            .window
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIProviderDescriptor.swift
@@ -47,6 +47,8 @@ public enum AzureOpenAIProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Azure OpenAI usage history is not exposed by the deployment validation probe." }),
+            presentation: ProviderUsagePresentation(menu: ProviderMenuDescriptorPresentation(
+                primaryDescriptionIsDetail: { _ in true })),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [AzureOpenAIAPIFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderDescriptor.swift
@@ -61,6 +61,8 @@ public enum BedrockProviderDescriptor {
                 },
                 menuHintLines: [.literal("AWS Cost Explorer billing can lag.")],
                 supportsTokenSnapshot: true),
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                supportsInlineTokenCostDashboard: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [BedrockAPIFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Chutes/ChutesProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Chutes/ChutesProviderDescriptor.swift
@@ -43,6 +43,13 @@ public enum ChutesProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Chutes cost history is not available from CodexBar." }),
+            presentation: ProviderUsagePresentation(
+                menuCard: ProviderMenuCardPresentation(
+                    showsPrimaryBalanceDescription: true,
+                    hidesPrimaryResetWithoutDate: true),
+                menu: ProviderMenuDescriptorPresentation(
+                    primaryDescriptionIsDetail: { _ in true },
+                    secondaryDescriptionMode: .detailWhenResetDatePresent)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [ChutesAPIFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -176,7 +176,12 @@ public enum ClaudeProviderDescriptor {
                     }
                     return series
                 },
-                secondaryGloballyCapsPrimary: true),
+                secondaryGloballyCapsPrimary: true,
+                menuCard: ProviderMenuCardPresentation(
+                    costVisibilityResolver: { context in
+                        context.showOptionalUsage || context.snapshot?.loginMethod(for: .claude) == "Admin API"
+                    },
+                    supportsInlineTokenCostDashboard: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web, .cli, .oauth],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -131,7 +131,8 @@ public enum ClaudeProviderDescriptor {
             pace: ProviderPaceCapability(
                 primary: .session(maximumMinutes: 300),
                 secondary: .weekly,
-                tertiary: .weekly),
+                tertiary: .weekly,
+                sessionPaceWindowRule: .custom { _, _ in true }),
             history: .alwaysTracked,
             presentation: ProviderUsagePresentation(
                 identityPresenter: { provider, snapshot in
@@ -158,7 +159,24 @@ public enum ClaudeProviderDescriptor {
                     return ProviderCostPresentation(
                         showsGenericFallback: !(cost.used == 0 && cost.limit == 0 && cost.balance != nil),
                         balances: balances)
-                }),
+                },
+                iconDecorations: [.notches],
+                automaticSelectionPrioritizesExhaustedWindow: false,
+                menuBarWindowResolver: self.menuBarWindow,
+                planUtilizationSeriesResolver: { snapshot in
+                    var series: Set<ProviderPlanUtilizationSeries> = []
+                    if snapshot.primary != nil {
+                        series.insert(.session)
+                    }
+                    if snapshot.secondary != nil {
+                        series.insert(.weekly)
+                    }
+                    if snapshot.tertiary != nil {
+                        series.insert(.tertiary)
+                    }
+                    return series
+                },
+                secondaryGloballyCapsPrimary: true),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web, .cli, .oauth],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
@@ -169,6 +187,24 @@ public enum ClaudeProviderDescriptor {
                     ClaudeUsageFetcher(browserDetection: browserDetection).detectVersion()
                 },
                 browserSupportExemption: { sourceMode, _, _ in sourceMode == .auto }))
+    }
+
+    private static func menuBarWindow(
+        context: ProviderMenuBarWindowContext) -> ProviderMenuBarWindowResolution
+    {
+        guard context.metric == .automatic || context.metric == .primaryAndSecondary,
+              let cost = context.snapshot.providerCost,
+              cost.limit > 0,
+              context.snapshot.secondary == nil,
+              context.snapshot.tertiary == nil,
+              context.snapshot.primary == nil || context.snapshot.primary?.isSyntheticPlaceholder == true
+        else { return .unhandled }
+        let usedPercent = max(0, min(100, (cost.used / cost.limit) * 100))
+        return .resolved(RateWindow(
+            usedPercent: usedPercent,
+            windowMinutes: nil,
+            resetsAt: cost.resetsAt,
+            resetDescription: nil))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -71,7 +71,11 @@ public enum CodexProviderDescriptor {
             pace: ProviderPaceCapability(
                 primary: .session(maximumMinutes: 300),
                 secondary: .weekly,
-                showsHeadroomHint: true),
+                showsHeadroomHint: true,
+                sessionPaceWindowRule: .custom { window, _ in
+                    guard let minutes = window.windowMinutes else { return true }
+                    return minutes != 7 * 24 * 60 && minutes != 30 * 24 * 60
+                }),
             history: .alwaysTracked,
             presentation: ProviderUsagePresentation(
                 identityPresenter: { provider, snapshot in
@@ -81,7 +85,18 @@ public enum CodexProviderDescriptor {
                     let display = CodexPlanFormatting.displayName(plan) ?? plan
                     return ProviderIdentityPresentation(badge: display, plan: display)
                 },
-                creditResolver: { $0.codexCreditLimit?.remaining ?? $0.remaining }),
+                creditResolver: { $0.codexCreditLimit?.remaining ?? $0.remaining },
+                iconWindowResolver: self.iconWindows,
+                iconDecorations: [.face],
+                automaticSelectionPrioritizesExhaustedWindow: false,
+                planUtilizationSeriesResolver: self.planUtilizationSeries,
+                planUtilizationSeriesNormalizer: { series, windowMinutes in
+                    guard windowMinutes == 30 * 24 * 60,
+                          series == .session || series == .weekly
+                    else { return series }
+                    return .monthly
+                },
+                secondaryGloballyCapsPrimary: true),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web, .cli, .oauth],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
@@ -129,6 +144,82 @@ public enum CodexProviderDescriptor {
 
     private static func noDataMessage() -> String {
         self.noDataMessage(env: ProcessInfo.processInfo.environment)
+    }
+
+    private enum UsageLane: Hashable {
+        case session
+        case weekly
+        case monthly
+    }
+
+    private static func iconWindows(context: ProviderIconWindowContext) -> ProviderUsageWindowPair {
+        let windows = self.visibleWindows(snapshot: context.snapshot, now: context.now)
+        return ProviderUsageWindowPair(primary: windows.first, secondary: windows.dropFirst().first)
+    }
+
+    private static func planUtilizationSeries(
+        snapshot: UsageSnapshot) -> Set<ProviderPlanUtilizationSeries>?
+    {
+        let lanes = Set(self.windowsByLane(snapshot: snapshot).keys)
+        return Set(lanes.map { lane in
+            switch lane {
+            case .session: .session
+            case .weekly: .weekly
+            case .monthly: .monthly
+            }
+        })
+    }
+
+    private static func visibleWindows(snapshot: UsageSnapshot, now: Date) -> [RateWindow] {
+        let slotted = [
+            self.classified(snapshot.primary, fallback: .session),
+            self.classified(snapshot.secondary, fallback: .weekly),
+        ].compactMap(\.self)
+        let windowsByLane = self.windowsByLane(snapshot: snapshot)
+        let weekly = windowsByLane[.weekly]
+        var seen: Set<UsageLane> = []
+        return slotted.compactMap { lane, _ in
+            guard seen.insert(lane).inserted, var window = windowsByLane[lane] else { return nil }
+            if lane == .session, self.weeklyCapsSession(weekly, now: now) {
+                window = RateWindow(
+                    usedPercent: 100,
+                    windowMinutes: window.windowMinutes,
+                    resetsAt: window.resetsAt,
+                    resetDescription: window.resetDescription,
+                    nextRegenPercent: window.nextRegenPercent,
+                    isSyntheticPlaceholder: window.isSyntheticPlaceholder)
+            }
+            guard window.remainingPercent > 0 || window.resetsAt.map({ $0 > now }) != false else { return nil }
+            return window
+        }
+    }
+
+    private static func windowsByLane(snapshot: UsageSnapshot) -> [UsageLane: RateWindow] {
+        let slotted = [
+            self.classified(snapshot.primary, fallback: .session),
+            self.classified(snapshot.secondary, fallback: .weekly),
+        ].compactMap(\.self)
+        var result: [UsageLane: RateWindow] = [:]
+        for (lane, window) in slotted {
+            result[lane] = window
+        }
+        return result
+    }
+
+    private static func classified(_ window: RateWindow?, fallback: UsageLane) -> (UsageLane, RateWindow)? {
+        guard let window else { return nil }
+        let lane: UsageLane = switch window.windowMinutes {
+        case 5 * 60: .session
+        case 7 * 24 * 60: .weekly
+        case 30 * 24 * 60: .monthly
+        default: fallback
+        }
+        return (lane, window)
+    }
+
+    private static func weeklyCapsSession(_ weekly: RateWindow?, now: Date) -> Bool {
+        guard let weekly, weekly.remainingPercent <= 0 else { return false }
+        return weekly.resetsAt.map { $0 > now } ?? true
     }
 
     private static func noDataMessage(env: [String: String], fileManager: FileManager = .default) -> String {

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -96,7 +96,10 @@ public enum CodexProviderDescriptor {
                     else { return series }
                     return .monthly
                 },
-                secondaryGloballyCapsPrimary: true),
+                secondaryGloballyCapsPrimary: true,
+                menuCard: ProviderMenuCardPresentation(
+                    creditsVisibility: .requiresValueOrError,
+                    supportsInlineTokenCostDashboard: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web, .cli, .oauth],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
@@ -70,6 +70,25 @@ public enum CopilotProviderDescriptor {
             pace: ProviderPaceCapability(
                 resetWindowPace: .resetDatePresent,
                 inferredMonthlyDuration: .windowDurationMissing),
+            presentation: ProviderUsagePresentation(
+                iconWindowResolver: { context in
+                    guard let id = context.secondaryOverrideWindowID,
+                          let extra = context.snapshot.extraRateWindows?.first(where: { $0.id == id })?.window
+                    else {
+                        return ProviderUsageWindowPair(
+                            primary: context.snapshot.primary,
+                            secondary: context.snapshot.secondary)
+                    }
+                    return ProviderUsageWindowPair(primary: context.snapshot.primary, secondary: extra)
+                },
+                automaticSelectionPrioritizesExhaustedWindow: false,
+                menuBarWindowResolver: { context in
+                    guard context.metric == .automatic,
+                          let primary = context.snapshot.primary,
+                          let secondary = context.snapshot.secondary
+                    else { return .unhandled }
+                    return .resolved(primary.usedPercent >= secondary.usedPercent ? primary : secondary)
+                }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [CopilotAPIFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
@@ -88,7 +88,8 @@ public enum CopilotProviderDescriptor {
                           let secondary = context.snapshot.secondary
                     else { return .unhandled }
                     return .resolved(primary.usedPercent >= secondary.usedPercent ? primary : secondary)
-                }),
+                },
+                menuCard: ProviderMenuCardPresentation(primaryDescriptionPlacement: .detailLeft)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [CopilotAPIFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Crof/CrofProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Crof/CrofProviderDescriptor.swift
@@ -45,13 +45,22 @@ public enum CrofProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Crof cost summary is not available via API." }),
-            presentation: ProviderUsagePresentation(rateWindowLabeler: { metadata, snapshot, _ in
-                ProviderRateWindowLabels(
-                    primary: Self.primaryLabel(snapshot: snapshot),
-                    secondary: metadata.weeklyLabel,
-                    tertiary: metadata.opusLabel ?? "Sonnet",
-                    showsTertiary: metadata.supportsOpus)
-            }),
+            presentation: ProviderUsagePresentation(
+                rateWindowLabeler: { metadata, snapshot, _ in
+                    ProviderRateWindowLabels(
+                        primary: Self.primaryLabel(snapshot: snapshot),
+                        secondary: metadata.weeklyLabel,
+                        tertiary: metadata.opusLabel ?? "Sonnet",
+                        showsTertiary: metadata.supportsOpus)
+                },
+                menuCard: ProviderMenuCardPresentation(
+                    primaryDescriptionPlacement: .detailBySecondaryPresence,
+                    hidesPrimaryResetWithoutSecondary: true,
+                    movePrimaryDetailToStatus: { $0?.secondary == nil }),
+                menu: ProviderMenuDescriptorPresentation(
+                    primaryDescriptionIsDetail: { $0.secondary == nil },
+                    duplicatesPrimaryDetailWhenResetDatePresent: true,
+                    secondaryDescriptionMode: .resetOverride)),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "crof",

--- a/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
@@ -76,7 +76,11 @@ public enum CursorProviderDescriptor {
                     .tertiary: [.tertiary, .secondary, .primary],
                 ],
                 automaticSelectionPrioritizesExhaustedWindow: false,
-                menuBarWindowResolver: self.menuBarWindow),
+                menuBarWindowResolver: self.menuBarWindow,
+                menuCard: ProviderMenuCardPresentation(
+                    costVisibilityResolver: { $0.showOptionalUsage },
+                    supportsInlineTokenCostDashboard: true,
+                    primaryDetailKind: .requestQuota)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .cli, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [CursorStatusFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
@@ -71,6 +71,12 @@ public enum CursorProviderDescriptor {
                 menuHintLines: [.estimate],
                 supportsTokenSnapshot: self.supportsTokenSnapshot),
             pace: ProviderPaceCapability(resetWindowPace: .windowDurationPresent),
+            presentation: ProviderUsagePresentation(
+                requestedMenuBarLaneOrders: [
+                    .tertiary: [.tertiary, .secondary, .primary],
+                ],
+                automaticSelectionPrioritizesExhaustedWindow: false,
+                menuBarWindowResolver: self.menuBarWindow),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .cli, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [CursorStatusFetchStrategy()] })),
@@ -85,6 +91,23 @@ public enum CursorProviderDescriptor {
                     false
                     #endif
                 }))
+    }
+
+    private static func menuBarWindow(
+        context: ProviderMenuBarWindowContext) -> ProviderMenuBarWindowResolution
+    {
+        guard context.metric == .automatic else { return .unhandled }
+        let total = context.snapshot.primary
+        let subquotas = [context.snapshot.secondary, context.snapshot.tertiary].compactMap(\.self)
+        let usableSubquotas = subquotas.filter { $0.remainingPercent > 0 }
+        if let total, total.remainingPercent <= 0 {
+            return .resolved(total)
+        }
+        if !subquotas.isEmpty, usableSubquotas.isEmpty {
+            return .resolved(subquotas.max(by: { $0.usedPercent < $1.usedPercent }))
+        }
+        return .resolved(([total].compactMap(\.self) + usableSubquotas)
+            .max(by: { $0.usedPercent < $1.usedPercent }))
     }
 
     private static var supportsTokenSnapshot: Bool {

--- a/Sources/CodexBarCore/Providers/DeepInfra/DeepInfraProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/DeepInfra/DeepInfraProviderDescriptor.swift
@@ -52,6 +52,12 @@ public enum DeepInfraProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "DeepInfra per-request cost history is not available in CodexBar." }),
+            presentation: ProviderUsagePresentation(
+                menuCard: ProviderMenuCardPresentation(
+                    showsPrimaryBalanceDescription: true,
+                    hidesPrimaryResetWithoutDate: true,
+                    movePrimaryDetailToStatus: { _ in true }),
+                menu: ProviderMenuDescriptorPresentation(primaryDescriptionIsDetail: { _ in true })),
             fetchPlan: .apiToken(
                 strategyID: "deepinfra.api",
                 resolveToken: { ProviderTokenResolver.deepInfraToken(environment: $0) },

--- a/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekProviderDescriptor.swift
@@ -105,6 +105,39 @@ public enum DeepSeekProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "DeepSeek per-day cost history is not available via API." }),
+            presentation: ProviderUsagePresentation(
+                menuCard: ProviderMenuCardPresentation(
+                    usageNotesResolver: { context in
+                        if context.isRefreshing {
+                            return .localized([])
+                        }
+                        let state = context.snapshot?.deepseekDetailedUsageState
+                        if context.snapshot?.primary == nil {
+                            if state == .webSessionRequired {
+                                return .localized(["Sign in to DeepSeek Platform in Chrome for detailed usage."])
+                            }
+                            if state == .profileSelectionRequired {
+                                return .localized(["Select a DeepSeek Chrome profile in Settings."])
+                            }
+                        }
+                        guard context.tokenCostInlineDashboardEnabled, context.showOptionalUsage else {
+                            return .unhandled
+                        }
+                        guard context.snapshot?.details.isEmpty == false else {
+                            if state == .webSessionRequired {
+                                return .localized(["Sign in to DeepSeek Platform in Chrome for detailed usage."])
+                            }
+                            if state == .profileSelectionRequired {
+                                return .localized(["Select a DeepSeek Chrome profile in Settings."])
+                            }
+                            return .localized(["Detailed usage unavailable."])
+                        }
+                        return .unhandled
+                    },
+                    showsPrimaryBalanceDescription: true,
+                    hidesPrimaryResetWithoutDate: true,
+                    movePrimaryDetailToStatus: { _ in true }),
+                menu: ProviderMenuDescriptorPresentation(primaryDescriptionIsDetail: { _ in true })),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Devin/DevinProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinProviderDescriptor.swift
@@ -55,17 +55,19 @@ public enum DevinProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Devin cost summary is not supported." }),
-            presentation: ProviderUsagePresentation(costPresenter: { snapshot in
-                guard let cost = snapshot.providerCost, cost.period == "Extra usage balance" else {
-                    return ProviderCostPresentation()
-                }
-                return ProviderCostPresentation(
-                    showsGenericFallback: false,
-                    balances: [ProviderCostPresentation.Balance(
-                        label: "Extra usage",
-                        amount: cost.used,
-                        currencyCode: cost.currencyCode)])
-            }),
+            presentation: ProviderUsagePresentation(
+                costPresenter: { snapshot in
+                    guard let cost = snapshot.providerCost, cost.period == "Extra usage balance" else {
+                        return ProviderCostPresentation()
+                    }
+                    return ProviderCostPresentation(
+                        showsGenericFallback: false,
+                        balances: [ProviderCostPresentation.Balance(
+                            label: "Extra usage",
+                            amount: cost.used,
+                            currencyCode: cost.currencyCode)])
+                },
+                menuCard: ProviderMenuCardPresentation(costVisibilityResolver: { $0.showOptionalUsage })),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [DevinWebFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Factory/FactoryProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryProviderDescriptor.swift
@@ -66,7 +66,8 @@ public enum FactoryProviderDescriptor {
                         showsTertiary: true)
                 },
                 iconDecorations: [.factory],
-                menuBarWindowResolver: self.secondaryFirstMenuBarWindow),
+                menuBarWindowResolver: self.secondaryFirstMenuBarWindow,
+                menuCard: ProviderMenuCardPresentation(costVisibilityResolver: { $0.showOptionalUsage })),
             fetchPlan: ProviderFetchPlan(
                 // `.cli` remains as an Auto compatibility alias for persisted configs from older builds
                 // that advertised `[.auto, .cli]` while only implementing the web strategy.

--- a/Sources/CodexBarCore/Providers/Factory/FactoryProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryProviderDescriptor.swift
@@ -50,20 +50,23 @@ public enum FactoryProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Droid cost summary is not supported." }),
-            presentation: ProviderUsagePresentation(rateWindowLabeler: { metadata, snapshot, _ in
-                guard snapshot.tertiary != nil else {
+            presentation: ProviderUsagePresentation(
+                rateWindowLabeler: { metadata, snapshot, _ in
+                    guard snapshot.tertiary != nil else {
+                        return ProviderRateWindowLabels(
+                            primary: metadata.sessionLabel,
+                            secondary: metadata.weeklyLabel,
+                            tertiary: metadata.opusLabel ?? "Sonnet",
+                            showsTertiary: metadata.supportsOpus)
+                    }
                     return ProviderRateWindowLabels(
-                        primary: metadata.sessionLabel,
-                        secondary: metadata.weeklyLabel,
-                        tertiary: metadata.opusLabel ?? "Sonnet",
-                        showsTertiary: metadata.supportsOpus)
-                }
-                return ProviderRateWindowLabels(
-                    primary: "5-hour",
-                    secondary: "Weekly",
-                    tertiary: "Monthly",
-                    showsTertiary: true)
-            }),
+                        primary: "5-hour",
+                        secondary: "Weekly",
+                        tertiary: "Monthly",
+                        showsTertiary: true)
+                },
+                iconDecorations: [.factory],
+                menuBarWindowResolver: self.secondaryFirstMenuBarWindow),
             fetchPlan: ProviderFetchPlan(
                 // `.cli` remains as an Auto compatibility alias for persisted configs from older builds
                 // that advertised `[.auto, .cli]` while only implementing the web strategy.
@@ -76,6 +79,16 @@ public enum FactoryProviderDescriptor {
                     guard sourceMode == .auto || sourceMode == .cli else { return false }
                     return environment.map { FactorySettingsReader.apiKey(environment: $0) != nil } == true
                 }))
+    }
+
+    private static func secondaryFirstMenuBarWindow(
+        context: ProviderMenuBarWindowContext) -> ProviderMenuBarWindowResolution
+    {
+        guard context.metric == .automatic else { return .unhandled }
+        return .resolved(
+            ProviderUsagePresentation.exhausted(context.snapshot.primary, context.snapshot.secondary)
+                ?? context.snapshot.secondary
+                ?? context.snapshot.primary)
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiProviderDescriptor.swift
@@ -46,13 +46,15 @@ public enum GeminiProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Gemini cost summary is not supported." }),
-            presentation: ProviderUsagePresentation(identityPresenter: { provider, snapshot in
-                guard let plan = snapshot.loginMethod(for: provider), !plan.isEmpty else {
-                    return ProviderIdentityPresentation(badge: nil, plan: nil)
-                }
-                let display = UsageFormatter.cleanPlanName(plan)
-                return ProviderIdentityPresentation(badge: display, plan: display)
-            }),
+            presentation: ProviderUsagePresentation(
+                identityPresenter: { provider, snapshot in
+                    guard let plan = snapshot.loginMethod(for: provider), !plan.isEmpty else {
+                        return ProviderIdentityPresentation(badge: nil, plan: nil)
+                    }
+                    let display = UsageFormatter.cleanPlanName(plan)
+                    return ProviderIdentityPresentation(badge: display, plan: display)
+                },
+                iconDecorations: [.gemini]),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [GeminiStatusFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
@@ -61,25 +61,32 @@ public enum KiloProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Kilo cost summary is not supported." }),
-            presentation: ProviderUsagePresentation(identityPresenter: { provider, snapshot in
-                guard let loginMethod = snapshot.loginMethod(for: provider) else {
-                    return ProviderIdentityPresentation(badge: nil, plan: nil)
-                }
-                let parts = loginMethod
-                    .components(separatedBy: "·")
-                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                    .filter { !$0.isEmpty }
-                guard let first = parts.first else {
-                    return ProviderIdentityPresentation(badge: nil, plan: nil)
-                }
-                let firstIsActivity = first.lowercased().hasPrefix("auto top-up:")
-                let plan = firstIsActivity ? nil : UsageFormatter.cleanPlanName(first)
-                let activity = firstIsActivity ? parts : Array(parts.dropFirst())
-                return ProviderIdentityPresentation(
-                    badge: plan,
-                    plan: plan,
-                    details: activity.map { ProviderIdentityPresentation.Detail(label: "Activity", value: $0) })
-            }),
+            presentation: ProviderUsagePresentation(
+                identityPresenter: { provider, snapshot in
+                    guard let loginMethod = snapshot.loginMethod(for: provider) else {
+                        return ProviderIdentityPresentation(badge: nil, plan: nil)
+                    }
+                    let parts = loginMethod
+                        .components(separatedBy: "·")
+                        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                        .filter { !$0.isEmpty }
+                    guard let first = parts.first else {
+                        return ProviderIdentityPresentation(badge: nil, plan: nil)
+                    }
+                    let firstIsActivity = first.lowercased().hasPrefix("auto top-up:")
+                    let plan = firstIsActivity ? nil : UsageFormatter.cleanPlanName(first)
+                    let activity = firstIsActivity ? parts : Array(parts.dropFirst())
+                    return ProviderIdentityPresentation(
+                        badge: plan,
+                        plan: plan,
+                        details: activity.map { ProviderIdentityPresentation.Detail(label: "Activity", value: $0) })
+                },
+                menuCard: ProviderMenuCardPresentation(
+                    showsPrimaryBalanceDescription: true,
+                    hidesPrimaryResetWithoutDate: true),
+                menu: ProviderMenuDescriptorPresentation(
+                    primaryDescriptionIsDetail: { _ in true },
+                    secondaryDescriptionMode: .detailWhenResetDatePresent)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .cli],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -71,7 +71,28 @@ public enum KimiProviderDescriptor {
                 resetWindowPace: .windowDuration(minutes: self.weeklyWindowMinutes),
                 primary: .exact(kind: .weekly, minutes: self.weeklyWindowMinutes),
                 secondary: .exact(kind: .session, minutes: self.sessionWindowMinutes),
-                tertiary: .exact(kind: .session, minutes: self.sessionWindowMinutes)),
+                tertiary: .exact(kind: .session, minutes: self.sessionWindowMinutes),
+                sessionPaceWindowRule: .windowDuration(minutes: self.sessionWindowMinutes)),
+            presentation: ProviderUsagePresentation(
+                semanticWindowResolver: { snapshot in
+                    let candidates = [snapshot.primary, snapshot.secondary, snapshot.tertiary]
+                        + (snapshot.extraRateWindows ?? []).map(\.window)
+                    let usable = candidates.compactMap { window -> RateWindow? in
+                        guard let window, !window.isSyntheticPlaceholder else { return nil }
+                        return window
+                    }
+                    let session = usable.first { window in
+                        guard let minutes = window.windowMinutes else { return false }
+                        return (60...(12 * 60)).contains(minutes)
+                    }
+                    let cadenceWeekly = usable.first { $0.windowMinutes == 7 * 24 * 60 }
+                    let primary = snapshot.primary.flatMap { $0.isSyntheticPlaceholder ? nil : $0 }
+                    return ProviderSemanticWindows(session: session, weekly: primary ?? cadenceWeekly)
+                },
+                primarySemanticWindow: .weekly,
+                secondarySemanticWindow: .session,
+                menuBarWindowResolver: self.menuBarWindow,
+                widgetRowLimitResolver: { _, _ in 3 }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
@@ -86,6 +107,16 @@ public enum KimiProviderDescriptor {
                             KimiSettingsReader.hasKimiCodeCredential(environment: environment)
                     } == true
                 }))
+    }
+
+    private static func menuBarWindow(
+        context: ProviderMenuBarWindowContext) -> ProviderMenuBarWindowResolution
+    {
+        guard context.metric == .automatic else { return .unhandled }
+        return .resolved(
+            ProviderUsagePresentation.exhausted(context.snapshot.primary, context.snapshot.secondary)
+                ?? context.snapshot.secondary
+                ?? context.snapshot.primary)
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -92,7 +92,8 @@ public enum KimiProviderDescriptor {
                 primarySemanticWindow: .weekly,
                 secondarySemanticWindow: .session,
                 menuBarWindowResolver: self.menuBarWindow,
-                widgetRowLimitResolver: { _, _ in 3 }),
+                widgetRowLimitResolver: { _, _ in 3 },
+                menuCard: ProviderMenuCardPresentation(resetWindowUsesWeeklyPace: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Kiro/KiroProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroProviderDescriptor.swift
@@ -37,6 +37,8 @@ public enum KiroProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Kiro cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                primaryDetailKind: .kiroCredits)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .cli],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [KiroCLIFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMProviderDescriptor.swift
@@ -49,6 +49,13 @@ public enum LiteLLMProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "LiteLLM spend is reported by the provider API." }),
+            presentation: ProviderUsagePresentation(menuBarWindowResolver: { context in
+                guard context.metric == .automatic else { return .unhandled }
+                return .resolved(
+                    ProviderUsagePresentation.exhausted(context.snapshot.primary, context.snapshot.secondary)
+                        ?? context.snapshot.secondary
+                        ?? context.snapshot.primary)
+            }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [LiteLLMAPIFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMProviderDescriptor.swift
@@ -49,13 +49,17 @@ public enum LiteLLMProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "LiteLLM spend is reported by the provider API." }),
-            presentation: ProviderUsagePresentation(menuBarWindowResolver: { context in
-                guard context.metric == .automatic else { return .unhandled }
-                return .resolved(
-                    ProviderUsagePresentation.exhausted(context.snapshot.primary, context.snapshot.secondary)
-                        ?? context.snapshot.secondary
-                        ?? context.snapshot.primary)
-            }),
+            presentation: ProviderUsagePresentation(
+                menuBarWindowResolver: { context in
+                    guard context.metric == .automatic else { return .unhandled }
+                    return .resolved(
+                        ProviderUsagePresentation.exhausted(context.snapshot.primary, context.snapshot.secondary)
+                            ?? context.snapshot.secondary
+                            ?? context.snapshot.primary)
+                },
+                menuCard: ProviderMenuCardPresentation(
+                    showsPrimaryBalanceDescription: true,
+                    hidesPrimaryResetWithoutDate: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [LiteLLMAPIFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Manus/ManusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Manus/ManusProviderDescriptor.swift
@@ -51,6 +51,9 @@ public enum ManusProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Manus cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                showsPrimaryBalanceDescription: true,
+                clearsPrimaryReset: true)),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "manus",

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
@@ -49,17 +49,22 @@ public enum MiMoProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Xiaomi MiMo cost summary is not supported." }),
             pace: .calendarMonthResetWindow,
-            presentation: ProviderUsagePresentation(identityPresenter: { provider, snapshot in
-                let balance = snapshot.detailRow(label: "Balance")?.value
-                guard let plan = snapshot.loginMethod(for: provider),
-                      !plan.isEmpty,
-                      !plan.localizedCaseInsensitiveContains("balance:")
-                else {
-                    return ProviderIdentityPresentation(badge: balance, plan: nil)
-                }
-                let display = UsageFormatter.cleanPlanName(plan)
-                return ProviderIdentityPresentation(badge: balance ?? display, plan: display)
-            }),
+            presentation: ProviderUsagePresentation(
+                identityPresenter: { provider, snapshot in
+                    let balance = snapshot.detailRow(label: "Balance")?.value
+                    guard let plan = snapshot.loginMethod(for: provider),
+                          !plan.isEmpty,
+                          !plan.localizedCaseInsensitiveContains("balance:")
+                    else {
+                        return ProviderIdentityPresentation(badge: balance, plan: nil)
+                    }
+                    let display = UsageFormatter.cleanPlanName(plan)
+                    return ProviderIdentityPresentation(badge: balance ?? display, plan: display)
+                },
+                menuCard: ProviderMenuCardPresentation(
+                    showsPrimaryBalanceDescription: true,
+                    hidesPrimaryResetWithoutDate: true),
+                menu: ProviderMenuDescriptorPresentation(primaryDescriptionIsDetail: { _ in true })),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { context in

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
@@ -92,6 +92,15 @@ public enum MiniMaxProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "MiniMax cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(
+                automaticSelectionPrioritizesExhaustedWindow: false,
+                menuBarWindowResolver: { context in
+                    guard context.metric == .automatic else { return .unhandled }
+                    return .resolved(ProviderUsagePresentation.mostConstrained(
+                        context.snapshot.primary,
+                        context.snapshot.secondary,
+                        context.snapshot.tertiary))
+                }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -64,7 +64,16 @@ public enum MistralProviderDescriptor {
                 return .resolved(context.snapshot.extraRateWindows?.first {
                     $0.id == "mistral-monthly-plan"
                 }?.window)
-            }),
+            }, menuCard: ProviderMenuCardPresentation(
+                usesProviderCostHistoryAsPrimaryDashboard: true,
+                primaryCostHistoryResolver: { snapshot, tokenSnapshot in
+                    if let projected = snapshot?.mistralUsage?.toCostUsageTokenSnapshot() {
+                        return projected
+                    }
+                    return snapshot == nil ? tokenSnapshot : nil
+                },
+                showsPrimaryBalanceDescription: true,
+                hidesPrimaryResetWithoutDate: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [MistralWebFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -59,6 +59,12 @@ public enum MistralProviderDescriptor {
                 supportsTokenCost: true,
                 noDataMessage: { "Mistral cost history needs a billing web session." },
                 menuHintLines: [.literal("Reported by Mistral billing usage.")]),
+            presentation: ProviderUsagePresentation(menuBarWindowResolver: { context in
+                guard context.metric == .monthlyPlan else { return .unhandled }
+                return .resolved(context.snapshot.extraRateWindows?.first {
+                    $0.id == "mistral-monthly-plan"
+                }?.window)
+            }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [MistralWebFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/NeuralWatt/NeuralWattProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/NeuralWatt/NeuralWattProviderDescriptor.swift
@@ -52,6 +52,11 @@ public enum NeuralWattProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Neuralwatt token cost history is not available via the quota API." }),
+            presentation: ProviderUsagePresentation(
+                menuCard: ProviderMenuCardPresentation(
+                    showsPrimaryBalanceDescription: true,
+                    hidesPrimaryResetWithoutDate: true),
+                menu: ProviderMenuDescriptorPresentation(primaryDescriptionIsDetail: { _ in true })),
             fetchPlan: .apiToken(
                 strategyID: "neuralwatt.api",
                 resolveToken: { ProviderTokenResolver.neuralWattToken(environment: $0) },

--- a/Sources/CodexBarCore/Providers/Notion/NotionProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Notion/NotionProviderDescriptor.swift
@@ -75,7 +75,11 @@ public enum NotionProviderDescriptor {
                 resetWindowPace: .windowDuration(minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
                 inferredMonthlyDuration: .windowDuration(
                     minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
-                primary: .session(maximumMinutes: self.rollingWindowMaxMinutes)),
+                primary: .session(maximumMinutes: self.rollingWindowMaxMinutes),
+                sessionPaceWindowRule: .custom { window, _ in
+                    guard let minutes = window.windowMinutes else { return false }
+                    return minutes <= Self.rollingWindowMaxMinutes
+                }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [NotionWebFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -56,6 +56,13 @@ public enum OllamaProviderDescriptor {
                 primary: .session(maximumMinutes: 300, requiresDuration: true),
                 secondary: .weeklyWithDuration,
                 sessionPaceWindowRule: .windowDurationPresent),
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                usageNotesResolver: { context in
+                    guard context.snapshot?.identity?.loginMethod == "API key" else { return .unhandled }
+                    return .localized([
+                        "API key verified. Cloud quotas need browser cookies. Sign in to Ollama.",
+                    ])
+                })),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -54,7 +54,8 @@ public enum OllamaProviderDescriptor {
                 noDataMessage: { "Ollama cost summary is not supported." }),
             pace: ProviderPaceCapability(
                 primary: .session(maximumMinutes: 300, requiresDuration: true),
-                secondary: .weeklyWithDuration),
+                secondary: .weeklyWithDuration,
+                sessionPaceWindowRule: .windowDurationPresent),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIProviderDescriptor.swift
@@ -51,6 +51,18 @@ public enum OpenAIAPIProviderDescriptor {
                 supportsTokenCost: true,
                 noDataMessage: { "OpenAI usage needs an Admin API key for organization usage." },
                 menuHintLines: [.literal("Reported by OpenAI Admin API organization usage.")]),
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                usageNotesResolver: { context in
+                    context.snapshot?.openAIAPIUsage.map(ProviderUsageNotesResolution.openAIAPI) ?? .unhandled
+                },
+                costVisibilityResolver: { $0.snapshot?.openAIAPIUsage == nil },
+                usesProviderCostHistoryAsPrimaryDashboard: true,
+                primaryCostHistoryResolver: { snapshot, tokenSnapshot in
+                    if let projected = snapshot?.openAIAPIUsage?.toCostUsageTokenSnapshot() {
+                        return projected
+                    }
+                    return snapshot == nil ? tokenSnapshot : nil
+                })),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "openai",

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -62,19 +62,28 @@ public enum OpenCodeGoProviderDescriptor {
                 }),
             pace: .calendarMonthResetWindow,
             history: .alwaysTracked,
-            presentation: ProviderUsagePresentation(planUtilizationSeriesResolver: { snapshot in
-                var series: Set<ProviderPlanUtilizationSeries> = []
-                if snapshot.primary != nil {
-                    series.insert(.session)
-                }
-                if snapshot.secondary != nil {
-                    series.insert(.weekly)
-                }
-                if snapshot.tertiary != nil {
-                    series.insert(.monthly)
-                }
-                return series
-            }),
+            presentation: ProviderUsagePresentation(
+                planUtilizationSeriesResolver: { snapshot in
+                    var series: Set<ProviderPlanUtilizationSeries> = []
+                    if snapshot.primary != nil {
+                        series.insert(.session)
+                    }
+                    if snapshot.secondary != nil {
+                        series.insert(.weekly)
+                    }
+                    if snapshot.tertiary != nil {
+                        series.insert(.monthly)
+                    }
+                    return series
+                },
+                menuCard: ProviderMenuCardPresentation(
+                    costVisibilityResolver: { context in
+                        context.showOptionalUsage ||
+                            (context.snapshot?.primary == nil &&
+                                context.snapshot?.secondary == nil &&
+                                context.snapshot?.providerCost?.period == "Zen balance")
+                    },
+                    supportsInlineTokenCostDashboard: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -62,6 +62,19 @@ public enum OpenCodeGoProviderDescriptor {
                 }),
             pace: .calendarMonthResetWindow,
             history: .alwaysTracked,
+            presentation: ProviderUsagePresentation(planUtilizationSeriesResolver: { snapshot in
+                var series: Set<ProviderPlanUtilizationSeries> = []
+                if snapshot.primary != nil {
+                    series.insert(.session)
+                }
+                if snapshot.secondary != nil {
+                    series.insert(.weekly)
+                }
+                if snapshot.tertiary != nil {
+                    series.insert(.monthly)
+                }
+                return series
+            }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterProviderDescriptor.swift
@@ -64,6 +64,9 @@ public enum OpenRouterProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "OpenRouter cost summary is not yet supported." }),
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                showsCreditsSection: false,
+                primaryDescriptionPlacement: .reset)),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "openrouter",

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift
@@ -56,6 +56,21 @@ public enum PerplexityProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Perplexity cost tracking is not supported." }),
+            presentation: ProviderUsagePresentation(
+                iconWindowResolver: { context in
+                    let windows = context.snapshot.orderedPerplexityDisplayWindows()
+                    return ProviderUsageWindowPair(primary: windows.first, secondary: windows.dropFirst().first)
+                },
+                requestedMenuBarLaneOrders: [
+                    .primary: [.primary, .secondary, .tertiary],
+                    .secondary: [.secondary, .tertiary, .primary],
+                    .tertiary: [.tertiary, .secondary, .primary],
+                ],
+                automaticSelectionPrioritizesExhaustedWindow: false,
+                menuBarWindowResolver: { context in
+                    guard context.metric == .automatic else { return .unhandled }
+                    return .resolved(context.snapshot.automaticPerplexityWindow())
+                }),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "perplexity",

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift
@@ -70,7 +70,10 @@ public enum PerplexityProviderDescriptor {
                 menuBarWindowResolver: { context in
                     guard context.metric == .automatic else { return .unhandled }
                     return .resolved(context.snapshot.automaticPerplexityWindow())
-                }),
+                },
+                menu: ProviderMenuDescriptorPresentation(
+                    secondaryDescriptionMode: .resetOverride,
+                    tertiaryDescriptionOverridesReset: true)),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "perplexity",

--- a/Sources/CodexBarCore/Providers/Poe/PoeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Poe/PoeProviderDescriptor.swift
@@ -42,6 +42,8 @@ public enum PoeProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Poe usage history is unavailable." }),
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                primaryDetailKind: .poeBalance)),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "poe",

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -180,6 +180,7 @@ public struct ProviderPaceCapability: Sendable {
     public let secondary: ProviderStandardPaceLane?
     public let tertiary: ProviderStandardPaceLane?
     public let showsHeadroomHint: Bool
+    public let sessionPaceWindowRule: ProviderPaceWindowRule
 
     public init(
         resetWindowPace: ProviderPaceWindowRule = .unsupported,
@@ -187,7 +188,8 @@ public struct ProviderPaceCapability: Sendable {
         primary: ProviderStandardPaceLane? = nil,
         secondary: ProviderStandardPaceLane? = nil,
         tertiary: ProviderStandardPaceLane? = nil,
-        showsHeadroomHint: Bool = false)
+        showsHeadroomHint: Bool = false,
+        sessionPaceWindowRule: ProviderPaceWindowRule = .unsupported)
     {
         self.resetWindowPace = resetWindowPace
         self.inferredMonthlyDuration = inferredMonthlyDuration
@@ -195,6 +197,7 @@ public struct ProviderPaceCapability: Sendable {
         self.secondary = secondary
         self.tertiary = tertiary
         self.showsHeadroomHint = showsHeadroomHint
+        self.sessionPaceWindowRule = sessionPaceWindowRule
     }
 
     public func supportsResetWindowPace(window: RateWindow, now: Date) -> Bool {
@@ -230,6 +233,10 @@ public struct ProviderPaceCapability: Sendable {
         }
         guard let lane, lane.windowRule.matches(window: window, now: now) else { return nil }
         return lane.kind
+    }
+
+    public func supportsSessionPace(window: RateWindow, now: Date) -> Bool {
+        self.sessionPaceWindowRule.matches(window: window, now: now)
     }
 
     private static func inferredMonthlyWindowMinutes(endingAt resetsAt: Date) -> Int? {

--- a/Sources/CodexBarCore/Providers/ProviderUsagePresentation.swift
+++ b/Sources/CodexBarCore/Providers/ProviderUsagePresentation.swift
@@ -155,6 +155,184 @@ public enum ProviderWidgetFamily: Sendable {
     case medium
 }
 
+public struct ProviderUsageNotesContext: Sendable {
+    public let snapshot: UsageSnapshot?
+    public let isRefreshing: Bool
+    public let tokenCostInlineDashboardEnabled: Bool
+    public let showOptionalUsage: Bool
+
+    public init(
+        snapshot: UsageSnapshot?,
+        isRefreshing: Bool,
+        tokenCostInlineDashboardEnabled: Bool,
+        showOptionalUsage: Bool)
+    {
+        self.snapshot = snapshot
+        self.isRefreshing = isRefreshing
+        self.tokenCostInlineDashboardEnabled = tokenCostInlineDashboardEnabled
+        self.showOptionalUsage = showOptionalUsage
+    }
+}
+
+public enum ProviderUsageNotesResolution: Sendable {
+    case unhandled
+    case openAIAPI(OpenAIAPIUsageSnapshot)
+    case localized([String])
+}
+
+public enum ProviderCreditsVisibility: Sendable, Equatable {
+    case standard
+    case requiresValueOrError
+    case hiddenWhenUsageSnapshotPresent
+    case hidden
+}
+
+public struct ProviderCostVisibilityContext: Sendable {
+    public let snapshot: UsageSnapshot?
+    public let showOptionalUsage: Bool
+
+    public init(snapshot: UsageSnapshot?, showOptionalUsage: Bool) {
+        self.snapshot = snapshot
+        self.showOptionalUsage = showOptionalUsage
+    }
+}
+
+public enum ProviderPrimaryDescriptionPlacement: Sendable {
+    case standard
+    case reset
+    case detail
+    case detailLeft
+    case detailBySecondaryPresence
+}
+
+public enum ProviderPrimaryDetailKind: Sendable {
+    case none
+    case poeBalance
+    case kiroCredits
+    case requestQuota
+}
+
+public struct ProviderMenuCardPresentation: Sendable {
+    public typealias UsageNotesResolver = @Sendable (ProviderUsageNotesContext) -> ProviderUsageNotesResolution
+    public typealias CostVisibilityResolver = @Sendable (ProviderCostVisibilityContext) -> Bool
+    public typealias SnapshotPredicate = @Sendable (_ snapshot: UsageSnapshot?) -> Bool
+    public typealias PrimaryCostHistoryResolver = @Sendable (
+        _ snapshot: UsageSnapshot?,
+        _ tokenSnapshot: CostUsageTokenSnapshot?) -> CostUsageTokenSnapshot?
+
+    private let usageNotesResolver: UsageNotesResolver
+    private let costVisibilityResolver: CostVisibilityResolver
+    private let movePrimaryDetailToStatus: SnapshotPredicate
+    private let primaryCostHistoryResolver: PrimaryCostHistoryResolver
+    public let creditsVisibility: ProviderCreditsVisibility
+    public let showsCreditsSection: Bool
+    public let usesProviderCostHistoryAsPrimaryDashboard: Bool
+    public let supportsInlineTokenCostDashboard: Bool
+    public let primaryDescriptionPlacement: ProviderPrimaryDescriptionPlacement
+    public let showsPrimaryBalanceDescription: Bool
+    public let hidesPrimaryResetWithoutDate: Bool
+    public let hidesPrimaryResetWithoutSecondary: Bool
+    public let clearsPrimaryReset: Bool
+    public let primaryDetailKind: ProviderPrimaryDetailKind
+    public let usesAbacusPace: Bool
+    public let usesSyntheticRollingRegen: Bool
+    public let usesRawPrimaryResetDescription: Bool
+    public let resetWindowUsesWeeklyPace: Bool
+
+    public init(
+        usageNotesResolver: @escaping UsageNotesResolver = { _ in .unhandled },
+        creditsVisibility: ProviderCreditsVisibility = .standard,
+        showsCreditsSection: Bool = true,
+        costVisibilityResolver: @escaping CostVisibilityResolver = { _ in true },
+        usesProviderCostHistoryAsPrimaryDashboard: Bool = false,
+        primaryCostHistoryResolver: @escaping PrimaryCostHistoryResolver = { _, tokenSnapshot in tokenSnapshot },
+        supportsInlineTokenCostDashboard: Bool = false,
+        primaryDescriptionPlacement: ProviderPrimaryDescriptionPlacement = .standard,
+        showsPrimaryBalanceDescription: Bool = false,
+        hidesPrimaryResetWithoutDate: Bool = false,
+        hidesPrimaryResetWithoutSecondary: Bool = false,
+        clearsPrimaryReset: Bool = false,
+        movePrimaryDetailToStatus: @escaping SnapshotPredicate = { _ in false },
+        primaryDetailKind: ProviderPrimaryDetailKind = .none,
+        usesAbacusPace: Bool = false,
+        usesSyntheticRollingRegen: Bool = false,
+        usesRawPrimaryResetDescription: Bool = false,
+        resetWindowUsesWeeklyPace: Bool = false)
+    {
+        self.usageNotesResolver = usageNotesResolver
+        self.creditsVisibility = creditsVisibility
+        self.showsCreditsSection = showsCreditsSection
+        self.costVisibilityResolver = costVisibilityResolver
+        self.usesProviderCostHistoryAsPrimaryDashboard = usesProviderCostHistoryAsPrimaryDashboard
+        self.primaryCostHistoryResolver = primaryCostHistoryResolver
+        self.supportsInlineTokenCostDashboard = supportsInlineTokenCostDashboard
+        self.primaryDescriptionPlacement = primaryDescriptionPlacement
+        self.showsPrimaryBalanceDescription = showsPrimaryBalanceDescription
+        self.hidesPrimaryResetWithoutDate = hidesPrimaryResetWithoutDate
+        self.hidesPrimaryResetWithoutSecondary = hidesPrimaryResetWithoutSecondary
+        self.clearsPrimaryReset = clearsPrimaryReset
+        self.movePrimaryDetailToStatus = movePrimaryDetailToStatus
+        self.primaryDetailKind = primaryDetailKind
+        self.usesAbacusPace = usesAbacusPace
+        self.usesSyntheticRollingRegen = usesSyntheticRollingRegen
+        self.usesRawPrimaryResetDescription = usesRawPrimaryResetDescription
+        self.resetWindowUsesWeeklyPace = resetWindowUsesWeeklyPace
+    }
+
+    public func usageNotes(context: ProviderUsageNotesContext) -> ProviderUsageNotesResolution {
+        self.usageNotesResolver(context)
+    }
+
+    public func showsProviderCost(context: ProviderCostVisibilityContext) -> Bool {
+        self.costVisibilityResolver(context)
+    }
+
+    public func movesPrimaryDetailToStatus(snapshot: UsageSnapshot?) -> Bool {
+        self.movePrimaryDetailToStatus(snapshot)
+    }
+
+    public func primaryCostHistory(
+        snapshot: UsageSnapshot?,
+        tokenSnapshot: CostUsageTokenSnapshot?) -> CostUsageTokenSnapshot?
+    {
+        self.primaryCostHistoryResolver(snapshot, tokenSnapshot)
+    }
+}
+
+public enum ProviderSecondaryDescriptionMode: Sendable, Equatable {
+    case standard
+    case resetOverride
+    case detailWhenResetDatePresent
+}
+
+public struct ProviderMenuDescriptorPresentation: Sendable {
+    public typealias SnapshotPredicate = @Sendable (_ snapshot: UsageSnapshot) -> Bool
+
+    private let primaryDescriptionIsDetail: SnapshotPredicate
+    public let duplicatesPrimaryDetailWhenResetDatePresent: Bool
+    public let showsPrimaryWeeklyPace: Bool
+    public let secondaryDescriptionMode: ProviderSecondaryDescriptionMode
+    public let tertiaryDescriptionOverridesReset: Bool
+
+    public init(
+        primaryDescriptionIsDetail: @escaping SnapshotPredicate = { _ in false },
+        duplicatesPrimaryDetailWhenResetDatePresent: Bool = false,
+        showsPrimaryWeeklyPace: Bool = false,
+        secondaryDescriptionMode: ProviderSecondaryDescriptionMode = .standard,
+        tertiaryDescriptionOverridesReset: Bool = false)
+    {
+        self.primaryDescriptionIsDetail = primaryDescriptionIsDetail
+        self.duplicatesPrimaryDetailWhenResetDatePresent = duplicatesPrimaryDetailWhenResetDatePresent
+        self.showsPrimaryWeeklyPace = showsPrimaryWeeklyPace
+        self.secondaryDescriptionMode = secondaryDescriptionMode
+        self.tertiaryDescriptionOverridesReset = tertiaryDescriptionOverridesReset
+    }
+
+    public func usesPrimaryDescriptionAsDetail(snapshot: UsageSnapshot) -> Bool {
+        self.primaryDescriptionIsDetail(snapshot)
+    }
+}
+
 public struct ProviderUsagePresentation: Sendable {
     public typealias RateWindowLabeler = @Sendable (
         _ metadata: ProviderMetadata,
@@ -197,6 +375,8 @@ public struct ProviderUsagePresentation: Sendable {
     public let requestedMenuBarLaneOrders: [ProviderMenuBarMetric: [ProviderUsageLane]]
     public let automaticSelectionPrioritizesExhaustedWindow: Bool
     public let secondaryGloballyCapsPrimary: Bool
+    public let menuCard: ProviderMenuCardPresentation
+    public let menu: ProviderMenuDescriptorPresentation
 
     public init(
         rateWindowLabeler: RateWindowLabeler? = nil,
@@ -218,7 +398,9 @@ public struct ProviderUsagePresentation: Sendable {
         planUtilizationSeriesResolver: @escaping PlanUtilizationSeriesResolver = Self.standardPlanUtilizationSeries,
         planUtilizationSeriesNormalizer: @escaping PlanUtilizationSeriesNormalizer = { series, _ in series },
         widgetRowLimitResolver: @escaping WidgetRowLimitResolver = { _, _ in nil },
-        secondaryGloballyCapsPrimary: Bool = false)
+        secondaryGloballyCapsPrimary: Bool = false,
+        menuCard: ProviderMenuCardPresentation = ProviderMenuCardPresentation(),
+        menu: ProviderMenuDescriptorPresentation = ProviderMenuDescriptorPresentation())
     {
         self.rateWindowLabeler = rateWindowLabeler
         self.identityPresenter = identityPresenter
@@ -238,6 +420,8 @@ public struct ProviderUsagePresentation: Sendable {
         self.planUtilizationSeriesNormalizer = planUtilizationSeriesNormalizer
         self.widgetRowLimitResolver = widgetRowLimitResolver
         self.secondaryGloballyCapsPrimary = secondaryGloballyCapsPrimary
+        self.menuCard = menuCard
+        self.menu = menu
     }
 
     public func rateWindowLabels(

--- a/Sources/CodexBarCore/Providers/ProviderUsagePresentation.swift
+++ b/Sources/CodexBarCore/Providers/ProviderUsagePresentation.swift
@@ -58,6 +58,103 @@ public struct ProviderCostPresentation: Sendable, Equatable {
     }
 }
 
+public enum ProviderUsageLane: Sendable, Hashable {
+    case primary
+    case secondary
+    case tertiary
+}
+
+public enum ProviderSemanticWindow: Sendable, Equatable {
+    case session
+    case weekly
+}
+
+public struct ProviderSemanticWindows: Sendable, Equatable {
+    public let session: RateWindow?
+    public let weekly: RateWindow?
+
+    public init(session: RateWindow?, weekly: RateWindow?) {
+        self.session = session
+        self.weekly = weekly
+    }
+}
+
+public struct ProviderUsageWindowPair: Sendable, Equatable {
+    public let primary: RateWindow?
+    public let secondary: RateWindow?
+
+    public init(primary: RateWindow?, secondary: RateWindow?) {
+        self.primary = primary
+        self.secondary = secondary
+    }
+}
+
+public struct ProviderIconDecorations: OptionSet, Sendable {
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    public static let face = Self(rawValue: 1 << 0)
+    public static let notches = Self(rawValue: 1 << 1)
+    public static let gemini = Self(rawValue: 1 << 2)
+    public static let antigravity = Self(rawValue: 1 << 3)
+    public static let factory = Self(rawValue: 1 << 4)
+    public static let warp = Self(rawValue: 1 << 5)
+}
+
+public struct ProviderIconWindowContext: Sendable {
+    public let snapshot: UsageSnapshot
+    public let secondaryOverrideWindowID: String?
+    public let now: Date
+
+    public init(snapshot: UsageSnapshot, secondaryOverrideWindowID: String?, now: Date) {
+        self.snapshot = snapshot
+        self.secondaryOverrideWindowID = secondaryOverrideWindowID
+        self.now = now
+    }
+}
+
+public struct ProviderMenuBarWindowContext: Sendable {
+    public let metric: ProviderMenuBarMetric
+    public let snapshot: UsageSnapshot
+    public let supportsAverage: Bool
+    public let prioritizesExhaustedQuotas: Bool
+    public let now: Date
+
+    public init(
+        metric: ProviderMenuBarMetric,
+        snapshot: UsageSnapshot,
+        supportsAverage: Bool,
+        prioritizesExhaustedQuotas: Bool,
+        now: Date)
+    {
+        self.metric = metric
+        self.snapshot = snapshot
+        self.supportsAverage = supportsAverage
+        self.prioritizesExhaustedQuotas = prioritizesExhaustedQuotas
+        self.now = now
+    }
+}
+
+public enum ProviderMenuBarWindowResolution: Sendable {
+    case unhandled
+    case resolved(RateWindow?)
+}
+
+public enum ProviderPlanUtilizationSeries: Sendable, Hashable {
+    case session
+    case weekly
+    case tertiary
+    case monthly
+}
+
+public enum ProviderWidgetFamily: Sendable {
+    case small
+    case medium
+}
+
 public struct ProviderUsagePresentation: Sendable {
     public typealias RateWindowLabeler = @Sendable (
         _ metadata: ProviderMetadata,
@@ -69,25 +166,78 @@ public struct ProviderUsagePresentation: Sendable {
     public typealias CostPresenter = @Sendable (_ snapshot: UsageSnapshot) -> ProviderCostPresentation
     public typealias ExtraRateWindowSelector = @Sendable (_ snapshot: UsageSnapshot) -> [NamedRateWindow]
     public typealias CreditResolver = @Sendable (_ credits: CreditsSnapshot) -> Double?
+    public typealias IconWindowResolver = @Sendable (ProviderIconWindowContext) -> ProviderUsageWindowPair
+    public typealias SemanticWindowResolver = @Sendable (_ snapshot: UsageSnapshot) -> ProviderSemanticWindows
+    public typealias MenuBarWindowResolver = @Sendable (
+        ProviderMenuBarWindowContext) -> ProviderMenuBarWindowResolution
+    public typealias PlanUtilizationSeriesResolver = @Sendable (
+        _ snapshot: UsageSnapshot) -> Set<ProviderPlanUtilizationSeries>?
+    public typealias PlanUtilizationSeriesNormalizer = @Sendable (
+        _ series: ProviderPlanUtilizationSeries,
+        _ windowMinutes: Int) -> ProviderPlanUtilizationSeries
+    public typealias WidgetRowLimitResolver = @Sendable (
+        _ rows: [WidgetSnapshot.WidgetUsageRowSnapshot]?,
+        _ family: ProviderWidgetFamily) -> Int?
 
     private let rateWindowLabeler: RateWindowLabeler?
     private let identityPresenter: IdentityPresenter?
     private let costPresenter: CostPresenter
     private let extraRateWindowSelector: ExtraRateWindowSelector
     private let creditResolver: CreditResolver?
+    private let iconWindowResolver: IconWindowResolver
+    private let semanticWindowResolver: SemanticWindowResolver
+    private let menuBarWindowResolver: MenuBarWindowResolver
+    private let planUtilizationSeriesResolver: PlanUtilizationSeriesResolver
+    private let planUtilizationSeriesNormalizer: PlanUtilizationSeriesNormalizer
+    private let widgetRowLimitResolver: WidgetRowLimitResolver
+    public let iconDecorations: ProviderIconDecorations
+    public let treatsExhaustedSecondaryIconWindowAsMissing: Bool
+    public let primarySemanticWindow: ProviderSemanticWindow
+    public let secondarySemanticWindow: ProviderSemanticWindow
+    public let requestedMenuBarLaneOrders: [ProviderMenuBarMetric: [ProviderUsageLane]]
+    public let automaticSelectionPrioritizesExhaustedWindow: Bool
+    public let secondaryGloballyCapsPrimary: Bool
 
     public init(
         rateWindowLabeler: RateWindowLabeler? = nil,
         identityPresenter: IdentityPresenter? = nil,
         costPresenter: @escaping CostPresenter = { _ in ProviderCostPresentation() },
         extraRateWindowSelector: @escaping ExtraRateWindowSelector = { _ in [] },
-        creditResolver: CreditResolver? = nil)
+        creditResolver: CreditResolver? = nil,
+        iconWindowResolver: @escaping IconWindowResolver = { context in
+            ProviderUsageWindowPair(primary: context.snapshot.primary, secondary: context.snapshot.secondary)
+        },
+        iconDecorations: ProviderIconDecorations = [],
+        treatsExhaustedSecondaryIconWindowAsMissing: Bool = false,
+        semanticWindowResolver: @escaping SemanticWindowResolver = Self.standardSemanticWindows,
+        primarySemanticWindow: ProviderSemanticWindow = .session,
+        secondarySemanticWindow: ProviderSemanticWindow = .weekly,
+        requestedMenuBarLaneOrders: [ProviderMenuBarMetric: [ProviderUsageLane]] = [:],
+        automaticSelectionPrioritizesExhaustedWindow: Bool = true,
+        menuBarWindowResolver: @escaping MenuBarWindowResolver = { _ in .unhandled },
+        planUtilizationSeriesResolver: @escaping PlanUtilizationSeriesResolver = Self.standardPlanUtilizationSeries,
+        planUtilizationSeriesNormalizer: @escaping PlanUtilizationSeriesNormalizer = { series, _ in series },
+        widgetRowLimitResolver: @escaping WidgetRowLimitResolver = { _, _ in nil },
+        secondaryGloballyCapsPrimary: Bool = false)
     {
         self.rateWindowLabeler = rateWindowLabeler
         self.identityPresenter = identityPresenter
         self.costPresenter = costPresenter
         self.extraRateWindowSelector = extraRateWindowSelector
         self.creditResolver = creditResolver
+        self.iconWindowResolver = iconWindowResolver
+        self.iconDecorations = iconDecorations
+        self.treatsExhaustedSecondaryIconWindowAsMissing = treatsExhaustedSecondaryIconWindowAsMissing
+        self.semanticWindowResolver = semanticWindowResolver
+        self.primarySemanticWindow = primarySemanticWindow
+        self.secondarySemanticWindow = secondarySemanticWindow
+        self.requestedMenuBarLaneOrders = requestedMenuBarLaneOrders
+        self.automaticSelectionPrioritizesExhaustedWindow = automaticSelectionPrioritizesExhaustedWindow
+        self.menuBarWindowResolver = menuBarWindowResolver
+        self.planUtilizationSeriesResolver = planUtilizationSeriesResolver
+        self.planUtilizationSeriesNormalizer = planUtilizationSeriesNormalizer
+        self.widgetRowLimitResolver = widgetRowLimitResolver
+        self.secondaryGloballyCapsPrimary = secondaryGloballyCapsPrimary
     }
 
     public func rateWindowLabels(
@@ -123,5 +273,93 @@ public struct ProviderUsagePresentation: Sendable {
 
     public func creditRemaining(_ credits: CreditsSnapshot) -> Double? {
         self.creditResolver?(credits)
+    }
+
+    public func iconWindows(context: ProviderIconWindowContext) -> ProviderUsageWindowPair {
+        self.iconWindowResolver(context)
+    }
+
+    public func semanticWindows(snapshot: UsageSnapshot) -> ProviderSemanticWindows {
+        self.semanticWindowResolver(snapshot)
+    }
+
+    public func requestedMenuBarLaneOrder(for metric: ProviderMenuBarMetric) -> [ProviderUsageLane] {
+        if let order = self.requestedMenuBarLaneOrders[metric] {
+            return order
+        }
+        return switch metric {
+        case .primary: [.primary, .secondary]
+        case .secondary: [.secondary, .primary]
+        case .tertiary: [.primary, .secondary]
+        default: []
+        }
+    }
+
+    public func menuBarWindow(context: ProviderMenuBarWindowContext) -> ProviderMenuBarWindowResolution {
+        self.menuBarWindowResolver(context)
+    }
+
+    public func planUtilizationSeries(snapshot: UsageSnapshot) -> Set<ProviderPlanUtilizationSeries>? {
+        self.planUtilizationSeriesResolver(snapshot)
+    }
+
+    public func normalizePlanUtilizationSeries(
+        _ series: ProviderPlanUtilizationSeries,
+        windowMinutes: Int) -> ProviderPlanUtilizationSeries
+    {
+        self.planUtilizationSeriesNormalizer(series, windowMinutes)
+    }
+
+    public func widgetRowLimit(
+        rows: [WidgetSnapshot.WidgetUsageRowSnapshot]?,
+        family: ProviderWidgetFamily) -> Int?
+    {
+        self.widgetRowLimitResolver(rows, family)
+    }
+
+    public static func window(in snapshot: UsageSnapshot, following lanes: [ProviderUsageLane]) -> RateWindow? {
+        for lane in lanes {
+            let window = switch lane {
+            case .primary: snapshot.primary
+            case .secondary: snapshot.secondary
+            case .tertiary: snapshot.tertiary
+            }
+            if let window {
+                return window
+            }
+        }
+        return nil
+    }
+
+    public static func mostConstrained(_ windows: RateWindow?...) -> RateWindow? {
+        windows.compactMap(\.self).max(by: { $0.usedPercent < $1.usedPercent })
+    }
+
+    public static func exhausted(_ windows: RateWindow?...) -> RateWindow? {
+        windows.compactMap(\.self).first(where: { $0.remainingPercent <= 0 })
+    }
+
+    public static func standardSemanticWindows(snapshot: UsageSnapshot) -> ProviderSemanticWindows {
+        let candidates = [snapshot.primary, snapshot.secondary, snapshot.tertiary]
+            + (snapshot.extraRateWindows ?? []).map(\.window)
+        let usable = candidates.compactMap { window -> RateWindow? in
+            guard let window, !window.isSyntheticPlaceholder else { return nil }
+            return window
+        }
+        return ProviderSemanticWindows(
+            session: usable.first { window in
+                guard let minutes = window.windowMinutes else { return false }
+                return (60...(12 * 60)).contains(minutes)
+            },
+            weekly: usable.first { $0.windowMinutes == 7 * 24 * 60 })
+    }
+
+    public static func standardPlanUtilizationSeries(
+        snapshot: UsageSnapshot) -> Set<ProviderPlanUtilizationSeries>?
+    {
+        let windows = [snapshot.primary, snapshot.secondary, snapshot.tertiary].compactMap(\.self)
+            + (snapshot.extraRateWindows?.filter(\.usageKnown).map(\.window) ?? [])
+        guard windows.contains(where: { $0.windowMinutes == 7 * 24 * 60 }) else { return nil }
+        return [.weekly]
     }
 }

--- a/Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift
@@ -58,6 +58,11 @@ public enum QoderProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Qoder cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(
+                menuCard: ProviderMenuCardPresentation(
+                    showsPrimaryBalanceDescription: true,
+                    hidesPrimaryResetWithoutDate: true),
+                menu: ProviderMenuDescriptorPresentation(primaryDescriptionIsDetail: { _ in true })),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "qoder",

--- a/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
@@ -71,13 +71,19 @@ public enum Sub2APIProviderDescriptor {
         tokenCost: ProviderTokenCostConfig(
             supportsTokenCost: false,
             noDataMessage: { "sub2api spend is reported by its usage API." }),
-        presentation: ProviderUsagePresentation(rateWindowLabeler: { metadata, snapshot, _ in
-            ProviderRateWindowLabels(
-                primary: Self.primaryLabel(snapshot: snapshot) ?? metadata.sessionLabel,
-                secondary: metadata.weeklyLabel,
-                tertiary: metadata.opusLabel ?? "Sonnet",
-                showsTertiary: metadata.supportsOpus)
-        }),
+        presentation: ProviderUsagePresentation(
+            rateWindowLabeler: { metadata, snapshot, _ in
+                ProviderRateWindowLabels(
+                    primary: Self.primaryLabel(snapshot: snapshot) ?? metadata.sessionLabel,
+                    secondary: metadata.weeklyLabel,
+                    tertiary: metadata.opusLabel ?? "Sonnet",
+                    showsTertiary: metadata.supportsOpus)
+            },
+            menuCard: ProviderMenuCardPresentation(usesRawPrimaryResetDescription: true),
+            menu: ProviderMenuDescriptorPresentation(
+                primaryDescriptionIsDetail: { _ in true },
+                secondaryDescriptionMode: .resetOverride,
+                tertiaryDescriptionOverridesReset: true)),
         fetchPlan: Self.fetchPlan(),
         cli: ProviderCLIConfig(
             name: "sub2api",

--- a/Sources/CodexBarCore/Providers/Synthetic/SyntheticProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Synthetic/SyntheticProviderDescriptor.swift
@@ -41,6 +41,8 @@ public enum SyntheticProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Synthetic cost summary is not supported." }),
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                usesSyntheticRollingRegen: true)),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "synthetic",

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIProviderDescriptor.swift
@@ -41,6 +41,8 @@ public enum VertexAIProviderDescriptor {
                 },
                 menuHintLines: [.localized("cost_estimate_hint")],
                 supportsTokenSnapshot: true),
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                supportsInlineTokenCostDashboard: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .oauth],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [VertexAIOAuthFetchStrategy()] })),

--- a/Sources/CodexBarCore/Providers/Warp/WarpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Warp/WarpProviderDescriptor.swift
@@ -41,6 +41,9 @@ public enum WarpProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Warp cost summary is not available." }),
+            presentation: ProviderUsagePresentation(
+                iconDecorations: [.warp],
+                treatsExhaustedSecondaryIconWindowAsMissing: true),
             fetchPlan: .apiToken(
                 strategyID: "warp.api",
                 resolveToken: { ProviderTokenResolver.warpToken(environment: $0) },

--- a/Sources/CodexBarCore/Providers/Warp/WarpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Warp/WarpProviderDescriptor.swift
@@ -43,7 +43,13 @@ public enum WarpProviderDescriptor {
                 noDataMessage: { "Warp cost summary is not available." }),
             presentation: ProviderUsagePresentation(
                 iconDecorations: [.warp],
-                treatsExhaustedSecondaryIconWindowAsMissing: true),
+                treatsExhaustedSecondaryIconWindowAsMissing: true,
+                menuCard: ProviderMenuCardPresentation(
+                    showsPrimaryBalanceDescription: true,
+                    hidesPrimaryResetWithoutDate: true),
+                menu: ProviderMenuDescriptorPresentation(
+                    primaryDescriptionIsDetail: { _ in true },
+                    secondaryDescriptionMode: .resetOverride)),
             fetchPlan: .apiToken(
                 strategyID: "warp.api",
                 resolveToken: { ProviderTokenResolver.warpToken(environment: $0) },

--- a/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
@@ -91,9 +91,17 @@ public enum ZaiProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "z.ai cost summary is not supported." }),
-            presentation: ProviderUsagePresentation(extraRateWindowSelector: { snapshot in
-                (snapshot.extraRateWindows ?? []).filter { $0.id == "zai-mcp" }
-            }),
+            presentation: ProviderUsagePresentation(
+                extraRateWindowSelector: { snapshot in
+                    (snapshot.extraRateWindows ?? []).filter { $0.id == "zai-mcp" }
+                },
+                automaticSelectionPrioritizesExhaustedWindow: false,
+                menuBarWindowResolver: { context in
+                    guard context.metric == .automatic else { return .unhandled }
+                    return .resolved(ProviderUsagePresentation.mostConstrained(
+                        context.snapshot.primary,
+                        context.snapshot.secondary))
+                }),
             fetchPlan: self.fetchPlan(),
             cli: ProviderCLIConfig(
                 name: "zai",

--- a/Sources/CodexBarCore/Providers/ZenMux/ZenMuxProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ZenMux/ZenMuxProviderDescriptor.swift
@@ -38,6 +38,9 @@ public enum ZenMuxProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "ZenMux cost history is not exposed by the Management API." }),
+            presentation: ProviderUsagePresentation(menuCard: ProviderMenuCardPresentation(
+                primaryDescriptionPlacement: .detailLeft,
+                hidesPrimaryResetWithoutDate: true)),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [ZenMuxAPIFetchStrategy()] })),

--- a/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
+++ b/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
@@ -2,6 +2,8 @@ import AppIntents
 import CodexBarCore
 import WidgetKit
 
+/// Provider-specific by design: AppIntents requires compile-time enum cases and display representations;
+/// runtime presentation policy still comes from each provider descriptor below this literal WidgetKit surface.
 enum BurnProviderChoice: String, AppEnum {
     case codex
     case claude
@@ -95,10 +97,8 @@ struct BurnDownState {
     }
 
     var secondaryGloballyCapsPrimary: Bool {
-        switch self.entry.provider {
-        case .codex, .claude: true
-        default: false
-        }
+        guard let provider = self.entry.provider.firstPartyProvider else { return false }
+        return ProviderDescriptorRegistry.descriptor(for: provider).presentation.secondaryGloballyCapsPrimary
     }
 
     var secondaryExhausted: Bool {

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -573,31 +573,21 @@ struct WidgetUsageRow: Identifiable, Equatable {
     }
 
     static func smallWidgetRowLimit(for entry: WidgetSnapshot.ProviderEntry) -> Int? {
-        if entry.provider == .kimi {
-            return 3
-        }
-        return self.antigravityQuotaSummaryRowLimit(for: entry, limit: 2)
+        self.widgetRowLimit(for: entry, family: .small)
     }
 
     static func mediumWidgetRowLimit(for entry: WidgetSnapshot.ProviderEntry) -> Int? {
-        if entry.provider == .kimi {
-            return 3
-        }
-        return self.antigravityQuotaSummaryRowLimit(for: entry, limit: 3)
+        self.widgetRowLimit(for: entry, family: .medium)
     }
 
-    private static func antigravityQuotaSummaryRowLimit(
+    private static func widgetRowLimit(
         for entry: WidgetSnapshot.ProviderEntry,
-        limit: Int) -> Int?
+        family: ProviderWidgetFamily) -> Int?
     {
-        guard entry.provider == .antigravity,
-              entry.usageRows?.contains(where: {
-                  $0.id.hasPrefix("antigravity-quota-summary-")
-              }) == true
-        else {
-            return nil
-        }
-        return limit
+        guard let provider = entry.provider.firstPartyProvider else { return nil }
+        return ProviderDescriptorRegistry.descriptor(for: provider).presentation.widgetRowLimit(
+            rows: entry.usageRows,
+            family: family)
     }
 
     static func rows(

--- a/Tests/CodexBarTests/ProviderPresentationPolicyCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ProviderPresentationPolicyCharacterizationTests.swift
@@ -1,0 +1,297 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarWidget
+
+struct ProviderPresentationPolicyCharacterizationTests {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test
+    func `automatic exhaustion priority is pinned for every provider`() {
+        let optOut: Set<UsageProvider> = [
+            .antigravity, .perplexity, .zai, .copilot, .cursor, .minimax, .claude, .codex,
+        ]
+
+        for provider in UsageProvider.allCases {
+            #expect(
+                MenuBarMetricWindowResolver.automaticSelectionPrioritizesExhaustedWindow(for: provider)
+                    == !optOut.contains(provider),
+                "Unexpected exhaustion priority for \(provider.rawValue)")
+        }
+    }
+
+    @Test
+    func `requested metric lane fallback order is pinned`() {
+        let primary = RateWindow(usedPercent: 11, windowMinutes: 300, resetsAt: nil, resetDescription: "primary")
+        let secondary = RateWindow(
+            usedPercent: 22,
+            windowMinutes: 10080,
+            resetsAt: nil,
+            resetDescription: "secondary")
+        let tertiary = RateWindow(
+            usedPercent: 33,
+            windowMinutes: 43200,
+            resetsAt: nil,
+            resetDescription: "tertiary")
+
+        let fixtures: [(UsageProvider, MenuBarMetricPreference, UsageSnapshot, String?)] = [
+            (.zai, .tertiary, self.snapshot(primary: primary, secondary: secondary, tertiary: tertiary), "primary"),
+            (.cursor, .tertiary, self.snapshot(primary: primary, secondary: secondary, tertiary: tertiary), "tertiary"),
+            (
+                .perplexity,
+                .tertiary,
+                self.snapshot(primary: primary, secondary: secondary, tertiary: tertiary),
+                "tertiary"),
+            (
+                .antigravity,
+                .tertiary,
+                self.snapshot(primary: primary, secondary: secondary, tertiary: tertiary),
+                "tertiary"),
+            (.zai, .primary, self.snapshot(primary: nil, secondary: secondary, tertiary: tertiary), "secondary"),
+            (.perplexity, .primary, self.snapshot(primary: nil, secondary: secondary, tertiary: tertiary), "secondary"),
+            (.antigravity, .primary, self.snapshot(primary: nil, secondary: nil, tertiary: tertiary), "tertiary"),
+            (.zai, .secondary, self.snapshot(primary: primary, secondary: nil, tertiary: tertiary), "primary"),
+            (.perplexity, .secondary, self.snapshot(primary: primary, secondary: nil, tertiary: tertiary), "tertiary"),
+            (.antigravity, .secondary, self.snapshot(primary: primary, secondary: nil, tertiary: tertiary), "primary"),
+        ]
+
+        for (provider, preference, snapshot, expected) in fixtures {
+            let selected = MenuBarMetricWindowResolver.rateWindow(
+                preference: preference,
+                provider: provider,
+                snapshot: snapshot,
+                supportsAverage: false,
+                now: self.now)
+            #expect(selected?.resetDescription == expected, "Unexpected \(preference) lane for \(provider.rawValue)")
+        }
+    }
+
+    @Test
+    func `semantic windows and legacy percent migration preserve Kimi lane inversion`() {
+        let primary = RateWindow(usedPercent: 25, windowMinutes: nil, resetsAt: nil, resetDescription: "weekly")
+        let secondary = RateWindow(usedPercent: 50, windowMinutes: 180, resetsAt: nil, resetDescription: "session")
+        let snapshot = self.snapshot(primary: primary, secondary: secondary)
+
+        let kimi = MenuBarLayoutSemanticWindowResolver.windows(provider: .kimi, snapshot: snapshot)
+        let generic = MenuBarLayoutSemanticWindowResolver.windows(provider: .zai, snapshot: snapshot)
+
+        #expect(kimi.session == secondary)
+        #expect(kimi.weekly == primary)
+        #expect(generic.session == secondary)
+        #expect(generic.weekly == nil)
+        #expect(MenuBarLayout.migrated(
+            iconStyle: .bars,
+            displayMode: .percent,
+            metricPreference: .primary,
+            resetTimeDisplayStyle: .countdown,
+            provider: .kimi).lines == [[.icon, .percent(window: .weekly)]])
+        #expect(MenuBarLayout.migrated(
+            iconStyle: .bars,
+            displayMode: .percent,
+            metricPreference: .secondary,
+            resetTimeDisplayStyle: .countdown,
+            provider: .kimi).lines == [[.icon, .percent(window: .session)]])
+    }
+
+    @Test
+    func `session pace eligibility matrix is pinned`() {
+        let fixtures: [(UsageProvider, Int?, Bool)] = [
+            (.codex, nil, true),
+            (.codex, 300, true),
+            (.codex, 540, true),
+            (.codex, 10080, false),
+            (.codex, 43200, false),
+            (.claude, nil, true),
+            (.ollama, nil, false),
+            (.ollama, 300, true),
+            (.antigravity, nil, true),
+            (.antigravity, 300, true),
+            (.antigravity, 301, false),
+            (.kimi, 180, false),
+            (.kimi, 300, true),
+            (.notion, nil, false),
+            (.notion, 360, true),
+            (.notion, 361, false),
+            (.zai, 300, false),
+        ]
+
+        for (provider, minutes, expected) in fixtures {
+            let window = RateWindow(
+                usedPercent: 50,
+                windowMinutes: minutes,
+                resetsAt: self.now.addingTimeInterval(3600),
+                resetDescription: nil)
+            #expect(
+                (UsagePaceText.sessionPace(provider: provider, window: window, now: self.now) != nil) == expected,
+                "Unexpected session pace eligibility for \(provider.rawValue):\(String(describing: minutes))")
+        }
+    }
+
+    @Test
+    @MainActor
+    func `decorated icon style membership is pinned`() throws {
+        let decoratedStyles: Set<IconStyle> = [.codex, .claude, .gemini, .antigravity, .factory, .warp]
+        for style in IconStyle.allCases {
+            let decorated = IconRenderer.makeIcon(
+                primaryRemaining: 60,
+                weeklyRemaining: 40,
+                creditsRemaining: nil,
+                stale: false,
+                style: style,
+                hideCritters: false)
+            let plain = IconRenderer.makeIcon(
+                primaryRemaining: 60,
+                weeklyRemaining: 40,
+                creditsRemaining: nil,
+                stale: false,
+                style: style,
+                hideCritters: true)
+            #expect(
+                try (#require(decorated.tiffRepresentation) != #require(plain.tiffRepresentation))
+                    == decoratedStyles.contains(style),
+                "Unexpected icon decoration membership for \(style.rawValue)")
+        }
+    }
+
+    @Test
+    func `credit visibility exceptions are pinned`() {
+        let codex = ProviderDescriptorRegistry.descriptor(for: .codex).metadata
+        let amp = ProviderDescriptorRegistry.descriptor(for: .amp).metadata
+        let openRouter = ProviderDescriptorRegistry.descriptor(for: .openrouter).metadata
+        let snapshot = self.snapshot(primary: RateWindow(
+            usedPercent: 20,
+            windowMinutes: nil,
+            resetsAt: nil,
+            resetDescription: nil))
+
+        #expect(UsageMenuCardView.Model.creditsLine(
+            metadata: codex,
+            snapshot: nil,
+            credits: nil,
+            error: nil) == nil)
+        #expect(UsageMenuCardView.Model.creditsLine(
+            metadata: amp,
+            snapshot: snapshot,
+            credits: nil,
+            error: nil) == nil)
+        #expect(UsageMenuCardView.Model.creditsLine(
+            metadata: openRouter,
+            snapshot: snapshot,
+            credits: nil,
+            error: nil) == openRouter.creditsHint)
+    }
+
+    @Test
+    func `history series selection special cases are pinned`() {
+        let session = RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+        let weekly = RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)
+        let monthly = RateWindow(usedPercent: 30, windowMinutes: 43200, resetsAt: nil, resetDescription: nil)
+        let histories = [
+            self.history(.session, minutes: 300),
+            self.history(.weekly, minutes: 10080),
+            self.history(.opus, minutes: 10080),
+            self.history(.monthly, minutes: 43200),
+        ]
+
+        let fixtures: [(UsageProvider, UsageSnapshot, [String])] = [
+            (
+                .codex,
+                self.snapshot(primary: session, secondary: weekly, tertiary: monthly),
+                ["session:300", "weekly:10080"]),
+            (
+                .claude,
+                self.snapshot(primary: session, secondary: weekly, tertiary: weekly),
+                ["session:300", "weekly:10080", "opus:10080"]),
+            (
+                .opencodego,
+                self.snapshot(primary: session, secondary: weekly, tertiary: monthly),
+                ["session:300", "weekly:10080", "monthly:43200"]),
+            (.zai, self.snapshot(primary: session, secondary: weekly, tertiary: monthly), ["weekly:10080"]),
+        ]
+
+        for (provider, snapshot, expected) in fixtures {
+            let model = PlanUtilizationHistoryChartMenuView._modelSnapshotForTesting(
+                histories: histories,
+                provider: provider,
+                snapshot: snapshot)
+            #expect(model.visibleSeries == expected, "Unexpected history series for \(provider.rawValue)")
+        }
+    }
+
+    @Test
+    func `widget row caps and burn down global cap providers are pinned`() throws {
+        let antigravityRows = [
+            WidgetSnapshot.WidgetUsageRowSnapshot(
+                id: "antigravity-quota-summary-gemini-session",
+                title: "Gemini",
+                percentLeft: 80),
+        ]
+        let rowFixtures: [(UsageProvider, [WidgetSnapshot.WidgetUsageRowSnapshot]?, Int?, Int?)] = [
+            (.kimi, nil, 3, 3),
+            (.antigravity, antigravityRows, 2, 3),
+            (.antigravity, nil, nil, nil),
+            (.codex, nil, nil, nil),
+        ]
+        for (provider, rows, small, medium) in rowFixtures {
+            let entry = self.widgetEntry(provider: provider, usageRows: rows)
+            #expect(WidgetUsageRow.smallWidgetRowLimit(for: entry) == small)
+            #expect(WidgetUsageRow.mediumWidgetRowLimit(for: entry) == medium)
+        }
+
+        for provider in UsageProvider.allCases {
+            let entry = self.widgetEntry(
+                provider: provider,
+                primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: nil, resetDescription: nil))
+            let state = try #require(BurnDownState(
+                snapshot: WidgetSnapshot(
+                    entries: [entry],
+                    enabledProviders: [provider.instanceID],
+                    generatedAt: self.now),
+                provider: provider,
+                selection: .session,
+                now: self.now))
+            #expect(state.secondaryGloballyCapsPrimary == [.codex, .claude].contains(provider))
+        }
+    }
+
+    private func snapshot(
+        primary: RateWindow?,
+        secondary: RateWindow? = nil,
+        tertiary: RateWindow? = nil) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: primary,
+            secondary: secondary,
+            tertiary: tertiary,
+            updatedAt: self.now)
+    }
+
+    private func history(_ name: PlanUtilizationSeriesName, minutes: Int) -> PlanUtilizationSeriesHistory {
+        PlanUtilizationSeriesHistory(
+            name: name,
+            windowMinutes: minutes,
+            entries: [PlanUtilizationHistoryEntry(capturedAt: self.now, usedPercent: 10, resetsAt: nil)])
+    }
+
+    private func widgetEntry(
+        provider: UsageProvider,
+        primary: RateWindow? = nil,
+        secondary: RateWindow? = nil,
+        usageRows: [WidgetSnapshot.WidgetUsageRowSnapshot]? = nil) -> WidgetSnapshot.ProviderEntry
+    {
+        WidgetSnapshot.ProviderEntry(
+            provider: provider,
+            updatedAt: self.now,
+            primary: primary,
+            secondary: secondary,
+            tertiary: nil,
+            usageRows: usageRows,
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+    }
+}


### PR DESCRIPTION
## Summary

Move provider-specific usage presentation policy out of shared UI switches and into each provider descriptor, without changing the characterized output. `ProviderUsagePresentation` is now the typed policy seam for rate-window selection, semantic lanes, icon and history behavior, menu-card details, cost/credit visibility, and the runtime portions of widget presentation.

The design keeps standard behavior in descriptor defaults and uses narrow, sendable resolvers only where presentation depends on the current snapshot. Shared consumers now ask `ProviderDescriptorRegistry` for policy instead of accumulating provider-ID branches, so new provider exceptions live beside the provider metadata they describe.

## Change clusters

| Cluster | Commit position | Files changed | Added | Removed | Net |
| --- | ---: | ---: | ---: | ---: | ---: |
| Characterization inventory | 1 | 1 | 297 | 0 | +297 |
| Window, icon, pace, history, and widget runtime policy | 2 | 27 | 823 | 451 | +372 |
| Menu descriptor and menu-card policy | 3 | 42 | 553 | 229 | +324 |
| Full branch (deduplicated files) | — | 57 | 1,643 | 650 | +993 |

The pin-before-migrate order is intentional: the characterization commit lands first, followed by the window cluster and then the menu cluster.

## Characterization inventory

The first commit pins the existing presentation matrix before ownership moves. It covers:

- automatic exhausted-window priority across every provider;
- requested primary, secondary, and tertiary lane fallback order;
- semantic session/weekly mapping and Kimi's legacy lane inversion migration;
- session pace eligibility and window-duration boundaries;
- decorated icon-style membership;
- credit visibility exceptions;
- plan-utilization history series selection and normalization;
- widget row caps and the Codex/Claude burn-down global-cap rule.

## WidgetKit boundary

The migration deliberately stops at the literal `BurnProviderChoice` / AppIntents declaration. WidgetKit requires compile-time enum cases and statically extractable display representations, so that provider list cannot be derived from runtime descriptors. Runtime widget policy does move into descriptors: row limits and the secondary-global-cap behavior now resolve through `ProviderUsagePresentation`. Existing synchronization tests continue to guard the unavoidable literal WidgetKit inventory.

## Verification

- `make check` — SwiftFormat clean; SwiftLint 0 violations across 1,799 files; manifests and generated indices current
- `make test` — 821/821 selections green in 69/69 first-pass groups, with no retries or timeouts
- Linux CLI build — green in the worker gate
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "make test"` — clean, no accepted/actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
