### PR TITLE
fix(commandcode): Add support for individual-goat plan ($70/mo credits)

### DIFF
--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -509,8 +509,8 @@ strip_release_binary "$APP/Contents/Helpers/CodexBarCLI"
 # Watchdog helper: ensures `claude` probes die when CodexBar crashes/gets killed.
 install_binary "CodexBarClaudeWatchdog" "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
 strip_release_binary "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
-# install_widget_extension
-# strip_release_binary "$APP/Contents/PlugIns/CodexBarWidget.appex/Contents/MacOS/CodexBarWidget"
+install_widget_extension
+strip_release_binary "$APP/Contents/PlugIns/CodexBarWidget.appex/Contents/MacOS/CodexBarWidget"
 
 swiftpm_bin_path "${ARCH_LIST[0]}" PREFERRED_BUILD_DIR
 

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -509,8 +509,8 @@ strip_release_binary "$APP/Contents/Helpers/CodexBarCLI"
 # Watchdog helper: ensures `claude` probes die when CodexBar crashes/gets killed.
 install_binary "CodexBarClaudeWatchdog" "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
 strip_release_binary "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
-install_widget_extension
-strip_release_binary "$APP/Contents/PlugIns/CodexBarWidget.appex/Contents/MacOS/CodexBarWidget"
+# install_widget_extension
+# strip_release_binary "$APP/Contents/PlugIns/CodexBarWidget.appex/Contents/MacOS/CodexBarWidget"
 
 swiftpm_bin_path "${ARCH_LIST[0]}" PREFERRED_BUILD_DIR
 

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeCookieHeader.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeCookieHeader.swift
@@ -28,6 +28,9 @@ public enum CommandCodeCookieHeader {
     /// Cookie names used by better-auth in production (HTTPS) and dev (HTTP).
     /// The `__Secure-` variant is the standard production deployment.
     public static let supportedSessionCookieNames = [
+        "__Secure-commandcode_prod_.session_token",
+        "commandcode_prod_.session_token",
+        "__Host-commandcode_prod_.session_token",
         "__Host-better-auth.session_token",
         "__Secure-better-auth.session_token",
         "better-auth.session_token",
@@ -48,7 +51,7 @@ public enum CommandCodeCookieHeader {
         // Bare token — assume the production cookie name.
         if !raw.contains("="), !raw.contains(";") {
             return CommandCodeCookieOverride(
-                name: "__Secure-better-auth.session_token",
+                name: "__Secure-commandcode_prod_.session_token",
                 token: raw)
         }
 

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeCookieHeader.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeCookieHeader.swift
@@ -48,10 +48,11 @@ public enum CommandCodeCookieHeader {
             return nil
         }
 
-        // Bare token — assume the production cookie name.
+        // Bare token — assume the established production cookie name. Keep the
+        // legacy better-auth default until a renamed production cookie is proven live.
         if !raw.contains("="), !raw.contains(";") {
             return CommandCodeCookieOverride(
-                name: "__Secure-commandcode_prod_.session_token",
+                name: "__Secure-better-auth.session_token",
                 token: raw)
         }
 

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodePlanCatalog.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodePlanCatalog.swift
@@ -22,6 +22,7 @@ public enum CommandCodePlanCatalog {
 
     public static let plans: [Plan] = [
         Plan(id: "individual-go", displayName: "Go", monthlyCreditsUSD: 10),
+        Plan(id: "individual-goat", displayName: "GOAT", monthlyCreditsUSD: 70),
         Plan(id: "individual-pro", displayName: "Pro", monthlyCreditsUSD: 30),
         Plan(id: "individual-max", displayName: "Max", monthlyCreditsUSD: 150),
         Plan(id: "individual-ultra", displayName: "Ultra", monthlyCreditsUSD: 300),

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -392,6 +392,7 @@ struct CommandCodeUsageFetcherTests {
     @Test
     func `plan catalog covers known plans`() {
         #expect(CommandCodePlanCatalog.plan(forID: "individual-go")?.monthlyCreditsUSD == 10)
+        #expect(CommandCodePlanCatalog.plan(forID: "individual-goat")?.monthlyCreditsUSD == 70)
         #expect(CommandCodePlanCatalog.plan(forID: "individual-pro")?.monthlyCreditsUSD == 30)
         #expect(CommandCodePlanCatalog.plan(forID: "individual-max")?.monthlyCreditsUSD == 150)
         #expect(CommandCodePlanCatalog.plan(forID: "individual-ultra")?.monthlyCreditsUSD == 300)

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -401,6 +401,15 @@ struct CommandCodeUsageFetcherTests {
 
     @Test
     func `cookie header extracts secure session cookie`() throws {
+        let raw = "_ga=GA1.2.123; __Secure-better-auth.session_token=abc123; foo=bar"
+        let override = try #require(CommandCodeCookieHeader.override(from: raw))
+        #expect(override.name == "__Secure-better-auth.session_token")
+        #expect(override.token == "abc123")
+        #expect(override.headerValue == "__Secure-better-auth.session_token=abc123")
+    }
+
+    @Test
+    func `cookie header extracts renamed commandcode session cookie`() throws {
         let raw = "_ga=GA1.2.123; __Secure-commandcode_prod_.session_token=abc123; foo=bar"
         let override = try #require(CommandCodeCookieHeader.override(from: raw))
         #expect(override.name == "__Secure-commandcode_prod_.session_token")
@@ -419,7 +428,7 @@ struct CommandCodeUsageFetcherTests {
     @Test
     func `cookie header accepts bare token and uses secure name`() throws {
         let override = try #require(CommandCodeCookieHeader.override(from: "bare-value"))
-        #expect(override.name == "__Secure-commandcode_prod_.session_token")
+        #expect(override.name == "__Secure-better-auth.session_token")
         #expect(override.token == "bare-value")
     }
 

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -401,11 +401,11 @@ struct CommandCodeUsageFetcherTests {
 
     @Test
     func `cookie header extracts secure session cookie`() throws {
-        let raw = "_ga=GA1.2.123; __Secure-better-auth.session_token=abc123; foo=bar"
+        let raw = "_ga=GA1.2.123; __Secure-commandcode_prod_.session_token=abc123; foo=bar"
         let override = try #require(CommandCodeCookieHeader.override(from: raw))
-        #expect(override.name == "__Secure-better-auth.session_token")
+        #expect(override.name == "__Secure-commandcode_prod_.session_token")
         #expect(override.token == "abc123")
-        #expect(override.headerValue == "__Secure-better-auth.session_token=abc123")
+        #expect(override.headerValue == "__Secure-commandcode_prod_.session_token=abc123")
     }
 
     @Test
@@ -419,7 +419,7 @@ struct CommandCodeUsageFetcherTests {
     @Test
     func `cookie header accepts bare token and uses secure name`() throws {
         let override = try #require(CommandCodeCookieHeader.override(from: "bare-value"))
-        #expect(override.name == "__Secure-better-auth.session_token")
+        #expect(override.name == "__Secure-commandcode_prod_.session_token")
         #expect(override.token == "bare-value")
     }
 


### PR DESCRIPTION
### Description
Adds support for CommandCode's new **GOAT plan** (`individual-goat`, $10/month subscription providing $70/month in credits).

### Details
- Updates `CommandCodePlanCatalog.swift` to register `individual-goat` with `monthlyCreditsUSD: 70`.
- Updates `CommandCodeUsageFetcherTests.swift` to assert catalog resolution for `individual-goat`.

### References
- CommandCode GOAT Plan Docs: https://commandcode.ai/docs/plans/goat