### PR TITLE
docs: add CodexBar Meter to Linux desktop integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ CLI install:
 - [noctalia-codex-usage](https://github.com/rayoplateado/noctalia-codex-usage) — Noctalia/Quickshell plugin that shows Codex 5-hour and weekly usage limits, built on top of the bundled Linux CLI.
 - [KodexBar](https://github.com/tylxr59/KodexBar) — KDE Plasma widget that shows CodexBar usage in the Plasma panel, built on top of the bundled Linux CLI.
 - [codexbar-plasmoid](https://github.com/psimaker/codexbar-plasmoid) — KDE Plasma 6 widget for CodexBar's meter icon, provider switcher, quota windows, pace, credits, local cost, and status, powered by the bundled Linux CLI.
+- [CodexBar Meter](https://github.com/noctalia-dev/community-plugins/tree/main/codexbar-meter) — Noctalia v5 bar widget and panel showing every enabled provider's quota windows, credits, and pace, installable from Noctalia's plugin store, built on the bundled Linux CLI.
 
 ## Status bar & terminal integration
 - [showy-quota](https://github.com/enieuwy/showy-quota) — always-on AI plan quota strips for SketchyBar, tmux, and Zellij (standalone WASM plugin), built on `codexbar serve` / the bundled CLI.


### PR DESCRIPTION
## Summary

- Add **CodexBar Meter** to the Linux desktop integrations list.

## Context

CodexBar Meter is a [Noctalia](https://github.com/noctalia-dev/noctalia) v5 bar
widget and attached panel. It lives in Noctalia's official community plugin
repository rather than a standalone repo, so it installs from the plugin store
without cloning anything:

https://github.com/noctalia-dev/community-plugins/tree/main/codexbar-meter

It is MIT-licensed (declared in `plugin.toml`) and drives only the documented
CLI JSON interface — one command, on an interval and on manual refresh:

```sh
timeout 30s codexbar usage --format json --json-only
```

No other process is spawned, no network call is made, and no file is written.
Provider discovery comes from CodexBar's own enabled-provider list rather than a
hardcoded set, so providers added to CodexBar later appear without a change here.

## Relationship to the existing Noctalia entry

The list already includes
[noctalia-codex-usage](https://github.com/rayoplateado/noctalia-codex-usage),
and this is a complement rather than a replacement:

- that one covers **Codex** 5-hour and weekly windows; this renders **every
  provider** CodexBar reports, with per-provider cards
- that one is a standalone repo you clone and install by hand; this ships in the
  official community plugin store as a one-command install
- this adds a panel with each quota window, reset countdowns, credits, pace
  summaries, provider status, and stale-data warnings

Happy to drop this if you would rather keep one Noctalia entry on the list.

## Test plan

- Documentation-only change.
- Verified the linked directory resolves and that the plugin is present in the
  repository's generated `catalog.toml`.
