### PR TITLE
fix: retain flicker-probe sessions so release builds actually record

### DIFF
--- a/Sources/CodexBar/MenuSwitchFlickerProbe.swift
+++ b/Sources/CodexBar/MenuSwitchFlickerProbe.swift
@@ -42,6 +42,13 @@ enum MenuSwitchFlickerProbe {
         }
     }
 
+    /// In-flight sessions must be strongly owned here: an unretained
+    /// `ProbeSession(...).begin()` temporary lets the release-mode optimizer
+    /// deallocate the session at creation ("weak reference will always be nil"),
+    /// so the driving timer's `[weak self]` never fires and the probe records
+    /// nothing. Sessions unregister themselves in `finish()`.
+    private(set) static var activeSessions: [ProbeSession] = []
+
     static func startIfRequested(controller: StatusItemController) {
         guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_FLICKER_PROBE_DIR"],
               !dir.isEmpty else { return }
@@ -53,15 +60,34 @@ enum MenuSwitchFlickerProbe {
         // carried-over state such as the stable-height session floor).
         let holdMode = ProcessInfo.processInfo.environment["CODEXBAR_FLICKER_PROBE_MODE"] == "hold"
         DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-            ProbeSession(controller: controller, directory: directory, holdMode: holdMode).begin()
+            self.beginRetainedSession(controller: controller, directory: directory, holdMode: holdMode)
             guard !holdMode else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                ProbeSession(
+                self.beginRetainedSession(
                     controller: controller,
                     directory: directory.appendingPathComponent("second"),
-                    holdMode: false).begin()
+                    holdMode: false)
             }
         }
+    }
+
+    static func beginRetainedSession(
+        controller: StatusItemController,
+        directory: URL,
+        holdMode: Bool,
+        configuration: ProbeSession.Configuration = ProbeSession.Configuration())
+    {
+        let session = ProbeSession(
+            controller: controller,
+            directory: directory,
+            holdMode: holdMode,
+            configuration: configuration)
+        self.activeSessions.append(session)
+        session.begin()
+    }
+
+    static func endSession(_ session: ProbeSession) {
+        self.activeSessions.removeAll { $0 === session }
     }
 
     /// Background frame grabber: samples the window's WindowServer composite and
@@ -152,10 +178,27 @@ enum MenuSwitchFlickerProbe {
 
     @MainActor
     final class ProbeSession {
+        /// Timing and menu-opening seams. Production uses the defaults; tests
+        /// shorten the schedule and substitute a non-blocking menu opener so the
+        /// session can run against a synthetic menu without NSMenu tracking.
+        struct Configuration {
+            /// Three away/back cycles give slower external captures several chances
+            /// to land on any transient artifact. Always ends on the original segment.
+            var switchScheduleMs: [Int] = [400, 1000, 1600, 2200, 2800, 3400]
+            var sessionEndMs = 4200
+            var holdSessionEndMs = 30000
+            /// Replaces `controller.openMenuFromShortcut()`, which blocks in
+            /// NSMenu's synchronous tracking loop until the session cancels it.
+            /// A substitute must likewise pump the main run loop until the
+            /// session's timer stops, then return.
+            var openMenu: (@MainActor () -> Void)?
+        }
+
         private let controller: StatusItemController
         private let directory: URL
         private let holdMode: Bool
-        private var timer: Timer?
+        private let configuration: Configuration
+        private(set) var timer: Timer?
         private var log: [String] = []
         private var startedAt: DispatchTime?
         private var switchScheduleIndex = 0
@@ -165,10 +208,16 @@ enum MenuSwitchFlickerProbe {
         private var originalSegment: Int?
         private var targetSegment: Int?
 
-        init(controller: StatusItemController, directory: URL, holdMode: Bool = false) {
+        init(
+            controller: StatusItemController,
+            directory: URL,
+            holdMode: Bool = false,
+            configuration: Configuration = Configuration())
+        {
             self.controller = controller
             self.directory = directory
             self.holdMode = holdMode
+            self.configuration = configuration
         }
 
         func begin() {
@@ -183,20 +232,20 @@ enum MenuSwitchFlickerProbe {
             RunLoop.main.add(timer, forMode: .common)
             self.timer = timer
             // Blocks in menu tracking until `cancelTracking()`; the timer keeps firing.
-            self.controller.openMenuFromShortcut()
+            if let openMenu = self.configuration.openMenu {
+                openMenu()
+            } else {
+                self.controller.openMenuFromShortcut()
+            }
             self.finish()
         }
-
-        /// Three away/back cycles give slower external captures several chances
-        /// to land on any transient artifact. Always ends on the original segment.
-        private static let switchScheduleMs = [400, 1000, 1600, 2200, 2800, 3400]
-        private static let sessionEndMs = 4200
-        private static let holdSessionEndMs = 30000
 
         private func tick() {
             guard let startedAt = self.startedAtOrLocateMenu() else { return }
             let now = Int((DispatchTime.now().uptimeNanoseconds - startedAt.uptimeNanoseconds) / 1_000_000)
-            let endMs = self.holdMode ? Self.holdSessionEndMs : Self.sessionEndMs
+            let endMs = self.holdMode
+                ? self.configuration.holdSessionEndMs
+                : self.configuration.sessionEndMs
             if now >= endMs {
                 self.timer?.invalidate()
                 self.timer = nil
@@ -204,8 +253,8 @@ enum MenuSwitchFlickerProbe {
                 return
             }
             guard !self.holdMode,
-                  self.switchScheduleIndex < Self.switchScheduleMs.count,
-                  now >= Self.switchScheduleMs[self.switchScheduleIndex] else { return }
+                  self.switchScheduleIndex < self.configuration.switchScheduleMs.count,
+                  now >= self.configuration.switchScheduleMs[self.switchScheduleIndex] else { return }
             let switchIndex = self.switchScheduleIndex
             self.switchScheduleIndex += 1
             // Cycle through overview (segment 0) too so full-rebuild transitions
@@ -308,6 +357,7 @@ enum MenuSwitchFlickerProbe {
                 to: self.directory.appendingPathComponent("probe-log.txt"),
                 atomically: true,
                 encoding: .utf8)
+            MenuSwitchFlickerProbe.endSession(self)
         }
     }
 

--- a/Tests/CodexBarTests/MenuSwitchFlickerProbeTests.swift
+++ b/Tests/CodexBarTests/MenuSwitchFlickerProbeTests.swift
@@ -1,0 +1,128 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+/// The flicker probe's `ProbeSession` is driven by a `[weak self]` timer, so it
+/// only works while something strong owns the session. These tests pin the
+/// ownership contract (sessions live in `MenuSwitchFlickerProbe.activeSessions`
+/// until `finish()`) and prove a session actually records switch activity and
+/// frame samples when run against a synthetic merged menu.
+@MainActor
+@Suite(.serialized)
+struct MenuSwitchFlickerProbeTests {
+    private func makeSettings() -> SettingsStore {
+        let suite = "MenuSwitchFlickerProbeTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    @Test
+    func `retained probe session records switch activity and frame samples`() throws {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        let previousMenuRefresh = StatusItemController.menuRefreshEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
+            StatusItemController.setMenuRefreshEnabledForTesting(previousMenuRefresh)
+        }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            let shouldEnable = provider == .codex || provider == .claude
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+
+        // Synthetic merged menu: the switcher view is hosted in a real window so
+        // the session can resolve a window number for its frame grabber.
+        let switcher = ProviderSwitcherView(
+            providers: [.codex, .claude],
+            selected: .provider(.codex),
+            includesOverview: true,
+            width: 320,
+            showsIcons: false,
+            iconProvider: { _ in NSImage() },
+            weeklyRemainingProvider: { _ in nil },
+            onSelect: { _ in })
+        let menu = StatusItemMenu()
+        let switcherItem = NSMenuItem()
+        switcherItem.view = switcher
+        menu.addItem(switcherItem)
+        menu.addItem(.separator())
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 200),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false)
+        defer { window.orderOut(nil) }
+        window.contentView?.addSubview(switcher)
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("flicker-probe-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        var sessionWasRetainedWhileRunning = false
+        var configuration = MenuSwitchFlickerProbe.ProbeSession.Configuration()
+        configuration.switchScheduleMs = [40, 80, 120, 160, 200, 240]
+        configuration.sessionEndMs = 400
+        configuration.openMenu = {
+            // Stand-in for NSMenu's blocking tracking loop: expose the menu the
+            // way tracking would and pump the run loop until the session's
+            // timer schedule completes.
+            sessionWasRetainedWhileRunning = !MenuSwitchFlickerProbe.activeSessions.isEmpty
+            controller.openMenus[ObjectIdentifier(menu)] = menu
+            let deadline = Date().addingTimeInterval(10)
+            while let session = MenuSwitchFlickerProbe.activeSessions.last,
+                  session.timer != nil,
+                  Date() < deadline
+            {
+                RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.01))
+            }
+            controller.openMenus.removeValue(forKey: ObjectIdentifier(menu))
+        }
+
+        MenuSwitchFlickerProbe.beginRetainedSession(
+            controller: controller,
+            directory: directory,
+            holdMode: false,
+            configuration: configuration)
+
+        #expect(sessionWasRetainedWhileRunning, "session must be strongly owned while it runs")
+        #expect(MenuSwitchFlickerProbe.activeSessions.isEmpty, "finished session must be released")
+
+        let log = try String(contentsOf: directory.appendingPathComponent("probe-log.txt"), encoding: .utf8)
+        #expect(log.contains("menu located"), "probe never found the open menu: \(log)")
+        #expect(log.contains("handled=true"), "probe never performed a switch: \(log)")
+
+        let capturedLine = try #require(
+            log.split(separator: "\n").first { $0.hasPrefix("captured ") },
+            "probe log missing sample summary: \(log)")
+        let sampleCount = try #require(Int(capturedLine.split(separator: " ")[1]))
+        #expect(sampleCount > 0, "probe recorded no frame samples: \(log)")
+    }
+}


### PR DESCRIPTION
## Summary

The Tahoe menu-flicker self-probe (`MenuSwitchFlickerProbe`) was silently dead in release builds: each `ProbeSession(...).begin()` ran as an unretained temporary whose only other reference was the driving timer's `[weak self]`. The release optimizer deallocated the session at creation — surfacing as the compiler warning "weak reference will always be nil" at the two creation sites — so the timer never ticked, the menu was never located, and no frames or logs were recorded.

## Changes

- Sessions are now strongly owned in `MenuSwitchFlickerProbe.activeSessions` from creation until `finish()` unregisters them (`beginRetainedSession` / `endSession`). This covers both the normal end-of-schedule path and the give-up path, which both funnel through `finish()`.
- `ProbeSession` gained a `Configuration` seam: switch schedule / session-end timings (previously file statics) and an `openMenu` closure standing in for the blocking `openMenuFromShortcut()` tracking loop.
- New `MenuSwitchFlickerProbeTests` runs a full session against a real `StatusItemController` and `ProviderSwitcherView` menu on a ~400ms schedule, asserting the session stays retained while running, is released after finishing, and records `menu located`, `handled=true` switches, and a positive frame-sample count.

## Proof

- Original code: `swift build -c release` reproduces the warning at both creation sites; fixed code compiles warning-free (only the pre-existing `CGWindowListCreateImage` deprecation remains).
- `swift test --filter MenuSwitchFlickerProbeTests` passes (0.8s).
- `make check` clean (0 violations, 1810 files).
- Codex autoreview (gpt-5.6-sol, high): clean, no actionable findings.
