### PR TITLE
Fix Codex quota refresh after manual reset

### DIFF
--- a/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
@@ -143,7 +143,12 @@ struct CodexWeeklyResetConfirmation: Sendable {
                previousWeekly,
                capturedAt: previous.updatedAt)
         {
-            if confirmation.updatedAt < previousBoundary.addingTimeInterval(-2 * 60) {
+            let confirmsManualReset = Self.confirmsManualResetCreditRedemption(
+                previous: previous,
+                confirmation: confirmation)
+            if confirmation.updatedAt < previousBoundary.addingTimeInterval(-2 * 60),
+               !confirmsManualReset
+            {
                 return .preservePrevious
             }
             guard initialBoundary.timeIntervalSince(previousBoundary) >= Self.resetEquivalenceToleranceSeconds,
@@ -153,6 +158,27 @@ struct CodexWeeklyResetConfirmation: Sendable {
             }
         }
         return .publishConfirmation
+    }
+
+    private static func confirmsManualResetCreditRedemption(
+        previous: UsageSnapshot,
+        confirmation: UsageSnapshot) -> Bool
+    {
+        guard let previousCredits = previous.codexResetCredits,
+              let confirmationCredits = confirmation.codexResetCredits,
+              self.isFinite(previousCredits.updatedAt),
+              self.isFinite(confirmationCredits.updatedAt),
+              confirmationCredits.updatedAt >= previousCredits.updatedAt
+        else {
+            return false
+        }
+        let previouslyAvailableIDs = Set(previousCredits.credits.lazy
+            .filter { $0.status == .available }
+            .map(\.id))
+        guard !previouslyAvailableIDs.isEmpty else { return false }
+        return confirmationCredits.credits.contains { credit in
+            previouslyAvailableIDs.contains(credit.id) && credit.status == .redeemed
+        }
     }
 
     private static func initialDecisionWithoutWeeklyBaseline(

--- a/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
@@ -271,6 +271,47 @@ struct CodexWeeklyResetConfirmationTests {
     }
 
     @Test
+    func `redeemed reset credit confirms an early manual weekly reset`() throws {
+        let formatter = ISO8601DateFormatter()
+        let previousCapturedAt = try #require(formatter.date(from: "2026-07-28T03:09:20Z"))
+        let previousReset = try #require(formatter.date(from: "2026-08-02T10:17:56Z"))
+        let initialCapturedAt = try #require(formatter.date(from: "2026-07-28T03:59:23Z"))
+        let initialReset = try #require(formatter.date(from: "2026-08-04T03:59:21Z"))
+        let previous = self.snapshot(
+            capturedAt: previousCapturedAt,
+            weeklyUsed: 100,
+            weeklyReset: previousReset,
+            resetCredits: self.resetCredits(
+                status: .available,
+                capturedAt: previousCapturedAt))
+        let initial = self.snapshot(
+            capturedAt: initialCapturedAt,
+            weeklyUsed: 0,
+            weeklyReset: initialReset,
+            resetCredits: self.resetCredits(
+                status: .redeeming,
+                capturedAt: initialCapturedAt))
+        let confirmationCapturedAt = initialCapturedAt.addingTimeInterval(30)
+        let confirmation = self.snapshot(
+            capturedAt: confirmationCapturedAt,
+            weeklyUsed: 0,
+            weeklyReset: initialReset.addingTimeInterval(30),
+            resetCredits: self.resetCredits(
+                status: .redeemed,
+                capturedAt: confirmationCapturedAt))
+
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: initial)
+                == .requiresConfirmation)
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: confirmation)
+                == .publishConfirmation)
+    }
+
+    @Test
     func `prior boundary due tolerance includes the exact two minute edge`() {
         let previousBoundary = self.resetAt
         let nextBoundary = previousBoundary.addingTimeInterval(7 * 24 * 60 * 60)
@@ -442,20 +483,23 @@ struct CodexWeeklyResetConfirmationTests {
         offset: TimeInterval,
         weeklyUsed: Double?,
         weeklyReset: Date?,
-        weeklyInPrimary: Bool = false) -> UsageSnapshot
+        weeklyInPrimary: Bool = false,
+        resetCredits: CodexRateLimitResetCreditsSnapshot? = nil) -> UsageSnapshot
     {
         self.snapshot(
             capturedAt: self.capturedAt.addingTimeInterval(offset),
             weeklyUsed: weeklyUsed,
             weeklyReset: weeklyReset,
-            weeklyInPrimary: weeklyInPrimary)
+            weeklyInPrimary: weeklyInPrimary,
+            resetCredits: resetCredits)
     }
 
     private func snapshot(
         capturedAt: Date,
         weeklyUsed: Double?,
         weeklyReset: Date?,
-        weeklyInPrimary: Bool = false) -> UsageSnapshot
+        weeklyInPrimary: Bool = false,
+        resetCredits: CodexRateLimitResetCreditsSnapshot? = nil) -> UsageSnapshot
     {
         let weekly = weeklyUsed.map {
             RateWindow(
@@ -472,6 +516,26 @@ struct CodexWeeklyResetConfirmationTests {
         return UsageSnapshot(
             primary: weeklyInPrimary ? weekly : session,
             secondary: weeklyInPrimary ? session : weekly,
+            codexResetCredits: resetCredits,
+            updatedAt: capturedAt)
+    }
+
+    private func resetCredits(
+        status: CodexRateLimitResetCreditStatus,
+        capturedAt: Date) -> CodexRateLimitResetCreditsSnapshot
+    {
+        CodexRateLimitResetCreditsSnapshot(
+            credits: [CodexRateLimitResetCredit(
+                id: "manual-reset-credit",
+                resetType: "codex_rate_limits",
+                status: status,
+                grantedAt: capturedAt.addingTimeInterval(-24 * 60 * 60),
+                expiresAt: capturedAt.addingTimeInterval(24 * 60 * 60),
+                redeemStartedAt: status == .available ? nil : capturedAt,
+                redeemedAt: status == .redeemed ? capturedAt : nil,
+                title: nil,
+                description: nil)],
+            availableCount: status == .available ? 1 : 0,
             updatedAt: capturedAt)
     }
 }


### PR DESCRIPTION
## Summary

- accept a confirmed early weekly reset when the same Codex reset credit transitions from `available` to `redeemed`
- preserve the existing premature-reset guard when there is no matching redemption evidence
- add regression coverage for manual reset credit redemption before the previous natural weekly boundary

## Root cause

`CodexWeeklyResetConfirmation` rejected every reset observed more than two minutes before the previously scheduled weekly boundary. A manual reset credit intentionally moves that boundary early, so the app kept preserving the stale pre-reset snapshot even after two matching low-usage samples.

The merged confirmation path treats a provider-reported redemption of the same stable reset credit ID as evidence that the early boundary change is legitimate. All other boundary and two-sample confirmation checks remain in place.

## User impact

For providers that retain the consumed credit as `redeemed`, Codex quota usage refreshes automatically after a user redeems a manual reset credit, without weakening protection against transient or premature zero-usage responses.

## Validation for the merged change

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter CodexWeeklyResetConfirmationTests` (16 tests passed)
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test` (821 selections across 69 groups, 0 failures)

No UI changes; screenshots are not applicable.

## Post-merge provider finding

This PR was merged at head `288380d52eb75e49c93fdc7754f877a25b0ac2aa` before the following provider trace was recovered. The follow-up described here is **not part of this merged PR**.

Observed on CodexBar 0.47.0 with a signed-in Codex OAuth account. Account identity, tokens, and reset-credit IDs are omitted.

| Captured at (UTC) | Weekly used | Reset boundary (UTC) |
|---|---:|---|
| 2026-08-06 08:59:18 | 98% | 2026-08-10 01:00:26 |
| 2026-08-06 09:28:18 | 99% | 2026-08-10 01:00:26 |
| 2026-08-06 09:33:18 | 0% | 2026-08-13 09:33:18 |

The successful reset-credit inventory persisted with the post-redemption observation was:

```json
{"availableCount":0,"credits":[]}
```

A later read-only live OAuth fetch returned the same successful empty inventory. In this observed provider shape, the consumed credit is omitted instead of retained as a `redeemed` row, so the merged same-row transition remains conservative and may still preserve the stale snapshot.

Follow-up commit `endless7/CodexBar@78035f4f` handles both representations, but only when two independent low-usage inventories corroborate consumption and the available count decreased. It has 18 focused tests, a clean `make check`, and 821 full-suite selections across 69 groups with no failures or retries. The account has no reset credit remaining, so this validation replays the exact redacted timeline through production decision code; it is not presented as a second live redemption.
