### PR TITLE
feat: expose all claude-swap accounts in the dashboard-v1 snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.47.1 — Unreleased
 
 ### Added
+- Dashboard v1 snapshot: Claude rows now include all claude-swap accounts (windows, pace, active flag, redacted identity) when the integration is enabled.
 - CLI: expose Codex cost-history completeness in JSON and add an experimental provider-native-only scan mode (#2520). Thanks @NickGuAI!
 - Usage & Spend: add an accessible daily, weekly, and cumulative token-activity heatmap backed by the existing persistent cost scan cache (#2548). Thanks @Yuxin-Qiao!
 - Settings: the sidebar is now resizable — drag the divider between 200–380pt; the width persists across launches.

--- a/Sources/CodexBarCLI/CLIDashboardCommand.swift
+++ b/Sources/CodexBarCLI/CLIDashboardCommand.swift
@@ -26,6 +26,11 @@ struct DashboardSnapshotResult {
     let usageCacheKeys: [String?]
 }
 
+struct DashboardClaudeSwapCollection: Sendable {
+    let accounts: [ProviderAccountUsageSnapshot]?
+    let adapterError: String?
+}
+
 /// Collects the stable dashboard-v1 payload independently of its transport.
 /// The CLI command encodes it directly while `codexbar serve` wraps it in the
 /// existing authenticated HTTP cache.
@@ -33,6 +38,8 @@ struct DashboardSnapshotProducer: Sendable {
     let collectUsage: @Sendable ([UsageProvider]) async throws -> UsageCommandOutput
     let collectCost: @Sendable ([UsageProvider], CodexBarConfig) async -> [CostPayload]
     let now: @Sendable () -> Date
+    var collectClaudeSwapAccounts: @Sendable (CodexBarConfig) async -> DashboardClaudeSwapCollection? = { _ in nil }
+    var weeklyWorkDays: @Sendable () -> Int? = { nil }
 
     func collect(
         config: CodexBarConfig,
@@ -46,15 +53,23 @@ struct DashboardSnapshotProducer: Sendable {
         let costPayloads = await self.collectCost(
             CodexBarCLI.costProviders(from: selection),
             config)
+        let claudeSwap = await self.collectClaudeSwapAccounts(config)
+        let generatedAt = self.now()
 
         let payload = DashboardSnapshotBuilder.makeSnapshot(
             usagePayloads: usageOutput.payload,
             costPayloads: costPayloads,
             config: config,
             identityMode: .redacted,
-            generatedAt: self.now(),
+            generatedAt: generatedAt,
             refreshInterval: refreshInterval,
-            codexBarVersion: codexBarVersion)
+            codexBarVersion: codexBarVersion,
+            claudeSwap: claudeSwap.map {
+                DashboardClaudeSwapInput(
+                    accounts: $0.accounts,
+                    adapterError: $0.adapterError,
+                    weeklyWorkDays: self.weeklyWorkDays())
+            })
         return DashboardSnapshotResult(
             payload: payload,
             usageCacheKeys: usageOutput.payload.map(\.cacheAccountKey))
@@ -86,12 +101,42 @@ struct DashboardSnapshotProducer: Sendable {
                     }
                 }
             },
-            now: { Date() })
+            now: { Date() },
+            collectClaudeSwapAccounts: { config in
+                // Provider-specific by design: the dashboard opts into Claude's local multi-account adapter.
+                guard CodexBarCLI.dashboardClaudeSwapIsEligible(config: config) else { return nil }
+                let path = config.providerConfig(for: .claude)?.sanitizedClaudeSwapExecutablePath ?? ""
+                let timeout = min(
+                    ClaudeSwapAccountReader.defaultTimeout,
+                    context.usage.providerTimeout ?? ClaudeSwapAccountReader.defaultTimeout)
+                do {
+                    let list = try await ClaudeSwapAccountReader.readAccountList(
+                        executablePath: path,
+                        timeout: timeout)
+                    return DashboardClaudeSwapCollection(
+                        accounts: ClaudeSwapAccountProjection.accountSnapshots(from: list),
+                        adapterError: nil)
+                } catch {
+                    let diagnostic = CLIClaudeSwapText.sanitizeDiagnostic(error.localizedDescription)
+                    return DashboardClaudeSwapCollection(
+                        accounts: nil,
+                        adapterError: diagnostic.isEmpty ? "claude-swap list failed." : diagnostic)
+                }
+            },
+            weeklyWorkDays: { CodexBarCLI.weeklyProgressWorkDaysFromDefaults() })
     }
 }
 
 extension CodexBarCLI {
     static let dashboardCostRefreshesPricingInBackground = false
+
+    /// Dashboard-only claude-swap eligibility: Claude enabled and the integration switched on.
+    /// (Cards have their own eligibility in CLIClaudeSwapCards; serve /usage stays untouched.)
+    static func dashboardClaudeSwapIsEligible(config: CodexBarConfig) -> Bool {
+        // Provider-specific by design: only enabled Claude rows can expose claude-swap accounts.
+        config.enabledProviders().compactMap(\.firstPartyProvider).contains(.claude)
+            && config.providerConfig(for: .claude)?.claudeSwapEnabled == true
+    }
 
     static func runDashboard(_ values: ParsedValues) async {
         guard let timeout = decodeDashboardTimeout(from: values) else {

--- a/Sources/CodexBarCLI/DashboardPayloads.swift
+++ b/Sources/CodexBarCLI/DashboardPayloads.swift
@@ -46,6 +46,11 @@ struct DashboardProviderPayload: Encodable {
     let display: DashboardDisplayPayload
     let error: ProviderErrorPayload?
     let updatedAt: Date?
+    /// Per-account entries from a local multi-account source (today: claude-swap).
+    /// Additive schema-v1 data; absent for providers without such a source.
+    let accounts: [DashboardAccountPayload]?
+    /// Row-local failure of the multi-account source; the ambient provider row stays intact.
+    let accountsError: String?
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -60,6 +65,8 @@ struct DashboardProviderPayload: Encodable {
         case display
         case error
         case updatedAt
+        case accounts
+        case accountsError
     }
 
     func encode(to encoder: Encoder) throws {
@@ -74,6 +81,42 @@ struct DashboardProviderPayload: Encodable {
         try container.encode(self.credits, forKey: .credits)
         try container.encode(self.cost, forKey: .cost)
         try container.encode(self.display, forKey: .display)
+        try container.encode(self.error, forKey: .error)
+        try container.encode(self.updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(self.accounts, forKey: .accounts)
+        try container.encodeIfPresent(self.accountsError, forKey: .accountsError)
+    }
+}
+
+struct DashboardAccountPayload: Encodable {
+    let id: String
+    let label: String
+    let active: Bool
+    let identity: DashboardIdentityPayload?
+    let windows: [DashboardWindowPayload]
+    let pace: ProviderPacePayload?
+    let error: String?
+    let updatedAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case label
+        case active
+        case identity
+        case windows
+        case pace
+        case error
+        case updatedAt
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.label, forKey: .label)
+        try container.encode(self.active, forKey: .active)
+        try container.encode(self.identity, forKey: .identity)
+        try container.encode(self.windows, forKey: .windows)
+        try container.encode(self.pace, forKey: .pace)
         try container.encode(self.error, forKey: .error)
         try container.encode(self.updatedAt, forKey: .updatedAt)
     }

--- a/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
+++ b/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
@@ -1,6 +1,12 @@
 import CodexBarCore
 import Foundation
 
+struct DashboardClaudeSwapInput {
+    let accounts: [ProviderAccountUsageSnapshot]?
+    let adapterError: String?
+    let weeklyWorkDays: Int?
+}
+
 /// Projects the CLI's provider usage and cost payloads into the stable,
 /// display-oriented `/dashboard/v1/snapshot` contract.
 enum DashboardSnapshotBuilder {
@@ -12,7 +18,8 @@ enum DashboardSnapshotBuilder {
         identityMode: DashboardIdentityMode,
         generatedAt: Date,
         refreshInterval: TimeInterval,
-        codexBarVersion: String?) -> DashboardSnapshotPayload
+        codexBarVersion: String?,
+        claudeSwap: DashboardClaudeSwapInput? = nil) -> DashboardSnapshotPayload
     {
         var costByProvider: [String: CostPayload] = [:]
         for cost in costPayloads {
@@ -24,14 +31,22 @@ enum DashboardSnapshotBuilder {
             sortKeys[provider.rawValue] = index * 10
         }
 
+        var attachedClaudeSwap = false
         let providers = usagePayloads.enumerated().map { index, payload in
-            self.makeProvider(
+            var rowClaudeSwap: DashboardClaudeSwapInput?
+            // Provider-specific by design: claude-swap account data belongs only on the first Claude row.
+            if !attachedClaudeSwap, UsageProvider(rawValue: payload.provider) == .claude {
+                rowClaudeSwap = claudeSwap
+                attachedClaudeSwap = true
+            }
+            return self.makeProvider(
                 payload: payload,
                 cost: costByProvider[payload.provider],
                 enabledProviders: enabledProviders,
                 sortKey: sortKeys[payload.provider] ?? (10000 + index),
                 identityMode: identityMode,
-                generatedAt: generatedAt)
+                generatedAt: generatedAt,
+                claudeSwap: rowClaudeSwap)
         }
 
         let refreshSeconds = self.dashboardRefreshSeconds(refreshInterval)
@@ -52,13 +67,23 @@ enum DashboardSnapshotBuilder {
         enabledProviders: Set<UsageProvider>,
         sortKey: Int,
         identityMode: DashboardIdentityMode,
-        generatedAt: Date) -> DashboardProviderPayload
+        generatedAt: Date,
+        claudeSwap: DashboardClaudeSwapInput?) -> DashboardProviderPayload
     {
         let provider = UsageProvider(rawValue: payload.provider)
         let descriptor = provider.map { ProviderDescriptorRegistry.descriptor(for: $0) }
         let metadata = descriptor?.metadata
 
         let error = payload.error ?? cost?.error
+        let accounts = claudeSwap?.adapterError == nil
+            ? claudeSwap?.accounts?.map { account in
+                self.makeClaudeSwapAccount(
+                    account,
+                    identityMode: identityMode,
+                    weeklyWorkDays: claudeSwap?.weeklyWorkDays,
+                    generatedAt: generatedAt)
+            }
+            : nil
         return DashboardProviderPayload(
             id: payload.provider,
             name: metadata?.displayName ?? payload.provider,
@@ -78,7 +103,39 @@ enum DashboardSnapshotBuilder {
                 payload: payload,
                 cost: cost,
                 error: error,
-                generatedAt: generatedAt))
+                generatedAt: generatedAt),
+            accounts: accounts,
+            accountsError: claudeSwap?.adapterError)
+    }
+
+    private static func makeClaudeSwapAccount(
+        _ account: ProviderAccountUsageSnapshot,
+        identityMode: DashboardIdentityMode,
+        weeklyWorkDays: Int?,
+        generatedAt: Date) -> DashboardAccountPayload
+    {
+        let email = account.snapshot?.identity?.accountEmail
+        let redactedEmail = identityMode != .none && email?.contains("@") == true
+            ? self.dashboardEmail(email, mode: identityMode)
+            : nil
+        let identity = redactedEmail.map { DashboardIdentityPayload(accountEmail: $0, plan: nil) }
+        // Provider-specific by design: claude-swap account windows and pace use Claude's presentation semantics.
+        let metadata = ProviderDescriptorRegistry.descriptor(for: UsageProvider.claude).metadata
+        return DashboardAccountPayload(
+            id: "\(account.id.source):\(account.id.opaqueID)",
+            label: "Account \(account.id.opaqueID)",
+            active: account.isActive,
+            identity: identity,
+            windows: self.makeWindows(provider: .claude, metadata: metadata, usage: account.snapshot),
+            pace: account.snapshot.flatMap {
+                CLIRenderer.providerPacePayload(
+                    provider: .claude,
+                    snapshot: $0,
+                    weeklyWorkDays: weeklyWorkDays,
+                    now: generatedAt)
+            },
+            error: account.error,
+            updatedAt: account.snapshot?.updatedAt)
     }
 
     private static func dashboardSource(from source: String) -> String {

--- a/Tests/CodexBarTests/DashboardClaudeSwapSnapshotTests.swift
+++ b/Tests/CodexBarTests/DashboardClaudeSwapSnapshotTests.swift
@@ -1,0 +1,329 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBarCLI
+
+struct DashboardClaudeSwapSnapshotTests {
+    private let generatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test
+    func `projects ordered claude swap accounts with windows pace and redacted identity`() throws {
+        let accounts = ClaudeSwapAccountProjection.accountSnapshots(
+            from: self.threeAccountList(),
+            now: self.generatedAt)
+        let providers = try self.providers(
+            identityMode: .redacted,
+            claudeSwap: DashboardClaudeSwapInput(accounts: accounts, adapterError: nil, weeklyWorkDays: nil))
+        let claude = try #require(providers.first { $0["id"] as? String == "claude" })
+        let rows = try #require(claude["accounts"] as? [[String: Any]])
+
+        #expect(rows.compactMap { $0["id"] as? String } == [
+            "claude-swap:2", "claude-swap:1", "claude-swap:3",
+        ])
+        #expect(rows.compactMap { $0["label"] as? String } == ["Account 2", "Account 1", "Account 3"])
+        #expect(rows.compactMap { $0["active"] as? Bool } == [true, false, false])
+
+        let active = try #require(rows.first)
+        let identity = try #require(active["identity"] as? [String: Any])
+        let windows = try #require(active["windows"] as? [[String: Any]])
+        let pace = try #require(active["pace"] as? [String: Any])
+        #expect(identity["accountEmail"] as? String == "redacted@personal.example")
+        #expect(identity["plan"] is NSNull)
+        #expect(windows.compactMap { $0["kind"] as? String } == [
+            "session", "weekly", "claude-weekly-scoped-fable",
+        ])
+        #expect(windows.compactMap { $0["label"] as? String } == ["Session", "Weekly", "Fable only"])
+        #expect(pace["primary"] is [String: Any])
+        #expect(pace["secondary"] is [String: Any])
+        #expect(active["updatedAt"] as? String == "2027-01-15T08:00:00Z")
+    }
+
+    @Test
+    func `per account failure keeps healthy siblings and ambient row intact`() throws {
+        let list = ClaudeSwapAccountList(
+            activeAccountNumber: 1,
+            accounts: [
+                self.accountRow(number: 1, email: "healthy@example.com", active: true),
+                ClaudeSwapAccountRow(
+                    number: 2,
+                    email: "expired@example.com",
+                    isActive: false,
+                    usageStatus: .tokenExpired,
+                    fiveHour: nil,
+                    sevenDay: nil),
+            ])
+        let accounts = ClaudeSwapAccountProjection.accountSnapshots(from: list, now: self.generatedAt)
+        let providers = try self.providers(
+            identityMode: .redacted,
+            claudeSwap: DashboardClaudeSwapInput(accounts: accounts, adapterError: nil, weeklyWorkDays: nil))
+        let claude = try #require(providers.first { $0["id"] as? String == "claude" })
+        let rows = try #require(claude["accounts"] as? [[String: Any]])
+        let healthy = try #require(rows.first)
+        let failed = try #require(rows.last)
+
+        #expect((healthy["windows"] as? [[String: Any]])?.count == 2)
+        #expect(healthy["error"] is NSNull)
+        #expect(failed["error"] as? String ==
+            "Token expired. Switch to this account in claude-swap to refresh it.")
+        #expect((failed["windows"] as? [Any])?.isEmpty == true)
+        #expect(failed["identity"] is NSNull)
+        #expect(failed["pace"] is NSNull)
+        #expect(failed["updatedAt"] is NSNull)
+        #expect(claude["error"] is NSNull)
+    }
+
+    @Test
+    func `adapter failure adds only accounts error and preserves ambient fields`() throws {
+        let providers = try self.providers(
+            identityMode: .redacted,
+            claudeSwap: DashboardClaudeSwapInput(
+                accounts: nil,
+                adapterError: "claude-swap timed out.",
+                weeklyWorkDays: nil))
+        let claude = try #require(providers.first { $0["id"] as? String == "claude" })
+
+        #expect(claude["accounts"] == nil)
+        #expect(claude["accountsError"] as? String == "claude-swap timed out.")
+        #expect((claude["windows"] as? [[String: Any]])?.count == 1)
+        #expect((claude["identity"] as? [String: Any])?["accountEmail"] as? String ==
+            "redacted@ambient.example")
+    }
+
+    @Test
+    func `absent swap omits additive keys from every provider row`() throws {
+        let providers = try self.providers(identityMode: .redacted, claudeSwap: nil)
+
+        #expect(providers.count == 2)
+        for provider in providers {
+            #expect(provider["accounts"] == nil)
+            #expect(provider["accountsError"] == nil)
+        }
+    }
+
+    @Test
+    func `account identity honors redaction modes and rejects placeholder labels`() throws {
+        let realAccount = ClaudeSwapAccountProjection.accountSnapshots(
+            from: ClaudeSwapAccountList(
+                activeAccountNumber: 1,
+                accounts: [self.accountRow(number: 1, email: "person@example.com", active: true)]),
+            now: self.generatedAt)
+        let placeholderAccount = ClaudeSwapAccountProjection.accountSnapshots(
+            from: ClaudeSwapAccountList(
+                activeAccountNumber: 2,
+                accounts: [self.accountRow(number: 2, email: "", active: true)]),
+            now: self.generatedAt)
+
+        let none = try self.firstAccount(mode: .none, accounts: realAccount)
+        let full = try self.firstAccount(mode: .full, accounts: realAccount)
+        let placeholder = try self.firstAccount(mode: .full, accounts: placeholderAccount)
+
+        #expect(none["identity"] is NSNull)
+        #expect((full["identity"] as? [String: Any])?["accountEmail"] as? String == "person@example.com")
+        #expect(placeholder["identity"] is NSNull)
+    }
+
+    @Test
+    func `enabled swap with no accounts emits an empty array`() throws {
+        let providers = try self.providers(
+            identityMode: .redacted,
+            claudeSwap: DashboardClaudeSwapInput(accounts: [], adapterError: nil, weeklyWorkDays: nil))
+        let claude = try #require(providers.first { $0["id"] as? String == "claude" })
+
+        #expect((claude["accounts"] as? [Any])?.isEmpty == true)
+        #expect(claude["accountsError"] == nil)
+    }
+
+    @Test
+    func `producer collects swap accounts with config while its default omits them`() async throws {
+        let recorder = DashboardClaudeSwapConfigRecorder()
+        let account = ClaudeSwapAccountProjection.accountSnapshots(
+            from: ClaudeSwapAccountList(
+                activeAccountNumber: 1,
+                accounts: [self.accountRow(number: 1, email: "person@example.com", active: true)]),
+            now: self.generatedAt)
+        let config = self.enabledSwapConfig()
+        let ambient = self.ambientPayload()
+        var producer = DashboardSnapshotProducer(
+            collectUsage: { _ in
+                var output = UsageCommandOutput()
+                output.payload = [ambient]
+                return output
+            },
+            collectCost: { _, _ in [] },
+            now: { Date(timeIntervalSince1970: 1_800_000_000) })
+        producer.collectClaudeSwapAccounts = { config in
+            await recorder.record(config)
+            return DashboardClaudeSwapCollection(accounts: account, adapterError: nil)
+        }
+
+        let result = try await producer.collect(config: config, refreshInterval: 0, codexBarVersion: nil)
+        let rows = try self.providerRows(result.payload)
+        let claude = try #require(rows.first)
+        #expect((claude["accounts"] as? [Any])?.count == 1)
+        #expect(await recorder.receivedEnabledSwapConfig())
+
+        let defaultProducer = DashboardSnapshotProducer(
+            collectUsage: { _ in
+                var output = UsageCommandOutput()
+                output.payload = [ambient]
+                return output
+            },
+            collectCost: { _, _ in [] },
+            now: { Date(timeIntervalSince1970: 1_800_000_000) })
+        let defaultResult = try await defaultProducer.collect(
+            config: config,
+            refreshInterval: 0,
+            codexBarVersion: nil)
+        #expect(try #require(self.providerRows(defaultResult.payload).first)["accounts"] == nil)
+    }
+
+    @Test
+    func `dashboard swap eligibility requires enabled Claude and integration opt in`() {
+        var disabled = ProviderConfig(id: .claude, enabled: false)
+        disabled.claudeSwapEnabled = true
+        let unset = ProviderConfig(id: .claude, enabled: true)
+        var explicitFalse = ProviderConfig(id: .claude, enabled: true)
+        explicitFalse.claudeSwapEnabled = false
+        var enabled = ProviderConfig(id: .claude, enabled: true)
+        enabled.claudeSwapEnabled = true
+
+        #expect(!CodexBarCLI.dashboardClaudeSwapIsEligible(config: CodexBarConfig(providers: [disabled])))
+        #expect(!CodexBarCLI.dashboardClaudeSwapIsEligible(config: CodexBarConfig(providers: [unset])))
+        #expect(!CodexBarCLI.dashboardClaudeSwapIsEligible(config: CodexBarConfig(providers: [explicitFalse])))
+        #expect(CodexBarCLI.dashboardClaudeSwapIsEligible(config: CodexBarConfig(providers: [enabled])))
+    }
+
+    private func providers(
+        identityMode: DashboardIdentityMode,
+        claudeSwap: DashboardClaudeSwapInput?) throws -> [[String: Any]]
+    {
+        let snapshot = DashboardSnapshotBuilder.makeSnapshot(
+            usagePayloads: [self.ambientPayload(), self.codexPayload()],
+            costPayloads: [],
+            config: CodexBarConfig(providers: [
+                ProviderConfig(id: .claude, enabled: true),
+                ProviderConfig(id: .codex, enabled: true),
+            ]),
+            identityMode: identityMode,
+            generatedAt: self.generatedAt,
+            refreshInterval: 60,
+            codexBarVersion: nil,
+            claudeSwap: claudeSwap)
+        return try self.providerRows(snapshot)
+    }
+
+    private func firstAccount(
+        mode: DashboardIdentityMode,
+        accounts: [ProviderAccountUsageSnapshot]) throws -> [String: Any]
+    {
+        let providers = try self.providers(
+            identityMode: mode,
+            claudeSwap: DashboardClaudeSwapInput(accounts: accounts, adapterError: nil, weeklyWorkDays: nil))
+        let claude = try #require(providers.first { $0["id"] as? String == "claude" })
+        return try #require((claude["accounts"] as? [[String: Any]])?.first)
+    }
+
+    private func threeAccountList() -> ClaudeSwapAccountList {
+        ClaudeSwapAccountList(
+            activeAccountNumber: 2,
+            accounts: [
+                self.accountRow(number: 1, email: "work@example.com", active: false),
+                self.accountRow(number: 3, email: "third@example.net", active: false),
+                self.accountRow(
+                    number: 2,
+                    email: "personal@personal.example",
+                    active: true,
+                    scoped: [ClaudeSwapScopedUsageWindow(
+                        name: "Fable",
+                        usedPercent: 33,
+                        resetsAt: self.generatedAt.addingTimeInterval(2 * 24 * 60 * 60))]),
+            ])
+    }
+
+    private func accountRow(
+        number: Int,
+        email: String,
+        active: Bool,
+        scoped: [ClaudeSwapScopedUsageWindow] = []) -> ClaudeSwapAccountRow
+    {
+        ClaudeSwapAccountRow(
+            number: number,
+            email: email,
+            isActive: active,
+            usageStatus: .ok,
+            fiveHour: ClaudeSwapUsageWindow(
+                usedPercent: 40,
+                resetsAt: self.generatedAt.addingTimeInterval(60 * 60)),
+            sevenDay: ClaudeSwapUsageWindow(
+                usedPercent: 60,
+                resetsAt: self.generatedAt.addingTimeInterval(2 * 24 * 60 * 60)),
+            scoped: scoped)
+    }
+
+    private func ambientPayload() -> ProviderPayload {
+        ProviderPayload(
+            provider: .claude,
+            account: nil,
+            version: nil,
+            source: "web",
+            status: nil,
+            usage: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 20,
+                    windowMinutes: 300,
+                    resetsAt: self.generatedAt.addingTimeInterval(60 * 60),
+                    resetDescription: nil),
+                secondary: nil,
+                tertiary: nil,
+                updatedAt: self.generatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .claude,
+                    accountEmail: "ambient@ambient.example",
+                    accountOrganization: nil,
+                    loginMethod: "pro")),
+            credits: nil,
+            antigravityPlanInfo: nil,
+            openaiDashboard: nil,
+            error: nil)
+    }
+
+    private func codexPayload() -> ProviderPayload {
+        ProviderPayload(
+            provider: .codex,
+            account: nil,
+            version: nil,
+            source: "oauth",
+            status: nil,
+            usage: nil,
+            credits: nil,
+            antigravityPlanInfo: nil,
+            openaiDashboard: nil,
+            error: nil)
+    }
+
+    private func enabledSwapConfig() -> CodexBarConfig {
+        var claude = ProviderConfig(id: .claude, enabled: true)
+        claude.claudeSwapEnabled = true
+        return CodexBarConfig(providers: [claude])
+    }
+
+    private func providerRows(_ payload: DashboardSnapshotPayload) throws -> [[String: Any]] {
+        let json = try #require(CodexBarCLI.encodeJSON(payload, pretty: false))
+        let data = try #require(json.data(using: .utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        return try #require(object["providers"] as? [[String: Any]])
+    }
+}
+
+private actor DashboardClaudeSwapConfigRecorder {
+    private var received = false
+
+    func record(_ config: CodexBarConfig) {
+        self.received = config.enabledProviders().compactMap(\.firstPartyProvider).contains(.claude)
+            && config.providerConfig(for: .claude)?.claudeSwapEnabled == true
+    }
+
+    func receivedEnabledSwapConfig() -> Bool {
+        self.received
+    }
+}

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -149,7 +149,9 @@ The accepted multi-account design in
   email.
 - Terminal scope: this automatic precedence is cards-only and works on every supported CLI platform. An explicit
   Claude provider or `--source auto` remains eligible, while `--account`, `--account-index`, `--all-accounts`, and
-  explicit non-auto source flags bypass the adapter. `codexbar usage` and `codexbar serve` are unchanged.
+  explicit non-auto source flags bypass the adapter. `codexbar usage` and serve `/usage`/`/cost` remain unchanged,
+  while `codexbar dashboard` and `GET /dashboard/v1/snapshot` additionally nest one entry per swap account in the
+  Claude provider row, with identity redacted per the dashboard policy.
 - Isolation: CodexBar never reads claude-swap or Claude Code credential storage for this feature; the
   subprocess handles its own credential access. In the app, adapter failures keep the last successful accounts as
   stale data, surface the error in provider settings, and never affect the ambient Claude usage card. In terminal

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -172,6 +172,50 @@ The snapshot is a stable display contract, not a raw dump of provider internals.
 }
 ```
 
+### Multi-account providers (claude-swap)
+
+When the claude-swap integration is enabled, the Claude provider row additionally includes an `accounts` array. This
+is an additive schema-v1 extension: other provider rows and Claude rows without the integration keep their existing
+shape. Account identity follows the dashboard's always-redacted policy. A failure limited to one account stays in that
+account's `error`; a failure of the whole adapter sets `accountsError` while leaving the ambient Claude row intact.
+
+```json
+{
+  "id": "claude",
+  "identity": { "accountEmail": "redacted@example.com", "plan": "Max" },
+  "windows": [{ "kind": "session", "label": "Session", "usedPercent": 20, "remainingPercent": 80, "resetAt": "2026-07-16T17:00:00Z" }],
+  "accounts": [
+    {
+      "id": "claude-swap:2",
+      "label": "Account 2",
+      "active": true,
+      "identity": { "accountEmail": "redacted@personal.example", "plan": null },
+      "windows": [
+        { "kind": "session", "label": "Session", "usedPercent": 40, "remainingPercent": 60, "resetAt": "2026-07-16T17:00:00Z" },
+        { "kind": "weekly", "label": "Weekly", "usedPercent": 60, "remainingPercent": 40, "resetAt": "2026-07-18T12:00:00Z" },
+        { "kind": "claude-weekly-scoped-fable", "label": "Fable only", "usedPercent": 33, "remainingPercent": 67, "resetAt": "2026-07-18T12:00:00Z" }
+      ],
+      "pace": {
+        "primary": { "stage": "ahead", "deltaPercent": 20, "expectedUsedPercent": 20, "willLastToReset": true, "etaSeconds": null, "runOutProbability": null, "summary": "20% in deficit | Expected 20% used | Lasts to reset" },
+        "secondary": { "stage": "ahead", "deltaPercent": 31, "expectedUsedPercent": 29, "willLastToReset": false, "etaSeconds": 144000, "runOutProbability": null, "summary": "31% in deficit | Expected 29% used | Runs out in 1d 16h" }
+      },
+      "error": null,
+      "updatedAt": "2026-07-16T12:00:00Z"
+    },
+    {
+      "id": "claude-swap:1",
+      "label": "Account 1",
+      "active": false,
+      "identity": null,
+      "windows": [],
+      "pace": null,
+      "error": "Token expired. Switch to this account in claude-swap to refresh it.",
+      "updatedAt": null
+    }
+  ]
+}
+```
+
 ## Fields
 
 - `schemaVersion`: Dashboard API schema version.
@@ -191,3 +235,16 @@ The snapshot is a stable display contract, not a raw dump of provider internals.
 - `providers[].display`: UI hints for ordering and coloring.
 - `providers[].error`: Provider error payload when the latest fetch failed.
 - `providers[].updatedAt`: Best-known update timestamp for the provider row.
+- `providers[].accounts`: Ordered local multi-account entries when an integration supplies them; an enabled source
+  with no accounts emits `[]`.
+  - `id`: Stable source and slot identifier, such as `claude-swap:2`.
+  - `label`: Stable, non-sensitive display key, such as `Account 2`.
+  - `active`: Whether this is the source's active account.
+  - `identity`: Dashboard-redacted account email with a `null` plan, or `null`.
+  - `windows`: Account-local session, weekly, and scoped windows in the same shape as `providers[].windows`.
+  - `pace`: Account-local primary, secondary, and tertiary pace values when computable. Each pace value contains
+    `stage`, `deltaPercent`, `expectedUsedPercent`, `willLastToReset`, `etaSeconds`, `runOutProbability`, and `summary`.
+  - `error`: Account-local diagnostic, or `null`.
+  - `updatedAt`: Account snapshot update timestamp, or `null`.
+- `providers[].accountsError`: Whole-adapter diagnostic when account collection fails; `accounts` is then absent and
+  the ambient provider data remains available.


### PR DESCRIPTION
## Summary

With the claude-swap integration enabled, the dashboard-v1 snapshot (`codexbar dashboard` and `GET /dashboard/v1/snapshot`) reported only the active swap slot, even though `claude-swap list` knows every configured account. Dashboards built on the snapshot (e.g. a tailnet portal) had to shell out to claude-swap out-of-band to see the full fleet.

The Claude provider row now nests one entry per swap account:

- `accounts[]` with stable `id` (`claude-swap:<slot>`), non-sensitive `label` (`Account <slot>`), `active` flag, per-account windows (5h, 7d, model-scoped weeklies with their scope names), locally computed `pace`, per-account sentinel `error` text, and `updatedAt`.
- Account identity goes through the existing always-redacted dashboard policy (`redacted@domain`); placeholder labels never leak into identity, and claude-swap's `organizationName` is deliberately excluded (it can embed the raw email).
- A whole-adapter failure sets `accountsError` on the row and leaves the ambient Claude data intact; a single failing account never discards healthy siblings.

## Schema compatibility

Additive within schema v1 — `schemaVersion` stays 1. The two new fields are `encodeIfPresent`, so every provider row without claude-swap data stays byte-identical to 0.47.0. The one-shot command and the HTTP route share the same producer, so both transports pick this up together. `codexbar usage`, serve `/usage`/`/cost`, and cards are unchanged. Spend is not included: schema-v1 `claude-swap list` output carries no spend field and the strict parser allow-list stays as accepted in the multi-account design.

## Proof

- `swift test --filter DashboardClaudeSwapSnapshotTests` — 8 new tests: multi-account ordering/windows/pace/redaction, per-account failure isolation, adapter failure, additive-key absence, redaction modes incl. placeholder labels, empty account list, producer wiring, eligibility.
- Full `make test` sharded suite green; `make check` clean.
- Live one-shot + serve proof with a synthetic 6-account cswap stub (fake accounts, no credentials):

```json
"accounts": [
  {"id": "claude-swap:2", "label": "Account 2", "active": true,
   "identity": {"accountEmail": "redacted@example.com", "plan": null},
   "windows": [{"kind": "session", "usedPercent": 15}, {"kind": "weekly", "usedPercent": 39},
               {"kind": "claude-weekly-scoped-fable", "label": "Fable only", "usedPercent": 72}]},
  {"id": "claude-swap:4", "label": "Account 4", "active": false,
   "error": "Token expired. Switch to this account in claude-swap to refresh it.", "windows": []}
]
```

  All six synthetic accounts appear via both `codexbar dashboard` and an authenticated `curl` of `/dashboard/v1/snapshot` (401 without the bearer token), and a real claude-swap binary run shows the same shape with redacted identity.
