### PR TITLE
feat(cli): add --output <path> to the dashboard snapshot command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Currency: Korean won (KRW) in the preferred-currency picker, with correct zero-decimal formatting (#2669, refs #2449). Thanks @kes02!
 - Dashboard v1 snapshot: Claude rows now include all claude-swap accounts (windows, pace, active flag, redacted identity) when the integration is enabled.
 - CLI: add a built-in auto-refreshing web dashboard at `/` to `codexbar serve`.
+- CLI: `codexbar dashboard --output <path>` atomically writes the snapshot to a file (temp file + fsync + rename, `0644`) instead of stdout, so static-webroot publishers no longer need a shell wrapper.
 - CLI: expose Codex cost-history completeness in JSON and add an experimental provider-native-only scan mode (#2520). Thanks @NickGuAI!
 - Usage & Spend: add an accessible daily, weekly, and cumulative token-activity heatmap backed by the existing persistent cost scan cache (#2548). Thanks @Yuxin-Qiao!
 - Settings: the sidebar is now resizable — drag the divider between 200–380pt; the width persists across launches.

--- a/Sources/CodexBarCLI/CLIDashboardCommand.swift
+++ b/Sources/CodexBarCLI/CLIDashboardCommand.swift
@@ -1,3 +1,10 @@
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 import CodexBarCore
 import Commander
 import Foundation
@@ -24,6 +31,11 @@ struct DashboardOptions: CommanderParsable {
         name: .long("identity"),
         help: "Account identity detail: redacted (default) or full. The HTTP serve transport is always redacted; full is for one-shot snapshots consumed on trusted, private surfaces.")
     var identity: String?
+
+    @Option(
+        name: .long("output"),
+        help: "Write the snapshot atomically to this file (0644) instead of stdout. The parent directory must already exist; it is not created.")
+    var output: String?
 }
 
 struct DashboardSnapshotResult {
@@ -157,6 +169,12 @@ extension CodexBarCLI {
                 message: "--identity must be redacted or full.",
                 kind: .args)
         }
+        guard let outputDestination = decodeDashboardOutputDestination(from: values) else {
+            exit(
+                code: .failure,
+                message: "--output requires a non-empty file path.",
+                kind: .args)
+        }
 
         let configSnapshot: CLIServeConfigSnapshot
         do {
@@ -219,7 +237,92 @@ extension CodexBarCLI {
         guard let json = Self.encodeJSON(result.payload, pretty: values.flags.contains("pretty")) else {
             Self.exit(code: .failure, message: "Could not encode dashboard snapshot.")
         }
-        print(json)
+        switch outputDestination {
+        case .stdout:
+            print(json)
+        case let .file(path):
+            do {
+                // Match stdout shape: the published document ends with a newline.
+                try Self.writeDashboardSnapshotAtomically(Data((json + "\n").utf8), toPath: path)
+            } catch {
+                Self.exit(code: .failure, message: error.localizedDescription)
+            }
+        }
+    }
+
+    enum DashboardOutputDestination: Equatable {
+        case stdout
+        case file(String)
+    }
+
+    /// `nil` means the flag was given with an empty path (an args error);
+    /// an absent flag keeps the historical stdout behavior.
+    static func decodeDashboardOutputDestination(from values: ParsedValues) -> DashboardOutputDestination? {
+        guard let raw = values.options["output"]?.last else { return .stdout }
+        guard !raw.isEmpty else { return nil }
+        return .file(raw)
+    }
+
+    /// Atomically publish the snapshot: stage a temp file in the destination
+    /// directory, fsync, then `rename(2)` over the target so readers (e.g. a
+    /// static webroot) never observe a partial document. The file is world-
+    /// readable (`0644`) — dashboard snapshots are meant to be served. The
+    /// parent directory must already exist; it is deliberately not created.
+    static func writeDashboardSnapshotAtomically(_ data: Data, toPath path: String) throws {
+        let url = URL(fileURLWithPath: path)
+        let directory = url.deletingLastPathComponent()
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(ENOENT),
+                userInfo: [
+                    NSFilePathErrorKey: path,
+                    NSLocalizedDescriptionKey:
+                        "--output directory does not exist: \(directory.path) (parent directories are not created)",
+                ])
+        }
+
+        let staged = directory.appendingPathComponent(
+            ".\(url.lastPathComponent).codexbar-dashboard-\(UUID().uuidString)", isDirectory: false)
+        let descriptor = staged.path.withCString {
+            open($0, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, mode_t(0o644))
+        }
+        guard descriptor >= 0 else { throw Self.dashboardOutputPOSIXError(errno, path: staged.path) }
+
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        var handleOpen = true
+        do {
+            // Force 0644 even if umask narrowed the O_CREAT mode.
+            guard fchmod(descriptor, mode_t(0o644)) == 0 else {
+                throw Self.dashboardOutputPOSIXError(errno, path: staged.path)
+            }
+            try handle.write(contentsOf: data)
+            try handle.synchronize()
+            try handle.close()
+            handleOpen = false
+
+            let renamed = staged.path.withCString { src in
+                url.path.withCString { dst in rename(src, dst) }
+            }
+            guard renamed == 0 else { throw Self.dashboardOutputPOSIXError(errno, path: url.path) }
+        } catch {
+            if handleOpen { try? handle.close() }
+            try? FileManager.default.removeItem(at: staged)
+            throw error
+        }
+    }
+
+    private static func dashboardOutputPOSIXError(_ code: Int32, path: String) -> Error {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(code),
+            userInfo: [
+                NSFilePathErrorKey: path,
+                NSLocalizedDescriptionKey: "Could not write --output file \(path): \(String(cString: strerror(code)))",
+            ])
     }
 
     /// `.none` is deliberately not accepted: the flag chooses between the safe

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -158,7 +158,7 @@ extension CodexBarCLI {
         CodexBar \(version)
 
         Usage:
-          codexbar dashboard [--pretty] [--timeout <seconds>]
+          codexbar dashboard [--pretty] [--timeout <seconds>] [--output <path>]
                              [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>]
                              [-v|--verbose]
 
@@ -168,6 +168,9 @@ extension CodexBarCLI {
           failures as row-level errors without dropping healthy rows.
           Stdout contains only the JSON document; diagnostics are written to stderr.
           --timeout accepts 0...86400 seconds and defaults to 30; 0 disables the deadline.
+          --output atomically writes the snapshot to a file (0644) instead of stdout;
+          the parent directory must already exist (it is not created), and nothing is
+          printed to stdout on success.
 
         Global flags:
           -h, --help      Show help
@@ -180,6 +183,7 @@ extension CodexBarCLI {
           codexbar dashboard
           codexbar dashboard --pretty
           codexbar dashboard --timeout 60
+          codexbar dashboard --output /var/www/dashboard/snapshot.json
         """
     }
 
@@ -452,7 +456,7 @@ extension CodexBarCLI {
                        [--days <days>] [--group-by project]
           codexbar sessions [--json|--json-v2] [--pretty]
           codexbar sessions focus <id>
-          codexbar dashboard [--pretty] [--timeout <seconds>]
+          codexbar dashboard [--pretty] [--timeout <seconds>] [--output <path>]
           codexbar serve [--host <host>] [--port <port>] [--refresh-interval <seconds>]
                        [--request-timeout <seconds>]
                        [--dashboard-token <token>] [--allow-plain-http]

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -14,16 +14,18 @@ final class CLIEntryTests: XCTestCase {
     func test_rootHelpAdvertisesDashboardSnapshotCommand() {
         let help = CodexBarCLI.rootHelp(version: "0.0.0")
 
-        XCTAssertTrue(help.contains("codexbar dashboard [--pretty] [--timeout <seconds>]"))
+        XCTAssertTrue(help.contains("codexbar dashboard [--pretty] [--timeout <seconds>] [--output <path>]"))
     }
 
     func test_dashboardCommandIsRegisteredAndParsesOptions() throws {
         let program = Program(descriptors: CodexBarCLI.commandDescriptors())
-        let invocation = try program.resolve(argv: ["dashboard", "--pretty", "--timeout", "45"])
+        let invocation = try program.resolve(
+            argv: ["dashboard", "--pretty", "--timeout", "45", "--output", "/tmp/snapshot.json"])
 
         XCTAssertEqual(invocation.path, ["dashboard"])
         XCTAssertTrue(invocation.parsedValues.flags.contains("pretty"))
         XCTAssertEqual(invocation.parsedValues.options["timeout"], ["45"])
+        XCTAssertEqual(invocation.parsedValues.options["output"], ["/tmp/snapshot.json"])
     }
 
     func test_dashboardTimeoutIsBoundedAndCanBeDisabled() {
@@ -80,6 +82,83 @@ final class CLIEntryTests: XCTestCase {
         XCTAssertTrue(providers.isEmpty)
         let host = try XCTUnwrap(object["host"] as? [String: Any])
         XCTAssertEqual(host["refreshIntervalSeconds"] as? Int, 0)
+    }
+
+    func test_dashboardOutputWritesSnapshotFileAndKeepsStdoutSilent() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-dashboard-output-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var config = CodexBarConfig.makeDefault()
+        config.providers = config.providers.map { provider in
+            var disabled = provider
+            disabled.enabled = false
+            return disabled
+        }
+        let configURL = root.appendingPathComponent("config.json")
+        try CodexBarConfigStore(fileURL: configURL).save(config)
+
+        let snapshotURL = root.appendingPathComponent("snapshot.json")
+        // Pre-existing content must be atomically replaced, not appended to.
+        try Data("stale".utf8).write(to: snapshotURL)
+
+        let result = try Self.runCLI(
+            arguments: ["dashboard", "--output", snapshotURL.path],
+            environment: [CodexBarConfigStore.pathEnvironmentKey: configURL.path])
+        XCTAssertEqual(result.status, 0)
+        XCTAssertTrue(result.stdout.isEmpty)
+
+        let written = try Data(contentsOf: snapshotURL)
+        XCTAssertEqual(written.last, 0x0A)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: written) as? [String: Any])
+        XCTAssertEqual(object["schemaVersion"] as? Int, 1)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: snapshotURL.path)
+        XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.uint16Value, 0o644)
+
+        // The staged temp file must not survive a successful publish.
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: root.path)
+            .filter { $0.contains("codexbar-dashboard-") }
+        XCTAssertEqual(leftovers, [])
+    }
+
+    func test_dashboardOutputRejectsEmptyPathAsArgsError() throws {
+        let result = try Self.runCLI(arguments: ["dashboard", "--output", ""])
+
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.stdout.isEmpty)
+        let stderrText = try XCTUnwrap(String(bytes: result.stderr, encoding: .utf8))
+        XCTAssertTrue(stderrText.contains("--output requires a non-empty file path."))
+    }
+
+    func test_dashboardAtomicWriteFailsWhenDirectoryIsMissing() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-missing-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("snapshot.json")
+
+        XCTAssertThrowsError(
+            try CodexBarCLI.writeDashboardSnapshotAtomically(Data("{}".utf8), toPath: missing.path))
+        { error in
+            XCTAssertTrue(error.localizedDescription.contains("does not exist"))
+        }
+    }
+
+    func test_dashboardAtomicWriteReplacesExistingFile() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-atomic-write-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let target = root.appendingPathComponent("snapshot.json")
+        try Data("old".utf8).write(to: target)
+
+        try CodexBarCLI.writeDashboardSnapshotAtomically(Data("new".utf8), toPath: target.path)
+
+        XCTAssertEqual(try Data(contentsOf: target), Data("new".utf8))
+        let attributes = try FileManager.default.attributesOfItem(atPath: target.path)
+        XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.uint16Value, 0o644)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: root.path), ["snapshot.json"])
     }
 
     func test_decodesFormatFromOptionsAndFlags() {

--- a/Tests/CodexBarTests/DashboardClaudeSwapSnapshotTests.swift
+++ b/Tests/CodexBarTests/DashboardClaudeSwapSnapshotTests.swift
@@ -71,6 +71,23 @@ struct DashboardClaudeSwapSnapshotTests {
     }
 
     @Test
+    func `dashboard output flag decodes stdout default file paths and rejects empty`() {
+        #expect(CodexBarCLI.decodeDashboardOutputDestination(from: self.parsedValues(output: nil)) == .stdout)
+        #expect(CodexBarCLI.decodeDashboardOutputDestination(from: self.parsedValues(output: "/tmp/snapshot.json"))
+            == .file("/tmp/snapshot.json"))
+        #expect(CodexBarCLI.decodeDashboardOutputDestination(from: self.parsedValues(output: "relative.json"))
+            == .file("relative.json"))
+        #expect(CodexBarCLI.decodeDashboardOutputDestination(from: self.parsedValues(output: "")) == nil)
+    }
+
+    private func parsedValues(output: String?) -> ParsedValues {
+        ParsedValues(
+            positional: [],
+            options: output.map { ["output": [$0]] } ?? [:],
+            flags: [])
+    }
+
+    @Test
     func `per account failure keeps healthy siblings and ambient row intact`() throws {
         let list = ClaudeSwapAccountList(
             activeAccountNumber: 1,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -82,6 +82,7 @@ See `docs/configuration.md` for the schema.
   - Provider failures remain row-level errors alongside healthy rows; a valid partial snapshot exits `0`.
   - Stdout contains only the snapshot document. Diagnostics and optional `--json-output` logs go to stderr.
   - `--pretty` formats the document. `--timeout <seconds>` accepts `0...86400`, defaults to `30`, and uses `0` to disable the command deadline.
+  - `--output <path>` atomically writes the snapshot to a file (`0644`) instead of stdout — staged in the destination directory, fsync'd, then renamed over the target so readers never observe a partial document. The parent directory must already exist (it is not created), and stdout stays silent on success.
   - Starts no HTTP server and requires no dashboard bearer token. See `docs/dashboard-api.md` for the shared payload contract.
 - `codexbar serve` starts a foreground HTTP server for usage and cost JSON, a token-gated dashboard snapshot, and a built-in web UI at `/`.
   - `--host <host>` accepts `localhost` or an IPv4 address and defaults to `127.0.0.1`; `localhost` is normalized to `127.0.0.1`. Binding a non-loopback host requires a dashboard token **and** `--allow-plain-http` (see `docs/dashboard-api.md` for the threat model).


### PR DESCRIPTION
## Summary

Adds an `--output <path>` option to the one-shot `codexbar dashboard` command that atomically writes the snapshot JSON to a file instead of stdout.

Consumers that publish the snapshot to a static webroot currently need a shell wrapper (redirect to a temp file, then `install` over the target) so readers never observe a partial document. `--output` removes that wrapper: the snapshot is staged as a temp file in the destination directory, fsync'd, then renamed over the target with `0644` permissions, so the publish is a single atomic step.

## Behavior

- Flag absent: stdout behavior is unchanged (JSON document plus trailing newline).
- Flag present: nothing is printed to stdout on success; the written file matches the stdout shape, including the trailing newline.
- Empty path: rejected as an args error before any provider work starts.
- Missing parent directory: fails with a clear error; directories are deliberately not created (conservative CLI behavior, noted in the help text).
- Follows the `--identity` pattern from PR 2716 for option declaration, decoding helper, and tests.

## Testing

- `swift test --filter CLIEntryTests`: 35 tests passed, including new end-to-end coverage (writes file with silent stdout, replaces pre-existing content, verifies 0644 and no leftover staging files, empty-path args error, missing-directory failure).
- `swift test --filter DashboardClaudeSwapSnapshotTests`: 11 tests passed, including the new decoder test.
- Release build plus manual smoke test of success, missing-directory, and empty-path cases.
- Autoreview (codex, local mode): clean, no accepted or actionable findings.
