### PR TITLE
Add Claude setting to suppress Keychain access explanation

### DIFF
--- a/Sources/CodexBar/CookieHeaderStore.swift
+++ b/Sources/CodexBar/CookieHeaderStore.swift
@@ -72,7 +72,7 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.notify(KeychainPromptContext(
                 kind: self.promptKind,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/CookieHeaderStore.swift
+++ b/Sources/CodexBar/CookieHeaderStore.swift
@@ -72,7 +72,7 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: self.promptKind,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/CookieHeaderStore.swift
+++ b/Sources/CodexBar/CookieHeaderStore.swift
@@ -72,7 +72,7 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: self.promptKind,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/CopilotTokenStore.swift
+++ b/Sources/CodexBar/CopilotTokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .copilotToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/CopilotTokenStore.swift
+++ b/Sources/CodexBar/CopilotTokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .copilotToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/CopilotTokenStore.swift
+++ b/Sources/CodexBar/CopilotTokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.notify(KeychainPromptContext(
                 kind: .copilotToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/KeychainPromptCoordinator.swift
+++ b/Sources/CodexBar/KeychainPromptCoordinator.swift
@@ -59,6 +59,14 @@ struct KeychainPromptAlertModel: Equatable {
     let documentationURL: String
 }
 
+enum ClaudeOAuthPromptExplanationPreference {
+    static let userDefaultsKey = "claudeOAuthPromptExplanationEnabled"
+
+    static func isEnabled(in userDefaults: UserDefaults = .standard) -> Bool {
+        userDefaults.object(forKey: self.userDefaultsKey) as? Bool ?? false
+    }
+}
+
 @MainActor
 private final class KeychainPromptLearnMoreTarget: NSObject {
     private let documentationURL: String
@@ -117,9 +125,25 @@ enum KeychainPromptCoordinator {
     }
 
     private static func presentKeychainPrompt(_ context: KeychainPromptContext) {
+        guard self.shouldPresentExplanation(for: context) else {
+            self.log.info("Keychain prompt explanation suppressed", metadata: ["kind": "claudeOAuth"])
+            return
+        }
         let model = self.alertModel(for: context)
         self.log.info("Keychain prompt requested", metadata: ["kind": "\(context.kind)"])
         self.presentAlert(model)
+    }
+
+    static func shouldPresentExplanation(
+        for context: KeychainPromptContext,
+        userDefaults: UserDefaults = .standard) -> Bool
+    {
+        switch context.kind {
+        case .claudeOAuth:
+            ClaudeOAuthPromptExplanationPreference.isEnabled(in: userDefaults)
+        default:
+            true
+        }
     }
 
     private static func presentBrowserCookiePrompt(_ context: BrowserCookieKeychainPromptContext) {

--- a/Sources/CodexBar/KeychainPromptCoordinator.swift
+++ b/Sources/CodexBar/KeychainPromptCoordinator.swift
@@ -88,9 +88,6 @@ enum KeychainPromptCoordinator {
         "https://github.com/steipete/CodexBar/blob/main/docs/keychain-prompts.md"
 
     static func install() {
-        KeychainPromptHandler.handler = { context in
-            _ = self.presentKeychainPrompt(context)
-        }
         KeychainPromptHandler.resultHandler = { context in
             self.presentKeychainPrompt(context)
         }

--- a/Sources/CodexBar/KeychainPromptCoordinator.swift
+++ b/Sources/CodexBar/KeychainPromptCoordinator.swift
@@ -89,6 +89,9 @@ enum KeychainPromptCoordinator {
 
     static func install() {
         KeychainPromptHandler.handler = { context in
+            _ = self.presentKeychainPrompt(context)
+        }
+        KeychainPromptHandler.resultHandler = { context in
             self.presentKeychainPrompt(context)
         }
         BrowserCookieKeychainPromptHandler.handler = { context in

--- a/Sources/CodexBar/KeychainPromptCoordinator.swift
+++ b/Sources/CodexBar/KeychainPromptCoordinator.swift
@@ -63,7 +63,7 @@ enum ClaudeOAuthPromptExplanationPreference {
     static let userDefaultsKey = "claudeOAuthPromptExplanationEnabled"
 
     static func isEnabled(in userDefaults: UserDefaults = .standard) -> Bool {
-        userDefaults.object(forKey: self.userDefaultsKey) as? Bool ?? false
+        userDefaults.object(forKey: self.userDefaultsKey) as? Bool ?? true
     }
 }
 
@@ -124,14 +124,15 @@ enum KeychainPromptCoordinator {
             && !executableURL.pathComponents.contains(where: { $0.hasSuffix(".app") })
     }
 
-    private static func presentKeychainPrompt(_ context: KeychainPromptContext) {
+    private static func presentKeychainPrompt(_ context: KeychainPromptContext) -> Bool {
         guard self.shouldPresentExplanation(for: context) else {
             self.log.info("Keychain prompt explanation suppressed", metadata: ["kind": "claudeOAuth"])
-            return
+            return false
         }
         let model = self.alertModel(for: context)
         self.log.info("Keychain prompt requested", metadata: ["kind": "\(context.kind)"])
         self.presentAlert(model)
+        return true
     }
 
     static func shouldPresentExplanation(

--- a/Sources/CodexBar/KimiTokenStore.swift
+++ b/Sources/CodexBar/KimiTokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .kimiToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/KimiTokenStore.swift
+++ b/Sources/CodexBar/KimiTokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .kimiToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/KimiTokenStore.swift
+++ b/Sources/CodexBar/KimiTokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.notify(KeychainPromptContext(
                 kind: .kimiToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/MiniMaxAPITokenStore.swift
+++ b/Sources/CodexBar/MiniMaxAPITokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .minimaxToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/MiniMaxAPITokenStore.swift
+++ b/Sources/CodexBar/MiniMaxAPITokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .minimaxToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/MiniMaxAPITokenStore.swift
+++ b/Sources/CodexBar/MiniMaxAPITokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.notify(KeychainPromptContext(
                 kind: .minimaxToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/MiniMaxCookieStore.swift
+++ b/Sources/CodexBar/MiniMaxCookieStore.swift
@@ -44,7 +44,7 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .minimaxCookie,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/MiniMaxCookieStore.swift
+++ b/Sources/CodexBar/MiniMaxCookieStore.swift
@@ -44,7 +44,7 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.notify(KeychainPromptContext(
                 kind: .minimaxCookie,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/MiniMaxCookieStore.swift
+++ b/Sources/CodexBar/MiniMaxCookieStore.swift
@@ -44,7 +44,7 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .minimaxCookie,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -23,6 +23,7 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         _ = settings.claudeCookieSource
         _ = settings.claudeCookieHeader
         _ = settings.claudeOAuthKeychainPromptMode
+        _ = settings.claudeOAuthPromptExplanationEnabled
         _ = settings.claudeOAuthKeychainReadStrategy
         _ = settings.claudeWebExtrasEnabled
         _ = settings.claudeSwapEnabled
@@ -116,6 +117,19 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                 actions: [],
                 isVisible: nil,
                 isEnabled: { !context.settings.debugDisableKeychainAccess },
+                onChange: nil,
+                onAppDidBecomeActive: nil,
+                onAppearWhenEnabled: nil),
+            ProviderSettingsToggleDescriptor(
+                id: "claude-oauth-prompt-explanation",
+                title: "Show Keychain access explanation",
+                subtitle: "Shows CodexBar's explanation before macOS asks for Claude OAuth Keychain access. " +
+                    "This does not change the macOS prompt or OAuth behavior.",
+                binding: context.boolBinding(\.claudeOAuthPromptExplanationEnabled),
+                statusText: nil,
+                actions: [],
+                isVisible: nil,
+                isEnabled: nil,
                 onChange: nil,
                 onAppDidBecomeActive: nil,
                 onAppearWhenEnabled: nil),

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -598,6 +598,14 @@ extension SettingsStore {
         }
     }
 
+    var claudeOAuthPromptExplanationEnabled: Bool {
+        get { self.defaultsState.claudeOAuthPromptExplanationEnabled }
+        set {
+            self.defaultsState.claudeOAuthPromptExplanationEnabled = newValue
+            self.userDefaults.set(newValue, forKey: ClaudeOAuthPromptExplanationPreference.userDefaultsKey)
+        }
+    }
+
     var claudeOAuthKeychainReadStrategy: ClaudeOAuthKeychainReadStrategy {
         get {
             guard let raw = self.defaultsState.claudeOAuthKeychainReadStrategyRaw else {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -493,7 +493,7 @@ extension SettingsStore {
         let claudeOAuthKeychainReadStrategyRaw = Self.loadClaudeOAuthKeychainReadStrategyRaw(userDefaults: userDefaults)
         let claudeOAuthKeychainPromptModeRaw = userDefaults.string(forKey: "claudeOAuthKeychainPromptMode")
         let claudeOAuthPromptExplanationEnabled = userDefaults.object(
-            forKey: ClaudeOAuthPromptExplanationPreference.userDefaultsKey) as? Bool ?? false
+            forKey: ClaudeOAuthPromptExplanationPreference.userDefaultsKey) as? Bool ?? true
         let claudeWebExtrasEnabledRaw = userDefaults.object(forKey: "claudeWebExtrasEnabled") as? Bool ?? false
         let creditsExtrasDefault = userDefaults.object(forKey: "showOptionalCreditsAndExtraUsage") as? Bool
         let showOptionalCreditsAndExtraUsage = creditsExtrasDefault ?? true

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -492,6 +492,8 @@ extension SettingsStore {
         let menuBarShowsHighestUsage = userDefaults.object(forKey: "menuBarShowsHighestUsage") as? Bool ?? false
         let claudeOAuthKeychainReadStrategyRaw = Self.loadClaudeOAuthKeychainReadStrategyRaw(userDefaults: userDefaults)
         let claudeOAuthKeychainPromptModeRaw = userDefaults.string(forKey: "claudeOAuthKeychainPromptMode")
+        let claudeOAuthPromptExplanationEnabled = userDefaults.object(
+            forKey: ClaudeOAuthPromptExplanationPreference.userDefaultsKey) as? Bool ?? false
         let claudeWebExtrasEnabledRaw = userDefaults.object(forKey: "claudeWebExtrasEnabled") as? Bool ?? false
         let creditsExtrasDefault = userDefaults.object(forKey: "showOptionalCreditsAndExtraUsage") as? Bool
         let showOptionalCreditsAndExtraUsage = creditsExtrasDefault ?? true
@@ -604,6 +606,7 @@ extension SettingsStore {
             confettiOnWeeklyLimitResetsEnabled: confettiOnReset.weekly,
             menuBarShowsHighestUsage: menuBarShowsHighestUsage,
             claudeOAuthKeychainPromptModeRaw: claudeOAuthKeychainPromptModeRaw,
+            claudeOAuthPromptExplanationEnabled: claudeOAuthPromptExplanationEnabled,
             claudeOAuthKeychainReadStrategyRaw: claudeOAuthKeychainReadStrategyRaw,
             claudeWebExtrasEnabledRaw: claudeWebExtrasEnabledRaw,
             showOptionalCreditsAndExtraUsage: showOptionalCreditsAndExtraUsage,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -53,6 +53,7 @@ struct SettingsDefaultsState {
     var confettiOnWeeklyLimitResetsEnabled: Bool
     var menuBarShowsHighestUsage: Bool
     var claudeOAuthKeychainPromptModeRaw: String?
+    var claudeOAuthPromptExplanationEnabled: Bool
     var claudeOAuthKeychainReadStrategyRaw: String?
     var claudeWebExtrasEnabledRaw: Bool
     var showOptionalCreditsAndExtraUsage: Bool

--- a/Sources/CodexBar/SyntheticTokenStore.swift
+++ b/Sources/CodexBar/SyntheticTokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .syntheticToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/SyntheticTokenStore.swift
+++ b/Sources/CodexBar/SyntheticTokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.notify(KeychainPromptContext(
                 kind: .syntheticToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/SyntheticTokenStore.swift
+++ b/Sources/CodexBar/SyntheticTokenStore.swift
@@ -44,7 +44,7 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .syntheticToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/ZaiTokenStore.swift
+++ b/Sources/CodexBar/ZaiTokenStore.swift
@@ -61,7 +61,7 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .zaiToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/ZaiTokenStore.swift
+++ b/Sources/CodexBar/ZaiTokenStore.swift
@@ -61,7 +61,7 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            _ = KeychainPromptHandler.handler?(KeychainPromptContext(
                 kind: .zaiToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBar/ZaiTokenStore.swift
+++ b/Sources/CodexBar/ZaiTokenStore.swift
@@ -61,7 +61,7 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
+            KeychainPromptHandler.notify(KeychainPromptContext(
                 kind: .zaiToken,
                 service: self.service,
                 account: self.account))

--- a/Sources/CodexBarCore/KeychainAccessPreflight.swift
+++ b/Sources/CodexBarCore/KeychainAccessPreflight.swift
@@ -59,12 +59,12 @@ public enum KeychainPromptHandler {
         if let taskHandlerStore {
             return taskHandlerStore.handler(context)
         }
-        if let resultHandler {
-            return resultHandler(context)
+        if let handler {
+            handler(context)
+            return true
         }
-        guard let handler else { return false }
-        handler(context)
-        return true
+        if let resultHandler { return resultHandler(context) }
+        return false
     }
 
     #if DEBUG
@@ -117,6 +117,7 @@ public enum KeychainPromptHandler {
             try await operation()
         }
     }
+
     #endif
 }
 

--- a/Sources/CodexBarCore/KeychainAccessPreflight.swift
+++ b/Sources/CodexBarCore/KeychainAccessPreflight.swift
@@ -44,7 +44,11 @@ public enum KeychainPromptHandler {
     }
 
     @TaskLocal private static var taskHandlerStore: HandlerStore?
-    public nonisolated(unsafe) static var handler: ((KeychainPromptContext) -> Bool)?
+    /// Compatibility callback for clients that only need notification delivery.
+    public nonisolated(unsafe) static var handler: ((KeychainPromptContext) -> Void)?
+
+    /// Optional result-capable callback used when callers need to know whether a prompt was shown.
+    public nonisolated(unsafe) static var resultHandler: ((KeychainPromptContext) -> Bool)?
 
     public static func notify(_ context: KeychainPromptContext) {
         _ = self.notifyIfHandled(context)
@@ -55,8 +59,12 @@ public enum KeychainPromptHandler {
         if let taskHandlerStore {
             return taskHandlerStore.handler(context)
         }
+        if let resultHandler {
+            return resultHandler(context)
+        }
         guard let handler else { return false }
-        return handler(context)
+        handler(context)
+        return true
     }
 
     #if DEBUG

--- a/Sources/CodexBarCore/KeychainAccessPreflight.swift
+++ b/Sources/CodexBarCore/KeychainAccessPreflight.swift
@@ -36,15 +36,15 @@ public struct KeychainPromptContext: Sendable {
 
 public enum KeychainPromptHandler {
     final class HandlerStore: @unchecked Sendable {
-        let handler: (KeychainPromptContext) -> Void
+        let handler: (KeychainPromptContext) -> Bool
 
-        init(handler: @escaping (KeychainPromptContext) -> Void) {
+        init(handler: @escaping (KeychainPromptContext) -> Bool) {
             self.handler = handler
         }
     }
 
     @TaskLocal private static var taskHandlerStore: HandlerStore?
-    public nonisolated(unsafe) static var handler: ((KeychainPromptContext) -> Void)?
+    public nonisolated(unsafe) static var handler: ((KeychainPromptContext) -> Bool)?
 
     public static func notify(_ context: KeychainPromptContext) {
         _ = self.notifyIfHandled(context)
@@ -53,12 +53,10 @@ public enum KeychainPromptHandler {
     @discardableResult
     static func notifyIfHandled(_ context: KeychainPromptContext) -> Bool {
         if let taskHandlerStore {
-            taskHandlerStore.handler(context)
-            return true
+            return taskHandlerStore.handler(context)
         }
         guard let handler else { return false }
-        handler(context)
-        return true
+        return handler(context)
     }
 
     #if DEBUG
@@ -66,7 +64,13 @@ public enum KeychainPromptHandler {
         _ handler: ((KeychainPromptContext) -> Void)?,
         operation: () throws -> T) rethrows -> T
     {
-        try self.$taskHandlerStore.withValue(handler.map(HandlerStore.init(handler:))) {
+        let resultHandler = handler.map { callback in
+            { context in
+                callback(context)
+                return true
+            }
+        }
+        return try self.$taskHandlerStore.withValue(resultHandler.map(HandlerStore.init(handler:))) {
             try operation()
         }
     }
@@ -75,7 +79,33 @@ public enum KeychainPromptHandler {
         _ handler: ((KeychainPromptContext) -> Void)?,
         operation: () async throws -> T) async rethrows -> T
     {
-        try await self.$taskHandlerStore.withValue(handler.map(HandlerStore.init(handler:))) {
+        let resultHandler = handler.map { callback in
+            { context in
+                callback(context)
+                return true
+            }
+        }
+        return try await self.$taskHandlerStore.withValue(resultHandler.map(HandlerStore.init(handler:))) {
+            try await operation()
+        }
+    }
+
+    static func withResultHandlerForTesting<T>(
+        result: Bool,
+        operation: () throws -> T) rethrows -> T
+    {
+        let handler: (KeychainPromptContext) -> Bool = { _ in result }
+        return try self.$taskHandlerStore.withValue(HandlerStore(handler: handler)) {
+            try operation()
+        }
+    }
+
+    static func withResultHandlerForTesting<T>(
+        result: Bool,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        let handler: (KeychainPromptContext) -> Bool = { _ in result }
+        return try await self.$taskHandlerStore.withValue(HandlerStore(handler: handler)) {
             try await operation()
         }
     }

--- a/Tests/CodexBarTests/KeychainPromptCoordinatorTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptCoordinatorTests.swift
@@ -1,7 +1,7 @@
-import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
+@testable import CodexBarCore
 
 struct KeychainPromptCoordinatorTests {
     @Test
@@ -82,10 +82,24 @@ struct KeychainPromptCoordinatorTests {
             service: "Chrome Safe Storage",
             account: nil)
 
-        #expect(!KeychainPromptCoordinator.shouldPresentExplanation(for: claudeContext, userDefaults: defaults))
+        #expect(KeychainPromptCoordinator.shouldPresentExplanation(for: claudeContext, userDefaults: defaults))
         #expect(KeychainPromptCoordinator.shouldPresentExplanation(for: codexContext, userDefaults: defaults))
 
-        defaults.set(true, forKey: ClaudeOAuthPromptExplanationPreference.userDefaultsKey)
-        #expect(KeychainPromptCoordinator.shouldPresentExplanation(for: claudeContext, userDefaults: defaults))
+        defaults.set(false, forKey: ClaudeOAuthPromptExplanationPreference.userDefaultsKey)
+        #expect(!KeychainPromptCoordinator.shouldPresentExplanation(for: claudeContext, userDefaults: defaults))
+    }
+
+    @Test
+    func `prompt handler result reports whether an explanation was shown`() {
+        let context = KeychainPromptContext(
+            kind: .claudeOAuth,
+            service: "Claude Code-credentials",
+            account: nil)
+
+        let result = KeychainPromptHandler.withResultHandlerForTesting(result: false) {
+            KeychainPromptHandler.notifyIfHandled(context)
+        }
+
+        #expect(!result)
     }
 }

--- a/Tests/CodexBarTests/KeychainPromptCoordinatorTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptCoordinatorTests.swift
@@ -1,4 +1,5 @@
 import CodexBarCore
+import Foundation
 import Testing
 @testable import CodexBar
 
@@ -64,5 +65,27 @@ struct KeychainPromptCoordinatorTests {
         #expect(model.message.contains("Claude Code OAuth token"))
         #expect(model.message.contains("fetch your Claude usage"))
         #expect(model.learnMoreButtonTitle == "Learn More…")
+    }
+
+    @Test
+    func `Claude explanation follows its setting while other prompts remain unchanged`() throws {
+        let suite = "KeychainPromptCoordinatorTests-explanation"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let claudeContext = KeychainPromptContext(
+            kind: .claudeOAuth,
+            service: "Claude Code-credentials",
+            account: nil)
+        let codexContext = KeychainPromptContext(
+            kind: .codexCookie,
+            service: "Chrome Safe Storage",
+            account: nil)
+
+        #expect(!KeychainPromptCoordinator.shouldPresentExplanation(for: claudeContext, userDefaults: defaults))
+        #expect(KeychainPromptCoordinator.shouldPresentExplanation(for: codexContext, userDefaults: defaults))
+
+        defaults.set(true, forKey: ClaudeOAuthPromptExplanationPreference.userDefaultsKey)
+        #expect(KeychainPromptCoordinator.shouldPresentExplanation(for: claudeContext, userDefaults: defaults))
     }
 }

--- a/Tests/CodexBarTests/KeychainPromptCoordinatorTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptCoordinatorTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import CodexBar
 @testable import CodexBarCore
 
+@Suite(.serialized)
 struct KeychainPromptCoordinatorTests {
     @Test
     func `detects raw SwiftPM debug executable`() {
@@ -101,5 +102,25 @@ struct KeychainPromptCoordinatorTests {
         }
 
         #expect(!result)
+    }
+
+    @Test
+    func `legacy prompt handler takes precedence over result handler`() {
+        let context = KeychainPromptContext(
+            kind: .claudeOAuth,
+            service: "Claude Code-credentials",
+            account: nil)
+
+        let previousHandler = KeychainPromptHandler.handler
+        let previousResultHandler = KeychainPromptHandler.resultHandler
+        defer {
+            KeychainPromptHandler.handler = previousHandler
+            KeychainPromptHandler.resultHandler = previousResultHandler
+        }
+        KeychainPromptHandler.handler = { _ in }
+        KeychainPromptHandler.resultHandler = { _ in false }
+        let result = KeychainPromptHandler.notifyIfHandled(context)
+
+        #expect(result)
     }
 }

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2282,7 +2282,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SettingsStore.swift",
-            line: 1020,
+            line: 1023,
             anchor: "if !seen.contains(.factory), let zaiIndex = ordered.firstIndex(of: .zai) {",
             expectedProviderIDs: ["factory", "minimax", "zai"],
             expectedReferenceCount: 8,

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -553,6 +553,28 @@ struct SettingsStoreCoverageTests {
     }
 
     @Test
+    func `claude keychain prompt explanation is disabled by default`() {
+        let settings = Self.makeSettingsStore()
+        #expect(!settings.claudeOAuthPromptExplanationEnabled)
+    }
+
+    @Test
+    func `claude keychain prompt explanation persists across store reload`() throws {
+        let suite = "SettingsStoreCoverageTests-claude-keychain-prompt-explanation"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+
+        let first = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+        first.claudeOAuthPromptExplanationEnabled = true
+        #expect(
+            defaults.bool(forKey: ClaudeOAuthPromptExplanationPreference.userDefaultsKey))
+
+        let second = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+        #expect(second.claudeOAuthPromptExplanationEnabled)
+    }
+
+    @Test
     func `claude keychain prompt mode persists across store reload`() throws {
         let suite = "SettingsStoreCoverageTests-claude-keychain-prompt-mode"
         let defaults = try #require(UserDefaults(suiteName: suite))

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -553,9 +553,9 @@ struct SettingsStoreCoverageTests {
     }
 
     @Test
-    func `claude keychain prompt explanation is disabled by default`() {
+    func `claude keychain prompt explanation preserves the existing default`() {
         let settings = Self.makeSettingsStore()
-        #expect(!settings.claudeOAuthPromptExplanationEnabled)
+        #expect(settings.claudeOAuthPromptExplanationEnabled)
     }
 
     @Test

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -54,8 +54,8 @@ Admin API key setup:
   - `Always allow prompts`: allows interactive prompts in both user and background flows.
 - This setting only affects Claude OAuth Keychain prompting behavior; it does not switch your Claude usage source.
 - Preferences → Providers → Claude → Show Keychain access explanation controls CodexBar's explanatory alert before
-  the native macOS Keychain prompt. It is disabled by default and does not change Keychain authorization or OAuth
-  behavior.
+  the native macOS Keychain prompt. It remains enabled by default for existing installations; disable it when you
+  no longer need the explanation. This does not change Keychain authorization or OAuth behavior.
 - If Preferences → Advanced → Disable Keychain access is enabled, this policy remains visible but inactive until
   Keychain access is re-enabled.
 

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -53,6 +53,9 @@ Admin API key setup:
   - `Only on user action` (default): interactive prompts are reserved for user-initiated repair flows.
   - `Always allow prompts`: allows interactive prompts in both user and background flows.
 - This setting only affects Claude OAuth Keychain prompting behavior; it does not switch your Claude usage source.
+- Preferences → Providers → Claude → Show Keychain access explanation controls CodexBar's explanatory alert before
+  the native macOS Keychain prompt. It is disabled by default and does not change Keychain authorization or OAuth
+  behavior.
 - If Preferences → Advanced → Disable Keychain access is enabled, this policy remains visible but inactive until
   Keychain access is re-enabled.
 

--- a/docs/keychain-prompts.md
+++ b/docs/keychain-prompts.md
@@ -20,9 +20,10 @@ Before a Keychain read that may require interaction, CodexBar shows an explanati
 **Learn More** opens this page without dismissing that explanation or starting the macOS prompt. Choose **OK** only
 when you are ready to continue, or use the opt-out below.
 
-For Claude OAuth, the explanatory alert is disabled by default. Enable **Preferences → Providers → Claude → Show
-Keychain access explanation** if you want to see it before the native macOS authorization prompt. This preference only
-controls CodexBar's explanation; it does not change whether macOS asks for access or whether Claude OAuth can run.
+For Claude OAuth, the explanatory alert remains enabled by default for existing installations. Disable **Preferences →
+Providers → Claude → Show Keychain access explanation** after you have acknowledged the explanation and no longer need
+to see it before the native macOS authorization prompt. This preference only controls CodexBar's explanation; it does
+not change whether macOS asks for access or whether Claude OAuth can run.
 
 After you acknowledge the Claude OAuth explanation, CodexBar does not repeat that explanation for six hours. This
 cooldown only applies to CodexBar's explanatory alert: macOS can still show its own Keychain authorization prompt,

--- a/docs/keychain-prompts.md
+++ b/docs/keychain-prompts.md
@@ -20,6 +20,10 @@ Before a Keychain read that may require interaction, CodexBar shows an explanati
 **Learn More** opens this page without dismissing that explanation or starting the macOS prompt. Choose **OK** only
 when you are ready to continue, or use the opt-out below.
 
+For Claude OAuth, the explanatory alert is disabled by default. Enable **Preferences → Providers → Claude → Show
+Keychain access explanation** if you want to see it before the native macOS authorization prompt. This preference only
+controls CodexBar's explanation; it does not change whether macOS asks for access or whether Claude OAuth can run.
+
 After you acknowledge the Claude OAuth explanation, CodexBar does not repeat that explanation for six hours. This
 cooldown only applies to CodexBar's explanatory alert: macOS can still show its own Keychain authorization prompt,
 and the Claude **Never prompt** and global **Disable Keychain access** settings remain in effect.


### PR DESCRIPTION
## Summary

- Add a Claude setting, `Show Keychain access explanation`, with an explicit opt-out.
- Suppress CodexBar's explanatory pre-alert for Claude OAuth Keychain access when the setting is off.
- Preserve the existing explanation-by-default behavior for installations that have not set the preference.
- Add a separate result-capable prompt callback so the app can report whether an explanation was actually shown,
  without changing the public `KeychainPromptHandler.handler` callback signature.
- Preserve explicit legacy handler overrides ahead of the default result-capable route.
- Preserve the native macOS Keychain prompt and all OAuth/Keychain behavior.
- Add persistence and prompt-gating tests and document the distinction between the two prompts.

## Motivation

When refreshing Claude usage, CodexBar can show its explanatory alert before macOS asks for access to the Claude OAuth Keychain item. After the user has already granted access with “Always Allow”, seeing the explanatory alert again is cumbersome. The existing cooldown is temporary and does not provide a durable preference for an already-authorized setup.

This change makes the common already-authorized flow quiet after the user disables the explanation in Claude settings,
while preserving the current explanation-by-default behavior for upgrades. That avoids silently changing an existing
installation's security/education flow; new or existing users can opt out explicitly once they understand the prompt.

## Scope and safety

This only suppresses CodexBar's explanatory alert for the `.claudeOAuth` prompt context. It does not disable Keychain
access, change `ClaudeOAuthKeychainPromptMode`, bypass native macOS authorization, or alter OAuth refresh behavior.
The native macOS authorization prompt remains controlled by macOS. The additive result callback keeps the existing
six-hour cooldown semantics correct: only a displayed CodexBar explanation acknowledges the cooldown, while existing
CodexBarCore clients can continue assigning the public `Void` callback.

## Follow-up UX option

If maintainers prefer an inline acknowledgement, the same preference could later be exposed directly in this alert with an option such as “Don't show this again.” I kept this PR settings-first so the preference is explicit, discoverable, and consistent with the existing Claude authentication controls.

## Verification

- `make check`
- `make test` (823 selections, 69 groups, all passed)
- `swift test --filter 'KeychainPromptCoordinatorTests|SettingsStoreCoverageTests|ClaudeOAuthKeychainPreAlertGateTests'`
  (59 tests, all passed)
- The focused tests cover the unset/default state, explicit opt-out state, persistence, and the false handler result
  used by suppression, plus precedence for legacy public handler overrides; the full suite covers the unchanged native
  Keychain integration paths.
- The production app compilation path built successfully during validation. Complete packaging was attempted with
  `./Scripts/compile_and_run.sh`, but the separate Widget extension `xcodebuild` stalled in the locked CI-like local
  environment; no Keychain credentials or native authorization prompts were touched.
- UI screenshot capture was not possible because the Mac was locked during the runtime check. No live provider or
  Keychain reads were performed.

## Screenshots

Not included: this reuses the existing provider settings UI and changes the visibility of the existing explanatory flow
rather than adding a new visual component. The focused and full test commands above are the available redacted terminal
evidence for both preference states.

## Related

Related to #2588 and #2668.
